### PR TITLE
Upstreamize RHV chapter

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -18,6 +18,10 @@ ifeval::["{build}" == "foreman"]
 :foreman-installer: foreman-installer
 :foreman.example.com: foreman.example.com
 :OVirt: oVirt
+:OVirtShort: oVirt
+:OVirtLegacy: oVirt
+:OVirtLegacyShort: oVirt
+:ovirt.example.com: ovirt.example.com
 :OpenStack: OpenStack
 :ProjectNameXY: Foreman{nbsp}1.22
 :ProjectNameX: Foreman
@@ -30,12 +34,17 @@ ifeval::["{build}" == "foreman"]
 :SmartProxy: Smart{nbsp}Proxy
 :smartproxy.example.com: smartproxy.example.com
 :smartproxy_port: 8443
+:Team: Foreman developers
 endif::[]
 
 ifeval::["{build}" == "satellite"]
 :foreman-installer: satellite-installer
 :foreman.example.com: satellite.example.com
 :OVirt: Red{nbsp}Hat{nbsp}Virtualization
+:OVirtShort: RHV
+:OVirtLegacy: Red{nbsp}Hat{nbsp}Enterprise{nbsp}Virtualization
+:OVirtLegacyShort: RHEV
+:ovirt.example.com: rhv.example.com
 :OpenStack: Red{nbsp}Hat OpenStack Platform
 :ProjectNameXY: Red{nbsp}Hat Satellite{nbsp}6.4
 :ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
@@ -48,4 +57,5 @@ ifeval::["{build}" == "satellite"]
 :SmartProxy: Capsule
 :smartproxy.example.com: capsule.example.com
 :smartproxy_port: 9090
+:Team: Red{nbsp}Hat
 endif::[]

--- a/guides/doc-Provisioning_Guide/topics/Virt-RHV.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-RHV.adoc
@@ -1,26 +1,41 @@
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization]]
-== Provisioning Virtual Machines in Red Hat Virtualization
+== Provisioning Virtual Machines in {OVirt}
 
+ifeval::["{build}" == "satellite"]
 Red Hat Virtualization (version 4.0 and later) or Red Hat Enterprise Virtualization (version 3.6 and earlier) is an enterprise-grade server and desktop virtualization platform built on Red Hat Enterprise Linux.
+endif::[]
+ifeval::["{build}" == "foreman"]
+{OVirt} is an enterprise-grade server and desktop virtualization platform built on Red Hat compatible system.
+endif::[]
 
-With {ProjectNameX}, you can manage virtualization functions through Red Hat Virtualization's REST API version 3. REST API version 4 is not yet supported by {ProjectX}. This includes creating virtual machines and controlling their power states.
+With {ProjectNameX}, you can manage virtualization functions through {OVirt}'s REST API version 3. REST API version 4 is not yet supported by {ProjectX}. This includes creating virtual machines and controlling their power states.
 
-Use the following procedures to add a connection to a Red Hat Virtualization environment and provision a virtual machine.
+Use the following procedures to add a connection to a {OVirt} environment and provision a virtual machine.
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Enterprise_Virtualization-Prerequisites_for_Red_Hat_Virtualization_Provisioning]]
-=== Prerequisites for Red Hat Virtualization Provisioning
+=== Prerequisites for {OVirt} Provisioning
 
-The requirements for Red Hat Virtualization provisioning include:
+The requirements for {OVirt} provisioning include:
 
-  * Synchronized content repositories for the version of Red Hat Enterprise Linux that you want to use. For more information, see link:/html/content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red Hat Repositories] in the _Content Management Guide_.
-  * A {SmartProxyServer} managing a logical network on the Red Hat Virtualization environment. Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}. For more information, see xref:Configuring_Networking[].
+ifeval::["{Build}" == "foreman"]
+  * The installation media that you require for the operating systems you want to use to provision using {OVirt}.
+endif::[]
+ifeval::["{Build}" == "satellite"]
+  * Synchronized content repositories for Red{nbsp}Hat Enterprise Linux. For more information, see link:/html/content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
+endif::[]
+  * A {SmartProxyServer} managing a logical network on the {OVirt} environment. Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}. For more information, see xref:Configuring_Networking[].
   * An existing template, other than the `blank` template, if you want to use image-based provisioning. For more information about creating templates for virtual machines, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.0/html/virtual_machine_management_guide/chap-templates[Templates] in the _Virtual Machine Management Guide_.
