### PR TITLE
Fix grammar and spelling errors in provisioning guide

### DIFF
--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -61,13 +61,13 @@ Use the `--uuid` field to store the full path of the image location on the KVM s
 ----
 endif::[]
 ifeval::["{context}" == "rhv-provisioning"]
-Use the `--uuid` option to store the template UUID on the {OVirt} server.
+Use the `--uuid` option to store the template UUID on the {oVirt} server.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer compute-resource image create \
---name "__{OVirtShort}_Image__" \
---compute-resource "__My_{OVirtShort}__"
+--name "__{oVirtShort}_Image__" \
+--compute-resource "__My_{oVirtShort}__"
 --operatingsystem "RedHat _version_" \
 --architecture "x86_64" \
 --username root \

--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -48,6 +48,9 @@ Synchronized content on {SmartProxyServer}s always uses an HTTP path.
 +
 . From the *Operating system family* list, select the distribution or family of the installation medium.
 For example, CentOS and Fedora are in the `Red Hat` family.
+ifeval::["{build}" != "satellite"]
+Debian and Ubuntu belong to the `Debian` family.
+endif::[]
 . Click the *Organizations* and *Locations* tabs, to change the provisioning context.
 {ProjectServer} adds the installation medium to the set provisioning context.
 . Click *Submit* to save your installation medium.

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -7,7 +7,7 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 
 * VMware
 * Libvirt
-* {OVirt}
+* {oVirt}
 
 .Prerequisites
 

--- a/guides/doc-Managing_Hosts/topics/proc_creating_a_report_template.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_creating_a_report_template.adoc
@@ -36,7 +36,7 @@ If the input value is mandatory, select the *Required* check box.
 If this field remains undefined, the users receive a free-text field in which they can enter the value they want.
 . Optional: In the *Default* field, enter a value, for example, a host name, that you want to set as the default template input.
 . Optional: In the *Description* field, you can enter information that you want to display as inline help about the input when you generate the report.
-. Optional: Click the *Type* tab, and select whether this template is a snippet to be included in other templates,
+. Optional: Click the *Type* tab, and select whether this template is a snippet to be included in other templates.
 . Click the *Location* tab and add the locations where you want to use the template.
 . Click the *Organizations* tab and add the organizations where you want to use the template.
 . Click *Submit* to save your changes.

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite.adoc
@@ -82,7 +82,7 @@ For Red{nbsp}Hat Enterprise Linux 6.3 hosts, the release version defaults to Red
 
 . In the {Project} web UI, navigate to *Hosts* > *Content Hosts*.
 . Select the check box next to the host that needs to be changed.
-. From the *Select Action* list, select *Set Release Version*
+. From the *Select Action* list, select *Set Release Version*.
 . From the *Release Version* list, select *6.3*.
 . Click *Done*.
 ====

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -225,7 +225,7 @@ Confirm each aspect of the operating system.
 +
 For more information about associating provisioning templates, see xref:provisioning-templates_provisioning[].
 +
-ifeval::["{build}" == "satellite"]
+ifeval::["{build}" != "satellite"]
 . If you use the Katello plug-in, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
@@ -326,7 +326,7 @@ For more information, see link:{BaseURL}/planning_for_red_hat_satellite/chap-red
 # {installer-scenario} \
 --foreman-proxy-httpboot true \
 --foreman-proxy-http true \
---foreman-proxy-tftp true 
+--foreman-proxy-tftp true
 ----
 
 . In the {Project} web UI, navigate to *Hosts* > *Create Host*.
@@ -399,7 +399,7 @@ endif::[]
 # {installer-scenario} \
 --foreman-proxy-httpboot true \
 --foreman-proxy-http true \
---foreman-proxy-tftp true 
+--foreman-proxy-tftp true
 ----
 
 . Create the host with the `hammer host create` command.

--- a/guides/doc-Provisioning_Guide/topics/Infoblox_Integration.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Infoblox_Integration.adoc
@@ -9,7 +9,8 @@ endif::[]
 
 === Limitations
 
