### PR TITLE
The tested image format for liveimg is TAR

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -2,7 +2,9 @@
 == Using a {LoraxCompose} Image for Provisioning
 
 In {Project}, you can integrate with {Cockpit} to perform actions and monitor your hosts.
-Using {Cockpit}, you can access {LoraxCompose} and build images that you can then upload to {Project} and use this image to provision hosts.
+Using {Cockpit}, you can access {LoraxCompose} and build images that you can then upload to a HTTP server and use this image to provision hosts.
+When you configure {Project} for image provisioning, Anaconda installer partitions disks, downloads and mounts the image and copies files over to a host.
+The preferred image type is TAR.
 
 ifdef::foreman-el,katello[]
 For more information about integrating {Cockpit} with {Project}, see https://theforeman.org/plugins/foreman_remote_execution/1.7/index.html#3.6Cockpitintegration[Cockpit integration].
@@ -14,7 +16,12 @@ endif::[]
 
 .Prerequisites
 
-. Use `scp` or `rsync` to copy the image using SSH to the base operating system of {Project}.
+. An existing TAR image created via {LoraxCompose}.
+
+.Procedure
+
+To use the {LoraxCompose} image with Anaconda Kickstart in {Project}, complete the following steps:
+
 ifdef::satellite[]
 . On {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository.
 For more information, see {ContentManagementDocURL}importing_individual_iso_images_and_files[Importing Individual ISO Images and Files] in the _Content Management Guide_.
@@ -23,10 +30,9 @@ ifdef::foreman-el,katello[]
 . If you use the Katello plug-in, on {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository.
 For more information, see {ContentManagementDocURL}importing_individual_iso_images_and_files[Importing Individual ISO Images and Files] in the _Content Management Guide_.
 endif::[]
-
-.Procedure
-
-To use the {LoraxCompose} image with Anaconda Kickstart in {Project}, complete the following steps:
+ifdef::foreman[]
+. Copy the TAR image to an existing HTTP server which installed hosts can reach.
+endif::[]
 
 . In the {Project} web UI, navigate to *Configure* > *Host Groups*, and select the host group that you want to use.
 . Click the *Parameters* tab, and then click *Add Parameter*.


### PR DESCRIPTION
Since this is coming back to us, let's clear this and also cherry pick it into 6.9 if no objections are made.

Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->