### PR TITLE
Use attribute for installing package on Satellite

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
@@ -273,8 +273,9 @@ To set up {Project} to use Kerberos authentication for remote execution on hosts
 
 . To install the `tfm-rubygem-net-ssh-krb` package, enter the following command:
 +
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum install tfm-rubygem-net-ssh-krb
+# {packages-install} tfm-rubygem-net-ssh-krb
 ----
 +
 . To install and enable Kerberos authentication for remote execution, enter the following command:


### PR DESCRIPTION
Bug 1859359 - [DDF] This command fails, I'm presuming because of package lock. The command in step 2 installs it if missing though

https://bugzilla.redhat.com/show_bug.cgi?id=1859359