### PR TITLE
Clarify DNS providers - ISC DNS vs ISC BIND

### DIFF
--- a/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
@@ -20,7 +20,7 @@ Infrastructure and host management services:
 
 * *DHCP* – {SmartProxy} can act as a DHCP server or it can integrate with an existing solution, including ISC DHCP servers, Active Directory, and Libvirt instances.
 
-* *DNS* – {SmartProxy} can act as a DNS server or it can integrate with an existing solution, including ISC BIND or Active Directory.
+* *DNS* – {SmartProxy} can act as a DNS server or it can integrate with an existing solution, including ISC BIND and Active Directory.
 
 * *TFTP* – {SmartProxy} can act as a TFTP server or integrate with any UNIX-based TFTP server.
 

--- a/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
@@ -20,7 +20,7 @@ Infrastructure and host management services:
 
 * *DHCP* – {SmartProxy} can act as a DHCP server or it can integrate with an existing solution, including ISC DHCP servers, Active Directory, and Libvirt instances.
 
-* *DNS* – {SmartProxy} can act as a DNS server or it can integrate with an existing solution, including ISC DNS, Active Directory, or BIND.
+* *DNS* – {SmartProxy} can act as a DNS server or it can integrate with an existing solution, including ISC BIND or Active Directory.
 
 * *TFTP* – {SmartProxy} can act as a TFTP server or integrate with any UNIX-based TFTP server.
 


### PR DESCRIPTION
The Internet Systems Consortium produce a DNS server (and related tools) distributed as ISC BIND (it used to be an acronym, see BIND on Wikipedia, but it is no longer developed by UCB, rather ISC). A google search for "ISC DNS" will take you to the ISC BIND9 page, so I don't feel we should confuse readers with separate references to ISC DNS (a name possibly unique to this document) and the actual ISC product.