### PR TITLE
BZ#1698333 - FDI instructions updated

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
@@ -1,7 +1,14 @@
 [[building-a-discovery-image]]
 = Building a Discovery Image
 
-The Discovery image is a minimal operating system based on {RHEL} that is PXE-booted on hosts to acquire initial hardware information and to check in to the {Project}. Discovered hosts keep running the Discovery image until they are rebooted into Anaconda, which then initiates the provisioning process.
+The Discovery image is a minimal operating system that is PXE-booted on hosts to acquire initial hardware information and to check in to the {Project}. Discovered hosts keep running the Discovery image until they are rebooted into Anaconda, which then initiates the provisioning process.
++
+ifeval::["{build}" == "satellite"]
+The operating system image is based on {RHEL}.
+endif::[]
+ifeval::["{build}" != "satellite"]
+The operating system image is based on {CentOS}.
+endif::[]
 
 ifeval::["{build}" == "satellite"]
 The `foreman-discovery-image` package contains this image. You must install the package on the {SmartProxy} that provides TFTP services.
@@ -9,7 +16,7 @@ endif::[]
 
 Use this procedure to build a {Project} discovery image or rebuild an image if you change configuration files.
 
-Do not use this procedure on your production {Project} or {SmartProxy}.
+Do not use this procedure on your production {Project} or {SmartProxy}. It's recommended to either use dedicated environment, or copy synchronized repositories and kickstart file to a separate server.
 
 .Prerequisites
 
@@ -26,21 +33,15 @@ ifeval::["{build}" == "satellite"]
 # {foreman-maintain} packages install livecd-tools
 ----
 endif::[]
-ifeval::["{build}" == "foreman"]
-+
-The following steps are relevant only if you use the Katello plug-in to build the Discovery image from content repositories. If you do not use the content repositories to build the Discovery image, skip to the procedure section.
-endif::[]
-+
-Because Anaconda installer cannot publish through HTTPS, you must enable publishing through HTTP for Kickstart repositories:
-+
-. In the {Project} web UI, navigate to *Content* > *Products* and in the *Products* window, click the *Repositories* tab.
-. Select a Kickstart repository and for the *Publish via HTTP*, option, click the *Edit* icon, select the check box, and click *Save*.
 ifeval::["{build}" == "satellite"]
-. Enable and synchronize the *Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7* and *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64* repositories. For more information about synchronizing repositories, see {baseurl}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
++
+Synchronize required repositories which will be used to build the Discovery image:
++
+. Enable and synchronize the *Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7* repository.
+. Enable and synchronize the *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64* repository.
++
+For more information about synchronizing repositories, see {baseurl}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
 endif::[]
-. Repeat the previous steps for the {Project} repository.
-
-Note that publishing via HTTP does not apply to any Red{nbsp}Hat repositories.
 
 .Procedure
 
@@ -53,13 +54,13 @@ To build the {Project} discovery image, complete the following steps:
 # vim /usr/share/foreman-discovery-image/foreman-discovery-image.ks
 ----
 +
-. Replace `repo --name=rhel --baseurl=http://_{foreman-example-com}_` with with your own repository URLs. To find the URLs, navigate to *Content* > *Products* and click the *Repositories* tab and copy the URL for both repositories into the file:
+. Replace the `repo` lines in the kickstart file with repository URLs.
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
 ifeval::["{build}" == "satellite"]
-repo --name=rhel --baseurl=http://_{foreman-example-com}_/pulp/repos/MyOrg/Library/content/dist/rhel/server/7/7.7/x86_64/kickstart/
-repo --name=sat --baseurl=http://_{foreman-example-com}_/pulp/repos/MyOrg/Library/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/{ProductVersion}/os/
+repo --name=rhel --baseurl=file:///var/lib/pulp/published/yum/https/repos/Default_Organization/Library/content/dist/rhel/server/7/7.7/x86_64
+repo --name=sat --baseurl=file:///var/lib/pulp/published/yum/https/repos/Default_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/{ProductVersion}/os
 endif::[]
 ifeval::["{build}" == "foreman"]
 repo --name=centos --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os

--- a/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
@@ -1,13 +1,13 @@
 [[building-a-discovery-image]]
 = Building a Discovery Image
 
-The Discovery image is a minimal operating system that is PXE-booted on hosts to acquire initial hardware information and to check in to the {Project}. Discovered hosts keep running the Discovery image until they are rebooted into Anaconda, which then initiates the provisioning process.
-+
+The Discovery image is a minimal operating system that is PXE-booted on hosts to acquire initial hardware information and to check in with {Project}. Discovered hosts keep running the Discovery image until they are rebooted into Anaconda, which then initiates the provisioning process.
+
 ifeval::["{build}" == "satellite"]
 The operating system image is based on {RHEL}.
 endif::[]
 ifeval::["{build}" != "satellite"]
-The operating system image is based on {CentOS}.
+The operating system image is based on Cent OS.
 endif::[]
 
 ifeval::["{build}" == "satellite"]
@@ -16,7 +16,7 @@ endif::[]
 
 Use this procedure to build a {Project} discovery image or rebuild an image if you change configuration files.
 
-Do not use this procedure on your production {Project} or {SmartProxy}. It's recommended to either use dedicated environment, or copy synchronized repositories and kickstart file to a separate server.
+Do not use this procedure on your production {Project} or {SmartProxy}. Use either a dedicated environment or copy the synchronized repositories and a kickstart file to a separate server.
 
 .Prerequisites
 
@@ -35,10 +35,10 @@ ifeval::["{build}" == "satellite"]
 endif::[]
 ifeval::["{build}" == "satellite"]
 +
-Synchronize required repositories which will be used to build the Discovery image:
+Synchronize the repositories that you want to use to build the Discovery image, for example:
 +
-. Enable and synchronize the *Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7* repository.
-. Enable and synchronize the *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64* repository.
+* *Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7*.
+* *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64*.
 +
 For more information about synchronizing repositories, see {baseurl}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
 endif::[]
@@ -54,7 +54,7 @@ To build the {Project} discovery image, complete the following steps:
 # vim /usr/share/foreman-discovery-image/foreman-discovery-image.ks
 ----
 +
-. Replace the `repo` lines in the kickstart file with repository URLs.
+. Replace the `repo` lines in the kickstart file with the repository URLs:
 +
 [options="nowrap" subs="quotes,attributes"]
 ----


### PR DESCRIPTION
Couple of changes, the main change is that it's not possible to Publish via HTTP anymore in Katello. Therefore local repository URLs must be used. This means the procedure MUST be either done on Satellite (which we actually disencourage to do) or files should be copied over to a different server. Maybe we should change our mind and simply tell the user to do this on the Satellite server. That would do it, it's harmless.