### PR TITLE
Big cleanup of attributes

### DIFF
--- a/guides/.gitignore
+++ b/guides/.gitignore
@@ -1,6 +1,8 @@
 /build/
+/build-*/
 /common/build.adoc
 /upstreamize_report.md
 .alink
 /scripts/docs-Red_Hat_Satellite_6/
 /scripts/foreman-documentation/
+*.diff

--- a/guides/README.md
+++ b/guides/README.md
@@ -19,11 +19,11 @@ In MacOS required tools can be installed via brew but instead "make" call "gmake
 
 Alternatively, XCode development environment can be installed to have make utility available on PATH, however this takes about an hour to download and install and requires several gigabytes of HDD space:
 
-	xcode-select --install
+		xcode-select --install
 
 If AsciiDoctor is not available in repositories or under RVM/rbenv, simply install it from rubygems:
 
-  	gem install asciidoctor asciidoctor-pdf --pre
+		gem install asciidoctor asciidoctor-pdf --pre
 
 Then simply run `make` or `make html` which builds HTML artifacts.
 Generating PDF output is slow, therefore command `make pdf` must be used separately.
@@ -49,7 +49,6 @@ Currently there are three different versions:
 `make BUILD=katello` - this generates a katello build of the guide
 
 `make BUILD=foreman-deb` - This generates  a version for Foreman installed on Debian.
-
 
 The final artifacts can be found in the ./build subdirectory.
 Note that GNU Makefile tracks changes and only builds relevant artifacts, to trigger full rebuild use `make clean` to delete build directory and start over.
@@ -94,7 +93,14 @@ Therefore, never write "Foreman" or "Satellite" words directly, but use the foll
 | {SmartProxy} | Smart Proxy | Capsule |
 
 The table only covers the most frequent terms.
