### PR TITLE
Remove unneccessary {ProductVersion}

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Integrating_Satellite_and_Ansible_Tower.adoc
+++ b/guides/doc-Managing_Hosts/topics/Integrating_Satellite_and_Ansible_Tower.adoc
@@ -1,7 +1,7 @@
 [[chap-Red_Hat_Satellite-Managing_Hosts-Integrating_Satellite_and_Ansible_Tower]]
 == Integrating {ProjectName} and Ansible Tower
 
-You can integrate {ProjectName}{nbsp}{ProductVersion} and Ansible Tower to use {ProjectServer} as a dynamic inventory source for Ansible Tower.
+You can integrate {ProjectName} and Ansible Tower to use {ProjectServer} as a dynamic inventory source for Ansible Tower.
 
 You can also use the provisioning callback function to run playbooks on hosts managed by {Project}, from either the host or Ansible Tower. When provisioning new hosts from {ProjectServer}, you can use the provisioning callback function to trigger playbook runs from Ansible Tower. The playbook configures the host following Kickstart deployment.
 


### PR DESCRIPTION
Fixes #210 

I spotted this a while back while sharing with an upstream community member. 
I don't think that the product version here is necessary. It's been a feature since Satellite 6.3... it adds no value. 