### PR TITLE
Ignore cdn.redhat.com during link checking

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -36,7 +36,7 @@ browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 linkchecker: html
-	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
+	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com --ignore-url=cdn.redhat.com "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"


### PR DESCRIPTION
It needs X509 client cert which we don't have and don't want to use actually.