### PR TITLE
Add proxy configuration for PXE smart proxy

### DIFF
--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -15,4 +15,8 @@ include::modules/proc_using-an-http-proxy-for-all-http-requests.adoc[leveloffset
 
 include::modules/proc_excluding-hosts-from-receiving-proxied-requests.adoc[leveloffset=+1]
 
+ifeval::["{build}" != "satellite"]
+include::modules/proc_configuring-pxe-files-proxy.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_resetting-the-http-proxy.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_configuring-pxe-files-proxy.adoc
+++ b/guides/common/modules/proc_configuring-pxe-files-proxy.adoc
@@ -1,11 +1,11 @@
 [id="configuring-proxy-for-pxe-files_{context}"]
-= Configuring proxy for PXE files downloads
+= Configuring a proxy for PXE files downloads
 
-For Red Hat content served via CDN, {SmartProxy} downloads PXE files from synced repositories. However when configuring and installing operating system via Installation Media, {SmartProxy} connects directly via `wget` utility.
+For Red Hat content served through the Content Delivery Network, {SmartProxy} downloads PXE files from synchronized repositories. However, when configuring and installing an operating system using Installation Media, {SmartProxy} connects directly using the `wget` utility.
 
 .Procedure
 
-. On {SmartProxy} with TFTP feature, to verify the ports that are permitted by SELinux for the HTTP cache, enter a command as follows:
+. On {SmartProxy} with the TFTP feature, to verify the ports that are permitted by SELinux for the HTTP cache, enter the following command:
 +
 [options="nowrap",subs="+quotes"]
 ----
@@ -21,7 +21,7 @@ Environment="http_proxy=http://proxy.example.com:8888"
 Environment="https_proxy=https://proxy.example.com:8888"
 ----
 +
-. Save the file, it should appear as `/etc/systemd/system/foreman-proxy.service.d/overrides.conf`.
+. Save the file. Verify that the file appears as `/etc/systemd/system/foreman-proxy.service.d/overrides.conf`.
 . Restart the `foreman-proxy` service:
 +
 [options="nowrap",subs="+quotes"]
@@ -29,4 +29,4 @@ Environment="https_proxy=https://proxy.example.com:8888"
 # systemctl restart foreman-proxy
 ----
 +
-. Create a new host or enter Build mode for existing one to redownload PXE files to the TFTP {SmartProxy}.
+. Create a host or enter build mode for an existing host to re-download PXE files to the TFTP {SmartProxy}.

--- a/guides/common/modules/proc_configuring-pxe-files-proxy.adoc
+++ b/guides/common/modules/proc_configuring-pxe-files-proxy.adoc
@@ -1,0 +1,32 @@
+[id="configuring-proxy-for-pxe-files_{context}"]
+= Configuring proxy for PXE files downloads
+
+For Red Hat content served via CDN, {SmartProxy} downloads PXE files from synced repositories. However when configuring and installing operating system via Installation Media, {SmartProxy} connects directly via `wget` utility.
+
+.Procedure
+
+. On {SmartProxy} with TFTP feature, to verify the ports that are permitted by SELinux for the HTTP cache, enter a command as follows:
++
+[options="nowrap",subs="+quotes"]
+----
+# systemctl edit foreman-proxy
+----
++
+. Insert the following test into the editor:
++
+[options="nowrap",subs="+quotes"]
+----
+[Service]
+Environment="http_proxy=http://proxy.example.com:8888"
+Environment="https_proxy=https://proxy.example.com:8888"
+----
++
+. Save the file, it should appear as `/etc/systemd/system/foreman-proxy.service.d/overrides.conf`.
+. Restart the `foreman-proxy` service:
++
+[options="nowrap",subs="+quotes"]
+----
+# systemctl restart foreman-proxy
+----
++
+. Create a new host or enter Build mode for existing one to redownload PXE files to the TFTP {SmartProxy}.


### PR DESCRIPTION
This was brought by a user on IRC. It is not relevant downstream as the only content we support is RHEL via CDN and that goes into Katello which do not need to be proxied at all.