### PR TITLE
Corrected protocols for ICMP/ECHO

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -80,18 +80,21 @@ endif::[]
 |====
 
 
-
 .Ports for {SmartProxy} to Client Communication
 [cols="24%,20%,18%,38%a",options="header"]
 |====
 | Port | Protocol | Service | Required For
-| 7 | TCP and UDP | ICMP | DHCP {SmartProxy} to Client network, ICMP ECHO to verify IP address is free (Optional)
+| - | ICMP | ping | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
+| 7 | TCP | echo | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
 | 68 | UDP | DHCP | {SmartProxy} to Client broadcasts, DHCP broadcasts for Client provisioning from a {SmartProxy} (Optional)
 | 8443 | TCP |HTTP | {SmartProxy} to Client "reboot" command to a discovered host during provisioning (Optional)
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
 This includes the base operating system on which a {SmartProxyServer} is running.
+
+A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
+This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
 
 .Optional Network Ports

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -75,7 +75,8 @@ endif::[]
 | 8140 | TCP | HTTPS | Puppet agent to Puppet master connections
 | 9090 | TCP | HTTPS | Sending SCAP reports to the integrated {SmartProxy}, for the discovery image during provisioning, and for communicating with {ProjectServer} to copy the SSH keys for Remote Execution (Rex) configuration
 ifeval::["{mode}" == "connected"]
-| 7 | TCP and UDP | ICMP | External DHCP on a Client to {Project} network, ICMP ECHO to verify IP address is free (Optional)
+| - | ICMP | ping | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
+| 7 | TCP | echo | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
 endif::[]
 | 53 | TCP and UDP | DNS | Client DNS queries to a {Project}'s integrated {SmartProxy} DNS service (Optional)
 | 67 | UDP | DHCP | Client to {Project}'s integrated {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {Project}'s integrated {SmartProxy} (Optional)
@@ -84,6 +85,9 @@ endif::[]
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
 This includes the base operating system on which a {SmartProxyServer} is running.
+
+A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
+This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
 .Ports for {Project} to {SmartProxy} Communication
 [cols="24%,20%,18%,38%",options="header"]


### PR DESCRIPTION
ICMP has no ports, it is a different (port-less) protocol and Smart Porxy uses ping message type.

ECHO is an (ancient) protocol which works both on TCP and UDP, however Smart Proxy only uses TCP version.

Both are used to find out if an IP address, which is considered as free to be used, is not alive.

This can be turned off completely via a setting option (via the installer).