### PR TITLE
Remove "the" before "ProjectServer"

### DIFF
--- a/guides/common/modules/con_acd_introduction.adoc
+++ b/guides/common/modules/con_acd_introduction.adoc
@@ -11,7 +11,7 @@ These hosts have dependencies on each other, for example, an application server 
 The number of deployed hosts depends on the expected usage of the application.
 You can scale an application instance vertically via compute profile or horizontally by choosing multiple hosts to run the same service to handle increased workloads.
 
-Within ACD, Ansible playbooks are executed on the {ProjectServer}.
+Within ACD, Ansible playbooks are executed on {ProjectServer}.
 Ensure that {ProjectServer} can connect to all managed hosts using Ansible.
 
 .Host Centric vs. Application Centric Deployment

--- a/guides/common/modules/con_provisioning-contexts.adoc
+++ b/guides/common/modules/con_provisioning-contexts.adoc
@@ -6,7 +6,7 @@ The organization and location that a component belongs to sets the ownership and
 
 Organizations divide {ProjectNameX} components into logical groups based on ownership, purpose, content, security level, and other divisions.
 You can create and manage multiple organizations through {ProjectNameX} and assign components to each individual organization.
-This ensures the {ProjectServer} provisions hosts within a certain organization and only uses components that are assigned to that organization.
+This ensures {ProjectServer} provisions hosts within a certain organization and only uses components that are assigned to that organization.
 For more information about organizations, see {ContentManagementDocURL}Managing_Organizations[Managing Organizations] in the _Content Management Guide_.
 
 Locations function similar to organizations.

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -1,7 +1,7 @@
 [id="configuring-capsule-default-certificate_{context}"]
 = Configuring {SmartProxyServer} with a Default SSL Certificate
 
-Use this section to configure {SmartProxyServer} with an SSL certificate that is signed by the {ProjectServer} default Certificate Authority (CA).
+Use this section to configure {SmartProxyServer} with an SSL certificate that is signed by {ProjectServer} default Certificate Authority (CA).
 
 .Prerequisites
 

--- a/guides/common/modules/proc_configuring-external-dns.adoc
+++ b/guides/common/modules/proc_configuring-external-dns.adoc
@@ -87,7 +87,7 @@ Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to t
 # systemctl restart foreman-proxy
 ----
 
-. Log in to the {ProjectServer} web UI.
+. Log in to {ProjectServer} web UI.
 
 . Navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProductName}, and from the list in the *Actions* column, select *Refresh*.
 

--- a/guides/common/modules/proc_configuring-external-tftp.adoc
+++ b/guides/common/modules/proc_configuring-external-tftp.adoc
@@ -41,7 +41,7 @@ _TFTP_Server_IP_Address_:/exports/var/lib/tftpboot /mnt/nfs/var/lib/tftpboot nfs
 # {foreman-installer} --foreman-proxy-tftp-servername=_TFTP_Server_FQDN_
 ----
 
-. Log in to the {ProjectServer} web UI.
+. Log in to {ProjectServer} web UI.
 
 . Navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProductName}, and from the list in the *Actions* column, select *Refresh*.
 

--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -98,7 +98,7 @@ bash-4.2$ exit
 ----
 [cols="40%,60%",options="header"]
 
-. Log in to the {ProjectServer} web UI.
+. Log in to {ProjectServer} web UI.
 
 . Navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProductName}, and from the list in the *Actions* column, select *Refresh*.
 

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -40,7 +40,7 @@ baseurl=file:///media/rhel7-server/
 # yum repolist
 ----
 
-. Create a directory to serve as the mount point for the ISO file of the {ProjectServer}.
+. Create a directory to serve as the mount point for the ISO file of {ProjectServer}.
 +
 [options="nowrap"]
 ----

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -3,7 +3,7 @@
 
 In {Project}, you can use {CRname} provisioning to create hosts over a network connection or from an existing image:
 
-* If you want to create a host over a network connection, the new host must be able to access either the {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} on a {CRname} virtual network, so that the host has access to PXE provisioning services.
+* If you want to create a host over a network connection, the new host must be able to access either {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} on a {CRname} virtual network, so that the host has access to PXE provisioning services.
 This new host entry triggers the {CRname} server to create and start a virtual machine.
 If the virtual machine detects the defined {SmartProxyServer} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -18,7 +18,7 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 -k __/root/satellite_cert/satellite_cert_key.pem__ \  <2>
 -b __/root/satellite_cert/ca_cert_bundle.pem__        <3>
 ----
-<1> Path to the {ProjectServer} certificate file that is signed by a Certificate Authority.
+<1> Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
 <2> Path to the private key that was used to sign {SmartProxyServer} certificate.
 <3> Path to the Certificate Authority bundle.
 +

--- a/guides/common/modules/proc_installing-server-packages-el.adoc
+++ b/guides/common/modules/proc_installing-server-packages-el.adoc
@@ -7,7 +7,7 @@
 # {package-manager} update
 ----
 ifdef::satellite[]
-. Install the {ProjectServer} packages:
+. Install {ProjectServer} packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="installing-server-packages_{context}"]
 [id="installing-the-satellite-server-packages_{context}"]
-= Installing the {ProjectServer} Packages
+= Installing {ProjectServer} Packages
 
 ifdef::foreman-el,katello[]
 * xref:#centos-7[CentOS 7]

--- a/guides/common/modules/proc_registering-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-to-satellite-server.adoc
@@ -17,7 +17,7 @@ Use this procedure to register the base operating system on which you want to in
 For more information on manifests and repositories, see {ContentManagementDocURL}Managing_Subscriptions/[Managing Subscriptions] in the _{ProjectName} Content Management Guide_.
 
 .Proxy and Network Prerequisites
-* The {ProjectServer} base operating system must be able to resolve the host name of the {SmartProxy} base operating system and vice versa.
+* {ProjectServer} base operating system must be able to resolve the host name of the {SmartProxy} base operating system and vice versa.
 ifndef::foreman-deb[]
 * The base operating system on which you want to install {SmartProxyServer} must not be configured to use a proxy to connect to the Red Hat CDN.
 endif::[]

