### PR TITLE
Added some missing discovery kernel options

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -59,6 +59,26 @@ fdi.ipv6.method::
 This option overrides it, set it to `ignore` to disable the IPv6 stack.
 This option only works in DHCP mode.
 
+fdi.zips::
+  Filenames with extensions to be downloaded and started during boot.
+For more information, see see xref:Extending_the_Discovery_Image[].
+
+fdi.zipserver::
+  TFTP server to use to download extensions from.
+For more information, see see xref:Extending_the_Discovery_Image[].
+
+fdi.countdown::
+  Number of seconds to wait until text-user interface is refreshed after the initial discovery attempt.
+This value defaults to 45 second.
+Increase this value when status page reports N/A.
+
+fdi.dhcp_timeout::
+  NetworkManager DHCP timeout.
+This value default to 300 seconds.
+
+fdi.vlan.primary::
+  VLAN tagging ID to set for the primary interface.
+
 .Using the `discovery-remaster` Tool to Remaster an OS Image
 
 ifeval::["{build}" == "satellite"]

--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -68,13 +68,13 @@ fdi.zipserver::
 For more information, see see xref:Extending_the_Discovery_Image[].
 
 fdi.countdown::
-  Number of seconds to wait until text-user interface is refreshed after the initial discovery attempt.
-This value defaults to 45 second.
-Increase this value when status page reports N/A.
+  Number of seconds to wait until the text-user interface is refreshed after the initial discovery attempt.
+This value defaults to 45 seconds.
+Increase this value when status page reports IP address as N/A.
 
 fdi.dhcp_timeout::
   NetworkManager DHCP timeout.
-This value default to 300 seconds.
+The default value is 300 seconds.
 
 fdi.vlan.primary::
   VLAN tagging ID to set for the primary interface.

--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -70,7 +70,7 @@ For more information, see see xref:Extending_the_Discovery_Image[].
 fdi.countdown::
   Number of seconds to wait until the text-user interface is refreshed after the initial discovery attempt.
 This value defaults to 45 seconds.
-Increase this value when status page reports IP address as N/A.
+Increase this value if the status page reports the IP address as `N/A`.
 
 fdi.dhcp_timeout::
   NetworkManager DHCP timeout.


### PR DESCRIPTION
These are the misisng ones from https://theforeman.org/plugins/foreman_discovery/15.0/index.html#3.1.5Discoveryimagekerneloptions

I skipped those which are not relevant anymore or I don't want them to be documented.