### PR TITLE
Prepare anchors for upstreamization

### DIFF
--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -1,6 +1,7 @@
 ifdef::context[:parent-context: {context}]
 
 
+[id="configuring-custom-server-certificate_{context}"]
 [id="configuring-satellite-custom-server-certificate_{context}"]
 
 = Configuring {ProjectServer} with a Custom SSL Certificate

--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -1,3 +1,4 @@
+[id="configuring-with-an-http-proxy_{context}"]
 [id="configuring-satellite-with-an-http-proxy_{context}"]
 = Configuring {ProjectServer} with an HTTP Proxy
 

--- a/guides/common/assembly_installing-satellite-server-connected.adoc
+++ b/guides/common/assembly_installing-satellite-server-connected.adoc
@@ -1,3 +1,4 @@
+[id="installing-server-connected"]
 [id="installing-satellite-server-connected"]
 = Installing {ProjectServer}
 

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -1,3 +1,4 @@
+[id="installing-server-disconnected"]
 [id="installing-satellite-server-disconnected"]
 = Installing {ProjectServer}
 

--- a/guides/common/assembly_using-satellite-ansible-content-collections.adoc
+++ b/guides/common/assembly_using-satellite-ansible-content-collections.adoc
@@ -1,5 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
+[id="managing-with-ansible-content-collections_{context}"]
 [id="using-satellite-ansible-content-collections_{context}"]
 == Managing {Project} with Ansible Collections
 

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -1,3 +1,4 @@
+[id="attaching-infrastructure-subscription_{context}"]
 [id="attaching-satellite-infrastructure-subscription_{context}"]
 
 = Attaching the {Project} Infrastructure Subscription

--- a/guides/common/modules/proc_configuring-satellite-automatically-using-an-answer-file.adoc
+++ b/guides/common/modules/proc_configuring-satellite-automatically-using-an-answer-file.adoc
@@ -1,3 +1,4 @@
+[id="configuring-automatically-using-an-answer-file_{context}"]
 [id="configuring-satellite-automatically-using-an-answer-file_{context}"]
 = Configuring {Project} Automatically using an Answer File
 

--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -1,3 +1,4 @@
+[id="configuring-deployment-with-an-external-dhcp-server_{context}"]
 [id="configuring-satellite-deployment-with-an-external-dhcp-server_{context}"]
 = Configuring {ProductName} with an External DHCP Server
 

--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -1,3 +1,4 @@
+[id="configuring-for-outgoing-emails_{context}"]
 [id="configuring-satellite-for-outgoing-emails_{context}"]
 = Configuring {ProjectServer} for Outgoing Emails
 

--- a/guides/common/modules/proc_configuring-satellite-manually.adoc
+++ b/guides/common/modules/proc_configuring-satellite-manually.adoc
@@ -1,3 +1,4 @@
+[id="configuring-manually_{context}"]
 [id="configuring-satellite-manually_{context}"]
 = Configuring {Project} Manually
 

--- a/guides/common/modules/proc_configuring-satellite-to-synchronize-content-with-a-local-cdn-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-synchronize-content-with-a-local-cdn-server.adoc
@@ -1,3 +1,4 @@
+[id="configuring-to-synchronize-content-with-a-local-cdn-server_{context}"]
 [id="configuring-satellite-to-synchronize-content-with-a-local-cdn-server_{context}"]
 = Configuring {Project} to Synchronize Content with a Local CDN Server
 

--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -1,3 +1,4 @@
+[id="configuring-to-use-external-databases_{context}"]
 [id="configuring-satellite-to-use-external-databases_{context}"]
 = Configuring Satellite to use External Databases
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -1,3 +1,4 @@
+[id="deploying-a-custom-ssl-certificate-to-server_{context}"]
 [id="deploying-a-custom-ssl-certificate-to-satellite-server_{context}"]
 
 = Deploying a Custom SSL Certificate to {ProjectServer}

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -1,3 +1,4 @@
+[id="enabling-client-connections_{context}"]
 [id="enabling-client-connections-to-satellite_{context}"]
 = Enabling Connections from a Client to {ProjectServer}
 

