### PR TITLE
Rename Bare metal hosts chapter

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -1,5 +1,5 @@
-[[Provisioning_Bare_Metal_Hosts]]
-== Provisioning Bare Metal Hosts
+[[Using_PXE_to_Provision_Hosts]]
+== Using PXE to Provision Hosts
 
 There are four main ways to provision bare metal instances with {ProjectName} {ProductVersion}:
 


### PR DESCRIPTION
chapter entitled "Provisioning Bare Metal Hosts" is just wrong for multiple reasons:

* It describes PXE workflow.
* PXE can be used on bare metal, virtualization and even on some clouds.
* It's confusing.
* We want to add new chapters on HTTP Boot provisioning as well.

Therefore I suggest to rename this.