### PR TITLE
WIP: Update Katello installation guide

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -22,5 +22,6 @@ include::modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc[
 //Deploying a Custom SSL Certificate to Hosts
 include::modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc[leveloffset=+1]
 
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_installing-satellite-server-connected.adoc
+++ b/guides/common/assembly_installing-satellite-server-connected.adoc
@@ -24,7 +24,7 @@ On Debian or Ubuntu operating systems, installations with the Katello plug-in ar
 Ignore any references to the Katello plug-in.
 endif::[]
 
-Note that the {ProjectX} installation script is based on Puppet, which means that if you run the installation script more than once, it might overwrite any manual configuration changes.
+Note that the {Project} installation script is based on Puppet, which means that if you run the installation script more than once, it might overwrite any manual configuration changes.
 ⁠
 To avoid this and determine which future changes apply, use the `--noop` argument when you run the installation script.
 This argument ensures that no actual changes are made.

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -26,6 +26,7 @@
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
+:RepoRHEL7ServerExtra: rhel-7-server-extras-rpms
 :SatelliteAnsibleVersion: 2.9
 :SpecialCaseProductVersion: 6.8
 //the above attribute is for Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
@@ -43,6 +44,10 @@ ifeval::["{build}" == "katello"]
 endif::[]
 ifeval::["{build}" == "satellite"]
 :satellite:
+endif::[]
+ifdef::katello[]
+:project-installation-guide-title: Installing Foreman {ProjectVersion} server with Katello
+:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server {ProjectVersion} with Katello
 endif::[]
 ifdef::katello,foreman-el[]
 :project-installation-guide-title: Installing Foreman {ProjectVersion} server

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,6 +5,7 @@
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
 .Procedure
+
 .For {RHEL} users
 ifeval::["{build}" == "foreman-el"]
 This procedure is only for Katello plug-in users.
@@ -25,7 +26,15 @@ ifdef::foreman,katello[]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
 --enable {RepoRHEL7ServerOptional} \
---enable {RepoRHEL7ServerSoftwareCollections}
+--enable {RepoRHEL7ServerSoftwareCollections} \
+--enable {RepoRHEL7ServerExtra}
+----
++
+. Install the `yum-utils` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# yum install yum-utils
 ----
 +
 endif::[]
@@ -120,7 +129,7 @@ endif::[]
 # yum install epel-release
 ----
 +
-. Install the `foreman-release-scl` package:
+. Install the `centos-release-scl-rh` package:
 +
 ----
 # yum install centos-release-scl-rh

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -2,6 +2,7 @@
 
 = Deploying a Custom SSL Certificate to {ProjectServer}
 
+
 Use this procedure to configure your {ProjectServer} to use a custom SSL certificate signed by a Certificate Authority.
 The `katello-certs-check` command validates the input certificate files and returns the commands necessary to deploy a custom SSL certificate to {ProjectServer}.
 
@@ -15,9 +16,9 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--c __/root/satellite_cert/satellite_cert.pem__ \      <1>
--k __/root/satellite_cert/satellite_cert_key.pem__ \  <2>
--b __/root/satellite_cert/ca_cert_bundle.pem__        <3>
+-c __/root/{project-context}_cert/{project-context}_cert.pem__ \      <1>
+-k __/root/{project-context}_cert/{project-context}_cert_key.pem__ \  <2>
+-b __/root/{project-context}_cert/ca_cert_bundle.pem__        <3>
 ----
 <1> Path to the {ProjectServer} certificate file that is signed by a Certificate Authority.
 <2> Path to the private key that was used to sign the {SmartProxyServer} certificate.
@@ -31,16 +32,16 @@ ifeval::["{build}" == "satellite"]
 ----
 Validation succeeded.
 
-To install the Red Hat Satellite Server with the custom certificates, run:
+To install the {ProjectServer} with the custom certificates, run:
 
-  satellite-installer --scenario satellite \
+  {foreman-installer} --scenario satellite \
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
 
-To update the certificates on a currently running Red Hat Satellite installation, run:
+To update the certificates on a currently running {ProjectServer} installation, run:
 
-  satellite-installer --scenario satellite \
+  {foreman-installer}--scenario satellite \
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
@@ -54,19 +55,19 @@ ifeval::["{build}" != "satellite"]
 ----
 Validation succeeded.
 
-To install the Katello main server with the custom certificates, run:
+To install the Katello main server with custom certificates, enter the following command:
 
-  foreman-installer --scenario katello \\
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+  foreman-installer --scenario katello \
+    --certs-server-cert "_/root/cert/cert.pem_" \
+    --certs-server-key "_/root/cert/cert_key.pem_" \
+    --certs-server-ca-cert "_/root/cert/cert_bundle.pem_"
 
-To update the certificates on a currently running Katello installation, run:
+To update the certificates on a currently running Katello installation, enter the following command:
 
-  foreman-installer --scenario katello \\
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
+  foreman-installer --scenario katello \
+    --certs-server-cert "_/root/cert/cert.pem_" \
+    --certs-server-key "_/root/cert/cert_key.pem_" \
+    --certs-server-ca-cert "_/root/cert/ca_cert_bundle.pem_" \
     --certs-update-server --certs-update-server-ca
 ----
 endif::[]

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -20,7 +20,7 @@ include::snip_firewalld.adoc[]
 --add-port="8140/tcp" --add-port="9090/tcp" \
 --add-port="53/udp" --add-port="53/tcp" \
 --add-port="67/udp" --add-port="69/udp" \
---add-port="5000/tcp"
+--add-port="5000/tcp" --add-port="5646/tcp"
 ----
 
 . Make the changes persistent:

--- a/guides/common/modules/proc_manually-checking-certificate-validity.adoc
+++ b/guides/common/modules/proc_manually-checking-certificate-validity.adoc
@@ -1,0 +1,21 @@
+[id="manually-checking-certificate-validity_{context}"]
+
+= Manually Checking Certificate Validity
+
+During the installation process, any certificates for Katello are checked for validity.
+The same can be performed manually with `katello-certs-check`.
+Manually checking certificate validity can be useful when looking into SSL-related issues or configuring custom certificates.
+
+.Procedure
+
+To manually check a certificate, enter the following command:
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+katello-certs-check -c ~/path/to/server.crt \
+                    -k ~/path/to/server.key \
+                    -b ~/path/to/cacert.crt
+----
+
+If you want to configure Katello with a set of invalid certs,
+the validation check can be skipped by passing `--certs-skip-check` to the {foreman-installer}.

--- a/guides/common/modules/ref_satellite-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_satellite-ports-and-firewalls-requirements.adoc
@@ -65,7 +65,7 @@ ifeval::["{build}" == "satellite"]
 | 5647 | TCP | AMQP | Katello Agent to communicate with {Project}'s Qpid dispatch router
 | 8000 | TCP | HTTP | Anaconda to download kickstart templates to hosts, and for downloading iPXE firmware
 endif::[]
-ifeval::["{build}" == "foreman-el"]
+ifdef::foreman,katello[]
 | 80 | TCP | HTTP | Operating system installers like Anaconda, yum, for obtaining Katello certificates, templates, and for downloading iPXE firmware
 | 443 | TCP | HTTPS | Subscription Management Services, yum, Telemetry Services, and for connection to the Katello Agent
 | 5646 | TCP | AMQP | The {SmartProxy} Qpid dispatch router to the Qpid dispatch router in {Project}
@@ -83,7 +83,7 @@ endif::[]
 ifeval::["{build}" == "satellite"]
 | 5000 | TCP | HTTPS | Connection to Katello for the Docker registry (Optional)
 endif::[]
-ifeval::["{build}" == "foreman-el"]
+ifdef::foreman,katello[]
 | 5000 | TCP | HTTPS | If you use the Katello plug-in, a connection to Katello for the Docker registry (Optional)
 endif::[]
 |====

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -24,12 +24,16 @@ Enable the Optional repository:
 Use `yum repolist` to validate because the command can fail silently if your subscription does not provide it.
 
 Apply all SELinux-related errata.
-| CentOS, Scientific Linux or Oracle Linux 7 | x86_64 only | EPEL is required
+| CentOS | x86_64 only | EPEL is required
 endif::[]
+ifdef::foreman,foreman-deb[]
+| Scientific Linux or Oracle Linux 7 | x86_64 only | EPEL is required
 | Ubuntu 16.04 (Xenial) | amd64 |
 | Ubuntu 18.04 (Bionic) | amd64 |
 | Debian 9 (Stretch) | amd64 |
+endif::[]
 |====
+
 
 Other operating systems must use alternative installation methods, such as from source.
 

--- a/guides/doc-Installing_Server_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Server_on_Red_Hat/master.adoc
@@ -45,11 +45,15 @@ include::common/modules/proc_configuring-satellite-for-outgoing-emails.adoc[leve
 
 include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 
-include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
+include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+1]
 
-include::common/assembly_using-external-databases.adoc[leveloffset=+2]
+ifdef::katello[]
+include::common/modules/proc_manually-checking-certificate-validity.adoc[leveloffset=+2]
+endif::[]
 
-include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
+include::common/assembly_using-external-databases.adoc[leveloffset=+1]
+
+include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
 
 
 include::common/assembly_configuring-external-services.adoc[leveloffset=+1]


### PR DESCRIPTION
Ahead of 4.0
This is a draft. 

@jjeffers - I wonder if we should also have installation instructions for EL8? I don't think we have and I just read this https://community.theforeman.org/t/what-is-the-state-of-katello-support-on-el8/22186/6?u=mcorr

I am trying to figure out how to change the title with ifdefs. 
Not working for me so far. 

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
