### PR TITLE
Add info about userdata remote_addr

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -406,7 +406,7 @@ You can now create an image from this virtual machine.
 
 You can use the xref:Provisioning_Virtual_Machines_in_VMware_vSphere-Adding_VMware_vSphere_Images_on_the_Satellite_Server[] section to add the image to {Project}.
 
-.Configuring {SmartProxy} to forward user data template
+.Configuring {SmartProxy} to Forward the user data Template
 
 {Project} must recognize the client IP address in order to serve correct template payload and when clients connects directly to {ProjectServer}, remote IP of the HTTP request can be used. However, when {Project} is deployed with {SmartProxy} templates feature, the callback URL is set to {SmartProxy} endpoint which forwards to the {ProjectServer} with HTTP header information X-Forwarded-For.
 

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -408,7 +408,7 @@ You can use the xref:Provisioning_Virtual_Machines_in_VMware_vSphere-Adding_VMwa
 
 .Configuring {SmartProxy} to Forward the user data Template
 
-{Project} must recognize the client IP address in order to serve correct template payload and when clients connects directly to {ProjectServer}, remote IP of the HTTP request can be used. However, when {Project} is deployed with {SmartProxy} templates feature, the callback URL is set to {SmartProxy} endpoint which forwards to the {ProjectServer} with HTTP header information X-Forwarded-For.
+If you deploy {Project} with the {SmartProxy} templates feature, you must configure {Project} to recognize hosts' IP addresses forwarded over the X-Forwarded-For HTTP header to serve correct template payload.
 
 For security reasons, {Project} recognizes this HTTP header only from localhost. For each individual {SmartProxy}, you must configure a regular expression to recognize IP address. From the web UI, you can do this by navigating to *Administer* > *Settings* > *Provisioning*, and changing the *Remote address* setting. From the CLI, you can do this by entering the following command:
 

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -410,7 +410,7 @@ You can use the xref:Provisioning_Virtual_Machines_in_VMware_vSphere-Adding_VMwa
 
 If you deploy {Project} with the {SmartProxy} templates feature, you must configure {Project} to recognize hosts' IP addresses forwarded over the X-Forwarded-For HTTP header to serve correct template payload.
 
-For security reasons, {Project} recognizes this HTTP header only from localhost. For each individual {SmartProxy}, you must configure a regular expression to recognize IP address. From the web UI, you can do this by navigating to *Administer* > *Settings* > *Provisioning*, and changing the *Remote address* setting. From the CLI, you can do this by entering the following command:
+For security reasons, {Project} recognizes this HTTP header only from localhost. For each individual {SmartProxy}, you must configure a regular expression to recognize hosts' IP addresses. From the web UI, you can do this by navigating to *Administer* > *Settings* > *Provisioning*, and changing the *Remote address* setting. From the CLI, you can do this by entering the following command:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -406,6 +406,16 @@ You can now create an image from this virtual machine.
 
 You can use the xref:Provisioning_Virtual_Machines_in_VMware_vSphere-Adding_VMware_vSphere_Images_on_the_Satellite_Server[] section to add the image to {Project}.
 
+.Configuring {SmartProxy} to forward user data template
+
+{Project} must recognize the client IP address in order to serve correct template payload and when clients connects directly to {ProjectServer}, remote IP of the HTTP request can be used. However, when {Project} is deployed with {SmartProxy} templates feature, the callback URL is set to {SmartProxy} endpoint which forwards to the {ProjectServer} with HTTP header information X-Forwarded-For.
+
+For security reasons, {Project} does recognize this HTTP header only from localhost. For each individual {SmartProxy}, a regular expression in *Administer* > *Settings* > *Provisioning* > *Remote address* must be updated to recognize IP address. From CLI this can be done using the following command:
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer settings set --name remote_addr --value '(localhost(4|6|4to6)?|192.168.122.(1|2|3))'
+----
 
 [[Provisioning_Virtual_Machines_in_VMware_vSphere-Caching_of_Compute_resources]]
 === Caching of Compute Resources

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -410,7 +410,7 @@ You can use the xref:Provisioning_Virtual_Machines_in_VMware_vSphere-Adding_VMwa
 
 {Project} must recognize the client IP address in order to serve correct template payload and when clients connects directly to {ProjectServer}, remote IP of the HTTP request can be used. However, when {Project} is deployed with {SmartProxy} templates feature, the callback URL is set to {SmartProxy} endpoint which forwards to the {ProjectServer} with HTTP header information X-Forwarded-For.
 
-For security reasons, {Project} does recognize this HTTP header only from localhost. For each individual {SmartProxy}, a regular expression in *Administer* > *Settings* > *Provisioning* > *Remote address* must be updated to recognize IP address. From CLI this can be done using the following command:
+For security reasons, {Project} recognizes this HTTP header only from localhost. For each individual {SmartProxy}, you must configure a regular expression to recognize IP address. From the web UI, you can do this by navigating to *Administer* > *Settings* > *Provisioning*, and changing the *Remote address* setting. From the CLI, you can do this by entering the following command:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
This was missing causing the feature not to work over smart-proxy templates module.

https://community.theforeman.org/t/using-cloud-init-templates-with-foreman-proxy-foreman-proxy-content/20269