### PR TITLE
Add note about RHEL 8 repositories

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Resources.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Resources.adoc
@@ -144,11 +144,15 @@ ifeval::["{build}" == "foreman"]
 The following feature is provided by Katello plugin.
 endif::[]
 
-{Project} contains a set of synchronized kickstart repositories that you use to install the provisioned host's operating system.
+{Project} contains a set of synchronized kickstart repositories that you use to install the provisioned host's operating system. For more information about adding repositories, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Selecting_Red_Hat_Repositories_to_Synchronize[Selecting Red Hat Repositories to Synchronize] in the _Content Management Guide_.
+
 
 To set up a kickstart repository, complete the following steps:
 
 . Add the synchronized kickstart repository that you want to use to the existing Content View or create a new Content View and add the kickstart repository.
++
+For Red{nbsp}Hat Enterprise Linux 8, ensure that you add both *Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart x86_64 8* and *Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart x86_64 8* repositories.
++
 . Publish a new version of the Content View where the kickstart repository is added and promote it to a required lifecycle environment. For more information, see link:/html/content_management_guide/managing_content_views[Managing Content Views] in the _Content Management Guide_.
 . When you create a host, in the *Operating System* tab, for *Media Selection*, select the *Synced Content* check box.
 


### PR DESCRIPTION
As part of

Bug 1757152 - Need to add a note in Satellite Provisioning Guide, as to
which repositories should be included in the synced Kickstart Repository
for a rhel 8 Operating System

https://bugzilla.redhat.com/show_bug.cgi?id=1757152