### PR TITLE
Fix asciidoc consistency & spelling errors

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Changing_the_Password.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Changing_the_Password.adoc
@@ -12,5 +12,3 @@ These steps show how to change your password.
 . In the *Password* field, enter a new password.
 . In the *Verify* field, enter the new password again.
 . Click the *Submit* button to save your new password.
-
-

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
@@ -13,9 +13,8 @@ For an example configuration, see https://access.redhat.com/solutions/1498773[Ho
 Direct AD integration means that {ProjectServer} is joined directly to the AD domain where the identity is stored.
 The recommended setup consists of two steps: 
 
-- Enrolling {ProjectServer} with the Active Directory server as described in xref:enrolling-satellite-server-with-the-ad-server_{context}[].
-
-- Configuring direct Active Directory integration with GSS-proxy as described in xref:configuring-direct-ad-integration-with-gss-proxy_{context}[].
+* Enrolling {ProjectServer} with the Active Directory server as described in xref:enrolling-satellite-server-with-the-ad-server_{context}[].
+* Configuring direct Active Directory integration with GSS-proxy as described in xref:configuring-direct-ad-integration-with-gss-proxy_{context}[].
 
 include::gss-proxy.adoc[leveloffset=+3]
 
@@ -38,5 +37,3 @@ From the {Project} point of view, the configuration process is the same as integ
 The {ProjectServer} has to be enrolled in the IPM domain and integrated as described in xref:sect-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication-Using_Identity_Management[].
 
 include::configuring-the-idm-server-to-use-cross-forest-trust.adoc[leveloffset=+3]
-
-

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -10,9 +10,8 @@ For more information, see xref:sect-{Project_Link}-Administering_{Project_Link}-
 [[br-Using-IdM-for-Authentication-prereq]]
 .Prerequisites
 
