### PR TITLE
Fix duplicate ID errors with {context} IDs

### DIFF
--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -5,7 +5,7 @@ If your network uses an HTTP Proxy, you can configure {ProjectServer} to use an 
 Use the FQDN instead of the IP address where possible to avoid losing connectivity because of network changes.
 
 The following procedure configures a proxy only for downloading content for {Project}.
-To use the CLI instead of the web UI, see the xref:cli-adding-a-default-http-proxy[].
+To use the CLI instead of the web UI, see the xref:cli-adding-a-default-http-proxy_{context}[].
 
 .Procedure
 
@@ -20,7 +20,7 @@ To use the CLI instead of the web UI, see the xref:cli-adding-a-default-http-pro
 . Navigate to *Administer* > *Settings*, and click the *Content* tab.
 . Set the *Default HTTP Proxy* setting to the created HTTP proxy.
 
-[[cli-adding-a-default-http-proxy]]
+[id="cli-adding-a-default-http-proxy_{context}"]
 .CLI procedure
 
 . Verify that the `http_proxy`, `https_proxy`, and `no_proxy` variables are not set.

--- a/guides/common/modules/proc_adding-azure-connection.adoc
+++ b/guides/common/modules/proc_adding-azure-connection.adoc
@@ -4,7 +4,7 @@
 Use this procedure to add Microsoft Azure Resource Manager as a compute resource in {Project}.
 Note that you must add a separate compute resource for each Azure Resource Manager region that you want to use.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-azure-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-azure-connection_{context}[].
 
 .Procedure
 
@@ -21,7 +21,7 @@ This tests if your connection to Azure Resource Manager is successful and loads 
 . From the *Azure Region* list, select the Azure region to use.
 . Click *Submit*.
 
-[[cli-adding-azure-connection]]
+[id="cli-adding-azure-connection_{context}"]
 .CLI procedure
 
 * Use the `hammer compute-resource create` command to add an Azure compute resource to {Project}.

--- a/guides/common/modules/proc_adding-azure-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-azure-details-to-a-compute-profile.adoc
@@ -4,7 +4,7 @@
 Use this procedure to add Azure hardware settings to a compute profile.
 When you create a host on Azure using this compute profile, these settings are automatically populated.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-azure-details-to-a-compute-profile[].
+To use the CLI instead of the web UI, see the xref:cli-adding-azure-details-to-a-compute-profile_{context}[].
 
 .Procedure
 
@@ -33,7 +33,7 @@ The scripts must contain `sudo` at the beginning because {ProjectName} downloads
 . Optional: If you want the virtual machine to use a static private IP, select the *Static Private IP* check box.
 . Click *Submit*.
 
-[[cli-adding-azure-details-to-a-compute-profile]]
+[id="cli-adding-azure-details-to-a-compute-profile_{context}"]
 .CLI procedure
 
 . Create a compute profile to use with the Azure Resource Manager compute resource:

--- a/guides/common/modules/proc_adding-gce-connection.adoc
+++ b/guides/common/modules/proc_adding-gce-connection.adoc
@@ -2,7 +2,7 @@
 = Adding a Google Compute Engine Connection to {ProjectServer}
 
 Use this procedure to add Google Compute Engine (GCE) as a compute resource in {Project}.
-To use the CLI instead of the web UI, see the xref:cli-adding-gce-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-gce-connection_{context}[].
 
 .Procedure
 
@@ -37,7 +37,7 @@ For example, `/usr/share/foreman/_gce_key_.json`.
 . From the *Zone* list, select the GCE zone to use.
 . Click *Submit*.
 
-[[cli-adding-gce-connection]]
+[id="cli-adding-gce-connection_{context}"]
 .CLI procedure
 
 . In GCE, generate a service account key in JSON format and upload this file to the `/usr/share/foreman/` directory on {ProjectServer}.

--- a/guides/common/modules/proc_adding-gce-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-gce-details-to-a-compute-profile.adoc
@@ -4,7 +4,7 @@
 Use this procedure to add GCE hardware settings to a compute profile.
 When you create a host on GCE using this compute profile, these settings are automatically populated.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-gce-details-to-a-compute-profile[].
+To use the CLI instead of the web UI, see the xref:cli-adding-gce-details-to-a-compute-profile_{context}[].
 
 .Procedure
 
@@ -20,7 +20,7 @@ If you need a permanent IP address, reserve a static public IP address on GCE an
 . In the *Size (GB)* field, enter the size of the storage to create on the host.
 . Click *Submit* to save the compute profile.
 
-[[cli-adding-gce-details-to-a-compute-profile]]
+[id="cli-adding-gce-details-to-a-compute-profile_{context}"]
 .CLI procedure
 
 . Create a compute profile to use with the GCE compute resource:

--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -5,7 +5,7 @@ To create hosts using image-based provisioning, you must add information about t
 
 ifdef::kvm-provisioning[Note that you can manage only directory pool storage types through {ProjectX}.]
 
-To use the CLI instead of the web UI, see the xref:cli-adding-images-to-server[].
+To use the CLI instead of the web UI, see the xref:cli-adding-images-to-server_{context}[].
 
 .Procedure
 
@@ -48,7 +48,7 @@ endif::[]
 . Optional: Select the *User Data* check box if the image supports user data input, such as `cloud-init` data.
 . Click *Submit* to save the image details.
 
-[[cli-adding-images-to-server]]
+[id="cli-adding-images-to-server_{context}"]
 .CLI procedure
 
 * Create the image with the `hammer compute-resource image create` command.

--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -20,7 +20,7 @@ For example *CentOS mirror (7.x)* must be used for CentOS 7 or earlier, and *Cen
 
 If you want to improve download performance when using installation media to install operating systems on multiple host, you must modify the installation medium's *Path* to point to the closest mirror or a local copy.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-installation-media[].
+To use the CLI instead of the web UI, see the xref:cli-adding-installation-media_{context}[].
 
 .Procedure
 
@@ -57,7 +57,7 @@ endif::[]
 {ProjectServer} adds the installation medium to the set provisioning context.
 . Click *Submit* to save your installation medium.
 
-[[cli-adding-installation-media]]
+[id="cli-adding-installation-media_{context}"]
 .CLI procedure
 
 * Create the installation medium using the `hammer medium create` command:

--- a/guides/common/modules/proc_adding-kvm-connection.adoc
+++ b/guides/common/modules/proc_adding-kvm-connection.adoc
@@ -2,7 +2,7 @@
 = Adding a KVM Connection to {ProjectServer}
 
 Use this procedure to add KVM as a compute resource in {Project}.
-To use the CLI instead of the web UI, see the xref:cli-adding-kvm-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-kvm-connection_{context}[].
 
 .Procedure
 
@@ -34,7 +34,7 @@ The password is randomly generated every time the console for the virtual machin
 If you want, add additional contexts to these tabs.
 . Click *Submit* to save the KVM connection.
 
