### PR TITLE
Add example outputs of katello-certs-check and capsule-certs-generate

### DIFF
--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -32,6 +32,80 @@ To configure {SmartProxyServer} with a default server certificate, complete the 
 ----
 +
 Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
++
+ifeval::["{build}" == "satellite"]
+.Example output of capsule-certs-generate
+[options="nowrap", subs="+quotes"]
+----
+Installing             Done                                               [100%]
+  Success!
+
+  To finish the installation, follow these steps:
+
+  If you do not have the Capsule registered to the Satellite instance, then please do the following:
+
+  1. yum -y localinstall http://_satellite.example.com_.com/pub/katello-ca-consumer-latest.noarch.rpm
+  2. subscription-manager register --org "_Default_Organization_"
+
+  Once this is completed run the steps below to start the Capsule installation:
+
+  1. Ensure that the satellite-capsule package is installed on the system.
+  2. Copy the following file _/root/capsule_cert/capsule_certs.tar_ to the system _capsule.example.com_ at the following location _/root/capsule_certs.tar_
+  scp _/root/capsule_cert/capsule_certs.tar_ _root@capsule.example.com:/root/capsule_certs.tar_
+  3. Run the following commands on the Capsule (possibly with the customized
+     parameters, see satellite-installer --scenario capsule --help and
+     documentation for more info on setting up additional services):
+
+satellite-installer \
+--scenario capsule \
+--certs-tar-file                              "_/root/capsule_certs.tar_"\
+--foreman-proxy-content-parent-fqdn           "_satellite.example.com_"\
+--foreman-proxy-register-in-foreman           "true"\
+--foreman-proxy-foreman-base-url              "https://_satellite.example.com_"\
+--foreman-proxy-trusted-hosts                 "_satellite.example.com_"\
+--foreman-proxy-trusted-hosts                 "_capsule.example.com_"\
+--foreman-proxy-oauth-consumer-key            "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_"\
+--foreman-proxy-oauth-consumer-secret         "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"\
+--puppet-server-foreman-url                   "https://_satellite.example.com_"
+----
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+.Example output of capsule-certs-generate
+[options="nowrap", subs="+quotes"]
+----
+Installing             Done                                               [100%]
+  Success!
+
+  To finish the installation, follow these steps:
+
+  If you do not have the Smart Proxy registered to the Katello instance, then please do the following:
+
+  1. yum -y localinstall http://_{foreman-example-com}_.com/pub/katello-ca-consumer-latest.noarch.rpm
+  2. subscription-manager register --org "_Default_Organization_"
+
+  Once this is completed run the steps below to start the Smart Proxy installation:
+
+  1. Ensure that the foreman-installer-katello package is installed on the system.
+  2. Copy the following file _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ to the system _{smartproxy-example-com}_ at the following location _/root/{smart-proxy-context}_certs.tar_
+  scp _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ _root@:{smartproxy-example-com}/root/{smart-proxy-context}_certs.tar_
+  3. Run the following commands on the Smart Proxy (possibly with the customized
+     parameters, see  foreman-installer --scenario foreman-proxy-content --help and
+     documentation for more info on setting up additional services):
+
+foreman-installer \
+--scenario foreman-proxy-content \
+--certs-tar-file                              "_/root/{smart-proxy-context}_certs.tar_"\
+--foreman-proxy-content-parent-fqdn           "_{foreman-example-com}_"\
+--foreman-proxy-register-in-foreman           "true"\
+--foreman-proxy-foreman-base-url              "https://_{foreman-example-com}_"\
+--foreman-proxy-trusted-hosts                 "_{foreman-example-com}_"\
+--foreman-proxy-trusted-hosts                 "_{smartproxy-example-com}_"\
+--foreman-proxy-oauth-consumer-key            "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_"\
+--foreman-proxy-oauth-consumer-secret         "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"\
+--puppet-server-foreman-url                   "https://_{foreman-example-com}_"
+----
+endif::[]
 
 . On {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
 +

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -34,28 +34,10 @@ To configure {SmartProxyServer} with a default server certificate, complete the 
 Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
 +
 ifeval::["{build}" == "satellite"]
-.Example output of capsule-certs-generate
-[options="nowrap", subs="+quotes"]
+.Example output of `{certs-generate}`
+[options="nowrap", subs="+quotes,attributes"]
 ----
-Installing             Done                                               [100%]
-  Success!
-
-  To finish the installation, follow these steps:
-
-  If you do not have the Capsule registered to the Satellite instance, then please do the following:
-
-  1. yum -y localinstall http://_satellite.example.com_.com/pub/katello-ca-consumer-latest.noarch.rpm
-  2. subscription-manager register --org "_Default_Organization_"
-
-  Once this is completed run the steps below to start the Capsule installation:
-
-  1. Ensure that the satellite-capsule package is installed on the system.
-  2. Copy the following file _/root/capsule_cert/capsule_certs.tar_ to the system _capsule.example.com_ at the following location _/root/capsule_certs.tar_
-  scp _/root/capsule_cert/capsule_certs.tar_ _root@capsule.example.com:/root/capsule_certs.tar_
-  3. Run the following commands on the Capsule (possibly with the customized
-     parameters, see satellite-installer --scenario capsule --help and
-     documentation for more info on setting up additional services):
-
+_output omitted_
 satellite-installer \
 --scenario capsule \
 --certs-tar-file                              "_/root/capsule_certs.tar_"\
@@ -71,28 +53,10 @@ satellite-installer \
 endif::[]
 
 ifeval::["{build}" != "satellite"]
-.Example output of capsule-certs-generate
-[options="nowrap", subs="+quotes"]
+.Example output of `{certs-generate}`
+[options="nowrap", subs="+quotes,attributes""]
 ----
-Installing             Done                                               [100%]
-  Success!
-
-  To finish the installation, follow these steps:
-
-  If you do not have the Smart Proxy registered to the Katello instance, then please do the following:
-
-  1. yum -y localinstall http://_{foreman-example-com}_.com/pub/katello-ca-consumer-latest.noarch.rpm
-  2. subscription-manager register --org "_Default_Organization_"
-
-  Once this is completed run the steps below to start the Smart Proxy installation:
-
-  1. Ensure that the foreman-installer-katello package is installed on the system.
-  2. Copy the following file _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ to the system _{smartproxy-example-com}_ at the following location _/root/{smart-proxy-context}_certs.tar_
-  scp _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ _root@:{smartproxy-example-com}/root/{smart-proxy-context}_certs.tar_
-  3. Run the following commands on the Smart Proxy (possibly with the customized
-     parameters, see  foreman-installer --scenario foreman-proxy-content --help and
-     documentation for more info on setting up additional services):
-
+_output omitted_
 foreman-installer \
 --scenario foreman-proxy-content \
 --certs-tar-file                              "_/root/{smart-proxy-context}_certs.tar_"\

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -30,6 +30,49 @@ To configure your {SmartProxyServer} with a custom SSL certificate, complete the
 <3> Path to the Certificate Authority bundle.
 +
 If the command is successful, it returns two `{certs-generate}` commands, one of which you must use to generate the certificate archive file for your {SmartProxyServer}.
++
+ifeval::["{build}" == "satellite"]
+.Example output of katello-certs-check
+[options="nowrap", subs="+quotes"]
+----
+Validation succeeded.
+
+To use them inside a NEW $CAPSULE, run this command:
+
+capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
+    --certs-tar  "~/$CAPSULE-certs.tar" \
+    --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
+    --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
+    --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
+
+To use them inside an EXISTING $CAPSULE, run this command INSTEAD:
+
+  capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
+    --certs-tar  "~/$CAPSULE-certs.tar" \
+    --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
+    --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
+    --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
+    --certs-update-server
+----
+endif::[]
+ifeval::["{build}" != "foreman"]
+----
+To use them inside a NEW $FOREMAN_PROXY, run this command:
+  foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" \
+    --certs-tar  "~$FOREMAN_PROXY-certs.tar" \
+    --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
+    --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
+    --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
+
+To use them inside an EXISTING $FOREMAN_PROXY, run this command INSTEAD:
+  foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY" \
+    --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
+    --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
+    --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
+    --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
+    --certs-update-server
+----
+endif::[]
 
 . On {ProjectServer}, from the output of the `katello-certs-check` command, depending on your requirements, enter the `{certs-generate}` command that generates a certificate for a new or existing {SmartProxy}.
 +
@@ -41,6 +84,82 @@ In this command, change `$FOREMAN_PROXY` to the FQDN of your {SmartProxyServer}.
 endif::[]
 +
 . Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
++
+ifeval::["{build}" == "satellite"]
+.Example output of capsule-certs-generate
+[options="nowrap", subs="+quotes"]
+----
+Installing             Done                                               [100%]
+  Success!
+
+  To finish the installation, follow these steps:
+
+  If you do not have the Capsule registered to the Satellite instance, then please do the following:
+
+  1. yum -y localinstall http://_satellite.example.com_.com/pub/katello-ca-consumer-latest.noarch.rpm
+  2. subscription-manager register --org "_Default_Organization_"
+
+  Once this is completed run the steps below to start the Capsule installation:
+
+  1. Ensure that the satellite-capsule package is installed on the system.
+  2. Copy the following file _/root/capsule_cert/capsule_certs.tar_ to the system _capsule.example.com_ at the following location _/root/capsule_certs.tar_
+  scp _/root/capsule_cert/capsule_certs.tar_ _root@capsule.example.com:/root/capsule_certs.tar_
+  3. Run the following commands on the Capsule (possibly with the customized
+     parameters, see satellite-installer --scenario capsule --help and
+     documentation for more info on setting up additional services):
+
+satellite-installer \
+--scenario capsule \
+--certs-tar-file                              "_/root/capsule_certs.tar_"\
+--foreman-proxy-content-parent-fqdn           "_satellite.example.com_"\
+--foreman-proxy-register-in-foreman           "true"\
+--foreman-proxy-foreman-base-url              "https://_satellite.example.com_"\
+--foreman-proxy-trusted-hosts                 "_satellite.example.com_"\
+--foreman-proxy-trusted-hosts                 "_capsule.example.com_"\
+--foreman-proxy-oauth-consumer-key            "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_"\
+--foreman-proxy-oauth-consumer-secret         "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"\
+--puppet-server-foreman-url                   "https://_satellite.example.com_"
+----
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+.Example output of capsule-certs-generate
+[options="nowrap", subs="+quotes"]
+----
+Installing             Done                                               [100%]
+  Success!
+
+  To finish the installation, follow these steps:
+
+  If you do not have the Smart Proxy registered to the Katello instance, then please do the following:
+
+  1. yum -y localinstall http://_{foreman-example-com}_.com/pub/katello-ca-consumer-latest.noarch.rpm
+  2. subscription-manager register --org "_Default_Organization_"
+
+  Once this is completed run the steps below to start the Smart Proxy installation:
+
+  1. Ensure that the foreman-installer-katello package is installed on the system.
+  2. Copy the following file _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ to the system _{smartproxy-example-com}_ at the following location _/root/{smart-proxy-context}_certs.tar_
+  scp _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ _root@:{smartproxy-example-com}/root/{smart-proxy-context}_certs.tar_
+  3. Run the following commands on the Smart Proxy (possibly with the customized
+     parameters, see  foreman-installer --scenario foreman-proxy-content --help and
+     documentation for more info on setting up additional services):
+
+foreman-installer \
+--scenario foreman-proxy-content \
+--certs-tar-file                              "_/root/{smart-proxy-context}_certs.tar_"\
+--foreman-proxy-content-parent-fqdn           "_{foreman-example-com}_"\
+--foreman-proxy-register-in-foreman           "true"\
+--foreman-proxy-foreman-base-url              "https://_{foreman-example-com}_"\
+--foreman-proxy-trusted-hosts                 "_{foreman-example-com}_"\
+--foreman-proxy-trusted-hosts                 "_{smartproxy-example-com}_"\
+--foreman-proxy-oauth-consumer-key            "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_"\
+--foreman-proxy-oauth-consumer-secret         "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"\
+--puppet-server-foreman-url                   "https://_{foreman-example-com}_"
+----
+endif::[]
+
+
 . On {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -30,10 +30,10 @@ To configure your {SmartProxyServer} with a custom SSL certificate, complete the
 <3> Path to the Certificate Authority bundle.
 +
 If the command is successful, it returns two `{certs-generate}` commands, one of which you must use to generate the certificate archive file for your {SmartProxyServer}.
-+
 ifeval::["{build}" == "satellite"]
-.Example output of katello-certs-check
-[options="nowrap", subs="+quotes"]
++
+.Example output of `katello-certs-check`
+[options="nowrap", subs="+quotes,attributes"]
 ----
 Validation succeeded.
 
@@ -55,8 +55,14 @@ To use them inside an EXISTING $CAPSULE, run this command INSTEAD:
     --certs-update-server
 ----
 endif::[]
-ifeval::["{build}" != "foreman"]
+
+ifeval::["{build}" != "satellite"]
++
+.Example output of `katello-certs-check`
+[options="nowrap", subs="+quotes,attributes"]
 ----
+Validation succeeded.
+
 To use them inside a NEW $FOREMAN_PROXY, run this command:
   foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" \
     --certs-tar  "~$FOREMAN_PROXY-certs.tar" \
@@ -86,28 +92,10 @@ endif::[]
 . Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
 +
 ifeval::["{build}" == "satellite"]
-.Example output of capsule-certs-generate
-[options="nowrap", subs="+quotes"]
+.Example output of `{certs-generate}`
+[options="nowrap", subs="+quotes,attributes"]
 ----
-Installing             Done                                               [100%]
-  Success!
-
-  To finish the installation, follow these steps:
-
-  If you do not have the Capsule registered to the Satellite instance, then please do the following:
-
-  1. yum -y localinstall http://_satellite.example.com_.com/pub/katello-ca-consumer-latest.noarch.rpm
-  2. subscription-manager register --org "_Default_Organization_"
-
-  Once this is completed run the steps below to start the Capsule installation:
-
-  1. Ensure that the satellite-capsule package is installed on the system.
-  2. Copy the following file _/root/capsule_cert/capsule_certs.tar_ to the system _capsule.example.com_ at the following location _/root/capsule_certs.tar_
-  scp _/root/capsule_cert/capsule_certs.tar_ _root@capsule.example.com:/root/capsule_certs.tar_
-  3. Run the following commands on the Capsule (possibly with the customized
-     parameters, see satellite-installer --scenario capsule --help and
-     documentation for more info on setting up additional services):
-
+_output omitted_
 satellite-installer \
 --scenario capsule \
 --certs-tar-file                              "_/root/capsule_certs.tar_"\
@@ -123,28 +111,10 @@ satellite-installer \
 endif::[]
 
 ifeval::["{build}" != "satellite"]
-.Example output of capsule-certs-generate
-[options="nowrap", subs="+quotes"]
+.Example output of `{certs-generate}`
+[options="nowrap", subs="+quotes,attributes"]
 ----
-Installing             Done                                               [100%]
-  Success!
-
-  To finish the installation, follow these steps:
-
-  If you do not have the Smart Proxy registered to the Katello instance, then please do the following:
-
-  1. yum -y localinstall http://_{foreman-example-com}_.com/pub/katello-ca-consumer-latest.noarch.rpm
-  2. subscription-manager register --org "_Default_Organization_"
-
-  Once this is completed run the steps below to start the Smart Proxy installation:
-
-  1. Ensure that the foreman-installer-katello package is installed on the system.
-  2. Copy the following file _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ to the system _{smartproxy-example-com}_ at the following location _/root/{smart-proxy-context}_certs.tar_
-  scp _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_ _root@:{smartproxy-example-com}/root/{smart-proxy-context}_certs.tar_
-  3. Run the following commands on the Smart Proxy (possibly with the customized
-     parameters, see  foreman-installer --scenario foreman-proxy-content --help and
-     documentation for more info on setting up additional services):
-
+_output omitted_
 foreman-installer \
 --scenario foreman-proxy-content \
 --certs-tar-file                              "_/root/{smart-proxy-context}_certs.tar_"\
@@ -158,7 +128,6 @@ foreman-installer \
 --puppet-server-foreman-url                   "https://_{foreman-example-com}_"
 ----
 endif::[]
-
 
 . On {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
 +

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -13,7 +13,7 @@ To deploy a custom certificate on your {ProjectServer}, complete the following s
 [options="nowrap", subs="+quotes"]
 ----
 # katello-certs-check \
--c __/root/satellite_cert/satellite_cert.pem__ \      <1>
+-c __/root/satellite_cert/{project-context}_cert.pem__ \      <1>
 -k __/root/satellite_cert/satellite_cert_key.pem__ \  <2>
 -b __/root/satellite_cert/ca_cert_bundle.pem__        <3>
 ----
@@ -22,6 +22,47 @@ To deploy a custom certificate on your {ProjectServer}, complete the following s
 <3> Path to the Certificate Authority bundle.
 +
 If the command is successful, it returns two `{foreman-installer}` commands, one of which you must use to deploy a certificate to {ProjectServer}.
++
+ifeval::["{build}" == "satellite"]
+.Example output of katello-certs-check
+[options="nowrap", subs="+quotes"]
+----
+Validation succeeded.
+
+To install the Red Hat Satellite Server with the custom certificates, run:
+
+  satellite-installer --scenario satellite \
+    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
+    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+
+To update the certificates on a currently running Red Hat Satellite installation, run:
+
+  satellite-installer --scenario satellite \
+    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
+    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
+    --certs-update-server --certs-update-server-ca
+----
+endif::[]
+ifeval::["{build}" != "satellite"]
+----
+To install the Katello main server with the custom certificates, run:
+
+  foreman-installer --scenario katello \\
+    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
+    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+
+To update the certificates on a currently running Katello installation, run:
+
+  foreman-installer --scenario katello \\
+    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
+    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
+    --certs-update-server --certs-update-server-ca
+----
+endif::[]
 
 . From the output of the `katello-certs-check` command, depending on your requirements, enter the `{foreman-installer}` command that deploys a certificate to a new {Project} or updates a certificate on a currently running {Project}.
 +

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -10,10 +10,10 @@ To deploy a custom certificate on your {ProjectServer}, complete the following s
 
 . Validate the custom SSL certificate input files. Note that for the `katello-certs-check` command to work correctly, Common Name (CN) in the certificate must match the FQDN of {ProjectServer}.
 +
-[options="nowrap", subs="+quotes"]
+[options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--c __/root/satellite_cert/{project-context}_cert.pem__ \      <1>
+-c __/root/satellite_cert/satellite_cert.pem__ \      <1>
 -k __/root/satellite_cert/satellite_cert_key.pem__ \  <2>
 -b __/root/satellite_cert/ca_cert_bundle.pem__        <3>
 ----
@@ -22,10 +22,10 @@ To deploy a custom certificate on your {ProjectServer}, complete the following s
 <3> Path to the Certificate Authority bundle.
 +
 If the command is successful, it returns two `{foreman-installer}` commands, one of which you must use to deploy a certificate to {ProjectServer}.
-+
 ifeval::["{build}" == "satellite"]
-.Example output of katello-certs-check
-[options="nowrap", subs="+quotes"]
++
+.Example output of `katello-certs-check`
+[options="nowrap", subs="+quotes,attributes"]
 ----
 Validation succeeded.
 
@@ -46,7 +46,12 @@ To update the certificates on a currently running Red Hat Satellite installation
 ----
 endif::[]
 ifeval::["{build}" != "satellite"]
++
+.Example output of `katello-certs-check`
+[options="nowrap", subs="+quotes,attributes"]
 ----
+Validation succeeded.
+
 To install the Katello main server with the custom certificates, run:
 
   foreman-installer --scenario katello \\


### PR DESCRIPTION
Bug 1810218 - Command for installing customer certs to satellite missing

https://bugzilla.redhat.com/show_bug.cgi?id=1810218