-- The {ProjectServer} has to run on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6.6 or later.
-
-- The base operating system of the {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
+* The {ProjectServer} has to run on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6.6 or later.
+* The base operating system of the {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
 However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/index.html#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_the_Red_Hat_Satellite_Content_Dashboard.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_the_Red_Hat_Satellite_Content_Dashboard.adoc
@@ -91,11 +91,11 @@ Click the subscription type to view hosts associated with subscriptions of the s
 [[varl-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Concepts_Cloud_CFSE_Dashboard_Concepts_Cloud_CFSE_Dashboard_Concepts_CFSEDashboard-Host_Collections]]
 *Host Collections*:: A list of all host collections in {Project} and their status, including the number of content hosts in each host collection.
 
-[[varl-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Concepts_Cloud_CFSE_Dashboard_Concepts_Cloud_CFSE_Dashboard_Concepts_CFSEDashboard-Virt-who_Congiguration_Status]]
+[[varl-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Concepts_Cloud_CFSE_Dashboard_Concepts_Cloud_CFSE_Dashboard_Concepts_CFSEDashboard-Virt-who_Configuration_Status]]
 *Virt-who Configuration Status*:: An overview of the status of reports received from the `virt-who` daemon running on hosts in the environment.
 The following table shows the possible states.
 +
-[[tabl-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Virt-who_Congiguration_Status-Virt-who_Congiguration_States]]
+[[tabl-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Virt-who_Configuration_Status-Virt-who_Configuration_States]]
 
 .Virt-who Configuration States
 [cols="2,7", options="header"]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -5,7 +5,7 @@ In the {Project} CLI, configure the direct Active Directory integration with GSS
 
 .Prerequisite
 
-- {Project} is enrolled with the Active Directory server.
+* {Project} is enrolled with the Active Directory server.
 +
 For more information, see xref:enrolling-satellite-server-with-the-ad-server_{context}[].
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
@@ -20,8 +20,8 @@ By default, {ProjectServer} uses the language and timezone settings of the userâ
 
 . Set a password for the user:
 .. From the *Authorized by* list, select the source by which the user is authenticated.
-- *INTERNAL*: to enable the user to be managed inside {ProjectServer}.
-- *EXTERNAL*: to configure external authentication as described in xref:chap-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication[].
+** *INTERNAL*: to enable the user to be managed inside {ProjectServer}.
+** *EXTERNAL*: to configure external authentication as described in xref:chap-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication[].
 
 .. Enter an initial password for the user in the *Password* field and the *Verify* field.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/email-notifications.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/email-notifications.adoc
@@ -6,10 +6,10 @@ The periodic notifications can be sent daily, weekly or monthly.
 
 The events that trigger a notification are the following:
 
-- Host build
-- Content View promotion
-- Error reported by host
-- Repository sync
+* Host build
+* Content View promotion
+* Error reported by host
+* Repository sync
 
 Users do not receive any email notifications by default.
 An administrator can configure users to receive notifications based on criteria such as the type of notification, and frequency.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/enrolling-satellite-server-with-the-ad-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/enrolling-satellite-server-with-the-ad-server.adoc
@@ -5,8 +5,7 @@
 In the {Project} CLI, enroll {ProjectServer} with the Active Directory server.
 
 .Prerequisites
-
-- GSS-proxy and nfs-utils are installed.
+* GSS-proxy and nfs-utils are installed.
 +
 Installing GSS-proxy and nfs-utils:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
@@ -11,14 +11,14 @@ Make sure that you are logged in to the web UI as an Admin user of {ProjectName}
 . From the *Username* column, click on the username of the required user.
 . Click on the *SSH Keys* tab.
 +
-- To Add SSH key
+* To Add SSH key
 ... Prepare the content of the public SSH key in a clipboard.
 ... Click *Add SSH Key*.
 ... In the *Key* field, paste the public SSH key content from the clipboard.
 ... In the *Name* field, enter a name for the SSH key.
 ... Click *Submit*.
 +
-- To Remove SSH key
+* To Remove SSH key
 ... Click *Delete* on the row of the SSH key to be deleted.
 ... Click *OK* in the confirmation prompt.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/notification-types.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/notification-types.adoc
@@ -3,21 +3,14 @@
 
 The following are the notifications created by {Project}:
 
-- *Audit summary*: A summary of all activity audited by the {ProjectServer}.
-
-- *Host built*: A notification sent when a host is built.
-
-- *Host errata advisory*: A summary of applicable and installable errata for hosts managed by the user.
-
-- *OpenSCAP policy summary*: A summary of OpenSCAP policy reports and their results.
-
-- *Promote errata*: A notification sent only after a Content View promotion.
+* *Audit summary*: A summary of all activity audited by the {ProjectServer}.
+* *Host built*: A notification sent when a host is built.
+* *Host errata advisory*: A summary of applicable and installable errata for hosts managed by the user.
+* *OpenSCAP policy summary*: A summary of OpenSCAP policy reports and their results.
+* *Promote errata*: A notification sent only after a Content View promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted Content View.
 This allows a user to monitor what updates have been applied to which hosts.
-
-- *Puppet error state*: A notification sent after a host reports an error related to Puppet.
-
-- *Puppet summary*: A summary of Puppet reports.
-
-- *Sync errata*: A notification sent only after synchronizing a repository.
+* *Puppet error state*: A notification sent after a host reports an error related to Puppet.
+* *Puppet summary*: A summary of Puppet reports.
+* *Sync errata*: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/testing-email-notifications.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/testing-email-notifications.adoc
@@ -4,8 +4,7 @@
 To verify that users are correctly subscribed to notifications, trigger the notifications manually.
 
 .Procedure
-
-- To trigger the notifications, execute the following command:
+* To trigger the notifications, execute the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -15,9 +14,7 @@ To verify that users are correctly subscribed to notifications, trigger the noti
 Replace _frequency_ with one of the following:
 
 * daily
-
 * weekly
-
 * monthly
 
 This triggers all notifications scheduled for the specified frequency for all the subscribed users.

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -51,8 +51,8 @@ You can clone {Project} server without including Pulp data. However, for your cl
 
 To transfer Pulp data to a target server, you have two options:
 
-- Clone using backup with Pulp data
-- Clone using backup without Pulp data and copy `/var/lib/pulp` manually from source server.
+* Clone using backup with Pulp data
+* Clone using backup without Pulp data and copy `/var/lib/pulp` manually from source server.
 
 If your `pulp_data.tar` file is greater than 500 GB, or if you use a slow storage system, such as NFS, and your `pulp_data.tar` file is greater than 100 GB, do not include `pulp_data.tar` in the backup because this can cause memory errors during extraction. Copy the `pulp_data.tar` file from the source server to the target server.
 

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -122,7 +122,8 @@ baseurl=file:///var/lib/pulp/published/yum/https/repos/Default_Organization/Libr
 enabled=1
 ----
 +
-. In the configuration file, replace `Default_Organization` in the `baseurl` with the correct organization label. To obtain the organization label, enter the commmand:
+. In the configuration file, replace `Default_Organization` in the `baseurl` with the correct organization label.
+To obtain the organization label, enter the command:
 +
 ----
 # ls /var/lib/pulp/published/yum/https/repos/

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -4,16 +4,11 @@
 
 This section describes how to upgrade {ProjectServer} from {ProductVersionPrevious} to {ProductVersion}. You can upgrade from any minor version of {ProjectName} Server {ProductVersionPrevious}.
 
-
 include::upgrading_satellite_server_prerequisites.adoc[leveloffset=+3]
 
-
 .Upgrade Scenarios
-
-- To upgrade a {ProjectServer} connected to the Red{nbsp}Hat Content Delivery Network, proceed to xref:upgrading_a_connected_satellite_server[].
-
-- To upgrade a {ProjectServer} not connected to the Red{nbsp}Hat Content Delivery Network, proceed to xref:upgrading_a_disconnected_satellite[].
-
+* To upgrade a {ProjectServer} connected to the Red{nbsp}Hat Content Delivery Network, proceed to xref:upgrading_a_connected_satellite_server[].
+* To upgrade a {ProjectServer} not connected to the Red{nbsp}Hat Content Delivery Network, proceed to xref:upgrading_a_disconnected_satellite[].
 
 .FIPS mode
 You cannot upgrade {ProjectServer} from a RHEL base system that is not operating in FIPS mode to a RHEL base system that is operating in FIPS mode.


### PR DESCRIPTION
This PR fixes two spelling errors (`commmand` and `congiguration`) as well as trailing whitespace and `*` instead of dashes for bullet points to greater consistency.

The two authentication sources `internal` and `external` are now indented below their parent bullet point.