### PR TITLE
Fixes #32169 - use yum.theforeman.org for Katello

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -21,7 +21,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
+# {package-manager} localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
 ifdef::foreman-el,katello[]

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -72,7 +72,7 @@ ifdef::foreman-el,katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
+# yum localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
 +
 . Install the `puppet6-release-el-7.noarch.rpm` package:
@@ -104,7 +104,7 @@ If you use a CentOS operating system, complete the following steps:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall https://fedorapeople.org/groups/katello/releases/yum/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
+# yum localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
 +
 . Install the `puppet6-release-el-7.noarch.rpm` package:


### PR DESCRIPTION

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
