### PR TITLE
Fix repositories as per @ekohl's feedback

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -24,8 +24,8 @@ ifeval::["{build}" == "foreman"]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable rhel-7-server-optional-rpms \
---enable rhel-7-server-extras-rpms
+--enable {RepoRHEL7ServerOptional} \
+--enable {RepoRHEL7ServerSoftwareCollections}
 ----
 +
 endif::[]
@@ -86,12 +86,6 @@ ifeval::["{build}" == "foreman"]
 ----
 # yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ----
-+
-. Install the `foreman-release-scl` package:
-+
-----
-# yum install foreman-release-scl
-----
 endif::[]
 
 ifeval::["{build}" == "foreman"]
@@ -119,10 +113,10 @@ If you use a CentOS operating system, complete the following steps:
 # yum localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
 ----
 +
-. Install the `epel-release-latest-7.noarch.rpm` package:
+. Install the `epel-release` package:
 +
 ----
-# yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+# yum install epel-release
 ----
 +
 . Install the `foreman-release-scl` package:

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -24,8 +24,8 @@ ifeval::["{build}" == "foreman"]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable rhel-7-server-optional-rpms \
---enable rhel-7-server-extras-rpms
+--enable {RepoRHEL7ServerOptional} \
+--enable {RepoRHEL7ServerSoftwareCollections}
 ----
 +
 endif::[]
@@ -85,12 +85,6 @@ ifeval::["{build}" == "foreman"]
 ----
 # yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ----
-+
-. Install the `foreman-release-scl` package:
-+
-----
-# yum install foreman-release-scl
-----
 endif::[]
 
 ifeval::["{build}" == "foreman"]
@@ -118,10 +112,10 @@ If you use a CentOS operating system, complete the following steps:
 # yum localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
 ----
 +
-. Install the `epel-release-latest-7.noarch.rpm` package:
+. Install the `epel-release` package:
 +
 ----
-# yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+# yum install epel-release
 ----
 +
 . Install the `foreman-release-scl` package:


### PR DESCRIPTION
* `foreman-release-scl` package is not required on RHEL
* epel-release can be installed via yum on CentOS
* Repositories required for installing Foreman on RHEL 7 are fixed as per Foreman manual at https://theforeman.org/manuals/2.0/index.html#2.1Installation

Bug 1832217 - [upstream] Missing repos in Install guides

https://bugzilla.redhat.com/show_bug.cgi?id=1832217