### PR TITLE
Convert to one sentence per line

### DIFF
--- a/guides/common/modules/snip_red-hat-images.adoc
+++ b/guides/common/modules/snip_red-hat-images.adoc
@@ -1,1 +1,4 @@
-The graphics in this section are Red Hat illustrations. Non-Red Hat illustrations are welcome. If you want to contribute alternative images, raise a pull request in the https://github.com/theforeman/foreman-documentation[Foreman Documentation] GitHub page. Note that in Red Hat terminology, "Satellite" refers to Foreman and "Capsule" refers to Smart Proxy.
+The graphics in this section are Red Hat illustrations.
+Non-Red Hat illustrations are welcome.
+If you want to contribute alternative images, raise a pull request in the https://github.com/theforeman/foreman-documentation[Foreman Documentation] GitHub page.
+Note that in Red Hat terminology, "Satellite" refers to Foreman and "Capsule" refers to Smart Proxy.

--- a/guides/doc-Configuring_Load_Balancer/topics/Before_You_Begin.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Before_You_Begin.adoc
@@ -1,13 +1,17 @@
 [id='load-balancing-considerations']
 = Load Balancing Considerations
 
-Distributing load between several {SmartProxyServer}s prevents any one {SmartProxy} from becoming a single point of failure. Configuring {SmartProxies} to use a load balancer can provide resilience against planned and unplanned outages. This improves availability and responsiveness.
+Distributing load between several {SmartProxyServer}s prevents any one {SmartProxy} from becoming a single point of failure.
+Configuring {SmartProxies} to use a load balancer can provide resilience against planned and unplanned outages.
+This improves availability and responsiveness.
 
 Consider the following guidelines when configuring load balancing:
 
-* If you use Puppet, Puppet certificate signing is assigned to the first {SmartProxy} that you configure. If the first {SmartProxy} is down, clients cannot obtain Puppet content.
+* If you use Puppet, Puppet certificate signing is assigned to the first {SmartProxy} that you configure.
+If the first {SmartProxy} is down, clients cannot obtain Puppet content.
 
-* This solution does not use Pacemaker or other similar HA tools to maintain one state across all {SmartProxies}. To troubleshoot issues, reproduce the issue on each {SmartProxy}, bypassing the load balancer.
+* This solution does not use Pacemaker or other similar HA tools to maintain one state across all {SmartProxies}.
+To troubleshoot issues, reproduce the issue on each {SmartProxy}, bypassing the load balancer.
 
 .Additional Maintenance Required for Load Balancing
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
@@ -5,7 +5,8 @@ The following section describes how to configure {SmartProxyServer}s that use cu
 
 == Creating Custom SSL Certificates for {SmartProxyServer}
 
-This procedure outlines how to create a configuration file for the Certificate Signing Request and include the load balancer and {SmartProxyServer} as Subject Alternative Names (SAN). Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.
+This procedure outlines how to create a configuration file for the Certificate Signing Request and include the load balancer and {SmartProxyServer} as Subject Alternative Names (SAN).
+Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.
 
 .Procedure
 
@@ -19,7 +20,8 @@ This procedure outlines how to create a configuration file for the Certificate S
 
 . Create a private key with which to sign the Certificate Signing Request (CSR).
 +
-Note that the private key must be unencrypted. If you use a password-protected private key, remove the private key password.
+Note that the private key must be unencrypted.
+If you use a password-protected private key, remove the private key password.
 +
 If you already have a private key for this {SmartProxyServer}, skip this step.
 +
@@ -57,7 +59,10 @@ subjectAltName = @alt_names
 DNS.1 = _loadbalancer.example.com_
 DNS.2 = _{smartproxy-example-com}_
 ----
