### PR TITLE
Enable satellite-sync to keep working versions upstream

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,8 +1,8 @@
 :ProjectVersion: 2.0
 :KatelloVersion: 3.15
-:TargetVersion: 6.8-beta
+:TargetVersion: 6.7
 :ProductVersion: 6.7
-:ProductVersionPrevious: 6.7
+:ProductVersionPrevious: 6.6
 :ProductVersionRepoTitle: 6.8 Beta
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.7-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.6-rpms

--- a/guides/scripts/satellite-sync.sh
+++ b/guides/scripts/satellite-sync.sh
@@ -119,6 +119,12 @@ fi
 cd $DS_REPO
 sed '1s/^/\:build\: satellite\n/' common/attributes.adoc > common/attributes.tmp
 mv common/attributes.tmp common/attributes.adoc
+sed 's/:TargetVersion: 6.7/:TargetVersion: 6.8-beta/g' common/attributes.adoc > common/attributes.tmp
+mv common/attributes.tmp common/attributes.adoc
+sed 's/:ProductVersion: 6.7/:ProductVersion: 6.8-beta/g' common/attributes.adoc > common/attributes.tmp
+mv common/attributes.tmp common/attributes.adoc
+sed 's/:ProductVersionPrevious: 6.6/:ProductVersionPrevious: 6.7/g' common/attributes.adoc > common/attributes.tmp
+mv common/attributes.tmp common/attributes.adoc
 find common -name '*.adoc' -type f -exec sed -i -e 's/{project-context}/satellite/g' -- {} +
 find common -name '*.adoc' -type f -exec sed -i -e 's/{smart-proxy-context}/capsule/g' -- {} +
 


### PR DESCRIPTION
Upstream, Git checks link with each PR. For the links to work, the ProductVersion attribute must be set to a version that has live docs on customer portal, which is now 6.7. Downstream, this versions needs to be changed to 6.8-beta. This is now done with the satellite-sync script