### PR TITLE
Install media corrections

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Resources.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Resources.adoc
@@ -198,6 +198,56 @@ To view the kickstart tree enter the following command:
 # hammer medium list --organization "_your_organization_"
 ----
 
+[[Configuring_Provisioning_Resources-Creating_Installation_Media]]
+=== Using Installation Media
+
+Installation media are sources of packages that {ProjectServer} uses to install a base operating system on a machine from an external repository. Installation media must be in the format of an operating system installation tree, and must be accessible to the machine hosting the installer through an HTTP URL. You can view installation media by navigating to *Hosts* > *Installation Media* menu.
+
+By default, {Project} includes installation media for some official Linux distributions. Note that some of those installation media are targeted for a specific version of an operating system. For example *CentOS mirror (7.x)* must be used for CentOS 7 or earlier, and *CentOS mirror (8.x)* must be used for CentOS 8 or later.
+
+If you want to improve download performance when using installation media to install operating systems on multiple host, you must modify the installation medium's *Path* to point to the closest mirror or a local copy. 
+
+.Procedure
+
+To create installation media, complete the following steps:
+
+. In the {Project} web UI, navigate to *Hosts* > *Installation Media* and click *Create Medium*.
+. In the *Name* field, enter a name to represent the installation media entry.
+. In the *Path* enter the URL or NFS share that contains the installation tree. You can use following variables in the path to represent multiple different system architectures and versions:
+  * `$arch` - The system architecture.
+  * `$version` - The operating system version.
+  * `$major` - The operating system major version.
+  * `$minor` - The operating system minor version.
++
+Example HTTP path:
++
+----
+http://download.example.com/centos/$version/Server/$arch/os/
+----
++
+Example NFS path:
++
+----
+nfs://download.example.com:/centos/$version/Server/$arch/os/
+----
++
+Synchronized content on {SmartProxyServer}s always uses an HTTP path. {SmartProxyServer} managed content does not support NFS paths.
++
+. From the *Operating system family* list, select the distribution or family of the installation medium. For example, CentOS, and Fedora are in the `Red Hat` family.
+. Click the *Organizations* and *Locations* tabs, to change the provisioning context. {ProjectServer} adds the installation medium to the set provisioning context.
+. Click *Submit* to save your installation medium.
+
+.For CLI Users
+
+Create the installation medium using the `hammer medium create` command:
+
+[options="nowrap" subs="+quotes"]
+----
+# hammer medium create --name "CustomOS" --os-family "Redhat" \
+--path 'http://download.example.com/centos/$version/Server/$arch/os/' \
+--organizations "_My_Organization_" --locations "_My_Location_"
+----
+
 [[Configuring_Provisioning_Resources-Creating_Partition_Tables]]
 === Creating Partition Tables
 
@@ -403,54 +453,6 @@ To set a default encrypted password for your hosts, complete the following steps
 . On the *Settings* page, select the *Provisioning* tab.
 . In the *Name* column, navigate to *Root password*, and click *Click to edit*.
 . Paste the encrypted password that you generate, and click *Save*.
-
-[[Configuring_Provisioning_Resources-Creating_Installation_Media]]
-=== Using Installation Media
-
-Installation media are sources of packages that {ProjectServer} uses to install a base operating system on a machine from external repository. Installation media must be in the format of an  +operating system installation tree, and must be accessible to the machine hosting the installer through an HTTP URL. You can view installation media by navigating to *Hosts* > *Installation +Media* menu.
-
-{Project} comes with a number of installation media pre-defined to official Linux distribution mirrors. The *Path* should be modified to point to the closest mirror or local copy in order to achieve better download performance when installing multiple hosts. Some installation media can be only used with specific versions, for example *CentOS mirror (7.x)* must be used for CentOS 7 or older and *CentOS mirror (8.x)* must be used for CentOS 8 or higher.
-
-.Procedure
-
-To create installation media, complete the following steps:
-
-. In the {Project} web UI, navigate to *Hosts* > *Installation Media* and click *Create Medium*.
-. In the *Name* field, enter a name to represent the installation media entry.
-. In the *Path* enter the URL or NFS share that contains the installation tree. You can use following variables in the path to represent multiple different system architectures and versions:
-  * `$arch` - The system architecture.
-  * `$version` - The operating system version.
-  * `$major` - The operating system major version.
-  * `$minor` - The operating system minor version.
-+
-Example HTTP path:
-+
-----
-http://download.example.com/centos/$version/Server/$arch/os/
-----
-+
-Example NFS path:
-+
-----
-nfs://download.example.com:/centos/$version/Server/$arch/os/
-----
-+
-Synchronized content on {SmartProxyServer}s always uses an HTTP path. {SmartProxyServer} managed content does not support NFS paths.
-+
-. From the *Operating system family* list, select the distribution or family of the installation medium. For example, CentOS, and Fedora are in the `Red Hat` family.
-. Click the *Organizations* and *Locations* tabs, to change the provisioning context. {ProjectServer} adds the installation medium to the set provisioning context.
-. Click *Submit* to save your installation medium.
-
-.For CLI Users
-
-Create the installation medium using the `hammer medium create` command:
-
-[options="nowrap" subs="+quotes"]
-----
-# hammer medium create --name "CustomOS" --os-family "Redhat" \
---path 'http://download.example.com/centos/$version/Server/$arch/os/' \
---organizations "_My_Organization_" --locations "_My_Location_"
-----
 
 [[Configuring_Provisioning_Resources-Accessing_Virtual_Machines_with_the_noVNC_Console]]
 === Using noVNC to Access Virtual Machines

--- a/guides/doc-Provisioning_Guide/topics/Resources.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Resources.adoc
@@ -404,13 +404,12 @@ To set a default encrypted password for your hosts, complete the following steps
 . In the *Name* column, navigate to *Root password*, and click *Click to edit*.
 . Paste the encrypted password that you generate, and click *Save*.
 
-
 [[Configuring_Provisioning_Resources-Creating_Installation_Media]]
-=== Using Third Party Installation Media
+=== Using Installation Media
 
-Installation media are sources of files for third parties that {ProjectServer} uses to install a third-party base operating system on a machine. Installation media must be in the format of an operating system installation tree, and must be accessible to the machine hosting the installer through an HTTP URL. You can view installation media by navigating to *Hosts* > *Installation Media* menu.
+Installation media are sources of packages that {ProjectServer} uses to install a base operating system on a machine from external repository. Installation media must be in the format of an  +operating system installation tree, and must be accessible to the machine hosting the installer through an HTTP URL. You can view installation media by navigating to *Hosts* > *Installation +Media* menu.
 
-For other installation media, for example, a locally mounted ISO image, you can add your own custom media paths using the following procedure.
+{Project} comes with a number of installation media pre-defined to official Linux distribution mirrors. The *Path* should be modified to point to the closest mirror or local copy in order to achieve better download performance when installing multiple hosts. Some installation media can be only used with specific versions, for example *CentOS mirror (7.x)* must be used for CentOS 7 or older and *CentOS mirror (8.x)* must be used for CentOS 8 or higher.
 
 .Procedure
 


### PR DESCRIPTION
Couple of issues solved:

1) The chapter uses "third-party" extensively, this does not make any sense upstream and I don't believe it's important to have even downstream.

2) Added note about CentOS mirror changes which are upcoming: https://community.theforeman.org/t/rfc-rename-centos-mirror-installation-media/18867

3) Moved the chapter closer to syncing, IM + syncing are essentially very important and for upstream users without Katello this should really come earlier.

The move is a separate commit so you can easily review the changes.