-<1> The certificate's common name must match the FQDN of {SmartProxyServer}. Ensure to change this when running the command on each {SmartProxyServer}. You can also set a wildcard value `*`. If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
+<1> The certificate's common name must match the FQDN of {SmartProxyServer}.
+Ensure to change this when running the command on each {SmartProxyServer}.
+You can also set a wildcard value `*`.
+If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
 <2> Under `[alt_names]`, include the FQDN of the load balancer as `DNS.1` and the FQDN of {SmartProxyServer} as `DNS.2`.
 
 . Create a Certificate Signing Request (CSR) for the SAN certificate:
@@ -75,7 +80,9 @@ DNS.2 = _{smartproxy-example-com}_
 
 . Send the certificate request to the Certificate Authority:
 +
-When you submit the request, specify the lifespan of the certificate. The method for sending the certificate request varies, so consult the Certificate Authority for the preferred method. In response to the request, you can expect to receive a Certificate Authority bundle and a signed certificate, in separate files.
+When you submit the request, specify the lifespan of the certificate.
+The method for sending the certificate request varies, so consult the Certificate Authority for the preferred method.
+In response to the request, you can expect to receive a Certificate Authority bundle and a signed certificate, in separate files.
 
 . Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and the {SmartProxyServer} private key to your {ProjectServer} to validate them.
 
@@ -109,7 +116,8 @@ If you use Puppet in your {Project} configuration, then you must complete the fo
 .Configuring {SmartProxyServer} to Generate and Sign Puppet Certificates
 
 
-Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing. In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}_ca.example.com`.
+Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing.
+In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}_ca.example.com`.
 
 . Append the following option to the `{certs-generate}` command that you obtain from the output of the `katello-certs-check` command:
 +
@@ -118,7 +126,8 @@ Complete this procedure only for the system where you want to configure {SmartPr
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 
-. On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates. For example:
+. On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates.
+For example:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -195,7 +204,8 @@ Complete this procedure for each {SmartProxyServer} excluding the system where y
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 
-. On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates. For example:
+. On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates.
+For example:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_without_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_without_Puppet_for_Load_Balancing.adoc
@@ -5,7 +5,8 @@ The following section describes how to configure {SmartProxyServer}s that use cu
 
 == Creating Custom SSL Certificates for {SmartProxyServer}
 
-This procedure outlines how to create a configuration file for the Certificate Signing Request and include the load balancer and {SmartProxyServer} as Subject Alternative Names (SAN). Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.
+This procedure outlines how to create a configuration file for the Certificate Signing Request and include the load balancer and {SmartProxyServer} as Subject Alternative Names (SAN).
+Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.
 
 .Procedure
 
@@ -19,7 +20,8 @@ This procedure outlines how to create a configuration file for the Certificate S
 
 . Create a private key with which to sign the Certificate Signing Request (CSR).
 +
-Note that the private key must be unencrypted. If you use a password-protected private key, remove the private key password.
+Note that the private key must be unencrypted.
+If you use a password-protected private key, remove the private key password.
 +
 If you already have a private key for this {SmartProxyServer}, skip this step.
 +
@@ -57,7 +59,10 @@ subjectAltName = @alt_names
 DNS.1 = _loadbalancer.example.com_
 DNS.2 = _{smartproxy-example-com}_
 ----
-<1> The certificate's common name must match the FQDN of {SmartProxyServer}. Ensure to change this when running the command on each {SmartProxyServer} that you configure for load balancing. You can also set a wildcard value `*`. If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
+<1> The certificate's common name must match the FQDN of {SmartProxyServer}.
+Ensure to change this when running the command on each {SmartProxyServer} that you configure for load balancing.
+You can also set a wildcard value `*`.
+If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
 <2> Under `[alt_names]`, include the FQDN of the load balancer as `DNS.1` and the FQDN of {SmartProxyServer} as `DNS.2`.
 
 . Create a Certificate Signing Request (CSR) for the SAN certificate.
@@ -75,7 +80,9 @@ DNS.2 = _{smartproxy-example-com}_
 
 . Send the certificate request to the Certificate Authority:
 +
-When you submit the request, specify the lifespan of the certificate. The method for sending the certificate request varies, so consult the Certificate Authority for the preferred method. In response to the request, you can expect to receive a Certificate Authority bundle and a signed certificate, in separate files.
+When you submit the request, specify the lifespan of the certificate.
+The method for sending the certificate request varies, so consult the Certificate Authority for the preferred method.
+In response to the request, you can expect to receive a Certificate Authority bundle and a signed certificate, in separate files.
 
 . Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and the {SmartProxyServer} private key to your {ProjectServer}.
 
@@ -109,7 +116,8 @@ Complete this procedure on each {SmartProxyServer} that you want to configure fo
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 
-. On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates. For example:
+. On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates.
+For example:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -132,7 +140,10 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 
-. Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command. Set the `--puppet-ca-server` option to point to the {SmartProxyServer} where you enter the command. You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not. Puppet is configured in its default single-node configuration.
+. Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.
+Set the `--puppet-ca-server` option to point to the {SmartProxyServer} where you enter the command.
+You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not.
+Puppet is configured in its default single-node configuration.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
@@ -12,7 +12,8 @@ If you use Puppet in your {Project} configuration, you must complete the followi
 [id='configuring-capsule-server-to-generate-and-sign-puppet-certificates-default-certs']
 .Configuring {SmartProxyServer} to Generate and Sign Puppet Certificates
 
-Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate and sign Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing. In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}_ca.example.com`.
+Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate and sign Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing.
+In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}_ca.example.com`.
 
 . On {ProjectServer}, generate Katello certificates for the system where you configure {SmartProxyServer} to generate and sign Puppet certificates:
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
@@ -27,7 +27,10 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 
-. Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command. Set the `--puppet-ca-server` option to point to the {SmartProxyServer} where you enter the command. You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not. Puppet is configured in its default single-node configuration.
+. Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.
+Set the `--puppet-ca-server` option to point to the {SmartProxyServer} where you enter the command.
+You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not.
+Puppet is configured in its default single-node configuration.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Servers_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Servers_for_Load_Balancing.adoc
@@ -1,11 +1,13 @@
 [id='configuring-capsule-servers-for-load-balancing']
 = Configuring {SmartProxyServer}s for Load Balancing
 
