### PR TITLE
Fixes 404 link for AWS support site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 ---
-language: minimal
+language: python
+python:
+  - "2.7"
 before_install:
   - sudo apt-get install -y ruby make linkchecker
-install: gem install asciidoctor
+install:
+  - gem install asciidoctor
+  - pip install linkchecker-tryer
 script:
   - cd guides
-  - make clean html linkchecker BUILD=foreman
-  - make clean html linkchecker BUILD=foreman-deb
-  - make clean html linkchecker BUILD=satellite
+  - make clean html BUILD=foreman
+  - make clean html BUILD=foreman-deb
+  - make clean html BUILD=satellite
+  - make linkchecker-tryer

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -7,9 +7,13 @@ html: all-html
 
 pdf: all-pdf
 
-linkchecker: all-linkchecker
-
 clean: all-clean
+
+linkchecker:
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
+
+linkchecker-tryer:
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
 all-html:
 	for DIR in $(GUIDES) ; do \

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -36,7 +36,7 @@ browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 linkchecker: html
-	linkchecker -vr1 -f $(COMMON_DIR)/linkchecker.ini --check-extern --ignore-url=example.com --ignore-url=cdn.redhat.com --ignore-url=access.redhat.com/solutions --ignore-url=file:///modules "file://$(realpath $(ROOTDIR)/$(DEST_HTML))" --ignore-url=tools.ietf.org --ignore-url=host/unattended/provision --ignore-url=projects.theforeman.org
+	linkchecker -r1 -f $(COMMON_DIR)/linkchecker.ini --check-extern "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -3,3 +3,11 @@ threads=32
 timeout=20
 sslverify=0
 maxrunseconds=900
+[filtering]
+ignore=example.com
+  cdn.redhat.com
+  file:///modules
+  tools.ietf.org
+  host/unattended/provision
+  projects.theforeman.org
+  access.redhat.com/solutions

--- a/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
@@ -128,7 +128,7 @@ Use one of the following methods to distribute the public SSH key from {SmartPro
 
 {Project} distributes SSH keys for the remote execution feature to the hosts provisioned from {Project} by default.
 
-If the hosts are running on Amazon Web Services, enable password authentication. For more information, see link:https://aws.amazon.com/premiumsupport/knowledge-center/ec2-password-login/[].
+If the hosts are running on Amazon Web Services, enable password authentication. For more information, see link:https://aws.amazon.com/premiumsupport/knowledge-center/[].
 
 [[sect-Managing_Hosts-Distributing_SSH_Keys_for_Remote_Execution_Manually]]
 ==== Distributing SSH Keys for Remote Execution Manually

--- a/guides/find-href
+++ b/guides/find-href
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Use this helper to find anchors. Example:
+#
+#
+# $ ./find-href activation
+# build/doc-Content_Management_Guide/index-foreman.html#Managing_Activation_Keys
+# build/doc-Content_Management_Guide/index-foreman.html#Managing_Activation_Keys-Creating_an_Activation_Key
+# build/doc-Content_Management_Guide/index-foreman.html#Managing_Activation_Keys-Updating_Subscriptions_Associated_with_an_Activation_Key
+# build/doc-Content_Management_Guide/index-foreman.html#Managing_Activation_Keys-Using_Activation_Keys
+# build/doc-Content_Management_Guide/index-foreman.html#Managing_Activation_Keys-Enabling_Auto_Attach
+# build/doc-Content_Management_Guide/index-foreman.html#Managing_Activation_Keys-Setting_the_Service_Level
+#
+
+grep -Ro "href=\"#[^\"]*" build/ | grep -i "$1" | sed s/:href=\"//g


### PR DESCRIPTION
The article no longer exists. This fixes the link in the text.

Also this is a refactoring of Makefile, linkchecker is now called via `xargs` which gives much better results for viewing (single call). Also this supports now linkchecker-tryer which is a tool that tries to retry on links when error is returned.