### PR TITLE
Infoblox upstreamization

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -27,6 +27,7 @@ ifeval::["{build}" == "foreman"]
 :ProjectServer: Foreman{nbsp}server
 :Project: Foreman
 :SmartProxyServer: Smart{nbsp}Proxy{nbsp}server
+:SmartProxies: Smart{nbsp}Proxies
 :SmartProxy: Smart{nbsp}Proxy
 :smartproxy.example.com: smartproxy.example.com
 :smartproxy_port: 8443
@@ -45,6 +46,7 @@ ifeval::["{build}" == "satellite"]
 :ProjectServer: Satellite{nbsp}Server
 :Project: Satellite
 :SmartProxyServer: Capsule{nbsp}Server
+:SmartProxies: Capsules
 :SmartProxy: Capsule
 :smartproxy.example.com: capsule.example.com
 :smartproxy_port: 9090

--- a/guides/doc-Provisioning_Guide/topics/Infoblox_Integration.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Infoblox_Integration.adoc
@@ -3,11 +3,13 @@
 
 You can use {SmartProxyServer} to connect to your Infoblox application to create and manage DHCP and DNS records, and to reserve IP addresses.
 
+ifeval::["{build}" == "satellite"]
 The supported Infoblox version is NIOS 8.0 or higher and {ProjectXY} or higher.
+endif::[]
 
 === Limitations
 
-All DHCP and DNS records can be managed only in a single Network or DNS view, After you install the Infoblox modules on {SmartProxy} and set up the view using the `satellite-installer` command, you cannot edit the view.
+All DHCP and DNS records can be managed only in a single Network or DNS view, After you install the Infoblox modules on {SmartProxy} and set up the view using the `{foreman-installer}` command, you cannot edit the view.
 
 {SmartProxyServer} communicates with a single Infoblox node using the standard HTTPS web API. If you want to configure clustering and High Availability, make the configurations in Infoblox.
 
@@ -23,7 +25,7 @@ The administration roles must have permissions or belong to an admin group that 
 
 === Installing the Infoblox CA Certificate on {SmartProxyServer}
 
-You must install Infoblox HTTPS CA certificate on the base system for all {SmartProxy}s that you want to integrate with Infoblox applications.
+You must install Infoblox HTTPS CA certificate on the base system for all {SmartProxies} that you want to integrate with Infoblox applications.
 
 You can download the certificate from the Infoblox web UI, or you can use the following OpenSSL commands to download the certificate:
 
@@ -57,7 +59,9 @@ Example positive response:
 ]
 ----
 
+ifeval::["{build}" == "satellite"]
 Use the following Red{nbsp}Hat Knowledgebase article to install the certificate: https://access.redhat.com/solutions/1519813[How to install a CA certificate on Red Hat Enterprise Linux 6 / 7].
+endif::[]
 
 [[Infoblox-Integration-Installing_the_DHCP_Infoblox_Module]]
 === Installing the DHCP Infoblox module
@@ -78,10 +82,10 @@ To install the Infoblox module for DHCP, complete the following steps:
 
 . On {SmartProxy}, enter the following command:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,+attributes"]
 ----
 
-# satellite-installer --enable-foreman-proxy-plugin-dhcp-infoblox \
+# {foreman-installer} --enable-foreman-proxy-plugin-dhcp-infoblox \
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed false \
 --foreman-proxy-dhcp-provider infoblox \
@@ -94,7 +98,7 @@ To install the Infoblox module for DHCP, complete the following steps:
 
 ----
 +
-. In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxy}s* and select the {SmartProxy} with the Infoblox DHCP module and click *Refresh*.
+. In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}* and select the {SmartProxy} with the Infoblox DHCP module and click *Refresh*.
 . Ensure that the *dhcp* features are listed.
 . For all domains managed through Infoblox, ensure that the DNS {SmartProxy} is set for that domain. To verify, in the {Project} web UI, navigate to *Infrastructure* > *Domains*, and inspect the settings of each domain.
 . For all subnets managed through Infoblox, ensure that DHCP {SmartProxy} and Reverse DNS {SmartProxy} is set. To verify, in the {Project} web UI, navigate to *Infrastructure* > *Subnets*, and inspect the settings of each subnet.
@@ -110,9 +114,9 @@ To install the DNS Infoblox module, complete the following steps:
 
 . On {SmartProxy}, enter the following command:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,+attributes"]
 ----
-# satellite-installer --enable-foreman-proxy-plugin-dns-infoblox \
+# {foreman-installer} --enable-foreman-proxy-plugin-dns-infoblox \
 --foreman-proxy-dns true \
 --foreman-proxy-dns-managed false \
 --foreman-proxy-dns-provider infoblox \
@@ -121,5 +125,5 @@ To install the DNS Infoblox module, complete the following steps:
 --foreman-proxy-plugin-dns-infoblox-password infoblox
 ----
 +
-. In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxy}s* and select the {SmartProxy} with the Infoblox DNS module and click *Refresh*.
+. In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}* and select the {SmartProxy} with the Infoblox DNS module and click *Refresh*.
 . Ensure that the *dns* features are listed.

--- a/guides/upstreamize.rb
+++ b/guides/upstreamize.rb
@@ -38,6 +38,7 @@ report.write("# Upstreamization report from #{Time.now.utc}\n")
             line.gsub!(/Satellite( |\u{00A0}|{nbsp})Server/, '{ProjectServer}')
             line.gsub!(/Satellite/, '{Project}')
             line.gsub!(/Capsule( |\u{00A0}|{nbsp})Server/, '{SmartProxyServer}')
+            line.gsub!(/Capsules/, '{SmartProxies}')
             line.gsub!(/Capsule/, '{SmartProxy}')
           end
           if line != orig_line


### PR DESCRIPTION
Easy peasy, one thing I hate hostname `Infoblox_hostname` I vote for changing this to simply `infoblox-host`. Issues:

* hostnames should always be lowercase
* dashes preferred over underscore
* it is a host not hostname