-This chapter outlines how to configure {SmartProxyServer}s for load balancing. Proceed to one of the following sections depending on your {ProjectServer} configuration:
+This chapter outlines how to configure {SmartProxyServer}s for load balancing.
+Proceed to one of the following sections depending on your {ProjectServer} configuration:
 
 . xref:configuring-capsule-server-with-default-ssl-certificates-for-load-balancing-without-puppet[]
 . xref:configuring-capsule-server-with-default-ssl-certificates-for-load-balancing-with-puppet[]
 . xref:configuring-capsule-server-with-custom-ssl-certificates-for-load-balancing-without-puppet[]
 . xref:configuring-capsule-server-with-custom-ssl-certificates-for-load-balancing-with-puppet[]
 
-Use different file names for the Katello certificates you create for each {SmartProxyServer}. For example, name the certificate archive file with the {SmartProxyServer} FQDN.
+Use different file names for the Katello certificates you create for each {SmartProxyServer}.
+For example, name the certificate archive file with the {SmartProxyServer} FQDN.

--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -27,7 +27,8 @@ However, you can install any suitable load balancing software solution that supp
 # semanage boolean --modify --on haproxy_connect_any
 ----
 
-. Configure the load balancer to balance the network load for the ports as described in xref:ports-configuration-for-the-load-balancer[]. For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg` file to correspond with the table.
+. Configure the load balancer to balance the network load for the ports as described in xref:ports-configuration-for-the-load-balancer[].
+For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg` file to correspond with the table.
 +
 You must configure sticky session on TCP port 443 to request yum metadata for RPM repositories from different {SmartProxyServer}s that you configure for load balancing.
 +
