### PR TITLE
Change unclear $(hostname) to the example URL of smart proxy

### DIFF
--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -53,7 +53,7 @@ ifeval::["{context}" == "{project-context}"]
 --foreman-proxy-dhcp-nameservers __172.17.13.2__ \
 --foreman-proxy-tftp true \
 --foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername $(hostname)
+--foreman-proxy-tftp-servername _{smartproxy-example-com}_
 ----
 
 You can monitor the progress of the `{foreman-installer}` command displayed in your prompt. You can view the logs in `/var/log/foreman-installer/satellite.log`. You can view the settings used, including the `admin_password` parameter, in the `/etc/foreman-installer/scenarios.d/satellite-answers.yaml` file.
@@ -78,7 +78,7 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 --foreman-proxy-dhcp-nameservers _172.17.13.2_ \
 --foreman-proxy-tftp true \
 --foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername $(hostname)
+--foreman-proxy-tftp-servername _{smartproxy-example-com}_
 ----
 endif::[]
 

--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -43,7 +43,6 @@ ifeval::["{context}" == "{project-context}"]
 --foreman-proxy-dns-managed true \
 --foreman-proxy-dns-interface __eth0__ \
 --foreman-proxy-dns-zone __example.com__ \
---foreman-proxy-dns-forwarders __192.0.2.1__ \
 --foreman-proxy-dns-reverse __2.0.192.in-addr.arpa__ \
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed true \
@@ -53,10 +52,10 @@ ifeval::["{context}" == "{project-context}"]
 --foreman-proxy-dhcp-nameservers __192.0.2.2__ \
 --foreman-proxy-tftp true \
 --foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername _192.0.2.0_
+--foreman-proxy-tftp-servername _192.0.2.3_
 ----
 
-You can monitor the progress of the `{foreman-installer}` command displayed in your prompt. You can view the logs in `/var/log/foreman-installer/satellite.log`. You can view the settings used, including the `admin_password` parameter, in the `/etc/foreman-installer/scenarios.d/satellite-answers.yaml` file.
+You can monitor the progress of the `{foreman-installer}` command displayed in your prompt. You can view the logs in `/var/log/foreman-installer/{project-context}.log`. You can view the settings used, including the `initial_admin_password` parameter, in the `/etc/foreman-installer/scenarios.d/{project-context}-answers.yaml` file.
 endif::[]
 
 ifeval::["{context}" == "{smart-proxy-context}"]
@@ -68,7 +67,6 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 --foreman-proxy-dns-managed true \
 --foreman-proxy-dns-interface _eth0_ \
 --foreman-proxy-dns-zone _example.com_ \
---foreman-proxy-dns-forwarders _192.0.2.1_ \
 --foreman-proxy-dns-reverse _2.0.192.in-addr.arpa_ \
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed true \
@@ -78,7 +76,7 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 --foreman-proxy-dhcp-nameservers _192.0.2.2_ \
 --foreman-proxy-tftp true \
 --foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername _192.0.2.0_
+--foreman-proxy-tftp-servername _192.0.2.3_
 ----
 endif::[]
 

--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -43,17 +43,17 @@ ifeval::["{context}" == "{project-context}"]
 --foreman-proxy-dns-managed true \
 --foreman-proxy-dns-interface __eth0__ \
 --foreman-proxy-dns-zone __example.com__ \
---foreman-proxy-dns-forwarders __172.17.13.1__ \
---foreman-proxy-dns-reverse __13.17.172.in-addr.arpa__ \
+--foreman-proxy-dns-forwarders __192.0.2.1__ \
+--foreman-proxy-dns-reverse __2.0.192.in-addr.arpa__ \
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed true \
 --foreman-proxy-dhcp-interface __eth0__ \
---foreman-proxy-dhcp-range "__172.17.13.100__ __172.17.13.150__" \
---foreman-proxy-dhcp-gateway __172.17.13.1__ \
---foreman-proxy-dhcp-nameservers __172.17.13.2__ \
+--foreman-proxy-dhcp-range "__192.0.2.100__ __192.0.2.150__" \
+--foreman-proxy-dhcp-gateway __192.0.2.1__ \
+--foreman-proxy-dhcp-nameservers __192.0.2.2__ \
 --foreman-proxy-tftp true \
 --foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername _{smartproxy-example-com}_
+--foreman-proxy-tftp-servername _192.0.2.0_
 ----
 
 You can monitor the progress of the `{foreman-installer}` command displayed in your prompt. You can view the logs in `/var/log/foreman-installer/satellite.log`. You can view the settings used, including the `admin_password` parameter, in the `/etc/foreman-installer/scenarios.d/satellite-answers.yaml` file.
@@ -68,17 +68,17 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 --foreman-proxy-dns-managed true \
 --foreman-proxy-dns-interface _eth0_ \
 --foreman-proxy-dns-zone _example.com_ \
---foreman-proxy-dns-forwarders _172.17.13.1_ \
---foreman-proxy-dns-reverse _13.17.172.in-addr.arpa_ \
+--foreman-proxy-dns-forwarders _192.0.2.1_ \
+--foreman-proxy-dns-reverse _2.0.192.in-addr.arpa_ \
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed true \
 --foreman-proxy-dhcp-interface _eth0_ \
---foreman-proxy-dhcp-range "_172.17.13.100_ _172.17.13.150_" \
---foreman-proxy-dhcp-gateway _172.17.13.1_ \
---foreman-proxy-dhcp-nameservers _172.17.13.2_ \
+--foreman-proxy-dhcp-range "_192.0.2.100_ _192.0.2.150_" \
+--foreman-proxy-dhcp-gateway _192.0.2.1_ \
+--foreman-proxy-dhcp-nameservers _192.0.2.2_ \
 --foreman-proxy-tftp true \
 --foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername _{smartproxy-example-com}_
+--foreman-proxy-tftp-servername _192.0.2.0_
 ----
 endif::[]
 


### PR DESCRIPTION
Bug 1792263 - [DDF] In example you add $(hostname) which represents FQDN of capsule server, but in Satellite provisioning guide in

https://bugzilla.redhat.com/show_bug.cgi?id=1792263