### PR TITLE
Update common content to adhere to templates

### DIFF
--- a/guides/common/assembly_configuring-an-alternate-cname.adoc
+++ b/guides/common/assembly_configuring-an-alternate-cname.adoc
@@ -1,5 +1,8 @@
-[id='configuring-an-alternate-cname_{context}']
-= Configure an Alternate CNAME for {Project}
+ifdef::context[:parent-context: {context}]
+
+[id="configuring-an-alternate-cname_{context}"]
+= Configuring an Alternate CNAME for {Project}
+
 You can configure an alternate CNAME for {Project}.
 This might be useful if you want to deploy the {Project} web interface on a different domain name than the one that is used by client systems to connect to {Project}.
 You must plan the alternate CNAME configuration in advance prior to installing {SmartProxies} and registering hosts to {Project} to avoid redeploying new certificates to hosts.
@@ -10,3 +13,6 @@ endif::[]
 
 include::modules/proc_configuring-project-with-an-alternate-cname.adoc[leveloffset=+1]
 include::modules/proc_configuring-hosts-to-use-an-alternate-cname-for-content-management.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -10,7 +10,7 @@ After you have defined a job template you can execute it multiple times.
 
 include::modules/con_about-running-jobs-on-hosts.adoc[leveloffset=+1]
 include::modules/con_remote-execution-workflow.adoc[leveloffset=+1]
-include::modules/proc_delegating-permissions-for-remote-execution.adoc[leveloffset=+1]
+include::modules/con_permissions-for-remote-execution.adoc[leveloffset=+1]
 include::modules/proc_creating-a-job-template.adoc[leveloffset=+1]
 include::modules/proc_configuring-the-fallback-to-any-smartproxy-setting.adoc[leveloffset=+1]
 include::modules/proc_configuring-the-global-smartproxy-remote-execution-setting.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-external-services.adoc
+++ b/guides/common/assembly_configuring-external-services.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="configuring-external-services"]
 = Configuring {ProductName} with External Services
 
@@ -10,3 +12,6 @@ include::assembly_configuring-external-dhcp.adoc[leveloffset=+1]
 include::modules/proc_configuring-external-tftp.adoc[leveloffset=+1]
 
 include::assembly_configuring-external-idm-dns.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_configuring-keycloak-external-authentication-with-cac-cards.adoc
+++ b/guides/common/assembly_configuring-keycloak-external-authentication-with-cac-cards.adoc
@@ -1,8 +1,9 @@
 ifdef::context[:parent-context: {context}]
-:context: keycloak-cac-cards
 
 [id="configuring-keycloak-authentication-with-cac-cards_{context}"]
 = Configuring {Keycloak} Authentication with {PIV} Cards
+
+:context: keycloak-cac-cards
 
 Use this section to configure {Project} to use {Keycloak} as an OpenID provider for external authentication with {PIV} cards.
 

--- a/guides/common/assembly_configuring-keycloak-external-authentication-with-totp.adoc
+++ b/guides/common/assembly_configuring-keycloak-external-authentication-with-totp.adoc
@@ -1,8 +1,9 @@
 ifdef::context[:parent-context: {context}]
-:context: keycloak-totp
 
 [id="configuring-keycloak-authentication-with-totp_{context}"]
 = Configuring {Keycloak} Authentication with TOTP
+
+:context: keycloak-totp
 
 Use this section to configure {Project} to use {Keycloak} as an OpenID provider for external authentication with TOTP cards.
 

--- a/guides/common/assembly_configuring-keycloak-external-authentication.adoc
+++ b/guides/common/assembly_configuring-keycloak-external-authentication.adoc
@@ -1,8 +1,9 @@
 ifdef::context[:parent-context: {context}]
-:context: keycloak-general
 
 [id="configuring-project-with-keycloak-authentication_{context}"]
 = Configuring {Project} with {Keycloak} Authentication
+
+:context: keycloak-general
 
 Use this section to configure {Project} to use {Keycloak} as an OpenID provider for external authentication.
 

--- a/guides/common/assembly_configuring-project-settings-for-keycloak-authentication.adoc
+++ b/guides/common/assembly_configuring-project-settings-for-keycloak-authentication.adoc
@@ -1,5 +1,3 @@
-ifdef::context[:parent-context: {context}]
-
 [id="configuring-project-settings-for-keycloak-authentication_{context}"]
 = Configuring {Project} Settings for {Keycloak} Authentication
 
@@ -7,6 +5,3 @@ Use this section to configure {Project} for {Keycloak} authentication using the 
 
 include::modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc[leveloffset=+1]
 include::modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc[leveloffset=+1]
-
-ifdef::parent-context[:context: {parent-context}]
-ifndef::parent-context[:!context:]

--- a/guides/common/assembly_configuring-project-settings-for-keycloak-authentication.adoc
+++ b/guides/common/assembly_configuring-project-settings-for-keycloak-authentication.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="configuring-project-settings-for-keycloak-authentication_{context}"]
 = Configuring {Project} Settings for {Keycloak} Authentication
 