@@ -47,7 +48,8 @@ You must configure sticky session on TCP port 443 to request yum metadata for RP
 | Docker (_Optional_)| 5000 | TCP | roundrobin | port 5000 on all {SmartProxyServer}s
 |====
 
-. Configure the load balancer to disable SSL offloading and allow client-side SSL certificates to pass through to back end servers. This is required because communication from clients to {SmartProxyServer}s depends on client-side SSL certificates.
+. Configure the load balancer to disable SSL offloading and allow client-side SSL certificates to pass through to back end servers.
+This is required because communication from clients to {SmartProxyServer}s depends on client-side SSL certificates.
 
 . Start and enable the HAProxy service:
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
@@ -1,7 +1,8 @@
 [id='load-balancing-solution-architecture']
 = Load Balancing Solution Architecture
 
-You can configure {ProjectServer} to use a load balancer to distribute client requests and network load across multiple {SmartProxyServer}s. This results in an overall performance improvement on {SmartProxyServer}s.
+You can configure {ProjectServer} to use a load balancer to distribute client requests and network load across multiple {SmartProxyServer}s.
+This results in an overall performance improvement on {SmartProxyServer}s.
 
 This guide outlines how to prepare {ProjectServer} and {SmartProxyServer} for load balancing, and provides guidelines on how to configure a load balancer and register clients in a load-balanced setup.
 
@@ -28,12 +29,14 @@ Load balancer works with the following services and features:
 * Content Management with `yum` repositories
 * Optional: Puppet
 
-NOTE: In the load-balanced setup, a load balancer distributes load only for the services and features mentioned above. If other services, such as provisioning or virt-who, are running on the individual {SmartProxies}, you must access them directly through {SmartProxies} and not through the load balancer.
+NOTE: In the load-balanced setup, a load balancer distributes load only for the services and features mentioned above.
+If other services, such as provisioning or virt-who, are running on the individual {SmartProxies}, you must access them directly through {SmartProxies} and not through the load balancer.
 
 .Managing Puppet Limitations
 
 Puppet Certificate Authority (CA) management does not support certificate signing in a load-balanced setup.
-Puppet CA stores certificate information, such as the serial number counter and CRL, on the file system. Multiple writer processes that attempt to use the same data can corrupt it.
+Puppet CA stores certificate information, such as the serial number counter and CRL, on the file system.
+Multiple writer processes that attempt to use the same data can corrupt it.
 
 To manage this Puppet limitation, complete the following steps:
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Preparing_Satellite_Server_and_Capsule_Servers.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Preparing_Satellite_Server_and_Capsule_Servers.adoc
@@ -1,7 +1,8 @@
 [id='preparing-satellite-server-and-capsule-servers']
 = Prerequisites for Configuring {SmartProxyServer}s for Load Balancing
 
-To configure {SmartProxyServer}s for load balancing, complete the following procedures described in _Installing {SmartProxyServer}_. {Project} does not support configuring existing {SmartProxyServer}s for load balancing.
+To configure {SmartProxyServer}s for load balancing, complete the following procedures described in _Installing {SmartProxyServer}_.
+{Project} does not support configuring existing {SmartProxyServer}s for load balancing.
 
 . {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering {SmartProxyServer} to {ProjectServer}]
 . {InstallingSmartProxyDocURL}attaching-satellite-infrastructure-subscription_{smart-proxy-context}[Attaching the {Project} Infrastructure Subscription]

--- a/guides/doc-Configuring_Load_Balancer/topics/Promoting_SCAP_Content_to_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Promoting_SCAP_Content_to_Clients.adoc
@@ -5,7 +5,8 @@ The following section describes how to promote Security Content Automation Proto
 
 .Prerequisites
 
-* Ensure that you configure the SCAP content. For more information, see {AdministeringDocURL}sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Security_Compliance_Management_with_OpenSCAP-Configuring_SCAP_Content[Configuring SCAP Content] in _Administering {ProjectName}_.
+* Ensure that you configure the SCAP content.
+For more information, see {AdministeringDocURL}sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Security_Compliance_Management_with_OpenSCAP-Configuring_SCAP_Content[Configuring SCAP Content] in _Administering {ProjectName}_.
 
 .Procedure
 
