### PR TITLE
Remove all support info and just keep link

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -26,7 +26,7 @@ With {ProjectName}, you can perform both BIOS and UEFI based PXE provisioning.
 Both BIOS and UEFI interfaces work as interpreters between the computer's operating system and firmware, initializing the hardware components and starting the operating system at boot time.
 
 ifeval::["{build}" == "satellite"]
-For more information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
+For information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
 endif::[]
 
 In {Project} provisioning, the PXE loader option defines the DHCP `filename` option to use during provisioning. For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned node to download the `pxelinux.0` file over TFTP. For UEFI systems, use the *PXEGrub2 UEFI* option to enable a TFTP client to download `grub2/grubx64.efi` file.

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -26,7 +26,7 @@ With {ProjectName}, you can perform both BIOS and UEFI based PXE provisioning.
 Both BIOS and UEFI interfaces work as interpreters between the computer's operating system and firmware, initializing the hardware components and starting the operating system at boot time.
 
 ifeval::["{build}" == "satellite"]
-To perform PXE provisioning with UEFI, you must use a {RHELServer} 7 or higher that has Intel x86_64. In {Project}, PXE provisioning with UEFI is supported only on bare-metal systems. Because of a GRUB-related limitation, you cannot use UEFI to provision with a full host image. UEFI is not supported for virtual machines. UEFI SecureBoot is also not supported. For more information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
+For more information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
 endif::[]
 
 In {Project} provisioning, the PXE loader option defines the DHCP `filename` option to use during provisioning. For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned node to download the `pxelinux.0` file over TFTP. For UEFI systems, use the *PXEGrub2 UEFI* option to enable a TFTP client to download `grub2/grubx64.efi` file.


### PR DESCRIPTION
As part of

Bug 1802078 - [DDF] I guess intention of this statement was for intended
for PXE Less provisioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1802078