### PR TITLE
Add Secure Boot info, improve HTTP UEFI Boot

### DIFF
--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -155,7 +155,7 @@ When {Project} is installed on {RHEL} or compatible operating systems using  `{f
 
 On Debian and Ubuntu operating systems, the grub2 bootloader is created using the `grub2-mkimage` unsigned. To perform the Secure Boot, the bootloader must be manually signed and key enrolled into the EFI firmware. Alternatively, grub2 from Ubuntu or {RHEL} can be copied to perform booting.
 
-Grub2 in {RHEL} 8.0-8.3 were updated to mitigate [Boot Hole Vulnerability](https://access.redhat.com/security/vulnerabilities/grub2bootloader) and keys of existing {RHEL} kernels were invalidated. To boot any of the affected {RHEL} kernel (or OS installer), you must enrol keys manually into the EFI firmware for each host:
+Grub2 in {RHEL} 8.0-8.3 were updated to mitigate [Boot Hole Vulnerability](https://access.redhat.com/security/vulnerabilities/grub2bootloader) and keys of existing {RHEL} kernels were invalidated. To boot any of the affected {RHEL} kernel (or OS installer), you must enroll keys manually into the EFI firmware for each host:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -84,22 +84,19 @@ For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
 
 Although TFTP protocol is not used for HTTP UEFI Booting, {Project} uses TFTP {SmartProxy} API to deploy bootloader configuration.
 
-* Ensure that both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
+For HTTP booting to work, ensure that {Project} has the following configurations:
 
-* Ensure that the UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
+* Both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
+
+* The UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
 
 * Ensure that the TCP port 8000 is open for the client to download the bootloader and Kickstart templates from the {SmartProxy}.
 
-* Ensure that the TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} using the HTTPS protocol.
+* The TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} using the HTTPS protocol.
 
-* Ensure that the subnet that functions as the host's provisioning interface has the following requirements:
-+
-** a DHCP {SmartProxy}
-** a HTTP Boot {SmartProxy}
-** a TFTP {SmartProxy}
-** a Templates {SmartProxy}
+* The subnet that functions as the host's provisioning interface has a DHCP {SmartProxy}, a HTTP Boot {SmartProxy},  a TFTP {SmartProxy}, and a Templates {SmartProxy}
 
-* Update the `grub2-efi` package to the latest version and execute the installer to copy the recent bootloader from `/boot` into `/var/lib/tftpboot` directory:
+* The  `grub2-efi` package is updated to the latest version. To update the `grub2-efi` package to the latest version and execute the installer to copy the recent bootloader from `/boot` into `/var/lib/tftpboot` directory, enter the following commands:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -62,40 +62,109 @@ For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
 You can use HTTP booting to boot systems over a network using HTTP.
 
 [[http-booting-requirements]]
-==== HTTP Booting Requirements
+==== HTTP Booting Requirements with managed DHCP
 To provision machines through HTTP booting ensure that you meet the following requirements:
-
-.Network requirements
-
-* Optional: If the host and the DHCP server are separated by a router, configure the DHCP relay agent and point to the DHCP server.
 
 .Client requirements
 
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
 For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
 
-* Ensure that your client has access to the DHCP and TFTP servers.
+* Ensure that your client has access to the DHCP and DNS servers.
+
+* Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
+
+.Network requirements
+
+* Optional: If the host and the DHCP server are separated by a router, configure the DHCP relay agent and point to the DHCP server.
 
 .{Project} requirements
+
+Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {SmartProxy} API to deploy bootloader configuration.
 
 * Ensure that both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
 
 * Ensure that the UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
 
-* Ensure that the TCP port 8000 is open for the client to download files and Kickstart templates from the {SmartProxy}.
+* Ensure that the TCP port 8000 is open for the client to download the bootloader and Kickstart templates from the {SmartProxy}.
 
-* Ensure that the host provisioning interface subnet has a DHCP {SmartProxy} set.
+* Ensure that the TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} using the HTTPS protocol.
 
-* Ensure that the host provisioning interface subnet has a HTTP Boot {SmartProxy} set.
+* Ensure that the subnet that functions as the host's provisioning interface has the following requirements:
++
+** a DHCP {SmartProxy}
+** a HTTP Boot {SmartProxy}
+** a TFTP {SmartProxy}
+** a Templates {SmartProxy}
 
-* Ensure that the host provisioning interface subnet has a Templates {SmartProxy} set.
-
-* Update the `grub2-efi` package to the latest version:
+* Update the `grub2-efi` package to the latest version and execute the installer to copy the recent bootloader from `/boot` into `/var/lib/tftpboot` directory:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install-project} grub2-efi
+# {foreman-installer}
 ----
+
+==== HTTP Booting Requirements with unmanaged DHCP
+To provision machines through HTTP booting without managed DHCP ensure that you meet the following requirements:
+
+.Client requirements
+
+* HTTP UEFI Boot URL must be set to one of:
+** `http://{smartproxy.example.com}:8000
+** `https://{smartproxy.example.com}:{smartproxy_port}
+* Ensure that your client has access to the DHCP and DNS servers.
+* Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
+* Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
+For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
+
+.Network requirements
+
+* An unmanaged DHCP server available for clients.
+* An unmanaged DNS server available for clients. In case DNS is not available, use IP address to configure clients.
+
+.{Project} requirements
+
+Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {SmartProxy} API to deploy bootloader configuration.
+
+* Ensure that both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
+
+* Ensure that the UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
+
+* Ensure that the TCP port 8000 is open for the client to download bootloader and Kickstart templates from the {SmartProxy}.
+
+* Ensure that the TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} via HTTPS protocol.
+
+* Ensure that the host provisioning interface subnet has a HTTP Boot {SmartProxy} set.
+
+* Ensure that the host provisioning interface subnet has a TFTP {SmartProxy} set.
+
+* Ensure that the host provisioning interface subnet has a Templates {SmartProxy} set.
+
+* Update the `grub2-efi` package to the latest version and execute the installer to copy the recent bootloader from the `/boot` directory into the `/var/lib/tftpboot` directory:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} grub2-efi
+# {foreman-installer}
+----
+
+ifeval::["{build}" != "satellite"]
+=== Secure Boot
+
+When {Project} is installed on {RHEL} or compatible operating systems using  `{foreman-installer}`, grub2 and shim bootloaders that are signed by Red Hat are deployed into the TFTP and HTTP UEFI Boot directory. PXE loader options named "SecureBoot" configure hosts to load `shim.efi`.
+
+On Debian and Ubuntu operating systems, the grub2 bootloader is created using the `grub2-mkimage` unsigned. To perform the Secure Boot, the bootloader must be manually signed and key enrolled into the EFI firmware. Alternatively, grub2 from Ubuntu or {RHEL} can be copied to perform booting.
+
+Grub2 in {RHEL} 8.0-8.3 were updated to mitigate [Boot Hole Vulnerability](https://access.redhat.com/security/vulnerabilities/grub2bootloader) and keys of existing {RHEL} kernels were invalidated. To boot any of the affected {RHEL} kernel (or OS installer), you must enrol keys manually into the EFI firmware for each host:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# pesign -P -h -i /boot/vmlinuz-<version>
+# mokutil --import-hash <hash value returned from pesign>
+# reboot
+----
+endif::[]
 
 === Kickstart
 You can use Kickstart to automate the installation process of a {ProjectName} or {SmartProxyServer} by creating a Kickstart file that contains all the information that is required for the installation.

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -67,12 +67,14 @@ To provision machines through HTTP booting ensure that you meet the following re
 
 .Client requirements
 
-* Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
+For HTTP booting to work, ensure that your environment has the following client-side configurations:
+ 
+* All the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
 For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
 
-* Ensure that your client has access to the DHCP and DNS servers.
+* Your client has access to the DHCP and DNS servers.
 
-* Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
+* Your client has access to the HTTP UEFI Boot {SmartProxy}.
 
 .Network requirements
 

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -82,7 +82,7 @@ For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
 
 .{Project} requirements
 
-Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {SmartProxy} API to deploy bootloader configuration.
+Although TFTP protocol is not used for HTTP UEFI Booting, {Project} uses TFTP {SmartProxy} API to deploy bootloader configuration.
 
 * Ensure that both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
 


### PR DESCRIPTION
We do not support Secure Boot in Satellite, what we don't support we don't document. However it is worth mentioning this upstream, there are some limitations and recent vulnerabilities made it even more complicated.

HTTP UEFI Boot can be used with or without managed DHCP, in that case EFI must be configured to boot via HTTP directly. This improves instructions.