@@ -18,10 +19,13 @@ The following section describes how to promote Security Content Automation Proto
 . In the pane to the left of the *Smart Class Parameter* window, click `server`.
 . In the *Default Behavior* area, select the *Override* check box.
 . From the *Key Type* list, select `string`.
-. In the *Default Value* field, enter the FQDN of your load balancer. For example, `_loadbalancer.example.com_`.
+. In the *Default Value* field, enter the FQDN of your load balancer.
+For example, `_loadbalancer.example.com_`.
 . In the lower left of the *Smart Class Parameter* window, click *Submit*.
-. Add the puppet module that contains the `foreman_scap_client` puppet class to a Content View. Publish and promote this Content View to your client's environment.
-. If you want to verify the configuration, run the Puppet agent on the client to promote the changes. Do not run the Puppet agent on every client manually because the Puppet agent runs on the clients every 30 minutes.
+. Add the puppet module that contains the `foreman_scap_client` puppet class to a Content View.
+Publish and promote this Content View to your client's environment.
+. If you want to verify the configuration, run the Puppet agent on the client to promote the changes.
+Do not run the Puppet agent on every client manually because the Puppet agent runs on the clients every 30 minutes.
 +
 ----
 # puppet agent -t --noop

--- a/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
@@ -1,7 +1,8 @@
 [id='registering-clients']
 = Registering Clients
 
-You can register a client running a Red{nbsp}Hat Enterprise Linux version 6, 7 or 8 operating system to {SmartProxyServer}s that you configure for load balancing. For more information about registering clients and configuring them to use Puppet, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
+You can register a client running a Red{nbsp}Hat Enterprise Linux version 6, 7 or 8 operating system to {SmartProxyServer}s that you configure for load balancing.
+For more information about registering clients and configuring them to use Puppet, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
 To register clients, proceed to one of the following procedures:
 
@@ -11,11 +12,13 @@ To register clients, proceed to one of the following procedures:
 [id='registering-clients-using-the-bootstrap-script']
 == Registering Clients Using the Bootstrap Script
 
-To register clients, enter the following command on the client. You must complete the registration procedure for each client.
+To register clients, enter the following command on the client.
+You must complete the registration procedure for each client.
 
 .Prerequisite
 
-Ensure that you install the bootstrap script on the client and change the script's file permissions to executable. For more information, see {ManagingHostsDocURL}registering-a-host-to-satellite-using-the-bootstrap-script[Registering Hosts to {ProjectName} Using The Bootstrap Script] in the _Managing Hosts_ guide.
+Ensure that you install the bootstrap script on the client and change the script's file permissions to executable.
+For more information, see {ManagingHostsDocURL}registering-a-host-to-satellite-using-the-bootstrap-script[Registering Hosts to {ProjectName} Using The Bootstrap Script] in the _Managing Hosts_ guide.
 
 * On Red{nbsp}Hat Enterprise Linux 8, enter the following command:
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Verifying_the_Load_Balancing_Configuration.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Verifying_the_Load_Balancing_Configuration.adoc
@@ -4,5 +4,6 @@
 You can verify the load balancing configuration by completing the following steps for each {SmartProxyServer} that you configure:
 
 . Shut down the base operating system for your {SmartProxyServer}.
-. Verify that content or subscription management features are available on the client registered to this {SmartProxy}. For example, enter the `subscription-manager refresh` command on the client.
+. Verify that content or subscription management features are available on the client registered to this {SmartProxy}.
+For example, enter the `subscription-manager refresh` command on the client.
 . Restart the base operating system for your {SmartProxyServer}.


### PR DESCRIPTION
This PR converts the Configuring Load balancer guide to follow the `one sentence per line` idea.
See #326 