### PR TITLE
Change the PostgreSQL 12 mount point

### DIFF
--- a/guides/common/modules/ref_satellite-storage-requirements.adoc
+++ b/guides/common/modules/ref_satellite-storage-requirements.adoc
@@ -27,7 +27,6 @@ ifdef::installing-satellite-server-disconnected[30 GB]
 
 |/var/log/ |10 MB |10 GB
 
-|/var/opt/rh/rh-postgresql12/lib/pgsql/ |100 MB |10 GB
 |/var/opt/rh/rh-postgresql12 |100 MB |10 GB
 
 |/var/spool/squid/ |0 MB |10 GB

--- a/guides/common/modules/ref_satellite-storage-requirements.adoc
+++ b/guides/common/modules/ref_satellite-storage-requirements.adoc
@@ -28,6 +28,7 @@ ifdef::installing-satellite-server-disconnected[30 GB]
 |/var/log/ |10 MB |10 GB
 
 |/var/opt/rh/rh-postgresql12/lib/pgsql/ |100 MB |10 GB
+|/var/opt/rh/rh-postgresql12 |100 MB |10 GB
 
 |/var/spool/squid/ |0 MB |10 GB
 


### PR DESCRIPTION
Bug 1896703 - Change directory to "/var/opt/rh/rh-postgresql12/" in Storage Requirements section to avoid warning during upgrade

https://bugzilla.redhat.com/show_bug.cgi?id=1896703