### PR TITLE
Handle custom term upstream

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -73,6 +73,20 @@ ifeval::["{build}" == "foreman"]
 :Team: Foreman developers
 :project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
 :project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
+:customcontent: content
+:customcontenttitle: Content
+:customproduct: product
+:customproducttitle: Product
+:customgpgtitle: GPG
+:customssltitle: SSL
+:customssl: SSL
+:customrpmtitle: RPM
+:customrpm: RPM
+:customrepo: repository
+:customfiletypetitle: File Type
+:customfiletype: file type
+:customostreecontenttitle: OSTree Content
+:customostreecontent: OSTree content
 endif::[]
 
 ifeval::["{build}" == "satellite"]
@@ -125,6 +139,20 @@ ifeval::["{build}" == "satellite"]
 :Team: Red{nbsp}Hat
 :project-client-RHEL7-url: rhel-7-server-satellite-tools-6-beta-rpms
 :project-client-name: Satellite Tools {ProductVersionRepoTitle}
+:customcontent: custom content
+:customcontenttitle: Custom Content
+:customproduct: custom product
+:customproducttitle: Custom Product
+:customgpgtitle: Custom GPG
+:customssltitle: Custom SSL
+:customssl: custom SSL
+:customrpmtitle: Custom RPM
+:customrpm: custom RPM
+:customrepo: custom repository
+:customfiletypetitle: Custom File Type
+:customfiletype: custom file type
+:customostreecontenttitle: Custom OSTree Content
+:customostreecontent: custom OSTree content
 endif::[]
 
 ifeval::["{build}" == "foreman-deb"]

--- a/guides/doc-Content_Management_Guide/master.adoc
+++ b/guides/doc-Content_Management_Guide/master.adoc
@@ -16,9 +16,21 @@ include::topics/Managing_Locations.adoc[]
 
 include::topics/Managing_Subscriptions.adoc[]
 
+ifeval::["{build}" == "satellite"]
+
 include::topics/Importing_Red_Hat_Content.adoc[]
 
 include::topics/Importing_Custom_Content.adoc[]
+
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+
+include::topics/Importing_Custom_Content.adoc[]
+
+include::topics/Importing_Red_Hat_Content.adoc[]
+
+endif::[]
 
 include::topics/Creating_an_Application_Life_Cycle.adoc[]
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Custom_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Custom_Content.adoc
@@ -1,9 +1,9 @@
 [[Importing_Custom_Content]]
-== Importing Custom Content
+== Importing {customcontenttitle}
 
-This chapter outlines how you can import custom content of different types to {Project}. If you want to import ISOs, Puppet modules, or different content types to {Project}, it is done with largely the same procedures in this chapter.
+This chapter outlines how you can import {customcontent} of different types to {Project}. If you want to import ISOs, Puppet modules, or different content types to {Project}, it is done with largely the same procedures in this chapter.
 
-For example, you can use the following chapters for information on specific types of custom content but the underlying procedures are the same:
+For example, you can use the following chapters for information on specific types of {customcontent} but the underlying procedures are the same:
 
 * xref:Managing_OSTree_Content[]
 * xref:Managing_ISO_Images[]
@@ -11,19 +11,25 @@ For example, you can use the following chapters for information on specific type
 * xref:Managing_Custom_Puppet_Content[]
 
 [[Using_Custom_Products_in_Satellite]]
-=== Using Custom Products in {Project}
+=== Using {customproducttitle}s in {Project}
 
-Both Red Hat content and custom content in {ProjectNameX} have similarities:
+ifeval::["{build}" == "satellite"]
+Both Red Hat content and {customcontent} in {Project} have similarities:
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+Both Red Hat content and non-RH {customcontent} in {Project} have similarities:
+endif::[]
 
   - The relationship between a product and its repositories is the same and the repositories still require synchronization.
-  - Custom products require a subscription for clients to access, similar to subscriptions to Red Hat Products. {ProjectNameX} creates a subscription for each custom product you create.
+  - {customproduct} require a subscription for clients to access, similar to subscriptions to Red Hat Products. {Project} creates a subscription for each {customproduct} you create.
 
 For more information about creating and packaging RPMs, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/rpm_packaging_guide/[RPM Packaging Guide] in the Red{nbsp}Hat Enterprise Linux documentation.
 
 [[Importing_Custom_Content-Importing_Custom_SSL_Certificates]]
-=== Importing Custom SSL Certificates
+=== Importing {customssltitle} Certificates
 
-Before you create custom content, ensure that you import any Custom SSL certificates that you require.
+Before you create {customcontent}, ensure that you import any {customssl} certificates that you require.
 
 If you require SSL certificates and keys to download RPMs, you can add them to {Project}.
 
