### PR TITLE
Substitute Satellite Tools with the attribute everywhere

### DIFF
--- a/guides/common/modules/enabling_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/enabling_the_satellite_tools_repository.adoc
@@ -1,12 +1,12 @@
 [[enabling_satellite_tools_repository]]
 
-= Enabling the Satellite Tools Repository
+= Enabling the {RepoRHEL7ServerSatelliteToolsProductVersion} Repository
 
 ifeval::["{build}" == "foreman"]
 You require the Katello plug-in to complete this procedure.
 endif::[]
 
-The Satellite Tools repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}. Installing the Katello agent is recommended to allow remote updates of clients. The base operating system of a {SmartProxyServer} is a client of {ProjectServer} and therefore must also have the Katello agent installed.
+The {RepoRHEL7ServerSatelliteToolsProductVersion} repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}. Installing the Katello agent is recommended to allow remote updates of clients. The base operating system of a {SmartProxyServer} is a client of {ProjectServer} and therefore must also have the Katello agent installed.
 
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
@@ -14,23 +14,23 @@ ifeval::["{mode}" == "disconnected"]
 endif::[]
 
 .Procedure
-To enable the Satellite Tools repository, complete the following steps:
+To enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Red Hat Repositories*.
 
-. Use the Search field to enter the following repository name: *{ProjectName} Tools {ProductVersionRepoTitle} (for RHEL 7 Server) (RPMs)*.
+. Use the Search field to enter the following repository name: *{RepoRHEL7ServerSatelliteToolsProductVersion}*.
 
-. In the Available Repositories pane, click on *{ProjectName} Tools {ProductVersionRepoTitle} (for RHEL 7 Server) (RPMs)* to expand the repository set.
+. In the Available Repositories pane, click on *{RepoRHEL7ServerSatelliteToolsProductVersion}* to expand the repository set.
 +
-If the *{ProjectName} Tools {ProductVersionRepoTitle}* items are not visible, it may be because they are not included in the Subscription Manifest obtained from the Customer Portal. To correct that, log in to the Customer Portal, add these repositories, download the Subscription Manifest and import it into {Project}.
+If the *{RepoRHEL7ServerSatelliteToolsProductVersion}* items are not visible, it may be because they are not included in the Subscription Manifest obtained from the Customer Portal. To correct that, log in to the Customer Portal, add these repositories, download the Subscription Manifest and import it into {Project}.
 
 . For the `x86_64` entry, click the *Enable* icon to enable the repository.
 
-Enable the Satellite Tools repository for every supported major version of {RHEL} running on your hosts. After enabling a Red Hat repository, a Product for this repository is automatically created.
+Enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository for every supported major version of {RHEL} running on your hosts. After enabling a Red Hat repository, a Product for this repository is automatically created.
 
 .For CLI Users
 
-Enable the Satellite Tools repository using the `hammer repository-set enable` command:
+Enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository using the `hammer repository-set enable` command:
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository-set enable --organization _"initial_organization_name"_ \

--- a/guides/common/modules/enabling_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/enabling_the_satellite_tools_repository.adoc
@@ -1,12 +1,12 @@
 [[enabling_satellite_tools_repository]]
 
-= Enabling the {RepoRHEL7ServerSatelliteToolsProductVersion} Repository
+= Enabling the Satellite Tools Repository
 
 ifeval::["{build}" == "foreman"]
 You require the Katello plug-in to complete this procedure.
 endif::[]
 
-The {RepoRHEL7ServerSatelliteToolsProductVersion} repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}. Installing the Katello agent is recommended to allow remote updates of clients. The base operating system of a {SmartProxyServer} is a client of {ProjectServer} and therefore must also have the Katello agent installed.
+The Satellite Tools repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}. Installing the Katello agent is recommended to allow remote updates of clients. The base operating system of a {SmartProxyServer} is a client of {ProjectServer} and therefore must also have the Katello agent installed.
 
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
@@ -14,15 +14,15 @@ ifeval::["{mode}" == "disconnected"]
 endif::[]
 
 .Procedure
