### PR TITLE
Fix hammer command to use array to list multiple hosts

### DIFF
--- a/guides/common/modules/configuring_satellite_http_proxy.adoc
+++ b/guides/common/modules/configuring_satellite_http_proxy.adoc
@@ -153,7 +153,7 @@ To exclude one or more hosts from communicating through the proxy, complete the 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer settings set --name=http_proxy_except_list --value=_hostname1.hostname2..._
+# hammer settings set --name=http_proxy_except_list --value=[_hostname1.hostname2..._]
 ----
 
 = Resetting the HTTP Proxy


### PR DESCRIPTION
Bug 1828755 - Array format missing for Excluding Hosts from Receiving Proxied Requests in Satellite 6 documentation

https://bugzilla.redhat.com/show_bug.cgi?id=1828755