### PR TITLE
Add Configuring your Deployment to Run Ansible Roles

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
@@ -28,7 +28,7 @@ Complete this procedure to configure your {Project} deployment to run Ansible ro
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Importing_Ansible_Roles]]
 === Importing Ansible Roles
 
-You can import Ansible roles from the `/etc/ansible/roles` directory on {Project} or on a {SmartProxy} that has Ansible enabled. Ensure that roles that you import are located in the `/etc/ansible/roles` directory on all {SmartProxies} from where you want to use the roles.
+You can import Ansible roles from the `/etc/ansible/roles` directory on {Project} or on a {SmartProxy} that has Ansible enabled. Ensure that the roles that you import are located in the `/etc/ansible/roles` directory on all {SmartProxies} from where you want to use the roles.
 
 To import Ansible roles, complete the following steps:
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
@@ -3,6 +3,7 @@
 
 In {Project}, you can import Ansible roles to help with automation of routine tasks. Ansible is enabled by default only on {Project}.
 
+[[chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_your_Deployment_to_Run_Ansible_Roles]]
 === Configuring your Deployment to Run Ansible Roles
 
 Complete this procedure to configure your {Project} deployment to run Ansible roles.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
@@ -1,16 +1,33 @@
 [[chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Managing_Ansible_Roles]]
 == Managing Ansible Roles
 
-In {Project}, you can import Ansible roles and Red{nbsp}Hat Enterprise Linux system roles to help with automation of routine tasks. Ansible is enabled by default on {Project} and {SmartProxy}.
+In {Project}, you can import Ansible roles to help with automation of routine tasks. Ansible is enabled by default only on {Project}.
 
-If you use custom or third party Ansible roles, you must add the roles to the `/etc/ansible/roles` directory of the {SmartProxy} or {Project} where you want to use them.
+=== Configuring your Deployment to Run Ansible Roles
 
-You must import the Ansible roles into {ProjectServer} from the `/etc/ansible/roles` directory before you can use them.
+Complete this procedure to configure your {Project} deployment to run Ansible roles.
+
+.Procedure
+
+. Add the roles to the `/etc/ansible/roles` directory on the {Project} and all {SmartProxies} from where you want to use the roles. If you want to use custom or third party Ansible roles, ensure to configure an external version control system to synchronize roles between {Project} and {SmartProxies}.
+
+. On all {SmartProxies} that you want to use to run Ansible roles on hosts, enable the Ansible plug-in:
++
+----
+# satellite-installer --scenario capsule \
+--enable-foreman-proxy-plugin-ansible true
+----
+
+. Distribute SSH keys to enable {SmartProxies} to connect to hosts using SSH. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html-single/managing_hosts/index#sect-Managing_Hosts-Establishing_a_Secure_Connection_for_Remote_Commands[Distributing SSH Keys for Remote Execution] in the _Managing Hosts_ guide. {Project} runs Ansible roles the same way it runs remote execution jobs.
+
+. Import the Ansible roles into {Project}. For more information, see xref:sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Importing_Ansible_Roles[].
+
+. Proceed to https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html-single/managing_hosts/index#Using_Ansible_Roles[Using Ansible Roles] in the _Managing Hosts_ guide.
 
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Importing_Ansible_Roles]]
 === Importing Ansible Roles
 
-You can import Ansible roles from a {SmartProxy} that has Ansible enabled or from the `/etc/ansible/roles` directory where {ProjectServer} is installed.
+You can import Ansible roles from the `/etc/ansible/roles` directory on {Project} or on a {SmartProxy} that has Ansible enabled. Ensure that roles that you import are located in the `/etc/ansible/roles` directory on all {SmartProxies} from where you want to use the roles.
 
 To import Ansible roles, complete the following steps:
 

--- a/guides/doc-Managing_Hosts/topics/Using_Ansible_Roles.adoc
+++ b/guides/doc-Managing_Hosts/topics/Using_Ansible_Roles.adoc
@@ -8,7 +8,7 @@ You can use Ansible roles for remote management of Red{nbsp}Hat Enterprise Linux
 
 .Prerequisites
 
-You must import the roles to {Project} before you can assign them to a host. For more information, see link:{BaseURL}administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-managing_ansible_roles#sect-{Project_Link}-Administering_{Project_Link}-Adding_RHEL_System_Roles[Adding Red Hat Enterprise Linux System Roles] in _Administering {ProjectName}_.
+* You must configure your deployment to run Ansible roles. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-managing_ansible_roles#sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_your_Deployment_to_Run_Ansible_Roles[Configuring your Deployment to Run Ansible Roles] in the _Administering_ guide.
 
 .Procedure
 
@@ -32,7 +32,7 @@ You can run Ansible roles on a host through the {Project} web UI.
 
 .Prerequisites
 
-* You must have imported the Ansible roles to {Project}.
+* You must configure your deployment to run Ansible roles. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-managing_ansible_roles#sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_your_Deployment_to_Run_Ansible_Roles[Configuring your Deployment to Run Ansible Roles] in the _Administering_ guide.
 * You must have assigned the Ansible roles to the host.
 
 .Procedure
@@ -50,8 +50,7 @@ You can use Ansible roles for remote management of Red{nbsp}Hat Enterprise Linux
 
 .Prerequisites
 
-You must import the roles to {Project} before you can assign them to a host group. For more information, see
-link:{BaseURL}administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-managing_ansible_roles#sect-{Project_Link}-Administering_{Project_Link}-Adding_RHEL_System_Roles[Adding Red Hat Enterprise Linux System Roles] in _Administering {ProjectName}_.
+* You must configure your deployment to run Ansible roles. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-managing_ansible_roles#sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_your_Deployment_to_Run_Ansible_Roles[Configuring your Deployment to Run Ansible Roles] in the _Administering_ guide.
 
 .Procedure
 
@@ -68,7 +67,7 @@ You can run Ansible roles on a host group through the {Project} web UI.
 
 .Prerequisites
 
-* You must have imported the Ansible roles to {Project}.
+* You must configure your deployment to run Ansible roles. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html/administering_red_hat_satellite/chap-red_hat_satellite-administering_red_hat_satellite-managing_ansible_roles#sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_your_Deployment_to_Run_Ansible_Roles[Configuring your Deployment to Run Ansible Roles] in the _Administering_ guide.
 * You must have assigned the Ansible roles to the host group.
 * You must have at least one host in your host group.
 


### PR DESCRIPTION
Bug 1834626 - [DDF] I've discovered that in order to use Ansible through a capsule you need to run the follwing command first

https://bugzilla.redhat.com/show_bug.cgi?id=1834626