### PR TITLE
Update our index-foreman.html links

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -116,15 +116,15 @@ ifdef::katello,foreman-el[]
 :ansible-namespace-example: `theforeman.foreman._module_name_`
 :awx: AWX
 :BaseURL: https://docs.theforeman.org/nightly/
-:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman.html#
-:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman.html#
-:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman.html#
-:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman.html#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman.html#
-:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman.html#
-:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman.html#
-:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman.html#
-:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman.html#
+:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman-el.html#
+:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman-el.html#
+:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman-el.html#
+:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman-el.html#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman-el.html#
+:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman-el.html#
+:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman-el.html#
+:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-el.html#
+:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-el.html#
 endif::[]
 
 ifdef::satellite[]
@@ -262,13 +262,13 @@ ifdef::foreman-deb[]
 :project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
 :project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
 :BaseURL: https://docs.theforeman.org/nightly/
-:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman.html#
-:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman.html#
-:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman.html#
-:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman.html#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman.html#
-:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman.html#
-:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman.html#
-:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman.html#
-:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman.html#
+:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman-el.html#
+:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman-el.html#
+:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman-el.html#
+:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman-el.html#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman-el.html#
+:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman-el.html#
+:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman-el.html#
+:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-el.html#
+:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-el.html#
 endif::[]


### PR DESCRIPTION
When our HTML link validation was down, we also missed this.

Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->