### PR TITLE
Remove trailing colon from header

### DIFF
--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -1,6 +1,6 @@
 [id="creating-a-job-template_{context}"]
 
-= Creating a Job Template:
+= Creating a Job Template
 
 . Navigate to *Hosts* > *Job templates*.
 . Click *New Job Template*.


### PR DESCRIPTION
This purely for consistency reasons; see `git grep -i -n "^=" guides | grep ":$"` as there are no other headers like this.