### PR TITLE
Implement the new {foreman-client} attribute

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -66,8 +66,8 @@ ifeval::["{build}" == "foreman"]
 :smartproxy-example-com: smartproxy.example.com
 :smartproxy_port: 8443
 :Team: Foreman developers
-:RepoRHEL7ServerSatelliteToolsProductVersion: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
-:foreman-client: https://yum.theforeman.org/client/{ProjectVersion}/
+:project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
+:project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
 endif::[]
 
 ifeval::["{build}" == "satellite"]
@@ -113,8 +113,8 @@ ifeval::["{build}" == "satellite"]
 :smartproxy-example-com: capsule.example.com
 :smartproxy_port: 9090
 :Team: Red{nbsp}Hat
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.7-rpms
-:foreman-client: Satellite Tools {ProductVersion}
+:project-client-RHEL7-url: rhel-7-server-satellite-tools-6.7-rpms
+:project-client-name: Satellite Tools {ProductVersion}
 endif::[]
 
 ifeval::["{build}" == "foreman-deb"]
@@ -158,6 +158,6 @@ ifeval::["{build}" == "foreman-deb"]
 :smartproxy-example-com: smartproxy.example.com
 :smartproxy_port: 8443
 :Team: Foreman developers
-:RepoRHEL7ServerSatelliteToolsProductVersion: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
-:foreman-client: https://yum.theforeman.org/client/{ProjectVersion}/
+:project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
+:project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
 endif::[]

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -67,6 +67,7 @@ ifeval::["{build}" == "foreman"]
 :smartproxy_port: 8443
 :Team: Foreman developers
 :RepoRHEL7ServerSatelliteToolsProductVersion: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
+:foreman-client: https://yum.theforeman.org/client/{ProjectVersion}/
 endif::[]
 
 ifeval::["{build}" == "satellite"]
@@ -113,6 +114,7 @@ ifeval::["{build}" == "satellite"]
 :smartproxy_port: 9090
 :Team: Red{nbsp}Hat
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.7-rpms
+:foreman-client: Satellite Tools {ProductVersion}
 endif::[]
 
 ifeval::["{build}" == "foreman-deb"]
@@ -157,4 +159,5 @@ ifeval::["{build}" == "foreman-deb"]
 :smartproxy_port: 8443
 :Team: Foreman developers
 :RepoRHEL7ServerSatelliteToolsProductVersion: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
+:foreman-client: https://yum.theforeman.org/client/{ProjectVersion}/
 endif::[]

--- a/guides/common/modules/enabling_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/enabling_the_satellite_tools_repository.adoc
@@ -26,7 +26,7 @@ If the *{ProjectName} Tools {ProductVersionRepoTitle}* items are not visible, it
 
 . For the `x86_64` entry, click the *Enable* icon to enable the repository.
 
-Enable the {RepoRHEL7ServerSatelliteToolsProductVersion} repository for every supported major version of {RHEL} running on your hosts. After enabling a Red Hat repository, a Product for this repository is automatically created.
+Enable the {foreman-client} repository for every supported major version of {RHEL} running on your hosts. After enabling a Red Hat repository, a Product for this repository is automatically created.
 
 .For CLI Users
 

--- a/guides/common/modules/enabling_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/enabling_the_satellite_tools_repository.adoc
@@ -26,7 +26,7 @@ If the *{ProjectName} Tools {ProductVersionRepoTitle}* items are not visible, it
 
 . For the `x86_64` entry, click the *Enable* icon to enable the repository.
 
-Enable the {foreman-client} repository for every supported major version of {RHEL} running on your hosts. After enabling a Red Hat repository, a Product for this repository is automatically created.
+Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts. After enabling a Red Hat repository, a Product for this repository is automatically created.
 
 .For CLI Users
 

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -36,7 +36,7 @@ ifeval::["{build}" == "satellite"]
 # subscription-manager repos --enable={RepoRHEL7Server} \
 --enable={RepoRHEL7ServerSatelliteCapsuleProductVersion} \
 --enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion} \