@@ -35,9 +41,9 @@ If you require SSL certificates and keys to download RPMs, you can add them to {
 
 
 [[Importing_Custom_Content-Importing_a_Custom_GPG_Key]]
-=== Importing a Custom GPG Key
+=== Importing a {customgpgtitle} Key
 
-Before you create custom content, ensure that you import any GPG keys that you require.
+Before you create {customcontent}, ensure that you import any GPG keys that you require.
 
 .Prerequisites
 
@@ -65,7 +71,7 @@ To import a GPG key, complete the following procedure:
 . Enter the name of your repository and select *GPG Key* from the *Type* list.
 . Either paste the GPG key into the *Content Credential Contents* field, or click *Browse* and select the GPG key file that you want to import.
 +
-If your custom repository contains content signed by multiple GPG keys, you must enter all required GPG keys in the *Content Credential Contents* field with new lines between each key, for example:
+If your {customrepo} contains content signed by multiple GPG keys, you must enter all required GPG keys in the *Content Credential Contents* field with new lines between each key, for example:
 +
 ----
 -----BEGIN PGP PUBLIC KEY BLOCK-----
@@ -106,16 +112,16 @@ $ scp ~/etc/pki/rpm-gpg/RPM-GPG-KEY-_EXAMPLE-95_ root@{foreman-example-com}:~/.
 ----
 
 [[Importing_Custom_Content-Creating_a_Custom_Product]]
-=== Creating a Custom Product
+=== Creating a {customproducttitle}
 
-Use this procedure to create a custom product that you can then add repositories to.
+Use this procedure to create a {customproduct} that you can then add repositories to.
 
 .Procedure
 
-To create a custom product, complete the following procedure:
+To create a {customproduct}, complete the following procedure:
 
 . In the {Project} web UI, navigate to *Content* > *Products*, click *Create Product*.
-. In the *Name* field, enter a name for the product. {ProjectNameX} automatically completes the *Label* field based on what you have entered for *Name*.
+. In the *Name* field, enter a name for the product. {Project} automatically completes the *Label* field based on what you have entered for *Name*.
 . Optional: From the *GPG Key* list, select the GPG key for the product.
 . Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the product.
 . Optional: From the *SSL Client Cert* list, select the SSL client certificate for the product.
@@ -138,14 +144,19 @@ To create the product, enter the following command:
 ----
 
 [[Importing_Custom_Content-Creating_a_Custom_RPM_Repository]]
-=== Adding a Custom RPM Repository
+=== Adding a {customrpmtitle} Repository
 
-Use this procedure to add a custom RPM repository in {Project}.
+Use this procedure to add a {customrpm} repository in {Project}.
 
-The Products window in the {Project} web UI also provides a *Repo Discovery* function that finds all repositories from a URL and you can select which ones to add to your custom product. For example, you can use the *Repo Discovery* to search, for example, `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures. This helps users save time importing multiple repositories from a single source.
+The Products window in the {Project} web UI also provides a *Repo Discovery* function that finds all repositories from a URL and you can select which ones to add to your {customproduct}. For example, you can use the *Repo Discovery* to search, for example, `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures. This helps users save time importing multiple repositories from a single source.
 
-.Support for Custom RPMs
+ifeval::["{build}" == "satellite"]
+
+.Support for {customrpmtitle}s
+
 Red Hat does not support the upstream RPMs directly from third-party sites. These RPMs are used to demonstrate the synchronization process. For any issues with these RPMs, contact the third-party developers.
+
+endif::[]
 
 .Procedure
 
@@ -189,15 +200,15 @@ If you want to perform an immediate synchronization, in your product window, cli
 ----
 
 [[uploading-content-to-a-custom-rpm-repository]]
-=== Uploading Content to a Custom RPM Repository
+=== Uploading Content to a {customrpmtitle} Repository
 
-You can upload individual RPMs and source RPMs to a custom RPM repository. You can upload RPMs using the {Project} web UI or the Hammer CLI. You must use the Hammer CLI to upload source RPMs.
+You can upload individual RPMs and source RPMs to a {customrpm} repository. You can upload RPMs using the {Project} web UI or the Hammer CLI. You must use the Hammer CLI to upload source RPMs.
 
 .Procedure
 
 . In the {Project} web UI, click *Content* > *Products*.
-. Click the name of the custom Product.
-. In the *Repositories* tab, click the name of the custom RPM repository.
+. Click the name of the {customproduct}.
+. In the *Repositories* tab, click the name of the {customrpm} repository.
 . Under *Upload Package*, click *Browse...* and select the RPM you want to upload.
 . Click *Upload*.
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Custom_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Custom_Content.adoc
@@ -144,9 +144,9 @@ To create the product, enter the following command:
 ----
 
 [[Importing_Custom_Content-Creating_a_Custom_RPM_Repository]]
-=== Adding a {customrpmtitle} Repository
+=== Adding {customrpmtitle} Repositories
 
-Use this procedure to add a {customrpm} repository in {Project}.
+Use this procedure to add {customrpm} repositories in {Project}.
 
 The Products window in the {Project} web UI also provides a *Repo Discovery* function that finds all repositories from a URL and you can select which ones to add to your {customproduct}. For example, you can use the *Repo Discovery* to search, for example, `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures. This helps users save time importing multiple repositories from a single source.
 
@@ -200,9 +200,9 @@ If you want to perform an immediate synchronization, in your product window, cli
 ----
 
 [[uploading-content-to-a-custom-rpm-repository]]
-=== Uploading Content to a {customrpmtitle} Repository
+=== Uploading Content to {customrpmtitle} Repositories
 
-You can upload individual RPMs and source RPMs to a {customrpm} repository. You can upload RPMs using the {Project} web UI or the Hammer CLI. You must use the Hammer CLI to upload source RPMs.
+You can upload individual RPMs and source RPMs to {customrpm} repositories. You can upload RPMs using the {Project} web UI or the Hammer CLI. You must use the Hammer CLI to upload source RPMs.
 
 .Procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Custom_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Custom_Content.adoc
@@ -22,7 +22,7 @@ Both Red Hat content and non-RH {customcontent} in {Project} have similarities:
 endif::[]
 
   - The relationship between a product and its repositories is the same and the repositories still require synchronization.
-  - {customproduct} require a subscription for clients to access, similar to subscriptions to Red Hat Products. {Project} creates a subscription for each {customproduct} you create.
+  - {customproduct}s require a subscription for clients to access, similar to subscriptions to Red Hat Products. {Project} creates a subscription for each {customproduct} you create.
 
 For more information about creating and packaging RPMs, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/rpm_packaging_guide/[RPM Packaging Guide] in the Red{nbsp}Hat Enterprise Linux documentation.
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
@@ -68,7 +68,7 @@ To change the default download policy for repositories, complete the following s
 
 To change the default download policy for Red Hat repositories to one of `immediate`, `on_demand`, or `background`, enter the following command:
 
-[subs="+quotes"]topics/Managing_ISOs_and_Files.adoc
+[subs="+quotes"]
 ----
 # hammer settings set \
 --name default_redhat_download_policy \

--- a/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
@@ -51,7 +51,7 @@ These policies are not available if a {SmartProxy} was installed or updated with
 
 === Changing the Default Download Policy
 
-You can set the default download policy that {Project} applies to repositories that you create in all organizations. {Project} uses separate settings for Red Hat and {customrepos}. Changing the default value does not change existing settings.
+You can set the default download policy that {Project} applies to repositories that you create in all organizations. {Project} uses separate settings for Red Hat and {customrepo}. Changing the default value does not change existing settings.
 
 .Procedure
 
@@ -62,7 +62,7 @@ To change the default download policy for repositories, complete the following s
 . Change the default download policy depending on your requirements:
 +
 * To change the default download policy for Red Hat repositories, change the value of the *Default Red Hat Repository download policy* setting.
-* To change the default download policy for {customrepos}, change the value of the *Default Custom Repository download policy* setting.
+* To change the default download policy for {customrepo}, change the value of the *Default Custom Repository download policy* setting.
 
 .For CLI Users
 
@@ -75,7 +75,7 @@ To change the default download policy for Red Hat repositories to one of `immedi
 --value _immediate_
 ----
 
-To change the default download policy for {customrepos} to one of `immediate`, `on_demand`, or `background`, enter the following command:
+To change the default download policy for {customrepo} to one of `immediate`, `on_demand`, or `background`, enter the following command:
 
 [subs="+quotes"]
 ----

--- a/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
@@ -51,7 +51,7 @@ These policies are not available if a {SmartProxy} was installed or updated with
 
 === Changing the Default Download Policy
 
-You can set the default download policy that {Project} applies to repositories that you create in all organizations. {Project} uses separate settings for Red Hat and custom repositories. Changing the default value does not change existing settings.
+You can set the default download policy that {Project} applies to repositories that you create in all organizations. {Project} uses separate settings for Red Hat and {customrepos}. Changing the default value does not change existing settings.
 
 .Procedure
 
@@ -62,20 +62,20 @@ To change the default download policy for repositories, complete the following s
 . Change the default download policy depending on your requirements:
 +
 * To change the default download policy for Red Hat repositories, change the value of the *Default Red Hat Repository download policy* setting.
-* To change the default download policy for custom repositories, change the value of the *Default Custom Repository download policy* setting.
+* To change the default download policy for {customrepos}, change the value of the *Default Custom Repository download policy* setting.
 
 .For CLI Users
 
 To change the default download policy for Red Hat repositories to one of `immediate`, `on_demand`, or `background`, enter the following command:
 
-[subs="+quotes"]
+[subs="+quotes"]topics/Managing_ISOs_and_Files.adoc
 ----
 # hammer settings set \
 --name default_redhat_download_policy \
 --value _immediate_
 ----
 
-To change the default download policy for custom repositories to one of `immediate`, `on_demand`, or `background`, enter the following command:
+To change the default download policy for {customrepos} to one of `immediate`, `on_demand`, or `background`, enter the following command:
 
 [subs="+quotes"]
 ----

--- a/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
@@ -51,7 +51,19 @@ These policies are not available if a {SmartProxy} was installed or updated with
 
 === Changing the Default Download Policy
 
-You can set the default download policy that {Project} applies to repositories that you create in all organizations. {Project} uses separate settings for Red Hat and {customrepo}. Changing the default value does not change existing settings.
+You can set the default download policy that {Project} applies to repositories that you create in all organizations.
+
+ifeval::["{build}" == "satellite"]
+
+Depending on whether it is a Red Hat or {customrepo}, {Project} uses separate settings. Changing the default value does not change existing settings.
+
+endif::[]
+
+ifeval::["{build}" != "satellite"]
+
+Depending on whether it is a Red Hat or non-Red Hat {customrepo}, {Project} uses separate settings. Changing the default value does not change existing settings.
+
+endif::[]
 
 .Procedure
 
@@ -61,8 +73,15 @@ To change the default download policy for repositories, complete the following s
 . Click the *Content* tab.
 . Change the default download policy depending on your requirements:
 +
-* To change the default download policy for Red Hat repositories, change the value of the *Default Red Hat Repository download policy* setting.
-* To change the default download policy for {customrepo}, change the value of the *Default Custom Repository download policy* setting.
+* To change the default download policy for a Red Hat repository, change the value of the *Default Red Hat Repository download policy* setting.
+ifeval::["{build}" == "satellite"]
+* To change the default download policy for a {customrepo}, change the value of the *Default Custom Repository download policy* setting.
+endif::[]
+ifeval::["{build}" != "satellite"]
+* To change the default download policy for a non-Red Hat {customrepo}, change the value of the *Default Custom Repository download policy* setting.
+endif::[]
+
+
 
 .For CLI Users
 
@@ -75,7 +94,13 @@ To change the default download policy for Red Hat repositories to one of `immedi
 --value _immediate_
 ----
 
-To change the default download policy for {customrepo} to one of `immediate`, `on_demand`, or `background`, enter the following command:
+ifeval::["{build}" == "satellite"]
+To change the default download policy for a {customrepo} to one of `immediate`, `on_demand`, or `background`, enter the following command:
+endif::[]
+
+ifeval::["{build}" == "satellite"]
+To change the default download policy for a non-Red Hat {customrepo} to one of `immediate`, `on_demand`, or `background`, enter the following command:
+endif::[]
 
 [subs="+quotes"]
 ----

--- a/guides/doc-Content_Management_Guide/topics/Introduction.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Introduction.adoc
@@ -5,7 +5,7 @@ In the context of {ProjectX}, _content_ is defined as the software installed on 
 
 ifeval::["{build}" == "foreman"]
 [IMPORTANT]
-The Katello plug-in provides content management features to Foreman. You can only use this guide if you have the Katello plug-in installed. 
+The Katello plug-in provides content management features to Foreman. You can only use this guide if you have the Katello plug-in installed.
 endif::[]
 
 {ProjectNameX} manages the following content:
@@ -28,7 +28,7 @@ RPM Packages::
 Kickstart Trees::
   Import the kickstart trees for creating a system. New systems access these kickstart trees over a network to use as base content for their installation. {ProjectNameX} also contains some predefined kickstart templates as well as the ability to create your own, which are used to provision systems and customize the installation.
 
-You can also manage custom content in {ProjectNameX}. For example:
+You can also manage other types of {customcontent} in {Project}. For example:
 
 ISO and KVM Images::
   Download and manage media for installation and provisioning. For example, {Project} downloads, stores and manages ISO images and guest images for specific Red Hat Enterprise Linux and non-Red Hat operating systems.
@@ -39,4 +39,4 @@ Puppet Modules::
 OSTree::
   You can import OSTree branches and publish this content to an HTTP location.
 
-You can use the procedure to add custom content for any type of content you require, for example, SSL certificates and OVAL files.
+You can use the procedure to add {customcontent} for any type of content you require, for example, SSL certificates and OVAL files.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -60,8 +60,8 @@ If there are subscriptions specified and auto-attach is enabled, hosts using the
 +
 If there are subscriptions specified and auto-attach is disabled, hosts using the activation key are associated with all subscriptions specified in the activation key. Setting system purpose on the activation key does not affect this scenario.
 
-.Custom Products
-If a custom product, typically containing content not provided by Red Hat, is assigned to an activation key, this product is always enabled for the registered content host regardless of the auto-attach setting.
+.{customproducttitle}s
+If a {customproduct}, typically containing content not provided by Red Hat, is assigned to an activation key, this product is always enabled for the registered content host regardless of the auto-attach setting.
 
 .Procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -135,7 +135,7 @@ Use this procedure to create a Content View using one repository and no filters.
 
 .Prerequisites
 
-Before you begin, upload the required Puppet module to a repository within a custom product. For more information, see {BaseURL}puppet_guide/chap-red_hat_satellite-puppet_guide-adding_puppet_modules_to_red_hat_satellite_6[Adding Puppet Modules to {ProjectNameX}] in the _Puppet Guide_.
+Before you begin, upload the required Puppet module to a repository within a {customproduct}. For more information, see {BaseURL}puppet_guide/chap-red_hat_satellite-puppet_guide-adding_puppet_modules_to_red_hat_satellite_6[Adding Puppet Modules to {ProjectNameX}] in the _Puppet Guide_.
 
 .Procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -1,32 +1,32 @@
 [[Managing_Custom_File_Type_Content]]
-== Managing Custom File Type Content
+== Managing {customfiletypetitle} Content
 
-In {Project}, you might require methods of managing and distributing SSH keys and source code files or larger files such as virtual machine images and ISO files. To achieve this, custom products in {ProjectName} include repositories for custom file types. This provides a generic method to incorporate arbitrary files in a product.
+In {Project}, you might require methods of managing and distributing SSH keys and source code files or larger files such as virtual machine images and ISO files. To achieve this, (customproduct)s in {ProjectName} include repositories for {customfiletype}s. This provides a generic method to incorporate arbitrary files in a product.
 
-You can upload files to the repository and synchronize files from an upstream {ProjectServer}. When you add files to a custom file type repository, you can use the normal {Project} management functions such as adding a specific version to a Content View to provide version control and making the repository of files available on various {SmartProxyServer}s. Clients must download the files over HTTP or HTTPS using `curl -O`.
+You can upload files to the repository and synchronize files from an upstream {ProjectServer}. When you add files to a {customfiletype} repository, you can use the normal {Project} management functions such as adding a specific version to a Content View to provide version control and making the repository of files available on various {SmartProxyServer}s. Clients must download the files over HTTP or HTTPS using `curl -O`.
 
-You can create a file type repository in {ProjectServer} only in a custom product, but there is flexibility in how you create the file type repository. You can create an independent file type repository in a directory on the system where {Project} is installed, or on a remote HTTP server, and then synchronize the contents of that directory into {Project}. This method is useful when you have multiple files to add to a {Project} repository.
+You can create a file type repository in {ProjectServer} only in a (customproduct), but there is flexibility in how you create the file type repository. You can create an independent file type repository in a directory on the system where {Project} is installed, or on a remote HTTP server, and then synchronize the contents of that directory into {Project}. This method is useful when you have multiple files to add to a {Project} repository.
 
 [[Importing_Custom_Content-Creating_a_Custom_File_Type_Repository]]
-=== Creating a Custom File Type Repository in {ProjectName}
+=== Creating a {customfiletypetitle} Repository in {ProjectName}
 
-The procedure for creating a custom file type repository is the same as the procedure for creating any custom content, except that when you create the repository, you select the *file* type. You must create a product and then add a custom repository.
+The procedure for creating a {customfiletype} repository is the same as the procedure for creating any {customcontent}, except that when you create the repository, you select the *file* type. You must create a product and then add a {customrepo}.
 
 .Procedure
 
-To create a custom product, complete the following procedure:
+To create a (customproduct), complete the following procedure:
 
 . In the {Project} web UI, navigate to *Content* > *Products*, click *Create Product* and enter the following details:
-. In the *Name* field, enter a name for the product. {ProjectNameX} automatically completes the *Label* field based on what you have entered for *Name*.
+. In the *Name* field, enter a name for the product. {Project} automatically completes the *Label* field based on what you have entered for *Name*.
 . Optional: From the *GPG Key* list, select the GPG key for the product.
 . Optional: From the *Sync Plan* list, select a synchronization plan for the product.
 . In the *Description* field, enter a description of the product, and then click *Save*.
 
-To create a repository for your custom product, complete the following procedure:
+To create a repository for your (customproduct), complete the following procedure:
 
 . In the Products window, select the name of a product that you want to create a repository for.
 . Click the *Repositories* tab, and then click *New Repository*.
-. In the *Name* field, enter a name for the repository. {ProjectNameX} automatically completes the *Label* field based on the name.
+. In the *Name* field, enter a name for the repository. {Project} automatically completes the *Label* field based on the name.
 . From the *Type* list, select *file*.
 . In the *Upstream URL* field, enter the URL of the upstream repository to use as a source.
 . Select the *Verify SSL* check box if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.
@@ -36,7 +36,7 @@ To create a repository for your custom product, complete the following procedure
 
 .For CLI Users
 
-. Create a Custom Product
+. Create a {customproduct}
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -89,9 +89,9 @@ To create a repository for your custom product, complete the following procedure
 
 
 [[Importing_Custom_Content-Creating_a_Custom_File_Type_Repository_Local_Directory]]
-=== Creating a Custom File Type Repository in a Local Directory
+=== Creating a {customfiletypetitle} Repository in a Local Directory
 
-You can create a custom file type repository, from a directory of files, on the base system where {Project} is installed using the `pulp-manifest` command. You can then synchronize the files into {ProjectServer}. When you add files to a file type repository, you can work with the files as with any other repository.
+You can create a {customfiletype} repository, from a directory of files, on the base system where {Project} is installed using the `pulp-manifest` command. You can then synchronize the files into {ProjectServer}. When you add files to a file type repository, you can work with the files as with any other repository.
 
 Use this procedure to configure a repository in a directory on the base system where {Project} is installed. To create a file type repository in a directory on a remote server, see xref:Managing_Custom_File_Type_Content-Creating_a_Remote_File_Type_Repository[].
 
@@ -149,7 +149,7 @@ PULP_MANIFEST test.txt
 
 To import files from a file type repository in a local directory, complete the following procedure:
 
-. Ensure a custom product exists in {ProjectServer}.
+. Ensure a {customproduct} exists in {ProjectServer}.
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select the name of a product.
 . Click the *Repositories* tab and select *New Repository*.
@@ -174,7 +174,7 @@ To update the file type repository, complete the following steps:
 [[Managing_Custom_File_Type_Content-Creating_a_Remote_File_Type_Repository]]
 === Creating a Remote File Type Repository
 
-You can create a custom file type repository from a directory of files that is external to {ProjectServer} using the `pulp-manifest` command. You can then synchronize the files into {ProjectServer} over HTTP or HTTPS. When you add files to a file type repository, you can work with the files as with any other repository.
+You can create a {customfiletype} repository from a directory of files that is external to {ProjectServer} using the `pulp-manifest` command. You can then synchronize the files into {ProjectServer} over HTTP or HTTPS. When you add files to a file type repository, you can work with the files as with any other repository.
 
 Use this procedure to configure a repository in a directory on a remote server. To create a file type repository in a directory on the base system where {ProjectServer} is installed, see xref:Importing_Custom_Content-Creating_a_Custom_File_Type_Repository_Local_Directory[].
 
@@ -242,7 +242,7 @@ PULP_MANIFEST test.txt
 
 To import files from a remote file type repository, complete the following procedure:
 
-. Ensure a custom product exists in {ProjectServer}, or create a custom product. For more information see xref:Importing_Custom_Content-Creating_a_Custom_File_Type_Repository[]
+. Ensure a {customproduct} exists in {ProjectServer}, or create a {customproduct}. For more information see xref:Importing_Custom_Content-Creating_a_Custom_File_Type_Repository[]
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select the name of a product.
 . Click the *Repositories* tab and select *New Repository*.
@@ -260,14 +260,14 @@ To import files from a remote file type repository, complete the following proce
 Visit the URL where the repository is published to view the files.
 
 [[Importing_Custom_Content-Uploading_Files_To_a_Custom_File_Type_Repository]]
-=== Uploading Files To a Custom File Type Repository in {ProjectName}
+=== Uploading Files To a {customfiletypetitle} Repository in {ProjectName}
 
 .Procedure
 
-To upload files to a custom file type repository, complete the following steps:
+To upload files to a {customfiletype} repository, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Products*.
-. Select a custom product by name.
+. Select a {customproduct} by name.
 . Select a file type repository by name.
 . Click *Browse* to search and select the file you want to upload.
 . Click *Upload* to upload the selected file to {ProjectServer}.
@@ -286,13 +286,13 @@ To upload files to a custom file type repository, complete the following steps:
 The `--path` option can indicate a file, a directory of files, or a glob expression of files. Globs must be escaped by single or double quotes.
 
 [[Importing_Custom_Content-Downloading_Files_From_a_Custom_File_Type_Repository]]
-=== Downloading Files to a Host From a Custom File Type Repository in {ProjectName}
+=== Downloading Files to a Host From a {customfiletypetitle} Repository in {ProjectName}
 
 You can download files to a client over HTTPS using `curl -O`, and optionally over HTTP if the *Publish via HTTP* repository option is selected.
 
 .Prerequisites
 
-* You have a custom file type repository. See xref:Importing_Custom_Content-Creating_a_Custom_File_Type_Repository[] for more information.
+* You have a {customfiletype} repository. See xref:Importing_Custom_Content-Creating_a_Custom_File_Type_Repository[] for more information.
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 +
@@ -301,10 +301,10 @@ You can download files to a client over HTTPS using `curl -O`, and optionally ov
 
 .Procedure
 
-To download files to a host from a custom file type repository, complete the following procedure:
+To download files to a host from a {customfiletype} repository, complete the following procedure:
 
 . In the {Project} web UI, navigate to *Content* > *Products*.
-. Select a custom product by name.
+. Select a {customproduct} by name.
 . Select a file type repository by name.
 . Check to see if *Publish via HTTP* is enabled. If it is not, you require the certificates to use HTTPS.
 . Copy the URL where the repository is published.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_Puppet_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_Puppet_Content.adoc
@@ -6,7 +6,7 @@ In {Project}, if you want to incorporate state configuration of hosts using Pupp
 [[Importing_Custom_Content-Creating_a_Custom_Puppet_Repository]]
 === Creating a Puppet Repository
 
-The procedure for creating a Puppet module repository is the same as the procedure for creating any (customcontent), except that when you create the repository, you select the *puppet* type. You must create a product and then add a {customrepos}.
+The procedure for creating a Puppet module repository is the same as the procedure for creating any (customcontent), except that when you create the repository, you select the *puppet* type. You must create a product and then add a {customrepo}.
 
 .Procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_Puppet_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_Puppet_Content.adoc
@@ -1,12 +1,12 @@
 [[Managing_Custom_Puppet_Content]]
-== Managing Custom Puppet Content
+== Managing Puppet Content
 
-In {Project}, if you want to incorporate state configuration of hosts using Puppet modules, you can create a custom product with repositories for Puppet modules to achieve this.
+In {Project}, if you want to incorporate state configuration of hosts using Puppet modules, you can create a {customproduct} with repositories for Puppet modules to achieve this.
 
 [[Importing_Custom_Content-Creating_a_Custom_Puppet_Repository]]
-=== Creating a Custom Puppet Repository
+=== Creating a Puppet Repository
 
-The procedure for creating a custom Puppet module repository is the same as the procedure for creating any custom content, except that when you create the repository, you select the *puppet* type. You must create a product and then add a custom repository.
+The procedure for creating a Puppet module repository is the same as the procedure for creating any (customcontent), except that when you create the repository, you select the *puppet* type. You must create a product and then add a {customrepos}.
 
 .Procedure
 
@@ -34,10 +34,14 @@ The procedure for creating a custom Puppet module repository is the same as the 
 [[Importing_Custom_Content-Managing_Puppet_Modules]]
 === Managing Individual Puppet Modules
 
-If you want to create a custom product that contains both RPM content and a Puppet module to install and configure a server using the custom RPM content, use the procedure in xref:Importing_Custom_Content-Creating_a_Custom_Puppet_Repository[] and then use the following procedure to upload Puppet modules.
+If you want to create a {customproduct} that contains both RPM content and a Puppet module to install and configure a server using the {customrpm} content, use the procedure in xref:Importing_Custom_Content-Creating_a_Custom_Puppet_Repository[] and then use the following procedure to upload Puppet modules.
+
+ifeval::["{build}" == "satellite"]
 
 .Support for Custom RPMs
 Red Hat does not support the modules from Puppet Forge. For any issues with these modules, contact the module developer.
+
+endif::[]
 
 .Prerequisites
 
@@ -79,8 +83,13 @@ $ scp ~/_puppet_module_.tar.gz root@{foreman-example-com}:~/.
 
 In addition to creating a repository of uploaded Puppet modules, {ProjectServer} can synchronize a complete Puppet module repository. In this example, {ProjectServer} synchronizes the entire Puppet Forge repository.
 
+ifeval::["{build}" == "satellite"]
+
 .Support for Custom RPMs
 Red Hat does not support the modules from Puppet Forge. The modules are used to demonstrate the synchronization process. For any issues with these modules, contact the module developer.
+
+endif::[]
+
 
 .Procedure
 
@@ -173,7 +182,7 @@ Use the following procedure to synchronize Puppet modules from a Git repository.
 
 .Procedure
 
-. Create a custom product and click *Create Repository*.
+. Create a {customproduct} and click *Create Repository*.
 . From the *Type* list, select *puppet*.
 . In the *URL* field, enter the URL of the external Git repository to use as a source in the following format: `file:///modules`.
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
@@ -61,15 +61,15 @@ To import Red Hat ISO images, complete the following steps:
 
 === Importing Individual ISO Images and Files
 
-Use this procedure to manually import ISO content and other files to {ProjectServer}. To import custom files, you can complete the following steps in the web UI or using the Hammer CLI. However, if the size of the file that you want to upload is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
+Use this procedure to manually import ISO content and other files to {ProjectServer}. To import files, you can complete the following steps in the web UI or using the Hammer CLI. However, if the size of the file that you want to upload is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
 
-. Create a custom product.
+. Create a {customproduct}.
 . Add a repository for files to the product.
 . Upload a file to the repository.
 
 .Procedure
 
-To import custom ISO images, complete the following steps:
+To import ISO images, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Products*, and in the Products window, click *Create Product*.
 . In the *Name* field, enter a name to identify the product. This name populates the *Label* field.
@@ -89,7 +89,7 @@ To import custom ISO images, complete the following steps:
 
 .For CLI Users
 
-. Create the custom product:
+. Create the {customproduct}:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
@@ -1,7 +1,7 @@
 [[Managing_OSTree_Content]]
 == Managing OSTree Content
 
-*OSTree* is a tool to manage bootable, immutable, versioned file system trees. You can use a custom OSTree content on a build system, then export an OSTree
+*OSTree* is a tool to manage bootable, immutable, versioned file system trees. You can use a {customostreecontent} on a build system, then export an OSTree
 repository to a static HTTP. Red Hat Enterprise Linux Atomic Server uses OSTree content composed from RPM files as a method to keep the operating system up to date.
 
 You can use {ProjectNameX} to synchronize and manage OSTree branches from an OSTree repository.
@@ -75,13 +75,13 @@ To find and synchronize OSTree content, complete the following steps:
 --organization "_My_Organization_"
 ----
 
-=== Importing Custom OSTree Content
+=== Importing {customostreecontenttitle}
 
 In addition to importing OSTree content from Red{nbsp}Hat CDN, you can also import content from other sources. This requires a published HTTP location for the OSTree to import.
 
 .Procedure
 
-To import custom OSTree content, complete the following steps:
+To import {customostreecontent}, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Products* and click *Create Product*.
 . In the *Name* field, enter a name for your OSTree content. This automatically populates the *Label* field.
@@ -104,12 +104,12 @@ To import custom OSTree content, complete the following steps:
 
 .For CLI Users
 
-. Create the custom `OSTree Content` product:
+. Create a {customostreecontent} product:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer product create \
---name "_Custom OSTree Content_" \
+--name "_{customostreecontenttitle}_" \
 --sync-plan "_Example_Plan_" \
 --description "OSTree Content" \
 --organization "_My_Organization_"
@@ -120,7 +120,7 @@ To import custom OSTree content, complete the following steps:
 [options="nowrap" subs="+quotes"]
 ----
 # hammer repository create \
---name "_Custom OSTree_" \
+--name "_OSTree_" \
 --content-type "ostree" \
 --url "_http://www.example.com/rpm-ostree/_" \
 --product "_OSTree Content_" \
@@ -132,7 +132,7 @@ To import custom OSTree content, complete the following steps:
 [options="nowrap" subs="+quotes"]
 ----
 # hammer repository synchronize \
---name "_Custom OStree_" \
+--name "_OSTree_" \
 --product "OSTree Content" \
 --organization "_My_Organization_"
 ----

--- a/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
@@ -1,7 +1,7 @@
 [[Managing_OSTree_Content]]
 == Managing OSTree Content
 
-*OSTree* is a tool to manage bootable, immutable, versioned file system trees. You can use a {customostreecontent} on a build system, then export an OSTree
+*OSTree* is a tool to manage bootable, immutable, versioned file system trees. You can use {customostreecontent} on a build system, then export an OSTree
 repository to a static HTTP. Red Hat Enterprise Linux Atomic Server uses OSTree content composed from RPM files as a method to keep the operating system up to date.
 
 You can use {ProjectNameX} to synchronize and manage OSTree branches from an OSTree repository.
@@ -104,7 +104,7 @@ To import {customostreecontent}, complete the following steps:
 
 .For CLI Users
 
-. Create a {customostreecontent} product:
+. Create a product for your {customostreecontent}:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
@@ -106,7 +106,7 @@ To import {customostreecontent}, complete the following steps:
 
 . Create a product for your {customostreecontent}:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer product create \
 --name "_{customostreecontenttitle}_" \


### PR DESCRIPTION
Fixes #158

There is no such thing as "custom" in Foreman or Satellite terminology. 
This slipped in to mean "non-Red Hat". 
I have filtered it out of the upstream docs as it is extremely confusing. 
I forget all my docs skillz so if there is a simpler way to implement this, let me know. 