### PR TITLE
Fix the Satellite Tools repo attribute

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -141,7 +141,7 @@ ifeval::["{build}" == "satellite"]
 :smartproxy-example-com: capsule.example.com
 :smartproxy_port: 9090
 :Team: Red{nbsp}Hat
-:project-client-RHEL7-url: rhel-7-server-satellite-tools-6-beta-rpms
+:project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-name: Satellite Tools {ProductVersionRepoTitle}
 :customcontent: custom content
 :customcontenttitle: Custom Content


### PR DESCRIPTION
Bug 1892454 - Capsule installation repo instructions refer to rhel-7-server-satellite-tools-6-beta-rpms

https://bugzilla.redhat.com/show_bug.cgi?id=1892454