### PR TITLE
Fix inline code with trailing tilde

### DIFF
--- a/guides/common/modules/proc_using-the-api-to-obtain-ssh-keys-for-remote-execution.adoc
+++ b/guides/common/modules/proc_using-the-api-to-obtain-ssh-keys-for-remote-execution.adoc
@@ -6,7 +6,7 @@ To use the {Project} API to download the public key from {SmartProxy}, complete 
 
 .Procedure
 
-. On the target host, create the `~/.ssh~` directory to store the SSH key:
+. On the target host, create the `~/.ssh` directory to store the SSH key:
 +
 ----
 # mkdir ~/.ssh


### PR DESCRIPTION
The trailing tilde produces subscripted inline code which is not desirable.
The first tilde refers to the home directory of the user and is therefore necessary.

See [built docs](https://docs.theforeman.org/nightly/Managing_Hosts/index-foreman-el.html#using-the-api-to-obtain-ssh-keys-for-remote-execution_managing-hosts)