### PR TITLE
GlobalReg procedure: Selecting SmartProxy is not optional

### DIFF
--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-project-using-the-global-registration-template.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-project-using-the-global-registration-template.adoc
@@ -56,7 +56,7 @@ Optional: If the *Registration* feature is not enabled on your {SmartProxy}, ent
 
 . From the *Operating System* list, select the operating system of hosts that you want to register.
 
-. Optional: If you want to register hosts through {SmartProxy}, from the *{SmartProxy}* list, select the {SmartProxy} to register hosts to.
+. From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through {SmartProxy}.
 
 ifeval::["{build}" == "satellite"]
 . From the *Insights* list, select whether you want to register the hosts to Insights or not.
@@ -77,7 +77,7 @@ Therefore, do not delete, block, or change permissions of the user during the to
 If you keep this field blank, {Project} uses the default network interface.
 
 ifeval::["{build}" == "satellite"]
-. In the *Activation Key(s)* field, enter one or more activation keys to assign to hosts.
+. Optional: In the *Activation Key(s)* field, enter one or more activation keys to assign to hosts if you are not using a Host Group with an activation key.
 endif::[]
 
 ifeval::["{build}" != "satellite"]

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-project-using-the-global-registration-template.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-project-using-the-global-registration-template.adoc
@@ -77,7 +77,7 @@ Therefore, do not delete, block, or change permissions of the user during the to
 If you keep this field blank, {Project} uses the default network interface.
 
 ifeval::["{build}" == "satellite"]
-. Optional: In the *Activation Key(s)* field, enter one or more activation keys to assign to hosts if you are not using a Host Group with an activation key.
+. In the *Activation Key(s)* field, enter one or more activation keys to assign to hosts if you are not using a Host Group with an activation key.
 endif::[]
 
 ifeval::["{build}" != "satellite"]


### PR DESCRIPTION
Hello

1] As per subject, we need to mark that step as optional and mention having an AK in a HG also works.
2] If a user does not select the smart proxy to use, it defaults to the internal one and that might not be what the user expected and if the user connected without using FQDN there will be problems..So lets not say that step is optional.

Thank you