### PR TITLE
Fix path for puppet.conf file

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/app-Deploy_FIPS_hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app-Deploy_FIPS_hosts.adoc
@@ -348,7 +348,7 @@ $ hammer os update --title "RedHat 7.2" \
 
 On the {ProjectServer}, all external {SmartProxyServer}s, and *all* existing hosts, configure Puppet to use the SHA256 message digest algorithm.
 
-Edit the `/etc/puppet/puppet.conf` file, adding the line `digest_algorithm = sha256` in the `[main]` stanza.
+Edit the `/etc/puppetlabs/puppet/puppet.conf` file, adding the line `digest_algorithm = sha256` in the `[main]` stanza.
 
 [NOTE]
 ====


### PR DESCRIPTION
As part of

Bug 1763347 - Wrong puppet.conf path on Appendix C.4 of provisioning
guide

https://bugzilla.redhat.com/show_bug.cgi?id=1763347