### PR TITLE
Disable weak encryption using installer commands

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -14,7 +14,7 @@ Apache and Qpid services in {Project} have TLS 1.0 and 1.1 encryption enabled by
 # vi /etc/foreman-installer/custom-hiera.yaml
 ----
 
-. Add the following entry:
+. Add the following entries:
 +
 [options="nowrap"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -27,12 +27,12 @@ To disable weak encryption for {Project}, complete the following steps:
 # Apache
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
 ----
-+
+
 . Enter the `{foreman-installer}` command with the following arguments:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-tls-disabled-versions=1.1 \
+# {foreman-installer} \
 --foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
 ----
 +
@@ -67,7 +67,8 @@ apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+T
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
+# {foreman-installer} \
+--foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
 ----
 +
 . Restart the `{foreman-maintain}` services:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -20,6 +20,10 @@ Apache and Qpid services in {Project} have TLS 1.0 and 1.1 encryption enabled by
 ----
 # Apache
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
+
+# QPID Dispatch
+foreman_proxy_content::qpid_router_ssl_protocols: [ 'TLSv1.2' ]
+foreman_proxy_content::qpid_router_ssl_ciphers: 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-CBC-SHA'
 ----
 
 . Enter the `{foreman-installer}` command to configure Qpid to use TLS 1.2 only:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -1,11 +1,7 @@
-[[Disabling_Weak_SSL_Encryption]]
-
-== Disabling Weak Encryption
-
-You might want to change the encryption settings for {Project} depending on the security requirements of your infrastructure or to fix vulnerabilities quickly. Use the following sections to disable weak SSL encryption and 64-bit cipher suites.
-
 [[Disabling_Weak_SSL_2-0_and_3-0_Encryption]]
-=== Disabling TLS 1.0 and 1.1 Encryption
+== Disabling TLS 1.0 and TLS 1.1 Encryption
+
+You might want to change the encryption settings for {Project} depending on the security requirements of your infrastructure or to fix vulnerabilities quickly.
 
 Apache and Qpid services in {Project} have TLS 1.0 and 1.1 encryption enabled by default. Use this procedure on {Project} and {SmartProxy} to configure {Project} and {SmartProxy} to only allow TLS 1.2, as required, for example, by PCI-DSS regulations.
 
@@ -39,35 +35,4 @@ apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+T
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service restart
-----
-
-[[Disabling_64-bit_Block_Size_Cipher_Suites]]
-=== Disabling 64-bit Block Size Cipher Suites (SWEET32)
-
-If you want to update your cipher suites for {Project}, you can edit the ciphers and then add your changes to the `/etc/foreman-installer/custom-hiera.yaml` file to make these changes persistent.
-
-You can use the following procedure to update your cipher suite.
-
-The minimum browser requirements for the following Ciphers is Firefox 27.
-
-.Procedure
-
-. Open the `/etc/foreman-installer/custom-hiera.yaml` file for editing:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# vi /etc/foreman-installer/custom-hiera.yaml
-----
-
-. Add the following entry for `apache`:
-+
-----
-apache::mod::ssl::ssl_cipher: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
-----
-
-. Run the `{foreman-installer}` tool to add the changes to the Apache configuration:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {installer-scenario}
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -59,28 +59,15 @@ To disable weak encryption for {SmartProxy}, complete the following steps:
 +
 [options="nowrap"]
 ----
-# Foreman Proxy
-foreman_proxy::tls_disabled_versions: [ '1.1' ]
-
-# Dynflow
-foreman_proxy::plugin::dynflow::tls_disabled_versions: [ '1.1' ]
-
 # Apache
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
-
-# QPID Dispatch
-foreman_proxy_content::qpid_router_ssl_protocols: [ 'TLSv1.2' ]
-foreman_proxy_content::qpid_router_ssl_ciphers: 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-CBC-SHA'
-
-# PULP
-pulp::ssl_protocol: "ALL -SSLv3 -TLSv1 -TLSv1.1 +TLSv1.2"
 ----
 +
 . Rerun the `{foreman-installer}` tool with no arguments:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} 
+# {foreman-installer} --foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
 ----
 +
 . Restart the `{foreman-maintain}` services:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -63,7 +63,7 @@ To disable weak encryption for {SmartProxy}, complete the following steps:
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
 ----
 +
