### PR TITLE
Remove the redundant step

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Running_Jobs_on_Hosts.adoc
@@ -271,13 +271,6 @@ Before you can use Kerberos authentication for remote execution on {ProjectName}
 
 To set up {Project} to use Kerberos authentication for remote execution on hosts, complete the following steps:
 
-. To install the `tfm-rubygem-net-ssh-krb` package, enter the following command:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {package-install-project} tfm-rubygem-net-ssh-krb
-----
-+
 . To install and enable Kerberos authentication for remote execution, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
The package is installed by the `satellite installer --foreman-proxy-plugin-remote-execution-ssh-ssh-kerberos-auth true` step

Bug 1859359 - [DDF] This command fails, I'm presuming because of package lock. The command in step 2 installs it if missing though

https://bugzilla.redhat.com/show_bug.cgi?id=1859359