### PR TITLE
Remove "the" before "{SmartProxyServer}"

### DIFF
--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -16,7 +16,7 @@ You can use KVM provisioning to create hosts over a network connection or from a
 
 include::modules/snip_common-compute-resource-prereqs.adoc[]
 * A {SmartProxyServer} managing a network on the KVM server.
-Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}.
+Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking[Configuring Networking].
 ifdef::satellite[]
 * A {RHEL} server running KVM virtualization tools (libvirt daemon).

--- a/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
@@ -21,7 +21,7 @@ This method does not require {Project} to connect to the provisioned virtual mac
 
 include::modules/snip_common-compute-resource-prereqs.adoc[]
 * A {SmartProxyServer} managing a logical network on the {oVirt} environment.
-Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}.
+Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 For more information, see {ProvisioningDocURL}Configuring_Networking[Configuring Networking].
 * An existing template, other than the `blank` template, if you want to use image-based provisioning.
 For more information about creating templates for virtual machines, see

--- a/guides/common/modules/con_provisioning-workflow.adoc
+++ b/guides/common/modules/con_provisioning-workflow.adoc
@@ -10,8 +10,8 @@ The provisioning process follows a basic PXE workflow:
 {Project} loads this IP address into the *IP address* field in the Create Host window.
 When you complete all the options for the new host, submit the new host request.
 . Depending on the configuration specifications of the host and its domain and subnet, {Project} creates the following settings:
-* A DHCP record on the {SmartProxyServer} that is associated with the subnet.
-* A forward DNS record on the {SmartProxyServer} that is associated with the domain.
+* A DHCP record on {SmartProxyServer} that is associated with the subnet.
+* A forward DNS record on {SmartProxyServer} that is associated with the domain.
 * A reverse DNS record on the DNS {SmartProxyServer} that is associated with the subnet.
 * PXELinux, Grub, Grub2, and iPXE configuration files for the host in the TFTP {SmartProxyServer} that is associated with the subnet.
 * A Puppet certificate on the associated Puppet server.

--- a/guides/common/modules/proc_configuring-capsule-container-gateway.adoc
+++ b/guides/common/modules/proc_configuring-capsule-container-gateway.adoc
@@ -1,7 +1,7 @@
 [id="configuring-capsule-container-gateway_{context}"]
 = Container Gateway Configuration
 
-Use this section to configure the Container Gateway on the {SmartProxyServer}.
+Use this section to configure the Container Gateway on {SmartProxyServer}.
 
 .Prerequisites
 

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -9,7 +9,7 @@ ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
 For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering to {ProjectServer}].
 endif::[]
-* The {SmartProxyServer} packages are installed.
+* {SmartProxyServer} packages are installed.
 For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -12,7 +12,7 @@ Do not use the same command on more than one {SmartProxyServer}.
 For more information, see {InstallingProjectDocURL}configuring-satellite-custom-server-certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{project-installation-guide-title}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
 For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering to {ProjectServer}].
-* The {SmartProxyServer} packages are installed.
+* {SmartProxyServer} packages are installed.
 For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure
@@ -26,8 +26,8 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 -k __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \  <2>
 -b __/root/{smart-proxy-context}_cert/ca_cert_bundle.pem__      <3>
 ----
-<1> Path to the {SmartProxyServer} certificate file that is signed by a Certificate Authority.
-<2> Path to the private key that was used to sign the {SmartProxyServer} certificate.
+<1> Path to {SmartProxyServer} certificate file that is signed by a Certificate Authority.
+<2> Path to the private key that was used to sign {SmartProxyServer} certificate.
 <3> Path to the Certificate Authority bundle.
 +
 If you set a wildcard value `*` for the certificate's Common Name `CN =` in the `/root/{context}_cert/openssl.cnf` configuration file, you must add the `-t {certs-proxy-context}` option to the `katello-certs-check` command.

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -19,7 +19,7 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 -b __/root/satellite_cert/ca_cert_bundle.pem__        <3>
 ----
 <1> Path to the {ProjectServer} certificate file that is signed by a Certificate Authority.
