### PR TITLE
Add version to upstream titles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,12 +57,6 @@ jobs:
           make html BUILD=foreman-deb
           make html BUILD=satellite
 
-      - name: List files
-        run: find build
-
-      - name: Remove Last Modified
-        run: sed -i -E 's/^Last updated ([[:digit:]]+-[[:digit:]]+)-[[:digit:]]+ [[:digit:]]+:[[:digit:]]+:[[:digit:]]+ UTC$/Last updated \1/' build/*/*.html
-
       - name: Upload HTML
         uses: actions/upload-artifact@v2
         with:
@@ -152,7 +146,7 @@ jobs:
           path: web/public/
 
   publish:
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/2.3'
+    if: github.repository == 'theforeman/foreman-documentation' && startsWith(github.ref, 'refs/heads/(master|[0-9]+\.[0-9]+)')
     needs:
       - build-html
       - build-web

--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ When a commit is pushed into `X.Y`:
 
 ## Branching new release
 
-* Edit [Github Action](https://github.com/theforeman/foreman-documentation/blob/master/.github/workflows/deploy.yml) and modify this line `if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/2.3'` to include the new version. Only last two stable versions are needed.
 * Create new directory [/web/content/version-X.Y](https://github.com/theforeman/foreman-documentation/tree/master/web/content/version-2.3) and copy `index.md` and edit it accordingly.
 * Edit [/web/content/versions.md](https://github.com/theforeman/foreman-documentation/blob/master/web/content/versions.md) and add the new version to the menu.
 * Push the changes into `master`.
 * Check the site if links and landing page appeared correctly.
+* Create new `X.Y` branch.
+* Update `attributes.adoc`: DocState, Version attributes
 * Push into `X.Y` branch.
 * HTML guildes should be deployed into `/X.Y`
+* Update `attributes.adoc` in old version to "unsupported".
 
 ## License
 

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -12,6 +12,8 @@ IMAGES_TS = $(DEST_DIR)/.timestamp-images
 SOURCES = master.adoc $(shell find . -type f -name \*.adoc)
 IMAGES = $(shell find ./images ./common/images -type f 2>/dev/null || true)
 UNAME = $(shell uname)
+DATE_MDY = $(shell LC_ALL=C date "+%b %d %Y")
+DATE_MY = $(shell LC_ALL=C date "+%b %Y")
 
 ifeq ($(UNAME), Linux)
 BROWSER_OPEN = xdg-open
@@ -50,7 +52,7 @@ $(IMAGES_TS): $(IMAGES)
 	touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES)
-	asciidoctor -a build=$(BUILD) -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $<
+	asciidoctor -a build=$(BUILD) -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $<
 
 $(DEST_PDF): $(SOURCES) $(IMAGES)
 	asciidoctor-pdf -a build=$(BUILD) -d book --trace -o $@ $<

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,5 +1,10 @@
-:ProjectVersion: 2.0
-:KatelloVersion: 3.15
+// NOTE: Avoid empty lines so it can be included in the header section
+// Document state: "nightly" for master, "stable" for last two releases,
+// "unsupported" for the rest and "satellite" for satellite build
+:DocState: nightly
+// Versions used in text and code
+:ProjectVersion: 2.3
+:KatelloVersion: 3.18
 :TargetVersion: 6.8
 :TargetVersionMaintainUpgrade: 6.8
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
@@ -17,7 +22,6 @@
 //Do not update the puppet4 repo versions. They must stay at 6.3.
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
 // Change to "Red Hat Satellite Infrastructure Subscription (Beta)" for beta releases
-
 :RepoRHEL7Server: rhel-7-server-rpms
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
@@ -25,10 +29,9 @@
 :SatelliteAnsibleVersion: 2.9
 :SpecialCaseProductVersion: 6.8
 //the above attribute is for Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
-
 ifeval::["{build}" == "foreman"]
-:project-installation-guide-title: Installing Foreman server
-:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server
+:project-installation-guide-title: Installing Foreman {ProjectVersion} server
+:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server {ProjectVersion}
 :smart-proxy-context: smart-proxy
 :project-context: foreman
 :foreman-installer: foreman-installer
@@ -107,8 +110,8 @@ ifeval::["{build}" == "foreman"]
 :PlanningDocURL: {BaseURL}Planning_Guide/index-foreman.html#
 :ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman.html#
 endif::[]
-
 ifeval::["{build}" == "satellite"]
+:DocState: satellite
 :project-installation-guide-title: Installing Satellite Server from a Connected Network
 :smart-proxy-installation-guide-title: Installing Capsule Server
 :smart-proxy-context: capsule
@@ -189,7 +192,6 @@ ifeval::["{build}" == "satellite"]
 :PlanningDocURL: {BaseURL}planning_for_red_hat_satellite/index#
 :ProvisioningDocURL: {BaseURL}provisioning_guide/index#
 endif::[]
-
 ifeval::["{build}" == "foreman-deb"]
 :smart-proxy-context: smart-proxy
 :project-context: foreman

--- a/guides/common/header.adoc
+++ b/guides/common/header.adoc
@@ -1,0 +1,18 @@
+// Common document headers - avoid empty lines
+:numbered:
+ifeval::["{build}" != "satellite"]
+:toc:
+:toc-placement: left
+endif::[]
+ifeval::["{DocState}" == "nightly"]
+:revnumber: Nightly
+:revdate: published {date_my}
+endif::[]
+ifeval::["{DocState}" == "stable"]
+:revnumber: {ProjectVersion}
+:revdate: published {date_mdy}
+endif::[]
+ifeval::["{DocState}" == "unsupported"]
+:revnumber: {ProjectVersion} (unsupported)
+:revdate: published {date_mdy}
+endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/master.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/master.adoc
@@ -1,11 +1,7 @@
+include::common/attributes.adoc[]
 :imagesdir: images
 :administering-red-hat-satellite:
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-include::common/attributes.adoc[]
+include::common/header.adoc[]
 
 :context: admin
 

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -1,11 +1,6 @@
-:imagesdir: common/images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-
 include::common/attributes.adoc[]
+:imagesdir: common/images
+include::common/header.adoc[]
 
 :configuring-ansible:
 :context: ansible-admin

--- a/guides/doc-Configuring_Ansible/master.adoc
+++ b/guides/doc-Configuring_Ansible/master.adoc
@@ -1,17 +1,10 @@
-:imagesdir: common/images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-
 include::common/attributes.adoc[]
+:imagesdir: common/images
+include::common/header.adoc[]
 
 :configuring-ansible:
 
 :context: ansible
-
-
 
 = Configuring {Project} to use Ansible
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -1,11 +1,6 @@
-:imagesdir: images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-
 include::common/attributes.adoc[]
+:imagesdir: images
+include::common/header.adoc[]
 
 = Configuring {SmartProxies} with a Load Balancer
 

--- a/guides/doc-Deploying_on_AWS/master.adoc
+++ b/guides/doc-Deploying_on_AWS/master.adoc
@@ -1,11 +1,6 @@
-:imagesdir: images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-
 include::common/attributes.adoc[]
+:imagesdir: images
+include::common/header.adoc[]
 
 :deploying-on-aws:
 :context: deploying-on-aws

--- a/guides/doc-Installing_Satellite_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Satellite_Server_Disconnected/master.adoc
@@ -1,12 +1,7 @@
+include::common/attributes.adoc[]
 :imagesdir: common/images
 :installing-satellite-server-disconnected:
-:numbered:
-ifeval::["{build}" == "foreman"]
-:toc:
-:toc-placement: left
-endif::[]
-
-include::common/attributes.adoc[]
+include::common/header.adoc[]
 
 :context: satellite
 :mode: disconnected

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -1,12 +1,8 @@
-= Managing Hosts
-:imagesdir: images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-
 include::common/attributes.adoc[]
+:imagesdir: images
+include::common/header.adoc[]
+
+= Managing Hosts
 
 :context: managing-hosts
 

--- a/guides/doc-Planning_Guide/master.adoc
+++ b/guides/doc-Planning_Guide/master.adoc
@@ -1,11 +1,6 @@
-:imagesdir: images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
-
 include::common/attributes.adoc[]
+:imagesdir: images
+include::common/header.adoc[]
 
 = Planning for {ProjectName}
 

--- a/guides/doc-Provisioning_Guide/master.adoc
+++ b/guides/doc-Provisioning_Guide/master.adoc
@@ -1,14 +1,10 @@
-= Provisioning Guide
+include::common/attributes.adoc[]
 :imagesdir: images
-:numbered:
-ifeval::["{build}" != "satellite"]
-:toc:
-:toc-placement: left
-endif::[]
+include::common/header.adoc[]
 
 :context: provisioning
 
-include::common/attributes.adoc[]
+= Provisioning Guide
 
 [id="provisioning-introduction"]
 == Introduction

--- a/web/content/_index.md
+++ b/web/content/_index.md
@@ -6,6 +6,6 @@ This is work-in-progress documentation site for <a href="https://www.theforeman.
 
 Official documentation [is available here](https://theforeman.org/manuals/nightly/index.html).
 
-Available guides for the latest nigtly build:
+Available guides for the latest nightly build:
 
 {{% guide-list version="nightly" %}}

--- a/web/content/version-2.3/index.md
+++ b/web/content/version-2.3/index.md
@@ -4,8 +4,8 @@ title: "Foreman 2.3 and Katello 3.18 documentation"
 
 This is work-in-progress documentation site for <a href="https://www.theforeman.org">Foreman</a> open-source software.
 
-Official documentation [is available here](https://theforeman.org/manuals/nightly/index.html).
+Official documentation [is available here](https://theforeman.org/manuals/2.3/index.html).
 
-Available guides for the latest nigtly build:
+Available guides for version 2.3:
 
 {{% guide-list version="2.3" %}}

--- a/web/layouts/404.html
+++ b/web/layouts/404.html
@@ -12,7 +12,7 @@
 </script>
 </p>
 
-<p>Available guides for the latest nigtly build:</p>
+<p>Available guides for the latest nightly build:</p>
 
 {{ with site.GetPage "/404" }}
 {{ .Content }}


### PR DESCRIPTION
We have a branch support online now:

https://docs.theforeman.org/2.3/Planning_Guide/index-foreman.html

However it's not clear what guide version are you looking at. This introduces version number upstream to all titles, downstream there is a subtitle inserted but we don't do this workflow upstream. This will do it.