-The rest are defined in the [attributes file](common/attributes.adoc).
+The rest are defined in the attribute files:
+
+* [attributes.adoc](common/attributes.adoc): version definitions and includes for other attribute files.
+* [attributes-base.adoc](common/attributes-base.adoc): base attributes common for all builds.
+* [attributes-foreman-el.adoc](common/attributes-foreman-el.adoc): base overrides for foreman-el build.
+* [attributes-foreman-deb.adoc](common/attributes-foreman-deb.adoc): base overrides for foreman-deb build.
+* [attributes-katello.adoc](common/attributes-katello.adoc): base overrides for katello build.
+* [attributes-satellite.adoc](common/attributes-satellite.adoc): base overrides for satellite build.
 
 Variables cannot be used in shell or code examples.
 To use them, use "attributes" keyword:

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -1,0 +1,96 @@
+// URLs
+:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman-el.html#
+:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman-el.html#
+:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman-el.html#
+:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman-el.html#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman-el.html#
+:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman-el.html#
+:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman-el.html#
+:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-el.html#
+:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-el.html#
+:UpgradingDocURL: {BaseURL}Upgrading_and_Updating/index-foreman-el.html#
+
+// Repositories and subscriptions (used both in Katello and Satellite guides)
+:SatelliteSub: Red Hat Satellite Infrastructure Subscription
+:RepoRHEL7Server: rhel-7-server-rpms
+:RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
+:RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
+:RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
+// For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
+:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-beta-rpms
+:RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
+:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-beta-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-beta-rpms
+:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-beta-rpms
+// Do not update the puppet4 repo versions. They must stay at 6.3.
+:RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
+:RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms
+
+// Base attributes
+:ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key
+:ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
+:ansible-namespace-example: `theforeman.foreman._module_name_`
+:ansible-namespace: `theforeman.foreman`
+:ansiblefilepath: /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/
+:awx: AWX
+:certs-generate: foreman-proxy-certs-generate
+:certs-proxy-context: foreman-proxy
+:Cockpit: Cockpit
+:customcontent: content
+:customfiletype: file type
+:customfiletypetitle: File Type
+:customgpgtitle: GPG
+:customostreecontent: OSTree content
+:customostreecontenttitle: OSTree Content
+:customproduct: product
+:customproducttitle: Product
+:customrepo: repository
+:customrpm: RPM
+:customrpmtitle: RPM
+:customssl: SSL
+:customssltitle: SSL
+:foreman-example-com: foreman.example.com
+:foreman-installer: foreman-installer
+:foreman-maintain: foreman-maintain
+:FreeIPA: FreeIPA
+:Keycloak-short: Keycloak
+:Keycloak: Keycloak
+:KubeVirt: KubeVirt
+:LoraxCompose: Lorax Composer
+:OpenStack: OpenStack
+:ovirt-example-com: ovirt.example.com
+:oVirt: oVirt
+:oVirtEngine: oVirt Engine
+:oVirtShort: oVirt
+:package-clean: yum clean
+:package-install-project: yum install
+:package-install: yum install
+:package-remove-project: yum remove
+:package-remove: yum remove
+:package-update-project: yum update
+:package-update: yum update
+:PIV: PIV
+:Project_Link: Red_Hat_Satellite
+:project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
+:project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
+:project-context: foreman
+:project-change-hostname: katello-change-hostname
+:Project: Foreman
+:ProjectName: Foreman
+:ProjectNameX: Foreman
+:ProjectNameXY: Foreman{nbsp}{ProjectVersion}
+:ProjectServer: Foreman{nbsp}server
+:ProjectX: Foreman
+// FIXME: This should be: :ProjectXY: Foreman{nbsp}{ProjectVersion}
+:ProjectXY: Foreman{nbsp}1.22
+:provision-script: OS installer recipe
+:RHEL: Red{nbsp}Hat Enterprise Linux
+:RHELServer: Red{nbsp}Hat Enterprise Linux Server
+:smart-proxy-context: smart-proxy
+:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server {ProjectVersion}
+:SmartProxies: Smart{nbsp}Proxies
+:smartproxy_port: 8443
+:smartproxy-example-com: smartproxy.example.com
+:SmartProxy: Smart{nbsp}Proxy
+:SmartProxyServer: Smart{nbsp}Proxy{nbsp}server
+:Team: Foreman developers

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -1,0 +1,30 @@
+// URLs
+:BaseFilenameURL: index-{build}.html
+:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/{BaseFilenameURL}#
+:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/{BaseFilenameURL}#
+:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
+:ContentManagementDocURL: {BaseURL}Content_Management_Guide/{BaseFilenameURL}#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/{BaseFilenameURL}#
+:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/{BaseFilenameURL}#
+:ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
+:PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
+:ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#
+
+// Attributes only for foreman-deb build
+:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server on Debian
+
+// Overrides for foreman-deb build
+:foreman-installer-package: foreman-installer
+:installer-scenario-smartproxy: foreman-installer --no-enable-foreman
+:installer-scenario-smartproxy: foreman-installer --no-enable-foreman
+:installer-scenario: foreman-installer
+:installer-scenario: foreman-installer --scenario foreman
+:package-clean: apt-get clean
+:package-install-project: apt-get install
+:package-install: apt-get install
+:package-remove-project: apt-get remove
+:package-remove: apt-get remove
+:package-update-project: apt-get upgrade
+:package-update: apt-get upgrade
+:project-installation-guide-title: Installing Foreman {ProjectVersion} server on Enterprise Linux
+:project-installation-guide-title: Installing Foreman server on Debian

