### PR TITLE
Add assembly/doc files for satellite ansible content collections

### DIFF
--- a/guides/common/assembly_using-satellite-ansible-content-collections.adoc
+++ b/guides/common/assembly_using-satellite-ansible-content-collections.adoc
@@ -1,0 +1,12 @@
+ifdef::context[:parent-context: {context}]
+
+[id="using-satellite-ansible-content-collections_{context}"]
+== Using {Project} Ansible Content Collections
+
+The {Project} Ansible Content Collections is a set of Ansible modules and plug-ins that you can use to manage {Project}.
+
+include::modules/proc_installing-satellite-ansible-modules-via-rpm.adoc[leveloffset=+1]
+
+include::modules/proc_listing-using-satellite-ansible-modules.adoc[leveloffset=+1]
+
+

--- a/guides/common/modules/proc_installing-satellite-ansible-modules-via-rpm.adoc
+++ b/guides/common/modules/proc_installing-satellite-ansible-modules-via-rpm.adoc
@@ -1,0 +1,37 @@
+[id="installing-satellite-ansible-modules-via-rpm_{context}"]
+== Installing the {Project} Ansible Modules from RPM
+
+Use this procedure to install the {Project} Ansible modules.
+
+ifeval::["{build}" == "satellite"]
+.Prerequisite
+
+* Ensure that the Ansible 2.9 or later repository is enabled and the ansible package is updated:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable rhel-7-server-ansible-2.9-rpms
+# {foreman-maintain} packages update ansible
+----
+endif::[]
+
+.Procedure
+
+ifeval::["{build}" == "satellite"]
+
+* Install the RPM using the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} ansible-collection-redhat-satellite
+----
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+* Install the RPM from the client repository on yum.theforeman.org using the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} ansible-collection-theforeman-foreman
+----
+endif::[]

--- a/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
+++ b/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
@@ -1,0 +1,47 @@
+[id="listing-using-satellite-ansible-modules_{context}"]
+== Viewing the {Project} Ansible Modules
+
+You can view the installed {Project} Ansible modules by listing the content of the following directory:
+
+ifeval::["{build}" == "satellite"]
+----
+# ls /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
+----
+
+Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at https://cloud.redhat.com/ansible/automation-hub/redhat/satellite/docs in the Automation Hub.
+
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+----
+# ls /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/
+----
+
+Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at https://galaxy.ansible.com/theforeman/foreman in the Ansible Galaxy.
+
+endif::[]
+
+
+[NOTE]
+====
+At the time of writing, the `ansible-doc -l` command does not list collections yet.
+====
+
+ifeval::["{build}" == "satellite"]
+
+All modules are in the `redhat.satellite` namespace and can be referred to in the format `redhat.satellite._module_name_`. For example, to display information about the `activation_key` module, enter the following command:
+----
+$ ansible-doc redhat.satellite.activation_key
+----
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+
+All modules are in the `theforeman.foreman` namespace and can be referred to in the format `theforeman.foreman._module_name_`. For example, to display information about the `katello_activation_key` module, enter the following command:
+----
+$ ansible-doc theforeman.foreman.katello_activation_key
+----
+endif::[]
+
+
+

--- a/guides/doc-Administering_Red_Hat_Satellite/master.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/master.adoc
@@ -19,6 +19,8 @@ include::common/assembly_migrating-from-internal-databases-to-external-databases
 
 include::topics/adding_rhel_system_roles.adoc[]
 
+include::common/assembly_using-satellite-ansible-content-collections.adoc[]
+
 include::topics/Users_and_Roles.adoc[]
 
 include::topics/Security_Compliance_Management.adoc[]


### PR DESCRIPTION
Content files backported from master #228 . PR for 6.8-beta

[RFE] Include Satellite Ansible modules with Ansible Core modules
https://bugzilla.redhat.com/show_bug.cgi?id=1828242