### PR TITLE
Move rhsm warning in repo configuring

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -2,13 +2,12 @@
 
 = Configuring Repositories
 
-ifeval::["{build}" == "foreman"]
-This procedure is only for Katello plug-in and {RHEL}-based operating system users.
-endif::[]
-
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
 .Procedure
+ifeval::["{build}" == "foreman"]
+Skip steps involving `subscription-manager` when not installing on {RHEL} operating system.
+endif::[]
 To configure the required repositories, complete the following steps:
 
 . Disable all repositories:

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -6,7 +6,7 @@ Use this procedure to enable the repositories that are required to install {Prod
 
 .Procedure
 ifeval::["{build}" == "foreman"]
-Skip steps involving `subscription-manager` when not installing on {RHEL} operating system.
+This procedure is only for Katello plug-in users. Skip steps involving `subscription-manager` when not installing on the {RHEL} operating system.
 endif::[]
 To configure the required repositories, complete the following steps:
 


### PR DESCRIPTION
We tell the reader to skip whole chapter, however we only want them to skip first two items on the list involving rhsm. Then the rest still applies.