--- a/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
@@ -1,3 +1,4 @@
+[id="enabling-connections-from-proxy-to-server_{context}"]
 [id="enabling-connections-from-capsule-to-satellite_{context}"]
 = Enabling Connections from {SmartProxyServer} to {ProjectServer}
 

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -1,3 +1,4 @@
+[id="enabling-the-tools-repository_{context}"]
 [id="enabling-the-satellite-tools-repository_{context}"]
 = Enabling the {project-client-name} Repository
 

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc
@@ -1,3 +1,4 @@
+[id="importing-a-subscription-manifest-into-server_{context}"]
 [id="importing-a-subscription-manifest-into-satellite-server_{context}"]
 = Importing a Subscription Manifest into {ProjectServer}
 

--- a/guides/common/modules/proc_installing-satellite-ansible-modules-via-rpm.adoc
+++ b/guides/common/modules/proc_installing-satellite-ansible-modules-via-rpm.adoc
@@ -1,3 +1,4 @@
+[id="installing-ansible-modules-via-rpm_{context}"]
 [id="installing-satellite-ansible-modules-via-rpm_{context}"]
 == Installing the {Project} Ansible Modules from RPM
 

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -1,3 +1,4 @@
+[id="installing-server-packages_{context}"]
 [id="installing-the-satellite-server-packages_{context}"]
 = Installing the {ProjectServer} Packages
 

--- a/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
+++ b/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
@@ -1,3 +1,4 @@
+[id="listing-using-ansible-modules_{context}"]
 [id="listing-using-satellite-ansible-modules_{context}"]
 == Viewing the {Project} Ansible Modules
 

--- a/guides/common/modules/proc_registering-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-to-satellite-server.adoc
@@ -1,3 +1,4 @@
+[id="registering-to-server_{context}"]
 [id="registering-to-satellite-server_{context}"]
 
 = Registering to {ProjectServer}

--- a/guides/common/modules/proc_reverting-satellite-to-download-content-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_reverting-satellite-to-download-content-from-red-hat-cdn.adoc
@@ -1,3 +1,4 @@
+[id="reverting-to-download-content-from-red-hat-cdn_{context}"]
 [id="reverting-satellite-to-download-content-from-red-hat-cdn_{context}"]
 = Reverting {Project} to Download Content from Red Hat CDN
 

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -1,3 +1,4 @@
+[id="synchronizing-the-tools-repository_{context}"]
 [id="synchronizing-the-satellite-tools-repository_{context}"]
 = Synchronizing the {project-client-name} Repository
 

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -1,3 +1,4 @@
+[id='using-insights-with-server_{context}']
 [id='using-insights-with-satellite-server_{context}']
 = Using Red{nbsp}Hat Insights with {ProjectServer}
 

--- a/guides/common/modules/ref_satellite-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_satellite-ports-and-firewalls-requirements.adoc
@@ -1,3 +1,4 @@
+[id="ports-and-firewalls-requirements_{context}"]
 [id="satellite-ports-and-firewalls-requirements_{context}"]
 = Ports and Firewalls Requirements
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
@@ -116,6 +116,7 @@ In that case, complete the following steps:
 . If some Pulp tasks failed due to the full disk, run them again.
 
 ifeval::["{build}" == "satellite"]