-<2> Path to the private key that was used to sign the {SmartProxyServer} certificate.
+<2> Path to the private key that was used to sign {SmartProxyServer} certificate.
 <3> Path to the Certificate Authority bundle.
 +
 If the command is successful, it returns two `{foreman-installer}` commands, one of which you must use to deploy a certificate to {ProjectServer}.

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -2,30 +2,30 @@
 
 = Assigning the Correct Organization and Location to {SmartProxyServer} in the {Project} web UI
 
-After installing the {SmartProxyServer} packages, if there is more than one organization or location, you must assign the correct organization and location to {SmartProxy} to make {SmartProxy} visible in the {Project} web UI.
+After installing {SmartProxyServer} packages, if there is more than one organization or location, you must assign the correct organization and location to {SmartProxy} to make {SmartProxy} visible in the {Project} web UI.
 
 .Procedure
 
 . Log into the {Project} web UI.
 . From the *Organization* list in the upper-left of the screen, select *Any Organization*.
 . From the *Location* list in the upper-left of the screen, select *Any Location*.
-. Navigate to *Hosts* > *All Hosts* and select the {SmartProxyServer}.
+. Navigate to *Hosts* > *All Hosts* and select {SmartProxyServer}.
 . From the *Select Actions* list, select *Assign Organization*.
 . From the *Organization* list, select the organization where you want to assign this {SmartProxy}.
 . Click *Fix Organization on Mismatch*.
 . Click *Submit*.
-. Select the {SmartProxyServer}. From the *Select Actions* list, select *Assign Location*.
+. Select {SmartProxyServer}. From the *Select Actions* list, select *Assign Location*.
 . From the *Location* list, select the location where you want to assign this {SmartProxy}.
 . Click *Fix Location on Mismatch*.
 . Click *Submit*.
 . Navigate to *Administer* > *Organizations* and click the organization to which you have assigned {SmartProxy}.
-. Click the *{SmartProxies}* tab and ensure that the {SmartProxyServer} is listed under the *Selected items* list, then click *Submit*.
+. Click *{SmartProxies}* tab and ensure that {SmartProxyServer} is listed under the *Selected items* list, then click *Submit*.
 . Navigate to *Administer* > *Locations* and click the location to which you have assigned {SmartProxy}.
-. Click the *{SmartProxies}* tab and ensure that the {SmartProxyServer} is listed under the *Selected items* list, then click *Submit*.
+. Click *{SmartProxies}* tab and ensure that {SmartProxyServer} is listed under the *Selected items* list, then click *Submit*.
 
 .Verification
 
-Optionally, you can verify if the {SmartProxyServer} is correctly listed in the {Project} web UI.
+Optionally, you can verify if {SmartProxyServer} is correctly listed in the {Project} web UI.
 
 . Select the organization from the *Organization* list.
 . Select the location from the *Location* list.

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -2,7 +2,7 @@
 
 = Installing {SmartProxyServer} Packages
 
