### PR TITLE
Add introductory sentence to LDAP section

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_LDAP_Authentication_for_Red_Hat_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_LDAP_Authentication_for_Red_Hat_Satellite.adoc
@@ -1,6 +1,8 @@
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Using_LDAP]]
 === Using LDAP
 
+{Project} supports LDAP authentication using one or multiple LDAP directories.
+
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Using_Configuring_TLS_for_Secure-LDAP]]
 
 If you require {ProjectName} to use `TLS` to establish a secure LDAP connection (LDAPS), first obtain certificates used by the LDAP server you are connecting to and mark them as trusted on the base operating system of your {ProjectServer} as described below.


### PR DESCRIPTION
Hi @xprazak2

As part of [Foreman manual reboot](https://community.theforeman.org/t/foreman-manual-reboot/22606), I have reviewed the LDAP section [in the Foreman manual](https://theforeman.org/manuals/2.3/index.html#4.1.1LDAPAuthentication) against the upstreamed [Satellite docs](https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Using_LDAP). The idea would be to ensure we have everything in this repo, deprecate and then remove that content. 

I have found corresponding entries for everything except the following: 

```
**Active Directory password changes**

When using Active Directory, please be aware that users will be able to log in for up to an hour after a password change using the old password. This is a function of the AD domain controller and not Foreman.

**Brute-force protection**

Foreman allows only 30 failed attempts in the last 5 minutes per one IP address by default. Any subsequent login attempts are not allowed and error message is shown: “Too many tries, please try again in a few minutes.” If this is triggered by accident, the silent period can be removed by deleting failed login cache entries:

find /usr/share/foreman/tmp/cache -name failed_login\*

This will only work when using the file store Rails cache implementation.

```

If you're not the right person to assess, please let me know. I have two questions. 
1. Is this info still relevant? If so, could you suggest a good location for it in the new docs.
2. If it is relevant, is it also relevant for Satellite customers?

Thank you!

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
