### PR TITLE
Correct the Google resolver IP

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -85,7 +85,7 @@ To configure network services on {Project}'s integrated {SmartProxy}, complete t
 --foreman-proxy-dhcp-server "_192.168.140.2_" \
 --foreman-proxy-dns true \
 --foreman-proxy-dns-managed true \
---foreman-proxy-dns-forwarders "_8.8.8.8_; _4.4.4.4_" \
+--foreman-proxy-dns-forwarders "_8.8.8.8_; _8.8.4.4_" \
 --foreman-proxy-dns-interface "eth1" \
 --foreman-proxy-dns-reverse "_140.168.192.in-addr.arpa_" \
 --foreman-proxy-dns-server "_192.168.140.2_" \


### PR DESCRIPTION
Per https://developers.google.com/speed/public-dns/

I do wonder if we should point to possible other services. There's [Quad9's 9.9.9.9](https://www.quad9.net/) and [Cloudflare's 1.1.1.1](https://www.cloudflare.com/learning/dns/what-is-1.1.1.1/) as well.

Technically forwarders aren't even needed.