-Before installing the {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
+Before installing {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
 
 .Procedure
 To install {SmartProxyServer}, complete the following steps:

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -8,7 +8,7 @@ The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} wit
 However, scalability is highly variable, especially when managing Puppet clients.
 
 {SmartProxyServer} scalability when managing Puppet clients depends on the number of CPUs, the run-interval distribution, and the number of Puppet managed resources.
-The {SmartProxyServer} has a limitation of 100 concurrent Puppet agents running at any single point in time.
+{SmartProxyServer} has a limitation of 100 concurrent Puppet agents running at any single point in time.
 Running more than 100 concurrent Puppet agents results in a 503 HTTP error.
 
 For example, assuming that Puppet agent runs are evenly distributed with less than 100 concurrent Puppet agents running at any single point during a run-interval, a {SmartProxyServer} with 4 CPUs has a maximum of 1250-1600 Puppet clients with a moderate workload of 10 Puppet classes assigned to each Puppet client.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -249,7 +249,7 @@ To create a realm, complete the following steps:
 . In the {Project} web UI, navigate to *Infrastructure* > *Realms* and click *Create Realm*.
 . In the *Name* field, enter a name for the realm.
 . From the *Realm Type* list, select the type of realm.
-. From the *Realm {SmartProxy}* list, select the {SmartProxyServer} where you have configured {FreeIPA}.
+. From the *Realm {SmartProxy}* list, select {SmartProxyServer} where you have configured {FreeIPA}.
 . Click the *Locations* tab and from the *Locations* list, select the location where you want to add the new realm.
 . Click the *Organizations* tab and from the *Organizations* list, select the organization where you want to add the new realm.
 . Click *Submit*.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Capsules.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Capsules.adoc
@@ -9,14 +9,14 @@ The following section shows how to use the {Project} web UI to find {SmartProxy}
 Navigate to *Infrastructure* > *{SmartProxies}* to view a table of {SmartProxyServer}s registered to the {ProjectServer}.
 The information contained in the table answers the following questions:
 
-*Is the {SmartProxyServer} running?*:: This is indicated by a green icon in the *Status* column.
-A red icon indicates an inactive {SmartProxy}, use the `service foreman-proxy restart` command on the {SmartProxyServer} to activate it.
+*Is {SmartProxyServer} running?*:: This is indicated by a green icon in the *Status* column.
+A red icon indicates an inactive {SmartProxy}, use the `service foreman-proxy restart` command on {SmartProxyServer} to activate it.
 
-*What services are enabled on the {SmartProxyServer}?*:: In the *Features* column you can verify if the {SmartProxy} for example provides a DHCP service or acts as a Pulp mirror.
+*What services are enabled on {SmartProxyServer}?*:: In the *Features* column you can verify if {SmartProxy} for example provides a DHCP service or acts as a Pulp mirror.
 {SmartProxy} features can be enabled during installation or configured in addition.
 For more information, see {InstallingSmartProxyDocURL}[Installing {SmartProxyServer}].
 
-*What organizations and locations is the {SmartProxyServer} assigned to?*:: A {SmartProxyServer} can be assigned to multiple organizations and locations, but only {SmartProxies} belonging to the currently selected organization are displayed.
+*What organizations and locations is {SmartProxyServer} assigned to?*:: A {SmartProxyServer} can be assigned to multiple organizations and locations, but only {SmartProxies} belonging to the currently selected organization are displayed.
 To list all {SmartProxies}, select *Any Organization* from the context menu in the top left corner.
 +
 After changing the {SmartProxy} configuration, select *Refresh* from the drop-down menu in the *Actions* column to make sure the {SmartProxy} table is up to date.
@@ -25,10 +25,10 @@ Click the {SmartProxy} name to view further details.
 At the *Overview* tab, you can find the same information as in the {SmartProxy} table.
 In addition, you can answer to the following questions:
 
-*Which hosts are managed by the {SmartProxyServer}?*:: The number of associated hosts is displayed next to the *Hosts managed* label.
+*Which hosts are managed by {SmartProxyServer}?*:: The number of associated hosts is displayed next to the *Hosts managed* label.
 Click the number to view the details of associated hosts.
 
-*How much storage space is available on the {SmartProxyServer}?*:: The amount of storage space occupied by the Pulp content in `/var/lib/pulp` is displayed.
+*How much storage space is available on {SmartProxyServer}?*:: The amount of storage space occupied by the Pulp content in `/var/lib/pulp` is displayed.
 Also the remaining storage space available on the {SmartProxy} can be ascertained.
 
 [[sect-Documentation-Administering_Red_Hat_Satellite-Monitoring_Services]]
@@ -36,7 +36,7 @@ Also the remaining storage space available on the {SmartProxy} can be ascertaine
 
 Navigate to *Infrastructure* > *{SmartProxies}* and click the name of the selected {SmartProxy}.
 At the *Services* tab, you can find basic information on {SmartProxy} services, such as the list of DNS domains, or the number of Pulp workers.
-The appearance of the page depends on what services are enabled on the {SmartProxyServer}.
+The appearance of the page depends on what services are enabled on {SmartProxyServer}.
 Services providing more detailed status information can have dedicated tabs at the {SmartProxy} page (see xref:sect-Documentation-Administering_{Project_Link}-Monitoring_Puppet[]).
 
 [[sect-Documentation-Administering_Red_Hat_Satellite-Monitoring_Puppet]]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
@@ -73,5 +73,5 @@ For more information, see {ManagingHostsDocURL}configuring-and-setting-up-remote
 +
 . In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}*.
 . Locate {SmartProxyServer} in the list, and click *Edit* to the right of it.