--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -1,0 +1,5 @@
+// Overrides for foreman-el build
+:foreman-installer-package: foreman-installer
+:installer-scenario-smartproxy: foreman-installer --no-enable-foreman
+:installer-scenario: foreman-installer --scenario foreman
+:project-installation-guide-title: Installing Foreman {ProjectVersion} server on Enterprise Linux

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -1,0 +1,17 @@
+// URLs
+:BaseFilenameURL: index-{build}.html
+//:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/{BaseFilenameURL}#
+//:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/{BaseFilenameURL}#
+//:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
+//:ContentManagementDocURL: {BaseURL}Content_Management_Guide/{BaseFilenameURL}#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/{BaseFilenameURL}#
+//:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/{BaseFilenameURL}#
+//:ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
+//:PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
+//:ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#
+
+// Overrides for katello build
+:foreman-installer-package: foreman-installer-katello
+:installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content
+:installer-scenario: foreman-installer --scenario katello
+:project-installation-guide-title: Installing Foreman {ProjectVersion} server with Katello {KatelloVersion} plugin on Enterprise Linux

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -1,0 +1,81 @@
+// URLs (published on Red Hat Portal)
+:AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
+:ConfiguringAnsibleDocURL: {BaseURL}configuring_satellite_to_use_ansible/index#
+:ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#
+:ContentManagementDocURL: {BaseURL}content_management_guide/index#
+:ManagingHostsDocURL: {BaseURL}managing_hosts/index#
+:InstallingProjectDocURL: {BaseURL}installing_satellite_server_from_a_connected_network/index#
+:InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
+:PlanningDocURL: {BaseURL}planning_for_red_hat_satellite/index#
+:ProvisioningDocURL: {BaseURL}provisioning_guide/index#
+:UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
+
+// Attributes only for satellite build
+:ProductVersionRepoTitle: Beta
+// Change to "Red Hat Satellite Infrastructure Subscription (Beta)" for beta releases
+
+// Overrides for satellite build
+:ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
+:ansible-galaxy: https://cloud.redhat.com/ansible/automation-hub/redhat/satellite/docs
+:ansible-namespace-example: `redhat.satellite._module_name_`
+:ansible-namespace: `redhat.satellite`
+:ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
+:awx: Ansible Tower
+:certs-generate: capsule-certs-generate
+:certs-proxy-context: capsule
+:Cockpit: Red{nbsp}Hat web console
+:customcontent: custom content
+:customfiletype: custom file type
+:customfiletypetitle: Custom File Type
+:customgpgtitle: Custom GPG
+:customostreecontent: custom OSTree content
+:customostreecontenttitle: Custom OSTree Content
+:customproduct: custom product
+:customproducttitle: Custom Product
+:customrepo: custom repository
+:customrpm: custom RPM
+:customrpmtitle: Custom RPM
+:customssl: custom SSL
+:customssltitle: Custom SSL
+:DocState: satellite
+:foreman-example-com: satellite.example.com
+:foreman-installer-package: satellite-installer
+:foreman-installer: satellite-installer
+:foreman-maintain: satellite-maintain
+:FreeIPA: Red{nbsp}Hat Identity Management
+:installer-scenario-smartproxy: satellite-installer --scenario capsule
+:installer-scenario: satellite-installer --scenario satellite
+:Keycloak-short: RHSSO
+:Keycloak: Red{nbsp}Hat Single Sign-On
+:KubeVirt: Container-native Virtualization
+:LoraxCompose: Red{nbsp}Hat Image Builder
+:OpenStack: Red{nbsp}Hat OpenStack Platform
+:ovirt-example-com: rhv.example.com
+:oVirt: Red{nbsp}Hat{nbsp}Virtualization
+:oVirtEngine: Red{nbsp}Hat Virtualization Manager
+:oVirtShort: RHV
+:package-install-project: satellite-maintain packages install
+:package-remove-project: satellite-maintain packages remove
+:package-update-project: satellite-maintain packages update
+:PIV: CAC
+:project-client-name: Satellite Tools {ProductVersionRepoTitle}
+:project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
+:project-context: satellite
+:project-change-hostname: satellite-change-hostname
+:project-installation-guide-title: Installing Satellite Server from a Connected Network
+:Project: Satellite
+:ProjectName: Red{nbsp}Hat Satellite
+:ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
+:ProjectNameXY: Red{nbsp}Hat Satellite{nbsp}{ProductVersionRepoTitle}
+:ProjectServer: Satellite{nbsp}Server
+:ProjectX: Satellite{nbsp}6
+:ProjectXY: Satellite{nbsp}{ProductVersionRepoTitle}
+:provision-script: kickstart
+:smart-proxy-context: capsule
+:smart-proxy-installation-guide-title: Installing Capsule Server
+:SmartProxies: Capsules
+:smartproxy_port: 9090
+:smartproxy-example-com: capsule.example.com
+:SmartProxy: Capsule
+:SmartProxyServer: Capsule{nbsp}Server
+:Team: Red{nbsp}Hat

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,8 +1,8 @@
-// NOTE: Avoid empty lines so it can be included in the header section
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
 :DocState: nightly
-// Versions used in text and code
+
+// Version numbers
 :ProjectVersion: 2.4
 :KatelloVersion: 4.0
 :TargetVersion: 6.8
@@ -10,25 +10,20 @@
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :ProductVersion: 6.9-beta
 :ProductVersionPrevious: 6.8
