### PR TITLE
Clarify what command to run to install custom cert on Foreman

### DIFF
--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -5,6 +5,10 @@ ifdef::context[:parent-context: {context}]
 
 = Configuring {ProjectServer} with a Custom SSL Certificate
 
+ifeval::["{build}" != "satellite"]
+This procedure is only for Katello plug-in users.
+endif::[]
+
 By default, {ProjectNameX} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts. If you cannot use a {Project} self-signed certificate, you can configure {ProjectServer} to use an SSL certificate signed by an external Certificate Authority.
 
 To configure your {ProjectServer} with a custom certificate, complete the following procedures:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -71,7 +71,7 @@ endif::[]
 
 . From the output of the `katello-certs-check` command, depending on your requirements, enter the `{foreman-installer}` command that installs a new {Project} with custom SSL certificates or updates certificates on a currently running {Project}.
 +
-If you are unsure what command to run, you can verify that {Project} is installed by checking if the file `/etc/foreman-installer/scenarios.d/.installed` exists. If the file exists, run the second `{foreman-installer}` command that updates certificates.
+If you are unsure which command to run, you can verify that {Project} is installed by checking if the file `/etc/foreman-installer/scenarios.d/.installed` exists. If the file exists, run the second `{foreman-installer}` command that updates certificates.
 +
 IMPORTANT: Do not delete the certificate archive file after you deploy the certificate. It is required, for example, when upgrading {ProjectServer}.
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -69,7 +69,9 @@ To update the certificates on a currently running Katello installation, run:
 ----
 endif::[]
 
-. From the output of the `katello-certs-check` command, depending on your requirements, enter the `{foreman-installer}` command that deploys a certificate to a new {Project} or updates a certificate on a currently running {Project}.
+. From the output of the `katello-certs-check` command, depending on your requirements, enter the `{foreman-installer}` command that installs a new {Project} with custom SSL certificates or updates certificates on a currently running {Project}.
++
+If you are unsure what command to run, you can verify that {Project} is installed by checking if the file `/etc/foreman-installer/scenarios.d/.installed` exists. If the file exists, run the second `{foreman-installer}` command that updates certificates.
 +
 IMPORTANT: Do not delete the certificate archive file after you deploy the certificate. It is required, for example, when upgrading {ProjectServer}.
 


### PR DESCRIPTION
Bug 1812251 - [DDF] Suggest to edit wording. Users who have installed a fresh Satellite from e.g. quick start, should always run the

https://bugzilla.redhat.com/show_bug.cgi?id=1812251