-. Edit the *Name* and *URL* fields to match the {SmartProxyServer}'s new host name, then click *Submit*.
-. On your DNS server, add a record for the {SmartProxyServer}'s new host name, and delete the record for the previous host name.
+. Edit the *Name* and *URL* fields to match {SmartProxyServer}'s new host name, then click *Submit*.
+. On your DNS server, add a record for {SmartProxyServer}'s new host name, and delete the record for the previous host name.

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
@@ -84,9 +84,9 @@ When you submit the request, specify the lifespan of the certificate.
 The method for sending the certificate request varies, so consult the Certificate Authority for the preferred method.
 In response to the request, you can expect to receive a Certificate Authority bundle and a signed certificate, in separate files.
 
-. Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and the {SmartProxyServer} private key to your {ProjectServer} to validate them.
+. Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and {SmartProxyServer} private key to your {ProjectServer} to validate them.
 
-. On {ProjectServer}, validate the {SmartProxyServer} certificate input files:
+. On {ProjectServer}, validate {SmartProxyServer} certificate input files:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -140,7 +140,7 @@ For example:
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
-Retain a copy of the example `{foreman-installer}` command from the output for installing the {SmartProxyServer} certificates.
+Retain a copy of the example `{foreman-installer}` command from the output for installing {SmartProxyServer} certificates.
 
 . Copy the certificate archive file from {ProjectServer} to {SmartProxyServer}.
 
@@ -218,7 +218,7 @@ For example:
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
-Retain a copy of the example `{foreman-installer}` command from the output for installing the {SmartProxyServer} certificates.
+Retain a copy of the example `{foreman-installer}` command from the output for installing {SmartProxyServer} certificates.
 
 . Copy the certificate archive file from {ProjectServer} to {SmartProxyServer}.
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_without_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_without_Puppet_for_Load_Balancing.adoc
@@ -84,9 +84,9 @@ When you submit the request, specify the lifespan of the certificate.
 The method for sending the certificate request varies, so consult the Certificate Authority for the preferred method.
 In response to the request, you can expect to receive a Certificate Authority bundle and a signed certificate, in separate files.
 
-. Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and the {SmartProxyServer} private key to your {ProjectServer}.
+. Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and {SmartProxyServer} private key to your {ProjectServer}.
 
-. On {ProjectServer}, validate the {SmartProxyServer} certificate input files:
+. On {ProjectServer}, validate {SmartProxyServer} certificate input files:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -130,7 +130,7 @@ For example:
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
-Retain a copy of the example `{foreman-installer}` command from the output for installing the {SmartProxyServer} certificates.
+Retain a copy of the example `{foreman-installer}` command from the output for installing {SmartProxyServer} certificates.
 
 . Copy the certificate archive file from {ProjectServer} to {SmartProxyServer}:
 +
@@ -141,7 +141,7 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 
 . Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.
-Set the `--puppet-ca-server` option to point to the {SmartProxyServer} where you enter the command.
+Set the `--puppet-ca-server` option to point to {SmartProxyServer} where you enter the command.
 You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not.
 Puppet is configured in its default single-node configuration.
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
@@ -25,7 +25,7 @@ In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smar
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
-Retain a copy of the example `{foreman-installer}` command that is output by the `{certs-generate}` command for installing the {SmartProxyServer} certificate.
+Retain a copy of the example `{foreman-installer}` command that is output by the `{certs-generate}` command for installing {SmartProxyServer} certificate.
 
 . Copy the certificate archive file from {ProjectServer} to {SmartProxyServer}:
 +
@@ -114,7 +114,7 @@ Complete this procedure on each {SmartProxyServer} excluding the system where yo
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
-Retain a copy of the example `{foreman-installer}` command that is output by the `{certs-generate}` command for installing the {SmartProxyServer} certificate.
+Retain a copy of the example `{foreman-installer}` command that is output by the `{certs-generate}` command for installing {SmartProxyServer} certificate.
 
 . Copy the certificate archive file from {ProjectServer} to {SmartProxyServer}:
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
@@ -17,7 +17,7 @@ Complete this procedure on each {SmartProxyServer} that you want to configure fo
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
-Retain a copy of the example `{foreman-installer}` command that is output by the `{certs-generate}` command for installing the {SmartProxyServer} certificate.
+Retain a copy of the example `{foreman-installer}` command that is output by the `{certs-generate}` command for installing {SmartProxyServer} certificate.
 
 . Copy the certificate archive file from {ProjectServer} to {SmartProxyServer}.
 +
@@ -28,7 +28,7 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 
 . Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.