-To enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository, complete the following steps:
+To enable the Satellite Tools repository, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Red Hat Repositories*.
 
-. Use the Search field to enter the following repository name: *{RepoRHEL7ServerSatelliteToolsProductVersion}*.
+. Use the Search field to enter the following repository name: *{ProjectName} Tools {ProductVersionRepoTitle} (for RHEL 7 Server) (RPMs)*.
 
-. In the Available Repositories pane, click on *{RepoRHEL7ServerSatelliteToolsProductVersion}* to expand the repository set.
+. In the Available Repositories pane, click on *{ProjectName} Tools {ProductVersionRepoTitle} (for RHEL 7 Server) (RPMs)* to expand the repository set.
 +
-If the *{RepoRHEL7ServerSatelliteToolsProductVersion}* items are not visible, it may be because they are not included in the Subscription Manifest obtained from the Customer Portal. To correct that, log in to the Customer Portal, add these repositories, download the Subscription Manifest and import it into {Project}.
+If the *{ProjectName} Tools {ProductVersionRepoTitle}* items are not visible, it may be because they are not included in the Subscription Manifest obtained from the Customer Portal. To correct that, log in to the Customer Portal, add these repositories, download the Subscription Manifest and import it into {Project}.
 
 . For the `x86_64` entry, click the *Enable* icon to enable the repository.
 
@@ -30,7 +30,7 @@ Enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository for every su
 
 .For CLI Users
 
-Enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository using the `hammer repository-set enable` command:
+Enable the Satellite Tools repository using the `hammer repository-set enable` command:
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository-set enable --organization _"initial_organization_name"_ \

--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -10,9 +10,9 @@ The `katello-agent` package depends on the `gofer` package that provides the `go
 Before installing the Katello agent, ensure the following conditions are met:
 
 ifeval::["build" == "satellite"]
-* You have enabled the Satellite Tools repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#enabling_satellite_tools_repository[Enabling the Satellite ToolsRepository] in _{project-installation-guide-title}_.
+* You have enabled the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#enabling_satellite_tools_repository[Enabling the {RepoRHEL7ServerSatelliteToolsProductVersion}Repository] in _{project-installation-guide-title}_.
 
-* You have synchronized the Satellite Tools repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#synchronizing_satellite_tools_repository[Synchronizing the Satellite ToolsRepository] in _{project-installation-guide-title}_.
+* You have synchronized the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#synchronizing_satellite_tools_repository[Synchronizing the {RepoRHEL7ServerSatelliteToolsProductVersion}Repository] in _{project-installation-guide-title}_.
 endif::[]
 
 * You have enabled the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on the client.

--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -9,10 +9,10 @@ The `katello-agent` package depends on the `gofer` package that provides the `go
 .Prerequisites
 Before installing the Katello agent, ensure the following conditions are met:
 
-ifeval::["build" == "satellite"]
-* You have enabled the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#enabling_satellite_tools_repository[Enabling the {RepoRHEL7ServerSatelliteToolsProductVersion}Repository] in _{project-installation-guide-title}_.
+ifeval::["{build}" == "satellite"]
+* You have enabled the Satellite Tools repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#enabling_satellite_tools_repository[Enabling the Satellite Tools Repository] in _{project-installation-guide-title}_.
 
-* You have synchronized the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#synchronizing_satellite_tools_repository[Synchronizing the {RepoRHEL7ServerSatelliteToolsProductVersion}Repository] in _{project-installation-guide-title}_.
+* You have synchronized the Satellite Tools repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#synchronizing_satellite_tools_repository[Synchronizing the Satellite Tools Repository] in _{project-installation-guide-title}_.
 endif::[]
 
 * You have enabled the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on the client.

--- a/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
@@ -1,18 +1,18 @@
 [[synchronizing_satellite_tools_repository]]
-= Synchronizing the Satellite Tools Repository
+= Synchronizing the {RepoRHEL7ServerSatelliteToolsProductVersion} Repository
 
 ifeval::["{build}" == "foreman"]
