### PR TITLE
Added IPv6 FDI options

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -34,7 +34,7 @@ fdi.ssh::
   By default, the SSH service is disabled. Set this to `1` or `true` to enable SSH access.
 
 fdi.ipv4.method::
-  By default, NetworkManager IPv4 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable IPv4 stack. This option only works in DHCP mode.
+  By default, NetworkManager IPv4 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable the IPv4 stack. This option works only in DHCP mode.
 
 fdi.ipv6.method::
   By default, NetworkManager IPv6 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable IPv6 stack. This option only works in DHCP mode.

--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -4,7 +4,7 @@
 You can create a customized Discovery ISO to automate the image configuration process after booting. The Discovery image uses a Linux kernel for the operating system, which passes kernel parameters to configure the discovery service. These kernel parameters include the following entries:
 
 proxy.url::
-  The URL of the {SmartProxyServer} providing the Discovery service.
+  The URL of the {SmartProxyServer} or {ProjectServer} providing the Discovery service.
 
 proxy.type::
   The proxy type. This is usually set to `proxy` to connect to {SmartProxyServer}. This parameter also supports a legacy `foreman` option, where communication goes directly to {ProjectServer} instead of a {SmartProxyServer}.
@@ -23,6 +23,21 @@ fdi.pxfactvalue1, fdi.pxfactvalue2 ... fdi.pxfactvalueN::
 
 fdi.pxauto::
   To set automatic or semi-automatic mode. If set to 0, the image uses semi-automatic mode, which allows you to confirm your choices through a set of dialog options. If set to 1, the image uses automatic mode and proceeds without any confirmation.
+
+fdi.initnet::
+  By default, the image initializes all network interfaces (value `all`). When this setting is set to `bootif`, only the network interface it was network-booted from will be initialized.
+
+fdi.rootpw::
+  By default, root account is locked. Use this option to set root password. Accepts both clear and encrypted passwords.
+
+fdi.ssh::
+  By default, the SSH service is disabled. Set this to `1` or `true` to enable SSH access.
+
+fdi.ipv4.method::
+  By default, NetworkManager IPv4 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable IPv4 stack. This option only works in DHCP mode.
+
+fdi.ipv6.method::
+  By default, NetworkManager IPv6 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable IPv6 stack. This option only works in DHCP mode.
 
 .Using the `discovery-remaster` Tool to Remaster an OS Image
 

--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -37,7 +37,7 @@ fdi.ipv4.method::
   By default, NetworkManager IPv4 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable the IPv4 stack. This option works only in DHCP mode.
 
 fdi.ipv6.method::
-  By default, NetworkManager IPv6 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable IPv6 stack. This option only works in DHCP mode.
+  By default, NetworkManager IPv6 method setting is set to `auto`. This option overrides it, set it to `ignore` to disable the IPv6 stack. This option only works in DHCP mode.
 
 .Using the `discovery-remaster` Tool to Remaster an OS Image
 

--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -28,7 +28,7 @@ fdi.initnet::
   By default, the image initializes all network interfaces (value `all`). When this setting is set to `bootif`, only the network interface it was network-booted from will be initialized.
 
 fdi.rootpw::
-  By default, root account is locked. Use this option to set root password. Accepts both clear and encrypted passwords.
+  By default, the `root` account is locked. Use this option to set a root password. You can enter both clear and encrypted passwords.
 
 fdi.ssh::
   By default, the SSH service is disabled. Set this to `1` or `true` to enable SSH access.


### PR DESCRIPTION
This adds two brand new options, do not merge yet the patch is still pending.

https://github.com/theforeman/foreman-discovery-image/pull/125

Adds few more options which are there. I am not adding all of them, most of them are pretty low-level and don't need to be customized:

https://theforeman.org/plugins/foreman_discovery/15.0/index.html#3.1.5Discoveryimagekerneloptions