### PR TITLE
Fix the tools repo name for downstream

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -10,7 +10,7 @@
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.8-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.7-rpms
 :RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-7-server-satellite-capsule-6.8-rpms
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.8-rpms
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-rpms
 :RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
 :RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms


### PR DESCRIPTION
Bug 1895410 - Need correction in Satellite tools Repository which we enable during Capsule 6.8 Installation

https://bugzilla.redhat.com/show_bug.cgi?id=1895410