-:ProductVersionRepoTitle: Beta
-// For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
-:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-beta-rpms
-:RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
-:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-beta-rpms
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-beta-rpms
-:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-beta-rpms
-:RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
-:RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms
-//Do not update the puppet4 repo versions. They must stay at 6.3.
-:SatelliteSub: Red Hat Satellite Infrastructure Subscription
-// Change to "Red Hat Satellite Infrastructure Subscription (Beta)" for beta releases
-:RepoRHEL7Server: rhel-7-server-rpms
-:RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
-:RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
-:RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 :SatelliteAnsibleVersion: 2.9
+// For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
 :SpecialCaseProductVersion: 6.8
-//the above attribute is for Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
+
+//
+// WHERE ARE MY ATTRIBUTES?
+//
+// All attributes were moved into separate files:
+// * attributes-base.adoc (upstream attributes common for all builds)
+// * attributes-foreman-el.adoc (attributes overridden or unique to Red Hat Enteprise Linux and clones)
+// * attributes-foreman-deb.adoc (attributes overridden or unique to Debian/Ubuntu)
+// * attributes-katello.adoc (attributes overridden or unique to Katello)
+// * attributes-satellite.adoc (attributes overridden or unique to Satellite)
+
 // Define properties to represent each build. Allows doing 'or' and 'and' operations for conditions.
 ifeval::["{build}" == "foreman-el"]
 :foreman-el:
@@ -45,242 +40,24 @@ ifeval::["{build}" == "satellite"]
 :satellite:
 endif::[]
 
-ifdef::katello,foreman-el[]
-:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server {ProjectVersion}
-:smart-proxy-context: smart-proxy
-:project-context: foreman
-:foreman-installer: foreman-installer
-:foreman-maintain: foreman-maintain
-:foreman-example-com: foreman.example.com
-:package-install: yum install
-:package-update: yum update
-:package-clean: yum clean
-:package-remove: yum remove
-:package-install-project: yum install
-:package-update-project: yum update
-:package-remove-project: yum remove
-:certs-generate: foreman-proxy-certs-generate
-:certs-proxy-context: foreman-proxy
-:project-change-hostname: katello-change-hostname
-:oVirt: oVirt
-:oVirtShort: oVirt
-:oVirtEngine: oVirt Engine
-:LoraxCompose: Lorax Composer
-:Cockpit: Cockpit
-:ovirt-example-com: ovirt.example.com
-:KubeVirt: KubeVirt
-:OpenStack: OpenStack
-:FreeIPA: FreeIPA
-:Keycloak: Keycloak
-:Keycloak-short: Keycloak
-:PIV: PIV
-:ProjectNameXY: Foreman{nbsp}1.22
-:ProjectNameX: Foreman
-:ProjectName: Foreman
-:ProjectXY: Foreman{nbsp}1.22
-:ProjectX: Foreman
-:ProjectServer: Foreman{nbsp}server
-:Project: Foreman
-:Project_Link: Red_Hat_Satellite
-:provision-script: OS installer recipe
-:RHEL: Red{nbsp}Hat Enterprise Linux
-:RHELServer: Red{nbsp}Hat Enterprise Linux Server
-:SmartProxyServer: Smart{nbsp}Proxy{nbsp}server
-:SmartProxies: Smart{nbsp}Proxies
-:SmartProxy: Smart{nbsp}Proxy
-:smartproxy-example-com: smartproxy.example.com
-:smartproxy_port: 8443
-:Team: Foreman developers
-:project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
-:project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
-:customcontent: content
-:customproduct: product
-:customproducttitle: Product
-:customgpgtitle: GPG
-:customssltitle: SSL
-:customssl: SSL
-:customrpmtitle: RPM
-:customrpm: RPM
-:customrepo: repository
-:customfiletypetitle: File Type
-:customfiletype: file type
-:customostreecontenttitle: OSTree Content
-:customostreecontent: OSTree content
-:ansiblefilepath: /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/
-:ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key
-:ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
-:ansible-namespace: `theforeman.foreman`
-:ansible-namespace-example: `theforeman.foreman._module_name_`
-:awx: AWX
+// Load base attributes
 :BaseURL: https://docs.theforeman.org/nightly/
-:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman-el.html#
-:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman-el.html#
-:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman-el.html#
-:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman-el.html#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman-el.html#
-:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman-el.html#
-:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman-el.html#
-:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-el.html#
-:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-el.html#
-:UpgradingDocURL: {BaseURL}Upgrading_and_Updating/index-foreman-el.html#
-endif::[]
-ifdef::satellite[]
-:DocState: satellite
-:project-installation-guide-title: Installing Satellite Server from a Connected Network
-:smart-proxy-installation-guide-title: Installing Capsule Server
-:smart-proxy-context: capsule
-:project-context: satellite
-:foreman-installer: satellite-installer
-:foreman-installer-package: satellite-installer
-:installer-scenario: satellite-installer --scenario satellite
-:installer-scenario-smartproxy: satellite-installer --scenario capsule
-:package-install: yum install
-:package-update: yum update
-:package-clean: yum clean
-:package-remove: yum remove
-:package-install-project: satellite-maintain packages install
-:package-update-project: satellite-maintain packages update
-:package-remove-project: satellite-maintain packages remove
-:certs-generate: capsule-certs-generate
-:certs-proxy-context: capsule
-:foreman-maintain: satellite-maintain
-:foreman-example-com: satellite.example.com
-:project-change-hostname: satellite-change-hostname
-:LoraxCompose: Red{nbsp}Hat Image Builder
-:Cockpit: Red{nbsp}Hat web console
-:oVirt: Red{nbsp}Hat{nbsp}Virtualization
-:oVirtShort: RHV
-:oVirtEngine: Red{nbsp}Hat Virtualization Manager
-:ovirt-example-com: rhv.example.com
-:KubeVirt: Container-native Virtualization
-:OpenStack: Red{nbsp}Hat OpenStack Platform
-:FreeIPA: Red{nbsp}Hat Identity Management
-:Keycloak: Red{nbsp}Hat Single Sign-On
-:Keycloak-short: RHSSO
-:PIV: CAC
-:ProjectNameXY: Red{nbsp}Hat Satellite{nbsp}{ProductVersionRepoTitle}
-:ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
-:ProjectName: Red{nbsp}Hat Satellite
-:ProjectXY: Satellite{nbsp}{ProductVersionRepoTitle}
-:ProjectX: Satellite{nbsp}6
-:ProjectServer: Satellite{nbsp}Server
-:Project: Satellite
-:Project_Link: Red_Hat_Satellite
-:provision-script: kickstart
-:RHEL: Red{nbsp}Hat Enterprise Linux
-:RHELServer: Red{nbsp}Hat Enterprise Linux Server
-:SmartProxyServer: Capsule{nbsp}Server
-:SmartProxies: Capsules
-:SmartProxy: Capsule
-:smartproxy-example-com: capsule.example.com
-:smartproxy_port: 9090
-:Team: Red{nbsp}Hat
-:project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
-:project-client-name: Satellite Tools {ProductVersionRepoTitle}
-:customcontent: custom content
-:customproduct: custom product
-:customproducttitle: Custom Product
-:customgpgtitle: Custom GPG
-:customssltitle: Custom SSL
-:customssl: custom SSL
-:customrpmtitle: Custom RPM
-:customrpm: custom RPM
-:customrepo: custom repository
-:customfiletypetitle: Custom File Type
-:customfiletype: custom file type
-:customostreecontenttitle: Custom OSTree Content
-:customostreecontent: custom OSTree content
-:ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
-:ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
-:ansible-galaxy: https://cloud.redhat.com/ansible/automation-hub/redhat/satellite/docs
-:ansible-namespace: `redhat.satellite`
-:ansible-namespace-example: `redhat.satellite._module_name_`
-:awx: Ansible Tower
-:BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/
-:ManagingHostsDocURL: {BaseURL}managing_hosts/index#
-:ConfiguringAnsibleDocURL: {BaseURL}configuring_satellite_to_use_ansible/index#
-:AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
-:InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
-:InstallingProjectDocURL: {BaseURL}installing_satellite_server_from_a_connected_network/index#
-:ContentManagementDocURL: {BaseURL}content_management_guide/index#
-:ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#
-:PlanningDocURL: {BaseURL}planning_for_red_hat_satellite/index#
-:ProvisioningDocURL: {BaseURL}provisioning_guide/index#
-:UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
+include::attributes-base.adoc[]
+
+// Load overrides for specific scenarios
+ifdef::foreman-el[]
+include::attributes-foreman-el.adoc[]
 endif::[]
 
 ifdef::foreman-deb[]