+ifeval::["{Build}" == "satellite"]
   * An activation key for host registration. For more information, see link:/html/content_management_guide/managing_activation_keys#Managing_Activation_Keys-Creating_an_Activation_Key[Creating An Activation Key] in the _Content Management_ guide.
+endif::[]
+ifeval::["{Build}" == "foreman"]
+  * If the Katello plugin is installed, an activation key for host registration. For more information, see link:/html/content_management_guide/managing_activation_keys#Managing_Activation_Keys-Creating_an_Activation_Key[Creating An Activation Key] in the _Content Management_ guide.
+endif::[]
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization-Creating_a_Red_Hat_Virtualization_User]]
-=== Creating a Red Hat Virtualization User
+=== Creating a {OVirt} User
 
-The Red Hat Virtualization server requires an administration-like user for {ProjectServer} communication. For security reasons, Red Hat advises against using the `admin@internal` user for such communication. Instead, create a new Red Hat Virtualization user with the following permissions:
+The {OVirt} server requires an administration-like user for {ProjectServer} communication. For security reasons, {Team} advises against using the `admin@internal` user for such communication. Instead, create a new {OVirt} user with the following permissions:
 
   - System
     * Configure System
@@ -47,35 +62,42 @@ The Red Hat Virtualization server requires an administration-like user for {Proj
     * Disk Profile
       ** Attach Disk Profile
 
-For more information about how to create a user and add permissions in Red Hat Virtualization, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.1/html/administration_guide/sect-red_hat_enterprise_virtualization_manager_user_tasks[Administering User Tasks From the Administration Portal] in the _Red Hat Virtualization Administration Guide_.
+ifeval::["{build}" == "satellite"]
+For more information about how to create a user and add permissions in {OVirt}, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.1/html/administration_guide/sect-red_hat_enterprise_virtualization_manager_user_tasks[Administering User Tasks From the Administration Portal] in the _Red Hat Virtualization Administration Guide_.
+endif::[]
+ifeval::["{build}" == "foreman"]
+For more information about how to create a user and add permissions in {OVirt}, see https://www.ovirt.org/documentation/admin-guide/chap-Users_and_Roles.html[Users and Roles] in the {OVirt} documentation.
+endif::[]
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization-Adding_a_Red_Hat_Virtualization_Connection_to_the_Satellite_Server]]
-=== Adding a Red Hat Virtualization Connection to {ProjectServer}
+=== Adding a {OVirt} Connection to {ProjectServer}
 
-Use this procedure to add a Red Hat Virtualization connection to {ProjectServer}'s compute resources.
+Use this procedure to add a {OVirt} connection to {ProjectServer}'s compute resources.
 
 .Procedure
 
-To add a Red Hat Virtualization connection to {Project}, complete the following steps:
+To add a {OVirt} connection to {Project}, complete the following steps:
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources*, and in the Compute Resources window, click *Create Compute Resource*.
 . In the *Name* field, enter a name for the new compute resource.
-. From the *Provider* list, select *RHV*.
+. From the *Provider* list, select *{OVirtShort}*.
 . In the *Description* field, enter a description for the compute resource.
-. In the *URL* field, enter the connection URL for the Red Hat Virtualization Manager's API.
+. In the *URL* field, enter the connection URL for the {OVirt} Manager's API.
 +
-For example, in RHEV 3.6 and earlier, the URL is
-of the following form: `https://rhvm.example.com/ovirt-engine/api`. In RHV 4.0 and
-later, the URL is of the following form: `https://rhvm.example.com/ovirt-engine/api/v3`.
+For example, in {OVirtLegacyShort} 3.6 and earlier, the URL is
+of the following form: `https://{ovirt.example.com}/ovirt-engine/api`. In {OVirtShort} 4.0 and
+later, the URL is of the following form: `https://{ovirt.example.com}/ovirt-engine/api/v3`.
 +
 . Optionally, select the *Use APIv4 (experimental)* check box to evaluate the new engine API.
 +
