### PR TITLE
Removed trends section from document

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Resources.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Resources.adoc
@@ -7,7 +7,7 @@ This includes host configuration, content views, compliance, subscriptions, regi
 include::Using_the_Red_Hat_Satellite_Content_Dashboard.adoc[]
 
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Monitoring_Satellite_Server]]
-=== Monitoring {ProjectServer} 
+=== Monitoring {ProjectServer}
 
 From the *About* page in the {ProjectServer} web UI, you can find an overview of the following:
 
@@ -31,40 +31,3 @@ After Pulp failure, the status of Pulp might show *OK* instead of *Error* for up
 ====
 
 include::Monitoring_Capsules.adoc[]
-
-=== Monitoring Trends
-[[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Monitoring_Trends]]
-
-You can use trends to track changes in your infrastructure over time, such as Puppet reports or Facts, and then plan accordingly.
-
-[[proc-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Monitoring_Trends-To_View_a_Trend]]
-.To View a Trend:
-
-. Navigate to *Monitor* > *Trends*.
-. On the Trends page, select the trend you want to view from the *Trends* list.
-
-[[proc-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Monitoring_Trends-To_Create_a_Trend]]
-.To Create a Trend:
-
-. Navigate to *Monitor* > *Trends*.
-. On the Trends page, click the *Add Trend Counter*.
-. From the *Trend type* list, select the category for the new trend.
-. From the *Trendable* list, select the subject for the new trend (if applicable).
-. In the *Name* field, enter a name for the new trend.
-. Click *Submit*.
-
-[NOTE]
-====
-If this is the first trend, create a `cron` job to collect trend data:
-
-----
-# foreman-rake trends:counter 
-----
-
-You can set the interval for trend data collection.
-For example, to collect data once an hour, on the hour:
-
-----
-0 * * * * /usr/sbin/foreman-rake trends:counter
-----
-====


### PR DESCRIPTION
Removal of trends ection in Administration Guide

Bug 1901926 - [RFE] Remove documentation of Trends and Statistics from Satellite docs

https://bugzilla.redhat.com/show_bug.cgi?id=1901926



Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