---enable={RepoRHEL7ServerSatelliteToolsProductVersion} \
+--enable={project-client-RHEL7-url} \
 --enable={RepoRHEL7ServerSoftwareCollections} \
 --enable={RepoRHEL7ServerAnsible}
 ----

--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -15,7 +15,7 @@ ifeval::["{build}" == "satellite"]
 * You have synchronized the Satellite Tools repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#synchronizing_satellite_tools_repository[Synchronizing the Satellite Tools Repository] in _{project-installation-guide-title}_.
 endif::[]
 
-* You have enabled the {RepoRHEL7ServerSatelliteToolsProductVersion} repository on the client.
+* You have enabled the {foreman-client} repository on the client.
 
 .Procedure
 To install the Katello agent, complete the following steps:

--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -15,7 +15,7 @@ ifeval::["{build}" == "satellite"]
 * You have synchronized the Satellite Tools repository on {ProjectServer}. For more information, see {BaseURL}installing_satellite_server_from_a_connected_network/performing_additional_configuration_on_satellite_server#synchronizing_satellite_tools_repository[Synchronizing the Satellite Tools Repository] in _{project-installation-guide-title}_.
 endif::[]
 
-* You have enabled the {foreman-client} repository on the client.
+* You have enabled the {project-client-name} repository on the client.
 
 .Procedure
 To install the Katello agent, complete the following steps:

--- a/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
@@ -2,7 +2,7 @@
 = Synchronizing the Satellite Tools Repository
 
 ifeval::["{build}" == "satellite"]
-Use this section to synchronize the {foreman-client} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
+Use this section to synchronize the {project-client-name} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}.
 endif::[]
 

--- a/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
+++ b/guides/common/modules/synchronizing_the_satellite_tools_repository.adoc
@@ -1,13 +1,8 @@
 [[synchronizing_satellite_tools_repository]]
 = Synchronizing the Satellite Tools Repository
 
-ifeval::["{build}" == "foreman"]
-If you use the Katello plug-in, you can synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
-This repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}.
-endif::[]
-
 ifeval::["{build}" == "satellite"]