-:smart-proxy-context: smart-proxy
-:project-context: foreman
-:project-installation-guide-title: Installing Foreman server on Debian
-:smart-proxy-installation-guide-title: Installing an External Smart Proxy Server on Debian
-:foreman-installer: foreman-installer
-:foreman-maintain: foreman-maintain
-:foreman-example-com: foreman.example.com
-:installer-scenario: foreman-installer
-:package-install: apt-get install
-:package-update: apt-get upgrade
-:package-clean: apt-get clean
-:package-remove: apt-get remove
-:package-install-project: apt-get install
-:package-update-project: apt-get upgrade
-:package-remove-project: apt-get remove
-:certs-generate: foreman-proxy-certs-generate
-:installer-scenario-smartproxy: foreman-installer --no-enable-foreman
-:project-change-hostname: katello-change-hostname
-:oVirt: oVirt
-:oVirtShort: oVirt
-:oVirtEngine: oVirt Engine
-:ovirt-example-com: ovirt.example.com
-:LoraxCompose: Lorax Composer
-:Cockpit: Cockpit
-:KubeVirt: KubeVirt
-:OpenStack: OpenStack
-:FreeIPA: FreeIPA
-:Keycloak: Keycloak
-:Keycloak-short: Keycloak
-:PIV: PIV
-:ProjectNameXY: Foreman{nbsp}1.22
-:ProjectNameX: Foreman
-:ProjectName: Foreman
-:ProjectXY: Foreman{nbsp}1.22
-:ProjectX: Foreman
-:ProjectServer: Foreman{nbsp}server
-:Project: Foreman
-:Project_Link: Red_Hat_Satellite
-:provision-script: OS installer recipe
-:RHEL: Red{nbsp}Hat Enterprise Linux
-:RHELServer: Red{nbsp}Hat Enterprise Linux Server
-:SmartProxyServer: Smart{nbsp}Proxy{nbsp}server
-:SmartProxies: Smart{nbsp}Proxies
-:SmartProxy: Smart{nbsp}Proxy
-:smartproxy-example-com: smartproxy.example.com
-:smartproxy_port: 8443
-:Team: Foreman developers
-:project-client-RHEL7-url: https://yum.theforeman.org/client/{ProjectVersion}/el7/x86_64/foreman-client-release.rpm
-:project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/
-:BaseURL: https://docs.theforeman.org/nightly/
-:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman-deb.html#
-:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman-deb.html#
-:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman-deb.html#
-:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman-deb.html#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman-deb.html#
-:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman-deb.html#
-:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman-deb.html#
-:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-deb.html#
-:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-deb.html#
+include::attributes-foreman-deb.adoc[]
 endif::[]
-// Overrides for specific scenarios from the defaults
-ifdef::foreman-deb,foreman-el[]
-:foreman-installer-package: foreman-installer
-:project-installation-guide-title: Installing Foreman {ProjectVersion} server on Enterprise Linux
-:installer-scenario: foreman-installer --scenario foreman
-:installer-scenario-smartproxy: foreman-installer --no-enable-foreman
-endif::[]
+
 ifdef::katello[]
-:foreman-installer-package: foreman-installer-katello
-:project-installation-guide-title: Installing Foreman {ProjectVersion} server with Katello {KatelloVersion} plugin on Enterprise Linux
-:installer-scenario: foreman-installer --scenario katello
-:installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-katello.html#
+include::attributes-katello.adoc[]
+endif::[]
+
+ifdef::satellite[]
+:BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/
+include::attributes-satellite.adoc[]
 endif::[]

--- a/guides/diff-vs-master.sh
+++ b/guides/diff-vs-master.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+CURRENT_BRANCH=$(git branch --show-current)
+BRANCH1=${1:-$CURRENT_BRANCH}
+BRANCH2=${2:-master}
+
+rm -rf build-*/ *.diff
+
+set -e
+for BRANCH in $BRANCH1 $BRANCH2; do
+  git checkout $BRANCH
+  for BUILD in foreman-el foreman-deb katello satellite; do
+    make clean
+    make BUILD=$BUILD BUILD_DIR=../build-$BUILD-$BRANCH
+  done
+done
+git checkout $BRANCH1
+set +e
+
+set -x
+for BUILD in foreman-el foreman-deb katello satellite; do
+  diff -r build-$BUILD-$BRANCH1 build-$BUILD-$BRANCH2 > $BUILD-$BRANCH1-vs-$BRANCH2.diff
+done
+set +x
+
+echo "Done! Make sure to delete build-*/ and *.diff. Cheers!"