-Set the `--puppet-ca-server` option to point to the {SmartProxyServer} where you enter the command.
+Set the `--puppet-ca-server` option to point to {SmartProxyServer} where you enter the command.
 You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not.
 Puppet is configured in its default single-node configuration.
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Servers_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Servers_for_Load_Balancing.adoc
@@ -10,4 +10,4 @@ Proceed to one of the following sections depending on your {ProjectServer} confi
 . xref:configuring-capsule-server-with-custom-ssl-certificates-for-load-balancing-with-puppet[]
 
 Use different file names for the Katello certificates you create for each {SmartProxyServer}.
-For example, name the certificate archive file with the {SmartProxyServer} FQDN.
+For example, name the certificate archive file with {SmartProxyServer} FQDN.

--- a/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
@@ -200,19 +200,19 @@ You can use both the {Project} web UI and the Hammer to remove life cycle enviro
 
 .CLI procedure
 
-. Select the {SmartProxyServer} that you want from the list and take note of its *id*:
+. Select {SmartProxyServer} that you want from the list and take note of its *id*:
 +
 ----
 # hammer capsule list
 ----
 +
-. To verify the {SmartProxyServer}'s details, enter the following command:
+. To verify {SmartProxyServer}'s details, enter the following command:
 +
 [subs="+quotes"]
 ----
 # hammer capsule info --id _capsule_id_
 ----
-. Verify the list of life cycle environments currently attached to the {SmartProxyServer} and take note of the *environment id*:
+. Verify the list of life cycle environments currently attached to {SmartProxyServer} and take note of the *environment id*:
 +
 [subs="+quotes"]
 ----

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-bmc-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-bmc-interface.adoc
@@ -16,7 +16,7 @@ You only need the MAC address for the BMC interface if the BMC interface is mana
 .Procedure
 
 . Enable BMC on the {SmartProxy} server if it is not already enabled:
-.. Configure BMC power management on the {SmartProxyServer} by running the `{foreman-installer}` script with the following options:
+.. Configure BMC power management on {SmartProxyServer} by running the `{foreman-installer}` script with the following options:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-physical-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-physical-interface.adoc
@@ -14,7 +14,7 @@ This setting is required.
 . Specify the *Device Identifier*, for example *eth0*.
 The identifier is used to specify this physical interface when creating bonded interfaces, VLANs, and aliases.
 . Specify the *DNS name* associated with the host's IP address.
-{Project} saves this name in the {SmartProxyServer} associated with the selected domain (the "DNS A" field) and the {SmartProxyServer} associated with the selected subnet (the "DNS PTR" field).
+{Project} saves this name in {SmartProxyServer} associated with the selected domain (the "DNS A" field) and {SmartProxyServer} associated with the selected subnet (the "DNS PTR" field).
 A single host can therefore have several DNS entries.
 . Select a domain from the *Domain* list.
 To create and manage domains, navigate to *Infrastructure* > *Domains*.

--- a/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
@@ -47,9 +47,9 @@ ifndef::satellite[]
 Content related features, provided by the Katello plug-in:
 endif::[]
 
-* *Repository synchronization* – the content from the {ProjectServer} (more precisely from selected life cycle environments) is pulled to the {SmartProxyServer} for content delivery (enabled by Pulp).
+* *Repository synchronization* – the content from {ProjectServer} (more precisely from selected life cycle environments) is pulled to {SmartProxyServer} for content delivery (enabled by Pulp).
 
-* *Content delivery* – hosts configured to use the {SmartProxyServer} download content from that {SmartProxy} rather than from the central {ProjectServer} (enabled by Pulp).
+* *Content delivery* – hosts configured to use {SmartProxyServer} download content from that {SmartProxy} rather than from the central {ProjectServer} (enabled by Pulp).
 
 * *Host action delivery* – {SmartProxyServer} executes scheduled actions on hosts.
 

--- a/guides/doc-Planning_Guide/topics/Glossary.adoc
+++ b/guides/doc-Planning_Guide/topics/Glossary.adoc
@@ -106,7 +106,7 @@ Once a content view is published, it can be promoted through the life cycle envi
 
 [[varl-Glossary_of_Terms-Discovery_Plug-in]]
 *Discovery Plug-in*:: Enables automatic bare-metal discovery of unknown hosts on the provisioning network.
