### PR TITLE
State that Azure Government is not supported

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Cloud-Azure.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Azure.adoc
@@ -2,6 +2,8 @@
 == Provisioning Cloud Instances in Microsoft Azure Resource Manager
 {ProjectName} can interact with Microsoft Azure Resource Manager, including creating new virtual machines and controlling their power management states. Only image-based provisioning is supported for creating Azure hosts.
 
+Note that {Project} does not support Azure Government.
+
 [[Provisioning_Virtual_Machines_in_Azure-Prerequisites_for_Azure_Provisioning]]
 === Prerequisites for Azure Provisioning
 


### PR DESCRIPTION
Bug 1829368 - Missing "No AzureGovCloud support" text for Azure provisioning

https://bugzilla.redhat.com/show_bug.cgi?id=1829368