### PR TITLE
Better separate the smart proxy installation instructions between Katello and Foreman

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -7,16 +7,18 @@ ifdef::context[:parent-context: {context}]
 Before you install {SmartProxyServer}, you must ensure that your environment meets the requirements for installation.
 For more information, see {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation].
 
-ifndef::foreman-deb[]
+ifdef::satellite,katello[]
 // Registering {SmartProxyServer} to {ProjectServer}
-include::modules/proc_registering-to-satellite-server.adoc[leveloffset=+1]
+include::modules/proc_registering-capsule-to-satellite-server.adoc[leveloffset=+1]
 
-// Attaching the {Project} Infrastructure Subscription
+ifdef::satellite[]
+// Attaching the Satellite Infrastructure Subscription
 include::modules/proc_attaching-satellite-infrastructure-subscription.adoc[leveloffset=+1]
+endif::[]
 
 // Configuring Repositories
 
-include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
+include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::foreman-deb[]
@@ -37,16 +39,12 @@ include::modules/proc_synchronizing-the-system-clock-with-chronyd.adoc[leveloffs
 // Assigning the Correct Organization and Location to {SmartProxyServer} in the {Project} web UI
 include::modules/proc_enabling-capsule-in-UI.adoc[leveloffset=+1]
 
-ifndef::foreman-deb[]
+ifdef::katello,satellite[]
 [id="configuring-capsule-server-with-ssl-certificates"]
 == Configuring {SmartProxyServer} with SSL Certificates
 endif::[]
 
-ifdef::foreman-el,katello[]
-This procedure is only for Katello plug-in users.
-endif::[]
-
-ifndef::foreman-deb[]
+ifdef::katello,satellite[]
 {ProjectName} uses SSL certificates to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
 Depending on the requirements of your organization, you must configure your {SmartProxyServer} with a default or custom certificate.
 

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -1,8 +1,17 @@
 [id="installing-capsule-server-packages_{context}"]
+[id="installing-the-satellite-capsule-server-packages_{context}"]
 
 = Installing {SmartProxyServer} Packages
 
 Before installing {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
+
+ifdef::foreman-el,katello[]
+* xref:#centos-7-package[Red Hat Enterprise Linux 7 / CentOS Linux 7]
+* xref:#centos-8-package[Red Hat Enterprise Linux 8 / CentOS Linux 8]
+endif::[]
+ifdef::satellite[]
+* xref:#rhel-7-package[Red Hat Enterprise Linux 7]
+endif::[]
 
 .Procedure
 To install {SmartProxyServer}, complete the following steps:
@@ -28,4 +37,24 @@ ifndef::satellite[]
 ----
 # {package-install} foreman-proxy-content
 ----
+
+ifdef::foreman-el,katello[]
+== [[centos-7-package]]Red Hat Enterprise Linux 7 / CentOS Linux 7
+endif::[]
+
+ifdef::satellite[]
+== [[rhel-7-package]]Red Hat Enterprise Linux 7
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
+:package-manager: yum
+include::proc_installing-proxy-packages-el.adoc[]
+endif::[]
+
+ifdef::foreman-el,katello[]
+== [[centos-8-package]]Red Hat Enterprise Linux 8 / CentOS Linux 8
+
+:package-manager: dnf
+include::proc_installing-proxy-packages-el.adoc[]
+
 endif::[]

--- a/guides/common/modules/proc_installing-proxy-packages-el.adoc
+++ b/guides/common/modules/proc_installing-proxy-packages-el.adoc
@@ -1,0 +1,32 @@
+[id="configuring-foreman-proxy-repositories-el-{package-manager}"]
+
+. Update all packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} update
+----
+ifdef::satellite[]
+. Install the {ProjectServer} packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} install satellite-capsule
+----
+endif::[]
+ifdef::foreman-el[]
+. Install `{foreman-installer-package}`
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} install {foreman-installer-package}
+----
+endif::[]
+ifdef::katello[]
+. Install `foreman-proxy-content`
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} install foreman-proxy-content
+----
+endif::[]

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -4,6 +4,7 @@
 
 .Procedure
 
+ifdef::foreman-el,foreman-deb[]
 * To install an external {SmartProxy}, enter the following command:
 +
 [options="nowrap", subs="+quotes,attributes"]
@@ -22,3 +23,9 @@
   --foreman-proxy-oauth-consumer-key=_oAuth_Consumer_Key_ \
   --foreman-proxy-oauth-consumer-secret=_oAuth_Consumer_Secret_
 ----
