### PR TITLE
Change OpenStack's API version to 3 in URLs

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -36,7 +36,7 @@ browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 linkchecker: html
-	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com --ignore-url=cdn.redhat.com --ignore-url=file:///modules "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
+	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com --ignore-url=cdn.redhat.com --ignore-url=file:///modules "file://$(realpath $(ROOTDIR)/$(DEST_HTML))" --ignore-url=tools.ietf.org
 
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"

--- a/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
@@ -5,7 +5,7 @@ On {ProjectServer}, you must enable the incoming connection from {SmartProxyServ
 
 .Prerequisites
 
-* Ensure that the firewall rules on {ProjectServer} are configured to enable connections for client to {Project} communication, because {SmartProxyServer} is a client of {ProjectServer}. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/installing_satellite_server_from_a_connected_network/preparing_your_environment_for_installation#enabling-client-connections-to-satellite[Enabling Connections from a Client to {ProjectServer}] in _{project-installation-guide-title}_.
+* Ensure that the firewall rules on {ProjectServer} are configured to enable connections for client to {Project} communication, because {SmartProxyServer} is a client of {ProjectServer}. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/installing_satellite_server_from_a_connected_network/preparing-environment-for-satellite-installation#enabling-client-connections-to-satellite_satellite[Enabling Connections from a Client to {ProjectServer}] in _{project-installation-guide-title}_.
 
 .Procedure
 

--- a/guides/doc-Provisioning_Guide/topics/Cloud-OpenStack.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-OpenStack.adoc
@@ -27,7 +27,7 @@ To add a compute resource, use the following procedure:
 . In the *Name* field, enter a name to identify the compute resource for future use.
 . From the *Provider* list, select *RHEL OpenStack Platform*.
 . In the *Description* field, enter a description for the resource.
-. In the *URL* field, enter a URL to point to the OpenStack Authentication keystone service's API at the `tokens` resource. Use the following format: `http://openstack.example.com:5000/v2.0/tokens`.
+. In the *URL* field, enter a URL to point to the OpenStack Authentication keystone service's API at the `tokens` resource. Use the following format: `http://openstack.example.com:5000/v3.0/tokens`.
 . In the *User* and *Password* fields, enter the authentication user and password for {Project} to access the environment.
 . In the *Domain* field, enter the domain for V3 authentication.
 . From the *Tenant* list, select the tenant or project for {ProjectServer} to manage.
@@ -44,7 +44,7 @@ Create the connection with the `hammer compute-resource create` command:
 # hammer compute-resource create --name "_My_OpenStack_" \
 --provider "OpenStack" \
 --description "My OpenStack environment at _openstack.example.com_" \
---url "_http://openstack.example.com_:5000/v2.0/tokens" --user "_My_Username_" \
+--url "_http://openstack.example.com_:5000/v3.0/tokens" --user "_My_Username_" \
 --password "_My_Password_" --tenant "openstack" --locations "New York" \
 --organizations "_My_Organization_"
 ----

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -274,8 +274,7 @@ When you set up the compute resource and images for VMware provisioning in {Proj
 Because of the `cloud-init` service, the virtual machine always calls back to {Project} even if you register the virtual machine to {SmartProxy}. Ensure that you configure port and firewall settings to open any necessary connections.
 
 
-For more information about port and firewall requirements, see {BaseURL}installing_satellite_server_from_a_connected_network/preparing_your_environment_for_installation#satellite-ports-and-firewalls-requirements_satellite[Port and Firewall Requirements] in the _Installing {Project}_ and {BaseURL}installing_capsule_server/preparing-environment-for-capsule-installation#capsule-ports-and-firewalls-requirements_capsule[Ports and Firewalls Requirements] in _Installing {SmartProxyServer}_.
-
+For more information about port and firewall requirements, see {BaseURL}installing_satellite_server_from_a_connected_network/preparing-environment-for-satellite-installation#satellite-ports-and-firewalls-requirements_satellite[Port and Firewall Requirements] in the _Installing {Project}_ and {BaseURL}installing_capsule_server/preparing-environment-for-capsule-installation#capsule-ports-and-firewalls-requirements_capsule[Ports and Firewalls Requirements] in _Installing {SmartProxyServer}_.
 
 .Associating the `userdata` and `Cloud-init` Templates with the Operating System
 


### PR DESCRIPTION
Bug 1809975 - [DDF] As the V2 API is considered deprecated, this should have V3.0 included

https://bugzilla.redhat.com/show_bug.cgi?id=1809975