### PR TITLE
Improve 404 redirect and foreman attribute

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -102,8 +102,28 @@ To use them, use "attributes" keyword:
 Hide or show specific blocks, paragraphs, warnings or chapters via special variable called "build".
 Its value can be set either to "foreman-el" or "satellite":
 
-	ifeval::["{build}" == "foreman-el"]
+	ifeval::["{build}" == "katello"]
 	NOTE: This part is only relevant for deployments with Katello plugin.
+	endif::[]
+
+This syntax does not allow multiple conditionals, in that case use, now preferred, `ifdef` syntax:
+
+	ifdef::katello[]
+	NOTE: This part is only relevant for deployments with Katello plugin.
+	endif::[]
+
+Use comma for logic "or":
+
+	ifdef::katello,satellite[]
+	NOTE: This part is only relevant for deployments with Katello plugin or in Satellite environment.
+	endif::[]
+
+Some files are included in different contexts, there are attributes to find the correct context. In these cases use both `ifdef` and `ifeval`:
+
+	ifdef::foreman-el,foreman-deb[]
+	ifeval::["{context}" == "{project-context}"]
+	* A minimum of 4 GB RAM is required for {ProjectServer} to function.
+	endif::[]
 	endif::[]
 
 When doing review, consider checking out the topic branch and putting necessary changes on top of author's work to making many comments on github.

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -29,13 +29,14 @@
 :SatelliteAnsibleVersion: 2.9
 :SpecialCaseProductVersion: 6.8
 //the above attribute is for Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
-
 // Define properties to represent each build. Allows doing 'or' and 'and' operations for conditions.
 ifeval::["{build}" == "foreman-el"]
 :foreman-el:
+:foreman:
 endif::[]
 ifeval::["{build}" == "foreman-deb"]
 :foreman-deb:
+:foreman:
 endif::[]
 ifeval::["{build}" == "katello"]
 :katello:
@@ -43,7 +44,6 @@ endif::[]
 ifeval::["{build}" == "satellite"]
 :satellite:
 endif::[]
-
 ifdef::katello,foreman-el[]
 :project-installation-guide-title: Installing Foreman {ProjectVersion} server
 :smart-proxy-installation-guide-title: Installing an External Smart Proxy Server {ProjectVersion}
@@ -126,7 +126,6 @@ ifdef::katello,foreman-el[]
 :PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-el.html#
 :ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-el.html#
 endif::[]
-
 ifdef::satellite[]
 :DocState: satellite
 :project-installation-guide-title: Installing Satellite Server from a Connected Network

--- a/web/layouts/404.html
+++ b/web/layouts/404.html
@@ -4,10 +4,17 @@
 
 <p>We are sorry, but this page does not exist.
 <script>
-    if (document.location.toString().includes("/master/")) {
-        document.write("This page has been <a href=\"")
-        document.write(document.location.toString().replace("/master/", "/nightly/"))
-        document.write("\">moved</a>.")
+    var loc = document.location.toString();
+    if (loc.includes("/master/") || loc.includes("/index.html")) {
+        newLocation = document.location.toString()
+                .replace("/master/", "/nightly/")
+                .replace("/index.html", "/index-el.html");
+        document.write("This page has been <a href=\"");
+        document.write(newLocation);
+        document.write("\">moved</a>. Redirecting in 3 seconds.");
+        window.setTimeout(function() {
+            window.location.href = newLocation;
+        }, 3500);
     }
 </script>
 </p>


### PR DESCRIPTION
This improves redirect from `index.html` to `index-el.html` in 404 error. Files haven't been deployed yet, I am going to look into that in a moment. This fixes #406.

Second change is a proposal to introduce `foreman` attribute when `foreman-el` or `foreman-deb` is set so we can write easier if statements.