### PR TITLE
Add step to enable Ruby 2.7 module on EL8

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -49,6 +49,17 @@ include::proc_configuring-repositories-el.adoc[]
 
 endif::[]
 
+ifdef::foreman-el,katello[]
++
+. Enable Ruby 2.7 module:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} module reset ruby
+# {package-manager} module enable ruby:2.7
+----
+endif::[]
+
 ifdef::katello[]
 +
 . Enable `powertools` repository:


### PR DESCRIPTION

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
