### PR TITLE
Ignore access.redhat.com/solutions

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -36,7 +36,7 @@ browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 linkchecker: html
-	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com --ignore-url=cdn.redhat.com --ignore-url=file:///modules "file://$(realpath $(ROOTDIR)/$(DEST_HTML))" --ignore-url=tools.ietf.org --ignore-url=host/unattended/provision --ignore-url=projects.theforeman.org
+	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com --ignore-url=cdn.redhat.com --ignore-url=access.redhat.com/solutions --ignore-url=file:///modules "file://$(realpath $(ROOTDIR)/$(DEST_HTML))" --ignore-url=tools.ietf.org --ignore-url=host/unattended/provision --ignore-url=projects.theforeman.org
 
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"


### PR DESCRIPTION
These links are often 401 (paywalled), the tool is unable to check them as there is no way to configure it that 401 should be considered as success. This removes these links.

Example failure:

```
URL        `https://access.redhat.com/solutions/3397771'
Name       `Impact of Disk Speed on Satellite Operations'
Parent URL file:///home/travis/build/theforeman/foreman-documentation/guides/build/doc-Installing_Proxy_on_Debian/index-satellite.html, line 219, col 101
Real URL   https://access.redhat.com/solutions/3397771
Check time 2.051 seconds
Result     Error: 403 Forbidden
```