-The plug-in consists of three components: services running on the {ProjectServer} and the {SmartProxyServer}, and the Discovery image running on host.
+The plug-in consists of three components: services running on the {ProjectServer} and {SmartProxyServer}, and the Discovery image running on host.
 
 
 [[varl-Glossary_of_Terms-Discovery_Rule]]
@@ -361,7 +361,7 @@ Used in compliance policies.
 
 [[varl-Glossary_of_Terms-Scenario]]
 *Scenario*:: A set of predefined settings for the {Project} CLI installer.
-Scenario defines the type of installation, for example to install the {SmartProxyServer} execute `{installer-scenario-smartproxy}`.
+Scenario defines the type of installation, for example to install {SmartProxyServer} execute `{installer-scenario-smartproxy}`.
 Every scenario has its own answer file to store the scenario settings.
 
 
@@ -379,7 +379,7 @@ In upstream Foreman terminology, Smart Proxy is a synonym of {SmartProxy}.
 
 
 [[varl-Glossary_of_Terms-Subnet_Image]]
-*Subnet Image*:: A type of generic image for PXE-less provisioning that communicates through the {SmartProxyServer}.
+*Subnet Image*:: A type of generic image for PXE-less provisioning that communicates through {SmartProxyServer}.
 
 
 [[varl-Glossary_of_Terms-Subscription]]

--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -11,8 +11,8 @@ _{ProjectName}_ is a system management solution that enables you to deploy, conf
 _{ProjectName} Server_ synchronizes the content from Red{nbsp}Hat Customer{nbsp}Portal and other sources, and provides functionality including fine-grained life cycle management, user and group role-based access control, integrated subscription management, as well as advanced GUI, CLI, or API access.
 
 _{ProjectName} {SmartProxyServer}_ mirrors content from {ProjectName} Server to facilitate content federation across various geographical locations.
-Host systems can pull content and configuration from the {SmartProxyServer} in their location and not from the central {ProjectServer}.
-The {SmartProxyServer} also provides localized services such as Puppet Master, DHCP, DNS, or TFTP.
+Host systems can pull content and configuration from {SmartProxyServer} in their location and not from the central {ProjectServer}.
+{SmartProxyServer} also provides localized services such as Puppet Master, DHCP, DNS, or TFTP.
 {SmartProxyServer}s assist you in scaling your {Project} environment as the number of your managed systems increases.
 
 {SmartProxyServer}s decrease the load on the central server, increase redundancy, and reduce bandwidth usage.
@@ -53,14 +53,14 @@ The {ProjectServer} also contains a fine-grained authentication system to provid
 
 [[varl-Red_Hat_Satellite-Architecture_Guide-Red_Hat_Satellite_6_System_Architecture-Capsule_Servers]]
 *{SmartProxyServer}s*:: {SmartProxyServer}s mirror content from the {ProjectServer} to establish content sources in various geographical locations.
-This enables host systems to pull content and configuration from the {SmartProxyServer}s in their location and not from the central {ProjectServer}.
+This enables host systems to pull content and configuration from {SmartProxyServer}s in their location and not from the central {ProjectServer}.
 The recommended minimum number of {SmartProxyServer}s is therefore given by the number of geographic regions where the organization that uses {Project} operates.
 +
-Using Content Views, you can specify the exact subset of content that the {SmartProxyServer} makes available to hosts.
+Using Content Views, you can specify the exact subset of content that {SmartProxyServer} makes available to hosts.
 See xref:figu-{Project_Link}-Architecture_Guide-{Project_Link}_6_System_Architecture-Content_Life_Cycle_in_{Project_Link}_6[] for a closer look at life cycle management with the use of Content Views.
 +
-The communication between managed hosts and the {ProjectServer} is routed through the {SmartProxyServer} that can also manage multiple services on behalf of hosts.
-Many of these services use dedicated network ports, but the {SmartProxyServer} ensures that a single source IP address is used for all communications from the host to the {ProjectServer}, which simplifies firewall administration.
+The communication between managed hosts and the {ProjectServer} is routed through {SmartProxyServer} that can also manage multiple services on behalf of hosts.
+Many of these services use dedicated network ports, but {SmartProxyServer} ensures that a single source IP address is used for all communications from the host to the {ProjectServer}, which simplifies firewall administration.
 For more information on {SmartProxyServer}s see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
 
 
