### PR TITLE
Adapt cockpit guide for orcharhino documentation

### DIFF
--- a/guides/doc-Managing_Hosts/topics/proc_managing_and_monitoring_hosts_using_red_hat_web_console.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_managing_and_monitoring_hosts_using_red_hat_web_console.adoc
@@ -8,7 +8,7 @@ You can access the {Cockpit} web UI through the {Project} web UI and use the fun
 * {Cockpit} is enabled in {Project}.
 * {Cockpit} is installed on the host that you want to view:
 
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 ** For more information see https://cockpit-project.org/running.html[Running Cockpit].
 endif::[]
 
@@ -18,7 +18,9 @@ ifdef::satellite[]
 endif::[]
 
 * {Project} or {SmartProxy} can authenticate to the host with SSH keys.
+ifndef::orcharhino[]
 For more information, xref:ssh-keys-for-remote-execution-overview_{context}[].
+endif::[]
 
 .Procedure
 


### PR DESCRIPTION
This PR adapts cockpit documentation files for usage in the documentation of the downstream product orcharhino.