### PR TITLE
A tool to help to navigate modularized docs

### DIFF
--- a/guides/.gitignore
+++ b/guides/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /common/build.adoc
 /upstreamize_report.md
+.alink

--- a/guides/asciidoc-include-linker.rb
+++ b/guides/asciidoc-include-linker.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+require "find"
+require "fileutils"
+
+DIR=ARGV[1] || '.'
+ALDIR="#{DIR}/.alink"
+FileUtils.rm_rf(ALDIR)
+ 
+Find.find(DIR) do |file|
+  next if file.match(/^.\/(.git|.alink)/)
+  next unless file.match(/\.adoc\Z/)
+  dirname = File.dirname(file)
+  basename = File.basename(file)
+  counter = 0
+  File.open(file, "r").each_line do |line|
+    match = line.match(/include::(.*)\[/)
+    if match
+      target_string = match.captures.first
+      target_real = "#{dirname}/#{target_string}"
+      if File.exist?(target_real)
+        n = sprintf("%03d", counter)
+        link = "#{ALDIR}/#{dirname}/#{n}-#{basename}-#{target_string.tr('/', '_')}"
+        target = File.absolute_path(target_real)
+        counter += 1
+        #puts "#{link} -> #{target}"
+        FileUtils.mkdir_p(File.dirname(link))
+        FileUtils.ln_sf(target, link)
+      else
+        puts "Ignoring missing #{ref}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
I wrote a simple tool which creates symlinks in folder called `.alink`
which follows the order in which adoc includes appear in documents. This
makes navigation through modularized docs with a breeze.

Better to see it in a video:

https://www.youtube.com/watch?v=w03XYn-p1K0

Test it, share it, enjoy.