### PR TITLE
Add back old file and change include path

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -49,7 +49,7 @@ For more information about networking requirements, see xref:Configuring_Network
 For more information about the Discovery service, xref:configuring-the-discovery-service[].
 +
 * A bare metal host or a blank VM.
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 For information about the security token for unattended and PXE-less provisioning, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
 
@@ -281,6 +281,7 @@ To deploy SSH keys during provisioning, complete the following steps:
 . Create a host that is associated with the provisioning template or rebuild a host using the OS associated with the modified template. For more information, see {BaseURL}/managing_hosts/#sect-{Project_Link}-Managing_Hosts-Managing_Hosts-Creating_a_Host[Creating a Host] in the _Managing Hosts_ guide.
 +
 The SSH keys of the *Owned by* user are added automatically when the `create_users` snippet is executed during the provisioning process. You can set *Owned by* to an individual user or a user group. If you set *Owned by* to a user group, the SSH keys of all users in the user group are added automatically.
+
 
 
 

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
@@ -10,7 +10,7 @@ The requirements for Amazon EC2 provisioning include:
 
   * A {SmartProxyServer} managing a network in your EC2 environment. Use a Virtual Private Cloud (VPC) to ensure a secure network between the hosts and the {SmartProxyServer}.
   * An Amazon Machine Image (AMI) for image-based provisioning.
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 
 [[Provisioning_Cloud_Instances_in_Amazon_EC2-Adding_a_Amazon_EC2_Connection_to_the_Satellite_Server]]
@@ -289,6 +289,7 @@ For information about how to locate Red{nbsp}Hat Gold Images on Amazon Web Servi
 For information about how to install and use the Amazon Web Service Client on Linux, see https://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html[Install the AWS Command Line Interface on Linux] in the Amazon Web Services documentation.
 
 For information about importing and exporting virtual machines in Amazon Web Services, see https://aws.amazon.com/ec2/vm-import/[VM Import/Export] in the Amazon Web Services documentation.
+
 
 
 

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Azure.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Azure.adoc
@@ -14,7 +14,7 @@ Before you begin, ensure that the following conditions are met:
 * Optional: If you want to use Puppet with Azure hosts, navigate to *Administer* > *Settings* > *Puppet* and enable the `Use UUID for certificates` setting to configure Puppet to use consistent Puppet certificate IDs.
 * Based on your needs, associate a `finish` or `user_data` provisioning template with the operating system you want to use. For more information about provisioning templates, see xref:Configuring_Provisioning_Resources-Types_of_Provisioning_Templates[].
 * Optional: If you want the virtual machine to use a static private IP address, create a subnet in {Project} with the *Network Address* field matching the Azure subnet address.
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 ifeval::["{build}" == "foreman"]
 === Installing the Foreman AzureRm Plug-in
@@ -230,6 +230,7 @@ To create a host, enter the following command:
 --operatingsystem "_operating_system_name_" \
 --image _Azure_image_name_
 ----
+
 
 
 

--- a/guides/doc-Provisioning_Guide/topics/Cloud-GCE.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-GCE.adoc
@@ -11,7 +11,7 @@ Before you begin, ensure that the following conditions are met:
 * In your GCE project-wise metadata, set the `enable-oslogin` to `FALSE`. For more information, see https://cloud.google.com/compute/docs/instances/managing-instance-access#enable_oslogin[Enabling or disabling OS Login] in the GCE documentation.
 * Optional: If you want to use Puppet with GCE hosts, navigate to *Administer* > *Settings* > *Puppet* and enable the `Use UUID for certificates` setting to configure Puppet to use consistent Puppet certificate IDs.
 * Based on your needs, associate a `finish` or `user_data` provisioning template with the operating system you want to use. For more information about provisioning templates, see xref:Configuring_Provisioning_Resources-Types_of_Provisioning_Templates[].
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 [[Provisioning_Virtual_Machines_in_GCE-Adding_a_GCE_Connection]]
 === Adding a GCE Connection to {ProjectServer}
@@ -210,6 +210,7 @@ To create a host, enter the following command:
 --architecture _x86_64_ \
 --operatingsystem "_operating_system_name_" \
 ----
+
 
 
 

