### PR TITLE
Update UI label for SSH User

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
@@ -286,7 +286,7 @@ To set up {Project} to use Kerberos authentication for remote execution on hosts
  --foreman-proxy-plugin-remote-execution-ssh-ssh-kerberos-auth true
 ----
 +
-. To edit the default user for remote execution, in the {Project} web UI, navigate to *Administer* > *Settings* and click the *RemoteExecution* tab. In the *remote_execution_ssh_user* row, edit the second column and add the user name for the Kerberos account.
+. To edit the default user for remote execution, in the {Project} web UI, navigate to *Administer* > *Settings* and click the *RemoteExecution* tab. In the *SSH User* row, edit the second column and add the user name for the Kerberos account.
 . Navigate to *remote_execution_effective_user* and edit the second column to add the user name for the Kerberos account.
 
 To confirm that Kerberos authentication is ready to use, run a remote job on the host.


### PR DESCRIPTION
Bug 1859361 - [DDF] This is displayed as SSH User. Hovering over it shows remote_execution_ssh_user in the tool tip

https://bugzilla.redhat.com/show_bug.cgi?id=1859361