+[id='installing-and-updating-packages-on-server']
 [id='installing-and-updating-packages-on-satellite-server']
 === Managing Packages on the Base Operating System of {Project} or {SmartProxy}
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/assembly_backing-up-satellite-server-and-capsule-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/assembly_backing-up-satellite-server-and-capsule-server.adoc
@@ -1,3 +1,4 @@
+[id="backing-up-server-and-proxy"]
 [id="backing-up-satellite-server-and-capsule-server"]
 
 == Backing Up {ProjectServer} and {SmartProxyServer}

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -1,3 +1,4 @@
+[id='configuring-idm-authentication-on-server_{context}']
 [id='configuring-idm-authentication-on-satellite-server_{context}']
 = Configuring {FreeIPA} Authentication on {ProjectServer}
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-red-hat-satellite-to-use-ldap.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-red-hat-satellite-to-use-ldap.adoc
@@ -1,3 +1,4 @@
+[id='configuring-to-use-ldap_{context}']
 [id='configuring-red-hat-satellite-to-use-ldap_{context}']
 = Configuring {ProjectName} to use LDAP
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/enrolling-satellite-server-with-the-ad-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/enrolling-satellite-server-with-the-ad-server.adoc
@@ -1,3 +1,4 @@
+[id='enrolling-server-with-the-ad-server_{context}']
 [id='enrolling-satellite-server-with-the-ad-server_{context}']
 = Enrolling {ProjectServer} with the AD Server
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/log-files-provided-by-satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/log-files-provided-by-satellite.adoc
@@ -1,3 +1,4 @@
+[id='log-file-directories-provided_{context}']
 [id='log-file-directories-provided-by-satellite_{context}']
 = Log File Directories Provided by {Project}
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/predefined-roles-available-in-satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/predefined-roles-available-in-satellite.adoc
@@ -1,3 +1,4 @@
+[id='predefined-roles-available_{context}']
 [id='predefined-roles-available-in-satellite_{context}']
 = Predefined Roles Available in {Project}
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/proc_performing-a-full-backup-of-satellite-or-capsule.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/proc_performing-a-full-backup-of-satellite-or-capsule.adoc
@@ -1,3 +1,4 @@
+[id='performing-a-full-backup-_{context}']
 [id='performing-a-full-backup-of-satellite-or-capsule_{context}']
 
 = Performing a Full Backup of {ProjectServer} or {SmartProxyServer}

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/satellite-settings.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/satellite-settings.adoc
@@ -1,3 +1,4 @@
+[id='server-settings_{context}']
 [id='satellite-settings_{context}']
 = {Project} Settings
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Overview.adoc
@@ -17,6 +17,7 @@ ifeval::["{build}" != "satellite"]
 include::../common/modules/snip_red-hat-images.adoc[]
 endif::[]
 
+[id='load-balancing-solution-architecture']
 [id='satellite-load-balancing-solution-architecture']
 .{Project} Load Balancing Solution Architecture
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Preparing_Satellite_Server_and_Capsule_Servers.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Preparing_Satellite_Server_and_Capsule_Servers.adoc
@@ -1,3 +1,4 @@
+[id='preparing-server-and-proxies']
 [id='preparing-satellite-server-and-capsule-servers']
 = Prerequisites for Configuring {SmartProxyServer}s for Load Balancing
 

--- a/guides/doc-Managing_Hosts/topics/con_overview-of-hosts-in-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/con_overview-of-hosts-in-satellite.adoc
@@ -1,3 +1,4 @@
+[id="overview-of-hosts"]
 [id="overview-of-hosts-in-satellite"]
 = Overview of Hosts in {ProjectNameX}
 

--- a/guides/doc-Managing_Hosts/topics/proc_creating-a-host-in-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_creating-a-host-in-satellite.adoc
@@ -1,3 +1,4 @@
+[id="creating-a-host"]
 [id="creating-a-host-in-satellite"]
 = Creating a Host in {ProjectName}
 

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-manually.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-manually.adoc
@@ -1,3 +1,4 @@
+[id="registering-a-host"]
 [id="registering-a-host-to-satellite"]
 = Registering a Host to {ProjectName} Manually
 

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-using-the-bootstrap-script.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-using-the-bootstrap-script.adoc
@@ -1,3 +1,4 @@
+[id="registering-a-host-using-the-bootstrap-script"]
 [id="registering-a-host-to-satellite-using-the-bootstrap-script"]
 = Registering a Host to {ProjectName} Using The Bootstrap Script
 

--- a/guides/doc-Managing_Hosts/topics/proc_registering-an-atomic-host-to-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-an-atomic-host-to-satellite.adoc
@@ -1,3 +1,4 @@
+[id="registering-an-atomic-host"]
 [id="registering-an-atomic-host-to-satellite"]
 = Registering an Atomic Host to {ProjectName}
 

--- a/guides/doc-Managing_Hosts/topics/proc_removing-a-host-from-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_removing-a-host-from-satellite.adoc
@@ -1,3 +1,4 @@
+[id="removing-a-host"]
 [id="removing-a-host-from-satellite"]
 = Removing a Host from {ProjectName}
 

--- a/guides/doc-Managing_Hosts/topics/using_insights_with_satellite_hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/using_insights_with_satellite_hosts.adoc
@@ -1,3 +1,4 @@
+[id="using-insights"]
 [id="using-insights-with-satellite-hosts"]
 = Using Red{nbsp}Hat Insights with Hosts in {Project}
 


### PR DESCRIPTION
This prepares anchors so we can start removing product references from them.

Please cherry pick it into 2.3.