### PR TITLE
Document section about disabling registration to Insights

### DIFF
--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -2,7 +2,11 @@
 
 = Disabling Registration to Red Hat Insights
 
-{Project} is registered to Red Hat Insights by default. After {Project} installation or upgradation, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
+{Project} is registered to Red Hat Insights by default. After you install or upgrade {Project}, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
+
+.Prerequisites
+
+. You have registered {Project} to Red Hat Customer Portal.
 
 .Procedure
 
@@ -17,5 +21,5 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# insights-client --register
+# {foreman-installer} --register-with-insights
 ----

--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -2,7 +2,7 @@
 
 = Disabling Registration to Red Hat Insights
 
-{Project} is registered to Red Hat Insights by default. After {Project} installation, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
+{Project} is registered to Red Hat Insights by default. After {Project} installation or upgradation, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
 
 .Procedure
 

--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -1,0 +1,21 @@
+[id='disabling-registration-with-insights_{context}']
+
+= Disabling Registration to Red Hat Insights
+
+After {Project} installation, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}.
+
+.Procedure
+
+. Optional: To unregister Red Hat Insights from {ProjectServer}, enter the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# insights-client --unregister
+----
+
+. Optional: To register {ProjectServer} with Red Hat Insights, enter the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# insights-client --register
+----

--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -2,7 +2,7 @@
 
 = Disabling Registration to Red Hat Insights
 
-After {Project} installation, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}.
+{Project} is registered to Red Hat Insights by default. After {Project} installation, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
 
 .Procedure
 

--- a/guides/doc-Installing_Server_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Server_on_Red_Hat/master.adoc
@@ -26,6 +26,8 @@ include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 ifdef::satellite[]
 include::common/modules/proc_using-insights-with-satellite-server.adoc[leveloffset=+2]
 
+include::common/modules/proc_disabling-registration-to-insights.adoc[leveloffset=+2]
+
 include::common/modules/proc_enabling-the-satellite-tools-repository.adoc[leveloffset=+2]
 
 include::common/modules/proc_synchronizing-the-satellite-tools-repository.adoc[leveloffset=+2]


### PR DESCRIPTION
Bug 1899895 - Document optional disabling Satellite to Insights registration
https://bugzilla.redhat.com/show_bug.cgi?id=1899895



Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