+ifeval::["{build}" == "satellite"]
 [WARNING]
 The items listed in this step are provided as Technology Previews. For further information about the scope of Technology Preview status, and associated support implications, see https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+endif::[]
 +
-. In the *User* field, enter the name of a user with permissions to access Red Hat Virtualization Manager's resources.
+. In the *User* field, enter the name of a user with permissions to access {OVirt} Manager's resources.
 . In the *Password* field, enter the password of the user.
-. Click *Load Datacenters* to populate the *Datacenter* list with data centers from your Red Hat Virtualization environment.
+. Click *Load Datacenters* to populate the *Datacenter* list with data centers from your {OVirt} environment.
 . From the *Datacenter* list, select a data center.
 . From the *Quota ID* list, select a quota to limit resources available to {Project}.
 . In the *X509 Certification Authorities* field, enter the certificate authority for SSL/TLS access. Alternatively, if you leave the field blank, a self-signed certificate is generated on the first API request by the server.
@@ -85,14 +107,14 @@ The items listed in this step are provided as Technology Previews. For further i
 
 .For CLI Users
 
-To create a Red Hat Virtualization connection, enter the `hammer compute-resource create` command with `Ovirt` for `--provider` and the name of the data center you want to use for `--datacenter`.
+To create a {OVirt} connection, enter the `hammer compute-resource create` command with `Ovirt` for `--provider` and the name of the data center you want to use for `--datacenter`.
 
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,+attributes"]
 ----
 # hammer compute-resource create \
---name "_My_RHV_" --provider "Ovirt" \
---description "RHV server at _rhvm.example.com_" \
---url "_https://rhvm.example.com/ovirt-engine/api_" \
+--name "_My_{OVirtShort}_" --provider "Ovirt" \
+--description "{OVirtShort} server at _{ovirt.example.com}_" \
+--url "_https://{ovirt.example.com}/ovirt-engine/api_" \
 --use-v4 "false" --user "_Satellite_User_" \
 --password "_My_Password_" \
 --locations "New York" --organizations "_My_Organization_" \
