### PR TITLE
Correct HTTP Boot proxy requirement

### DIFF
--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -76,7 +76,7 @@ To provision machines through HTTP booting ensure that you meet the following re
 
 * Ensure that the host provisioning interface subnet has a DHCP {SmartProxy} set.
 
-* Ensure that the host provisioning interface subnet has a TFTP {SmartProxy} set.
+* Ensure that the host provisioning interface subnet has a HTTP Boot {SmartProxy} set.
 
 * Ensure that the host provisioning interface subnet has a Templates {SmartProxy} set.
 


### PR DESCRIPTION
I don't know why we have TFTP there, probably a copy paste problem.