### PR TITLE
Disable HTML link validator server cert check

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -36,7 +36,7 @@ browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 linkchecker: html
-	linkchecker -vr1 --check-extern --ignore-url=example.com "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
+	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -1,0 +1,5 @@
+[checking]
+threads=32
+timeout=20
+sslverify=0
+maxrunseconds=900


### PR DESCRIPTION
There is still an error ATM, it's because the target does not work.