### PR TITLE
Remove redundant line in note

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -44,7 +44,7 @@ ifeval::["{build}" == "satellite"]
 endif::[]
 
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on Red Hat Enterprise Linux] in the _Virtual Machine Management Guide_ for more information.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on Red Hat Enterprise Linux] in the _Virtual Machine Management Guide_.
 +
 . Clear any metadata:
 +


### PR DESCRIPTION
-Config Repositories section

Sat 6.9 beta installation guide refers to repositories of 6.8 instead of 6.9 beta
https://bugzilla.redhat.com/show_bug.cgi?id=1929429