-[[cli-adding-kvm-connection]]
+[id="cli-adding-kvm-connection_{context}"]
 .CLI procedure
 
 * To create a compute resource, enter the `hammer compute-resource create` command:

--- a/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile.adoc
@@ -4,7 +4,7 @@
 Use this procedure to add KVM hardware settings to a compute profile.
 When you create a host on KVM using this compute profile, these settings are automatically populated.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-kvm-details-to-a-compute-profile[].
+To use the CLI instead of the web UI, see the xref:cli-adding-kvm-details-to-a-compute-profile_{context}[].
 
 .Procedure
 
@@ -21,7 +21,7 @@ However, at least one interface must point to a {SmartProxy}-managed network.
 You can create multiple volumes for the host.
 . Click *Submit* to save the settings to the compute profile.
 
-[[cli-adding-kvm-details-to-a-compute-profile]]
+[id="cli-adding-kvm-details-to-a-compute-profile_{context}"]
 .CLI procedure
 
 . To create a compute profile, enter the following command:

--- a/guides/common/modules/proc_adding-openstack-connection.adoc
+++ b/guides/common/modules/proc_adding-openstack-connection.adoc
@@ -2,7 +2,7 @@
 = Adding the {OpenStack} Connection to {ProjectServer}
 
 Use this procedure to add {OpenStack} as a compute resource in {Project}.
-To use the CLI instead of the web UI, see the xref:cli-adding-openstack-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-openstack-connection_{context}[].
 
 .Procedure
 
@@ -20,7 +20,7 @@ Use the following format: `http://openstack.example.com:5000/v3.0/tokens`.
 Add any additional contexts that you want to these tabs.
 . Click *Submit* to save the {OpenStack} connection.
 
-[[cli-adding-openstack-connection]]
+[id="cli-adding-openstack-connection_{context}"]
 .CLI procedure
 
 * To create a compute resource, enter the `hammer compute-resource create` command:

--- a/guides/common/modules/proc_adding-rhv-connection.adoc
+++ b/guides/common/modules/proc_adding-rhv-connection.adoc
@@ -2,7 +2,7 @@
 = Adding the {oVirt} Connection to {ProjectServer}
 
 Use this procedure to add {oVirt} as a compute resource in {Project}.
-To use the CLI instead of the web UI, see the xref:cli-adding-rhv-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-rhv-connection_{context}[].
 
 .Procedure
 
@@ -23,7 +23,7 @@ Alternatively, if you leave the field blank, a self-signed certificate is genera
 . Click the *Organizations* tab and select the organization you want to use.
 . Click *Submit* to save the compute resource.
 
-[[cli-adding-rhv-connection]]
+[id="cli-adding-rhv-connection_{context}"]
 .CLI procedure
 
 * Enter the `hammer compute-resource create` command with `Ovirt` for `--provider` and the name of the data center you want to use for `--datacenter`.

--- a/guides/common/modules/proc_adding-rhv-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-rhv-details-to-a-compute-profile.adoc
@@ -4,7 +4,7 @@
 Use this procedure to add {oVirt} hardware settings to a compute profile.
 When you create a host on KVM using this compute profile, these settings are automatically populated.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-rhv-details-to-a-compute-profile[].
+To use the CLI instead of the web UI, see the xref:cli-adding-rhv-details-to-a-compute-profile_{context}[].
 
 .Procedure
 
@@ -31,7 +31,7 @@ For each volume, enter the following details:
 .. From the *Bootable* list, select whether you want a bootable or non-bootable volume.
 . Click *Submit* to save the compute profile.
 
-[[cli-adding-rhv-details-to-a-compute-profile]]
+[id="cli-adding-rhv-details-to-a-compute-profile_{context}"]
 .CLI procedure
 
 . To create a compute profile, enter the following command:

