### PR TITLE
Update installation links to 2.0

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,3 +1,5 @@
+:ProjectVersion: 2.0
+:KatelloVersion: 3.15
 :TargetVersion: 6.7-beta
 :ProductVersion: 6.7-beta
 :ProductVersionPrevious: 6.6

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -65,14 +65,16 @@ ifeval::["{build}" == "foreman"]
 +
 . Install the `foreman-release.rpm` package:
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall https://yum.theforeman.org/releases/1.24/el7/x86_64/foreman-release.rpm
+# yum localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
 ----
 +
 . Install the `katello-repos-latest.rpm` package
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall https://fedorapeople.org/groups/katello/releases/yum/3.14/katello/el7/x86_64/katello-repos-latest.rpm
+# yum localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
 +
 . Install the `puppet6-release-el-7.noarch.rpm` package:
@@ -101,14 +103,16 @@ If you use a Cent OS operating systems, complete the following steps:
 
 . Install the `foreman-release.rpm` package:
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall https://yum.theforeman.org/releases/1.24/el7/x86_64/foreman-release.rpm
+# yum localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
 ----
 +
 . Install the `katello-repos-latest.rpm` package
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall https://fedorapeople.org/groups/katello/releases/yum/3.14/katello/el7/x86_64/katello-repos-latest.rpm
+# yum localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
 +
 . Install the `puppet6-release-el-7.noarch.rpm` package:


### PR DESCRIPTION
We want our community users to start testing our installation guide with 2.0rc except we did not update the links to the correct URL! This fixes it. Since the new docs are not official, we don't need to do any warnings like "this is RC version of Foreman" yet. We can implement that later once we start branching off documentation with every Foreman release.