### PR TITLE
Change wording in Load Balanced configuration to quantify support for Provisioning

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
@@ -28,7 +28,7 @@ Load balancer works with the following services and features:
 * Content Management with `yum` repositories
 * Optional: Puppet
 
-NOTE: In the load-balanced setup, a load balancer distributes load only for the services and features mentioned above. If other services such as provisioning, or virt-who are running on the individual {SmartProxies}, you must access them directly through {SmartProxies} and not through the load balancer.
+NOTE: In the load-balanced setup, a load balancer distributes load only for the services and features mentioned above. If other services, such as provisioning or virt-who, are running on the individual {SmartProxies}, you must access them directly through {SmartProxies} and not through the load balancer.
 
 .Managing Puppet Limitations
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
@@ -28,7 +28,7 @@ Load balancer works with the following services and features:
 * Content Management with `yum` repositories
 * Optional: Puppet
 
-NOTE: The Load Balanced setup offers high availability for accessing yum or Puppet content. Other services running on the individual {SmartProxyServer}s such as provisioning, virt-who etc should not be accessed through the Load Balancer but can be accessed directly from the {SmartProxy}.
+NOTE: In the load-balanced setup, a load balancer distributes load only for the services and features mentioned above. If other services such as provisioning, or virt-who are running on the individual {SmartProxies}, you must access them directly through {SmartProxies} and not through the load balancer.
 
 .Managing Puppet Limitations
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
@@ -28,7 +28,7 @@ Load balancer works with the following services and features:
 * Content Management with `yum` repositories
 * Optional: Puppet
 
-NOTE: Provisioning hosts is not supported in the {Project} load-balanced setup.
+NOTE: The Load Balanced setup offers high availability for accessing yum or Puppet content. Other services running on the individual {SmartProxyServer}s such as provisioning, virt-who etc should not be accessed through the Load Balancer but can be accessed directly from the {SmartProxy}.
 
 .Managing Puppet Limitations
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1865846
"Provisioning hosts is not supported in the Satellite load-balanced setup." The previous statement does not make it clear that provisioning/virt-who or other content is supported to be installed on the individual capsules that are load balanced but not the HA itself.
