### PR TITLE
Added note about very important boot order

### DIFF
--- a/guides/common/modules/con_provisioning-workflow.adoc
+++ b/guides/common/modules/con_provisioning-workflow.adoc
@@ -1,5 +1,7 @@
 [id="provisioning-workflow_{context}"]
-= Provisioning Workflow
+= Network Boot Provisioning Workflow
+
+Booting from network assumes a host, either physical or virtual, is configured to boot from network as the first booting device, and from hard drive as the second booting device.
 
 The provisioning process follows a basic PXE workflow:
 

--- a/guides/common/modules/con_provisioning-workflow.adoc
+++ b/guides/common/modules/con_provisioning-workflow.adoc
@@ -1,7 +1,7 @@
 [id="provisioning-workflow_{context}"]
 = Network Boot Provisioning Workflow
 
-Booting from network assumes a host, either physical or virtual, is configured to boot from network as the first booting device, and from hard drive as the second booting device.
+PXE booting assumes that a host, either physical or virtual, is configured to boot from network as the first booting device, and from the hard drive as the second booting device.
 
 The provisioning process follows a basic PXE workflow:
 


### PR DESCRIPTION
Boot order is essential thing and it looks like users quite often don't set it properly. This is the right thing to open up with!

Also the chapter actually explains network boot (using PXE). This title is better.