### PR TITLE
Clarify temporary storage

### DIFF
--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -53,7 +53,9 @@ Packages that are duplicated in different repositories are only stored once on t
 
 .Temporary Storage
 
-The `/var/cache/pulp/` directory is used to temporarily store content while it is being synchronized. For content in RPM format, a maximum of 5 RPM files are stored in this directory at any time. After each file is synchronized, it is moved to the `/var/lib/pulp/` directory. Up to 8 RPM content synchronization tasks can run simultaneously by default, with each using up to 1 GB of metadata.
+The `/var/cache/pulp/` directory is used to temporarily store content while it is being synchronized. After a full synchronization task is completed, the content is moved to the `/var/lib/pulp/` directory.
+
+For content in RPM format, each RPM file is moved to the `/var/lib/pulp` directory after it is synchronized. A maximum of 5 RPM files is stored in the `/var/cache/pulp/` directory at any time. Up to 8 RPM content synchronization tasks can run simultaneously by default, with each using up to 1 GB of metadata.
 
 ifeval::["{build}" != "foreman-deb"]
 .Software Collections


### PR DESCRIPTION
Bug 1885914 - Wrong description about /var/cache/pulp content flow

https://bugzilla.redhat.com/show_bug.cgi?id=1885914