### PR TITLE
Bz#1804761

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,5 +1,5 @@
 :TargetVersion: 6.7-beta
-:ProductVersion: 6.7.beta
+:ProductVersion: 6.7-beta
 :ProductVersionPrevious: 6.6
 :ProductVersionRepoTitle: 6.7
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.7-rpms

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
-:TargetVersion: 6.6
-:ProductVersion: 6.6
-:ProductVersionPrevious: 6.5
+:TargetVersion: 6.7-beta
+:ProductVersion: 6.7.beta
+:ProductVersionPrevious: 6.6
 :ProductVersionRepoTitle: 6.7
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.7-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.6-rpms
@@ -36,6 +36,8 @@ ifeval::["{build}" == "foreman"]
 :oVirtShort: oVirt
 :oVirtLegacy: oVirt
 :oVirtLegacyShort: oVirt
+:lorax-composer: lorax-composer
+:cockpit: Cockpit
 :ovirt-example-com: ovirt.example.com
 :KubeVirt: KubeVirt
 :OpenStack: OpenStack
@@ -72,10 +74,12 @@ ifeval::["{build}" == "satellite"]
 :foreman-maintain: satellite-maintain
 :packages-install: satellite-maintain packages install
 :foreman-example-com: satellite.example.com
-:OVirt: Red{nbsp}Hat{nbsp}Virtualization
-:OVirtShort: RHV
-:OVirtLegacy: Red{nbsp}Hat{nbsp}Enterprise{nbsp}Virtualization
-:OVirtLegacyShort: RHEV
+:lorax-composer: Red{nbsp}Hat Image Builder
+:cockpit: Red{nbsp}Hat web console
+:oVirt: Red{nbsp}Hat{nbsp}Virtualization
+:oVirtShort: RHV
+:oVirtLegacy: Red{nbsp}Hat{nbsp}Enterprise{nbsp}Virtualization
+:oVirtLegacyShort: RHEV
 :ovirt-example-com: rhv.example.com
 :KubeVirt: Container-native Virtualization
 :OpenStack: Red{nbsp}Hat OpenStack Platform
@@ -108,11 +112,13 @@ ifeval::["{build}" == "foreman-deb"]
 :package-clean: apt-get clean
 :package-remove: apt-get remove
 :installer-scenario-smartproxy: foreman-installer --no-enable-foreman
-:OVirt: oVirt
-:OVirtShort: oVirt
-:OVirtLegacy: oVirt
-:OVirtLegacyShort: oVirt
+:oVirt: oVirt
+:oVirtShort: oVirt
+:oVirtLegacy: oVirt
+:oVirtLegacyShort: oVirt
 :ovirt-example-com: ovirt.example.com
+:lorax-composer: lorax-composer
+:cockpit: Cockpit
 :KubeVirt: KubeVirt
 :OpenStack: OpenStack
 :ProjectNameXY: Foreman{nbsp}1.22

--- a/guides/doc-Provisioning_Guide/master.adoc
+++ b/guides/doc-Provisioning_Guide/master.adoc
@@ -25,6 +25,8 @@ include::topics/Bare_Metal.adoc[]
 
 include::topics/configuring_the_discovery_service.adoc[]
 
+include::topics/proc_using-an-imagebuilder-image-for-provisioning.adoc[]
+
 include::topics/Virt-Libvirt.adoc[]
 
 include::topics/Virt-RHV.adoc[]

--- a/guides/doc-Provisioning_Guide/topics/Virt-Libvirt.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-Libvirt.adoc
@@ -1,4 +1,4 @@
-{package-install}[[Provisioning_Virtual_Machines_in_KVM]]
+[[Provisioning_Virtual_Machines_in_KVM]]
 == Provisioning Virtual Machines on a KVM Server (libvirt)
 
 Kernel-based Virtual Machines (KVMs) use an open source virtualization daemon and API called `libvirt` running on Red Hat Enterprise Linux. {ProjectNameX} can connect to the `libvirt` API on a KVM server, provision hosts on the hypervisor, and control certain virtualization functions.

