### PR TITLE
Fix command to match the suggested command from output

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -135,7 +135,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# scp /root/_{smartproxy-example-com}_-certs.tar \
+# scp /root/{smart-proxy-context}_cert/_{smartproxy-example-com}_-certs.tar \
 root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 ----
 


### PR DESCRIPTION
Bug 1836524 - [DDF] There is a small correction in the command. Please make it as scp /root/capsule_cert/capsule_certs.tar

https://bugzilla.redhat.com/show_bug.cgi?id=1836524