-. Rerun the `{foreman-installer}` tool with no arguments:
+. Enter the `{foreman-installer}` command with the following arguments:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -32,10 +32,3 @@ foreman_proxy_content::qpid_router_ssl_ciphers: 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-C
 # {foreman-installer} \
 --foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
 ----
-
-. Restart the `{foreman-maintain}` services:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} service restart
-----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -7,11 +7,9 @@ You might want to change the encryption settings for {Project} depending on the 
 [[Disabling_Weak_SSL_2-0_and_3-0_Encryption]]
 === Disabling Weak SSL 2.0 and SSL 3.0 Encryption
 
-Apache and Qpid services in {Project} use SSL 2.0 and SSL 3.0 encryption by default. If your {Project} or {SmartProxy} fails Nessus scans because of SSL vulnerabilities, or your security infrastructure requires that you disable SSL 2.0 and SSL 3.0, complete this procedure on {Project} or {SmartProxy} to remove weak encryption.
+Apache and Qpid services in {Project} have SSL encryption disabled by default, however, TLS 1.0 and 1.1 encryption is enabled. If your {Project} and {SmartProxy} fail Nessus scans because of encryption vulnerabilities, or your security infrastructure requires that you disable TSL 1.0 and TSL 1.1, complete this procedure on {Project} and {SmartProxy} to remove weak encryption.
 
 .Procedure
-
-To disable weak encryption, complete the following steps on {Project} or {SmartProxy}:
 
 . Open the `/etc/foreman-installer/custom-hiera.yaml` file for editing:
 +
@@ -28,7 +26,7 @@ To disable weak encryption, complete the following steps on {Project} or {SmartP
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
 ----
 
-. Enter the `{foreman-installer}` command with the following arguments:
+. Enter the `{foreman-installer}` command to configure Qpid to use TLS 1.2 only:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -5,9 +5,9 @@
 You might want to change the encryption settings for {Project} depending on the security requirements of your infrastructure or to fix vulnerabilities quickly. Use the following sections to disable weak SSL encryption and 64-bit cipher suites.
 
 [[Disabling_Weak_SSL_2-0_and_3-0_Encryption]]
-=== Disabling Weak SSL 2.0 and SSL 3.0 Encryption
+=== Disabling TLS 1.0 and 1.1 Encryption
 
-Apache and Qpid services in {Project} have SSL encryption disabled by default, however, TLS 1.0 and 1.1 encryption is enabled. If your {Project} and {SmartProxy} fail Nessus scans because of encryption vulnerabilities, or your security infrastructure requires that you disable TSL 1.0 and TSL 1.1, complete this procedure on {Project} and {SmartProxy} to remove weak encryption.
+Apache and Qpid services in {Project} have TLS 1.0 and 1.1 encryption enabled by default. Use this procedure on {Project} and {SmartProxy} to configure {Project} and {SmartProxy} to only allow TLS 1.2, as required, for example, by PCI-DSS regulations.
 
 .Procedure
 
@@ -58,13 +58,13 @@ The minimum browser requirements for the following Ciphers is Firefox 27.
 ----
 # vi /etc/foreman-installer/custom-hiera.yaml
 ----
-+
+
 . Add the following entry for `apache`:
 +
 ----
 apache::mod::ssl::ssl_cipher: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
 ----
-+
+
 . Run the `{foreman-installer}` tool to add the changes to the Apache configuration:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -25,7 +25,7 @@ apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+T
 foreman_proxy_content::qpid_router_ssl_ciphers: 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-CBC-SHA'
 ----
 
-. Enter the `{foreman-installer}` command to configure Qpid to use TLS 1.2 only:
+. Enter the `{foreman-installer}` command to apply the above configuration and configure Qpid to use TLS 1.2 only:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -24,28 +24,16 @@ To disable weak encryption for {Project}, complete the following steps:
 +
 [options="nowrap"]
 ----
-# Foreman Proxy
-foreman_proxy::tls_disabled_versions: [ '1.1' ]
-
-# Dynflow
-foreman_proxy::plugin::dynflow::tls_disabled_versions: [ '1.1' ]
-
 # Apache
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
-
-# Tomcat / Candlepin
-candlepin::tls_versions: [ '1.2' ]
-
-# QPID Dispatch
-foreman_proxy_content::qpid_router_ssl_protocols: [ 'TLSv1.2' ]
-foreman_proxy_content::qpid_router_ssl_ciphers: 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-CBC-SHA'
 ----
 +
-. Rerun the `{foreman-installer}` tool with no arguments:
+. Enter the `{foreman-installer}` command with the following arguments:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer}
+# {foreman-installer} --foreman-proxy-tls-disabled-versions=1.1 \
+--foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
 ----
 +
 . Restart the `{foreman-maintain}` services:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -52,26 +52,9 @@ You can use the following procedure to update your cipher suite.
 
 The minimum browser requirements for the following Ciphers is Firefox 27.
 
