### PR TITLE
Remove a duplicate step and fix a deprecated option 

### DIFF
--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -59,7 +59,7 @@ Note the {SmartProxy} ID of the {SmartProxy} that you want to add a life cycle t
 ----
 # hammer capsule content add-lifecycle-environment \
 --id _capsule_id_ --organization "_My_Organization_" \
---environment-id _environment_id_
+--lifecycle-environment-id _lifecycle-environment_id_
 ----
 +
 Repeat for each life cycle environment you want to add to {SmartProxyServer}.
@@ -78,5 +78,5 @@ Repeat for each life cycle environment you want to add to {SmartProxyServer}.
 [options="nowrap" subs="+quotes"]
 ----
 # hammer capsule content synchronize --id _external_capsule_id_ \
---environment-id _environment_id_
+--lifecycle-environment-id _lifecycle-environment_id_
 ----

--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -46,14 +46,6 @@ Note the {SmartProxy} ID of the {SmartProxy} that you want to add a life cycle t
 # hammer capsule info --id _capsule_id_
 ----
 +
-. Display the life cycle environments that are available and note the environment ID:
-+
-[options="nowrap" subs="+quotes"]
-----
-# hammer capsule content available-lifecycle-environments \
---id _capsule_id_
-----
-+
 . To view the life cycle environments available for your {SmartProxyServer}, enter the following command and note the ID and the organization name:
 +
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
Bug 1876185 - Deprecated command used to add lifecycle environment
    
https://bugzilla.redhat.com/show_bug.cgi?id=1876185

Bug 1876183 - Duplicate step to to check available lifecycle enviornment
    
https://bugzilla.redhat.com/show_bug.cgi?id=1876183