--- a/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -1,0 +1,38 @@
+[[using-an-image-builder-image-for-provisioning]]
+= Using a {lorax-composer} Image for Provisioning
+
+In {Project}, you can integrate with {cockpit} to perform actions and monitor your hosts. Using {cockpit} can access {lorax-composer} and build images that you can then upload to {Project} and use this image to provision hosts.
+
+ifeval::["{build}" == "foreman"]
+For more information about integrating {cockpit} with {Project}, see https://theforeman.org/plugins/foreman_remote_execution/1.7/index.html#3.6Cockpitintegration[Cockpit integration].
+endif::[]
+
+ifeval::["{build}" == "satellite"]
+For more information about integrating {cockpit} with {Project}, see {BaseURL}managing_hosts/host_management_and_monitoring_using_red_hat_web_console[Host Management and Monitoring Using Red{nbsp}Hat web console] in the _Managing Hosts_ guide.
+endif::[]
+
+.Prerequisites
+
+. Use `scp` or `rsync` to copy the image using SSH to the base operating system of {Project}.
+ifeval::["{build}" == "satellite"]
+. On {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository. For more information, see {BaseURL}content_management_guide/managing_iso_images#importing_individual_iso_images_and_files[Importing Individual ISO Images and Files] in the _Content Management Guide_.
+endif::[]
+ifeval::["{build}" == "foreman"]
+. If you use the Katello plug-in, on {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository. For more information, see {BaseURL}content_management_guide/managing_iso_images#importing_individual_iso_images_and_files[Importing Individual ISO Images and Files] in the _Content Management Guide_.
+endif::[]
+
+.Procedure
+
+To use the {lorax-composer} image with Anaconda Kickstart in Satellite, complete the following steps:
+
+. In the Satellite web UI, navigate to *Configure* > *Host Groups*, and select the host group that you want to use.
+. Click the *Parameters* tab, and then click *Add Parameter*.
+. In the *Name* field, enter `kickstart_liveimg`.
+. From the *Type* list, select *string*.
+. In the *Value* field, enter the absolute path or a relative path in the following format `custom/_product_/_repository_/_image_name_` that points to the exact location where you store the image.
+. Click *Submit* to save your changes.
+
+You can use this image for bare metal provisioning and provisioning using a compute resource.
+
+For more information about bare metal provisioning, see xref:Provisioning_Bare_Metal_Hosts[].
+For more information about provisioning with different compute resources, see the relevant chapter for the compute resource that you want to use.

--- a/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -1,5 +1,5 @@
 [[using-an-image-builder-image-for-provisioning]]
-= Using a {lorax-composer} Image for Provisioning
+== Using a {lorax-composer} Image for Provisioning
 
 In {Project}, you can integrate with {cockpit} to perform actions and monitor your hosts. Using {cockpit} can access {lorax-composer} and build images that you can then upload to {Project} and use this image to provision hosts.
 
@@ -23,9 +23,9 @@ endif::[]
 
 .Procedure
 
-To use the {lorax-composer} image with Anaconda Kickstart in Satellite, complete the following steps:
+To use the {lorax-composer} image with Anaconda Kickstart in {Project}, complete the following steps:
 
-. In the Satellite web UI, navigate to *Configure* > *Host Groups*, and select the host group that you want to use.
+. In the {Project} web UI, navigate to *Configure* > *Host Groups*, and select the host group that you want to use.
 . Click the *Parameters* tab, and then click *Add Parameter*.
 . In the *Name* field, enter `kickstart_liveimg`.
 . From the *Type* list, select *string*.

--- a/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -1,7 +1,7 @@
 [[using-an-image-builder-image-for-provisioning]]
 == Using a {lorax-composer} Image for Provisioning
 
-In {Project}, you can integrate with {cockpit} to perform actions and monitor your hosts. Using {cockpit} can access {lorax-composer} and build images that you can then upload to {Project} and use this image to provision hosts.
+In {Project}, you can integrate with {cockpit} to perform actions and monitor your hosts. Using {cockpit}, you can access {lorax-composer} and build images that you can then upload to {Project} and use this image to provision hosts.
 
 ifeval::["{build}" == "foreman"]
 For more information about integrating {cockpit} with {Project}, see https://theforeman.org/plugins/foreman_remote_execution/1.7/index.html#3.6Cockpitintegration[Cockpit integration].


### PR DESCRIPTION
Add section on how to use an Image Builder image in {Project}

As part of 

Bug 1804761 - The section 'Provisioning Using a Red Hat Image Builder Image' is not present in the Satellite 6.7 Beta Provisioning guide. 

https://bugzilla.redhat.com/show_bug.cgi?id=1804761