### PR TITLE
Remove deprecated command option from Hammer compute resource for VMware

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -91,12 +91,12 @@ Create the connection with the `hammer compute-resource create` command. Select 
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource create --name "_My_vSphere_" \
+# hammer compute-resource create --name "My_vSphere" \
 --provider "Vmware" \
 --description "vSphere server at _vsphere.example.com_" \
---server "_vsphere.example.com_" --user "_{Project}_User_" \
---password "p@55w0rd!" --locations "New York" --organizations "_My_Organization_" \
---uuid 72cb9454-81cd-4231-a863-d9baf0f399f8
+--server "_vsphere.example.com_" --user "_My_User_" \
+--password "_My_Password_" --locations "_My_Location_" --organizations "_My_Organization_" \
+--datacenter "_My_Datacenter_"
 ----
 
 [[Provisioning_Virtual_Machines_in_VMware_vSphere-Adding_VMware_vSphere_Images_on_the_Satellite_Server]]


### PR DESCRIPTION
As part of

https://bugzilla.redhat.com/show_bug.cgi?id=1758530

Issue #57