### PR TITLE
Document that users can configure hosts with Insights upon registration

### DIFF
--- a/guides/doc-Managing_Hosts/topics/using_insights_with_satellite_hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/using_insights_with_satellite_hosts.adoc
@@ -7,6 +7,9 @@ You can sort by category, view details of the impact and resolution, and then de
 
 To use Red{nbsp}Hat Insights to monitor hosts that you manage with {Project}, you must first install Red{nbsp}Hat Insights on your hosts and register your hosts with Red{nbsp}Hat Insights.
 
+For new {Project} hosts, you can install and configure {Project} hosts with Insights during registration using the global registration template.
+For more information, see {ManagingHostsDocURL}registering-a-host-to-project-using-the-global-registration-template_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
+
 To install and register your host using Puppet, or manually, see https://access.redhat.com/products/red-hat-insights/#getstarted[Red{nbsp}Hat Insights Getting Started].
 
 .Deploying Red{nbsp}Hat Insights using the Ansible Role


### PR DESCRIPTION
Bug 1903641 - [RFE] Document that it is possible to register hosts to
Insights automatically when registering hosts to Satellite using the
global registration template

https://bugzilla.redhat.com/show_bug.cgi?id=1903641