### PR TITLE
Fixed build error on mising file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+---
+language: minimal
+before_install:
+  - sudo apt-get install -y ruby make
+install: gem install asciidoctor
+script:
+  - cd guides
+  - make clean html BUILD=satellite
+  - make clean html BUILD=foreman

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,5 +1,3 @@
-include::build.adoc[]
-
 :TargetVersion: 6.4
 :ProductVersion: 6.4
 :ProductVersionPrevious: 6.3


### PR DESCRIPTION
I have noticed an error when building the project. The attributes file was including file named "build" which no longer exists since build option is now passed via command line. This is a regression introduced in 8773d0d4d57cf64680d88121d0bb424b669cdb78.