@@ -101,54 +123,56 @@ To create a Red Hat Virtualization connection, enter the `hammer compute-resourc
 
 Optionally, to evaluate the new engine API, change `false` to `true` for the `--use-v4` option.
 
+ifeval::["{build}" == "satellite"]
 [WARNING]
 ====
 The items listed in this step are provided as Technology Previews. For further information about the scope of Technology Preview status, and associated support implications, see https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
+endif::[]
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization-Adding_Red_Hat_Virtualization_Images_on_the_Satellite_Server]]
-=== Adding Red Hat Virtualization Images to {ProjectServer}
+=== Adding {OVirt} Images to {ProjectServer}
 
-Red Hat Virtualization uses templates as images for creating virtual machines. If you use image-based provisioning to create hosts, you must add Red Hat Virtualization template details to your {ProjectServer}. This includes access details and the template name.
+{OVirt} uses templates as images for creating virtual machines. If you use image-based provisioning to create hosts, you must add {OVirt} template details to your {ProjectServer}. This includes access details and the template name.
 
 .Procedure
 
-To add Red Hat Virtualization images on {ProjectServer}, complete the following steps:
+To add {OVirt} images on {ProjectServer}, complete the following steps:
 
-. In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources*, and in the Compute Resources window, click the name of your Red Hat Virtualization connection.
+. In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources*, and in the Compute Resources window, click the name of your {OVirt} connection.
 . Click the *Image* tab, and then click *New Image*.
 . In the *Name* field, enter a name for the image.
 . From the *Operatingsystem* list, select the image's base operating system.
 . From the *Architecture* list, select the operating system architecture.
 . In the *Username* field, enter the SSH user name for image access. This is normally the `root` user.
 . In the *Password* field, enter the SSH password for image access.
-. From the *Image* list, select the name of the image on Red Hat Virtualization.
+. From the *Image* list, select the name of the image on {OVirt}.
 . Click *Submit* to save the image details.
 
 .For CLI Users
 
-Create the image with the `hammer compute-resource image create` command. Use the `--uuid` option to store the template UUID on the Red Hat Virtualization server.
+Create the image with the `hammer compute-resource image create` command. Use the `--uuid` option to store the template UUID on the {OVirt} server.
 
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,+attributes"]
 ----
-# hammer compute-resource image create --name "_Test_RHV_Image_" \
+# hammer compute-resource image create --name "_Test_{OVirtShort}_Image_" \
 --operatingsystem "RedHat 7.2" --architecture "x86_64" --username root \
 --uuid "9788910c-4030-4ae0-bad7-603375dd72b1" \
---compute-resource "_My_RHV_"
+--compute-resource "_My_{OVirtShort}_"
 ----
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization-Adding_Red_Hat_Virtualization_Details_to_a_Compute_Profile]]
-=== Adding Red Hat Virtualization Details to a Compute Profile
+=== Adding {OVirt} Details to a Compute Profile
 
-You can predefine certain hardware settings for virtual machines on Red Hat Virtualization. You achieve this through adding these hardware settings to a compute profile.
+You can predefine certain hardware settings for virtual machines on {OVirt}. You achieve this through adding these hardware settings to a compute profile.
 
 .Procedure
 
-To add Red Hat Virtualization details to a compute profile, complete the following steps:
+To add {OVirt} details to a compute profile, complete the following steps:
 
-. In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles* and in the Compute Profiles window, click the name of the Red Hat Virtualization connection.
-. From the *Cluster* list, select the target host cluster in the Red Hat Virtualization environment.
-. From the *Template* list, select the RHV template to use for the *Cores* and *Memory* settings.
+. In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles* and in the Compute Profiles window, click the name of the {OVirt} connection.
+. From the *Cluster* list, select the target host cluster in the {OVirt} environment.
+. From the *Template* list, select the {OVirtShort} template to use for the *Cores* and *Memory* settings.
 . In the *Cores* field, enter the number of CPU cores to allocate to the new host.
 . In the *Memory* field, enter the amount of memory to allocate to the new host.
 . From the *Image* list, select image to use for image-based provisioning.
@@ -167,26 +191,26 @@ To add Red Hat Virtualization details to a compute profile, complete the followi
 The compute profile CLI commands are not yet implemented in {ProjectName} {ProductVersion}. As an alternative, you can include the same settings directly during the host creation process.
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization-Creating_Hosts_on_a_Red_Hat_Virtualization_Server]]
-=== Creating Network-Based Hosts on a Red Hat Virtualization Server
+=== Creating Network-Based Hosts on a {OVirt} Server
 
-In {Project}, you can create Red Hat Virtualization hosts over a network connection or from an existing image.
+In {Project}, you can create {OVirt} hosts over a network connection or from an existing image.
 
-To create a host over a network, the new host must have access to either {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} on a Red Hat Virtualization virtual network, so that the host has access to PXE provisioning services. The new host entry triggers the Red Hat Virtualization server to create the virtual machine. If the virtual machine detects the defined {SmartProxyServer} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
+To create a host over a network, the new host must have access to either {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} on a {OVirt} virtual network, so that the host has access to PXE provisioning services. The new host entry triggers the {OVirt} server to create the virtual machine. If the virtual machine detects the defined {SmartProxyServer} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
 
 .DHCP conflicts
-If you use a virtual network on the Red Hat Virtualization server for provisioning, ensure to select one that does not provide DHCP assignments. This causes DHCP conflicts with {ProjectServer} when booting new hosts.
+If you use a virtual network on the {OVirt} server for provisioning, ensure to select one that does not provide DHCP assignments. This causes DHCP conflicts with {ProjectServer} when booting new hosts.
 
-When you create a host with an existing image, the new host entry triggers the Red Hat Virtualization server to create the virtual machine, using the pre-existing image as a basis for the new volume.
+When you create a host with an existing image, the new host entry triggers the {OVirt} server to create the virtual machine, using the pre-existing image as a basis for the new volume.
 
 .Procedure
 
-To create a host for Red Hat Virtualization Server, complete the following steps:
+To create a host for {OVirt} Server, complete the following steps:
 
 . In the {Project} web UI, navigate to *Hosts* > *New Host*.
 . In the *Name* field, enter the name that you want to become the provisioned system's host name.
 . Click the *Organization* and *Location* tabs to ensure that the provisioning context is automatically set to the current context.
 . From the *Host Group* list, select the host group that you want to use to populate the form.
-. From the *Deploy on* list, select the Red Hat Virtualization connection.
+. From the *Deploy on* list, select the {OVirt} connection.
 . From the *Compute Profile* list, select a profile to use to automatically populate virtual machine-based settings.
 . Click the *Interface* tab and click *Edit* on the host's interface.
 . Verify that the fields are automatically populated with values. Note in particular:
@@ -194,9 +218,9 @@ To create a host for Red Hat Virtualization Server, complete the following steps
   * The *Name* from the *Host* tab becomes the *DNS name*.
   * {ProjectServer} automatically assigns an IP address for the new host.
 +
-. Ensure that the *MAC address* field is blank. The Red Hat Virtualization server assigns one to the host.
+. Ensure that the *MAC address* field is blank. The {OVirt} server assigns one to the host.
 . Verify that the *Managed*, *Primary*, and *Provision* options are automatically selected for the first interface on the host. If not, select them.
-. In the interface window, ensure that the Red Hat Virtualization-specific fields are populated with settings from the compute profile. Modify these settings to suit your needs.
+. In the interface window, ensure that the {OVirt}-specific fields are populated with settings from the compute profile. Modify these settings to suit your needs.
 . Click the *Operating System* tab, and confirm that all fields automatically contain values.
 . For network-based provisioning, ensure that the *Provisioning Method* is set to `Network Based`. For image-based provisioning, ensure that the *Provisioning Method* is set to `Image Based`.
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
@@ -208,11 +232,11 @@ To create a host for Red Hat Virtualization Server, complete the following steps
 
 To create a host with network-based provisioning, use the `hammer host create` command and include `--provision-method build`.
 
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,+attributes"]
 ----
-# hammer host create --name "rhv-test1" --organization "_My_Organization_" \
+# hammer host create --name "{OVirtShort}-test1" --organization "_My_Organization_" \
 --location "New York" --hostgroup "Base" \
---compute-resource "_My_RHV_" --provision-method build \
+--compute-resource "_My_{OVirtShort}_" --provision-method build \
 --build true --enabled true --managed true \
 --interface "managed=true,primary=true,provision=true,compute_name=eth0,compute_network=satnetwork" \
 --compute-attributes="cluster=Default,cores=1,memory=1073741824,start=true" \
@@ -221,11 +245,11 @@ To create a host with network-based provisioning, use the `hammer host create` c
 
 To create a host with image-based provisioning, use the `hammer host create` command and include `--provision-method image`.
 
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,+attributes"]
 ----
-# hammer host create --name "rhv-test2" --organization "_My_Organization_" \
+# hammer host create --name "{OVirtShort}-test2" --organization "_My_Organization_" \
 --location "New York" --hostgroup "Base" \
---compute-resource "_My_RHV_" --provision-method image \
+--compute-resource "_My_{OVirtShort}_" --provision-method image \
 --image "_Test_RHV_Image_" --enabled true --managed true \
 --interface "managed=true,primary=true,provision=true,compute_name=eth0,compute_network=satnetwork" \
 --compute-attributes="cluster=Default,cores=1,memory=1073741824,start=true" \


### PR DESCRIPTION
In addition I am commiting VSCode snippet file. If you use Visual Studio
Code editor for editing adoc files, you can now use `ifsat<TAB>` to
insert snippet quickly. Great time saver, I will add more as I find
those.

One question is on rhv.example.com. I felt like replacing it with
ovirt.example.com is not big deal because it continues with
/ovirt-engine in the URL anyway and I see no point in "hiding" that
OVirt is the upstream project for RHV. We are open source.

I also replaced "My RHV" with "My OVirt" in the compute resource names,
however this can be easily changed to something more neutral like "My
resource".

Other than that this is pretty straightforward conversion, no issues at
all.