### PR TITLE
fix missing repository enablement segments for katello

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,6 +5,7 @@
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
 .Procedure
+.For {RHEL} users
 ifeval::["{build}" == "foreman-el"]
 This procedure is only for Katello plug-in users.
 Skip steps involving `subscription-manager` when not installing on the {RHEL} operating system.
@@ -18,7 +19,7 @@ endif::[]
 ----
 +
 . Enable the following repositories:
-ifeval::["{build}" == "foreman-el"]
+ifdef::foreman,katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -40,7 +41,6 @@ ifeval::["{build}" == "satellite"]
 ----
 +
 endif::[]
-
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on Red Hat Enterprise Linux] in the _Virtual Machine Management Guide_ for more information.
 +
@@ -57,8 +57,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 ----
 # yum repolist enabled
 ----
-
-ifeval::["{build}" == "foreman-el"]
+ifdef::foreman,katello[]
 +
 . Install the `foreman-release.rpm` package:
 +
@@ -66,6 +65,8 @@ ifeval::["{build}" == "foreman-el"]
 ----
 # yum localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
 ----
+endif::[]
+ifdef::katello[]
 +
 . Install the `katello-repos-latest.rpm` package
 +
@@ -73,6 +74,7 @@ ifeval::["{build}" == "foreman-el"]
 ----
 # yum localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
+endif::[]
 +
 . Install the `puppet6-release-el-7.noarch.rpm` package:
 +
@@ -85,10 +87,8 @@ ifeval::["{build}" == "foreman-el"]
 ----
 # yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ----
-endif::[]
 
-ifeval::["{build}" == "foreman-el"]
-
+ifeval::["{build}" != "satellite"]
 .CentOS Users
 If you use a CentOS operating system, complete the following steps:
 
@@ -98,6 +98,7 @@ If you use a CentOS operating system, complete the following steps:
 ----
 # yum localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
 ----
+ifdef::katello[]
 +
 . Install the `katello-repos-latest.rpm` package
 +
@@ -105,6 +106,7 @@ If you use a CentOS operating system, complete the following steps:
 ----
 # yum localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
+endif::[]
 +
 . Install the `puppet6-release-el-7.noarch.rpm` package:
 +
@@ -121,6 +123,6 @@ If you use a CentOS operating system, complete the following steps:
 . Install the `foreman-release-scl` package:
 +
 ----
-# yum install foreman-release-scl
+# yum install centos-release-scl-rh
 ----
 endif::[]

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -20,7 +20,16 @@ ifeval::["{build}" == "satellite"]
 ----
 endif::[]
 
-ifeval::["{build}" == "foreman-el"]
+ifdef::foreman-el[]
+. Install the `foreman` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} foreman-installer
+----
+endif::[]
+
+ifdef::katello[]
 . Install the `katello` package:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

Closes #422 

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
