### PR TITLE
Treat asciidoctor warnings as errors

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -10,6 +10,7 @@ DEST_PDF = $(BUILD_DIR)/$(subst doc-,,$(NAME))-$(BUILD).pdf
 IMAGES_DIR = $(DEST_DIR)/images
 IMAGES_TS = $(DEST_DIR)/.timestamp-images
 SOURCES = master.adoc $(shell find . -type f -name \*.adoc)
+DEPENDENCIES = $(shell find $(COMMON_DIR) -type f -name \*.adoc)
 IMAGES = $(shell find ./images ./common/images -type f 2>/dev/null || true)
 UNAME = $(shell uname)
 DATE_MDY = $(shell LC_ALL=C date "+%b %d %Y")
@@ -51,10 +52,10 @@ $(IMAGES_TS): $(IMAGES)
 	pushd "$(IMAGES_DIR)" && for IMG in *.*; do ln -s ../../images/$$IMG ../common/images/$$IMG; done && popd
 	touch $(IMAGES_TS)
 
-$(DEST_HTML): $(SOURCES)
+$(DEST_HTML): $(SOURCES) $(DEPENDENCIES)
 	asciidoctor -a build=$(BUILD) -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
-	@! grep -q "^asciidoctor: ERROR" $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 
-$(DEST_PDF): $(SOURCES) $(IMAGES)
+$(DEST_PDF): $(SOURCES) $(IMAGES) $(DEPENDENCIES)
 	asciidoctor-pdf -a build=$(BUILD) -d book --trace -o $@ $< 2>&1 | tee $@.log
-	@! grep -q "^asciidoctor: ERROR" $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log

--- a/guides/common/modules/proc_creating-a-custom-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-certificate.adoc
@@ -75,19 +75,21 @@ authorityKeyIdentifier=keyid,issuer
 [ alt_names ]
 DNS.1 = _{context}.example.com_ <3>
 ----
-<1> In the `[ req_distinguished_name ]` section, enter information about your organization.
 ifeval::["{context}" == "{project-context}"]
+<1> In the `[ req_distinguished_name ]` section, enter information about your organization.
 <2> Set the certificate's Common Name `CN` to match the fully qualified domain name (FQDN) of your {ProductName}.
 To confirm a FQDN, on that {ProductName}, enter the `hostname -f` command.
 This is required to ensure that the `katello-certs-check` command validates the certificate correctly.
+<3> Set the Subject Alternative Name (SAN) `DNS.1` to match the fully qualified domain name (FQDN) of your server.
 endif::[]
 ifeval::["{context}" == "{smart-proxy-context}"]
+<1> In the `[ req_distinguished_name ]` section, enter information about your organization.
 <2> Set the certificate's Common Name `CN` to match the fully qualified domain name (FQDN) of your {ProductName} or a wildcard value `*`.
 To confirm a FQDN, on that {ProductName}, enter the `hostname -f` command.
 This is required to ensure that the `katello-certs-check` command validates the certificate correctly.
 If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
-endif::[]
 <3> Set the Subject Alternative Name (SAN) `DNS.1` to match the fully qualified domain name (FQDN) of your server.
+endif::[]
 
 . Generate the Certificate Signing Request (CSR):
 +

--- a/guides/common/modules/proc_installing-server-packages-deb.adoc
+++ b/guides/common/modules/proc_installing-server-packages-deb.adoc
@@ -1,4 +1,4 @@
-[id="configuring-foreman-repositories-deb"]
+[id="configuring-foreman-repositories-deb-{context}"]
 
 . Update all packages:
 +

--- a/guides/common/modules/proc_installing-server-packages-el.adoc
+++ b/guides/common/modules/proc_installing-server-packages-el.adoc
@@ -1,4 +1,4 @@
-[id="configuring-foreman-repositories-el-{package-manager}"]
+[id="configuring-foreman-repositories-el-{package-manager}-{context}"]
 
 . Update all packages:
 +


### PR DESCRIPTION
Thanks to changes in https://github.com/theforeman/foreman-documentation/pull/471 and two more changes, we can now treat, and I would never imagine saying that, WARNINGS as ERRORS. Meaning any asciidoc warning from now on will fail the build and PR tests as well. Neat, is it?

I also noticed that when you changed some adoc file in common directory, simply calling `make` would not recognize the change and you had to do `make clean`. This was because we were missing dependencies there.