@@ -95,7 +95,7 @@ You can then use Composite Content Views to combine published Content Views for 
 Which Content Views should be promoted to which {SmartProxyServer} depends on the {SmartProxy}'s intended functionality.
 Any {SmartProxyServer} can run DNS, DHCP, and TFTP as infrastructure services that can be supplemented, for example, with content or configuration services.
 
-You can update the {SmartProxyServer} by creating a new version of a Content View using synchronized content from the Library.
+You can update {SmartProxyServer} by creating a new version of a Content View using synchronized content from the Library.
 The new Content View version is then promoted through life cycle environments.
 You can also create in-place updates of Content Views.
 This means creating a minor version of the Content View in its current life cycle environment without promoting it from the Library.

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
@@ -11,7 +11,7 @@ Use the procedures in this chapter to add a connection to an Amazon EC2 account 
 The requirements for Amazon EC2 provisioning include:
 
   * A {SmartProxyServer} managing a network in your EC2 environment.
-Use a Virtual Private Cloud (VPC) to ensure a secure network between the hosts and the {SmartProxyServer}.
+Use a Virtual Private Cloud (VPC) to ensure a secure network between the hosts and {SmartProxyServer}.
   * An Amazon Machine Image (AMI) for image-based provisioning.
 include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 

--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -6,7 +6,7 @@ Use this chapter to configure network services in your integrated {SmartProxy} o
 
 New hosts must have access to your {SmartProxyServer}.
 {SmartProxyServer} can be either your integrated {SmartProxy} on {ProjectServer} or an external {SmartProxyServer}.
-You might want to provision hosts from an external {SmartProxyServer} when the hosts are on isolated networks and cannot connect to {ProjectServer} directly, or when the content is synchronized with the {SmartProxyServer}.
+You might want to provision hosts from an external {SmartProxyServer} when the hosts are on isolated networks and cannot connect to {ProjectServer} directly, or when the content is synchronized with {SmartProxyServer}.
 Provisioning using the external {SmartProxyServer} can save on network bandwidth.
 
 Configuring {SmartProxyServer} has two basic requirements:
@@ -231,9 +231,9 @@ endif::[]
 === Configuring Network Services
 
 Some provisioning methods use {SmartProxyServer} services.
-For example, a network might require the {SmartProxyServer} to act as a DHCP server.
+For example, a network might require {SmartProxyServer} to act as a DHCP server.
 A network can also use PXE boot services to install the operating system on new hosts.
-This requires configuring the {SmartProxyServer} to use the main PXE boot services: DHCP, DNS, and TFTP.
+This requires configuring {SmartProxyServer} to use the main PXE boot services: DHCP, DNS, and TFTP.
 
 Use the `{foreman-installer}` command with the options to configure these services on the {ProjectServer}.
 
@@ -275,20 +275,20 @@ To configure network services on {Project}'s integrated {SmartProxy}, complete t
 --foreman-proxy-tftp-managed true
 ----
 +
-. Find the {SmartProxyServer} that you configure:
+. Find {SmartProxyServer} that you configure:
 +
 ----
 # hammer proxy list
 ----
 +
-. Refresh features of the {SmartProxyServer} to view the changes:
+. Refresh features of {SmartProxyServer} to view the changes:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer proxy refresh-features --name "_{foreman-example-com}_"
 ----
 +
