### PR TITLE
Fail on asciidoc error and fix one context

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -52,7 +52,9 @@ $(IMAGES_TS): $(IMAGES)
 	touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES)
-	asciidoctor -a build=$(BUILD) -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $<
+	asciidoctor -a build=$(BUILD) -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -q "^asciidoctor: ERROR" $@.log
 
 $(DEST_PDF): $(SOURCES) $(IMAGES)
-	asciidoctor-pdf -a build=$(BUILD) -d book --trace -o $@ $<
+	asciidoctor-pdf -a build=$(BUILD) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -q "^asciidoctor: ERROR" $@.log

--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -17,7 +17,6 @@ include::modules/proc_enabling-openscap.adoc[leveloffset=+1]
 ifdef::katello,satellite[]
 // Adding Life Cycle Environments to {SmartProxyServer}s
 include::modules/proc_adding-life-cycle-environments.adoc[leveloffset=+1]
-
 endif::[]
 
 // Enabling Power Management on Managed Hosts
@@ -25,7 +24,6 @@ include::modules/proc_enabling-power-management-on-managed-hosts.adoc[leveloffse
 
 // Configuring DNS, DHCP, and TFTP on {SmartProxyServer}
 include::modules/proc_configuring-dns-dhcp-and-tftp.adoc[leveloffset=+1]
-endif::[]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -1,3 +1,5 @@
+ifdef::context[:parent-context: {context}]
+
 [id="installing-server-packages_{context}"]
 [id="installing-the-satellite-server-packages_{context}"]
 = Installing the {ProjectServer} Packages
@@ -19,6 +21,7 @@ endif::[]
 ifdef::foreman-el,katello[]
 == [[centos-7]]CentOS 7
 
+:context: centos7
 :package-manager: yum
 include::proc_installing-server-packages-el.adoc[]
 
@@ -27,6 +30,7 @@ endif::[]
 ifdef::foreman-el,katello[]
 == [[centos-8]]CentOS 8
 
+:context: centos8
 :package-manager: dnf
 include::proc_installing-server-packages-el.adoc[]
 
@@ -35,6 +39,7 @@ endif::[]
 ifdef::foreman-el,katello[]
 == [[rhel-7]]Red Hat Enterprise Linux 7
 
+:context: rhel7
 :package-manager: yum
 include::proc_installing-server-packages-el.adoc[]
 
@@ -43,6 +48,7 @@ endif::[]
 ifdef::foreman-deb[]
 == [[debian-10]]Debian 10 (Buster)
 
+:context: debian10
 include::proc_installing-server-packages-deb.adoc[]
 
 endif::[]
@@ -50,5 +56,9 @@ endif::[]
 ifdef::foreman-deb[]
 == [[ubuntu-1804]]Ubuntu 18.04 (Bionic)
 
+:context: ubuntu-bionic
 include::proc_installing-server-packages-deb.adoc[]
 endif::[]
+
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/guides/doc-Managing_Hosts/topics/Adding_Packages_to_System_Groups.adoc
+++ b/guides/doc-Managing_Hosts/topics/Adding_Packages_to_System_Groups.adoc
@@ -21,9 +21,9 @@ Selecting the *via remote execution - customize first* menu entry will take you 
 . In the field provided, specify the package or package group name.
 Then click:
 
-* *Install* &mdash; to install a new package using the default method.
+* *Install* - to install a new package using the default method.
 Alternatively, select the drop-down icon to the right of the button and select a method to use.
 Selecting the *via remote execution - customize first* menu entry will take you to the *Job invocation* page where you can customize the action.
-* *Update* &mdash; to update an existing package in the host collection using the default method.
+* *Update* - to update an existing package in the host collection using the default method.
 Alternatively, select the drop-down icon to the right of the button and select a method to use.
 Selecting the *via remote execution - customize first* menu entry will take you to the *Job invocation* page where you can customize the action.


### PR DESCRIPTION
This patch removes unmatched endif statement which caused asciidoc to print an ERROR.

Because asciidoc still returns zero code, the build continued. The makefile now checks for ERROR strings in asciidoc output and fail if one is found.

This patch also removes one warning - reused id. This is to serve as an example how to fix those. Once we get rid of all warnings we can start failing when warnings are found so everything can be even more strict.