### PR TITLE
Apply pondrejk feedback to the editing syspurpose procedure

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Administering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Administering_Hosts.adoc
@@ -72,16 +72,16 @@ For more information about system purpose, see https://access.redhat.com/documen
 .Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Content Hosts* and select Red{nbsp}Hat Enterprise Linux{nbsp}8 hosts that you want to edit.
-. Click the *Select Action* button and from the drop-down menu, click *Manage System Purpose*.
+. Click the *Select Action* list and select *Manage System Purpose*.
 . Select the system purpose attributes that you want to assign to the selected hosts.
-You can select on of the following values:
+You can select one of the following values:
 +
 * A specific attribute to set an all selected hosts.
 * *No Change* to keep the attribute set on the selected hosts.
 * *None (Clear)* to clear the attribute on the selected hosts.
 . Click *Assign*.
 . Navigate to *Hosts* > *Content Hosts* and select the same Red{nbsp}Hat Enterprise Linux{nbsp}8 hosts to automatically attach subscriptions based on the system purpose.
-. Click the *Select Action* button and from the drop-down menu, click *Manage Subscriptions*.
+. Click the *Select Action* list and select *Manage Subscriptions*.
 . Click *Auto-Attach* to attach subscriptions to all selected hosts automatically based on their system role.
 endif::[]
 

--- a/guides/doc-Managing_Hosts/topics/Administering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Administering_Hosts.adoc
@@ -7,21 +7,22 @@ This chapter describes creating, registering, administering, and removing hosts.
 include::proc_creating-a-host-in-satellite.adoc[leveloffset=+1]
 
 ifeval::["{build}" == "satellite"]
-[id="editing-the-system-purpose-of-a-host"]
-== Editing the System Purpose of Hosts
+== Editing the System Purpose of a Host
 
-You can edit the system purpose attributes of Red{nbsp}Hat Enterprise{nbsp}Linux 8 hosts.
-System purpose attributes define which subscriptions to attach automatically to hosts.
-For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+You can edit the system purpose attributes for a {RHEL} host. System purpose attributes define which subscriptions to attach automatically to this host. For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+
+.Prerequisites
+
+* The host that you want to edit must be registered with the subscription-manager.
 
 .Procedure
 
-. In the {Project} web UI, navigate to *Hosts* > *Content Hosts* and select Red{nbsp}Hat Enterprise Linux{nbsp}8 hosts that you want to edit.
-. Click the *Select Action* button and from the drop-down menu, click *Manage System Purpose*.
-. Select the system purpose attributes that you want to assign to the selected hosts and click *Assign*.
-. Navigate to *Hosts* > *Content Hosts* and select the same Red{nbsp}Hat Enterprise Linux{nbsp}8 hosts to automatically attach subscriptions based on the system purpose.
-. Click the *Select Action* button and from the drop-down menu, click *Manage Subscriptions*.
-. Click *Auto-Attach* to attach subscriptions to all selected hosts automatically.
+. In the {Project} web UI, navigate to *Hosts* > *Content Hosts* and click the name of the Red{nbsp}Hat Enterprise Linux{nbsp}8 host that you want to edit.
+. In the *System Purpose* area, click the *Edit* or *Remove* icon for the system purpose attributes that you want to edit, add, or remove.
+. Click *Save*.
+. Click the *Subscriptions* tab and select *Subscriptions*.
+. Click *Run Auto-Attach* to attach subscriptions to your host automatically.
+. Refresh the page to verify that the subscriptions list contains the correct subscriptions.
 
 .For CLI Users
 
@@ -56,6 +57,32 @@ For the list of values, see https://access.redhat.com/documentation/en-us/red_ha
 ----
 # subscription-manager status
 ----
+
+[id="editing-the-system-purpose-of-a-host"]
+== Editing the System Purpose of Multiple Hosts
+
+You can edit the system purpose attributes of {RHEL} hosts.
+System purpose attributes define which subscriptions to attach automatically to hosts.
+For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+
+.Prerequisites
+
+* The hosts that you want to edit must be registered with the subscription-manager.
+
+.Procedure
+
+. In the {Project} web UI, navigate to *Hosts* > *Content Hosts* and select Red{nbsp}Hat Enterprise Linux{nbsp}8 hosts that you want to edit.
+. Click the *Select Action* button and from the drop-down menu, click *Manage System Purpose*.
+. Select the system purpose attributes that you want to assign to the selected hosts.
+You can select on of the following values:
++
+* A specific attribute to set an all selected hosts.
+* *No Change* to keep the attribute set on the selected hosts.
+* *None (Clear)* to clear the attribute on the selected hosts.
+. Click *Assign*.
+. Navigate to *Hosts* > *Content Hosts* and select the same Red{nbsp}Hat Enterprise Linux{nbsp}8 hosts to automatically attach subscriptions based on the system purpose.
+. Click the *Select Action* button and from the drop-down menu, click *Manage Subscriptions*.
+. Click *Auto-Attach* to attach subscriptions to all selected hosts automatically based on their system role.
 endif::[]
 
 [id="changing-a-module-stream-for-a-host"]


### PR DESCRIPTION
* Return the procedure to edit syspurpose of a single host
* Say that editing syspurpose is possible on all RHEL hosts, not only 8
* Add a prerequisite that hosts must be registered with the submanager
* Describe that you can select a specific attribute, No Change, or None

Bug 1901920 - [RFE] Document setting system purpose on multiple hosts
via bulk action

https://bugzilla.redhat.com/show_bug.cgi?id=1901920