### PR TITLE
Remove outdated email.yaml references

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -3,17 +3,6 @@
 
 To send email messages from {ProjectServer}, you can use either an SMTP server, or the `sendmail` command.
 
-.Prerequisites
-
-* If you have upgraded from a previous release, rename or remove the configuration file `/usr/share/foreman/config/email.yaml` and restart the `httpd` service. For example:
-+
-[options="nowrap" subs="+quotes"]
-----
-# mv /usr/share/foreman/config/email.yaml \
-/usr/share/foreman/config/email.yaml-backup
-# systemctl restart httpd
-----
-
 .Procedure
 
 . In the {Project} web UI, navigate to *Administer* -> *Settings*.


### PR DESCRIPTION
Foreman 1.16 dropped support email.yaml support. It no longer reads this file so the instructions are completely useless. There never was a reason to restart httpd since the process never read it anyway.

Since Foreman 1.20 the installer also removes the outdated email.yaml. No user will on a supported version will ever see this file.