### PR TITLE
Remove link to guide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -47,7 +47,7 @@ If you customize configuration files, manually or use a tool such as Hiera, thes
 [[upgrade_paths]]
 == Upgrade Paths
 
-You can upgrade to {ProjectName} from the previous version. {ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to the {Project} version previous to this. For more information, see the {Project} {ProductVersionPrevious} {UpgradingDocURL}[Upgrading and Updating {ProjectName}] guide.
+You can upgrade to {ProjectName} from the previous version. {ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to the {Project} version previous to this. For more information, see the {Project} {ProductVersionPrevious} Upgrading and Updating {ProjectName} guide.
 
 .Overview of {Project} {ProductVersion} Upgrade Paths
 image::satellite_6.4_upgrade_paths.png[Overview of {Project} {ProductVersion} Upgrade Paths]


### PR DESCRIPTION
Remove ref to guide when guide doesn't exist yet

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