### PR DESCRIPTION
I know this is a change that will affect all of us, will break existing PRs and cause some cherry picking change but overall I think it's an important change to make rather sooner than later as another build flag is pending merge (https://github.com/theforeman/foreman-documentation/pull/453) and the attributes file is getting out of control.

**The problem**

As we migrated form Satellite docs, we started with Satellite attributes and enclosed them in if-statement and made a copy for "foreman" build. Then we added "katello" build, then we broke "foreman" into two and now there's another one incoming soon. Some if-blocks are copies (e.g. satellite vs foreman), other if-blocks are just overriding other values.

We need to have a consistent way of defining attributes and overriding them.

**The proposal**

Let's break huge attributes.adoc file into several files:

* attributes-base.adoc: The base file, all attributes which are supposed to be overridden should be here, with exception of attributes which are not supposed to be overridden per BUILD (e.g. versions).
* attributes-BUILD.adoc: Override files, for each BUILD a one. Only attributes which are defined in attributes.adoc can be here, so we make sure that someone guide is not defining own sandbox of attributes and everything is shared across the whole project. Builds can also define their own attributes visible only for that particular build.
* attributes.adoc: The main file which is included from guides, contains only the basic attributes (versions) and includes.

Initially, I thought it would be good idea to keep all attribute files sorted, but it turned out to be problematic as some attributes depend on others. Also it is useful to create groups of attributes, for example:

* BaseURL + URLs we use for xrefs.
* Own attributes visible only for the particular build.
* Overriden base attributes.

What is important is that instead of overriding satellite attributes, this patch turns it the other way around to the more logical: **base attributes are upstream attributes**, satellite overrides just like other builds. This makes much more sense to me.

**How to test this patch** (BEFORE YOU MERGE)

We must absolutely make sure this does not break our docs, so before merging MAKE SURE to build documentation **without** this patch, copy HTML pages to a safe place, then checkout this branch, rebase, make clean and generate all HTML pages. Then **compare** to the original and there must be exactly ZERO changes as there are no text changes in this patch on purpose.

**The oritinal proposal**

_Since I changed my mind after one night, I am keeping the original proposal here just for the record, skip to the next section. In short: I proposed some very strict rules about attributes and alphabetical order which turned not very practical._

Let's break huge attributes.adoc file into several files:

* attributes-base.adoc: The base file, ALL attributes ever defined must be here. It's the file which is ALWAYS included no matter which build is done. With exception of attributes which are not supposed to be overriden per BUILD (e.g. versions).
* attributes-BUILD.adoc: Override files, for each BUILD a one. Only attributes which are defined in attributes.adoc can be here, so we make sure that someone guide is not defining own sandbox of attributes and everything is shared across the whole project.
* attributes.adoc: The main file which is included from guides, contains only the basic attributes (versions) and includes.

What is important is that instead of overriding satellite attributes, this patch turns it the other way around to the more logical: base attributes are upstream attributes, satellite overrides many of them. This makes much more sense to me.

I do not want to stop there, if we are okay with this approach, I would like to write a script that will tighten up even more how we treat attributes and build would fail unless the following conditions are met:

* Attributes in all attribute-*.adoc files must be in the aplhanumeric order.
* Attributes overriden must be always present in the attributes-base.adoc file.
* If overriden attribute has the same value as the base one, it must be removed (no useless copies).
* Attributes referenced in attributes-*.adoc files (e.g. BaseURL) must be defined in the main attributes.adoc file to prevent ordering problems.
* In the future more rules (e.g. all downcase with dash characters).

I did split and review all attributes, then I sorted all files alphabetically, then I used a diff tool to remove those which are just copies (the value is the same). I also found one that is only defined in one BUILD but it should be present in the attributes-base.adoc (there is FIXME comment there - I do not want to change any of the content in this patch so will fix later).