### PR TITLE
Fixes s/discovery_rule/discovery-rule

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -357,11 +357,11 @@ When creating host name patterns, ensure the resulting host names are unique, do
 
 .For CLI Users
 
-Create the rule with the `hammer discovery_rule create` command:
+Create the rule with the `hammer discovery-rule create` command:
 
 [options="nowrap" subs="+quotes"]
 ----
-# hammer discovery_rule create --name "Hypervisor" \
+# hammer discovery-rule create --name "Hypervisor" \
 --search "cpu_count  > 8" --hostgroup "_My_Host_Group_" \
 --hostname "hypervisor-<%= rand(99999) %>" \
 --hosts-limit 5 --priority 5 --enabled true


### PR DESCRIPTION
Small fix for `hammer discovery-rule` command.

FYI: there is a convention for hammer commands naming which doesn't support underscores in command names or option names.