### PR TITLE
Remove outdated statements that Capsule and Sat versions must match

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -49,8 +49,6 @@ endif::[]
 * puppet
 * puppetserver
 
-NOTE: The {ProjectName} Server and {SmartProxyServer} versions must match. For example, a {ProjectXY} Server cannot run an earlier or later version of {SmartProxyServer}. Mismatching {ProjectServer} and {SmartProxyServer} versions results in the {SmartProxyServer} failing silently.
-
 ifeval::["{context}" == "{smart-proxy-context}"]
 For more information on scaling your {SmartProxyServer}s, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/installing_capsule_server/capsule-server-scalability-considerations_capsule[{SmartProxyServer} Scalability Considerations].
 endif::[]


### PR DESCRIPTION
Bug 1871844 - Need to update a note from Sat6.8 installation guide since
we support N-1 capsules
https://bugzilla.redhat.com/show_bug.cgi?id=1871844