### PR TITLE
Correct FIPS 140-2 link

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/app-Deploy_FIPS_hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app-Deploy_FIPS_hosts.adoc
@@ -2,7 +2,7 @@
 [[Provision_FIPS_Hosts]]
 == Provisioning FIPS-Compliant Hosts
 
-{Project} supports provisioning hosts that comply with the National Institute of Standards and Technology's http://csrc.nist.gov/groups/STM/cmvp/standards.html#02[Security Requirements for Cryptographic Modules] standard, reference number FIPS 140-2, referred to here as FIPS.
+{Project} supports provisioning hosts that comply with the National Institute of Standards and Technology's https://csrc.nist.gov/publications/detail/fips/140/2/final[Security Requirements for Cryptographic Modules] standard, reference number FIPS 140-2, referred to here as FIPS.
 
 To enable the provisioning of hosts that are FIPS-compliant, complete the following tasks:
 


### PR DESCRIPTION
The old link was no longer valid (404).