### PR TITLE
Favor remote execution over katello agent

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -91,7 +91,7 @@ If you want unlimited hosts to register with the activation key, ensure the *Unl
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the environment to use.
 . From the *Content View* list, select a Content View to use.
-If you want to use this activation key to register hosts, the Content View must contain the {project-client-name} repository because it is required to install the `katello-agent`.
+If you intend to use the deprecated `Katello Agent` instead of `Remote Execution`, the Content View must contain the {project-client-name} repository because it contains the `katello-agent` package.
 . Click *Save*.
 . Optional: For Red{nbsp}Hat Enterprise Linux 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.
 
@@ -278,14 +278,6 @@ This RPM installs the necessary certificates for accessing repositories on {Proj
 ----
 # hammer host list --organization "_My_Organization_"
 ----
-+
-. After registering a host to {ProjectServer}, install the `katello-agent` package on the host so that it can report back to {ProjectServer}:
-+
-----
-# yum install katello-agent
-----
-+
-The {project-client-name} repository provides this package.
 
 .Multiple Activation Keys
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
@@ -137,9 +137,6 @@ For more information, see {AdministeringDocURL}email-notifications_admin[Configu
 [[Managing_Errata-Limitations_to_Repository_Dependency_Resolution]]
 === Limitations to Repository Dependency Resolution
 
-There are a number of challenges to solving repository dependencies in {ProjectX}.
-This is a known issue.
-For more information, see https://bugzilla.redhat.com/show_bug.cgi?id=1508169[BZ#1508169], https://bugzilla.redhat.com/show_bug.cgi?id=1640420[BZ#1640420], https://bugzilla.redhat.com/show_bug.cgi?id=1508169[BZ#1508169], and https://bugzilla.redhat.com/show_bug.cgi?id=1629462[BZ#1629462].
 With {Project}, using incremental updates to your Content Views solves some repository dependency problems.
 However, dependency resolution at a repository level still remains problematic on occasion.
 
@@ -310,19 +307,17 @@ Use these procedures to review and apply errata to a host.
 * Synchronize {ProjectName} repositories with the latest errata available from Red{nbsp}Hat.
 For more information, see xref:Importing_Content-Synchronizing_Repositories[].
 
-* Register the host to an environment and Content View on {ProjectServer}.
+* Register the host to an environment and Content View on the {ProjectServer}.
 For more information, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
-* For RHEL 7 hosts, ensure that you install the `katello-agent` package.
-For more information, see {ManagingHostsDocURL}installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in the _Managing Hosts_ guide.
-+
-Note that the Katello agent is deprecated and will be removed in a future {Project} version.
-Migrate your workloads to use the remote execution feature to update clients remotely.
-For more information, see {ManagingHostsDocURL}host-management-without-goferd-and-katello-agent_managing-hosts[Host Management Without Goferd and Katello Agent] in the _Managing Hosts Guide_.
-
-.For Red{nbsp}Hat Enterprise Linux 8
-To apply an erratum to a RHEL 8 host, you can run a remote execution job on {ProjectServer} or update the host.
+* Configure the host for remote execution.
 For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs] in the  _Managing Hosts_ guide.
+
+[NOTE]
+====
+If the host is already configured to receive content updates with the deprecated Katello Agent, they should be migrated to remote execution instead.
+For more information, see {ManagingHostsDocURL}host-management-without-goferd-and-katello-agent_managing-hosts[Migrating from Katello Agent to Remote Execution] in the _Managing Hosts Guide_.
+====
 
 To apply an erratum to a RHEL 8 host, complete the following steps:
 
@@ -369,7 +364,19 @@ To apply an erratum to a RHEL 7 host, complete the following steps:
 ----
 
 . Apply the most recent erratum to the host.
-Identify the erratum to apply using the erratum ID:
+Identify the erratum to apply using the erratum ID.
++
+Using `Remote Execution`
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# hammer job-invocation create \
+--job-template "Run Command - SSH Default" \
+--inputs command="yum -y update" \
+--search-query "name = client.example.com"
+----
++
+Using `Katello Agent` (deprecated)
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -390,13 +397,14 @@ For more information, see xref:Importing_Content-Synchronizing_Repositories[].
 * Register the hosts to an environment and Content View on {ProjectServer}.
 For more information, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
-* Install the `katello-agent` package on hosts.
-For more information, see {ManagingHostsDocURL}installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in the _Managing Hosts_ guide.
-+
-Note that the Katello agent is deprecated and will be removed in a future {Project} version.
-Migrate your workloads to use the remote execution feature to update clients remotely.
-For more information, see {ManagingHostsDocURL}host-management-without-goferd-and-katello-agent_managing-hosts[Host Management Without Goferd and Katello Agent] in the _Managing Hosts Guide_.
+* Configure the host for remote execution.
+For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs] in the  _Managing Hosts_ guide.
 
+[NOTE]
+====
+If the host is already configured to receive content updates with the deprecated Katello Agent, they should be migrated to remote execution instead.
+For more information, see {ManagingHostsDocURL}host-management-without-goferd-and-katello-agent_managing-hosts[Migrating from Katello Agent to Remote Execution] in the _Managing Hosts Guide_.
+====
 .Procedure
 
 . Navigate to *Content* > *Errata*.

