### PR TITLE
Fix broken multiline ifdef directives

### DIFF
--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -14,8 +14,7 @@ ifdef::kvm-provisioning[Note that you can manage only directory pool storage typ
 . From the *Architecture* list, select the operating system architecture.
 . In the *Username* field, enter the SSH user name for image access.
 ifdef::kvm-provisioning,rhv-provisioning,openstack-provisioning[This is normally the `root` user.]
-ifdef::gce-provisioning[Specify a user other than `root`, because the `root` user cannot connect to a GCE instance using SSH keys.
-The username must begin with a letter and consist of lowercase letters and numbers.]
+ifdef::gce-provisioning[Specify a user other than `root`, because the `root` user cannot connect to a GCE instance using SSH keys. The username must begin with a letter and consist of lowercase letters and numbers.]
 ifdef::azure-provisioning[You cannot use the `root` user.]
 
 ifdef::kvm-provisioning,rhv-provisioning,openstack-provisioning[. In the *Password* field, enter the SSH password for image access.]

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -24,8 +24,7 @@ ifdef::azure-provisioning[* The *Azure Subnet* field is populated with the requi
 * The *Managed*, *Primary*, and *Provision* options are automatically selected for the first interface on the host.
 If not, select them.
 
-ifdef::azure-provisioning[. Optional: If you want to use a static private IP address, from the *IPv4 Subnet* list select the {Project} subnet with the *Network Address* field matching the Azure subnet address.
-In the *IPv4 Address* field, enter an IPv4 address within the range of your Azure subnet.]
+ifdef::azure-provisioning[. Optional: If you want to use a static private IP address, from the *IPv4 Subnet* list select the {Project} subnet with the *Network Address* field matching the Azure subnet address. In the *IPv4 Address* field, enter an IPv4 address within the range of your Azure subnet.]
 . Click the *Operating System* tab, and confirm that all fields automatically contain values.
 ifdef::openstack-provisioning[. If you want to change the image that populates automatically from your compute profile, from the *Images* list, select a different image to base the new host's root volume on.]
 ifdef::azure-provisioning[. For *Provisioning Method*, ensure *Image Based* is selected.]


### PR DESCRIPTION
When converting all source files to "one sentence per line", I probably broke two `ifdef` directives.

This should be fixed now; see `git grep -i -n "ifdef:" | grep -v "\]$"`: there are no more "ifdef" occurrences without a closed square bracket at the end of the line.