--- a/guides/common/modules/proc_resolving-package-dependancy-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependancy-errors.adoc
@@ -39,7 +39,7 @@ If you have successfully installed the {Project} packages, skip this procedure.
 # cd /media/sat6/
 ----
 
-. Verify that you have resoled the package dependency errors by installing the {ProjectServer} packages.
+. Verify that you have resoled the package dependency errors by installing {ProjectServer} packages.
 If there are further package dependency errors, repeat this procedure.
 +
 [options="nowrap"]

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -3,7 +3,7 @@
 
 = {SmartProxyServer} Scalability Considerations
 
-The maximum number of {SmartProxyServer}s that the {ProjectServer} can support has no fixed limit.
+The maximum number of {SmartProxyServer}s that {ProjectServer} can support has no fixed limit.
 The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with Red Hat Enterprise Linux 7.
 However, scalability is highly variable, especially when managing Puppet clients.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_in_to_Red_Hat_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_in_to_Red_Hat_Satellite.adoc
@@ -59,7 +59,7 @@ For more information, see xref:sect-{Project_Link}-Administering_{Project_Link}-
 
 .Procedure
 
-. Access the {ProjectServer} using a web browser pointed to the fully qualified domain name:
+. Access {ProjectServer} using a web browser pointed to the fully qualified domain name:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Capsules.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Capsules.adoc
@@ -6,7 +6,7 @@ The following section shows how to use the {Project} web UI to find {SmartProxy}
 [[sect-Documentation-Administering_Red_Hat_Satellite-Viewing_Capsule_Details]]
 ==== Viewing General {SmartProxy} Information
 
-Navigate to *Infrastructure* > *{SmartProxies}* to view a table of {SmartProxyServer}s registered to the {ProjectServer}.
+Navigate to *Infrastructure* > *{SmartProxies}* to view a table of {SmartProxyServer}s registered to {ProjectServer}.
 The information contained in the table answers the following questions:
 
 *Is {SmartProxyServer} running?*:: This is indicated by a green icon in the *Status* column.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Resources.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Monitoring_Resources.adoc
@@ -9,7 +9,7 @@ include::Using_the_Red_Hat_Satellite_Content_Dashboard.adoc[]
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Monitoring_Satellite_Server]]
 === Monitoring {ProjectServer}
 
-From the *About* page in the {ProjectServer} web UI, you can find an overview of the following:
+From the *About* page in {ProjectServer} web UI, you can find an overview of the following:
 
 * System Status, including {SmartProxies}, Available Providers, Compute Resources, and Plug-ins
 
@@ -23,7 +23,7 @@ From the *About* page in the {ProjectServer} web UI, you can find an overview of
 
 To navigate to the *About* page:
 
-* In the upper right corner of the {ProjectServer} web UI, click *Administer* > *About*.
+* In the upper right corner of {ProjectServer} web UI, click *Administer* > *About*.
 
 [NOTE]
 ====

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
@@ -20,7 +20,7 @@ include::gss-proxy.adoc[leveloffset=+3]
 
 Perform the following procedures on Red{nbsp}Hat Enterprise{nbsp}Linux that acts as a base operating system for your {ProjectServer}.
 For the examples in this section _EXAMPLE.ORG_ is the Kerberos realm for the AD domain.
-By completing the procedures, users that belong to the EXAMPLE.ORG realm can log in to the {ProjectServer}.
+By completing the procedures, users that belong to the EXAMPLE.ORG realm can log in to {ProjectServer}.
 
 include::enrolling-satellite-server-with-the-ad-server.adoc[leveloffset=+3]
 
@@ -34,6 +34,6 @@ include::kerberos-configuration-in-web-browsers.adoc[leveloffset=+3]
 include::active-directory-with-cross-forest-trust.adoc[leveloffset=+3]
 
 From the {Project} point of view, the configuration process is the same as integration with {FreeIPA} server without cross-forest trust configured.
-The {ProjectServer} has to be enrolled in the IPM domain and integrated as described in xref:sect-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication-Using_Identity_Management[].
+{ProjectServer} has to be enrolled in the IPM domain and integrated as described in xref:sect-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication-Using_Identity_Management[].
 
 include::configuring-the-idm-server-to-use-cross-forest-trust.adoc[leveloffset=+3]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -10,8 +10,8 @@ For more information, see xref:sect-{Project_Link}-Administering_{Project_Link}-
 [[br-Using-IdM-for-Authentication-prereq]]
 .Prerequisites
 
