### PR TITLE
Update /var/cache/pulp/ storage req to 32GB

### DIFF
--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -11,7 +11,7 @@ The runtime size was measured with Red{nbsp}Hat Enterprise Linux 6, 7, and 8 rep
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
-|/var/cache/pulp/ |1 MB | 20 GB (Minimum)
+|/var/cache/pulp/ |1 MB | 32 GB (Minimum)
 |/var/lib/pulp/ |1 MB |300 GB
 |/var/lib/mongodb/ |3.5 GB |50 GB
 |/var/spool/squid/ |0 GB |10 GB


### PR DESCRIPTION
Bug 1889005 - /var/cache/pulp size recommendations in the documentation are outdated and can lead to filesystem fill-up situations
https://bugzilla.redhat.com/show_bug.cgi?id=1889005