### PR TITLE
Update versions to 2.5/4.1 to match nightly

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -3,8 +3,8 @@
 // "unsupported" for the rest and "satellite" for satellite build
 :DocState: nightly
 // Versions used in text and code
-:ProjectVersion: 2.4
-:KatelloVersion: 4.0
+:ProjectVersion: 2.5
+:KatelloVersion: 4.1
 :TargetVersion: 6.8
 :TargetVersionMaintainUpgrade: 6.8
 // The above attribute should point to the GA version number (x.y) for all releases including Beta


### PR DESCRIPTION
Foreman 2.4 has branched and nightly is at 2.5. On the Katello side 4.0 has also branched and nightly is at 4.1.