### PR TITLE
Add the /var/spool/squid/ directory to Proxy storage reqs table

### DIFF
--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -14,5 +14,6 @@ The runtime size was measured with Red{nbsp}Hat Enterprise Linux 6, 7, and 8 rep
 |/var/cache/pulp/ |1 MB | 20 GB (Minimum)
 |/var/lib/pulp/ |1 MB |300 GB
 |/var/lib/mongodb/ |3.5 GB |50 GB
+|/var/spool/squid/ |0 GB |10 GB
 |/opt | 500 MB | Not Applicable
 |====


### PR DESCRIPTION
Bug 1822391 - [DDF] Squid Storage Requirements are missing on Capsule
installation guide

https://bugzilla.redhat.com/show_bug.cgi?id=1822391