### PR TITLE
Fix Qucikstart guide web links

### DIFF
--- a/web/layouts/shortcodes/guide-list.html
+++ b/web/layouts/shortcodes/guide-list.html
@@ -1,9 +1,9 @@
 {{ $path := default "nightly" (.Get "version") }}
 
 * [Planning for Foreman](/{{ $path }}/Planning_Guide/index-foreman-el.html)
-* [Foreman Quickstart Guide on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-el.html)
-* [Foreman Quickstart Guide on Debian/Ubuntu](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-deb.html)
-* [Katello Quickstart Guide on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-katello.html)
+* [Foreman Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-foreman-el.html)
+* [Foreman Quickstart Guide on Debian/Ubuntu](/{{ $path }}/Quickstart_Guide/index-foreman-deb.html)
+* [Katello Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-katello.html)
 * [Installing Foreman on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-el.html)
 * [Installing Katello on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-katello.html)
 * [Installing Smart Proxy on RHEL/CentOS](/{{ $path }}/Installing_Proxy_on_Red_Hat/index-foreman-el.html)


### PR DESCRIPTION

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
