### PR TITLE
Run make html in parallel when -j is used

### DIFF
--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,5 +1,8 @@
 SHELL := /bin/bash
-GUIDES = $(shell ls -d doc-*)
+ALL_DIRS = $(shell ls -d doc-*)
+GUIDES-HTML = $(ALL_DIRS)
+
+.PHONY: all html pdf linkchecker all-html all-pdf clean all-clean linkchecker-tryer $(GUIDES-HTML)
 
 all: html
 
@@ -15,30 +18,20 @@ linkchecker:
 linkchecker-tryer:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
-all-html:
-	for DIR in $(GUIDES) ; do \
-		pushd "$$DIR" && \
-		$(MAKE) html && \
-		popd ; \
-	done
+all-html: $(GUIDES-HTML)
+
+$(GUIDES-HTML):
+	$(MAKE) --directory=$@ html
 
 all-pdf:
-	for DIR in $(GUIDES) ; do \
-		pushd "$$DIR" && \
-		$(MAKE) pdf && \
-		popd ; \
+	for DIR in $(ALL_DIRS) ; do \
+		$(MAKE) --directory="$$DIR" pdf ; \
 	done
 
-all-linkchecker:
-	for DIR in $(GUIDES) ; do \
-		pushd "$$DIR" && \
-		$(MAKE) linkchecker && \
-		popd ; \
-	done
+$(GUIDES-PDF):
+	$(MAKE) --directory=$@ pdf
 
 all-clean:
-	for DIR in $(GUIDES) ; do \
-		pushd "$$DIR" && \
-		$(MAKE) clean && \
-		popd ; \
+	for DIR in $(ALL_DIRS) ; do \
+		$(MAKE) --directory="$$DIR" clean ; \
 	done

--- a/guides/README.md
+++ b/guides/README.md
@@ -39,6 +39,14 @@ Similarly, to build and open PDF version do:
 
     make open-pdf
 
+To speed up the build process, make sure to use `-j` option. Ideally, set it to amount of cores plus one:
+
+		make -j9
+
+An alias is often useful:
+
+		alias make="make -j$(nproc)"
+
 Currently there are three different versions:
 
 

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -29,7 +29,7 @@ html: prepare $(DEST_DIR)/$(BUILD).css $(IMAGES_TS) $(DEST_HTML)
 pdf: prepare $(DEST_PDF)
 
 prepare:
-	@mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(IMAGES_DIR) $(DEST_DIR)/common/images
+	mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(IMAGES_DIR) $(DEST_DIR)/common/images
 
 clean:
 	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)"

--- a/guides/diff-vs-master.sh
+++ b/guides/diff-vs-master.sh
@@ -10,7 +10,7 @@ for BRANCH in $BRANCH1 $BRANCH2; do
   git checkout $BRANCH
   for BUILD in foreman-el foreman-deb katello satellite; do
     make clean
-    make BUILD=$BUILD BUILD_DIR=../build-$BUILD-$BRANCH
+    make -j$(nproc) BUILD=$BUILD BUILD_DIR=../build-$BUILD-$BRANCH html
   done
 done
 git checkout $BRANCH1


### PR DESCRIPTION
When you run `make -j5` (pick amount of cores your CPU have + 1) this will now take advantage of GNU make parallel sub-make execution. For me everything is 5x faster.

I could probably implement this for PDFs too but that would make the Makefile a bit unreadable as directory names cannot be reused as targets, so perhaps this could be done via some string substitution. It is not worth the effort, we rarely build PDFs locally, the benefit here is to quickly build HTMLs.

@melcorr I suggest you create the following alias in your profile:

    alias make="make -j5"

Then building will be faster for you.