### PR TITLE
Fix broken reference

### DIFF
--- a/guides/doc-Installing_Server_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Server_on_Red_Hat/master.adoc
@@ -14,7 +14,7 @@ include::common/attributes.adoc[]
 
 = {project-installation-guide-title}
 
-include::common/assembly_preparing-environment-for-satellite-installation.adoc[leveloffset=+1]
+include::common/assembly_preparing-environment-for-installation.adoc[leveloffset=+1]
 
 include::common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This fixes the broken intro to Installation guide
This fixes #424

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
