### PR TITLE
Adapt ACD guide

### DIFF
--- a/guides/common/modules/con_acd_introduction.adoc
+++ b/guides/common/modules/con_acd_introduction.adoc
@@ -114,4 +114,6 @@ endif::[]
 == Prerequisites for Application Centric Deployment
 
 In order to use the ACD plugin, your {ProjectName} instance must be able to deploy a host and offer properly configured host groups.
+ifdef::foreman-el,foreman-deb,katello[]
 Refer to the https://docs.theforeman.org/[Foreman and Katello documentation] for more information.
+endif::[]


### PR DESCRIPTION
This PR adapts ACD documentation files for usage in the documentation of the downstream product orcharhino.