-If you use the Katello plug-in, you can synchronize the Satellite Tools repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
+If you use the Katello plug-in, you can synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}.
 endif::[]
 
 ifeval::["{build}" == "satellite"]
-Use this section to synchronize the Satellite Tools repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
+Use this section to synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}.
 endif::[]
 
 .Procedure
-To synchronize the Satellite Tools repository, complete the following steps:
+To synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Sync Status*.
 +
@@ -20,13 +20,13 @@ A list of product repositories available for synchronization is displayed.
 
 . Click the arrow next to the *Red{nbsp}Hat Enterprise Linux Server* product to view available content.
 
-. Select *{ProjectName} Tools {ProductVersionRepoTitle} (for RHEL 7 Server) RPMs x86_64*.
+. Select *{RepoRHEL7ServerSatelliteToolsProductVersion}*.
 
 . Click *Synchronize Now*.
 
 .For CLI Users
 
-Synchronize your Satellite Tools repository using the `hammer repository synchronize` command:
+Synchronize your {RepoRHEL7ServerSatelliteToolsProductVersion} repository using the `hammer repository synchronize` command:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
@@ -1,5 +1,5 @@
 [[synchronizing_satellite_tools_repository]]
-= Synchronizing the {RepoRHEL7ServerSatelliteToolsProductVersion} Repository
+= Synchronizing the Satellite Tools Repository
 
 ifeval::["{build}" == "foreman"]
 If you use the Katello plug-in, you can synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
@@ -12,7 +12,7 @@ This repository provides the `katello-agent` and `puppet` packages for clients r
 endif::[]
 
 .Procedure
-To synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository, complete the following steps:
+To synchronize the Satellite Tools repository, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Sync Status*.
 +
@@ -20,13 +20,13 @@ A list of product repositories available for synchronization is displayed.
 
 . Click the arrow next to the *Red{nbsp}Hat Enterprise Linux Server* product to view available content.
 
-. Select *{RepoRHEL7ServerSatelliteToolsProductVersion}*.
+. Select *{ProjectName} Tools {ProductVersionRepoTitle} (for RHEL 7 Server) RPMs x86_64*.
 
 . Click *Synchronize Now*.
 
 .For CLI Users
 
-Synchronize your {RepoRHEL7ServerSatelliteToolsProductVersion} repository using the `hammer repository synchronize` command:
+Synchronize your Satellite Tools repository using the `hammer repository synchronize` command:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -106,7 +106,7 @@ For more information about network interfaces, see {BaseURL}/managing_hosts/inde
 This creates the host entry and the relevant provisioning settings. This also includes creating the necessary directories and files for PXE booting the bare metal host. If you start the physical host and set its boot mode to PXE, the host detects the DHCP service of {ProjectServer}'s integrated {SmartProxy} and starts installing the operating system from its Kickstart tree.
 
 ifeval::["{build}" == "satellite"]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {ProjectName} Tools repository.
+When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {RepoRHEL7ServerSatelliteToolsProductVersion} repository.
 endif::[]
 
 ifeval::["{build}" == "foreman"]
@@ -253,7 +253,7 @@ Write the ISO to a USB storage device using the *dd* utility or *livecd-tools* i
 When you start the physical host and boot from the ISO or the USB storage device, the host connects to {ProjectServer} and starts installing operating system from its kickstart tree.
 
 ifeval::["{build}" == "satellite"]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{ProjectName} Tools* repository.
+When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{RepoRHEL7ServerSatelliteToolsProductVersion}* repository.
 endif::[]
 
 [[Configuring_Provisioning_Resources-Creating_Provisioning_Templates-Deploying_SSH_Keys_during_Provisioning]]


### PR DESCRIPTION
Skip this wording in command blocks because they require the full name of the repo

Bug 1835718 - Make the wording of Satellite Tools repository consistent throughout the guides

https://bugzilla.redhat.com/show_bug.cgi?id=1835718