--- a/guides/doc-Content_Management_Guide/topics/QuickStart.adoc
+++ b/guides/doc-Content_Management_Guide/topics/QuickStart.adoc
@@ -8,7 +8,7 @@ If you have installed {Project} with Katello and want to synchronize and manage 
 * Synchronize the Content.
 * Create `Activation Keys`.
 * Register Hosts to consume this content.
-* Manage RPMs on hosts using the `katello-agent`.
+* Install a package
 
 
 ==== Creating repositories to synchronize
@@ -92,3 +92,27 @@ Default_Organization_Centos_Stream_BaseOS_x86_64_os               BaseOS x86_64
 Uploading Enabled Repositories Report
 ----
 . Check the `/etc/yum.repos.d/redhat.conf` and ensure that the appropriate repositories have been enabled.
+
+==== Install a package
+
+Packages can now be installed while logged in to the Content Host
+
+----
+ # yum install screen
+----
+
+To manage packages through the {ProjectServer}, configure `Remote Execution`.
+For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs] in the  _Managing Hosts_ guide.
+
+Once configured, use this procedure to install a package from the {ProjectServer} web UI.
+
+.Procedure
+. In the {Project} web UI, navigate to *Hosts* > *Content Hosts*.
+. Click the name of the host which was registered above.
+. Click the *Packages* tab.
+. From the dropdown, click *Actions*.
+. Select *Package Install* from the dropdown.
+. Type *screen* into the text field.
+. From the dropdown next to the *Perform* button, select `via remote execution`.
+
+A `Job Invocation` will be created to perform the package installation and report the status back to the web UI.

--- a/guides/doc-Managing_Hosts/topics/Host_Management_without_Goferd.adoc
+++ b/guides/doc-Managing_Hosts/topics/Host_Management_without_Goferd.adoc
@@ -1,10 +1,8 @@
 [id="host-management-without-goferd-and-katello-agent_{context}"]
-== Host Management Without Goferd and Katello Agent
+== Migrating from Katello Agent to Remote Execution
 
-The `goferd` service that is used by the Katello agent to manage packages on content hosts consumes large amount of resources.
-To reduce memory and CPU load on content hosts, you can manage packages through remote execution.
-
-Note that the Katello agent is deprecated and will be removed in a future {Project} version; therefore, using remote execution will be the only way to manage packages on hosts.
+The Katello Agent is deprecated and will be removed in a future {Project} version; therefore, using remote execution will be the only way to manage packages on hosts.
+Follow these steps to switch to Remote Execution.
 
 .Prerequisites
 
@@ -17,15 +15,9 @@ For more information, see {InstallingProjectDocURL}synchronizing-the-satellite-t
 endif::[]
 
 * You have enabled the {project-client-name} repository on content hosts.
+* You have previously installed the `katello-agent` package on content hosts.
 
 .Procedure
-
-. Install  the `katello-host-tools` package on content hosts:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {package-install} katello-host-tools
-----
 
 . Stop the goferd service on content hosts:
 +
@@ -50,7 +42,7 @@ WARNING: If your host is installed on {oVirt} version 4.4 or lower, do not remov
 # {package-remove} katello-agent
 ----
 
-. Distribute the SSH keys to the content hosts.
+. Distribute the remote execution SSH keys to the content hosts.
 For more information, see xref:ssh-keys-for-remote-execution-overview_{context}[].
 
 . In the {Project} web UI, navigate to *Administer* > *Settings*.
@@ -59,13 +51,12 @@ For more information, see xref:ssh-keys-for-remote-execution-overview_{context}[
 
 . Set the *Use remote execution by default* parameter to *Yes*.
 
-The {Project} server now uses host management by remote execution instead of goferd.
+The {Project} server now uses host management by remote execution instead of katello-agent.
 
 .Hammer Limitations
 
-The following applies if you are using the `hammer` command to push errata.
-The `hammer` command is dependent on goferd to manage errata on content hosts.
-As a workaround, use the {Project} remote execution feature to apply errata.
+The `hammer host package` and `hammer host errata` commands currently depend on the Katello Agent.
+The following illustrates the {Project} remote execution equivalent via `hammer job-invocation`.
 
 For example, enter the following command to perform a `yum -y update` on _host123.example.org_:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -74,7 +65,4 @@ For example, enter the following command to perform a `yum -y update` on _host12
 --job-template "Run Command - SSH Default" \
 --inputs command="yum -y update" \
 --search-query "name ~ host123"
-Job invocation 24 created
-[.........................................] [100%]
-1 task(s), 1 success, 0 fail
 ----


### PR DESCRIPTION
As I was working on this PR my feelings changed on how to proceed so I'm opening this as a draft. The overall goals here are to:

- make it very clear that katello agent is no longer the preferred way of managing client content
- make sure the right guidance if provided (and linked to) w.r.t **migrating** from agent -> REX
- treat REX as the default rather than Agent

As the change is now, I've adjusted to include examples for REX (ie `hammer job-invocation ...`) in addition to katello agent (ie `hammer host package`).

However, I thought about how this is nightly documentation representing Katello 4.1 which we are still developing. In 4.1 we intend to migrate the `hammer host package` and `hammer host errata` commands to work with REX as well. This simplifies the examples considerably. Unless otherwise specified, the backend should be using REX rather than the agent.

Since we are actually going to be making those changes this sprint I'm leaning toward altering this PR to represent that future state of 4.1 rather than trying to illustrate REX and Agent here explicitly.

Nevertheless I think this is still eligible for review as I make various tweaks.
