### PR TITLE
Document that users can deploy SSH keys upon hosts registration

### DIFF
--- a/guides/common/modules/con_ssh-key-for-remote-execution-overview.adoc
+++ b/guides/common/modules/con_ssh-key-for-remote-execution-overview.adoc
@@ -11,6 +11,8 @@ Use one of the following methods to distribute the public SSH key from {SmartPro
 . xref:distributing-ssh-keys-for-remote-execution-manually_{context}[].
 . xref:using-the-api-to-obtain-ssh-keys-for-remote-execution_{context}[].
 . xref:configuring-a-kickstart-template-to-distribute-ssh-keys-during-provisioning_{context}[].
+. For new {Project} hosts, you can deploy SSH keys to {Project} hosts during registration using the global registration template.
+For more information, see {ManagingHostsDocURL}registering-a-host-to-project-using-the-global-registration-template_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
 
 {Project} distributes SSH keys for the remote execution feature to the hosts provisioned from {Project} by default.
 


### PR DESCRIPTION
Bug 1899630 - Bug 1903641 - [RFE] Document that it is possible to deploy
SSH keys to hosts automatically when registering hosts to Satellite
using the global registration template

https://bugzilla.redhat.com/show_bug.cgi?id=1899630