-* The {ProjectServer} has to run on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6.6 or later.
-* The base operating system of the {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
+* {ProjectServer} has to run on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6.6 or later.
+* The base operating system of {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
 However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/index.html#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/compliance-email-notifications.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/compliance-email-notifications.adoc
@@ -1,7 +1,7 @@
 [id='compliance-email-notifications_{context}']
 = Compliance Email Notifications
 
-The {ProjectServer} sends an OpenSCAP Summary email to all users who subscribe to the *Openscap policy summary* email notifications.
+{ProjectServer} sends an OpenSCAP Summary email to all users who subscribe to the *Openscap policy summary* email notifications.
 For more information on subscribing to email notifications, see xref:configuring-email-notifications_{context}[].
 Each time a policy is run, {Project} checks the results against the previous run, noting any changes between them.
 The email is sent according to the frequency requested by each subscriber, providing a summary of each policy and its most recent result.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/compliance-policy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/compliance-policy.adoc
@@ -2,8 +2,8 @@
 = Compliance Policy
 
 A scheduled audit, also known as a _compliance policy_, is a scheduled task that checks the specified hosts for compliance against an XCCDF profile.
-The schedule for scans is specified by the {ProjectServer} and the scans are performed on the host.
-When a scan completes, an _Asset Reporting File_ (ARF) is generated in XML format and uploaded to the {ProjectServer}.
+The schedule for scans is specified by {ProjectServer} and the scans are performed on the host.
+When a scan completes, an _Asset Reporting File_ (ARF) is generated in XML format and uploaded to {ProjectServer}.
 You can see the results of the scan in the compliance policy dashboard.
 No changes are made to the scanned host by the compliance policy.
 The SCAP content includes several profiles with associated rules but policies are not included by default.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
@@ -3,7 +3,7 @@
 = Configuring Host-Based Authentication Control
 
 HBAC rules define which machine within the domain a {FreeIPA} user is allowed to access.
-You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing the {ProjectServer}.
+You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing {ProjectServer}.
 With this approach, you can prevent {Project} from creating database entries for users that are not allowed to log in.
 For more information on HBAC, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/configuring-host-access.html[Configuring Host-Based Access Control] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 
@@ -36,7 +36,7 @@ Execute the following commands on the {FreeIPA} server:
 # ipa hbacrule-add-service allow_{project-context}_prod --hbacsvcs={project-context}-prod
 ----
 
-. Add the user who is to have access to the service {project-context}-prod, and the hostname of the {ProjectServer}:
+. Add the user who is to have access to the service {project-context}-prod, and the hostname of {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -57,8 +57,8 @@ Alternatively, host groups and user groups can be added to the _allow_{project-c
 . Ensure the allow_all rule is disabled on the {FreeIPA} server.
 For instructions on how to do so without disrupting other services see the https://access.redhat.com/solutions/67895[How to configure HBAC rules in IdM] article on the Red{nbsp}Hat Customer Portal.
 
-. Configure the {FreeIPA} integration with the {ProjectServer} as described in xref:configuring-idm-authentication-on-satellite-server_{context}[].
-On the {ProjectServer}, define the PAM service as root:
+. Configure the {FreeIPA} integration with {ProjectServer} as described in xref:configuring-idm-authentication-on-satellite-server_{context}[].
+On {ProjectServer}, define the PAM service as root:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -20,7 +20,7 @@ In the {Project} CLI, configure {FreeIPA} authentication by first creating a hos
 # klist
 ----
 +
-. On the {FreeIPA} server, create a host entry for the {ProjectServer} and generate a one-time password, for example:
+. On the {FreeIPA} server, create a host entry for {ProjectServer} and generate a one-time password, for example:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
@@ -10,7 +10,7 @@ Use the {Project} CLI to configure TLS for secure LDAP (LDAPS).
 .. If you use Active Directory Certificate Services, export the Enterprise PKI CA Certificate using the Base-64 encoded X.509 format.
 See https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with `TLS` on {ProjectX}] for information on creating and exporting a CA certificate from an Active Directory server.
 
-.. Download the LDAP server certificate to a temporary location on the Red{nbsp}Hat Enterprise{nbsp}Linux system where the {ProjectServer} is installed and remove it when finished.
+.. Download the LDAP server certificate to a temporary location on the Red{nbsp}Hat Enterprise{nbsp}Linux system where {ProjectServer} is installed and remove it when finished.
 +
 For example, `/tmp/example.crt`.
 The filename extensions `.cer` and `.crt` are only conventions and can refer to DER binary or PEM ASCII format certificates.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-complete-permission-table.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-complete-permission-table.adoc
@@ -6,7 +6,7 @@ Use the {Project} CLI to create a permission table.
 .Procedure
 
 . Ensure that the required packages are installed.
-Execute the following command on the {ProjectServer}:
+Execute the following command on {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/editing-a-compliance-policy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/editing-a-compliance-policy.adoc
@@ -10,5 +10,5 @@ In the {Project} web UI, edit the compliance policy.
 . Edit the necessary attributes.
 . Click *Submit*.
 
-An edited policy is applied to the host when its Puppet agent next checks with the {ProjectServer} for updates.
+An edited policy is applied to the host when its Puppet agent next checks with {ProjectServer} for updates.
 By default this occurs every 30 minutes.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/extra-scap-content.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/extra-scap-content.adoc
@@ -1,7 +1,7 @@
 [id='extra-scap-content_{context}']
 = Extra SCAP Content
 
-You can upload extra SCAP content into the {ProjectServer}, either content created by yourself or obtained elsewhere.
-SCAP content must be imported into the {ProjectServer} before being applied in a policy.
+You can upload extra SCAP content into {ProjectServer}, either content created by yourself or obtained elsewhere.
+SCAP content must be imported into {ProjectServer} before being applied in a policy.
 For example, the `scap-security-guide` RPM package available in the Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.2 repositories includes a profile for the Payment Card Industry Data Security Standard (PCI-DSS) version 3.
 You can upload this content into a {ProjectServer} even if it is not running Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.2 as the content is not specific to an operating system version.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/notification-types.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/notification-types.adoc
@@ -3,7 +3,7 @@
 
 The following are the notifications created by {Project}:
 
-* *Audit summary*: A summary of all activity audited by the {ProjectServer}.
+* *Audit summary*: A summary of all activity audited by {ProjectServer}.
 * *Host built*: A notification sent when a host is built.
 * *Host errata advisory*: A summary of applicable and installable errata for hosts managed by the user.
 * *OpenSCAP policy summary*: A summary of OpenSCAP policy reports and their results.

--- a/guides/doc-Content_Management_Guide/topics/QuickStart.adoc
+++ b/guides/doc-Content_Management_Guide/topics/QuickStart.adoc
@@ -64,7 +64,7 @@ Use the following procedure to register an existing CentOS Stream host to {Proje
 
 . Log on to the Centos 8 host you want register.
 . Download the consumer RPM for your {ProjectServer}.
-. This is located in the `pub` directory on the {ProjectServer}'s web server.
+. This is located in the `pub` directory on {ProjectServer}'s web server.
 For example, for a {ProjectServer} with the host name `{foreman-example-com}`, enter the following command on the host to register:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -39,7 +39,7 @@ The exported archive file contains the following data:
 
 .Prerequisites
 
-To export a Content View, ensure that the {ProjectServer} where you want to export meets the following conditions:
+To export a Content View, ensure that {ProjectServer} where you want to export meets the following conditions:
 
 * Ensure that the export directory has free storage space to accommodate the export.
 * Ensure that the `/var/lib/pulp/exports` directory has free storage space equivalent to the size of the repositories being exported for temporary files created during the export process.
@@ -137,7 +137,7 @@ You can customize the version numbers by changing the `major` and `minor` settin
 
 .Prerequisites
 
-To import a Content View, ensure that the {ProjectServer} where you want to import meets the following conditions:
+To import a Content View, ensure that {ProjectServer} where you want to import meets the following conditions:
 
 ifdef::satellite[]
 * If you want to import a Content View to {Project} in a disconnected environment, you must configure {Project} to synchronize content with a local CDN server and then synchronize content that the CV you export contains.
@@ -150,7 +150,7 @@ For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_
 
 .Procedure
 
-. Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on the {ProjectServer} where you want to import.
+. Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on {ProjectServer} where you want to import.
 . Set the SELinux permission of the archive files to `pulp:pulp`.
 +
 [subs="+quotes"]
@@ -166,7 +166,7 @@ For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_
 
 ----
 +
-. On the {ProjectServer} where you want to import, create a Content View with the same name and label as the exported Content View with the `Import Only` option set.
+. On {ProjectServer} where you want to import, create a Content View with the same name and label as the exported Content View with the `Import Only` option set.
 For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_View_CLI[].
 >>>>>>> 3f93a37... Adding initial docs for the new import/export
 . Ensure that you enable the repositories that the Products in the exported Content View version include.
@@ -230,7 +230,7 @@ The exported archive file contains the following data:
 
 .Prerequisites
 
-To export a contents of Library lifecycle envionment of the organization, ensure that the {ProjectServer} where you want to export meets the following conditions:
+To export a contents of Library lifecycle envionment of the organization, ensure that {ProjectServer} where you want to export meets the following conditions:
 
 * Ensure that the export directory has free storage space to accommodate the export.
 * Ensure that the `/var/lib/pulp/exports` directory has free storage space equivalent to the size of the repositories being exported for temporary files created during the export process.
@@ -310,13 +310,13 @@ For more information about exporting contents from the Library environment, see 
 
 .Prerequisites
 
-To import in to an Organization's library lifecycle environment  ensure that the {ProjectServer} where you want to import meets the following conditions:
+To import in to an Organization's library lifecycle environment  ensure that {ProjectServer} where you want to import meets the following conditions:
 
 * The products and repositories in the organization need to match the product/repositoriy structure in the content archive being imported.
 
 .Procedure
 
-. Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on the {ProjectServer} where you want to import.
+. Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on {ProjectServer} where you want to import.
 . Set the permission of the archive files to `pulp:pulp`.
 +
 [subs="+quotes"]
@@ -330,7 +330,7 @@ total 68M
 
 ----
 +
-. On the {ProjectServer} where you want to import, create/enable repositories the same name and label as the exported content.
+. On {ProjectServer} where you want to import, create/enable repositories the same name and label as the exported content.
 . In the {Project} web UI, navigate to *Content* > *Products*, click the *Yum content* tab and add the same `Yum` content that the exported Content View version includes.
 . Identify the Organization that you wish to import into.
 . To import the Library content to {ProjectServer}, enter the following command:

--- a/guides/doc-Deploying_on_AWS/topics/AWS_Deployment_Scenarios.adoc
+++ b/guides/doc-Deploying_on_AWS/topics/AWS_Deployment_Scenarios.adoc
@@ -15,7 +15,7 @@ endif::[]
 
 image:aws_image1.png[]
 
-The least complex configuration of {ProjectServer} in Amazon Web Services consists of both the {ProjectServer} and the content hosts residing within the same region and within the Virtual Private Cloud (VPC).
+The least complex configuration of {ProjectServer} in Amazon Web Services consists of both {ProjectServer} and the content hosts residing within the same region and within the Virtual Private Cloud (VPC).
 
 You can also use a different availability zone.
 
@@ -35,9 +35,9 @@ image:aws_image3.png[]
 
 .Scenario 3: Connecting different regions
 
-Create a site-to-site VPN connection between the different regions so that you can use the Internal DNS host name when you register the instance that runs {SmartProxyServer} to the {ProjectServer}.
+Create a site-to-site VPN connection between the different regions so that you can use the Internal DNS host name when you register the instance that runs {SmartProxyServer} to {ProjectServer}.
 
-If you do not establish a site-to-site VPN connection, use the external DNS host name when you register the instance that runs {SmartProxyServer} to the {ProjectServer}.
+If you do not establish a site-to-site VPN connection, use the external DNS host name when you register the instance that runs {SmartProxyServer} to {ProjectServer}.
 
 [NOTE]
 Most Public Cloud Providers do not charge for data being transferred into a region, or between availability zones within a single region; however, they do charge for data leaving the region to the Internet.

--- a/guides/doc-Deploying_on_AWS/topics/AWS_Prerequisites.adoc
+++ b/guides/doc-Deploying_on_AWS/topics/AWS_Prerequisites.adoc
@@ -46,7 +46,7 @@ ifndef::foreman-deb[]
 * Mount the synced content EBS volume separately in the operating system.
 * Optional: store other data on a separate EBS volume.
 endif::[]
-* If you want the {ProjectServer} and {SmartProxyServer} to communicate using external DNS hostnames, open the required ports for communication in the AWS Security Group that is associated with the instance.
+* If you want {ProjectServer} and {SmartProxyServer} to communicate using external DNS hostnames, open the required ports for communication in the AWS Security Group that is associated with the instance.
 
 ifndef::foreman-deb[]
 == Preparing for the {ProjectName} Installation

--- a/guides/doc-Deploying_on_AWS/topics/AWS_Use_Case_Considerations.adoc
+++ b/guides/doc-Deploying_on_AWS/topics/AWS_Use_Case_Considerations.adoc
@@ -49,7 +49,7 @@ You must do this when {ProjectServer} or {SmartProxyServer} has different intern
 ifndef::foreman-deb[]
 .On demand content sources
 You can use the *On demand* download policy to reduce the storage footprint of the Red Hat Enterprise Linux server that runs {Project}.
-When you set the download policy to *On Demand*, content syncs to the {ProjectServer} or {SmartProxyServer} when a content host requests it.
+When you set the download policy to *On Demand*, content syncs to {ProjectServer} or {SmartProxyServer} when a content host requests it.
 
 For more information, see {ContentManagementDocURL}Importing_Content[Importing Content] in the _Content Management Guide_.
 

--- a/guides/doc-Managing_Hosts/topics/Template_Writing.adoc
+++ b/guides/doc-Managing_Hosts/topics/Template_Writing.adoc
@@ -34,7 +34,7 @@ Note that the default templates provided by {ProjectName} (*Hosts* > *Provisioni
 
 When provisioning a host or running a remote job, the code in the ERB is executed and the variables are replaced with the host specific values.
 This process is referred to as *rendering*.
-The {ProjectServer} has the safemode rendering option enabled by default, which prevents any harmful code being executed from templates.
+{ProjectServer} has the safemode rendering option enabled by default, which prevents any harmful code being executed from templates.
 
 [[appe-Red_Hat_Satellite-Managing_Hosts-Template_Writing_Reference-ui]]
 === Accessing the Template Writing Reference in the {Project} web UI

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-manually.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host-to-satellite-manually.adoc
@@ -19,7 +19,7 @@ Red{nbsp}Hat Enterprise{nbsp}Linux hosts register to the Red{nbsp}Hat Content De
 
 Update each host configuration so that they receive updates from the correct {ProjectServer} or {SmartProxyServer}:
 
-. Note the fully qualified domain name (FQDN) of the {ProjectServer} or {SmartProxyServer}, for example _server.example.com_.
+. Note the fully qualified domain name (FQDN) of {ProjectServer} or {SmartProxyServer}, for example _server.example.com_.
 . Log in to the host as the `root` user and download the `katello-ca-consumer-latest.noarch.rpm` package from {ProjectServer} or {SmartProxyServer} to which the host is to be registered.
 The consumer RPM configures the host to download content from the content source that is specified in {ProjectName}.
 +

--- a/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
@@ -66,7 +66,7 @@ Some common configurations include:
 * *Infrastructure {SmartProxies}* [DNS + DHCP + TFTP] – provide infrastructure services for hosts.
 With provisioning template proxy enabled, infrastructure {SmartProxy} has all necessary services for provisioning new hosts.
 
-* *Content {SmartProxies}* [Pulp] – provide content synchronized from the {ProjectServer} to hosts.
+* *Content {SmartProxies}* [Pulp] – provide content synchronized from {ProjectServer} to hosts.
 
 * *Configuration {SmartProxies}* [Pulp + Puppet + PuppetCA] – provide content and run configuration services for hosts.
 
@@ -89,7 +89,7 @@ endif::[]
 image::satellite_6_topology_isolated.png[{ProjectName} topology with isolated host]
 
 
-The following diagram shows how the {Project} components interact when hosts connect directly to the {ProjectServer}.
+The following diagram shows how the {Project} components interact when hosts connect directly to {ProjectServer}.
 Note that as the base system of an external {SmartProxy} is a Client of the {Project}, this diagram is relevant even if you do not intend to have directly connected hosts.
 
 [[figu-Satellite_Topology_with_Internal_Capsule]]

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -65,7 +65,7 @@ You can use multiple manifests and they can be from different Red Hat subscripti
 {ProjectName} {ProductVersion} allows the use of future-dated subscriptions in the manifest.
 This enables uninterrupted access to repositories when future-dated subscriptions are added to a manifest before the expiry date of existing subscriptions.
 
-Note that the Subscription Manifest can be modified and reloaded to the {ProjectServer} in case of any changes in your infrastructure, or when adding more subscriptions.
+Note that the Subscription Manifest can be modified and reloaded to {ProjectServer} in case of any changes in your infrastructure, or when adding more subscriptions.
 Manifests should not be deleted.
 If you delete the manifest from the Red Hat Customer Portal or in the {Project} Web UI it will unregister all of your content hosts.
 
@@ -130,7 +130,7 @@ The *On demand* setting saves space and time by only downloading packages when r
 The *Background* setting saves time by completing the download after the initial synchronization.
 For detailed instructions on setting up content sources see {ContentManagementDocURL}Importing_Content[Importing Content] in the _Content Management Guide_.
 
-A custom repository within the {ProjectServer} is in most cases populated with content from an external staging server.
+A custom repository within {ProjectServer} is in most cases populated with content from an external staging server.
 Such servers lie outside of the {Project} infrastructure, however, it is recommended to use a revision control system (such as Git) on these servers to have better control over the custom content.
 [[sect-Defining_the_Content_Life_Cycle]]
 === Content Life Cycle
@@ -207,7 +207,7 @@ It is enabled and started automatically on content hosts after successfully inst
 Note that the Katello agent is deprecated and will be removed in a future {Project} version.
 
 * *Remote execution* - Remote execution via SSH transport allows the install, update, or removal of packages, the bootstrap of configuration management agents, and the trigger of Puppet runs.
-While the {ProjectServer} has remote execution enabled by default, it is disabled by default on {SmartProxyServer}s and content hosts and has to be manually enabled.
+While {ProjectServer} has remote execution enabled by default, it is disabled by default on {SmartProxyServer}s and content hosts and has to be manually enabled.
 
 * *Consider method for content deployment* - The use of remote execution allows the *Goferd* service to be disabled, thereby reducing memory and CPU load on content hosts.
 However, remote execution has to be manually configured on all content hosts before it can replace *Goferd*.
@@ -266,14 +266,14 @@ The same guide contains information on configuring external authentication sourc
 This section provides a short overview of selected {Project} capabilities that can be used for automating certain tasks or extending the core usage of {Project}:
 
 ifdef::satellite[]
-* *Importing existing hosts* – if you have existing hosts that have not been managed by {Project} in the past, you can import those hosts to the {ProjectServer}.
+* *Importing existing hosts* – if you have existing hosts that have not been managed by {Project} in the past, you can import those hosts to {ProjectServer}.
 This procedure is usually a step in transitioning from {ProjectName} 5.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/transitioning_from_red_hat_satellite_5_to_red_hat_satellite_6/index[_Transitioning from {ProjectName} 5 to {ProjectNameX}_] for detailed documentation.
 A high level overview of the transition process is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/articles/1187643[Transitioning from Red Hat Satellite 5 to Satellite 6].
 endif::[]
 
 * *Discovering bare metal hosts* – the {Project} Discovery plug-in enables automatic bare-metal discovery of unknown hosts on the provisioning network.
-These new hosts register themselves to the {ProjectServer} and the Puppet Agent on the client uploads system facts collected by Facter, such as serial ID, network interface, memory, and disk information.
+These new hosts register themselves to {ProjectServer} and the Puppet Agent on the client uploads system facts collected by Facter, such as serial ID, network interface, memory, and disk information.
 After registration you can initialize provisioning of those discovered hosts.
 For details, see {ProvisioningDocURL}creating-hosts-from-discovered-hosts[Creating Hosts from Discovered Hosts] in the _Provisioning Guide_.
 
@@ -285,7 +285,7 @@ For more information on remote execution see {ManagingHostsDocURL}configuring-an
 Find more information on errata management and OpenSCAP concepts in {ManagingHostsDocURL}[_Managing Hosts_].
 
 * *Incident management* – {Project} supports the incident management process by providing a centralized overview of all systems including reporting and email notifications.
-Detailed information on each host is accessible from the {ProjectServer}, including the event history of recent changes.
+Detailed information on each host is accessible from {ProjectServer}, including the event history of recent changes.
 ifdef::satellite[]
 {Project} is also integrated with https://access.redhat.com/products/red-hat-insights/#sat6[Red{nbsp}Hat Insights].
 endif::[]

--- a/guides/doc-Planning_Guide/topics/Glossary.adoc
+++ b/guides/doc-Planning_Guide/topics/Glossary.adoc
@@ -33,7 +33,7 @@ In {Project}, you can create a BMC interface to manage selected hosts.
 
 [[varl-Glossary_of_Terms-Bootdisk]]
 *Boot Disk*:: An ISO image used for PXE-less provisioning.
-This ISO enables the host to connect to the {ProjectServer}, boot the installation media, and install the operating system.
+This ISO enables the host to connect to {ProjectServer}, boot the installation media, and install the operating system.
 There are several kinds of boot disks: *host image*, *full host image*, *generic image*, and *subnet image*.
 
 
@@ -55,7 +55,7 @@ Catalogs are compiled by a Puppet Master from Puppet Manifests and data from Pup
 
 
 [[varl-Glossary_of_Terms-Compliance_Policy]]
-*Compliance Policy*:: Refers to a scheduled task executed on the {ProjectServer} that checks the specified hosts for compliance against SCAP content.
+*Compliance Policy*:: Refers to a scheduled task executed on {ProjectServer} that checks the specified hosts for compliance against SCAP content.
 
 
 [[varl-Glossary_of_Terms-Compute_Profile]]
@@ -84,7 +84,7 @@ Content is synchronized into the Library and then promoted into life cycle envir
 
 
 [[varl-Glossary_of_Terms-Content_Delivery_Network_CDN]]
-*Content Delivery Network (CDN)*:: The mechanism used to deliver Red{nbsp}Hat content to the {ProjectServer}.
+*Content Delivery Network (CDN)*:: The mechanism used to deliver Red{nbsp}Hat content to {ProjectServer}.
 
 
 [[varl-Glossary_of_Terms-Content_Host]]
@@ -101,12 +101,12 @@ Once a content view is published, it can be promoted through the life cycle envi
 
 
 [[varl-Glossary_of_Terms-Discovery_Image]]
-*Discovery Image*:: Refers to the minimal operating system based on Red Hat Enterprise Linux that is PXE-booted on hosts to acquire initial hardware information and to communicate with the {ProjectServer} before starting the provisioning process.
+*Discovery Image*:: Refers to the minimal operating system based on Red Hat Enterprise Linux that is PXE-booted on hosts to acquire initial hardware information and to communicate with {ProjectServer} before starting the provisioning process.
 
 
 [[varl-Glossary_of_Terms-Discovery_Plug-in]]
 *Discovery Plug-in*:: Enables automatic bare-metal discovery of unknown hosts on the provisioning network.
-The plug-in consists of three components: services running on the {ProjectServer} and {SmartProxyServer}, and the Discovery image running on host.
+The plug-in consists of three components: services running on {ProjectServer} and {SmartProxyServer}, and the Discovery image running on host.
 
 
 [[varl-Glossary_of_Terms-Discovery_Rule]]
@@ -165,7 +165,7 @@ The full host image contains an embedded Linux kernel and init RAM disk of the a
 
 [[varl-Glossary_of_Terms-Generic_Image]]
 *Generic Image*:: A boot disk for PXE-less provisioning that is not tied to a specific host.
-The generic image sends the host’s MAC address to the {ProjectServer}, which matches it against the host entry.
+The generic image sends the host’s MAC address to {ProjectServer}, which matches it against the host entry.
 
 
 [[varl-Glossary_of_Terms-Hammer]]
@@ -190,7 +190,7 @@ Host groups can be nested to create a hierarchical structure.
 
 [[varl-Glossary_of_Terms-Host_Image]]
 *Host Image*:: A boot disk used for PXE-less provisioning of a specific host.
-The host image only contains the boot files necessary to access the installation media on the {ProjectServer}.
+The host image only contains the boot files necessary to access the installation media on {ProjectServer}.
 
 
 [[varl-Glossary_of_Terms-Incremental_Update]]
@@ -200,7 +200,7 @@ Useful for rapid updates, for example when applying security errata.
 
 
 [[varl-Glossary_of_Terms-Job]]
-*Job*:: A command executed remotely on a host from the {ProjectServer}.
+*Job*:: A command executed remotely on a host from {ProjectServer}.
 Every job is defined in a job template.
 
 
@@ -221,7 +221,7 @@ The *On Demand* setting saves storage space and synchronization time by only dow
 
 
 [[varl-Glossary_of_Terms-Library]]
-*Library*:: A container for content from all synchronized repositories on the {ProjectServer}.
+*Library*:: A container for content from all synchronized repositories on {ProjectServer}.
 Libraries exist by default for each organization as the root of every life cycle environment path and the source of content for every content view.
 
 
@@ -415,4 +415,4 @@ Authentication and authorization is possible through built-in logic, through ext
 
 [[varl-Glossary_of_Terms-virt-who]]
 *virt-who*:: An agent for retrieving IDs of virtual machines from the hypervisor.
-When used with {Project}, virt-who reports those IDs to the {ProjectServer} so that it can provide subscriptions for hosts provisioned on virtual machines.
+When used with {Project}, virt-who reports those IDs to {ProjectServer} so that it can provide subscriptions for hosts provisioned on virtual machines.

--- a/guides/doc-Planning_Guide/topics/Hosts.adoc
+++ b/guides/doc-Planning_Guide/topics/Hosts.adoc
@@ -29,7 +29,7 @@ It is recommended to configure the majority of settings at the host group level 
 Configuring a new host then largely becomes a matter of adding it to the right host group.
 As host groups can be nested, you can create a structure that best fits your requirements (see xref:sect-{Project_Link}-Architecture_Guide-Host_Group_Hierarchies[]).
 
-* *Host collections* – a host registered to the {ProjectServer} for the purpose of subscription and content management is called *content host*.
+* *Host collections* – a host registered to {ProjectServer} for the purpose of subscription and content management is called *content host*.
 Content hosts can be organized into host collections, which enables performing bulk actions such as package management or errata installation.
 
 Locations and host groups can be nested, organizations and host collections are flat.

--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -44,33 +44,33 @@ In addition, you can use other supported content sources (Git repositories, Dock
 [[varl-Red_Hat_Satellite-Architecture_Guide-Red_Hat_Satellite_6_System_Architecture-RednbspHat_Satellite_Server]]
 *{ProjectName} Server*:: The {ProjectName} Server enables you to plan and manage the content life cycle and the configuration of {SmartProxyServer}s and hosts through GUI, CLI, or API.
 +
-The {ProjectServer} organizes the life cycle management by using organizations as principal division units.
+{ProjectServer} organizes the life cycle management by using organizations as principal division units.
 Organizations isolate content for groups of hosts with specific requirements and administration tasks.
 For example, the OS build team can use a different organization than the web development team.
 +
-The {ProjectServer} also contains a fine-grained authentication system to provide {Project} operators with permissions to access precisely the parts of the infrastructure that lie in their area of responsibility.
+{ProjectServer} also contains a fine-grained authentication system to provide {Project} operators with permissions to access precisely the parts of the infrastructure that lie in their area of responsibility.
 
 
 [[varl-Red_Hat_Satellite-Architecture_Guide-Red_Hat_Satellite_6_System_Architecture-Capsule_Servers]]
-*{SmartProxyServer}s*:: {SmartProxyServer}s mirror content from the {ProjectServer} to establish content sources in various geographical locations.
+*{SmartProxyServer}s*:: {SmartProxyServer}s mirror content from {ProjectServer} to establish content sources in various geographical locations.
 This enables host systems to pull content and configuration from {SmartProxyServer}s in their location and not from the central {ProjectServer}.
 The recommended minimum number of {SmartProxyServer}s is therefore given by the number of geographic regions where the organization that uses {Project} operates.
 +
 Using Content Views, you can specify the exact subset of content that {SmartProxyServer} makes available to hosts.
 See xref:figu-{Project_Link}-Architecture_Guide-{Project_Link}_6_System_Architecture-Content_Life_Cycle_in_{Project_Link}_6[] for a closer look at life cycle management with the use of Content Views.
 +
-The communication between managed hosts and the {ProjectServer} is routed through {SmartProxyServer} that can also manage multiple services on behalf of hosts.
-Many of these services use dedicated network ports, but {SmartProxyServer} ensures that a single source IP address is used for all communications from the host to the {ProjectServer}, which simplifies firewall administration.
+The communication between managed hosts and {ProjectServer} is routed through {SmartProxyServer} that can also manage multiple services on behalf of hosts.
+Many of these services use dedicated network ports, but {SmartProxyServer} ensures that a single source IP address is used for all communications from the host to {ProjectServer}, which simplifies firewall administration.
 For more information on {SmartProxyServer}s see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
 
 
 [[varl-Red_Hat_Satellite-Architecture_Guide-Red_Hat_Satellite_6_System_Architecture-Managed_Hosts]]
 *Managed Hosts*:: Hosts are the recipients of content from {SmartProxyServer}s.
 Hosts can be either physical or virtual.
-The {ProjectServer} can have directly managed hosts.
-The base system running a {SmartProxyServer} is also a managed host of the {ProjectServer}.
+{ProjectServer} can have directly managed hosts.
+The base system running a {SmartProxyServer} is also a managed host of {ProjectServer}.
 
-The following diagram provides a closer look at the distribution of content from the {ProjectServer} to {SmartProxies}.
+The following diagram provides a closer look at the distribution of content from {ProjectServer} to {SmartProxies}.
 
 ifndef::satellite[]
 include::../common/modules/snip_red-hat-images.adoc[]
@@ -172,7 +172,7 @@ Support for these frameworks is based on the Red{nbsp}Hat Knowledgebase article 
 
 
 [[form-Red_Hat_Satellite-Architecture_Guide-Red_Hat_Satellite_6_Supported_Usage-Pulp]]
-*Pulp*:: Pulp usage is only supported via the {ProjectServer} web UI, CLI, and API.
+*Pulp*:: Pulp usage is only supported via {ProjectServer} web UI, CLI, and API.
 Direct modification or interaction with Pulp's local API or database is not supported, as this can cause irreparable damage to the {ProjectName} databases.
 
 

--- a/guides/doc-Planning_Guide/topics/Org_Loc_and_Life_Cycle_Environments.adoc
+++ b/guides/doc-Planning_Guide/topics/Org_Loc_and_Life_Cycle_Environments.adoc
@@ -4,7 +4,7 @@
 {ProjectName} takes a consolidated approach to Organization and Location management.
 System administrators define multiple Organizations and multiple Locations in a single {ProjectServer}.
 For example, a company might have three Organizations (Finance, Marketing, and Sales) across three countries (United States, United Kingdom, and Japan).
-In this example, the {ProjectServer} manages all Organizations across all geographical Locations, creating nine distinct contexts for managing systems.
+In this example, {ProjectServer} manages all Organizations across all geographical Locations, creating nine distinct contexts for managing systems.
 In addition, users can define specific locations and nest them to create a hierarchy.
 For example, {Project} administrators might divide the United States into specific cities, such as Boston, Phoenix, or San Francisco.
 
@@ -17,7 +17,7 @@ endif::[]
 
 image::satellite_6_topology.png[Example Topology for {ProjectName}]
 
-The {ProjectServer} defines all locations and organizations.
+{ProjectServer} defines all locations and organizations.
 Each respective {Project} {SmartProxyServer} synchronizes content and handles configuration of systems in a different location.
 
 The main {ProjectServer} retains the management function, while the content and configuration is synchronized between the main {ProjectServer} and a {Project} {SmartProxyServer} assigned to certain locations.

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
@@ -19,13 +19,13 @@ include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 [[Provisioning_Cloud_Instances_in_Amazon_EC2-Adding_a_Amazon_EC2_Connection_to_the_Satellite_Server]]
 === Adding an Amazon EC2 Connection to the {ProjectServer}
 
-Use this procedure to add the Amazon EC2 connection in the {ProjectServer}'s compute resources.
+Use this procedure to add the Amazon EC2 connection in {ProjectServer}'s compute resources.
 To use the CLI instead of the web UI, see the xref:cli-adding-amazon-ec2-connection_{context}[].
 
 .Time Settings and Amazon Web Services
 Amazon Web Services uses time settings as part of the authentication process.
 Ensure that {ProjectServer}'s time is correctly synchronized.
-Ensure that an NTP service, such as `ntpd` or `chronyd`, is running properly on the {ProjectServer}.
+Ensure that an NTP service, such as `ntpd` or `chronyd`, is running properly on {ProjectServer}.
 Failure to provide the correct time to Amazon Web Services can lead to authentication failures.
 
 For more information about synchronizing time in {Project}, see {InstallingProjectDocURL}synchronizing-the-system-clock-with-chronyd_{project-context}[Synchronizing Time] in _{project-installation-guide-title}_.
@@ -163,7 +163,7 @@ To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-amazon-
 . From the *Compute Profile* list, select a profile to use to automatically populate virtual machine-based settings.
 . Click the *Interface* tab, and then click *Edit* on the host's interface, and verify that the fields are populated with values.
 Leave the *Mac Address* field blank.
-The {ProjectServer} automatically selects and IP address and the *Managed*, *Primary*, and *Provision* options for the first interface on the host.
+{ProjectServer} automatically selects and IP address and the *Managed*, *Primary*, and *Provision* options for the first interface on the host.
 . Click the *Operating System* tab and confirm that all fields are populated with values.
 . Click the *Virtual Machine* tab and confirm that all fields are populated with values.
 ifdef::foreman-el,katello[]

--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -235,7 +235,7 @@ For example, a network might require {SmartProxyServer} to act as a DHCP server.
 A network can also use PXE boot services to install the operating system on new hosts.
 This requires configuring {SmartProxyServer} to use the main PXE boot services: DHCP, DNS, and TFTP.
 
-Use the `{foreman-installer}` command with the options to configure these services on the {ProjectServer}.
+Use the `{foreman-installer}` command with the options to configure these services on {ProjectServer}.
 
 ifdef::satellite[]
 To configure these services on an external {SmartProxyServer}, run `{installer-scenario-smartproxy}`.

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -213,7 +213,7 @@ To use the CLI instead of the web UI, see the xref:cli-creating-hosts-on-vmware-
 Note in particular:
 +
   * The *Name* from the *Host* tab becomes the *DNS name*.
-  * The {ProjectServer} automatically assigns an IP address for the new host.
+  * {ProjectServer} automatically assigns an IP address for the new host.
 +
 . Ensure that the *MAC address* field is blank.
 The VMware vSphere server assigns one to the host.

--- a/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
@@ -259,7 +259,7 @@ Server or {SmartProxyServer}, for example _server.example.com_.
 
 . On the host, connect to a terminal on the host as the root user
 
-. Install the consumer RPM from the {ProjectServer} or {SmartProxyServer} to which the host is to be registered.
+. Install the consumer RPM from {ProjectServer} or {SmartProxyServer} to which the host is to be registered.
 The consumer RPM updates the content source location of the host and allows the host to download content from the content source specified in {ProjectName}.
 +
 ------------------------------------------------------------
@@ -329,7 +329,7 @@ For more information, see {ManagingHostsDocURL}installing-the-katello-agent_mana
 
 .Prerequisites
 
-The {project-client-name} repository must be enabled, synchronized to the {ProjectServer}, and made available to your hosts as it provides the required packages.
+The {project-client-name} repository must be enabled, synchronized to {ProjectServer}, and made available to your hosts as it provides the required packages.
 For more information about enabling {project-client-name}, see {ManagingHostsDocURL}installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in _Managing Hosts_.
 
 


### PR DESCRIPTION
This PR removes all but one instances of "the" before "{ProjectServer}":

git grep -i -n "the {ProjectServer}"

This came up during the review of the application centric deployment PR.

One instance remains:
```
# sed -n '19,20p' guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
[[Provisioning_Cloud_Instances_in_Amazon_EC2-Adding_a_Amazon_EC2_Connection_to_the_Satellite_Server]]
=== Adding an Amazon EC2 Connection to the {ProjectServer}
```

See https://github.com/theforeman/foreman-documentation/pull/465