@@ -5,3 +7,6 @@ Use this section to configure {Project} for {Keycloak} authentication using the 
 
 include::modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc[leveloffset=+1]
 include::modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="configuring-with-an-http-proxy_{context}"]
 [id="configuring-satellite-with-an-http-proxy_{context}"]
 = Configuring {ProjectServer} with an HTTP Proxy
@@ -21,3 +23,6 @@ include::modules/proc_configuring-pxe-files-proxy.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_resetting-the-http-proxy.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -12,3 +12,6 @@ include::modules/proc_importing-ansible-variables.adoc[leveloffset=+1]
 include::modules/proc_creating-ansible-variables.adoc[leveloffset=+1]
 include::modules/proc_overriding-ansible-variables.adoc[leveloffset=+1]
 include::modules/proc_adding-rhel-system-roles.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_importing-kickstart-repositories.adoc
+++ b/guides/common/assembly_importing-kickstart-repositories.adoc
@@ -20,4 +20,3 @@ include::modules/proc_importing-kickstart-repositories.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
-

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="installing-capsule-server"]
 
 = Installing {SmartProxyServer}
@@ -63,3 +65,6 @@ endif::[]
 ifdef::foreman-deb[]
 include::modules/proc_configuring-capsule-default-certificate.adoc[leveloffset=+1]
 endif::[]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="installing-server-disconnected"]
 [id="installing-satellite-server-disconnected"]
 = Installing {ProjectServer}
@@ -50,3 +52,6 @@ include::modules/proc_configuring-installation.adoc[leveloffset=+2]
 include::modules/proc_enabling-the-disconnected-mode.adoc[leveloffset=+1]
 
 include::modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="installing-server-connected"]
 [id="installing-satellite-server-connected"]
 = Installing {ProjectServer}
@@ -76,3 +78,6 @@ include::modules/proc_configuring-installation.adoc[leveloffset=+2]
 ifdef::satellite[]
 include::modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc[leveloffset=+1]
 endif::[]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_integrating-ansible-tower.adoc
+++ b/guides/common/assembly_integrating-ansible-tower.adoc
@@ -12,3 +12,6 @@ The playbook configures the host following Kickstart deployment.
 
 include::modules/proc_adding-server-as-a-dynamic-inventory-item.adoc[leveloffset=+1]
 include::modules/proc_configuring-a-provisioning-callback-for-a-host.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_job-template-examples-and-extensions.adoc
+++ b/guides/common/assembly_job-template-examples-and-extensions.adoc
@@ -13,3 +13,6 @@ include::modules/ref_example-restorecon-template.adoc[leveloffset=+1]
 include::modules/ref_example-rendering-of-the-restorecon-template.adoc[leveloffset=+1]
 include::modules/ref_example-of-executing-restorecon-on-multiple-hosts.adoc[leveloffset=+1]
 include::modules/ref_example-including-power-options-in-a-job-template.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="migrating-from-internal-databases-to-external-databases_{context}"]
 = Migrating from Internal {Project} Databases to External Databases
 
@@ -38,3 +40,6 @@ include::modules/proc_preparing-a-host-for-external-databases.adoc[leveloffset=+
 include::modules/proc_installing-postgresql.adoc[leveloffset=+1]
 
 include::modules/proc_migrating-to-external-databases.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="performing-additional-configuration-on-capsule-server"]
 
 = Performing Additional Configuration on {SmartProxyServer}
@@ -24,3 +26,6 @@ include::modules/proc_enabling-power-management-on-managed-hosts.adoc[leveloffse
 // Configuring DNS, DHCP, and TFTP on {SmartProxyServer}
 include::modules/proc_configuring-dns-dhcp-and-tftp.adoc[leveloffset=+1]
 endif::[]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="preparing-environment-for-capsule-installation"]
 
 = Preparing your Environment for Installation
@@ -26,3 +28,6 @@ include::modules/proc_enabling-connections-to-capsule.adoc[leveloffset=+1]
 
 // Verifying Firewall Settings
 include::modules/proc_verifying-firewall-settings.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
@@ -1,4 +1,6 @@
-[id="preparing-environment-for-installation-in-ipv6-network"]
+ifdef::context[:parent-context: {context}]
+
+[id="preparing-environment-for-installation-in-ipv6-network_{context}"]
 = Preparing your Environment for {Project} Installation in an IPv6 Network
 
 You can install and use {Project} in an IPv6 network.
@@ -10,3 +12,6 @@ For more information, see {InstallingProjectDocURL}configuring-for-uefi-http-boo
 include::modules/con_limitations-of-installation-in-an-ipv6-network.adoc[leveloffset=+1]
 
 include::modules/con_requirements-for-installation-in-an-ipv6-network.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="preparing-environment-for-installation"]
 [id="preparing-environment-for-satellite-installation"]
 = Preparing your Environment for Installation
