### PR TITLE
Update markup to make CLI procedures easier to find

### DIFF
--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -5,6 +5,7 @@ If your network uses an HTTP Proxy, you can configure {ProjectServer} to use an 
 Use the FQDN instead of the IP address where possible to avoid losing connectivity because of network changes.
 
 The following procedure configures a proxy only for downloading content for {Project}.
+To use the CLI instead of the web UI, see the xref:cli-adding-a-default-http-proxy[].
 
 .Procedure
 
@@ -19,7 +20,8 @@ The following procedure configures a proxy only for downloading content for {Pro
 . Navigate to *Administer* > *Settings*, and click the *Content* tab.
 . Set the *Default HTTP Proxy* setting to the created HTTP proxy.
 
-.For CLI Users
+[[cli-adding-a-default-http-proxy]]
+.CLI procedure
 
 . Verify that the `http_proxy`, `https_proxy`, and `no_proxy` variables are not set.
 +

--- a/guides/common/modules/proc_adding-azure-connection.adoc
+++ b/guides/common/modules/proc_adding-azure-connection.adoc
@@ -4,6 +4,8 @@
 Use this procedure to add Microsoft Azure Resource Manager as a compute resource in {Project}.
 Note that you must add a separate compute resource for each Azure Resource Manager region that you want to use.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-azure-connection[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources* and click *Create Compute Resource*.
@@ -19,7 +21,8 @@ This tests if your connection to Azure Resource Manager is successful and loads 
 . From the *Azure Region* list, select the Azure region to use.
 . Click *Submit*.
 
-.For CLI Users
+[[cli-adding-azure-connection]]
+.CLI procedure
 
 * Use the `hammer compute-resource create` command to add an Azure compute resource to {Project}.
 Note that the value for the `--region` option must be in lowercase and must not contain special characters.

--- a/guides/common/modules/proc_adding-azure-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-azure-details-to-a-compute-profile.adoc
@@ -4,6 +4,8 @@
 Use this procedure to add Azure hardware settings to a compute profile.
 When you create a host on Azure using this compute profile, these settings are automatically populated.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-azure-details-to-a-compute-profile[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles*.
@@ -31,7 +33,8 @@ The scripts must contain `sudo` at the beginning because {ProjectName} downloads
 . Optional: If you want the virtual machine to use a static private IP, select the *Static Private IP* check box.
 . Click *Submit*.
 
-.For CLI Users
+[[cli-adding-azure-details-to-a-compute-profile]]
+.CLI procedure
 
 . Create a compute profile to use with the Azure Resource Manager compute resource:
 +

--- a/guides/common/modules/proc_adding-gce-connection.adoc
+++ b/guides/common/modules/proc_adding-gce-connection.adoc
@@ -2,6 +2,7 @@
 = Adding a Google Compute Engine Connection to {ProjectServer}
 
 Use this procedure to add Google Compute Engine (GCE) as a compute resource in {Project}.
+To use the CLI instead of the web UI, see the xref:cli-adding-gce-connection[].
 
 .Procedure
 
@@ -36,7 +37,8 @@ For example, `/usr/share/foreman/_gce_key_.json`.
 . From the *Zone* list, select the GCE zone to use.
 . Click *Submit*.
 
-.For CLI Users
+[[cli-adding-gce-connection]]
+.CLI procedure
 
 . In GCE, generate a service account key in JSON format and upload this file to the `/usr/share/foreman/` directory on {ProjectServer}.
 

--- a/guides/common/modules/proc_adding-gce-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-gce-details-to-a-compute-profile.adoc
@@ -4,6 +4,8 @@
 Use this procedure to add GCE hardware settings to a compute profile.
 When you create a host on GCE using this compute profile, these settings are automatically populated.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-gce-details-to-a-compute-profile[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles*.
@@ -18,7 +20,8 @@ If you need a permanent IP address, reserve a static public IP address on GCE an
 . In the *Size (GB)* field, enter the size of the storage to create on the host.
 . Click *Submit* to save the compute profile.
 
-.For CLI Users
+[[cli-adding-gce-details-to-a-compute-profile]]
+.CLI procedure
 
 . Create a compute profile to use with the GCE compute resource:
 +

--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -5,6 +5,8 @@ To create hosts using image-based provisioning, you must add information about t
 
 ifdef::kvm-provisioning[Note that you can manage only directory pool storage types through {ProjectX}.]
 
+To use the CLI instead of the web UI, see the xref:cli-adding-images-to-server[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources* and click the name of the {CRname} connection.
@@ -38,7 +40,7 @@ For example, *custom://image-name*.
 * For a shared gallery image, use the prefix `gallery`.
 For example, *gallery://image-name*.
 * For public and RHEL Bring Your Own Subscription (BYOS) images, use the prefix `marketplace`.
-For example, *marketplace://OpenLogicCentOS:7.5:latest*. 
+For example, *marketplace://OpenLogicCentOS:7.5:latest*.
 +
 For more information, see https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage[Find Linux VM images in the Azure Marketplace with the Azure CLI].
 endif::[]
@@ -46,7 +48,8 @@ endif::[]
 . Optional: Select the *User Data* check box if the image supports user data input, such as `cloud-init` data.
 . Click *Submit* to save the image details.
 
-.For CLI Users
+[[cli-adding-images-to-server]]
+.CLI procedure
 
 * Create the image with the `hammer compute-resource image create` command.
 ifeval::["{context}" == "kvm-provisioning"]

--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -20,6 +20,8 @@ For example *CentOS mirror (7.x)* must be used for CentOS 7 or earlier, and *Cen
 
 If you want to improve download performance when using installation media to install operating systems on multiple host, you must modify the installation medium's *Path* to point to the closest mirror or a local copy.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-installation-media[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Installation Media* and click *Create Medium*.
@@ -55,7 +57,8 @@ endif::[]
 {ProjectServer} adds the installation medium to the set provisioning context.
 . Click *Submit* to save your installation medium.
 
-.For CLI Users
+[[cli-adding-installation-media]]
+.CLI procedure
 
 * Create the installation medium using the `hammer medium create` command:
 +

--- a/guides/common/modules/proc_adding-kvm-connection.adoc
+++ b/guides/common/modules/proc_adding-kvm-connection.adoc
@@ -2,6 +2,7 @@
 = Adding a KVM Connection to {ProjectServer}
 
 Use this procedure to add KVM as a compute resource in {Project}.
+To use the CLI instead of the web UI, see the xref:cli-adding-kvm-connection[].
 
 .Procedure
 
@@ -33,7 +34,8 @@ The password is randomly generated every time the console for the virtual machin
 If you want, add additional contexts to these tabs.
 . Click *Submit* to save the KVM connection.
 
-.For CLI Users
+[[cli-adding-kvm-connection]]
+.CLI procedure
 
 * To create a compute resource, enter the `hammer compute-resource create` command:
 +

--- a/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile.adoc
@@ -4,6 +4,8 @@
 Use this procedure to add KVM hardware settings to a compute profile.
 When you create a host on KVM using this compute profile, these settings are automatically populated.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-kvm-details-to-a-compute-profile[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles*.
@@ -19,7 +21,8 @@ However, at least one interface must point to a {SmartProxy}-managed network.
 You can create multiple volumes for the host.
 . Click *Submit* to save the settings to the compute profile.
 
-.For CLI Users
+[[cli-adding-kvm-details-to-a-compute-profile]]
+.CLI procedure
 
 . To create a compute profile, enter the following command:
 +

--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -23,7 +23,7 @@ You can use Hammer CLI on {ProjectServer} or the {Project} web UI.
 +
 For definitions of each synchronization type, see {ContentManagementDocURL}Importing_Content-Recovering_a_Repository[Recovering a Repository].
 
-.For CLI Users
+.CLI procedure
 
 . To display a list of all {SmartProxyServer}s, on {ProjectServer}, enter the following command:
 +

--- a/guides/common/modules/proc_adding-openstack-connection.adoc
+++ b/guides/common/modules/proc_adding-openstack-connection.adoc
@@ -2,6 +2,7 @@
 = Adding the {OpenStack} Connection to {ProjectServer}
 
 Use this procedure to add {OpenStack} as a compute resource in {Project}.
+To use the CLI instead of the web UI, see the xref:cli-adding-openstack-connection[].
 
 .Procedure
 
@@ -19,7 +20,8 @@ Use the following format: `http://openstack.example.com:5000/v3.0/tokens`.
 Add any additional contexts that you want to these tabs.
 . Click *Submit* to save the {OpenStack} connection.
 
-.For CLI Users
+[[cli-adding-openstack-connection]]
+.CLI procedure
 
 * To create a compute resource, enter the `hammer compute-resource create` command:
 +

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
@@ -21,7 +21,7 @@ If not selected, the instance boots the image directly.
 . In the *New boot volume size (GB)* field, enter the size, in GB, of the new boot volume.
 . Click *Submit* to save the compute profile.
 
-.For CLI Users
+.CLI procedure
 
 The compute profile CLI commands are not yet implemented in {ProjectName} {ProductVersion}.
 As an alternative, you can include the same settings directly during the host creation process.

--- a/guides/common/modules/proc_adding-rhv-connection.adoc
+++ b/guides/common/modules/proc_adding-rhv-connection.adoc
@@ -2,6 +2,7 @@
 = Adding the {oVirt} Connection to {ProjectServer}
 
 Use this procedure to add {oVirt} as a compute resource in {Project}.
+To use the CLI instead of the web UI, see the xref:cli-adding-rhv-connection[].
 
 .Procedure
 
@@ -22,7 +23,8 @@ Alternatively, if you leave the field blank, a self-signed certificate is genera
 . Click the *Organizations* tab and select the organization you want to use.
 . Click *Submit* to save the compute resource.
 
-.For CLI Users
+[[cli-adding-rhv-connection]]
+.CLI procedure
 
 * Enter the `hammer compute-resource create` command with `Ovirt` for `--provider` and the name of the data center you want to use for `--datacenter`.
 +

--- a/guides/common/modules/proc_adding-rhv-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-rhv-details-to-a-compute-profile.adoc
@@ -4,6 +4,8 @@
 Use this procedure to add {oVirt} hardware settings to a compute profile.
 When you create a host on KVM using this compute profile, these settings are automatically populated.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-rhv-details-to-a-compute-profile[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles*.
@@ -29,7 +31,8 @@ For each volume, enter the following details:
 .. From the *Bootable* list, select whether you want a bootable or non-bootable volume.
 . Click *Submit* to save the compute profile.
 
-.For CLI Users
+[[cli-adding-rhv-details-to-a-compute-profile]]
+.CLI procedure
 
 . To create a compute profile, enter the following command:
 +

--- a/guides/common/modules/proc_configuring-the-fallback-to-any-smartproxy-setting.adoc
+++ b/guides/common/modules/proc_configuring-the-fallback-to-any-smartproxy-setting.adoc
@@ -21,7 +21,7 @@ If the *Fallback to Any {SmartProxy}* setting is enabled, {Project} adds another
 . Click *RemoteExecution*.
 . Configure the *Fallback to Any {SmartProxy}* setting.
 
-.For CLI Users
+.CLI procedure
 
 Enter the `hammer settings set` command on {Project} to configure the *Fallback to Any {SmartProxy}* setting.
 For example, to set the value to `true`, enter the following command:

--- a/guides/common/modules/proc_configuring-the-global-smartproxy-remote-execution-setting.adoc
+++ b/guides/common/modules/proc_configuring-the-global-smartproxy-remote-execution-setting.adoc
@@ -14,11 +14,11 @@ If the *Enable Global {SmartProxy}* setting is enabled, {Project} adds another s
 . Click *RemoteExection*.
 . Configure the *Enable Global {SmartProxy}* setting.
 
-.For CLI Users
+.CLI procedure
 
-Enter the `hammer settings set` command on {Project} to configure the `Enable Global {SmartProxy}` setting.
+* Enter the `hammer settings set` command on {Project} to configure the `Enable Global {SmartProxy}` setting.
 For example, to set the value to `true`, enter the following command:
-
++
 ----
 # hammer settings set --name=remote_execution_global_proxy --value=true
 ----

--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -3,6 +3,7 @@
 = Creating a Job Template
 
 Use this procedure to create a job template.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-job-template[].
 
 .Procedure
 
@@ -32,7 +33,8 @@ For examples, see the *Help* tab.
 You can extend and customize job templates by including other templates in the template syntax.
 For more information, see the appendices in the _Managing Hosts_ guide.
 
-.For CLI Users
+[[cli-creating-a-job-template]]
+.CLI procedure
 
 . To create a job template using a template-definition file, enter the following command:
 +

--- a/guides/common/modules/proc_creating-architectures.adoc
+++ b/guides/common/modules/proc_creating-architectures.adoc
@@ -22,7 +22,7 @@ endif::[]
 If none are available, you can create and assign them under *Hosts* > *Operating Systems*.
 . Click *Submit*.
 
-.For CLI Users
+.CLI procedure
 
 * Enter the `hammer architecture create` command to create an architecture.
 Specify its name and operating systems that include this architecture:

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -16,6 +16,6 @@ A default installation of {ProjectName} contains three predefined profiles:
 A new window opens with the name of the compute profile.
 . In the new window, click the name of each compute resource and edit the attributes you want to set for this compute profile.
 
-.For CLI Users
+.CLI procedure
 
 The compute profile CLI commands are not yet implemented in {ProjectName} {ProductVersion}.

--- a/guides/common/modules/proc_creating-hardware-models.adoc
+++ b/guides/common/modules/proc_creating-hardware-models.adoc
@@ -11,7 +11,7 @@ Use this procedure to create a hardware model in {Project} so that you can speci
 . In the *Info* field, enter a description of the hardware model.
 . Click *Submit* to save your hardware model.
 
-.For CLI Users
+.CLI procedure
 
 * Create a hardware model using the `hammer model create` command.
 The only required parameter is `--name`.

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -4,6 +4,8 @@
 In {Project}, you can use {CRname} provisioning to create hosts from an existing image.
 The new host entry triggers the {CRname} server to create the instance using the pre-existing image as a basis for the new volume.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-image-only-hosts[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Create Host*.
@@ -43,7 +45,8 @@ If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host entry.
 
-.For CLI Users
+[[cli-creating-image-only-hosts]]
+.CLI procedure
 
 * Create the host with the `hammer host create` command and include `--provision-method image`.
 Replace the values in the following example with the appropriate values for your environment.

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -9,6 +9,8 @@ If the virtual machine detects the defined {SmartProxyServer} through the virtua
 
 * If you want to create a host with an existing image, the new host entry triggers the {CRname} server to create the virtual machine using a pre-existing image as a basis for the new volume.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-network-or-image-based-hosts[].
+
 .DHCP Conflicts
 For network-based provisioning, if you use a virtual network on the {CRname} server for provisioning, select a network that does not provide DHCP assignments.
 This causes DHCP conflicts with {ProjectServer} when booting new hosts.
@@ -50,7 +52,8 @@ If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host entry.
 
-.For CLI Users
+[[cli-creating-network-or-image-based-hosts]]
+.CLI procedure
 
 * To use network-based provisioning, create the host with the `hammer host create` command and include `--provision-method build`.
 Replace the values in the following example with the appropriate values for your environment.

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -11,7 +11,8 @@ ifdef::foreman-el,katello[]
 Importing operating systems from Red Hat's CDN is only possible when Katello is installed.
 endif::[]
 
-You can also add custom operating systems using the following procedure:
+You can also add custom operating systems using the following procedure.
+To use the CLI instead of the web UI, see the xref:cli-creating-operating-systems[].
 
 .Procedure
 
@@ -35,7 +36,8 @@ For more information, see {ProvisioningDocURL}adding-installation-media_provisio
 You can select other templates, for example an *iPXE template*, if you plan to use iPXE for provisioning.
 . Click *Submit* to save your provisioning template.
 
-.For CLI Users
+[[cli-creating-operating-systems]]
+.CLI procedure
 
 * Create the operating system using the `hammer os create` command:
 +

--- a/guides/common/modules/proc_creating-partition-tables.adoc
+++ b/guides/common/modules/proc_creating-partition-tables.adoc
@@ -6,6 +6,8 @@ A Partition table uses the same ERB syntax as provisioning templates.
 {ProjectName} contains a set of default partition tables to use, including a `Kickstart default`.
 You can also edit partition table entries to configure the preferred partitioning scheme, or create a partition table entry and add it to the operating system entry.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-partition-tables[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Partition Tables* and click *Create Partition Table*.
@@ -33,7 +35,8 @@ For example, Red Hat Enterprise Linux 7.2 requires a layout that matches a kicks
 {Project} adds the partition table to the current provisioning context.
 . Click *Submit* to save your partition table.
 
-.For CLI Users
+[[cli-creating-partition-tables]]
+.CLI procedure
 
 . Before you create a partition table with the CLI, create a plain text file that contains the partition layout.
 This example uses the `~/my-partition` file.

--- a/guides/common/modules/proc_creating-provisioning-templates.adoc
+++ b/guides/common/modules/proc_creating-provisioning-templates.adoc
@@ -11,7 +11,7 @@ Use this procedure to create a new provisioning template.
 . Fill in the rest of the fields as required.
 The *Help* tab provides information about the template syntax and details the available functions, variables, and methods that can be called on different types of objects within the template.
 
-.For CLI Users
+.CLI procedure
 
 . Before you create a template with the CLI, create a plain text file that contains the template.
 This example uses the `~/my-template` file.

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -9,11 +9,11 @@ After installing the {SmartProxyServer} packages, if there is more than one orga
 . Log into the {Project} web UI.
 . From the *Organization* list in the upper-left of the screen, select *Any Organization*.
 . From the *Location* list in the upper-left of the screen, select *Any Location*.
-. Navigate to *Hosts* > *All Hosts* and select the {SmartProxyServer}. 
-. From the *Select Actions* list, select *Assign Organization*. 
-. From the *Organization* list, select the organization where you want to assign this {SmartProxy}. 
-. Click *Fix Organization on Mismatch*. 
-. Click *Submit*. 
+. Navigate to *Hosts* > *All Hosts* and select the {SmartProxyServer}.
+. From the *Select Actions* list, select *Assign Organization*.
+. From the *Organization* list, select the organization where you want to assign this {SmartProxy}.
+. Click *Fix Organization on Mismatch*.
+. Click *Submit*.
 . Select the {SmartProxyServer}. From the *Select Actions* list, select *Assign Location*.
 . From the *Location* list, select the location where you want to assign this {SmartProxy}.
 . Click *Fix Location on Mismatch*.
@@ -23,9 +23,9 @@ After installing the {SmartProxyServer} packages, if there is more than one orga
 . Navigate to *Administer* > *Locations* and click the location to which you have assigned {SmartProxy}.
 . Click the *{SmartProxies}* tab and ensure that the {SmartProxyServer} is listed under the *Selected items* list, then click *Submit*.
 
-.Conclusion
+.Verification
 
-Optionally, you can now verify if the {SmartProxyServer} is correctly listed in the {Project} web UI.
+Optionally, you can verify if the {SmartProxyServer} is correctly listed in the {Project} web UI.
 
 . Select the organization from the *Organization* list.
 . Select the location from the *Location* list.

--- a/guides/common/modules/proc_enabling-the-disconnected-mode.adoc
+++ b/guides/common/modules/proc_enabling-the-disconnected-mode.adoc
@@ -10,7 +10,7 @@ When the disconnected mode is enabled, {ProjectServer} does not access the Red H
 . Click the *Content* tab.
 . Set the `Disconnected mode` value to `Yes`.
 
-.For CLI Users
+.CLI procedure
 
 * Enter the following command on {ProjectServer}:
 +

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -8,6 +8,8 @@ endif::[]
 
 The {project-client-name} repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
 
+To use the CLI instead of the web UI, see the xref:cli-enabling-the-tools-repository[].
+
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
 
@@ -30,7 +32,8 @@ To correct that, log in to the Customer Portal, add these repositories, download
 Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
 After enabling a Red Hat repository, a Product for this repository is automatically created.
 
-.For CLI Users
+[[cli-enabling-the-tools-repository]]
+.CLI procedure
 
 * Enable the {project-client-name} repository using the `hammer repository-set enable` command:
 +

--- a/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests.adoc
+++ b/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests.adoc
@@ -9,7 +9,7 @@ If you use an HTTP Proxy for all {Project} HTTP or HTTPS requests, you can preve
 . In the *HTTP(S) proxy except hosts* row, select the adjacent *Value* column and enter the names of one or more hosts that you want to exclude from proxy requests.
 . Click the tick icon to save your changes.
 
-.For CLI Users
+.CLI procedure
 
 * Enter the following command:
 +

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -4,6 +4,8 @@
 
 You can execute a job that is based on a job template against one or more hosts.
 
+To use the CLI instead of the web UI, see the xref:cli-executing-a-remote-job[].
+
 
 .Procedure
 
@@ -45,9 +47,10 @@ For more information about cron, see the https://access.redhat.com/documentation
 . Click *Submit*.
 This displays the *Job Overview* page, and when the job completes, also displays the status of the job.
 
-.For CLI Users
+[[cli-executing-a-remote-job]]
+.CLI procedure
 
-Enter the following command on {Project}:
+* Enter the following command on {Project}:
 
 ----
 # hammer settings set --name=remote_execution_global_proxy --value=false

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc
@@ -25,7 +25,7 @@ endif::[]
 . Navigate to the location that contains the Subscription Manifest file, then click *Open*.
 If the Manage Manifest window does not close automatically, click *Close* to return to the Subscriptions window.
 
-.For CLI Users
+.CLI procedure
 
 . Copy the Subscription Manifest file from your client to {ProjectServer}:
 +

--- a/guides/common/modules/proc_monitoring-remote-jobs.adoc
+++ b/guides/common/modules/proc_monitoring-remote-jobs.adoc
@@ -19,7 +19,7 @@ This displays the list of hosts on which the job is running.
 This displays the *Detail of Commands* page where you can monitor the job execution in real time.
 . Click *Back to Job* at any time to return to the *Job Details* page.
 
-.For CLI Users
+.CLI procedure
 
 To monitor the progress of a job while it is running, complete the following steps:
 

--- a/guides/common/modules/proc_resetting-the-http-proxy.adoc
+++ b/guides/common/modules/proc_resetting-the-http-proxy.adoc
@@ -8,7 +8,7 @@ If you want to reset the current HTTP proxy setting, unset the *Default HTTP Pro
 . Navigate to *Administer* > *Settings*, and click the *Content* tab.
 . Set the *Default HTTP Proxy* setting to *no global default*.
 
-.For CLI Users
+.CLI procedure
 
 * Set the `content_default_http_proxy` setting to an empty string:
 +

--- a/guides/common/modules/proc_setting-the-provisioning-context.adoc
+++ b/guides/common/modules/proc_setting-the-provisioning-context.adoc
@@ -14,7 +14,7 @@ If you have not selected an organization and location to use, the menu displays:
 Each user can set their default provisioning context in their account settings.
 Click the user name in the upper right of the {Project} web UI and select *My account* to edit your user account settings.
 
-.For CLI Users
+.CLI procedure
 
 * When using the CLI, include either `--organization` or `--organization-label` and `--location` or `--location-id` as an option.
 For example:

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -19,7 +19,7 @@ A list of product repositories available for synchronization is displayed.
 
 . Click *Synchronize Now*.
 
-.For CLI Users
+.CLI procedure
 
 * Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
 +

--- a/guides/common/modules/proc_using-an-http-proxy-for-all-http-requests.adoc
+++ b/guides/common/modules/proc_using-an-http-proxy-for-all-http-requests.adoc
@@ -11,7 +11,7 @@ Note that if you are using compute resources for provisioning, and you want to u
 . In the *HTTP(S) proxy* row, select the adjacent *Value* column and enter the proxy URL.
 . Click the tick icon to save your changes.
 
-.For CLI Users
+.CLI procedure
 
 * Enter the following command:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -132,10 +132,10 @@ Use this procedure to refresh the LDAP source manually.
 . Navigate to *Administer* > *Usergroups* and select a user group.
 . Navigate to the *External Groups* tab and click *Refresh* to the right of the required user group.
 
-.For CLI Users
+.CLI procedure
 
-Enter the following command:
-
+* Enter the following command:
++
 ----
 # foreman-rake ldap:refresh_usergroups
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding-permissions-to-a-role.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding-permissions-to-a-role.adoc
@@ -1,7 +1,7 @@
-[id='adding-permissions-to-a-role_{context}']
+[id="adding-permissions-to-a-role_{context}"]
 = Adding Permissions to a Role
 
-Use this procedure to add permissions to a role.
+Use this procedure to add permissions to a role. To use the CLI instead of the web UI, see the xref:cli-adding-permissions-to-a-role[].
 
 .Procedure
 . Navigate to *Administer* > *Roles*.
@@ -18,7 +18,8 @@ When you enable the *Override* check box, you can add additional locations and o
 . Click *Next*.
 . Click *Submit* to save changes.
 
-.For CLI Users
+[[cli-adding-permissions-to-a-role]]
+.CLI procedure
 
 To add permissions to a role, complete the following steps:
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding-permissions-to-a-role.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding-permissions-to-a-role.adoc
@@ -1,7 +1,8 @@
 [id="adding-permissions-to-a-role_{context}"]
 = Adding Permissions to a Role
 
-Use this procedure to add permissions to a role. To use the CLI instead of the web UI, see the xref:cli-adding-permissions-to-a-role[].
+Use this procedure to add permissions to a role.
+To use the CLI instead of the web UI, see the xref:cli-adding-permissions-to-a-role[].
 
 .Procedure
 . Navigate to *Administer* > *Roles*.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/assigning-roles-to-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/assigning-roles-to-a-user.adoc
@@ -1,7 +1,8 @@
 [id="assigning-roles-to-a-user_{context}"]
 = Assigning Roles to a User
 
-Use this procedure to assign roles to a user. To use the CLI instead of the web UI, see the xref:cli-assigning-roles-to-a-user[].
+Use this procedure to assign roles to a user.
+To use the CLI instead of the web UI, see the xref:cli-assigning-roles-to-a-user[].
 
 .Procedure
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/assigning-roles-to-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/assigning-roles-to-a-user.adoc
@@ -1,7 +1,7 @@
-[id='assigning-roles-to-a-user_{context}']
+[id="assigning-roles-to-a-user_{context}"]
 = Assigning Roles to a User
 
-Use this procedure to assign roles to a user.
+Use this procedure to assign roles to a user. To use the CLI instead of the web UI, see the xref:cli-assigning-roles-to-a-user[].
 
 .Procedure
 
@@ -25,7 +25,8 @@ To grant all the available permissions, select the *Admin* check box.
 To view the roles assigned to a user, click the *Roles* tab; the assigned roles are listed under *Selected items*.
 To remove an assigned role, click the role name in *Selected items*.
 
-.For CLI Users
+[[cli-assigning-roles-to-a-user]]
+.CLI procedure
 
 To assign roles to a user, enter the following command:
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-granular-permission-filter.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-granular-permission-filter.adoc
@@ -1,7 +1,7 @@
 [id='creating-a-granular-permission-filter_{context}']
 = Creating a Granular Permission Filter
 
-Use this procedure to create a granular filter.
+Use this procedure to create a granular filter. To use the CLI instead of the web UI, see the xref:cli-creating-a-granular-permission-filter[].
 
 {Project} does not apply search conditions to create actions.
 For example, limiting the _create_locations_ action with _name = "Default Location"_ expression in the search field does not prevent the user from assigning a custom name to the newly created location.
@@ -32,10 +32,11 @@ For most resource types, the *Search* field provides a drop-down list suggesting
 This list appears after placing the cursor in the search field.
 For many resource types, you can combine queries using logical operators such as _and_, _not_ and _has_ operators.
 
-.For CLI Users
+[[cli-creating-a-granular-permission-filter]]
+.CLI procedure
 
-To create a granular filter, enter the `hammer filter create` command with the `--search` option to limit permission filters, for example:
-
+* To create a granular filter, enter the `hammer filter create` command with the `--search` option to limit permission filters, for example:
++
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # hammer filter create \

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-granular-permission-filter.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-granular-permission-filter.adoc
@@ -1,7 +1,8 @@
 [id='creating-a-granular-permission-filter_{context}']
 = Creating a Granular Permission Filter
 
-Use this procedure to create a granular filter. To use the CLI instead of the web UI, see the xref:cli-creating-a-granular-permission-filter[].
+Use this procedure to create a granular filter.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-granular-permission-filter[].
 
 {Project} does not apply search conditions to create actions.
 For example, limiting the _create_locations_ action with _name = "Default Location"_ expression in the search field does not prevent the user from assigning a custom name to the newly created location.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-role.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-role.adoc
@@ -10,7 +10,7 @@ Use this procedure to create a role.
 . Provide a *Name* for the role.
 . Click *Submit* to save your new role.
 
-.For CLI Users
+.CLI procedure
 
 To create a role, enter the following command:
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user-group.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user-group.adoc
@@ -19,10 +19,10 @@ Alternatively, select the *Admin* check box to assign all available permissions.
 
 . Click *Submit*.
 
-.For CLI Users
+.CLI procedure
 
-To create a user group, enter the following command:
-
+* To create a user group, enter the following command:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # hammer user-group create \

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
@@ -1,7 +1,7 @@
 [id='creating-a-user_{context}']
 = Creating a User
 
-Use this procedure to create a user.
+Use this procedure to create a user. To use the CLI instead of the web UI, see the xref:cli-creating-a-user[].
 
 .Procedure
 
@@ -27,10 +27,11 @@ By default, {ProjectServer} uses the language and timezone settings of the userâ
 
 . Click *Submit* to create the user.
 
-.For CLI Users
+[[cli-creating-a-user]]
+.CLI procedure
 
-To create a user, enter the following command:
-
+* To create a user, enter the following command:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # hammer user create \

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
@@ -1,7 +1,8 @@
 [id='creating-a-user_{context}']
 = Creating a User
 
-Use this procedure to create a user. To use the CLI instead of the web UI, see the xref:cli-creating-a-user[].
+Use this procedure to create a user.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-user[].
 
 .Procedure
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
@@ -1,7 +1,8 @@
 [id='managing-ssh-keys-for-a-user_{context}']
 = Managing SSH Keys for a User
 
-Use this procedure to add or remove SSH keys for a user. To use the CLI instead of the web UI, see the xref:cli-managing-ssh-keys-for-a-user[].
+Use this procedure to add or remove SSH keys for a user.
+To use the CLI instead of the web UI, see the xref:cli-managing-ssh-keys-for-a-user[].
 
 .Prerequisites
 Make sure that you are logged in to the web UI as an Admin user of {ProjectName} or a user with the __create_ssh_key__ permission enabled for adding SSH key and __destroy_ssh_key__ permission for removing a key.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
@@ -1,7 +1,7 @@
 [id='managing-ssh-keys-for-a-user_{context}']
 = Managing SSH Keys for a User
 
-Use this procedure to add or remove SSH keys for a user.
+Use this procedure to add or remove SSH keys for a user. To use the CLI instead of the web UI, see the xref:cli-managing-ssh-keys-for-a-user[].
 
 .Prerequisites
 Make sure that you are logged in to the web UI as an Admin user of {ProjectName} or a user with the __create_ssh_key__ permission enabled for adding SSH key and __destroy_ssh_key__ permission for removing a key.
@@ -22,7 +22,8 @@ Make sure that you are logged in to the web UI as an Admin user of {ProjectName}
 ... Click *Delete* on the row of the SSH key to be deleted.
 ... Click *OK* in the confirmation prompt.
 
-.For CLI Users
+[[cli-managing-ssh-keys-for-a-user]]
+.CLI procedure
 
 To add an SSH key to a user, you must specify either the path to the public SSH key file, or the content of the public SSH key copied to the clipboard.
 

--- a/guides/doc-Content_Management_Guide/topics/Containers_importing_container_images.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Containers_importing_container_images.adoc
@@ -6,9 +6,9 @@ You can import container image repositories from Red Hat Registry or from other 
 This procedure uses repository discovery to find container images and import them as repositories.
 For more information about creating a product and repository manually, see xref:Importing_Content[].
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-importing-container-images[].
 
-To import container image repositories and create or associate them with a product, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Products* and click *Repo Discovery*.
 . From the *Repository Type* list, select *Container Images*.
@@ -33,7 +33,8 @@ To view the progress of the synchronization navigate to *Content* > *Sync Status
 When the synchronization completes, you can click *Container Image Manifests* to list the available manifests.
 From the list, you can also remove any manifests that you do not require.
 
-.For CLI Users
+[[cli-importing-container-images]]
+.CLI procedure
 
 . Create the custom `Red Hat Container Catalog` product:
 +

--- a/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
@@ -122,8 +122,7 @@ Then optionally add additional environments to the environment paths.
 . Click *Save*.
 . Optional: To add an environment to the environment path, click *Add New Environment*, complete the *Name* and *Description* fields, and select the prior environment from the *Prior Environment* list.
 
-
-.For CLI Users
+.CLI procedure
 
 . To create an environment path, enter the `hammer lifecycle-environment create` command and specify the Library environment with the `--prior` option:
 +
@@ -161,13 +160,11 @@ Use this procedure to remove a life cycle environment.
 
 .Procedure
 
-To remove a life cycle environment, complete the following steps:
-
 . In the {Project} web UI, navigate to *Content* > *Life Cycle Environments*.
 . Click the name of the life cycle environment that you want to remove, and then click *Remove Environment*.
 . Click *Remove* to remove the environment.
 
-.For CLI Users
+.CLI procedure
 
 . List the life cycle environments for your organization and note the name of the life cycle environment you want to remove:
 +
@@ -195,17 +192,13 @@ You can use both the {Project} web UI and the Hammer to remove life cycle enviro
 
 .Procedure
 
-To remove a life cycle environment from {SmartProxyServer}, complete the following step:
-
 . In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} that you want to remove a life cycle from.
 . Click *Edit* and click the *Life Cycle Environments* tab.
 . From the right menu, select the life cycle environments that you want to remove from {SmartProxy}, and then click *Submit*.
 . To synchronize {SmartProxy}'s content, click the *Overview* tab, and then click *Synchronize*.
 . Select either *Optimized Sync* or *Complete Sync*.
 
-.For CLI Users
-
-To remove a life cycle environment from {SmartProxyServer}, complete the following steps:
+.CLI procedure
 
 . Select the {SmartProxyServer} that you want from the list and take note of its *id*:
 +

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -51,10 +51,9 @@ In the Content Credentials window, click *Create Content Credential*.
 === Creating a {customproducttitle}
 
 Use this procedure to create a {customproduct} that you can then add repositories to.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-product[].
 
 .Procedure
-
-To create a {customproduct}, complete the following procedure:
 
 . In the {Project} web UI, navigate to *Content* > *Products*, click *Create Product*.
 . In the *Name* field, enter a name for the product.
@@ -67,7 +66,8 @@ To create a {customproduct}, complete the following procedure:
 . In the *Description* field, enter a description of the product.
 . Click *Save*.
 
-.For CLI Users
+[[cli-creating-a-custom-product]]
+.CLI procedure
 
 To create the product, enter the following command:
 
@@ -84,6 +84,7 @@ To create the product, enter the following command:
 === Adding {customrpmtitle} Repositories
 
 Use this procedure to add {customrpm} repositories in {Project}.
+To use the CLI instead of the web UI, see the xref:cli-adding-rpm-repositories[].
 
 The Products window in the {Project} web UI also provides a *Repo Discovery* function that finds all repositories from a URL and you can select which ones to add to your {customproduct}.
 For example, you can use the *Repo Discovery* to search, for example, `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures.
@@ -115,7 +116,8 @@ This ensures that the content that is no longer part of the upstream repository 
 . Optional: From the *GPG Key* list, select the GPG key for the product.
 . Click *Save*.
 
-.For CLI Users
+[[cli-adding-rpm-repositories]]
+.CLI procedure
 
 . Enter the following command to create the repository:
 +
@@ -166,7 +168,7 @@ To provision Red{nbsp}Hat Enterprise Linux 7 clients, you require the *Red{nbsp}
 . In the Available Repositories pane, click a repository to expand the repository set.
 . Click the *Enable* icon next to the base architecture and release version that you want.
 
-.For CLI Users
+.CLI procedure
 
 . To search for your product, enter the following command:
 +
@@ -202,17 +204,17 @@ For example:
 [[Importing_Content-Synchronizing_Repositories]]
 === Syncing Repositories
 
-.For Web UI Users
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Products* and select the product that contains the repositories that you want to synchronize.
 . Select the repositories that you want to synchronize and click *Sync Now*.
 
 To view the progress of the synchronization in the web UI, navigate to *Content* > *Sync Status* and expand the corresponding product or repository tree.
 
-.For CLI Users
+.CLI procedure
 
 * Synchronize an entire Product:
-
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer product synchronize \
@@ -221,7 +223,7 @@ To view the progress of the synchronization in the web UI, navigate to *Content*
 ----
 
 * Synchronize the repository individually:
-
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer repository synchronize \
@@ -322,10 +324,10 @@ ifndef::satellite[]
 * To change the default download policy for a non-Red Hat {customrepo}, change the value of the *Default Custom Repository download policy* setting.
 endif::[]
 
-.For CLI Users
+.CLI procedure
 
-To change the default download policy for Red Hat repositories to one of `immediate` or `on_demand`, enter the following command:
-
+* To change the default download policy for Red Hat repositories to one of `immediate` or `on_demand`, enter the following command:
++
 [subs="+quotes"]
 ----
 # hammer settings set \
@@ -333,14 +335,13 @@ To change the default download policy for Red Hat repositories to one of `immedi
 --value _immediate_
 ----
 
-ifdef::satellite[]
-To change the default download policy for a {customrepo} to one of `immediate` or `on_demand`, enter the following command:
+ifndef::satellite[]
+* To change the default download policy for a {customrepo} to one of `immediate` or `on_demand`, enter the following command:
 endif::[]
-
 ifdef::satellite[]
-To change the default download policy for a non-Red Hat {customrepo} to one of `immediate` or `on_demand`, enter the following command:
+* To change the default download policy for a non-Red Hat {customrepo} to one of `immediate` or `on_demand`, enter the following command:
 endif::[]
-
++
 [subs="+quotes"]
 ----
 # hammer settings set \
@@ -351,17 +352,15 @@ endif::[]
 [[changing_the_download_policy_for_a_repository]]
 === Changing the Download Policy for a Repository
 
-You can also set the download policy for a repository.
+You can set the download policy for a repository.
 
 .Procedure
-
-To set the download policy for a repository, complete the following steps:
 
 . In the web UI, navigate to *Content* > *Products*, and click the required product name.
 . On the *Repositories* tab, click the required repository name, locate the *Download Policy* field, and click the edit icon.
 . From the list, select the required download policy and then click `Save`.
 
-.For CLI Users
+.CLI procedure
 
 . List the repositories for an organization:
 +
@@ -400,7 +399,7 @@ You must use the Hammer CLI to upload source RPMs.
 
 To view all RPMs in this repository, click the number next to *Packages* under *Content Counts*.
 
-.For CLI Users
+.CLI procedure
 
 * Enter the following command to upload an RPM:
 +
@@ -446,8 +445,6 @@ Use this option if you have one of the following errors:
 
 .Procedure
 
-To synchronize a specific repository with an advanced option, complete the following steps:
-
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select the product containing the corrupted repository.
 . Select the name of a repository you want to synchronize.
@@ -492,6 +489,8 @@ To synchronize a specific repository with an advanced option, complete the follo
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for Products, repositories, and supported compute resources.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *HTTP Proxies* and select *New HTTP Proxy*.
@@ -503,7 +502,8 @@ You can then specify which HTTP proxy to use for Products, repositories, and sup
 . Click the *Organization* tab and add an organization.
 . Click *Submit*.
 
-.For CLI Users
+[[cli-adding-a-new-http-proxy]]
+.CLI procedure
 
 * On {ProjectServer}, enter the following command to add a new HTTP proxy:
 +
@@ -540,6 +540,7 @@ For more information, see xref:Adding_a_New_HTTP_Proxy[].
 === Changing the HTTP Proxy Policy for a Repository
 
 For granular control over network traffic, you can set an HTTP proxy policy for each repository.
+To use the CLI instead of the web UI, see the xref:cli-changing-the-http-proxy-policy-for-a-repository[].
 
 To set the same HTTP proxy policy for all repositories in a Product, see xref:Changing_the_HTTP_Proxy_Policy_for_a_Product[].
 
@@ -556,6 +557,7 @@ You must add HTTP proxies to {Project} before you can select a proxy from this l
 For more information, see xref:Adding_a_New_HTTP_Proxy[].
 . Click *Save*.
 
+[[cli-changing-the-http-proxy-policy-for-a-repository]]
 .For CLI users
 
 * On {ProjectServer}, enter the following command, specifying the HTTP proxy policy you want to use:
@@ -580,9 +582,9 @@ To add a new HTTP proxy to {Project}, see xref:Adding_a_New_HTTP_Proxy[].
 A synchronization plan checks and updates the content at a scheduled date and time.
 In {ProjectNameX}, you can create a synchronization plan and assign products to the plan.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-creating-a-synchronization-plan[].
 
-To create a synchronization plan, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Sync Plans* and click *New Sync Plan*.
 . In the *Name* field, enter a name for the plan.
@@ -593,7 +595,8 @@ To create a synchronization plan, complete the following steps:
 . Click the *Products* tab, then click *Add*.
 Select the *Red{nbsp}Hat Enterprise Linux Server* product and click *Add Selected*.
 
-.For CLI Users
+[[cli-creating-a-synchronization-plan]]
+.CLI procedure
 
 . To create the synchronization plan, enter the following command:
 +
@@ -677,6 +680,8 @@ When clients are consuming signed {customcontent}, ensure that the clients are c
 
 Red Hat content is already configured with the appropriate GPG key and thus GPG Key management of Red Hat Repositories is not supported.
 
+To use the CLI instead of the web UI, see the xref:cli-importing-a-gpg-key[].
+
 .Prerequisites
 
 Ensure that you have a copy of the GPG key used to sign the RPM content that you want to use and manage in {Project}. Most RPM distribution providers provide their GPG Key on their website. You can also extract this manually from an RPM:
@@ -698,8 +703,6 @@ $ rpm2cpio _example-9.5-2.noarch.rpm_ | cpio -idmv
 The GPG key is located relative to the extraction at `etc/pki/rpm-gpg/RPM-GPG-KEY-_EXAMPLE-95_`.
 
 .Procedure
-
-To import a GPG key, complete the following procedure:
 
 . In the {Project} web UI, navigate to *Content* > *Content Credentials* and in the upper-right of the window, click *Create Content Credential*.
 . Enter the name of your repository and select *GPG Key* from the *Type* list.
@@ -726,7 +729,8 @@ Wl5GnzcLGAnUSRamfqGUWcyMMinHHIKIc1X1P4I=
 ----
 . Click *Save*.
 
-.For CLI Users
+[[cli-importing-a-gpg-key]]
+.CLI procedure
 
 . Copy the GPG key to your {ProjectServer}:
 +

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -451,7 +451,7 @@ Use this option if you have one of the following errors:
 . From the *Select Action* menu, select *Advanced Sync*.
 . Select the option and click *Sync*.
 
-.For CLI users
+.CLI procedure
 
 . Obtain a list of repository IDs:
 +
@@ -558,7 +558,7 @@ For more information, see xref:Adding_a_New_HTTP_Proxy[].
 . Click *Save*.
 
 [[cli-changing-the-http-proxy-policy-for-a-repository]]
-.For CLI users
+.CLI procedure
 
 * On {ProjectServer}, enter the following command, specifying the HTTP proxy policy you want to use:
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -82,7 +82,8 @@ If a {customproduct}, typically containing content not provided by Red Hat, is a
 
 .Procedure
 
-To create an activation key, complete the following steps:
+To create an activation key, complete the following steps.
+To use the CLI instead of the web UI, see the xref:cli-creating-an-activation-key[].
 
 . In the {Project} web UI, navigate to *Content* > *Activation keys* and click *Create Activation Key*.
 . In the *Name* field, enter the name of the activation key.
@@ -95,7 +96,8 @@ If you want to use this activation key to register hosts, the Content View must 
 . Click *Save*.
 . Optional: For Red{nbsp}Hat Enterprise Linux 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.
 
-.For CLI Users
+[[cli-creating-an-activation-key]]
+.CLI procedure
 
 . Create the activation key:
 +
@@ -165,14 +167,13 @@ To enable, enter the following command:
 [[Managing_Activation_Keys-Updating_Subscriptions_Associated_with_an_Activation_Key]]
 === Updating Subscriptions Associated with an Activation Key
 
-You can change the subscriptions associated with an activation key using the web UI or using the Hammer command-line tool.
+Use this procedure to change the subscriptions associated with an activation key.
+To use the CLI instead of the web UI, see the xref:cli-updating-subscriptions-associated-with-an-activation-key[].
 
 Note that changes to an activation key apply only to machines provisioned after the change.
 To update subscriptions on existing content hosts, see <<Bulk_Updating_Content_Hosts_Subscriptions>>.
 
 .Procedure
-
-To update the subscriptions associated with an activation key, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Activation keys* and click the name of the activation key.
 . Click the *Subscriptions* tab.
@@ -182,7 +183,8 @@ To update the subscriptions associated with an activation key, complete the foll
 . To enable or disable a repository, select the check box for a repository and then change the status using the *Select Action* list.
 . Click the *Details* tab, select a Content View for this activation key, and then click *Save*.
 
-.For CLI Users
+[[cli-updating-subscriptions-associated-with-an-activation-key]]
+.CLI procedure
 
 . List the subscriptions that the activation key currently contains:
 +
@@ -320,8 +322,6 @@ Disable the option if you want to force attach all subscriptions associated with
 
 .Procedure
 
-To enable auto-attach, complete the following steps:
-
 . In the {Project} web UI, navigate to *Content* > *Activation Keys*.
 . Click the activation key name that you want to edit.
 . Click the *Subscriptions* tab.
@@ -329,10 +329,10 @@ To enable auto-attach, complete the following steps:
 . Select or clear the check box to enable or disable auto-attach.
 . Click *Save*.
 
-.For CLI Users
+.CLI procedure
 
-To enable auto-attach on the activation key:
-
+* Enter the following command to enable auto-attach on the activation key:
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer activation-key update --name "_My_Activation_Key_" \
@@ -348,8 +348,6 @@ For example, if the default service level on an activation key is set to Premium
 
 .Procedure
 
-To set the service level, complete the following steps:
-
 . In the {Project} web UI, navigate to *Content* > *Activation Keys*.
 . Click the activation key name you want to edit.
 . Click the edit icon next to *Service Level*.
@@ -357,10 +355,10 @@ To set the service level, complete the following steps:
 The list only contains service levels available to the activation key.
 . Click *Save*.
 
-.For CLI Users
+.CLI procedure
 
-To set a default service level to Premium on the activation key:
-
+* Enter the following command to set a default service level to Premium on the activation key:
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer activation-key update --name "_My_Activation_Key_" \

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -52,6 +52,7 @@ For more information about how to manage package dependencies within Content Vie
 === Creating a Content View
 
 Use this procedure to create a simple Content View.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-content-view[].
 
 .Prerequisites
 
@@ -59,8 +60,6 @@ While you can stipulate whether you want to resolve any package dependencies on 
 For more information, see xref:Managing_Content_Views-Resolving_Package_Dependencies[].
 
 .Procedure
-
-To create a content view, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Content Views* and click *Create New View*.
 . In the *Name* field, enter a name for the view.
@@ -80,8 +79,8 @@ To view more information about the Content View, click the Content View name.
 
 To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
-[[Managing_Content_Views-Creating_a_Simple_Content_View_CLI]]
-.Creating a Content View with Hammer CLI
+[[cli-creating-a-content-view]]
+.CLI procedure
 
 . Obtain a list of repository IDs:
 +
@@ -144,6 +143,7 @@ To view module streams for the repositories in your content view, complete the f
 === Creating a Content View with a Puppet Module
 
 Use this procedure to create a Content View using one repository and no filters.
+To use the CLI instead of the web UI, see the xref:cli-adding-a-puppet-module-to-a-content-view[].
 
 .Prerequisites
 
@@ -151,8 +151,6 @@ Before you begin, upload the required Puppet module to a repository within a {cu
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/puppet_guide/chap-red_hat_satellite-puppet_guide-adding_puppet_modules_to_red_hat_satellite_6[Adding Puppet Modules to {ProjectNameX}] in the _Puppet Guide_.
 
 .Procedure
-
-To create a Content View with a Puppet module, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Content Views* and click *Create New View*.
 . In the *Name* field, enter a name for the view.
@@ -168,10 +166,11 @@ In the *Description* field, enter a description to log the changes and click *Sa
 
 To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
-.For CLI Users
+[[cli-adding-a-puppet-module-to-a-content-view]]
+.CLI procedure
 
-To add a Puppet module to a Content View, enter the following command:
-
+* Enter the following command to add a Puppet module to a Content View:
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer content-view puppet-module add \
@@ -183,6 +182,7 @@ To add a Puppet module to a Content View, enter the following command:
 === Promoting a Content View
 
 Use this procedure to promote Content Views across different lifecycle environments.
+To use the CLI instead of the web UI, see the xref:cli-promoting-a-content-view[].
 
 .Permission Requirements for Content View Promotion
 
@@ -202,8 +202,6 @@ You must assign both permissions to a user to allow them to promote Content View
 
 .Procedure
 
-To promote a Content View, complete the following steps:
-
 . In the {Project} web UI, navigate to *Content* > *Content Views* and select the Content View that you want to promote.
 . Click the *Versions* tab for the Content View.
 . Select the version that you want to promote and in the *Actions* column, click *Promote*.
@@ -215,7 +213,8 @@ Select the *Production* environment and click *Promote Version*.
 
 Now the repository for the Content View appears in all environments.
 
-.For CLI Users
+[[cli-promoting-a-content-view]]
+.CLI procedure
 
 * Promote the Content View using the `hammer content-view version promote` each time:
 +
@@ -331,9 +330,10 @@ For example, if you attempt to include two Content Views using the same reposito
 [[Managing_Content_Views-Creating_a_Composite_Content_View]]
 === Creating a Composite Content View
 
-.Procedure
+Use this procedure to create a composite content view.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-composite-content-view[].
 
-To create a Composite Content View, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Content Views* and click *Create New View*.
 . In the *Name* field, enter a name for the view.
@@ -347,7 +347,8 @@ To create a Composite Content View, complete the following steps:
 In the *Description* field, enter a description and click *Save*.
 . Click *Promote* and select the lifecycle environments to promote the Composite Content View to, enter a description, and then click *Promote Version*.
 
-.For CLI Users
+[[cli-creating-a-composite-content-view]]
+.CLI procedure
 
 . Before you create the Composite Content Views, list the version IDs for your existing Content Views:
 +
@@ -565,11 +566,11 @@ For another example of how content filters work, see the following article: http
 === Creating a Content Filter
 
 Use this procedure to create a content filter.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-content-filter[].
+
 For examples of how to build a filter, see xref:Managing_Content_Views-Content_Filter_Examples[].
 
 .Procedure
-
-To create a content filter, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Content Views* and select a Content View.
 . Navigate to *Yum Content* > *Filters* and click *New Filter*.
@@ -585,7 +586,8 @@ In the *Description* field, enter a description of the changes, and click *Save*
 
 You can promote this Content View across all environments.
 
-.For CLI Users
+[[cli-creating-a-content-filter]]
+.CLI procedure
 
 . Add a filter to the Content View.
 Use the `--inclusion false` option to set the filter to an Exclude filter:

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -19,9 +19,11 @@ This method is useful when you have multiple files to add to a {Project} reposit
 The procedure for creating a {customfiletype} repository is the same as the procedure for creating any {customcontent}, except that when you create the repository, you select the *file* type.
 You must create a product and then add a {customrepo}.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-file-type-repository[].
+
 .Procedure
 
-To create a (customproduct), complete the following procedure:
+To create a {customproduct}, complete the following procedure:
 
 . In the {Project} web UI, navigate to *Content* > *Products*, click *Create Product* and enter the following details:
 . In the *Name* field, enter a name for the product.
@@ -30,7 +32,7 @@ To create a (customproduct), complete the following procedure:
 . Optional: From the *Sync Plan* list, select a synchronization plan for the product.
 . In the *Description* field, enter a description of the product, and then click *Save*.
 
-To create a repository for your (customproduct), complete the following procedure:
+To create a repository for your {customproduct}, complete the following procedure:
 
 . In the Products window, select the name of a product that you want to create a repository for.
 . Click the *Repositories* tab, and then click *New Repository*.
@@ -45,7 +47,8 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . Click *Save*.
 
-.For CLI Users
+[[cli-creating-a-custom-file-type-repository]]
+.CLI procedure
 
 . Create a {customproduct}
 +
@@ -286,9 +289,9 @@ Visit the URL where the repository is published to view the files.
 [[Importing_Content-Uploading_Files_To_a_Custom_File_Type_Repository]]
 === Uploading Files To a {customfiletypetitle} Repository in {ProjectName}
 
-.Procedure
+Use this procedure to upload files to a {customfiletype} repository.
 
-To upload files to a {customfiletype} repository, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select a {customproduct} by name.
@@ -297,7 +300,7 @@ To upload files to a {customfiletype} repository, complete the following steps:
 . Click *Upload* to upload the selected file to {ProjectServer}.
 . Visit the URL where the repository is published to see the file.
 
-.For CLI Users
+.CLI procedure
 
 [options="nowrap" subs="+quotes"]
 ----
@@ -329,8 +332,6 @@ See xref:Managing_Organizations-Creating_an_Organization_Debug_Certificate[] for
 
 .Procedure
 
-To download files to a host from a {customfiletype} repository, complete the following procedure:
-
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select a {customproduct} by name.
 . Select a file type repository by name.
@@ -338,7 +339,7 @@ To download files to a host from a {customfiletype} repository, complete the fol
 If it is not, you require the certificates to use HTTPS.
 . Copy the URL where the repository is published.
 
-.For CLI Users
+.CLI procedure
 
 . List the file type repositories.
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
@@ -39,6 +39,9 @@ This chapter shows how to manage errata and apply them to either a single host o
 === Inspecting Available Errata
 
 The following procedure describes how to view and filter the available errata and how to display metadata of the selected advisory.
+To use the CLI instead of the web UI, see the xref:cli-inspecting-available-errata[].
+
+.Procedure
 
 . Navigate to *Content* > *Errata* to view the list of available errata.
 
@@ -74,7 +77,8 @@ Press *Enter* to start the search.
 * The *Repositories* tab lists repositories that already contain the erratum.
 You can filter repositories by the environment and Content View, and search for them by the repository name.
 
-.For CLI Users
+[[cli-inspecting-available-errata]]
+.CLI procedure
 
 * To view errata that are available for all organizations, enter the following command:
 +
@@ -177,6 +181,8 @@ Create a content filter to exclude errata after a certain date.
 This ensures your production systems in the application life cycle are kept up to date to a certain point.
 Then you can modify the filter's start date to introduce new errata into your testing environment to test the compatibility of new packages into your application life cycle.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-a-content-view-filter-for-errata[].
+
 .Prerequisites
 
 * A Content View with the repositories that contain required errata is created.
@@ -215,7 +221,8 @@ This means the filter successfully excluded the all non-security errata from the
 . In the *Description* field, enter the description for promoting.
 . Click *Promote Version* to promote this Content View version across the required environments.
 
-.For CLI Users
+[[cli-creating-a-content-view-filter-for-errata]]
+.CLI procedure
 
 . Create a filter for the errata:
 +
@@ -255,10 +262,14 @@ This means the filter successfully excluded the all non-security errata from the
 ----
 
 [[Managing_Errata-Adding-Errata-To-An-Incremental-Content-View]]
-=== Adding Errata to an incremental Content View
+=== Adding Errata to an Incremental Content View
 
 If errata are available but not installable, you can create an incremental Content View version to add the errata to your content hosts.
 For example, if the Content View is version 1.0, it becomes Content View version 1.1, and when you publish, it becomes Content View version 2.0.
+
+To use the CLI instead of the web UI, see the xref:cli-adding-errata-to-an-incremental-content-view[].
+
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Errata*.
 . From the *Errata* list, click the name of the errata that you want to apply.
@@ -276,7 +287,8 @@ Then, the errata will be marked as `Installable` and you can use the procedure a
 
 . Click *Confirm* to apply the errata.
 
-.For CLI Users
+[[cli-adding-errata-to-an-incremental-content-view]]
+.CLI procedure
 
 . List the errata and its corresponding IDs:
 +
@@ -357,7 +369,7 @@ To apply an erratum to a RHEL 7 host, complete the following steps:
 In the confirmation window, click *Apply*.
 . After the task to update all packages associated with the selected errata completes, click the *Details* tab to view the updated packages.
 
-.For CLI Users
+.CLI procedure
 To apply an erratum to a RHEL 7 host, complete the following steps:
 
 . List all errata for the host:
@@ -405,7 +417,7 @@ For more information, see {ManagingHostsDocURL}host-management-without-goferd-an
 . Select the hosts you want to apply errata to and click *Apply to Hosts*.
 . Click *Confirm*.
 
-.For CLI Users
+.CLI procedure
 
 Although the CLI does not have the same tools as the Web UI, you can replicate a similar procedure with CLI commands.
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
@@ -9,9 +9,9 @@ You can also upload other files, such as virtual machine images, and publish the
 The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
 The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-importing-iso-images-from-red-hat[].
 
-To import Red Hat ISO images, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Red{nbsp}Hat Repositories*.
 . In the *Search* field, enter an image name, for example, `Red{nbsp}Hat Enterprise Linux 7 Server (ISOs)`.
@@ -25,7 +25,8 @@ To import Red Hat ISO images, complete the following steps:
 
 * In the web UI, navigate to *Content* > *Sync Status* and expand *Red Hat Enterprise Linux Server*.
 
-.For CLI Users
+[[cli-importing-iso-images-from-red-hat]]
+.CLI procedure
 
 . Locate the Red{nbsp}Hat Enterprise Linux Server product for `file` repositories:
 +
@@ -68,13 +69,9 @@ Use this procedure to manually import ISO content and other files to {ProjectSer
 To import files, you can complete the following steps in the web UI or using the Hammer CLI.
 However, if the size of the file that you want to upload is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
 
-. Create a {customproduct}.
-. Add a repository for files to the product.
-. Upload a file to the repository.
+To use the CLI instead of the web UI, see the xref:cli-importing-indovidual-iso-images-and-files[].
 
 .Procedure
-
-To import ISO images, complete the following steps:
 
 . In the {Project} web UI, navigate to *Content* > *Products*, and in the Products window, click *Create Product*.
 . In the *Name* field, enter a name to identify the product.
@@ -94,8 +91,8 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 . Navigate to the *Upload File* and click *Browse*.
 . Select the `.iso` file and click *Upload*.
 
-
-.For CLI Users
+[[cli-importing-indovidual-iso-images-and-files]]
+.CLI procedure
 
 . Create the {customproduct}:
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_Locations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Locations.adoc
@@ -11,10 +11,9 @@ Organizations and locations have the following conceptual differences:
 === Creating a Location
 
 Use this procedure to create a location so that you can manage your hosts and resources by location.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-location[].
 
 .Procedure
-
-To create a location, complete the following steps:
 
 . In the {Project} web UI, navigate to *Administer > Locations*.
 . Click *New Location*.
@@ -29,10 +28,11 @@ This includes networking resources, installation media, kickstart templates, and
 You can return to this page at any time by navigating to *Administer* > *Locations* and then selecting a location to edit.
 . Click *Submit* to save your changes.
 
-.For CLI Users
+[[cli-creating-a-location]]
+.CLI procedure
 
-Enter the following command to create a location:
-
+* Enter the following command to create a location:
++
 [subs="+quotes"]
 ----
 # hammer location create \
@@ -68,7 +68,7 @@ The location menu is the second menu item in the menu bar, on the upper left of 
 If you have not selected a current location, the menu displays *Any Location*.
 Click *Any location* and select the location to use.
 
-.For CLI Users
+.CLI procedure
 
 While using the CLI, include either `--location "_your_location_name_"` or `--location-id "_your_location_id_"` as an option.
 For example:
@@ -96,7 +96,7 @@ To delete a location, complete the following steps:
 . Select *Delete* from the list to the right of the name of the location you want to delete.
 . Click *OK* to delete the location.
 
-.For CLI Users
+.CLI procedure
 
 . Enter the following command to retrieve the ID of the location that you want to delete:
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
@@ -21,6 +21,8 @@ If you ever have a reason to enable the tool, enter the following command:
 
 Red{nbsp}Hat CDN provides OSTree Content for you to select and synchronize.
 
+To use the CLI instead of the web UI, see the xref:cli-selecting-ostree-content-to-synchronize[].
+
 .Procedure
 
 To find and synchronize OSTree content, complete the following steps:
@@ -45,7 +47,8 @@ Enter the required number into the field below.
 
 * In the {Project} web UI, navigate to *Content* > *Sync Status* and expand, for example, *Red{nbsp}Hat Enterprise Linux Atomic Host*.
 
-.For CLI Users
+[[cli-selecting-ostree-content-to-synchronize]]
+.CLI procedure
 
 . Search the Red{nbsp}Hat Enterprise Linux Server product for `ostree` repositories:
 +
@@ -84,9 +87,9 @@ Enter the required number into the field below.
 In addition to importing OSTree content from Red{nbsp}Hat CDN, you can also import content from other sources.
 This requires a published HTTP location for the OSTree to import.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-importing-ostree-content[].
 
-To import {customostreecontent}, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Products* and click *Create Product*.
 . In the *Name* field, enter a name for your OSTree content.
@@ -111,7 +114,8 @@ Enter the required number into the field below.
 .To view the Synchronization Status:
 * In the {Project} web UI, navigate to *Content* > *Sync Status* and expand the entry that you want to view.
 
-.For CLI Users
+[[cli-importing-ostree-content]]
+.CLI procedure
 
 . Create a product for your {customostreecontent}:
 +
@@ -151,9 +155,9 @@ Enter the required number into the field below.
 Use Content Views to manage OSTree branches across the application life cycle.
 This process uses the same publication and promotion method that RPMs and Puppet modules use.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-managing-ostree-content-with-content-views[].
 
-To create a content view for your OSTree and add a repository, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Content* > *Content Views* and click *Create New View*.
 . In the *Name* field, enter a plain text name for the view.
@@ -169,7 +173,8 @@ Click *Add Repository* to add the OSTree content from this repository to the Con
 
 You can also click *Promote* to promote this Content View across environments in the application life cycle.
 
-.For CLI Users
+[[cli-managing-ostree-content-with-content-views]]
+.CLI procedure
 
 . Obtain a list of repository IDs:
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
@@ -34,10 +34,9 @@ The next time the user logs on to {Project}, the user's account has the correct 
 === Creating an Organization
 
 Use this procedure to create an organization.
+To use the CLI instead of the web UI, see xref:cli-creating-an-organization[].
 
 .Procedure
-
-To create an organization, complete the following steps:
 
 . In the {Project} web UI, navigate to *Administer* > *Organizations*.
 . Click *New Organization*.
@@ -53,7 +52,8 @@ This includes networking resources, installation media, kickstart templates, and
 You can return to this page at any time by navigating to *Administer* > *Organizations* and then selecting an organization to edit.
 . Click *Submit*.
 
-.For CLI Users
+[[cli-creating-an-organization]]
+.CLI procedure
 
 . To create an organization, enter the following command:
 +
@@ -86,7 +86,7 @@ The organization menu is the first menu item in the menu bar, on the upper left 
 If you have not selected a current organization, the menu says *Any Organization*.
 Click the *Any Organization* button and select the organization to use.
 
-.For CLI Users
+.CLI procedure
 
 While using the CLI, include either `--organization "_your_organization_name_"` or `--organization-label "_your_organization_label_"` as an option.
 For example:
@@ -178,13 +178,11 @@ There must be at least one organization in the environment at any given time.
 
 .Procedure
 
-To delete an organization, complete the following steps:
-
 . In the {Project} web UI, navigate to *Administer* > *Organizations*.
 . From the list to the right of the name of the organization you want to delete, select *Delete*.
 . Click *OK* to delete the organization.
 
-.For CLI Users
+.CLI procedure
 
 . Enter the following command to retrieve the ID of the organization that you want to delete:
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_Subscriptions.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Subscriptions.adoc
@@ -153,8 +153,6 @@ You must have a Subscription Manifest file imported to {ProjectServer}.
 
 .Procedure
 
-To attach subscriptions to content hosts, complete the following steps:
-
 . In the {Project} web UI, ensure the context is set to the organization you want to use.
 . Navigate to *Hosts* > *Content Hosts*.
 . On the row of each content host whose subscription you want to change, select the corresponding check box.
@@ -163,7 +161,7 @@ To attach subscriptions to content hosts, complete the following steps:
 . Select the check box to the left of the subscriptions that you want to add or remove and click *Add Selected* or *Remove Selected* as required.
 . Click *Done* to save the changes.
 
-.For CLI Users
+.CLI procedure
 
 . Connect to {ProjectServer} as the root user, and then list the available subscriptions:
 +
@@ -183,4 +181,3 @@ To attach subscriptions to content hosts, complete the following steps:
 ----
 
 include::Bulk_Updating_Content_Hosts_Subscriptions.adoc[]
-

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -119,7 +119,7 @@ For more information, see xref:Importing_Content-Configuring_Download_Policies[]
 
 . Copy the archived file with the exported Content View version to the `/var/lib/pulp/katello-export` directory on the {ProjectServer} where you want to import.
 . On the {ProjectServer} where you want to import, create a Content View with the same name and label as the exported Content View.
-For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_View_CLI[].
+For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_View[].
 . Ensure that you enable the repositories that the Products in the exported Content View version include.
 For more information, see xref:Importing_Content-Selecting_Red_Hat_Repositories_to_Synchronize[].
 . In the {Project} web UI, navigate to *Content* > *Products*, click the *Yum content* tab and add the same `Yum` content that the exported Content View version includes.

--- a/guides/doc-Managing_Hosts/topics/Adding_Systems_to_System_Groups.adoc
+++ b/guides/doc-Managing_Hosts/topics/Adding_Systems_to_System_Groups.adoc
@@ -4,7 +4,7 @@
 The following procedure shows how to add hosts to host collections.
 [[form-Red_Hat_Satellite-Managing_Hosts-Adding_Hosts_to_a_Host_Collection-Task_Prerequisites]]
 
-*Prerequisites*
+.Prerequisites
 
 ifdef::satellite[]
 A host must be registered to {ProjectName} to add it to a Host Collection.
@@ -18,14 +18,14 @@ endif::[]
 Note that if you add a host to a host collection, the {Project} auditing system does not log the change.
 
 [[proc-Red_Hat_Satellite-Managing_Hosts-Adding_Hosts_to_a_Host_Collection-To_Add_Hosts_to_a_Host_Collection]]
-.To Add Hosts to a Host Collection:
+.Procedure
 
 . Click *Hosts* > *Host Collections*.
 . Click the host collection where the host should be added.
 . On the *Hosts* tab, select the *Add* subtab.
 . Select the hosts to be added from the table and click *Add Selected*.
 
-.For CLI Users
+.CLI procedure
 
 To add hosts to a host collection, enter the following command:
 

--- a/guides/doc-Managing_Hosts/topics/Administering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Administering_Hosts.adoc
@@ -24,7 +24,7 @@ You can edit the system purpose attributes for a {RHEL} host. System purpose att
 . Click *Run Auto-Attach* to attach subscriptions to your host automatically.
 . Refresh the page to verify that the subscriptions list contains the correct subscriptions.
 
-.For CLI Users
+.CLI procedure
 
 . Log in to the host and edit the required system purpose attributes.
 For example, set the usage type to `Production`, the role to `Red Hat Enterprise Linux Server`, and add the `addon` add on.

--- a/guides/doc-Managing_Hosts/topics/Creating_System_Groups.adoc
+++ b/guides/doc-Managing_Hosts/topics/Creating_System_Groups.adoc
@@ -4,7 +4,7 @@
 The following procedure shows how to create host collections.
 
 [[proc-Red_Hat_Satellite-Managing_Hosts-Creating_a_Host_Collection-To_Create_a_Host_Collection]]
-.To Create a Host Collection:
+.Procedure
 
 . Click *Hosts* > *Host Collections*.
 . Click *New Host Collection*.
@@ -13,10 +13,10 @@ The following procedure shows how to create host collections.
 . Add the Description of the host collection.
 . Click *Save*.
 
-.For CLI Users
+.CLI procedure
 
-To create a host collection, enter the following command:
-
+* To create a host collection, enter the following command:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # hammer host-collection create \

--- a/guides/doc-Managing_Hosts/topics/Generating_Host_Monitoring_Reports.adoc
+++ b/guides/doc-Managing_Hosts/topics/Generating_Host_Monitoring_Reports.adoc
@@ -17,7 +17,7 @@ To view all available results, do not populate the filter field with any values.
 A CSV file that contains the report is downloaded.
 If you have selected the *Send report via e-mail* check box, the host monitoring report is sent to your e-mail address.
 
-.For CLI Users
+.CLI procedure
 
 To generate a report, complete the following steps:
 

--- a/guides/doc-Managing_Hosts/topics/Synchronizing_Templates.adoc
+++ b/guides/doc-Managing_Hosts/topics/Synchronizing_Templates.adoc
@@ -104,7 +104,7 @@ For more information about each field, see xref:configuring-the-templatesync-plu
 The {Project} web UI displays the status of the import.
 The status is not persistent; if you leave the status page, you cannot return to it.
 
-.For CLI Users
+.CLI procedure
 
 * To import a template from a repository, enter the following command:
 +
@@ -138,7 +138,7 @@ For more information about each field, see xref:configuring-the-templatesync-plu
 The {Project} web UI displays the status of the export.
 The status is not persistent; if you leave the status page, you cannot return to it.
 
-.For CLI Users
+.CLI procedure
 
 . Clone a local copy of your Git repository:
 +

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
@@ -2,6 +2,7 @@
 = Adding a Bonded Interface
 
 Use this procedure to configure a bonded interface for a host.
+To use the CLI instead of the web UI, see the xref:cli-adding-a-bonded-interface[].
 
 .Procedure
 
@@ -30,10 +31,11 @@ See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7
 . Click *OK* to save the interface configuration.
 . Click *Submit* to apply the changes to the host.
 
-.For CLI Users
+[[cli-adding-a-bonded-interface]]
+.CLI procedure
 
-To create a host with a bonded interface, enter the following command:
-
+* To create a host with a bonded interface, enter the following command:
++
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # hammer host create --name bonded_interface \

--- a/guides/doc-Managing_Hosts/topics/proc_creating-a-host-group.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_creating-a-host-group.adoc
@@ -9,6 +9,8 @@ A host group functions as a template for common host settings, containing many o
 When you create a host with a host group, the host inherits the defined settings from the host group.
 You can then provide additional details to individualize the host.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-a-host-group[].
+
 .Host Group Hierarchy
 
 You can create a hierarchy of host groups.
@@ -54,11 +56,12 @@ To create a suitable Puppet environment to be associated with a host group, manu
 ====
 . Click *Submit* to save the host group.
 
-.For CLI Users
+[[cli-creating-a-host-group]]
+.CLI procedure
 
-Create the host group with the `hammer hostgroup create` command.
+* Create the host group with the `hammer hostgroup create` command.
 For example:
-
++
 ----
 # hammer hostgroup create --name "Base" \
 --lifecycle-environment "Production" --content-view "Base" \

--- a/guides/doc-Managing_Hosts/topics/proc_creating-a-host-in-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_creating-a-host-in-satellite.adoc
@@ -3,6 +3,7 @@
 = Creating a Host in {ProjectName}
 
 Use this procedure to create a host in {ProjectName}.
+To use the CLI instead of the web UI, see the xref:cli-creating-a-host[].
 
 .Procedure
 
@@ -66,10 +67,11 @@ endif::[]
 . On the *Additional Information* tab, enter additional information about the host.
 . Click *Submit* to complete your provisioning request.
 
-.For CLI Users
+[[cli-creating-a-host]]
+.CLI procedure
 
-To create a host associated to a host group, enter the following command:
-
+* To create a host associated to a host group, enter the following command:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # hammer host create \
@@ -83,7 +85,7 @@ To create a host associated to a host group, enter the following command:
 --location "_Your_Location_" \
 --ask-root-password yes
 ----
-
++
 This command prompts you to specify the root password.
 It is required to specify the host's IP and MAC address.
 Other properties of the primary network interface can be inherited from the host group or set using the `--subnet`, and `--domain` parameters.

--- a/guides/doc-Managing_Hosts/topics/proc_exporting_report_templates.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_exporting_report_templates.adoc
@@ -11,7 +11,7 @@ You can export report templates that you create in {Project}.
 
 An `.erb` file that contains the template downloads.
 
-.For CLI Users
+.CLI procedure
 
 . To view the report templates available for export, enter the following command:
 +

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-using-the-bootstrap-script.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-using-the-bootstrap-script.adoc
@@ -132,6 +132,7 @@ In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}* and fin
 == Setting Permissions for the Bootstrap Script
 
 Use this procedure to configure a {Project} user with the permissions required to run the bootstrap script.
+To use the CLI instead of the web UI, see the xref:li-setting-permissions-for-the-bootstrap-script[].
 
 .Procedure
 
@@ -163,7 +164,8 @@ If this is not acceptable to your security policy, create a new role with the fo
 
 . Click *Submit*.
 
-.For CLI Users
+[[cli-setting-permissions-for-the-bootstrap-script]]
+.CLI procedure
 
 . Create a role with the minimum permissions required by the bootstrap script.
 This example creates a role with the name _Bootstrap_:

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -84,9 +84,9 @@ You enter the host details on {ProjectServer} and boot your host.
 
 This method of provisioning hosts uses minimal interaction during the process.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-unattended-provisioning[].
 
-To create a host with unattended provisioning, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Create Host*.
 . In the *Name* field, enter a name for the host.
@@ -137,10 +137,11 @@ ifdef::foreman-el,katello[]
 If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
-.For CLI Users
+[[cli-creating-hosts-with-unattended-provisioning]]
+.CLI procedure
 
-Create the host with the `hammer host create` command.
-
+. Create the host with the `hammer host create` command.
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer host create --name "_My_Unattended_Host_" --organization "_My_Organization_" \
@@ -148,7 +149,8 @@ Create the host with the `hammer host create` command.
 --build true --enabled true --managed true
 ----
 
-Ensure the network interface options are set using the `hammer host interface update` command.
+. Ensure the network interface options are set using the `hammer host interface update` command.
++
 ----
 # hammer host interface update --host "test1" --managed true \
 --primary true --provision true
@@ -201,9 +203,9 @@ The *Full host image* is based on SYSLINUX and works with most hardware.
 endif::[]
 When using a *Host image*, *Generic image*, or *Subnet image*, see http://ipxe.org/appnote/hardware_drivers for a list of hardware drivers expected to work with an iPXE-based boot disk.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-pxe-less-provisioning[].
 
-To create a host with PXE-less provisioning, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Create Host*.
 . In the *Name* field, enter a name that you want to become the provisioned system's host name.
@@ -240,10 +242,11 @@ This creates a host entry and the host details page appears.
 The options on the upper-right of the window are the *Boot disk* menu.
 From this menu, one of the following images is available for download: *Host image*, *Full host image*, *Generic image*, and *Subnet image*.
 
-.For CLI Users
+[[cli-creating-hosts-with-pxe-less-provisioning]]
+.CLI procedure
 
-Create the host with the `hammer host create` command.
-
+. Create the host with the `hammer host create` command.
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer host create --name "_My_Bare_Metal_" --organization "_My_Organization_" \
@@ -251,16 +254,16 @@ Create the host with the `hammer host create` command.
 --build true --enabled true --managed true
 ----
 
-Ensure that your network interface options are set using the `hammer host interface update` command.
-
+. Ensure that your network interface options are set using the `hammer host interface update` command.
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer host interface update --host "test3" --managed true \
 --primary true --provision true
 ----
 
-Download the boot disk from {ProjectServer} with the `hammer bootdisk host` command:
-
+. Download the boot disk from {ProjectServer} with the `hammer bootdisk host` command:
++
 * For *Host image*:
 +
 [options="nowrap" subs="+quotes"]
@@ -304,6 +307,8 @@ endif::[]
 
 You can provision hosts from {Project} using the UEFI HTTP Boot.
 This is the only method with which you can provision hosts in IPv6 network.
+
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-uefi-http-boot-provisioning[].
 
 .Prerequisites
 
@@ -383,7 +388,8 @@ ifdef::foreman-el,katello[]
 If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
-.For CLI Users
+[[cli-creating-hosts-with-uefi-http-boot-provisioning]]
+.CLI procedure
 
 . On {SmartProxy} that you use for provisioning, update the `grub2-efi` package to the latest version:
 +

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
@@ -20,6 +20,7 @@ include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 === Adding an Amazon EC2 Connection to the {ProjectServer}
 
 Use this procedure to add the Amazon EC2 connection in the {ProjectServer}'s compute resources.
+To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-connection[].
 
 .Time Settings and Amazon Web Services
 Amazon Web Services uses time settings as part of the authentication process.
@@ -31,8 +32,6 @@ For more information about synchronizing time in {Project}, see {InstallingProje
 
 
 .Procedure
-
-To add an Amazon EC2 connection, complete the following steps:
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources* and in the Compute Resources window, click *Create Compute Resource*.
 . In the *Name* field, enter a name to identify the Amazon EC2 compute resource.
@@ -52,11 +51,12 @@ For more information, see http://docs.aws.amazon.com/general/latest/gr/managing-
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1793138[BZ1793138] is resolved, you can download a copy of the SSH keys only immediately after creating the Amazon EC2 compute resource.
 If you require SSH keys at a later stage, follow the procedure in xref:connecting_to_an_Amazon_EC2_instance_using_SSH[].
 
-.For CLI Users
+[[cli-adding-amazon-ec2-connection]]
+.CLI procedure
 
-Create the connection with the `hammer compute-resource create` command.
+* Create the connection with the `hammer compute-resource create` command.
 Use `--user` and `--password` options to add the access key and secret key respectively.
-
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-resource create --name "_My_EC2_" --provider "EC2" \
@@ -91,6 +91,8 @@ Amazon EC2 uses image-based provisioning to create hosts.
 You must add image details to your {ProjectServer}.
 This includes access details and image location.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-images[].
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources* and select an Amazon EC2 connection.
@@ -109,11 +111,12 @@ This also applies in reverse: if you enable the Finish scripts, this disables us
 . Optional: In the *IAM role* field, enter the Amazon security role used for creating the image.
 . Click *Submit* to save the image details.
 
-.For CLI Users
+[[cli-adding-amazon-ec2-images]]
+.CLI procedure
 
-Create the image with the `hammer compute-resource image create` command.
+* Create the image with the `hammer compute-resource image create` command.
 Use the `--uuid` field to store the full path of the image location on the Amazon EC2 server.
-
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-resource image create --name "Test Amazon EC2 Image" \
@@ -140,7 +143,7 @@ If you have a VPC for provisioning new hosts, use its subnet.
 . From the *Managed IP* list, select either a `Public` IP or a `Private` IP.
 . Click *Submit* to save the compute profile.
 
-.For CLI Users
+.CLI procedure
 
 The compute profile CLI commands are not yet implemented in {ProjectName}.
 As an alternative, you can include the same settings directly during the host creation process.
@@ -149,6 +152,7 @@ As an alternative, you can include the same settings directly during the host cr
 === Creating Image-Based Hosts on Amazon EC2
 
 The Amazon EC2 provisioning process creates hosts from existing images on the Amazon EC2 server.
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-amazon-ec2[].
 
 .Procedure
 
@@ -174,11 +178,11 @@ endif::[]
 
 This new host entry triggers the Amazon EC2 server to create the instance, using the pre-existing image as a basis for the new volume.
 
+[[cli-creating-hosts-on-amazon-ec2]]
+.CLI procedure
 
-.For CLI Users
-
-Create the host with the `hammer host create` command and include `--provision-method image` to use image-based provisioning.
-
+* Create the host with the `hammer host create` command and include `--provision-method image` to use image-based provisioning.
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer host create --name "ec2-test1" --organization "_My_Organization_" \
@@ -197,7 +201,7 @@ For more information about additional host creation parameters for this compute 
 You can connect remotely to an Amazon EC2 instance from {ProjectServer} using SSH.
 However, to connect to any Amazon Web Services EC2 instance that you provision through {ProjectName}, you must first access the private key that is associated with the compute resource in the Foreman database, and use this key for authentication.
 
-To locate the private key and connect to an Amazon EC2 server using SSH, complete the following steps:
+.Procedure
 
 . To locate the compute resource list, on your {ProjectServer} base system, enter the following command, and note the ID of the compute resource that you want to use:
 +
@@ -270,7 +274,7 @@ If you want to use a Finish template with SSH, {Project} must reside within the 
 {Project} currently performs SSH finish provisioning directly, not using {SmartProxyServer}.
 If {ProjectServer} does not reside within EC2, the EC2 virtual machine reports an internal IP rather than the necessary external IP with which it can be reached.
 
-To configure a finish template for Amazon EC2, complete the following steps:
+.Procedure
 
 . In the {ProjectName} web UI, navigate to *Hosts* > *Provisioning Templates*.
 . In the *Provisioning Templates* page, enter `Kickstart default finish` into the search field and click *Search*.

--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -479,6 +479,8 @@ If you experience timeouts during DNS conflict resolution, check the following s
 * The domain name must have a Start of Authority (SOA) record available from {ProjectServer}.
 * The system resolver in the `/etc/resolv.conf` file must have a valid and working configuration.
 
+To use the CLI instead of the web UI, see the xref:cli-adding-a-domain[].
+
 .Procedure
 
 To add a domain to {Project}, complete the following steps:
@@ -493,10 +495,11 @@ For example, user defined Boolean or string parameters to use in templates.
 . Click the *Organizations* tab, and add the organization that the domain belongs to.
 . Click *Submit* to save the changes.
 
-.For CLI Users
+[[cli-adding-a-domain]]
+.CLI procedure
 
-Use the `hammer domain create` command to create a domain:
-
+* Use the `hammer domain create` command to create a domain:
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer domain create --name "_domain_name.com_" \
@@ -512,9 +515,9 @@ In this example, the `--dns-id` option uses `1`, which is the ID of your integra
 You must add information for each of your subnets to {ProjectServer} because {Project} configures interfaces for new hosts.
 To configure interfaces, {ProjectServer} must have all the information about the network that connects these interfaces.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-adding-a-subnet[].
 
-To add a subnet to {ProjectServer}, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Subnets*, and in the Subnets window, click *Create Subnet*.
 . In the *Name* field, enter a name for the subnet.
@@ -543,10 +546,11 @@ For example, user defined Boolean or string parameters to use in templates.
 . Click the *Organizations* tab and select the organizations that use this {SmartProxy}.
 . Click *Submit* to save the subnet information.
 
-.For CLI Users
+[[cli-adding-a-subnet]]
+.CLI procedure
 
-Create the subnet with the following command:
-
+* Create the subnet with the following command:
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer subnet create --name "_My_Network_" \

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -46,13 +46,12 @@ For VMware vCenter Server version 6.5, set the following permissions:
 === Adding a VMware vSphere Connection to {ProjectServer}
 
 Use this procedure to add a VMware vSphere connection in {ProjectServer}'s compute resources.
+To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-connection[].
 
 Ensure that the host and network-based firewalls are configured to allow {Project} to vCenter communication on TCP port 443.
 Verify that {Project} is able to resolve the host name of vCenter and vCenter is able to resolve {ProjectServer}'s host name.
 
 .Procedure
-
-To add a connection, complete the following steps:
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources*, and in the Compute Resources window, click *Create Compute Resource*.
 . In the *Name* field, enter a name for the resource.
@@ -82,11 +81,12 @@ For more information, see xref:Provisioning_Virtual_Machines_in_VMware_vSphere-C
 You can also add additional contexts.
 . Click *Submit* to save the connection.
 
-.For CLI Users
+[[cli-adding-vmware-vsphere-connection]]
+.CLI procedure
 
-Create the connection with the `hammer compute-resource create` command.
+* Create the connection with the `hammer compute-resource create` command.
 Select `Vmware` as the `--provider` and set the instance UUID of the data center as the `--uuid`:
-
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer compute-resource create --name "My_vSphere" \
@@ -104,9 +104,9 @@ VMware vSphere uses templates as images for creating new virtual machines.
 If using image-based provisioning to create new hosts, you need to add VMware template details to your {ProjectServer}.
 This includes access details and the template name.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-images-to-server[].
 
-To add an image, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources* and in the Compute Resources window, click the VMware vSphere connection.
 . In the *Name* field, enter a name for the image.
@@ -120,11 +120,12 @@ This is normally the `root` user.
 Do not include the data center in the relative path.
 . Click *Submit* to save the image details.
 
-.For CLI Users
+[[cli-adding-vmware-vsphere-images-to-server]]
+.CLI procedure
 
-Create the image with the `hammer compute-resource image create` command.
+* Create the image with the `hammer compute-resource image create` command.
 Use the `--uuid` field to store the relative template path on the vSphere environment.
-
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-resource image create --name "_Test_vSphere_Image_" \
@@ -138,10 +139,9 @@ Use the `--uuid` field to store the relative template path on the vSphere enviro
 
 You can predefine certain hardware settings for virtual machines on VMware vSphere.
 You achieve this through adding these hardware settings to a compute profile.
+To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-details-to-a-compute-profile[].
 
 .Procedure
-
-To add VMware vSphere details to a compute profile, complete the following steps:
 
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Profiles* and, in the Compute Profiles window, click the name of the compute profile, and then click the vSphere connection.
 . In the *CPUs* field, enter the number of CPUs to allocate to the new host.
@@ -162,7 +162,8 @@ However, at least one interface must point to a {SmartProxy}-managed network.
 If unchecked, the disk uses lazy zero thick provisioning.
 . Click *Submit* to save the compute profile.
 
-.For CLI Users
+[[cli-adding-vmware-vsphere-details-to-a-compute-profile]]
+.CLI procedure
 
 . To create the compute profile, enter the following command:
 +
@@ -197,9 +198,9 @@ This causes DHCP conflicts with {ProjectServer} when booting new hosts.
 
 For image-based provisioning, use the pre-existing image as a basis for the new volume.
 
-.Procedure
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-vmware-vsphere[].
 
-To create a host for a VMware vSphere server, complete the following steps:
+.Procedure
 
 . In the {Project} web UI, navigate to *Hosts* > *Create Host*.
 . In the *Name* field, enter the name that you want to become the provisioned system's host name.
@@ -245,10 +246,11 @@ If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host entry.
 
-.For CLI Users
+[[cli-creating-hosts-on-vmware-vsphere]]
+.CLI procedure
 
-Create the host from a network with the `hammer host create` command and include `--provision-method build` to use network-based provisioning.
-
+* Create the host from a network with the `hammer host create` command and include `--provision-method build` to use network-based provisioning.
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer host create --name "vmware-test1" --organization "_My_Organization_" \
@@ -260,12 +262,8 @@ Create the host from a network with the `hammer host create` command and include
 --volume="size_gb=20G,datastore=Data,name=myharddisk,thin=true"
 ----
 
-For more information about additional host creation parameters for this compute resource, enter the `hammer host create --help` command.
-
-.For CLI Users
-
-Create the host from an image with the `hammer host create` command and include `--provision-method image` to use image-based provisioning.
-
+* Create the host from an image with the `hammer host create` command and include `--provision-method image` to use image-based provisioning.
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer host create --name "vmware-test2" --organization "_My_Organization_" \
@@ -480,7 +478,7 @@ To refresh the cache of compute resources to update compute resources informatio
 . In the {Project} web UI, navigate to *Infrastructure* > *Compute Resources*.
 . Select a VMware server you want to refresh the compute resources cache for and click the *Refresh Cache* button.
 
-.For CLI Users
+.CLI procedure
 
 Use this API call to refresh the compute resources cache:
 

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-discovery-rules.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-discovery-rules.adoc
@@ -6,13 +6,13 @@ These rules define how discovered hosts automatically provision themselves, base
 For example, you can automatically provision hosts with a high CPU count as hypervisors.
 Likewise, you can provision hosts with large hard disks as storage servers.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-discovery-rules[].
+
 .NIC Considerations
 Auto provisioning does not currently allow configuring NICs; all systems are being provisioned with the NIC configuration that was detected during discovery.
 However, you can set the NIC in the `{provision-script}` scriplet, using a script, or using configuration management at a later stage.
 
 .Procedure
-
-To create a rule, complete the following steps:
 
 . In the {Project} web UI, navigate to *Configure* > *Discovery rules*, and select *Create Rule*.
 . In the *Name* field, enter a name for the rule.
@@ -46,10 +46,11 @@ Rules with lower values have a higher priority.
 * From the *Discovered hosts* list on the right, select *Auto-Provision* to automatically provisions a single host.
 * On the upper right of the window, click *Auto-Provision All* to automatically provisions all hosts.
 
-.For CLI Users
+[[cli-creating-discovery-rules]]
+.CLI procedure
 
-Create the rule with the `hammer discovery-rule create` command:
-
+. Create the rule with the `hammer discovery-rule create` command:
++
 [options="nowrap" subs="+quotes"]
 ----
 # hammer discovery-rule create --name "Hypervisor" \
@@ -58,8 +59,8 @@ Create the rule with the `hammer discovery-rule create` command:
 --hosts-limit 5 --priority 5 --enabled true
 ----
 
-Automatically provision a host with the `hammer discovery auto-provision` command:
-
+. Automatically provision a host with the `hammer discovery auto-provision` command:
++
 ----
 # hammer discovery auto-provision --name "macabcdef123456"
 ----

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -4,6 +4,8 @@
 Provisioning discovered hosts follows a provisioning process that is similar to PXE provisioning.
 The main difference is that instead of manually entering the host's MAC address, you can select the host to provision from the list of discovered hosts.
 
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-from-discovered-hosts[].
+
 .Prerequisites
 
 * Configure a domain and subnet on {Project}.
@@ -18,8 +20,6 @@ include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 For information about the security token for unattended and PXE-less provisioning, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
 
 .Procedure
-
-To create a host from a discovered host, complete the following steps:
 
 . In the {Project} web UI, navigate to *Hosts* > *Discovered host*.
 Select the host you want to use and click *Provision* to the right of the list.
@@ -49,7 +49,8 @@ For more information about associating provisioning templates, see xref:provisio
 When the host provisioning is complete, the discovered host becomes a content host.
 To view the host, navigate to *Hosts* > *Content Hosts*.
 
-.For CLI Users
+[[cli-creating-hosts-from-discovered-hosts]]
+.CLI procedure
 
 . Identify the discovered host to use for provisioning:
 +


### PR DESCRIPTION
For Issue #457 

I changed the CLI procedure title everywhere, but didn't add an xref where the web UI procedure is very short and the CLI procedure is clearly visible, or where the CLI procedure just states that there are no CLI steps available (I opened Issue #459 to review those).


Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