-All DHCP and DNS records can be managed only in a single Network or DNS view, After you install the Infoblox modules on {SmartProxy} and set up the view using the `{foreman-installer}` command, you cannot edit the view.
+All DHCP and DNS records can be managed only in a single Network or DNS view.
+After you install the Infoblox modules on {SmartProxy} and set up the view using the `{foreman-installer}` command, you cannot edit the view.
 
 {SmartProxyServer} communicates with a single Infoblox node using the standard HTTPS web API.
 If you want to configure clustering and High Availability, make the configurations in Infoblox.
@@ -43,7 +44,6 @@ openssl x509 -text >/etc/pki/ca-trust/source/anchors/infoblox.crt
 ----
 
 * The `_infoblox.example.com_` entry must match the host name for the Infoblox application in the X509 certificate.
-
 
 To test the CA certificate, use a CURL query:
 [options="nowrap" subs="+quotes"]
@@ -92,7 +92,6 @@ To install the Infoblox module for DHCP, complete the following steps:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-
 # {foreman-installer} --enable-foreman-proxy-plugin-dhcp-infoblox \
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed false \
@@ -103,7 +102,6 @@ To install the Infoblox module for DHCP, complete the following steps:
 --foreman-proxy-plugin-dhcp-infoblox-password infoblox \
 --foreman-proxy-plugin-dhcp-infoblox-network-view default \
 --foreman-proxy-plugin-dhcp-infoblox-dns-view default
-
 ----
 +
 . In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}* and select the {SmartProxy} with the Infoblox DHCP module and click *Refresh*.

