### PR TITLE
Outline considerations for custom SSL certs

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-certificate.adoc
@@ -12,7 +12,11 @@ On {ProjectServer}, create a custom certificate for your {ProductName}. If you a
 Do not use the same certificate for both {ProjectServer} and {SmartProxyServer}.
 endif::[]
 
-IMPORTANT: Use the Privacy-Enhanced Mail (PEM) encoding for the SSL certificates.
+When you configure {ProductName} with custom certificates, note the following considerations:
+
+* You must use the Privacy-Enhanced Mail (PEM) encoding for the SSL certificates.
+* You cannot use the same certificate for both {ProjectServer} and {SmartProxyServer}.
+* The same Certificate Authority must sign certificates for {ProjectServer} and {SmartProxyServer}.
 
 .Procedure
 


### PR DESCRIPTION
Bug 1796892 - [DDF] It should be noted that the custom certificates for the capsules must be signed by the same CA as the Satellite

https://bugzilla.redhat.com/show_bug.cgi?id=1796892#