-. Open the `/etc/httpd/conf.d/ssl.conf` Apache configuration file for editing:
-+
-----
-# vi /etc/httpd/conf.d/ssl.conf
-----
-+
-. Update the values of `SSLCipherSuite` parameter:
-+
-----
-SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
-----
-+
-. Restart the *httpd* service:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# systemctl restart httpd
-----
-+
-. To make the change persistent across different {foreman-installer} executions, open the `/etc/foreman-installer/custom-hiera.yaml` file for editing:
+.Procedure
+
+. Open the `/etc/foreman-installer/custom-hiera.yaml` file for editing:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -22,7 +22,6 @@ Apache and Qpid services in {Project} have TLS 1.0 and 1.1 encryption enabled by
 apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
 
 # QPID Dispatch
-foreman_proxy_content::qpid_router_ssl_protocols: [ 'TLSv1.2' ]
 foreman_proxy_content::qpid_router_ssl_ciphers: 'ALL:!aNULL:+HIGH:-SSLv3:!IDEA-CBC-SHA'
 ----
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Disabling_Weak_Encryption.adoc
@@ -7,11 +7,11 @@ You might want to change the encryption settings for {Project} depending on the 
 [[Disabling_Weak_SSL_2-0_and_3-0_Encryption]]
 === Disabling Weak SSL 2.0 and SSL 3.0 Encryption
 
-If your {Project} fails Nessus scans because of SSL vulnerabilities, or your security infrastructure requires that you disable SSL 2.0 and SSL 3.0, you can edit the `/etc/foreman-installer/custom-hiera.yaml` file to remove weak encryption.
+Apache and Qpid services in {Project} use SSL 2.0 and SSL 3.0 encryption by default. If your {Project} or {SmartProxy} fails Nessus scans because of SSL vulnerabilities, or your security infrastructure requires that you disable SSL 2.0 and SSL 3.0, complete this procedure on {Project} or {SmartProxy} to remove weak encryption.
 
-.Disabling Weak SSL 2.0 and SSL 3.0 Encryption for {Project}
+.Procedure
 
-To disable weak encryption for {Project}, complete the following steps:
+To disable weak encryption, complete the following steps on {Project} or {SmartProxy}:
 
 . Open the `/etc/foreman-installer/custom-hiera.yaml` file for editing:
 +
@@ -19,8 +19,8 @@ To disable weak encryption for {Project}, complete the following steps:
 ----
 # vi /etc/foreman-installer/custom-hiera.yaml
 ----
-+
-. Add the following entries:
+
+. Add the following entry:
 +
 [options="nowrap"]
 ----
@@ -35,42 +35,7 @@ apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+T
 # {foreman-installer} \
 --foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
 ----
-+
-. Restart the `{foreman-maintain}` services:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} service restart
-----
 
-
-.Disabling Weak SSL 2.0 and SSL 3.0 Encryption for {SmartProxy}
-
-To disable weak encryption for {SmartProxy}, complete the following steps:
-
-. Open the `/etc/foreman-installer/custom-hiera.yaml` file for editing:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# vi /etc/foreman-installer/custom-hiera.yaml
-----
-+
-. Add the following entries:
-+
-[options="nowrap"]
-----
-# Apache
-apache::mod::ssl::ssl_protocol: [ 'ALL' , '-SSLv3' , '-TLSv1' , '-TLSv1.1' , '+TLSv1.2' ]
-----
-+
-. Enter the `{foreman-installer}` command with the following arguments:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} \
---foreman-proxy-content-qpid-router-ssl-protocols=TLSv1.2
-----
-+
 . Restart the `{foreman-maintain}` services:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
The doc say to make manual edits to files while the same can be done automatically by running the installer

Bug 1895336 - [Doc Bug] Disable weak ciphers out of date and are already updated in the documentation

https://bugzilla.redhat.com/show_bug.cgi?id=1895336