### PR TITLE
Update to section 6.5. Adding Custom RPM Repositories

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -107,6 +107,9 @@ endif::[]
 {ProjectNameX} automatically completes the *Label* field based on what you have entered for *Name*.
 . From the *Type* list, select the type of repository.
 You can select either a repository for RPM files (`yum`), Docker images (`docker`), Files (`file`) or other.
+. If `yum` content type is selected, you can restrict whether the repository is available to a host based on the host's architecture and OS version.
+.. Optional: From the *Restrict to Architecture* list, select the architecture. The repository will be enabled on content hosts with the selected architecture. Select *No restriction*, which is the default value, to make the repository available to all hosts regardless of the architecture.
+.. Optional: From the *Restrict to OS Version* list, select the OS version. The repository will be enabled on content hosts with the selected OS version. Select *No restriction*, which is the default value, to make the repository available to all hosts regardless of the OS version.
 . In the *URL* field, enter the URL of the external repository to use as a source.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs. See xref:Importing_Content-Configuring_Download_Policies[]
 . Ensure that the *Mirror on Sync* check box is selected.
@@ -126,6 +129,8 @@ This ensures that the content that is no longer part of the upstream repository 
 # hammer repository create \
 --name "_My_Repository_" \
 --content-type "yum" \
+--os-version "_My_OS_Version_" \
+--arch "_My_System_Architecture_" \
 --publish-via-http true \
 --url _http://yum.postgresql.org/9.5/redhat/rhel-7-x86_64/_ \
 --gpg-key "_My_Repository_" \

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -87,7 +87,7 @@ Use this procedure to add {customrpm} repositories in {Project}.
 To use the CLI instead of the web UI, see the xref:cli-adding-rpm-repositories_{context}[].
 
 The Products window in the {Project} web UI also provides a *Repo Discovery* function that finds all repositories from a URL and you can select which ones to add to your {customproduct}.
-For example, you can use the *Repo Discovery* to search, for example, `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures.
+For example, you can use the *Repo Discovery* to search `http://yum.postgresql.org/9.5/redhat/` and list all repositories for different Red Hat Enterprise Linux versions and architectures.
 This helps users save time importing multiple repositories from a single source.
 
 ifdef::satellite[]
@@ -102,7 +102,7 @@ endif::[]
 
 .Procedure
 
-. In the {Project} web UI, navigate to *Content* > *Products* and select the product that you want to use, and then click *Create Repository*.
+. In the {Project} web UI, navigate to *Content* > *Products* and select the product that you want to use, and then click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 {ProjectNameX} automatically completes the *Label* field based on what you have entered for *Name*.
 . From the *Type* list, select the type of repository.

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -106,10 +106,9 @@ endif::[]
 . In the *Name* field, enter a name for the repository.
 {ProjectNameX} automatically completes the *Label* field based on what you have entered for *Name*.
 . From the *Type* list, select the type of repository.
-You can select either a repository for RPM files (`yum`), Docker images (`docker`), Files (`file`) or other.
-. If `yum` content type is selected, you can restrict whether the repository is available to a host based on the host's architecture and OS version.
-.. Optional: From the *Restrict to Architecture* list, select the architecture. The repository will be enabled on content hosts with the selected architecture. Select *No restriction*, which is the default value, to make the repository available to all hosts regardless of the architecture.
-.. Optional: From the *Restrict to OS Version* list, select the OS version. The repository will be enabled on content hosts with the selected OS version. Select *No restriction*, which is the default value, to make the repository available to all hosts regardless of the OS version.
+You can select either a repository for RPM files (`yum`), Docker images (`docker`), Files (`file`) or other. Note that if the `yum` content type is selected, you can restrict whether the repository is available to a host based on the host's architecture and OS version.
+. Optional: From the *Restrict to Architecture* list, select the architecture. Ensure that *No restriction*, which is the default value, is selected to make the repository available to all hosts regardless of the architecture.
+. Optional: From the *Restrict to OS Version* list, select the OS version. Ensure that *No restriction*, which is the default value, is selected to make the repository available to all hosts regardless of the OS version.
 . In the *URL* field, enter the URL of the external repository to use as a source.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs. See xref:Importing_Content-Configuring_Download_Policies[]
 . Ensure that the *Mirror on Sync* check box is selected.


### PR DESCRIPTION
-label fix
-new steps

Need to add steps for custom repo creating to consider/explain restrict to Architecture & OS version feature
https://bugzilla.redhat.com/show_bug.cgi?id=1933782



Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
