### PR TITLE
Add command that patches Satellite base OS

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -38,6 +38,7 @@ ifeval::["{build}" == "foreman"]
 :package-clean: yum clean
 :package-remove: yum remove
 :package-install-project: yum install
+:package-update-project: yum update
 :package-remove-project: yum remove
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy
@@ -87,6 +88,7 @@ ifeval::["{build}" == "satellite"]
 :package-clean: yum clean
 :package-remove: yum remove
 :package-install-project: satellite-maintain packages install
+:package-update-project: satellite-maintain packages update
 :package-remove-project: satellite-maintain packages remove
 :certs-generate: capsule-certs-generate
 :certs-proxy-context: capsule
@@ -139,6 +141,7 @@ ifeval::["{build}" == "foreman-deb"]
 :package-clean: apt-get clean
 :package-remove: apt-get remove
 :package-install-project: apt-get install
+:package-update-project: apt-get update
 :package-remove-project: apt-get remove
 :certs-generate: foreman-proxy-certs-generate
 :installer-scenario-smartproxy: foreman-installer --no-enable-foreman

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
@@ -101,6 +101,7 @@ If you use an untypical file system (other than for example ext3, ext4, or xfs),
 +
 . If some Pulp tasks failed due to the full disk, run them again.
 
+ifeval::["{build}" == "satellite"]
 [id='installing-and-updating-packages-on-satellite-server']
 === Managing Packages on the Base Operating System of {Project} or {SmartProxy}
 
@@ -116,14 +117,21 @@ IMPORTANT: The `{foreman-maintain} packages` command restarts some services on t
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {foreman-maintain} packages install _package_1_ _package_2_
+# {package-install-project} _package_1_ _package_2_
 ----
 
-* To update packages on {Project} or {SmartProxy}, enter the following command:
+* To update specific packages on {Project} or {SmartProxy}, enter the following command:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {foreman-maintain} packages update _package_1_ _package_2_
+# {package-update-project} _package_1_ _package_2_
+----
+
+* To update all packages on {Project} or {SmartProxy}, enter the following command:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {package-update-project}
 ----
 
 .Using yum to Check for Package Updates
@@ -155,3 +163,4 @@ If you want to restore the default settings and enable {Project} or {SmartProxy}
 ----
 # {foreman-maintain} packages lock
 ----
+endif::[]


### PR DESCRIPTION
Mark the whole section Managing Packages on the Base Operating System of Satellite Server to be built for Satellite only as package lock is not enabled on Foreman by default

Bug 1859747 - [RFE] Add a section on patching the Operating System in the "Administering Red Hat Satellite documentation

https://bugzilla.redhat.com/show_bug.cgi?id=1859747