-. Verify the services configured on the {SmartProxyServer}:
+. Verify the services configured on {SmartProxyServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -458,7 +458,7 @@ IPTABLES_MODULES="ip_conntrack_tftp"
 === Adding a Domain to {ProjectServer}
 
 {ProjectServer} defines domain names for each host on the network.
-{ProjectServer} must have information about the domain and the {SmartProxyServer} responsible for domain name assignment.
+{ProjectServer} must have information about the domain and {SmartProxyServer} responsible for domain name assignment.
 
 .Checking for Existing Domains
 {ProjectServer} might already have the relevant domain created as part of {ProjectServer} installation.

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -10,7 +10,7 @@ VMware vSphere is an enterprise-level virtualization platform from VMware.
 The requirements for VMware vSphere provisioning include:
 
 * A {SmartProxyServer} managing a network on the vSphere environment.
-Ensure no other DHCP services run on this network to avoid conflicts with the {SmartProxyServer}.
+Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 For more information, see xref:Configuring_Networking[].
 * An existing VMware template if you want to use image-based provisioning.
 include::../common/modules/snip_common-compute-resource-prereqs.adoc[]

--- a/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
+++ b/guides/doc-Provisioning_Guide/topics/con_unattended-use-and-customization.adoc
@@ -6,7 +6,7 @@ The Discovery image uses a Linux kernel for the operating system, which passes k
 These kernel parameters include the following entries:
 
 proxy.url::
-  The URL of the {SmartProxyServer} or {ProjectServer} providing the Discovery service.
+  The URL of {SmartProxyServer} or {ProjectServer} providing the Discovery service.
 
 proxy.type::
   The proxy type.

--- a/guides/doc-Provisioning_Guide/topics/proc_installing-the-discovery-service.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_installing-the-discovery-service.adoc
@@ -32,14 +32,14 @@ endif::[]
 +
 . In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxy}*.
 
-. Click the {SmartProxyServer} and select *Refresh* from the *Actions* list.
+. Click {SmartProxyServer} and select *Refresh* from the *Actions* list.
 Locate *Discovery* in the list of features to confirm the Discovery service is now running.
 
 .Subnets
 
 All subnets with discoverable hosts require an appropriate {SmartProxyServer} selected to provide the Discovery service.
 
-To check this, navigate to *Infrastructure* > *{SmartProxies}* and verify if the {SmartProxyServer} that you want to use lists the Discovery feature.
+To check this, navigate to *Infrastructure* > *{SmartProxies}* and verify if {SmartProxyServer} that you want to use lists the Discovery feature.
 If not, click *Refresh features*.
 
 In the {Project} web UI, navigate to *Infrastructure* > *Subnets*, select a subnet, click the {SmartProxies} tab, and select the *Discovery Proxy* that you want to use.

--- a/guides/doc-Provisioning_Guide/topics/ref_the-provisioning-template-pxelinux-discovery-snippet.adoc
+++ b/guides/doc-Provisioning_Guide/topics/ref_the-provisioning-template-pxelinux-discovery-snippet.adoc
@@ -27,6 +27,6 @@ menuentry 'Foreman Discovery Image' --id discovery {
 }
 ----
 
-To use {SmartProxy} to proxy the discovery steps, edit `/var/lib/tftpboot/pxelinux.cfg/default` or `/var/lib/tftpboot/grub2/grub.cfg` and change the URL to the {SmartProxyServer} FQDN you want to use.
+To use {SmartProxy} to proxy the discovery steps, edit `/var/lib/tftpboot/pxelinux.cfg/default` or `/var/lib/tftpboot/grub2/grub.cfg` and change the URL to {SmartProxyServer} FQDN you want to use.
 
 The global template is available on {ProjectServer} and all {SmartProxies} that have the TFTP feature enabled.

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -6,7 +6,8 @@ When you upgrade {ProjectServer}, you can optionally create a clone of your {Pro
 
 Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
 
-The {Project} clone tool does not support migrating a {SmartProxyServer} to Red Hat Enterprise Linux 7. Instead you must backup the existing {SmartProxyServer}, restore it on Red Hat Enterprise Linux 7, then reconfigure the {SmartProxyServer}.
+The {Project} clone tool does not support migrating a {SmartProxyServer} to Red Hat Enterprise Linux 7.
+Instead you must backup the existing {SmartProxyServer}, restore it on Red Hat Enterprise Linux 7, then reconfigure {SmartProxyServer}.
 
 .Terminology
 Ensure that you understand the following terms:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -10,7 +10,7 @@
 
 .{SmartProxy} Considerations
 
-* If you use Content Views to control updates to a {SmartProxyServer}’s base operating system, or for the {SmartProxyServer} repository, you must publish updated versions of those Content Views.
+* If you use Content Views to control updates to a {SmartProxyServer}’s base operating system, or for {SmartProxyServer} repository, you must publish updated versions of those Content Views.
 
 
 [WARNING]


### PR DESCRIPTION
This PR removes all instances of `the` before `{SmartProxyServer}`:

`git grep -i -n "the {SmartProxyServer}"`

This came up during the review of the application centric deployment PR.

I think `the {ProjectServer}` occurs just as often for which I would create a separate PR if desired.