+endif::[]
+
+ifdef::katello[]
+* To install an external Smart Proxy with content, please refer to xref:configuring-capsule-server-with-ssl-certificates[].
+Running `foreman-proxy-certs-generate` is a required prerequisite to installing an external Smart Proxy with content.
+endif::[]

--- a/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
@@ -1,9 +1,13 @@
-[id="registering-to-server_{context}"]
-[id="registering-to-satellite-server_{context}"]
+[id="registering-capsule-to-server_{context}"]
+[id="registering-capsule-to-satellite-server_{context}"]
 
 = Registering to {ProjectServer}
 
 Use this procedure to register the base operating system on which you want to install {SmartProxyServer} to {ProjectServer}.
+
+ifdef::katello[]
+Registering your {SmartProxyServer} as a content host is optional unless you wish to download the installation packages from your synced repositories.
+endif::[]
 
 .Subscription Manifest Prerequisites
 * On {ProjectServer}, a manifest must be installed and it must contain the appropriate repositories for the organization you want {SmartProxy} to belong to.
@@ -13,14 +17,12 @@ Use this procedure to register the base operating system on which you want to in
 For more information on manifests and repositories, see {ContentManagementDocURL}Managing_Subscriptions/[Managing Subscriptions] in the _{ProjectName} Content Management Guide_.
 
 .Proxy and Network Prerequisites
-* {ProjectServer} base operating system must be able to resolve the host name of the {SmartProxy} base operating system and vice versa.
-ifndef::foreman-deb[]
+* The {ProjectServer} base operating system must be able to resolve the host name of the {SmartProxy} base operating system and vice versa.
 * The base operating system on which you want to install {SmartProxyServer} must not be configured to use a proxy to connect to the Red Hat CDN.
-endif::[]
 * You must configure the host and network-based firewalls accordingly.
 For more information, see {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements].
 * You must have a {ProjectServer} user name and password.
-For more information, see {AdministeringDocURL}chap-Administering-Configuring_External_Authentication[Configuring External Authentication] in _Administering {ProjectName}_.
+For more information, see {AdministeringDocURL}chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_External_Authentication[Configuring External Authentication] in _Administering {ProjectName}_.
 
 .Procedure
 

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -7,11 +7,33 @@ These values are based on expected use case scenarios and can vary according to 
 
 The runtime size was measured with Red{nbsp}Hat Enterprise Linux 6, 7, and 8 repositories synchronized.
 
+ifdef::foreman-el,katello[]
+== [[storage-centos-7]]Red Hat Enterprise Linux 7 / CentOS Linux 7
+endif::[]
+
+ifdef::satellite[]
+== [[storage-rhel-7]]Red Hat Enterprise Linux 7
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
 .Storage Requirements for {SmartProxyServer} Installation
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
-|/var/lib/pulp/ |1 MB |300 GB
+|/var/lib/pulp |1 MB |300 GB
 |/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |10 GB
 |/opt | 500 MB | Not Applicable
 |====
+endif::[]
+
+ifdef::foreman-el,katello[]
+== [[storage-centos-8]]Red Hat Enterprise Linux 8 / CentOS Linux 8
+
+.Storage Requirements for {SmartProxyServer} Installation
+[cols="1,1,1",options="header"]
+|====
+|Directory |Installation Size |Runtime Size
+|/var/lib/pulp |1 MB |300 GB
+|/var/lib/pgsql |100 MB |10 GB
+|====
+endif::[]

--- a/web/layouts/shortcodes/guide-list.html
+++ b/web/layouts/shortcodes/guide-list.html
@@ -6,6 +6,7 @@
 * [Katello Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-katello.html)
 * [Installing Foreman on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-el.html)
 * [Installing Katello on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-katello.html)
+* [Installing Smart Proxy with Content on RHEL/CentOS](/{{ $path }}/Installing_Proxy_on_Red_Hat/index-katello.html)
 * [Installing Smart Proxy on RHEL/CentOS](/{{ $path }}/Installing_Proxy_on_Red_Hat/index-foreman-el.html)
 * [Installing Foreman on Debian/Ubuntu](/{{ $path }}/Installing_Server_on_Debian/index-foreman-deb.html)
 * [Installing Smart Proxy on Debian/Ubuntu](/{{ $path }}/Installing_Proxy_on_Debian/index-foreman-deb.html)


### PR DESCRIPTION
This PR adds some better separation between vanilla (no Katello), content, and Satellite smart proxies.

I've removed the parts that say "Katello only" and hid those sections instead.

Let me know if I missed anything.