### PR TITLE
Add updates to discovery facts

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -239,13 +239,13 @@ In the {Project} web UI, navigate to *Hosts* > *Discovered hosts* and view the n
 
 {ProjectServer} assigns organization and location to discovered hosts according to the following sequence of rules:
 
-. If the `Discovery organization` or `Discovery location` values are set. To set these values, navigate to *Administer* > *Settings* > *Discovered*.
-. If the `foreman_organization` or `foreman_location` facts for a host are set. To configure fact names in *Administer* > *Settings* > *Puppet* section as the *Default organization* and *Default location* fact setting.
 . If a discovered host uses a subnet defined in {Project}, the host uses the first organization and location associated with the subnet.
+. If the `discovery_organization` or `discovery_location` fact values are set, the discovered host uses these fact values as an organization and location. To set these fact values, navigate to *Administer* > *Settings* > *Discovered*, and add these facts to the *Default organization* and *Default location* fields. Ensure that the discovered host's subnet also belongs to the organization and location set by the fact, otherwise  {Project} refuses to set it for security reasons.
 . If none of the previous conditions exists, {Project} assigns the first Organization and Location ordered by name.
 
 You can change the organization or location using the bulk actions menu of the *Discovered hosts* page. Select the discovered hosts to modify and select *Assign Organization* or *Assign Location* from the *Select Action* menu.
 
+Note that the `foreman_organization` and `foreman_location` facts are no longer valid values for assigning context for discovered hosts. You still can use these facts to configure the host for Puppet runs. To do this, navigate to *Administer* > *Settings* > *Puppet* section and add the `foreman_organization` and `foreman_location` facts to the *Default organization* and *Default location* fields.
 
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_from_Discovered_Hosts]]
 === Creating Hosts from Discovered Hosts


### PR DESCRIPTION
As part of

Bug 1741454 - Settings foreman_location and foreman_organization were
deprecated from discovery process

https://bugzilla.redhat.com/show_bug.cgi?id=1741454