-Use this section to synchronize the {RepoRHEL7ServerSatelliteToolsProductVersion} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
+Use this section to synchronize the {foreman-client} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent` and `puppet` packages for clients registered to {ProjectServer}.
 endif::[]
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -72,7 +72,7 @@ To create an activation key, complete the following steps:
 . If you want to set a limit, clear the *Unlimited hosts* check box, and in the *Limit* field, enter the maximum number of systems you can register with the activation key. If you want unlimited hosts to register with the activation key, ensure the *Unlimited Hosts* check box is selected.
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the environment to use.
-. From the *Content View* list, select a Content View to use. If you want to use this activation key to register hosts, the Content View must contain the `{project-client-name}` repository because it is required to install the `katello-agent`.
+. From the *Content View* list, select a Content View to use. If you want to use this activation key to register hosts, the Content View must contain the {project-client-name} repository because it is required to install the `katello-agent`.
 . Click *Save*.
 . Optional: For Red{nbsp}Hat Enterprise Linux 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.
 
@@ -130,7 +130,7 @@ To create an activation key, complete the following steps:
 --organization "_My_Organization_"
 ----
 +
-. Override the default auto-enable status for the `{project-client-name}` repository. The default status is set to disabled. To enable, enter the following command:
+. Override the default auto-enable status for the {project-client-name} repository. The default status is set to disabled. To enable, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -265,7 +265,7 @@ This RPM installs the necessary certificates for accessing repositories on {Proj
 # yum install katello-agent
 ----
 +
-The `{project-client-name}` repository provides this package.
+The {project-client-name} repository provides this package.
 
 .Multiple Activation Keys
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -72,7 +72,7 @@ To create an activation key, complete the following steps:
 . If you want to set a limit, clear the *Unlimited hosts* check box, and in the *Limit* field, enter the maximum number of systems you can register with the activation key. If you want unlimited hosts to register with the activation key, ensure the *Unlimited Hosts* check box is selected.
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the environment to use.
-. From the *Content View* list, select a Content View to use. If you want to use this activation key to register hosts, the Content View must contain the `{RepoRHEL7ServerSatelliteToolsProductVersion}` repository because it is required to install the `katello-agent`.
+. From the *Content View* list, select a Content View to use. If you want to use this activation key to register hosts, the Content View must contain the `{foreman-client}` repository because it is required to install the `katello-agent`.
 . Click *Save*.
 . Optional: For Red{nbsp}Hat Enterprise Linux 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.
 
@@ -130,7 +130,7 @@ To create an activation key, complete the following steps:
 --organization "_My_Organization_"
 ----
 +
-. Override the default auto-enable status for the `{RepoRHEL7ServerSatelliteToolsProductVersion}` repository. The default status is set to disabled. To enable, enter the following command:
+. Override the default auto-enable status for the `{foreman-client}` repository. The default status is set to disabled. To enable, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -265,7 +265,7 @@ This RPM installs the necessary certificates for accessing repositories on {Proj
 # yum install katello-agent
 ----
 +
-The `{RepoRHEL7ServerSatelliteToolsProductVersion}` repository provides this package.
+The `{foreman-client}` repository provides this package.
 
 .Multiple Activation Keys
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -72,7 +72,7 @@ To create an activation key, complete the following steps:
 . If you want to set a limit, clear the *Unlimited hosts* check box, and in the *Limit* field, enter the maximum number of systems you can register with the activation key. If you want unlimited hosts to register with the activation key, ensure the *Unlimited Hosts* check box is selected.
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the environment to use.
-. From the *Content View* list, select a Content View to use. If you want to use this activation key to register hosts, the Content View must contain the `{foreman-client}` repository because it is required to install the `katello-agent`.
+. From the *Content View* list, select a Content View to use. If you want to use this activation key to register hosts, the Content View must contain the `{project-client-name}` repository because it is required to install the `katello-agent`.
 . Click *Save*.
 . Optional: For Red{nbsp}Hat Enterprise Linux 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.
 
@@ -130,13 +130,13 @@ To create an activation key, complete the following steps:
 --organization "_My_Organization_"
 ----
 +
-. Override the default auto-enable status for the `{foreman-client}` repository. The default status is set to disabled. To enable, enter the following command:
+. Override the default auto-enable status for the `{project-client-name}` repository. The default status is set to disabled. To enable, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer activation-key content-override \
 --name "_My_Activation_Key_" \
---content-label {RepoRHEL7ServerSatelliteToolsProductVersion} \
+--content-label {project-client-RHEL7-url} \
 --value 1 \
 --organization "_My_Organization_"
 ----
@@ -265,7 +265,7 @@ This RPM installs the necessary certificates for accessing repositories on {Proj
 # yum install katello-agent
 ----
 +
-The `{foreman-client}` repository provides this package.
+The `{project-client-name}` repository provides this package.
 
 .Multiple Activation Keys
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -99,7 +99,7 @@ Use this procedure to configure a repository in a directory on the base system w
 
 To create a file type repository in a local directory, complete the following procedure:
 
-. Ensure the Server and `{RepoRHEL7ServerSatelliteToolsProductVersion}` repositories are enabled.
+. Ensure the Server and `{foreman-client}` repositories are enabled.
 ifeval::["build" == "satellite"]
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -183,14 +183,16 @@ Use this procedure to configure a repository in a directory on a remote server. 
 Before you create a remote file type repository, ensure the following conditions exist:
 
 * You have a Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 server registered to your {Project} or the Red{nbsp}Hat CDN.
-* Your server has an entitlement to the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}Server and `{RepoRHEL7ServerSatelliteToolsProductVersion}` repositories.
+ifeval::["{build}" == "satellite"]
+* Your server has an entitlement to the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}Server and `{foreman-client}` repositories.
+endif::[]
 * You have installed an HTTP server. For more information about configuring a web server, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-web_servers#s1-The_Apache_HTTP_Server[The Apache HTTP Server] in the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 _System Administrator's Guide_.
 
 .Procedure
 
 To create a file type repository in a remote directory, complete the following procedure:
 
-. On your remote server, ensure that the Server and `{RepoRHEL7ServerSatelliteToolsProductVersion}` repositories are enabled.
+. On your remote server, ensure that the Server and `{foreman-client}` repositories are enabled.
 ifeval::["build" == "satellite"]
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -99,7 +99,7 @@ Use this procedure to configure a repository in a directory on the base system w
 
 To create a file type repository in a local directory, complete the following procedure:
 
-. Ensure the Server and `{project-client-name}` repositories are enabled.
+. Ensure the Server and {project-client-name} repositories are enabled.
 ifeval::["build" == "satellite"]
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -184,7 +184,7 @@ Before you create a remote file type repository, ensure the following conditions
 
 * You have a Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 server registered to your {Project} or the Red{nbsp}Hat CDN.
 ifeval::["{build}" == "satellite"]
-* Your server has an entitlement to the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}Server and `{project-client-name}` repositories.
+* Your server has an entitlement to the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}Server and {project-client-name} repositories.
 endif::[]
 * You have installed an HTTP server. For more information about configuring a web server, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-web_servers#s1-The_Apache_HTTP_Server[The Apache HTTP Server] in the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 _System Administrator's Guide_.
 
@@ -192,7 +192,7 @@ endif::[]
 
 To create a file type repository in a remote directory, complete the following procedure:
 
-. On your remote server, ensure that the Server and `{project-client-name}` repositories are enabled.
+. On your remote server, ensure that the Server and {project-client-name} repositories are enabled.
 ifeval::["build" == "satellite"]
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -99,13 +99,13 @@ Use this procedure to configure a repository in a directory on the base system w
 
 To create a file type repository in a local directory, complete the following procedure:
 
-. Ensure the Server and `{foreman-client}` repositories are enabled.
+. Ensure the Server and `{project-client-name}` repositories are enabled.
 ifeval::["build" == "satellite"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable={RepoRHEL7ServerSatelliteToolsProductVersion}
+--enable={project-client-RHEL7-url}
 ----
 endif::[]
 
@@ -184,7 +184,7 @@ Before you create a remote file type repository, ensure the following conditions
 
 * You have a Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 server registered to your {Project} or the Red{nbsp}Hat CDN.
 ifeval::["{build}" == "satellite"]
-* Your server has an entitlement to the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}Server and `{foreman-client}` repositories.
+* Your server has an entitlement to the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}Server and `{project-client-name}` repositories.
 endif::[]
 * You have installed an HTTP server. For more information about configuring a web server, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-web_servers#s1-The_Apache_HTTP_Server[The Apache HTTP Server] in the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 _System Administrator's Guide_.
 
@@ -192,13 +192,13 @@ endif::[]
 
 To create a file type repository in a remote directory, complete the following procedure:
 
-. On your remote server, ensure that the Server and `{foreman-client}` repositories are enabled.
+. On your remote server, ensure that the Server and `{project-client-name}` repositories are enabled.
 ifeval::["build" == "satellite"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable={RepoRHEL7ServerSatelliteToolsProductVersion}
+--enable={project-client-RHEL7-url}
 ----
 endif::[]
 +

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -106,11 +106,11 @@ For more information about network interfaces, see {BaseURL}/managing_hosts/inde
 This creates the host entry and the relevant provisioning settings. This also includes creating the necessary directories and files for PXE booting the bare metal host. If you start the physical host and set its boot mode to PXE, the host detects the DHCP service of {ProjectServer}'s integrated {SmartProxy} and starts installing the operating system from its Kickstart tree.
 
 ifeval::["{build}" == "satellite"]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {foreman-client} repository.
+When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
 ifeval::["{build}" == "foreman"]
-If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the `{foreman-client}` repository.
+If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the `{project-client-name}` repository.
 endif::[]
 
 .For CLI Users
@@ -253,7 +253,7 @@ Write the ISO to a USB storage device using the *dd* utility or *livecd-tools* i
 When you start the physical host and boot from the ISO or the USB storage device, the host connects to {ProjectServer} and starts installing operating system from its kickstart tree.
 
 ifeval::["{build}" == "satellite"]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{foreman-client}* repository.
+When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{project-client-name}* repository.
 endif::[]
 
 [[Configuring_Provisioning_Resources-Creating_Provisioning_Templates-Deploying_SSH_Keys_during_Provisioning]]

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -110,7 +110,7 @@ When the installation completes, the host also registers to {ProjectServer} usin
 endif::[]
 
 ifeval::["{build}" == "foreman"]
-If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the `{project-client-name}` repository.
+If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
 .For CLI Users

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -106,11 +106,11 @@ For more information about network interfaces, see {BaseURL}/managing_hosts/inde
 This creates the host entry and the relevant provisioning settings. This also includes creating the necessary directories and files for PXE booting the bare metal host. If you start the physical host and set its boot mode to PXE, the host detects the DHCP service of {ProjectServer}'s integrated {SmartProxy} and starts installing the operating system from its Kickstart tree.
 
 ifeval::["{build}" == "satellite"]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {RepoRHEL7ServerSatelliteToolsProductVersion} repository.
+When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {foreman-client} repository.
 endif::[]
 
 ifeval::["{build}" == "foreman"]
-If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the `{RepoRHEL7ServerSatelliteToolsProductVersion}` repository.
+If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the `{foreman-client}` repository.
 endif::[]
 
 .For CLI Users
@@ -253,7 +253,7 @@ Write the ISO to a USB storage device using the *dd* utility or *livecd-tools* i
 When you start the physical host and boot from the ISO or the USB storage device, the host connects to {ProjectServer} and starts installing operating system from its kickstart tree.
 
 ifeval::["{build}" == "satellite"]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{RepoRHEL7ServerSatelliteToolsProductVersion}* repository.
+When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{foreman-client}* repository.
 endif::[]
 
 [[Configuring_Provisioning_Resources-Creating_Provisioning_Templates-Deploying_SSH_Keys_during_Provisioning]]

--- a/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
@@ -328,8 +328,7 @@ provide information about errata that are applicable for content hosts.
 
 .Prerequisites
 
-The `{RepoRHEL7ServerSatelliteToolsProductVersion}` repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the
-required packages. For more information about enabling {RepoRHEL7ServerSatelliteToolsProductVersion}, see {BaseURL}managing_hosts/registering_hosts#installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
+The `{foreman-client}` repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the required packages. For more information about enabling {foreman-client}, see {BaseURL}managing_hosts/registering_hosts#installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
 
 
 .To Install the Katello Agent

--- a/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
@@ -328,7 +328,7 @@ provide information about errata that are applicable for content hosts.
 
 .Prerequisites
 
-The `{project-client-name}` repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the required packages. For more information about enabling {project-client-name}, see {BaseURL}managing_hosts/registering_hosts#installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
+The {project-client-name} repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the required packages. For more information about enabling {project-client-name}, see {BaseURL}managing_hosts/registering_hosts#installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
 
 
 .To Install the Katello Agent

--- a/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
@@ -328,7 +328,7 @@ provide information about errata that are applicable for content hosts.
 
 .Prerequisites
 
-The `{foreman-client}` repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the required packages. For more information about enabling {foreman-client}, see {BaseURL}managing_hosts/registering_hosts#installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
+The `{project-client-name}` repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the required packages. For more information about enabling {project-client-name}, see {BaseURL}managing_hosts/registering_hosts#installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
 
 
 .To Install the Katello Agent


### PR DESCRIPTION
Get rid of the workaround that listed the foreman-client repository for el7 only, which might be confusing

Bug 1835718 - Make the wording of Satellite Tools repository consistent throughout the guides

https://bugzilla.redhat.com/show_bug.cgi?id=1835718