### PR TITLE
Add info about mountint /tmp with the exec mount option

### DIFF
--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -3,6 +3,8 @@
 
 Consider the following guidelines when installing {ProductName} to increase efficiency.
 
+* If you mount the `/tmp` directory as a separate file system, you must use the `exec` mount option in the `/etc/fstab` file. If `/tmp` is already mounted with the `noexec` option, you must change the option to `exec` and re-mount the file system. This is a requirement for the `puppetserver` service to work.
+
 * Because most {ProductName} data is stored in the `/var` directory, mounting `/var` on LVM storage can help the system to scale.
 
 * Using the same volume for the `/var/cache/pulp/` and `/var/lib/pulp/` directories can decrease the time required to move content from `/var/cache/pulp/` to `/var/lib/pulp/` after synchronizing.


### PR DESCRIPTION
Bug 1886219 - Add recommendation about not mounting /tmp filesystem with noexec option in Red Hat Satellite or Capsule servers

https://bugzilla.redhat.com/show_bug.cgi?id=1886219