@@ -9,9 +11,7 @@ include::modules/ref_system-requirements.adoc[leveloffset=+1]
 include::modules/ref_storage-requirements.adoc[leveloffset=+1]
 
 ifdef::katello,satellite[]
-
 include::modules/ref_storage-guidelines.adoc[leveloffset=+1]
-
 endif::[]
 
 include::modules/ref_supported-operating-systems.adoc[leveloffset=+1]
@@ -25,3 +25,6 @@ include::modules/proc_enabling-client-connections-to-satellite.adoc[leveloffset=
 include::modules/proc_verifying-firewall-settings.adoc[leveloffset=+1]
 
 include::modules/proc_verifying-dns-resolution.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -1,10 +1,10 @@
 ifdef::context[:parent-context: {context}]
 
-[id="provisioning-cloud-instances-azure"]
+[id="provisioning-cloud-instances-azure_{context}"]
 = Provisioning Cloud Instances on Microsoft Azure Resource Manager
 
-:azure-provisioning:
 :context: azure-provisioning
+:azure-provisioning:
 :CRname: Microsoft Azure Resource Manager
 
 {ProjectName} can interact with Microsoft Azure Resource Manager, including creating new virtual machines and controlling their power management states.
@@ -51,6 +51,7 @@ include::modules/proc_adding-azure-details-to-a-compute-profile.adoc[leveloffset
 include::modules/proc_creating-image-only-hosts.adoc[leveloffset=+1]
 
 :!azure-provisioning:
+:!CRname:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_provisioning-cloud-instances-gce.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-gce.adoc
@@ -1,10 +1,10 @@
 ifdef::context[:parent-context: {context}]
 
-[id="provisioning-cloud-instances-gce"]
+[id="provisioning-cloud-instances-gce_{context}"]
 = Provisioning Cloud Instances on Google Compute Engine
 
-:gce-provisioning:
 :context: gce-provisioning
+:gce-provisioning:
 :CRname: Google Compute Engine
 
 {ProjectName} can interact with Google Compute Engine (GCE), including creating new virtual machines and controlling their power management states.
@@ -36,6 +36,7 @@ include::modules/proc_adding-gce-details-to-a-compute-profile.adoc[leveloffset=+
 include::modules/proc_creating-image-only-hosts.adoc[leveloffset=+1]
 
 :!gce-provisioning:
+:!CRname:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
@@ -1,10 +1,10 @@
 ifdef::context[:parent-context: {context}]
 
-[id="provisioning-cloud-instances-openstack"]
+[id="provisioning-cloud-instances-openstack_{context}"]
 = Provisioning Cloud Instances on {OpenStack}
 
-:openstack-provisioning:
 :context: openstack-provisioning
+:openstack-provisioning:
 :CRname: {OpenStack}
 
 {OpenStack} provides the foundation to build a private or public Infrastructure-as-a-Service (IaaS) cloud.
@@ -35,6 +35,7 @@ include::modules/proc_adding-openstack-details-to-a-compute-profile.adoc[levelof
 include::modules/proc_creating-image-only-hosts.adoc[leveloffset=+1]
 
 :!openstack-provisioning:
+:!CRname:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
@@ -1,10 +1,10 @@
 ifdef::context[:parent-context: {context}]
 
-[id="provisioning-virtual-machines-kubevirt"]
+[id="provisioning-virtual-machines-kubevirt_{context}"]
 = Provisioning Virtual Machines on {KubeVirt}
 
-:kubevirt-provisioning:
 :context: kubevirt-provisioning
+:kubevirt-provisioning:
 :CRname: {KubeVirt}
 
 {KubeVirt} addresses the needs of development teams that have adopted or want to adopt Kubernetes but possess existing virtual machine (VM)-based workloads that cannot be easily containerized.
@@ -60,6 +60,7 @@ For more information about adding permissions to a role, see {AdministeringDocUR
 include::modules/proc_adding-kubevirt-connection.adoc[leveloffset=+1]
 
 :!kubevirt-provisioning:
+:!CRname:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -1,10 +1,10 @@
 ifdef::context[:parent-context: {context}]
 
-[id="provisioning-virtual-machines-kvm"]
+[id="provisioning-virtual-machines-kvm_{context}"]
 = Provisioning Virtual Machines on KVM (libvirt)
 
-:kvm-provisioning:
 :context: kvm-provisioning
+:kvm-provisioning:
 :CRname: KVM
 
 Kernel-based Virtual Machines (KVMs) use an open source virtualization daemon and API called `libvirt` running on {RHEL}.
@@ -78,6 +78,7 @@ include::modules/proc_creating-network-or-image-based-hosts.adoc[leveloffset=+1]
 
 
 :!kvm-provisioning:
+:!CRname:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
@@ -3,8 +3,8 @@ ifdef::context[:parent-context: {context}]
 [id="provisioning-virtual-machines-rhv_{context}"]
 = Provisioning Virtual Machines on {oVirt}
 
-:rhv-provisioning:
 :context: rhv-provisioning
+:rhv-provisioning:
 :CRname: {oVirt}
 
 {oVirt} is an enterprise-grade server and desktop virtualization platform.
@@ -80,6 +80,7 @@ include::modules/proc_adding-rhv-details-to-a-compute-profile.adoc[leveloffset=+
 include::modules/proc_creating-network-or-image-based-hosts.adoc[leveloffset=+1]
 
 :!rhv-provisioning:
+:!CRname:
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_using-ansible-roles.adoc
+++ b/guides/common/assembly_using-ansible-roles.adoc
@@ -8,3 +8,6 @@ include::modules/proc_assigning-ansible-roles-to-an-existing-host.adoc[leveloffs
 include::modules/proc_running-ansible-roles-on-a-host.adoc[leveloffset=+1]
 include::modules/proc_assigning-an-ansible-role-to-a-host-group.adoc[leveloffset=+1]
 include::modules/proc_running-ansible-roles-on-a-host-group.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="using-external-databases_{context}"]
 = Using External Databases with {Project}
 
@@ -30,3 +32,6 @@ include::modules/proc_preparing-a-host-for-external-databases.adoc[leveloffset=+
 include::modules/proc_installing-postgresql.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-satellite-to-use-external-databases.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/assembly_using-satellite-ansible-content-collections.adoc
+++ b/guides/common/assembly_using-satellite-ansible-content-collections.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="managing-with-ansible-content-collections_{context}"]
 [id="using-satellite-ansible-content-collections_{context}"]
-== Managing {Project} with Ansible Collections
+= Managing {Project} with Ansible Collections
 
 {Project} Ansible Collections is a set of Ansible modules that interact with the {Project} API.
 You can use {Project} Ansible Collections to manage and automate many aspects of {Project}.
@@ -10,3 +10,6 @@ You can use {Project} Ansible Collections to manage and automate many aspects of
 include::modules/proc_installing-satellite-ansible-modules-via-rpm.adoc[leveloffset=+1]
 
 include::modules/proc_listing-using-satellite-ansible-modules.adoc[leveloffset=+1]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/common/modules/con_permissions-for-remote-execution.adoc
+++ b/guides/common/modules/con_permissions-for-remote-execution.adoc
@@ -1,6 +1,5 @@
-[id="example-delegating-permissions-for-remote-execution_{context}"]
-
-= Delegating Permissions for Remote Execution
+[id="permissions-for-remote-execution_{context}"]
+= Permissions for Remote Execution
 
 You can control which users can run which jobs within your infrastructure, including which hosts they can target.
 The remote execution feature provides two built-in roles:

--- a/guides/common/modules/proc_adding-kubevirt-connection.adoc
+++ b/guides/common/modules/proc_adding-kubevirt-connection.adoc
@@ -1,4 +1,4 @@
-[id="adding-kubevirt-connection"]
+[id="adding-kubevirt-connection_{context}"]
 = Adding a {KubeVirt} Connection to {ProjectServer}
 
 Use this procedure to add {KubeVirt} as a compute resource in {Project}.

--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -15,8 +15,6 @@ You can use Hammer CLI on {ProjectServer} or the {Project} web UI.
 
 .Procedure
 
-To add a life cycle environment to {SmartProxyServer}, complete the following steps:
-
 . In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} that you want to add a life cycle to.
 . Click *Edit* and click the *Life Cycle Environments* tab.
 . From the left menu, select the life cycle environments that you want to add to {SmartProxy} and click *Submit*.

--- a/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
+++ b/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
@@ -14,8 +14,6 @@ For more information about managing users, roles, and permission filters, see {A
 
 .Procedure
 
-To add {ProjectServer} to {awx} as a Dynamic Inventory Item, complete the following procedure:
-
 . In the {awx} web UI, create a credential for your {Project}.
 For more information about creating credentials, see http://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#add-a-new-credential[Add a New Credential] and http://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#red-hat-satellite-6[{ProjectNameX} Credentials] in the _{awx} User Guide_.
 +

--- a/guides/common/modules/proc_assigning-an-ansible-role-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-an-ansible-role-to-a-host-group.adoc
@@ -1,4 +1,4 @@
-[id="assigning-an-ansible-role-to-a-host-group"]
+[id="assigning-an-ansible-role-to-a-host-group_{context}"]
 = Assigning an Ansible Role to a Host Group
 
 You can use Ansible roles for remote management of Red{nbsp}Hat Enterprise Linux versions 8, 7, and 6.9 or later.

--- a/guides/common/modules/proc_configuring-a-keytab-for-kerberos-ticket-granting-tickets.adoc
+++ b/guides/common/modules/proc_configuring-a-keytab-for-kerberos-ticket-granting-tickets.adoc
@@ -7,8 +7,6 @@ If you do not set up a keytab, you must manually retrieve tickets.
 
 .Procedure
 
-To ensure that the `foreman-proxy` user on {Project} can obtain Kerberos ticket granting tickets, complete the following steps:
-
 . Find the ID of the `foreman-proxy` user:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_configuring-a-provisioning-callback-for-a-host.adoc
+++ b/guides/common/modules/proc_configuring-a-provisioning-callback-for-a-host.adoc
@@ -38,8 +38,6 @@ For more information about job templates, see http://docs.ansible.com/ansible-to
 [[proc-Red_Hat_Satellite-Managing_Hosts-Integrating_Satellite_and_Ansible_Tower-To_Configure_Provisioning_Callback_for_a_Host]]
 .Procedure
 
-To configure provisioning callback for a new host in {Project}, complete the following steps:
-
 . In the {ProjectName} web UI, navigate to *Configure* > *Host Group*.
 . Create a host group or edit an existing host group.
 . In the Host Group window, click the *Parameters* tab.

--- a/guides/common/modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc
+++ b/guides/common/modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc
@@ -18,8 +18,6 @@ endif::[]
 
 .Procedure
 
-To use an alternative directory, complete this procedure.
-
 . Create a new directory, for example _new_place_:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -5,8 +5,6 @@ Use this section to configure {SmartProxyServer} with an SSL certificate that is
 
 .Prerequisites
 
-Before configuring {SmartProxyServer} with a default server certificate, ensure that your {SmartProxyServer} meets the following conditions:
-
 ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
 For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering to {ProjectServer}].
@@ -15,8 +13,6 @@ endif::[]
 For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure
-
-To configure {SmartProxyServer} with a default server certificate, complete the following steps:
 
 . On {ProjectServer}, to store all the source certificate files for your {SmartProxyServer}, create a directory that is accessible only to the `root` user, for example `/root/{smart-proxy-context}_cert`:
 +

--- a/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
+++ b/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
@@ -6,16 +6,12 @@ You can use Kerberos authentication to establish an SSH connection for remote ex
 
 .Prerequisites
 
-Before you can use Kerberos authentication for remote execution on {ProjectName}, you must set up a Kerberos server for identity management and ensure that you complete the following prerequisites:
-
 * Enroll {ProjectServer} on the Kerberos server
 * Enroll the {Project} target host on the Kerberos server
 * Configure and initialize a Kerberos user account for remote execution
 * Ensure that the foreman-proxy user on {Project} has a valid Kerberos ticket granting ticket
 
 .Procedure
-
-To set up {Project} to use Kerberos authentication for remote execution on hosts, complete the following steps:
 
 . To install and enable Kerberos authentication for remote execution, enter the following command:
 +

--- a/guides/common/modules/proc_configuring-repositories-proxy-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy-deb.adoc
@@ -4,6 +4,8 @@
 
 Use the following procedure to enable the repositories that are required to install {Project}.
 
+.Procedure
+
 . Add the Debian repository sources to the `/etc/apt/sources.list.d/foreman.list` file:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -11,7 +13,7 @@ Use the following procedure to enable the repositories that are required to inst
 # echo "deb http://deb.theforeman.org/ buster {ProjectVersion}" | tee /etc/apt/sources.list.d/foreman.list
 # echo "deb http://deb.theforeman.org/ plugins {ProjectVersion}" | tee -a /etc/apt/sources.list.d/foreman.list
 ----
-. Install the `ca-certificates` and `gpg` packages
+. Install the `ca-certificates` and `gpg` packages:
 +
 ----
 # apt-get -y install ca-certificates gpg

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -9,7 +9,6 @@ endif::[]
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
 .Procedure
-To configure the required repositories, complete the following steps:
 
 . Disable all repositories:
 +

--- a/guides/common/modules/proc_creating-a-custom-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-certificate.adoc
@@ -20,8 +20,6 @@ When you configure {ProductName} with custom certificates, note the following co
 
 .Procedure
 
-To create a custom SSL certificate, complete the following steps:
-
 . To store all the source certificate files, create a directory that is accessible only to the `root` user.
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -2,6 +2,10 @@
 
 = Creating a Job Template
 
+Use this procedure to create a job template.
+
+.Procedure
+
 . Navigate to *Hosts* > *Job templates*.
 . Click *New Job Template*.
 . Click the *Template* tab, and in the *Name* field, enter a unique name for your job template.
@@ -30,8 +34,8 @@ For more information, see the appendices in the _Managing Hosts_ guide.
 
 .For CLI Users
 
-To create a job template using a template-definition file, enter the following command:
-
+. To create a job template using a template-definition file, enter the following command:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # hammer job-template create \

--- a/guides/common/modules/proc_creating-hardware-models.adoc
+++ b/guides/common/modules/proc_creating-hardware-models.adoc
@@ -1,4 +1,4 @@
-[id="creating-hardware-models"]
+[id="creating-hardware-models_{context}"]
 = Creating Hardware Models
 
 Use this procedure to create a hardware model in {Project} so that you can specify which hardware model a host uses.

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -8,8 +8,6 @@ Do not use the same command on more than one {SmartProxyServer}.
 
 .Prerequisites
 
-Before configuring {SmartProxyServer} with a custom server certificate, ensure that your {Project} and {SmartProxies} meet the following conditions:
-
 * {ProjectServer} is configured with a custom certificate.
 For more information, see {InstallingProjectDocURL}configuring-satellite-custom-server-certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{project-installation-guide-title}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
@@ -18,8 +16,6 @@ For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-s
 For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure
-
-To configure your {SmartProxyServer} with a custom SSL certificate, complete the following steps:
 
 . On {ProjectServer}, validate the custom SSL certificate input files:
 +

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -8,8 +8,6 @@ The `katello-certs-check` command validates the input certificate files and retu
 
 .Procedure
 
-To deploy a custom certificate on your {ProjectServer}, complete the following steps:
-
 . Validate the custom SSL certificate input files.
 Note that for the `katello-certs-check` command to work correctly, Common Name (CN) in the certificate must match the FQDN of {ProjectServer}.
 +

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -7,9 +7,9 @@
 Use this procedure to configure the host-based firewall on the Red Hat Enterprise Linux 7 system that {Project} is installed on, to enable incoming connections from Clients, and to make the configuration persistent across system reboots.
 For more information on the ports used, see {InstallingProjectDocURL}satellite-ports-and-firewalls-requirements_{project-context}[Ports and Firewalls Requirements].
 
-.Procedure
-
 include::snip_firewalld.adoc[]
+
+.Procedure
 
 . To open the ports for client to {Project} communication, enter the following command on the base operating system that you want to install {Project} on:
 +

--- a/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
@@ -9,9 +9,9 @@ On {ProjectServer}, you must enable the incoming connection from {SmartProxyServ
 * Ensure that the firewall rules on {ProjectServer} are configured to enable connections for client to {Project} communication, because {SmartProxyServer} is a client of {ProjectServer}.
 For more information, see {InstallingProjectDocURL}enabling-client-connections-to-satellite_{project-context}[Enabling Connections from a Client to {ProjectServer}] in _{project-installation-guide-title}_.
 
-.Procedure
-
 include::snip_firewalld.adoc[]
+
+.Procedure
 
 . On {ProjectServer}, enter the following command to open the port for {SmartProxy} to {Project} communication:
 +

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -4,9 +4,9 @@
 
 On the base operating system on which you want to install {SmartProxy}, you must enable incoming connections from {ProjectServer} and clients to {SmartProxyServer} and make these rules persistent across reboots.
 
-.Procedure
-
 include::snip_firewalld.adoc[]
+
+.Procedure
 
 . On the base operating system on which you want to install {SmartProxy}, enter the following command to open the ports for {ProjectServer} and clients communication to {SmartProxyServer}:
 +

--- a/guides/common/modules/proc_importing-ansible-roles.adoc
+++ b/guides/common/modules/proc_importing-ansible-roles.adoc
@@ -5,7 +5,7 @@
 You can import Ansible roles from the `/etc/ansible/roles` directory on {Project} or on a {SmartProxy} that has Ansible enabled.
 Ensure that the roles that you import are located in the `/etc/ansible/roles` directory on all {SmartProxies} from where you want to use the roles.
 
-To import Ansible roles, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Configure* > *Roles* and click the {SmartProxy} that contains the roles that you want to import.
 . From the list of Ansible roles, select the check box of the roles you want to import, and then click *Update*.

--- a/guides/common/modules/proc_importing-ansible-variables.adoc
+++ b/guides/common/modules/proc_importing-ansible-variables.adoc
@@ -9,8 +9,6 @@ If you want to use Ansible variables in your Ansible playbooks, you must import 
 
 .Procedure
 
-To import Ansible variables, complete the following steps:
-
 . In the {Project} web UI, navigate to *Configure* > *Variables*.
 . In the upper right of the window, select the {SmartProxy} that contains the Ansible variables that you want to import.
 . Select the Ansible variables that you want to import, and click *Update*.

--- a/guides/common/modules/proc_installing-satellite-ansible-modules-via-rpm.adoc
+++ b/guides/common/modules/proc_installing-satellite-ansible-modules-via-rpm.adoc
@@ -1,6 +1,6 @@
 [id="installing-ansible-modules-via-rpm_{context}"]
 [id="installing-satellite-ansible-modules-via-rpm_{context}"]
-== Installing the {Project} Ansible Modules from RPM
+= Installing the {Project} Ansible Modules from RPM
 
 Use this procedure to install the {Project} Ansible modules.
 

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -2,6 +2,8 @@
 
 = Installing {SmartProxyServer}
 
+.Procedure
+
 * To install an external {SmartProxy}, enter the following command:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -12,7 +12,6 @@ The `katello-agent` package depends on the `gofer` package that provides the `go
 This service must be enabled so that {ProjectServer} or {SmartProxyServer} can provide information about errata that are applicable for content hosts.
 
 .Prerequisites
-Before installing the Katello agent, ensure the following conditions are met:
 
 ifdef::satellite[]
 * You have enabled the {project-client-name} repository on {ProjectServer}.
@@ -25,7 +24,6 @@ endif::[]
 * You have enabled the {project-client-name} repository on the client.
 
 .Procedure
-To install the Katello agent, complete the following steps:
 
 . Install the `katello-agent` package:
 +

--- a/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
+++ b/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
@@ -1,6 +1,6 @@
 [id="listing-using-ansible-modules_{context}"]
 [id="listing-using-satellite-ansible-modules_{context}"]
-== Viewing the {Project} Ansible Modules
+= Viewing the {Project} Ansible Modules
 
 ifdef::satellite[]
 You can view the installed {Project} Ansible modules by listing the content of the following directory:

--- a/guides/common/modules/proc_overriding-ansible-variables.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables.adoc
@@ -11,18 +11,16 @@ To ensure that the variable that you override follows the correct order of prece
 
 .Prerequisite
 
-You must have Ansible variables in {Project}.
+* You must have Ansible variables in {Project}.
 
-To import Ansible variables, see {ConfiguringAnsibleDocURL}importing-Ansible-variables_ansible[Importing Ansible Variables]
+** To import Ansible variables, see {ConfiguringAnsibleDocURL}importing-Ansible-variables_ansible[Importing Ansible Variables]
 
-To create Ansible variables, see {ConfiguringAnsibleDocURL}creating-Ansible-variables_ansible[Creating Ansible Variables]
+** To create Ansible variables, see {ConfiguringAnsibleDocURL}creating-Ansible-variables_ansible[Creating Ansible Variables]
 
 The following procedure makes reference to hosts and host groups.
 For more information about hosts and host groups, see the {ManagingHostsDocURL}[Managing Hosts] guide.
 
 .Procedure
-
-To override an Ansible variable, complete the following steps:
 
 . In the {Project} web UI, navigate to *Configure* > *Variables*.
 . Select the Ansible variable that you want to override and manage with {Project}.

--- a/guides/common/modules/proc_registering-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-to-satellite-server.adoc
@@ -9,9 +9,6 @@ endif::[]
 
 Use this procedure to register the base operating system on which you want to install {SmartProxyServer} to {ProjectServer}.
 
-.Prerequisites
-Before registering it to {ProjectServer}, ensure that the base operating system on which you want to install {SmartProxy} meets the following conditions:
-
 .Subscription Manifest Prerequisites
 * On {ProjectServer}, a manifest must be installed and it must contain the appropriate repositories for the organization you want {SmartProxy} to belong to.
 * The manifest must contain repositories for the base operating system on which you want to install {SmartProxy}, as well as any clients that you want to connect to {SmartProxy}.
@@ -30,7 +27,6 @@ For more information, see {InstallingSmartProxyDocURL}capsule-ports-and-firewall
 For more information, see {AdministeringDocURL}chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_External_Authentication[Configuring External Authentication] in _Administering {ProjectName}_.
 
 .Procedure
-To register your system to {ProjectServer}, complete the following steps:
 
 . Download the `katello-ca-consumer-latest.noarch.rpm` package on the base operating system on which you want to install {SmartProxy}.
 The consumer RPM configures the host to download content from the content source that is specified in {Project}.

--- a/guides/common/modules/proc_running-ansible-roles-on-a-host-group.adoc
+++ b/guides/common/modules/proc_running-ansible-roles-on-a-host-group.adoc
@@ -1,4 +1,4 @@
-[id="running-ansible-roles-on-a-host-group"]
+[id="running-ansible-roles-on-a-host-group_{context}"]
 = Running Ansible Roles on a Host Group
 
 You can run Ansible roles on a host group through the {Project} web UI.

--- a/guides/common/modules/proc_running-ansible-roles-on-a-host.adoc
+++ b/guides/common/modules/proc_running-ansible-roles-on-a-host.adoc
@@ -1,4 +1,4 @@
-[id="running-ansible-roles-on-a-host"]
+[id="running-ansible-roles-on-a-host_{context}"]
 
 = Running Ansible Roles on a Host
 

--- a/guides/common/modules/proc_setting-up-job-templates.adoc
+++ b/guides/common/modules/proc_setting-up-job-templates.adoc
@@ -10,6 +10,8 @@ You can use default templates as a base for developing your own.
 Default job templates are locked for editing.
 Clone the template and edit the clone.
 
+.Procedure
+
 . To clone a template, in the *Actions* column, select *Clone*.
 
 . Enter a unique name for the clone and click *Submit* to save the changes.

--- a/guides/common/modules/proc_tuning-with-predefined-profiles.adoc
+++ b/guides/common/modules/proc_tuning-with-predefined-profiles.adoc
@@ -1,4 +1,4 @@
-[id='tuning-with-predefined-profiles']
+[id='tuning-with-predefined-profiles_{context}']
 
 = Tuning {ProjectServer} with Predefined Profiles
 
@@ -58,8 +58,6 @@ RAM: 256G
 Number of CPU cores: 48+
 
 .Procedure
-
-To configure a tuning profile for your {Project} deployment, complete the following steps:
 
 . Optional: If you have configured the `custom-hiera.yaml` file on {ProjectServer}, back up the `/etc/foreman-installer/custom-hiera.yaml` file to `custom-hiera.original`.
 You can use the backup file to restore the `/etc/foreman-installer/custom-hiera.yaml` file to its original state if it becomes corrupted:

--- a/guides/common/modules/proc_verifying-firewall-settings.adoc
+++ b/guides/common/modules/proc_verifying-firewall-settings.adoc
@@ -4,11 +4,9 @@
 
 Use this procedure to verify your changes to the firewall settings.
 
-.Procedure
-
 include::snip_firewalld.adoc[]
 
-To verify the firewall settings, complete the following step:
+.Procedure
 
 . Enter the following command:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/master.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/master.adoc
@@ -13,7 +13,7 @@ include::topics/Starting_and_Stopping_Satellite.adoc[]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
 
-include::common/assembly_using-satellite-ansible-content-collections.adoc[]
+include::common/assembly_using-satellite-ansible-content-collections.adoc[leveloffset=+1]
 
 include::topics/Users_and_Roles.adoc[]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -36,14 +36,14 @@ For more information see xref:sect-{Project_Link}-Administering_{Project_Link}-C
 For more information see xref:active-directory-with-cross-forest-trust_{context}[].
 
 * Using {Keycloak} as an OpenID provider for external authentication to {Project}.
-For more information, see xref:configuring-project-with-keycloak-authentication_keycloak-general[].
+For more information, see xref:configuring-project-with-keycloak-authentication_admin[].
 
 * Using {Keycloak} as an OpenID provider for external authentication to {Project} with TOTP.
-For more information, see xref:configuring-keycloak-authentication-with-totp_keycloak-totp[].
+For more information, see xref:configuring-keycloak-authentication-with-totp_admin[].
 
 ifndef::satellite[]
 * Using {Keycloak} as an OpenID provider for external authentication to {Project} with {PIV} cards.
-For more information, see xref:configuring-keycloak-authentication-with-cac-cards_keycloak-cac-cards[].
+For more information, see xref:configuring-keycloak-authentication-with-cac-cards_admin[].
 endif::[]
 
 As well as providing access to {ProjectServer}, hosts provisioned with {Project} can also be integrated with {FreeIPA} realms.

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -7,4 +7,4 @@ include::common/header.adoc[]
 
 = Managing {Project} with Ansible
 
-include::common/assembly_using-satellite-ansible-content-collections.adoc[]
+include::common/assembly_using-satellite-ansible-content-collections.adoc[leveloffset=+1]


### PR DESCRIPTION
I've made some edits to get (almost) everything in `common` in compliance with the module templates. Some notes:

Assemblies:

* Added opening/closing context ifdefs to assemblies where it was missing. Technically those lines are only required when an assembly has a context of its own (to preserve the original guide-wide context value and reinstate it at the end of the assembly), such as in assembly_configuring-keycloak-external-authentication.adoc, but it doesn't hurt to just always include them.
  * Addendum to this, I actually had to not include those lines in more deeply nested assemblies, because it turns out if you nest master.adoc (with a context) > assembly (with a context) > assembly (doesn't matter if it has a context), it only reverts back to the second-level context, not the master file's context. I wonder if the template authors have a solution for that, aside from "don't nest assemblies that far" :laughing:  which I am in favour of, too, to be fair!
I can probably get rid of the deep nesting in another PR though, as the third-level assembly in question, assembly_configuring-project-settings-for-keycloak-authentication.adoc, has a module for using the web UI and a module for using the CLI, so could be converted into a single procedure file using the .Procedure/.For CLI Users structure we use in other places (that or just include those modules in the second-level assembly instead, with leveloffset=+2).

* Assemblies included in guides/other assemblies only really need their own context if you want to include the same module in multiple assemblies in the same guide, so I didn't give every assembly its own context (that would have ballooned out to changing a bunch of xrefs and links), but that's an option you could consider if you want strict template adherence.

* In assemblies that do have their own context, I moved it under the assembly title as per the assembly template.


Modules:

* I only corrected markup/placement that went against the templates. I did not correct tech writing elements, such as "Start each step with an active verb", even though that is written in the procedure template. I might consider doing that in later PRs.

* Some of the external services procedures were a bit convoluted with sub-headings and such, so I didn't change those, but may do so in the future.

* I'd like to address the structure/markup of proc_configuring-repositories.adoc and proc_installing-the-satellite-server-packages.adoc (there's no .Procedure markup, and proc_configuring-repositories-el.adoc and similar files should be snippet files), but I haven't yet as I see there's an open PR adding a similar structure for installing capsule packages, so maybe I'll do all these sections at a later date.


Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