--- a/guides/doc-Provisioning_Guide/topics/Cloud-OpenStack.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-OpenStack.adoc
@@ -12,7 +12,7 @@ Requirements for {OpenStack} Provisioning include:
 
   * A {SmartProxyServer} managing a network in your OpenStack environment. For more information, see xref:Configuring_Networking[].
   * An image added to OpenStack Image Storage (glance) service for image-based provisioning. For more information, see the https://access.redhat.com/documentation/en/red-hat-openstack-platform/9/paged/instances-and-images-guide/[{OpenStack} Instances and Images Guide].
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 [[Provisioning_Cloud_Instances_in_Red_Hat_OpenStack_Platform-Adding_a_Red_Hat_OpenStack_Platform_Connection_to_the_Satellite_Server]]
 === Adding a {OpenStack} Connection to the {ProjectServer}
@@ -151,6 +151,7 @@ Create the host with the `hammer host create` command and include the `--provisi
 ----
 
 For more information about additional host creation parameters for this compute resource, see xref:CLI_Params[].
+
 
 
 

--- a/guides/doc-Provisioning_Guide/topics/Common_Compute_Resource_Prereqs.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Common_Compute_Resource_Prereqs.adoc
@@ -1,0 +1,13 @@
+[[common_compute_resource_prerequisites]]
+
+ifeval::["{build}" == "foreman"]
+* The installation media that you require for the operating systems you want to use to provision.  If the Katello plug-in is installed, you can use synchronized content repositories for Red{nbsp}Hat Enterprise Linux. For more information, see {BaseURL}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
+* If the Katello plug-in is installed, an activation key for host registration. For more information, see {BaseURL}content_management_guide/managing_activation_keys#Managing_Activation_Keys-Creating_an_Activation_Key[Creating An Activation Key] in the _Content Management_ guide.
+endif::[]
+ifeval::["{build}" == "foreman-deb"]
+  * The installation media that you require for the operating systems you want to use to provision.
+endif::[]
+ifeval::["{build}" == "satellite"]
+  * Synchronized content repositories for Red{nbsp}Hat Enterprise Linux. For more information, see {BaseURL}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
+  * An activation key for host registration. For more information, see {BaseURL}content_management_guide/managing_activation_keys#Managing_Activation_Keys-Creating_an_Activation_Key[Creating An Activation Key] in the _Content Management_ guide.
+endif::[]

--- a/guides/doc-Provisioning_Guide/topics/Virt-RHV.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-RHV.adoc
@@ -19,7 +19,7 @@ The requirements for {OVirt} provisioning include:
 
   * A {SmartProxyServer} managing a logical network on the {OVirt} environment. Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}. For more information, see xref:Configuring_Networking[].
   * An existing template, other than the `blank` template, if you want to use image-based provisioning. For more information about creating templates for virtual machines, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.0/html/virtual_machine_management_guide/chap-templates[Templates] in the _Virtual Machine Management Guide_.
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 
 [[Provisioning_Virtual_Machines_in_Red_Hat_Virtualization-Creating_a_Red_Hat_Virtualization_User]]
@@ -375,6 +375,7 @@ To create a host with image-based provisioning, use the `hammer host create` com
 ----
 
 For more information about additional host creation parameters for this compute resource, see xref:CLI_Params[].
+
 
 
 

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -10,7 +10,7 @@ The requirements for VMware vSphere provisioning include:
 
 * A {SmartProxyServer} managing a network on the vSphere environment. Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}. For more information, see xref:Configuring_Networking[].
 * An existing VMware template if you want to use image-based provisioning.
-include::../../common/modules/snip_common-compute-resource-prereqs.adoc[]
+include::Common_Compute_Resource_Prereqs.adoc[]
 
 [[Provisioning_Virtual_Machines_in_VMware_vSphere-Creating_a_VMware_vSphere_User]]
 === Creating a VMware vSphere User
@@ -441,6 +441,7 @@ https://_{foreman-example-com}_/api/compute_resources/_compute_resource_id_/refr
 ----
 
 Use the `hammer compute-resource list` command to determine the ID of the VMware server you want to refresh the compute resources cache for.
+
 
 
 


### PR DESCRIPTION
Downstream build doesn't work with the temporary path to common in the non-common chapters

We will need to keep the old file until all the chapters are in common