### PR TITLE
Add ifevals for foreman and satellite port requirements

### DIFF
--- a/guides/common/modules/ports_prerequisites.adoc
+++ b/guides/common/modules/ports_prerequisites.adoc
@@ -9,7 +9,9 @@ The following tables indicate the destination port and the direction of network 
 | 443 | TCP | HTTPS | Subscription Management Services (access.redhat.com) and connecting to the Red{nbsp}Hat CDN (cdn.redhat.com).
 |====
 
+ifeval::["{build}" == "satellite"]
 Except in the case of a disconnected {Project}, {ProjectServer} needs access to the Red{nbsp}Hat CDN. For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red Hat] on the Red{nbsp}Hat Customer Portal.
+endif::[]
 
 .Ports for Browser-based User Interface Access to {Project}
 [cols="24%,20%,18%,38%",options="header"]
@@ -23,19 +25,30 @@ Except in the case of a disconnected {Project}, {ProjectServer} needs access to 
 [cols="24%,20%,18%,38%",options="header"]
 |====
 | Port | Protocol | Service | Required For
+ifeval::["{build}" == "satellite"]
 | 80 | TCP | HTTP | Anaconda, yum, for obtaining Katello certificates, templates, and for downloading iPXE firmware
 | 443 | TCP | HTTPS | Subscription Management Services, yum, Telemetry Services, and for connection to the Katello Agent
 | 5647 | TCP | amqp | Katello Agent to communicate with {Project}'s Qpid dispatch router
 | 8000 | TCP | HTTP | Anaconda to download kickstart templates to hosts, and for downloading iPXE firmware
+endif::[]
+ifeval::["{build}" == "foreman"]
+| 80 | TCP | HTTP | Operating system installers like Anaconda, yum, for obtaining Katello certificates, templates, and for downloading iPXE firmware
+| 443 | TCP | HTTPS | Subscription Management Services, yum, Telemetry Services, and for connection to the Katello Agent
+| 5647 | TCP | amqp | Katello Agent to communicate with {Project}'s Qpid dispatch router
+| 8000 | TCP | HTTP | Operating system installers like Anaconda to download kickstart templates to hosts, and for downloading iPXE firmware
+endif::[]
 | 8140 | TCP | HTTPS | Puppet agent to Puppet master connections
-| 9090 | TCP | HTTPS | Sending SCAP reports to the Smart Proxy in the
-integrated {SmartProxy}, for the discovery image during provisioning,
-and for communicating with {ProjectServer} to copy the SSH keys for Remote Execution (Rex) configuration
+| 9090 | TCP | HTTPS | Sending SCAP reports to the integrated {SmartProxy}, for the discovery image during provisioning, and for communicating with {ProjectServer} to copy the SSH keys for Remote Execution (Rex) configuration
 | 7 | TCP and UDP | ICMP | External DHCP on a Client to {Project} network, ICMP ECHO to verify IP address is free (Optional)
 | 53 | TCP and UDP | DNS | Client DNS queries to a {Project}'s integrated {SmartProxy} DNS service (Optional)
 | 67 | UDP | DHCP | Client to {Project}'s integrated {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {Project}'s integrated {SmartProxy} (Optional)
 | 69 | UDP |TFTP | Clients downloading PXE boot image files from a {Project}s' integrated {SmartProxy} for provisioning (Optional)
+ifeval::["{build}" == "satellite"]
 | 5000 | TCP | HTTPS | Connection to Katello for the Docker registry (Optional)
+endif::[]
+ifeval::["{build}" == "foreman"]
+| 5000 | TCP | HTTPS | If you use the Katello plug-in, a connection to Katello for the Docker registry (Optional)
+endif::[]
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}. This includes the base operating system on which a {SmartProxyServer} is running.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -5,7 +5,7 @@
 The following requirements apply to the networked base operating system:
 
 * x86_64 architecture
-ifeval::["{context}" == "satellite"]
+ifeval::["{build}" == "satellite"]
 * The latest version of Red Hat Enterprise Linux 7 Server
 endif::[]
 * 4-core 2.0 GHz CPU at a minimum


### PR DESCRIPTION
As part of

Bug 1802588 - [upstream] add ifevals for installing Satellite ports and
firewall requirements

https://bugzilla.redhat.com/show_bug.cgi?id=1802588