--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -98,16 +98,16 @@ If you encounter these problems, check the DNS setup on both {Project} and {Smar
 
 The `filename` option contains the full path to the file that downloads and executes during provisioning.
 The PXE loader that you select for the host or host group defines which `filename` option to use.
-When the PXE loader is set to `none`, {Project} does not populate the `filename`  option into the DHCP record.
+When the PXE loader is set to `none`, {Project} does not populate the `filename` option into the DHCP record.
 Depending on the PXE loader option, the `filename` changes as follows:
 
 |=======
 |PXE loader option | filename entry| Notes
 
-|PXELinux BIOS |  `pxelinux.0`|
+|PXELinux BIOS | `pxelinux.0`|
 |PXELinux UEFI | `pxelinux.efi`|
 |iPXE Chain BIOS | `undionly.kpxe`|
-|PXEGrub2 UEFI | `grub2/grubx64.efi`|  x64 can differ depending on architecture
+|PXEGrub2 UEFI | `grub2/grubx64.efi`| x64 can differ depending on architecture
 |iPXE UEFI HTTP | `http://_{smartproxy-example-com}_:8000/httpboot/ipxe-x64.efi` | Requires the `httpboot` feature and renders the `filename` as a full URL where _{smartproxy-example-com}_ is a known host name of {SmartProxy} in {Project}.
 |Grub2 UEFI HTTP | `http://_{smartproxy-example-com}_:8000/httpboot/grub2/grubx64.efi` | Requires the `httpboot` feature and renders the `filename` as a full URL where _{smartproxy-example-com}_ is a known host name of {SmartProxy} in {Project}.
 |=======
@@ -201,7 +201,7 @@ The host must be created with a subnet associated with a DHCP {SmartProxy}, and 
 It is possible to use an external DHCP service, but IP addresses must be entered manually.
 The SSH credentials corresponding to the configuration in the image must be configured in {Project} to enable the post-boot configuration to be made.
 
-Check following items when troubleshooting a virtual machine booted from an image that depends on post-configuration scripts:
+Check the following items when troubleshooting a virtual machine booted from an image that depends on post-configuration scripts:
 
   * The host has a subnet assigned in {ProjectServer}.
   * The subnet has a DHCP {SmartProxy} assigned in {ProjectServer}.
@@ -299,7 +299,7 @@ To configure network services on {Project}'s integrated {SmartProxy}, complete t
 ==== Multiple Subnets or Domains via Installer
 
 The {foreman-installer} options allow only for a single DHCP subnet or DNS domain.
-One way to define more than one subnet is by using custom configuration file.
+One way to define more than one subnet is by using a custom configuration file.
 
 For every additional subnet or domain, create an entry in `/etc/foreman-installer/custom-hiera.yaml` file:
 
@@ -469,7 +469,7 @@ Switch the context to `Any Organization` and `Any Location` then check the domai
 During the DNS record creation, {Project} performs conflict DNS lookups to verify that the host name is not in active use.
 This check runs against one of the following DNS servers:
 
-* The system-wide resolver if *Adminster* > *Settings* > *Query local nameservers* is set to *true*.
+* The system-wide resolver if *Administer* > *Settings* > *Query local nameservers* is set to *true*.
 * The nameservers that are defined in the subnet associated with the host.
 * The authoritative NS-Records that are queried from the SOA from the domain name associated with the host.
 

--- a/guides/doc-Provisioning_Guide/topics/configuring_the_discovery_service.adoc
+++ b/guides/doc-Provisioning_Guide/topics/configuring_the_discovery_service.adoc
@@ -21,13 +21,11 @@ image::PXE-mode.png[]
 
 To use {ProjectServer} to provide the Discovery image, install the following RPM packages:
 
-
 * `tfm-rubygem-foreman_discovery`
 ifeval::["{build}" == "satellite"]
 * `foreman-discovery-image`
 endif::[]
 * `tfm-rubygem-smart_proxy_discovery`
-
 
 The `tfm-rubygem-foreman_discovery` package contains the {Project} plug-in to handle discovered nodes, connections, and necessary database structures, and API.
 

--- a/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
@@ -46,7 +46,7 @@ For example, *Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7*.
 ** *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64*.
 
 +
-For more information about changing download policies, see {baseurl}content_management_guide/importing_red_hat_content#changing_the_download_policy_for_a_repository[Changing the Download Policy for a Repository] in the _Content Management Guide_.
+For more information about changing download policies, see {BaseURL}content_management_guide/importing_red_hat_content#changing_the_download_policy_for_a_repository[Changing the Download Policy for a Repository] in the _Content Management Guide_.
 
 * Synchronize the following {RHEL} 7 repositories required to build the Discovery image:
 +
@@ -55,7 +55,7 @@ For example, *Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.7*.
 ** *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64*.
 
 +
-For more information about synchronizing repositories, see {baseurl}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
+For more information about synchronizing repositories, see {BaseURL}content_management_guide/importing_red_hat_content#Importing_Red_Hat_Content-Synchronizing_Red_Hat_Repositories[Synchronizing Red{nbsp}Hat Repositories] in the _Content Management Guide_.
 endif::[]
 
 .Procedure

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -106,7 +106,7 @@ Ensure that the hypervisor that you want to use supports iPXE.
 The following virtualization hypervisors support iPXE:
 
 * libvirt
-* oVirt
+* {oVirt}
 * RHEV
 ifeval::["{build}" != "satellite"]
 * VMWare (https://ipxe.org/howto/vmware[via custom firmware])

--- a/guides/doc-Provisioning_Guide/topics/proc_implementing-pxe-less-discovery.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_implementing-pxe-less-discovery.adoc
@@ -20,7 +20,6 @@ endif::[]
 The console might freeze during the process.
 On some hardware, you might experience graphical hardware problems.
 
-
 image::PXEless-mode.png[]
 
 If you have not yet installed the Discovery service or image, see xref:building-a-discovery-image[].


### PR DESCRIPTION
This PR fixes various minor grammar and spelling errors, mostly in the host provisioning guide.


I have one open question: in `guides/doc-Provisioning_Guide/common/modules/proc_adding-installation-media.adoc`, I'd ideally like to add another "family" example, i.e. ```Debian and Ubuntu belong the the `Debian` family.```.
IMHO this should happen on a different branch/PR as it's **not** solely fixing grammar and spelling etc. I'm interested in your thoughts.