### PR TITLE
Change certs-reset to certs-update-server and remove reinstalling cert

### DIFF
--- a/guides/common/modules/proc_configuring-project-with-an-alternate-cname.adoc
+++ b/guides/common/modules/proc_configuring-project-with-an-alternate-cname.adoc
@@ -1,6 +1,6 @@
 [id='configuring-project-with-an-alternate-cname_{context}']
 = Configuring {Project} with an Alternate CNAME
-Use this procedure to configure {Project} with an alternate CNAME. Note that the procedures for users of a default {Project} certificate and custom certificate differ. Note that if you have any hosts registered to {Project}, you must update the `katello-ca-consumer` package on the hosts after regenerating the {Project} SSL certificate.
+Use this procedure to configure {Project} with an alternate CNAME. Note that the procedures for users of a default {Project} certificate and custom certificate differ.
 
 .For Default {Project} Certificate Users
 
@@ -8,7 +8,7 @@ Use this procedure to configure {Project} with an alternate CNAME. Note that the
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --certs-cname _alternate_fqdn_ --certs-reset
+# {foreman-installer} --certs-cname _alternate_fqdn_ --certs-update-server
 ----
 
 * If you have not installed {Project}, you can add the `--certs-cname _alternate_fqdn_` option to the `{foreman-installer}` command to install {Project} with an alternate CNAME.


### PR DESCRIPTION
Bug 1900761 - Reconfiguring Satellite with an Alternate CNAME does not
require --certs-reset but --certs-update-server instead

https://bugzilla.redhat.com/show_bug.cgi?id=1900761