--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -3,7 +3,7 @@
 = Creating a Job Template
 
 Use this procedure to create a job template.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-job-template[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-job-template_{context}[].
 
 .Procedure
 
@@ -33,7 +33,7 @@ For examples, see the *Help* tab.
 You can extend and customize job templates by including other templates in the template syntax.
 For more information, see the appendices in the _Managing Hosts_ guide.
 
-[[cli-creating-a-job-template]]
+[id="cli-creating-a-job-template_{context}"]
 .CLI procedure
 
 . To create a job template using a template-definition file, enter the following command:

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -4,7 +4,7 @@
 In {Project}, you can use {CRname} provisioning to create hosts from an existing image.
 The new host entry triggers the {CRname} server to create the instance using the pre-existing image as a basis for the new volume.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-image-only-hosts[].
+To use the CLI instead of the web UI, see the xref:cli-creating-image-only-hosts_{context}[].
 
 .Procedure
 
@@ -45,7 +45,7 @@ If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host entry.
 
-[[cli-creating-image-only-hosts]]
+[id="cli-creating-image-only-hosts_{context}"]
 .CLI procedure
 
 * Create the host with the `hammer host create` command and include `--provision-method image`.

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -9,7 +9,7 @@ If the virtual machine detects the defined {SmartProxyServer} through the virtua
 
 * If you want to create a host with an existing image, the new host entry triggers the {CRname} server to create the virtual machine using a pre-existing image as a basis for the new volume.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-network-or-image-based-hosts[].
+To use the CLI instead of the web UI, see the xref:cli-creating-network-or-image-based-hosts_{context}[].
 
 .DHCP Conflicts
 For network-based provisioning, if you use a virtual network on the {CRname} server for provisioning, select a network that does not provide DHCP assignments.
@@ -52,7 +52,7 @@ If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host entry.
 
-[[cli-creating-network-or-image-based-hosts]]
+[id="cli-creating-network-or-image-based-hosts_{context}"]
 .CLI procedure
 
 * To use network-based provisioning, create the host with the `hammer host create` command and include `--provision-method build`.

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -12,7 +12,7 @@ Importing operating systems from Red Hat's CDN is only possible when Katello is 
 endif::[]
 
 You can also add custom operating systems using the following procedure.
-To use the CLI instead of the web UI, see the xref:cli-creating-operating-systems[].
+To use the CLI instead of the web UI, see the xref:cli-creating-operating-systems_{context}[].
 
 .Procedure
 
@@ -36,7 +36,7 @@ For more information, see {ProvisioningDocURL}adding-installation-media_provisio
 You can select other templates, for example an *iPXE template*, if you plan to use iPXE for provisioning.
 . Click *Submit* to save your provisioning template.
 
-[[cli-creating-operating-systems]]
+[id="cli-creating-operating-systems_{context}"]
 .CLI procedure
 
 * Create the operating system using the `hammer os create` command:

--- a/guides/common/modules/proc_creating-partition-tables.adoc
+++ b/guides/common/modules/proc_creating-partition-tables.adoc
@@ -6,7 +6,7 @@ A Partition table uses the same ERB syntax as provisioning templates.
 {ProjectName} contains a set of default partition tables to use, including a `Kickstart default`.
 You can also edit partition table entries to configure the preferred partitioning scheme, or create a partition table entry and add it to the operating system entry.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-partition-tables[].
+To use the CLI instead of the web UI, see the xref:cli-creating-partition-tables_{context}[].
 
 .Procedure
 
@@ -35,7 +35,7 @@ For example, Red Hat Enterprise Linux 7.2 requires a layout that matches a kicks
 {Project} adds the partition table to the current provisioning context.
 . Click *Submit* to save your partition table.
 
-[[cli-creating-partition-tables]]
+[id="cli-creating-partition-tables_{context}"]
 .CLI procedure
 
 . Before you create a partition table with the CLI, create a plain text file that contains the partition layout.

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -8,7 +8,7 @@ endif::[]
 
 The {project-client-name} repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
 
-To use the CLI instead of the web UI, see the xref:cli-enabling-the-tools-repository[].
+To use the CLI instead of the web UI, see the xref:cli-enabling-the-tools-repository_{context}[].
 
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
@@ -32,7 +32,7 @@ To correct that, log in to the Customer Portal, add these repositories, download
 Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
 After enabling a Red Hat repository, a Product for this repository is automatically created.
 
-[[cli-enabling-the-tools-repository]]
+[id="cli-enabling-the-tools-repository_{context}"]
 .CLI procedure
 
 * Enable the {project-client-name} repository using the `hammer repository-set enable` command:

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -4,7 +4,7 @@
 
 You can execute a job that is based on a job template against one or more hosts.
 
-To use the CLI instead of the web UI, see the xref:cli-executing-a-remote-job[].
+To use the CLI instead of the web UI, see the xref:cli-executing-a-remote-job_{context}[].
 
 
 .Procedure
@@ -47,7 +47,7 @@ For more information about cron, see the https://access.redhat.com/documentation
 . Click *Submit*.
 This displays the *Job Overview* page, and when the job completes, also displays the status of the job.
 
-[[cli-executing-a-remote-job]]
+[id="cli-executing-a-remote-job_{context}"]
 .CLI procedure
 
 * Enter the following command on {Project}:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding-permissions-to-a-role.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding-permissions-to-a-role.adoc
@@ -2,7 +2,7 @@
 = Adding Permissions to a Role
 
 Use this procedure to add permissions to a role.
-To use the CLI instead of the web UI, see the xref:cli-adding-permissions-to-a-role[].
+To use the CLI instead of the web UI, see the xref:cli-adding-permissions-to-a-role_{context}[].
 
 .Procedure
 . Navigate to *Administer* > *Roles*.
@@ -19,10 +19,8 @@ When you enable the *Override* check box, you can add additional locations and o
 . Click *Next*.
 . Click *Submit* to save changes.
 
-[[cli-adding-permissions-to-a-role]]
+[id="cli-adding-permissions-to-a-role_{context}"]
 .CLI procedure
-
-To add permissions to a role, complete the following steps:
 
 . List all available permissions:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/assigning-roles-to-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/assigning-roles-to-a-user.adoc
@@ -2,7 +2,7 @@
 = Assigning Roles to a User
 
 Use this procedure to assign roles to a user.
-To use the CLI instead of the web UI, see the xref:cli-assigning-roles-to-a-user[].
+To use the CLI instead of the web UI, see the xref:cli-assigning-roles-to-a-user_{context}[].
 
 .Procedure
 
@@ -26,7 +26,7 @@ To grant all the available permissions, select the *Admin* check box.
 To view the roles assigned to a user, click the *Roles* tab; the assigned roles are listed under *Selected items*.
 To remove an assigned role, click the role name in *Selected items*.
 
-[[cli-assigning-roles-to-a-user]]
+[id="cli-assigning-roles-to-a-user_{context}"]
 .CLI procedure
 
 To assign roles to a user, enter the following command:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-granular-permission-filter.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-granular-permission-filter.adoc
@@ -2,7 +2,7 @@
 = Creating a Granular Permission Filter
 
 Use this procedure to create a granular filter.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-granular-permission-filter[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-granular-permission-filter_{context}[].
 
 {Project} does not apply search conditions to create actions.
 For example, limiting the _create_locations_ action with _name = "Default Location"_ expression in the search field does not prevent the user from assigning a custom name to the newly created location.
@@ -33,7 +33,7 @@ For most resource types, the *Search* field provides a drop-down list suggesting
 This list appears after placing the cursor in the search field.
 For many resource types, you can combine queries using logical operators such as _and_, _not_ and _has_ operators.
 
-[[cli-creating-a-granular-permission-filter]]
+[id="cli-creating-a-granular-permission-filter_{context}"]
 .CLI procedure
 
 * To create a granular filter, enter the `hammer filter create` command with the `--search` option to limit permission filters, for example:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
@@ -2,7 +2,7 @@
 = Creating a User
 
 Use this procedure to create a user.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-user[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-user_{context}[].
 
 .Procedure
 
@@ -28,7 +28,7 @@ By default, {ProjectServer} uses the language and timezone settings of the userâ
 
 . Click *Submit* to create the user.
 
-[[cli-creating-a-user]]
+[id="cli-creating-a-user_{context}"]
 .CLI procedure
 
 * To create a user, enter the following command:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/managing-ssh-keys-for-a-user.adoc
@@ -2,7 +2,7 @@
 = Managing SSH Keys for a User
 
 Use this procedure to add or remove SSH keys for a user.
-To use the CLI instead of the web UI, see the xref:cli-managing-ssh-keys-for-a-user[].
+To use the CLI instead of the web UI, see the xref:cli-managing-ssh-keys-for-a-user_{context}[].
 
 .Prerequisites
 Make sure that you are logged in to the web UI as an Admin user of {ProjectName} or a user with the __create_ssh_key__ permission enabled for adding SSH key and __destroy_ssh_key__ permission for removing a key.
@@ -23,7 +23,7 @@ Make sure that you are logged in to the web UI as an Admin user of {ProjectName}
 ... Click *Delete* on the row of the SSH key to be deleted.
 ... Click *OK* in the confirmation prompt.
 
-[[cli-managing-ssh-keys-for-a-user]]
+[id="cli-managing-ssh-keys-for-a-user_{context}"]
 .CLI procedure
 
 To add an SSH key to a user, you must specify either the path to the public SSH key file, or the content of the public SSH key copied to the clipboard.

--- a/guides/doc-Content_Management_Guide/topics/Containers_importing_container_images.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Containers_importing_container_images.adoc
@@ -6,7 +6,7 @@ You can import container image repositories from Red Hat Registry or from other 
 This procedure uses repository discovery to find container images and import them as repositories.
 For more information about creating a product and repository manually, see xref:Importing_Content[].
 
-To use the CLI instead of the web UI, see the xref:cli-importing-container-images[].
+To use the CLI instead of the web UI, see the xref:cli-importing-container-images_{context}[].
 
 .Procedure
 
@@ -33,7 +33,7 @@ To view the progress of the synchronization navigate to *Content* > *Sync Status
 When the synchronization completes, you can click *Container Image Manifests* to list the available manifests.
 From the list, you can also remove any manifests that you do not require.
 
-[[cli-importing-container-images]]
+[id="cli-importing-container-images_{context}"]
 .CLI procedure
 
 . Create the custom `Red Hat Container Catalog` product:

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -51,7 +51,7 @@ In the Content Credentials window, click *Create Content Credential*.
 === Creating a {customproducttitle}
 
 Use this procedure to create a {customproduct} that you can then add repositories to.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-product[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-product_{context}[].
 
 .Procedure
 
@@ -66,7 +66,7 @@ To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-product
 . In the *Description* field, enter a description of the product.
 . Click *Save*.
 
-[[cli-creating-a-custom-product]]
+[id="cli-creating-a-custom-product_{context}"]
 .CLI procedure
 
 To create the product, enter the following command:
@@ -84,7 +84,7 @@ To create the product, enter the following command:
 === Adding {customrpmtitle} Repositories
 
 Use this procedure to add {customrpm} repositories in {Project}.
-To use the CLI instead of the web UI, see the xref:cli-adding-rpm-repositories[].
+To use the CLI instead of the web UI, see the xref:cli-adding-rpm-repositories_{context}[].
 
 The Products window in the {Project} web UI also provides a *Repo Discovery* function that finds all repositories from a URL and you can select which ones to add to your {customproduct}.
 For example, you can use the *Repo Discovery* to search, for example, `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures.
@@ -116,7 +116,7 @@ This ensures that the content that is no longer part of the upstream repository 
 . Optional: From the *GPG Key* list, select the GPG key for the product.
 . Click *Save*.
 
-[[cli-adding-rpm-repositories]]
+[id="cli-adding-rpm-repositories_{context}"]
 .CLI procedure
 
 . Enter the following command to create the repository:
@@ -489,7 +489,7 @@ Use this option if you have one of the following errors:
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for Products, repositories, and supported compute resources.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy[].
+To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy_{context}[].
 
 .Procedure
 
@@ -502,7 +502,7 @@ To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy[]
 . Click the *Organization* tab and add an organization.
 . Click *Submit*.
 
-[[cli-adding-a-new-http-proxy]]
+[id="cli-adding-a-new-http-proxy_{context}"]
 .CLI procedure
 
 * On {ProjectServer}, enter the following command to add a new HTTP proxy:
@@ -540,7 +540,7 @@ For more information, see xref:Adding_a_New_HTTP_Proxy[].
 === Changing the HTTP Proxy Policy for a Repository
 
 For granular control over network traffic, you can set an HTTP proxy policy for each repository.
-To use the CLI instead of the web UI, see the xref:cli-changing-the-http-proxy-policy-for-a-repository[].
+To use the CLI instead of the web UI, see the xref:cli-changing-the-http-proxy-policy-for-a-repository_{context}[].
 
 To set the same HTTP proxy policy for all repositories in a Product, see xref:Changing_the_HTTP_Proxy_Policy_for_a_Product[].
 
@@ -557,7 +557,7 @@ You must add HTTP proxies to {Project} before you can select a proxy from this l
 For more information, see xref:Adding_a_New_HTTP_Proxy[].
 . Click *Save*.
 
-[[cli-changing-the-http-proxy-policy-for-a-repository]]
+[id="cli-changing-the-http-proxy-policy-for-a-repository_{context}"]
 .CLI procedure
 
 * On {ProjectServer}, enter the following command, specifying the HTTP proxy policy you want to use:
@@ -582,7 +582,7 @@ To add a new HTTP proxy to {Project}, see xref:Adding_a_New_HTTP_Proxy[].
 A synchronization plan checks and updates the content at a scheduled date and time.
 In {ProjectNameX}, you can create a synchronization plan and assign products to the plan.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-a-synchronization-plan[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-synchronization-plan_{context}[].
 
 .Procedure
 
@@ -595,7 +595,7 @@ To use the CLI instead of the web UI, see the xref:cli-creating-a-synchronizatio
 . Click the *Products* tab, then click *Add*.
 Select the *Red{nbsp}Hat Enterprise Linux Server* product and click *Add Selected*.
 
-[[cli-creating-a-synchronization-plan]]
+[id="cli-creating-a-synchronization-plan_{context}"]
 .CLI procedure
 
 . To create the synchronization plan, enter the following command:
@@ -680,7 +680,7 @@ When clients are consuming signed {customcontent}, ensure that the clients are c
 
 Red Hat content is already configured with the appropriate GPG key and thus GPG Key management of Red Hat Repositories is not supported.
 
-To use the CLI instead of the web UI, see the xref:cli-importing-a-gpg-key[].
+To use the CLI instead of the web UI, see the xref:cli-importing-a-gpg-key_{context}[].
 
 .Prerequisites
 
@@ -729,7 +729,7 @@ Wl5GnzcLGAnUSRamfqGUWcyMMinHHIKIc1X1P4I=
 ----
 . Click *Save*.
 
-[[cli-importing-a-gpg-key]]
+[id="cli-importing-a-gpg-key_{context}"]
 .CLI procedure
 
 . Copy the GPG key to your {ProjectServer}:

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -83,7 +83,7 @@ If a {customproduct}, typically containing content not provided by Red Hat, is a
 .Procedure
 
 To create an activation key, complete the following steps.
-To use the CLI instead of the web UI, see the xref:cli-creating-an-activation-key[].
+To use the CLI instead of the web UI, see the xref:cli-creating-an-activation-key_{context}[].
 
 . In the {Project} web UI, navigate to *Content* > *Activation keys* and click *Create Activation Key*.
 . In the *Name* field, enter the name of the activation key.
@@ -96,7 +96,7 @@ If you want to use this activation key to register hosts, the Content View must 
 . Click *Save*.
 . Optional: For Red{nbsp}Hat Enterprise Linux 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.
 
-[[cli-creating-an-activation-key]]
+[id="cli-creating-an-activation-key_{context}"]
 .CLI procedure
 
 . Create the activation key:
@@ -168,7 +168,7 @@ To enable, enter the following command:
 === Updating Subscriptions Associated with an Activation Key
 
 Use this procedure to change the subscriptions associated with an activation key.
-To use the CLI instead of the web UI, see the xref:cli-updating-subscriptions-associated-with-an-activation-key[].
+To use the CLI instead of the web UI, see the xref:cli-updating-subscriptions-associated-with-an-activation-key_{context}[].
 
 Note that changes to an activation key apply only to machines provisioned after the change.
 To update subscriptions on existing content hosts, see <<Bulk_Updating_Content_Hosts_Subscriptions>>.
@@ -183,7 +183,7 @@ To update subscriptions on existing content hosts, see <<Bulk_Updating_Content_H
 . To enable or disable a repository, select the check box for a repository and then change the status using the *Select Action* list.
 . Click the *Details* tab, select a Content View for this activation key, and then click *Save*.
 
-[[cli-updating-subscriptions-associated-with-an-activation-key]]
+[id="cli-updating-subscriptions-associated-with-an-activation-key_{context}"]
 .CLI procedure
 
 . List the subscriptions that the activation key currently contains:

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -52,7 +52,7 @@ For more information about how to manage package dependencies within Content Vie
 === Creating a Content View
 
 Use this procedure to create a simple Content View.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-content-view[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-content-view_{context}[].
 
 .Prerequisites
 
@@ -79,7 +79,7 @@ To view more information about the Content View, click the Content View name.
 
 To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
-[[cli-creating-a-content-view]]
+[id="cli-creating-a-content-view_{context}"]
 .CLI procedure
 
 . Obtain a list of repository IDs:
@@ -143,7 +143,7 @@ To view module streams for the repositories in your content view, complete the f
 === Creating a Content View with a Puppet Module
 
 Use this procedure to create a Content View using one repository and no filters.
-To use the CLI instead of the web UI, see the xref:cli-adding-a-puppet-module-to-a-content-view[].
+To use the CLI instead of the web UI, see the xref:cli-adding-a-puppet-module-to-a-content-view_{context}[].
 
 .Prerequisites
 
@@ -166,7 +166,7 @@ In the *Description* field, enter a description to log the changes and click *Sa
 
 To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
-[[cli-adding-a-puppet-module-to-a-content-view]]
+[id="cli-adding-a-puppet-module-to-a-content-view_{context}"]
 .CLI procedure
 
 * Enter the following command to add a Puppet module to a Content View:
@@ -182,7 +182,7 @@ To register a host to your content view, see {ManagingHostsDocURL}Registering_Ho
 === Promoting a Content View
 
 Use this procedure to promote Content Views across different lifecycle environments.
-To use the CLI instead of the web UI, see the xref:cli-promoting-a-content-view[].
+To use the CLI instead of the web UI, see the xref:cli-promoting-a-content-view_{context}[].
 
 .Permission Requirements for Content View Promotion
 
@@ -213,7 +213,7 @@ Select the *Production* environment and click *Promote Version*.
 
 Now the repository for the Content View appears in all environments.
 
-[[cli-promoting-a-content-view]]
+[id="cli-promoting-a-content-view_{context}"]
 .CLI procedure
 
 * Promote the Content View using the `hammer content-view version promote` each time:
@@ -331,7 +331,7 @@ For example, if you attempt to include two Content Views using the same reposito
 === Creating a Composite Content View
 
 Use this procedure to create a composite content view.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-composite-content-view[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-composite-content-view_{context}[].
 
 .Procedure
 
@@ -347,7 +347,7 @@ To use the CLI instead of the web UI, see the xref:cli-creating-a-composite-cont
 In the *Description* field, enter a description and click *Save*.
 . Click *Promote* and select the lifecycle environments to promote the Composite Content View to, enter a description, and then click *Promote Version*.
 
-[[cli-creating-a-composite-content-view]]
+[id="cli-creating-a-composite-content-view_{context}"]
 .CLI procedure
 
 . Before you create the Composite Content Views, list the version IDs for your existing Content Views:
@@ -566,7 +566,7 @@ For another example of how content filters work, see the following article: http
 === Creating a Content Filter
 
 Use this procedure to create a content filter.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-content-filter[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-content-filter_{context}[].
 
 For examples of how to build a filter, see xref:Managing_Content_Views-Content_Filter_Examples[].
 
@@ -586,7 +586,7 @@ In the *Description* field, enter a description of the changes, and click *Save*
 
 You can promote this Content View across all environments.
 
-[[cli-creating-a-content-filter]]
+[id="cli-creating-a-content-filter_{context}"]
 .CLI procedure
 
 . Add a filter to the Content View.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -19,7 +19,7 @@ This method is useful when you have multiple files to add to a {Project} reposit
 The procedure for creating a {customfiletype} repository is the same as the procedure for creating any {customcontent}, except that when you create the repository, you select the *file* type.
 You must create a product and then add a {customrepo}.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-file-type-repository[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-custom-file-type-repository_{context}[].
 
 .Procedure
 
@@ -47,7 +47,7 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . Click *Save*.
 
-[[cli-creating-a-custom-file-type-repository]]
+[id="cli-creating-a-custom-file-type-repository_{context}"]
 .CLI procedure
 
 . Create a {customproduct}

--- a/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
@@ -39,7 +39,7 @@ This chapter shows how to manage errata and apply them to either a single host o
 === Inspecting Available Errata
 
 The following procedure describes how to view and filter the available errata and how to display metadata of the selected advisory.
-To use the CLI instead of the web UI, see the xref:cli-inspecting-available-errata[].
+To use the CLI instead of the web UI, see the xref:cli-inspecting-available-errata_{context}[].
 
 .Procedure
 
@@ -77,7 +77,7 @@ Press *Enter* to start the search.
 * The *Repositories* tab lists repositories that already contain the erratum.
 You can filter repositories by the environment and Content View, and search for them by the repository name.
 
-[[cli-inspecting-available-errata]]
+[id="cli-inspecting-available-errata_{context}"]
 .CLI procedure
 
 * To view errata that are available for all organizations, enter the following command:
@@ -181,7 +181,7 @@ Create a content filter to exclude errata after a certain date.
 This ensures your production systems in the application life cycle are kept up to date to a certain point.
 Then you can modify the filter's start date to introduce new errata into your testing environment to test the compatibility of new packages into your application life cycle.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-a-content-view-filter-for-errata[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-content-view-filter-for-errata_{context}[].
 
 .Prerequisites
 
@@ -221,7 +221,7 @@ This means the filter successfully excluded the all non-security errata from the
 . In the *Description* field, enter the description for promoting.
 . Click *Promote Version* to promote this Content View version across the required environments.
 
-[[cli-creating-a-content-view-filter-for-errata]]
+[id="cli-creating-a-content-view-filter-for-errata_{context}"]
 .CLI procedure
 
 . Create a filter for the errata:
@@ -267,7 +267,7 @@ This means the filter successfully excluded the all non-security errata from the
 If errata are available but not installable, you can create an incremental Content View version to add the errata to your content hosts.
 For example, if the Content View is version 1.0, it becomes Content View version 1.1, and when you publish, it becomes Content View version 2.0.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-errata-to-an-incremental-content-view[].
+To use the CLI instead of the web UI, see the xref:cli-adding-errata-to-an-incremental-content-view_{context}[].
 
 .Procedure
 
@@ -287,7 +287,7 @@ Then, the errata will be marked as `Installable` and you can use the procedure a
 
 . Click *Confirm* to apply the errata.
 
-[[cli-adding-errata-to-an-incremental-content-view]]
+[id="cli-adding-errata-to-an-incremental-content-view_{context}"]
 .CLI procedure
 
 . List the errata and its corresponding IDs:

--- a/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
@@ -9,7 +9,7 @@ You can also upload other files, such as virtual machine images, and publish the
 The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
 The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
 
-To use the CLI instead of the web UI, see the xref:cli-importing-iso-images-from-red-hat[].
+To use the CLI instead of the web UI, see the xref:cli-importing-iso-images-from-red-hat_{context}[].
 
 .Procedure
 
@@ -25,7 +25,7 @@ To use the CLI instead of the web UI, see the xref:cli-importing-iso-images-from
 
 * In the web UI, navigate to *Content* > *Sync Status* and expand *Red Hat Enterprise Linux Server*.
 
-[[cli-importing-iso-images-from-red-hat]]
+[id="cli-importing-iso-images-from-red-hat_{context}"]
 .CLI procedure
 
 . Locate the Red{nbsp}Hat Enterprise Linux Server product for `file` repositories:
@@ -69,7 +69,7 @@ Use this procedure to manually import ISO content and other files to {ProjectSer
 To import files, you can complete the following steps in the web UI or using the Hammer CLI.
 However, if the size of the file that you want to upload is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
 
-To use the CLI instead of the web UI, see the xref:cli-importing-indovidual-iso-images-and-files[].
+To use the CLI instead of the web UI, see the xref:cli-importing-indovidual-iso-images-and-files_{context}[].
 
 .Procedure
 
@@ -91,7 +91,7 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 . Navigate to the *Upload File* and click *Browse*.
 . Select the `.iso` file and click *Upload*.
 
-[[cli-importing-indovidual-iso-images-and-files]]
+[id="cli-importing-indovidual-iso-images-and-files_{context}"]
 .CLI procedure
 
 . Create the {customproduct}:

--- a/guides/doc-Content_Management_Guide/topics/Managing_Locations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Locations.adoc
@@ -11,7 +11,7 @@ Organizations and locations have the following conceptual differences:
 === Creating a Location
 
 Use this procedure to create a location so that you can manage your hosts and resources by location.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-location[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-location_{context}[].
 
 .Procedure
 
@@ -28,7 +28,7 @@ This includes networking resources, installation media, kickstart templates, and
 You can return to this page at any time by navigating to *Administer* > *Locations* and then selecting a location to edit.
 . Click *Submit* to save your changes.
 
-[[cli-creating-a-location]]
+[id="cli-creating-a-location_{context}"]
 .CLI procedure
 
 * Enter the following command to create a location:

--- a/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
@@ -21,7 +21,7 @@ If you ever have a reason to enable the tool, enter the following command:
 
 Red{nbsp}Hat CDN provides OSTree Content for you to select and synchronize.
 
-To use the CLI instead of the web UI, see the xref:cli-selecting-ostree-content-to-synchronize[].
+To use the CLI instead of the web UI, see the xref:cli-selecting-ostree-content-to-synchronize_{context}[].
 
 .Procedure
 
@@ -47,7 +47,7 @@ Enter the required number into the field below.
 
 * In the {Project} web UI, navigate to *Content* > *Sync Status* and expand, for example, *Red{nbsp}Hat Enterprise Linux Atomic Host*.
 
-[[cli-selecting-ostree-content-to-synchronize]]
+[id="cli-selecting-ostree-content-to-synchronize_{context}"]
 .CLI procedure
 
 . Search the Red{nbsp}Hat Enterprise Linux Server product for `ostree` repositories:
@@ -87,7 +87,7 @@ Enter the required number into the field below.
 In addition to importing OSTree content from Red{nbsp}Hat CDN, you can also import content from other sources.
 This requires a published HTTP location for the OSTree to import.
 
-To use the CLI instead of the web UI, see the xref:cli-importing-ostree-content[].
+To use the CLI instead of the web UI, see the xref:cli-importing-ostree-content_{context}[].
 
 .Procedure
 
@@ -114,7 +114,7 @@ Enter the required number into the field below.
 .To view the Synchronization Status:
 * In the {Project} web UI, navigate to *Content* > *Sync Status* and expand the entry that you want to view.
 
-[[cli-importing-ostree-content]]
+[id="cli-importing-ostree-content_{context}"]
 .CLI procedure
 
 . Create a product for your {customostreecontent}:
@@ -155,7 +155,7 @@ Enter the required number into the field below.
 Use Content Views to manage OSTree branches across the application life cycle.
 This process uses the same publication and promotion method that RPMs and Puppet modules use.
 
-To use the CLI instead of the web UI, see the xref:cli-managing-ostree-content-with-content-views[].
+To use the CLI instead of the web UI, see the xref:cli-managing-ostree-content-with-content-views_{context}[].
 
 .Procedure
 
@@ -173,7 +173,7 @@ Click *Add Repository* to add the OSTree content from this repository to the Con
 
 You can also click *Promote* to promote this Content View across environments in the application life cycle.
 
-[[cli-managing-ostree-content-with-content-views]]
+[id="cli-managing-ostree-content-with-content-views_{context}"]
 .CLI procedure
 
 . Obtain a list of repository IDs:

--- a/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
@@ -34,7 +34,7 @@ The next time the user logs on to {Project}, the user's account has the correct 
 === Creating an Organization
 
 Use this procedure to create an organization.
-To use the CLI instead of the web UI, see xref:cli-creating-an-organization[].
+To use the CLI instead of the web UI, see xref:cli-creating-an-organization_{context}[].
 
 .Procedure
 
@@ -52,7 +52,7 @@ This includes networking resources, installation media, kickstart templates, and
 You can return to this page at any time by navigating to *Administer* > *Organizations* and then selecting an organization to edit.
 . Click *Submit*.
 
-[[cli-creating-an-organization]]
+[id="cli-creating-an-organization_{context}"]
 .CLI procedure
 
 . To create an organization, enter the following command:

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
@@ -2,7 +2,7 @@
 = Adding a Bonded Interface
 
 Use this procedure to configure a bonded interface for a host.
-To use the CLI instead of the web UI, see the xref:cli-adding-a-bonded-interface[].
+To use the CLI instead of the web UI, see the xref:cli-adding-a-bonded-interface_{context}[].
 
 .Procedure
 
@@ -31,7 +31,7 @@ See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7
 . Click *OK* to save the interface configuration.
 . Click *Submit* to apply the changes to the host.
 
-[[cli-adding-a-bonded-interface]]
+[id="cli-adding-a-bonded-interface_{context}"]
 .CLI procedure
 
 * To create a host with a bonded interface, enter the following command:

--- a/guides/doc-Managing_Hosts/topics/proc_creating-a-host-group.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_creating-a-host-group.adoc
@@ -9,7 +9,7 @@ A host group functions as a template for common host settings, containing many o
 When you create a host with a host group, the host inherits the defined settings from the host group.
 You can then provide additional details to individualize the host.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-a-host-group[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-host-group_{context}[].
 
 .Host Group Hierarchy
 
@@ -56,7 +56,7 @@ To create a suitable Puppet environment to be associated with a host group, manu
 ====
 . Click *Submit* to save the host group.
 
-[[cli-creating-a-host-group]]
+[id="cli-creating-a-host-group_{context}"]
 .CLI procedure
 
 * Create the host group with the `hammer hostgroup create` command.

--- a/guides/doc-Managing_Hosts/topics/proc_creating-a-host-in-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_creating-a-host-in-satellite.adoc
@@ -3,7 +3,7 @@
 = Creating a Host in {ProjectName}
 
 Use this procedure to create a host in {ProjectName}.
-To use the CLI instead of the web UI, see the xref:cli-creating-a-host[].
+To use the CLI instead of the web UI, see the xref:cli-creating-a-host_{context}[].
 
 .Procedure
 
@@ -67,7 +67,7 @@ endif::[]
 . On the *Additional Information* tab, enter additional information about the host.
 . Click *Submit* to complete your provisioning request.
 
-[[cli-creating-a-host]]
+[id="cli-creating-a-host_{context}"]
 .CLI procedure
 
 * To create a host associated to a host group, enter the following command:

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-using-the-bootstrap-script.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-using-the-bootstrap-script.adoc
@@ -132,7 +132,7 @@ In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}* and fin
 == Setting Permissions for the Bootstrap Script
 
 Use this procedure to configure a {Project} user with the permissions required to run the bootstrap script.
-To use the CLI instead of the web UI, see the xref:li-setting-permissions-for-the-bootstrap-script[].
+To use the CLI instead of the web UI, see the xref:cli-setting-permissions-for-the-bootstrap-script_{context}[].
 
 .Procedure
 
@@ -164,7 +164,7 @@ If this is not acceptable to your security policy, create a new role with the fo
 
 . Click *Submit*.
 
-[[cli-setting-permissions-for-the-bootstrap-script]]
+[id="cli-setting-permissions-for-the-bootstrap-script_{context}"]
 .CLI procedure
 
 . Create a role with the minimum permissions required by the bootstrap script.

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -84,7 +84,7 @@ You enter the host details on {ProjectServer} and boot your host.
 
 This method of provisioning hosts uses minimal interaction during the process.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-unattended-provisioning[].
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-unattended-provisioning_{context}[].
 
 .Procedure
 
@@ -137,7 +137,7 @@ ifdef::foreman-el,katello[]
 If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
-[[cli-creating-hosts-with-unattended-provisioning]]
+[id="cli-creating-hosts-with-unattended-provisioning_{context}"]
 .CLI procedure
 
 . Create the host with the `hammer host create` command.
@@ -203,7 +203,7 @@ The *Full host image* is based on SYSLINUX and works with most hardware.
 endif::[]
 When using a *Host image*, *Generic image*, or *Subnet image*, see http://ipxe.org/appnote/hardware_drivers for a list of hardware drivers expected to work with an iPXE-based boot disk.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-pxe-less-provisioning[].
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-pxe-less-provisioning_{context}[].
 
 .Procedure
 
@@ -242,7 +242,7 @@ This creates a host entry and the host details page appears.
 The options on the upper-right of the window are the *Boot disk* menu.
 From this menu, one of the following images is available for download: *Host image*, *Full host image*, *Generic image*, and *Subnet image*.
 
-[[cli-creating-hosts-with-pxe-less-provisioning]]
+[id="cli-creating-hosts-with-pxe-less-provisioning_{context}"]
 .CLI procedure
 
 . Create the host with the `hammer host create` command.
@@ -308,7 +308,7 @@ endif::[]
 You can provision hosts from {Project} using the UEFI HTTP Boot.
 This is the only method with which you can provision hosts in IPv6 network.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-uefi-http-boot-provisioning[].
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-with-uefi-http-boot-provisioning_{context}[].
 
 .Prerequisites
 
@@ -388,7 +388,7 @@ ifdef::foreman-el,katello[]
 If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
-[[cli-creating-hosts-with-uefi-http-boot-provisioning]]
+[id="cli-creating-hosts-with-uefi-http-boot-provisioning_{context}"]
 .CLI procedure
 
 . On {SmartProxy} that you use for provisioning, update the `grub2-efi` package to the latest version:

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
@@ -20,7 +20,7 @@ include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 === Adding an Amazon EC2 Connection to the {ProjectServer}
 
 Use this procedure to add the Amazon EC2 connection in the {ProjectServer}'s compute resources.
-To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-connection_{context}[].
 
 .Time Settings and Amazon Web Services
 Amazon Web Services uses time settings as part of the authentication process.
@@ -51,7 +51,7 @@ For more information, see http://docs.aws.amazon.com/general/latest/gr/managing-
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1793138[BZ1793138] is resolved, you can download a copy of the SSH keys only immediately after creating the Amazon EC2 compute resource.
 If you require SSH keys at a later stage, follow the procedure in xref:connecting_to_an_Amazon_EC2_instance_using_SSH[].
 
-[[cli-adding-amazon-ec2-connection]]
+[id="cli-adding-amazon-ec2-connection_{context}"]
 .CLI procedure
 
 * Create the connection with the `hammer compute-resource create` command.
@@ -91,7 +91,7 @@ Amazon EC2 uses image-based provisioning to create hosts.
 You must add image details to your {ProjectServer}.
 This includes access details and image location.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-images[].
+To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-images_{context}[].
 
 .Procedure
 
@@ -111,7 +111,7 @@ This also applies in reverse: if you enable the Finish scripts, this disables us
 . Optional: In the *IAM role* field, enter the Amazon security role used for creating the image.
 . Click *Submit* to save the image details.
 
-[[cli-adding-amazon-ec2-images]]
+[id="cli-adding-amazon-ec2-images_{context}"]
 .CLI procedure
 
 * Create the image with the `hammer compute-resource image create` command.
@@ -152,7 +152,7 @@ As an alternative, you can include the same settings directly during the host cr
 === Creating Image-Based Hosts on Amazon EC2
 
 The Amazon EC2 provisioning process creates hosts from existing images on the Amazon EC2 server.
-To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-amazon-ec2[].
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-amazon-ec2_{context}[].
 
 .Procedure
 
@@ -178,7 +178,7 @@ endif::[]
 
 This new host entry triggers the Amazon EC2 server to create the instance, using the pre-existing image as a basis for the new volume.
 
-[[cli-creating-hosts-on-amazon-ec2]]
+[id="cli-creating-hosts-on-amazon-ec2_{context}"]
 .CLI procedure
 
 * Create the host with the `hammer host create` command and include `--provision-method image` to use image-based provisioning.

--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -479,7 +479,7 @@ If you experience timeouts during DNS conflict resolution, check the following s
 * The domain name must have a Start of Authority (SOA) record available from {ProjectServer}.
 * The system resolver in the `/etc/resolv.conf` file must have a valid and working configuration.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-a-domain[].
+To use the CLI instead of the web UI, see the xref:cli-adding-a-domain_{context}[].
 
 .Procedure
 
@@ -495,7 +495,7 @@ For example, user defined Boolean or string parameters to use in templates.
 . Click the *Organizations* tab, and add the organization that the domain belongs to.
 . Click *Submit* to save the changes.
 
-[[cli-adding-a-domain]]
+[id="cli-adding-a-domain_{context}"]
 .CLI procedure
 
 * Use the `hammer domain create` command to create a domain:
@@ -515,7 +515,7 @@ In this example, the `--dns-id` option uses `1`, which is the ID of your integra
 You must add information for each of your subnets to {ProjectServer} because {Project} configures interfaces for new hosts.
 To configure interfaces, {ProjectServer} must have all the information about the network that connects these interfaces.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-a-subnet[].
+To use the CLI instead of the web UI, see the xref:cli-adding-a-subnet_{context}[].
 
 .Procedure
 
@@ -546,7 +546,7 @@ For example, user defined Boolean or string parameters to use in templates.
 . Click the *Organizations* tab and select the organizations that use this {SmartProxy}.
 . Click *Submit* to save the subnet information.
 
-[[cli-adding-a-subnet]]
+[id="cli-adding-a-subnet_{context}"]
 .CLI procedure
 
 * Create the subnet with the following command:

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -46,7 +46,7 @@ For VMware vCenter Server version 6.5, set the following permissions:
 === Adding a VMware vSphere Connection to {ProjectServer}
 
 Use this procedure to add a VMware vSphere connection in {ProjectServer}'s compute resources.
-To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-connection[].
+To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-connection_{context}[].
 
 Ensure that the host and network-based firewalls are configured to allow {Project} to vCenter communication on TCP port 443.
 Verify that {Project} is able to resolve the host name of vCenter and vCenter is able to resolve {ProjectServer}'s host name.
@@ -81,7 +81,7 @@ For more information, see xref:Provisioning_Virtual_Machines_in_VMware_vSphere-C
 You can also add additional contexts.
 . Click *Submit* to save the connection.
 
-[[cli-adding-vmware-vsphere-connection]]
+[id="cli-adding-vmware-vsphere-connection_{context}"]
 .CLI procedure
 
 * Create the connection with the `hammer compute-resource create` command.
@@ -104,7 +104,7 @@ VMware vSphere uses templates as images for creating new virtual machines.
 If using image-based provisioning to create new hosts, you need to add VMware template details to your {ProjectServer}.
 This includes access details and the template name.
 
-To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-images-to-server[].
+To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-images-to-server_{context}[].
 
 .Procedure
 
@@ -120,7 +120,7 @@ This is normally the `root` user.
 Do not include the data center in the relative path.
 . Click *Submit* to save the image details.
 
-[[cli-adding-vmware-vsphere-images-to-server]]
+[id="cli-adding-vmware-vsphere-images-to-server_{context}"]
 .CLI procedure
 
 * Create the image with the `hammer compute-resource image create` command.
@@ -139,7 +139,7 @@ Use the `--uuid` field to store the relative template path on the vSphere enviro
 
 You can predefine certain hardware settings for virtual machines on VMware vSphere.
 You achieve this through adding these hardware settings to a compute profile.
-To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-details-to-a-compute-profile[].
+To use the CLI instead of the web UI, see the xref:cli-adding-vmware-vsphere-details-to-a-compute-profile_{context}[].
 
 .Procedure
 
@@ -162,7 +162,7 @@ However, at least one interface must point to a {SmartProxy}-managed network.
 If unchecked, the disk uses lazy zero thick provisioning.
 . Click *Submit* to save the compute profile.
 
-[[cli-adding-vmware-vsphere-details-to-a-compute-profile]]
+[id="cli-adding-vmware-vsphere-details-to-a-compute-profile_{context}"]
 .CLI procedure
 
 . To create the compute profile, enter the following command:
@@ -198,7 +198,7 @@ This causes DHCP conflicts with {ProjectServer} when booting new hosts.
 
 For image-based provisioning, use the pre-existing image as a basis for the new volume.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-vmware-vsphere[].
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-vmware-vsphere_{context}[].
 
 .Procedure
 
@@ -246,7 +246,7 @@ If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host entry.
 
-[[cli-creating-hosts-on-vmware-vsphere]]
+[id="cli-creating-hosts-on-vmware-vsphere_{context}"]
 .CLI procedure
 
 * Create the host from a network with the `hammer host create` command and include `--provision-method build` to use network-based provisioning.

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-discovery-rules.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-discovery-rules.adoc
@@ -6,7 +6,7 @@ These rules define how discovered hosts automatically provision themselves, base
 For example, you can automatically provision hosts with a high CPU count as hypervisors.
 Likewise, you can provision hosts with large hard disks as storage servers.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-discovery-rules[].
+To use the CLI instead of the web UI, see the xref:cli-creating-discovery-rules_{context}[].
 
 .NIC Considerations
 Auto provisioning does not currently allow configuring NICs; all systems are being provisioned with the NIC configuration that was detected during discovery.
@@ -46,7 +46,7 @@ Rules with lower values have a higher priority.
 * From the *Discovered hosts* list on the right, select *Auto-Provision* to automatically provisions a single host.
 * On the upper right of the window, click *Auto-Provision All* to automatically provisions all hosts.
 
-[[cli-creating-discovery-rules]]
+[id="cli-creating-discovery-rules_{context}"]
 .CLI procedure
 
 . Create the rule with the `hammer discovery-rule create` command:

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -4,7 +4,7 @@
 Provisioning discovered hosts follows a provisioning process that is similar to PXE provisioning.
 The main difference is that instead of manually entering the host's MAC address, you can select the host to provision from the list of discovered hosts.
 
-To use the CLI instead of the web UI, see the xref:cli-creating-hosts-from-discovered-hosts[].
+To use the CLI instead of the web UI, see the xref:cli-creating-hosts-from-discovered-hosts_{context}[].
 
 .Prerequisites
 
@@ -49,7 +49,7 @@ For more information about associating provisioning templates, see xref:provisio
 When the host provisioning is complete, the discovered host becomes a content host.
 To view the host, navigate to *Hosts* > *Content Hosts*.
 
-[[cli-creating-hosts-from-discovered-hosts]]
+[id="cli-creating-hosts-from-discovered-hosts_{context}"]
 .CLI procedure
 
 . Identify the discovered host to use for provisioning:


### PR DESCRIPTION
For Issue #470

"It's only an xref to an ID within the same file", I thought when I added the CLI procedure IDs. "It doesn't need a complex ID", I thought. But no, if the file is being reused, the CLI procedure still needs the complex {context} ID (as does the xref to it), so now I've given all of them the appropriate ID format, which I should have just done in the first place.

There are still some duplicate IDs in the install guides, which need a different fix as shown in PR #469.

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
