### PR TITLE
DRAFT: Add PlanningDocURL attribute

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -103,6 +103,7 @@ ifeval::["{build}" == "foreman"]
 :InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman.html#
 :InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman.html#
 :ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman.html#
+:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman.html#
 :BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/
 // Remove the above BaseURL attribute when work with URLs is ready. This attribute redefines the BaseURL attribute to ensure that links that only use {BaseURL} work, we won't need that when all links use a specific-to-guide attribute instead
 endif::[]
@@ -184,6 +185,7 @@ ifeval::["{build}" == "satellite"]
 :InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
 :InstallingProjectDocURL: {BaseURL}installing_satellite_server_from_a_connected_network/index#
 :ContentManagementDocURL: {BaseURL}content_management_guide/index#
+:PlanningDocURL: {BaseURL}Planning_Guide/index#
 :BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/
 // Remove the above BaseURL attribute when work with URLs is ready. This attribute redefines the BaseURL attribute to ensure that links that only use {BaseURL} work, we won't need that when all links use a specific-to-guide attribute instead
 endif::[]
@@ -244,6 +246,7 @@ ifeval::["{build}" == "foreman-deb"]
 :InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman.html#
 :InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman.html#
 :ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman.html#
+:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman.html#
 :BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/
 // Remove the above BaseURL attribute when work with URLs is ready. This attribute redefines the BaseURL attribute to ensure that links that only use {BaseURL} work, we won't need that when all links use a specific-to-guide attribute instead
 endif::[]

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -12,7 +12,7 @@ If you use an application-based firewall, ensure that the application-based fire
 {ProjectServer} has an integrated {SmartProxy} and any host that is directly connected to {ProjectServer} is a Client of {Project} in the context of this section. This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
-Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}. For more information on {Project} Topology, see {BaseURL}planning_for_red_hat_satellite/chap-documentation-architecture_guide-capsule_server_overview#sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
+Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}. For more information on {Project} Topology, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
 
 Required ports can change based on your configuration.
 

--- a/guides/common/modules/ref_satellite-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_satellite-ports-and-firewalls-requirements.adoc
@@ -10,7 +10,7 @@ If you use an application-based firewall, ensure that the application-based fire
 {ProjectServer} has an integrated {SmartProxy} and any host that is directly connected to {ProjectServer} is a Client of {Project} in the context of this section. This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
-Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}. For more information on {Project} Topology, see {BaseURL}planning_for_red_hat_satellite/chap-documentation-architecture_guide-capsule_server_overview#sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
+Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}. For more information on {Project} Topology, see {PlanningDocURL}#sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
 
 Required ports can change based on your configuration.
 

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -13,7 +13,7 @@ endif::[]
 
 * If you want to clone a Content View from one organization to another organization on {ProjectServer}.
 
-You cannot use ISS to synchronize content from {ProjectServer} to {SmartProxyServer}. {SmartProxyServer} supports synchronization natively. For more information, see {BaseURL}planning_for_red_hat_satellite/chap-documentation-architecture_guide-capsule_server_overview[{SmartProxyServer} Overview] in _Planning for {ProjectNameX}_.
+You cannot use ISS to synchronize content from {ProjectServer} to {SmartProxyServer}. {SmartProxyServer} supports synchronization natively. For more information, see {PlanningDocURL}chap-documentation-architecture_guide-capsule_server_overview[{SmartProxyServer} Overview] in _Planning for {ProjectNameX}_.
 
 [[Using_ISS-Exporting-a-Content-View-Version]]
 === Exporting a Content View Version

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -308,7 +308,7 @@ This is the only method with which you can provision hosts in IPv6 network.
 .Prerequisites
 
 * Ensure that you meet the requirements for HTTP booting.
-For more information, see {BaseURL}/planning_for_red_hat_satellite/chap-red_hat_satellite-architecture_guide-provisioning_concepts#http_booting_requirements[HTTP Booting Requirements] in _Planning for {Project}_.
+For more information, see {PlanningDocURL}http_booting_requirements[HTTP Booting Requirements] in _Planning for {Project}_.
 
 .Procedure
 


### PR DESCRIPTION
- Replace Base URL with PlanningDocURL

This PR tries to solve #192. I am unsure if this is the way to go. I think I broke a link in `guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc` line 311. Or maybe the heading has changed from `http_booting_requirements` to `_http_booting` (https://docs.theforeman.org/master/Planning_Guide/index-foreman.html#_http_booting)?

@spetrosi please let me know if I can be of any help removing `{BaseURL}`/ introducing guide specific attributes/links.