### PR TITLE
Escape http links in inline code

### DIFF
--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -12,7 +12,7 @@ To use the CLI instead of the web UI, see the xref:cli-adding-a-default-http-pro
 . In the {Project} web UI, navigate to *Infrastructure* > *HTTP Proxies*.
 . Click *New HTTP Proxy*.
 . In the *Name* field, enter the name for the HTTP proxy.
-. In the *Url* field, enter the URL of the HTTP proxy in the following format: `https://_proxy.example.com_:8080`.
+. In the *Url* field, enter the URL of the HTTP proxy in the following format: `\https://_proxy.example.com_:8080`.
 . Optional: If authentication is required, in the *Username* field, enter the username to authenticate with.
 . Optional: If authentication is required, in the *Password* field, enter the password to authenticate with.
 . To test connection to the proxy, click the *Test Connection* button.

--- a/guides/common/modules/proc_adding-openstack-connection.adoc
+++ b/guides/common/modules/proc_adding-openstack-connection.adoc
@@ -11,7 +11,7 @@ To use the CLI instead of the web UI, see the xref:cli-adding-openstack-connecti
 . From the *Provider* list, select *RHEL OpenStack Platform*.
 . In the *Description* field, enter a description for the compute resource.
 . In the *URL* field, enter the URL for the OpenStack Authentication keystone service's API at the `tokens` resource.
-Use the following format: `http://openstack.example.com:5000/v3.0/tokens`.
+Use the following format: `\http://openstack.example.com:5000/v3.0/tokens`.
 . In the *User* and *Password* fields, enter the authentication user and password for {Project} to access the environment.
 . In the *Domain* field, enter the domain for V3 authentication.
 . From the *Tenant* list, select the tenant or project for {ProjectServer} to manage.

--- a/guides/common/modules/proc_adding-rhv-connection.adoc
+++ b/guides/common/modules/proc_adding-rhv-connection.adoc
@@ -10,7 +10,7 @@ To use the CLI instead of the web UI, see the xref:cli-adding-rhv-connection_{co
 . In the *Name* field, enter a name for the new compute resource.
 . From the *Provider* list, select *{oVirtShort}*.
 . In the *Description* field, enter a description for the compute resource.
-. In the *URL* field, enter the connection URL for the {oVirtEngine}'s API in the following form: `https://{ovirt-example-com}/ovirt-engine/api/v3`.
+. In the *URL* field, enter the connection URL for the {oVirtEngine}'s API in the following form: `\https://{ovirt-example-com}/ovirt-engine/api/v3`.
 . Optionally, select the *Use APIv4* check box to evaluate the new {oVirtEngine} API.
 . In the *User* field, enter the name of a user with permissions to access {oVirtEngine}'s resources.
 . In the *Password* field, enter the password of the user.

--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to configure {Project} settings for {Keycloak} authentication using the {Project} CLI.
 
-Note that you can navigate to the following URL within your realm to obtain values to configure {Project} settings: `https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/.well-known/openid-configuration`
+Note that you can navigate to the following URL within your realm to obtain values to configure {Project} settings: `\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/.well-known/openid-configuration`
 
 .Prerequisite
 

--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to configure {Project} settings for {Keycloak} authentication using the {Project} web UI.
 
-Note that you can navigate to the following URL within your realm to obtain values to configure {Project} settings: `https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/.well-known/openid-configuration`
+Note that you can navigate to the following URL within your realm to obtain values to configure {Project} settings: `\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/.well-known/openid-configuration`
 
 .Prerequisite
 

--- a/guides/common/modules/proc_configuring-satellite-to-synchronize-content-with-a-local-cdn-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-synchronize-content-with-a-local-cdn-server.adoc
@@ -65,6 +65,6 @@ For example, `/var/www/html/pub/sat-import/`:
 
 . Edit the *Red Hat CDN URL* field to point to the host name of the system that you use as a local CDN server with the newly created directory, for example:
 +
-`http://server.example.com/pub/sat-import/`
+`\http://server.example.com/pub/sat-import/`
 
 . Click *Update* and then upload your manifest into {Project}.

--- a/guides/common/modules/proc_configuring-the-project-client-in-keycloak.adoc
+++ b/guides/common/modules/proc_configuring-the-project-client-in-keycloak.adoc
@@ -11,7 +11,7 @@ Use this procedure to configure the {Project} client in the {Keycloak} web UI an
 * If you want your users to authenticate to {Project} using the CLI, from the *Access Type* list, select *public*.
 . In the *Valid redirect URI* fields, add a valid redirect URI.
 +
-* If you want your users to authenticate to {Project} using the web UI, in the blank field below the existing URI, enter a URI in the form `https://{foreman-example-com}/users/extlogin`. Note that you must add the string `/users/extlogin` after the {Project} FQDN.
+* If you want your users to authenticate to {Project} using the web UI, in the blank field below the existing URI, enter a URI in the form `\https://{foreman-example-com}/users/extlogin`. Note that you must add the string `/users/extlogin` after the {Project} FQDN.
 +
 After completing this step, the {Project} client for logging in using the web UI must have the following *Valid Redirect URIs*:
 +

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -78,6 +78,6 @@ If the file exists, run the second `{foreman-installer}` command that updates ce
 IMPORTANT: Do not delete the certificate archive file after you deploy the certificate.
 It is required, for example, when upgrading {ProjectServer}.
 
-. On a computer with network access to {ProjectServer}, navigate to the following URL: `https://_{foreman-example-com}_`.
+. On a computer with network access to {ProjectServer}, navigate to the following URL: `\https://_{foreman-example-com}_`.
 
 . In your browser, view the certificate details to verify the deployed certificate.

--- a/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_OSTree_Branches.adoc
@@ -102,7 +102,7 @@ This automatically populates the *Label* field.
 This automatically populates the *Label* field.
 . From the *Type* list, select `ostree`.
 . In the *URL* field, enter the URL of the registry to use as a source.
-For example `http://www.example.com/rpm-ostree/`.
+For example `\http://www.example.com/rpm-ostree/`.
 . From the *Upstream Sync Policy* menu, select one of the following policies to synchronize OSTree branches for this repository:
 * *Latest Only* - synchronize only the latest OSTree branch.
 * *All History* - synchronize all OSTree branches.

--- a/guides/doc-Managing_Hosts/topics/Synchronizing_Templates.adoc
+++ b/guides/doc-Managing_Hosts/topics/Synchronizing_Templates.adoc
@@ -67,7 +67,7 @@ You can synchronize templates with a version control system, such as Git, or a l
 ==== Importing Templates
 
 You can import templates from a repository of your choice.
-You can use different protocols to point to your repository, for example `/tmp/dir`, `git://example.com`, `https://example.com`, and `ssh://example.com`.
+You can use different protocols to point to your repository, for example `/tmp/dir`, `git://example.com`, `\https://example.com`, and `ssh://example.com`.
 
 .Prerequisites
 

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -110,8 +110,8 @@ To provision machines through HTTP booting without managed DHCP ensure that you 
 .Client requirements
 
 * HTTP UEFI Boot URL must be set to one of:
-** `http://{smartproxy.example.com}:8000
-** `https://{smartproxy.example.com}:{smartproxy_port}
+** `\http://{smartproxy.example.com}:8000`
+** `\https://{smartproxy.example.com}:{smartproxy_port}`
 * Ensure that your client has access to the DHCP and DNS servers.
 * Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -189,7 +189,7 @@ Generic image::
 A boot ISO that is not associated with a specific host.
 The ISO sends the host's MAC address to {ProjectServer}, which matches it against the host entry.
 The image does not store IP address details, and requires access to a DHCP server on the network to bootstrap.
-This image is also available from the `/bootdisk/disks/generic` URL on your {ProjectServer}, for example, `https://{foreman-example-com}/bootdisk/disks/generic`.
+This image is also available from the `/bootdisk/disks/generic` URL on your {ProjectServer}, for example, `\https://{foreman-example-com}/bootdisk/disks/generic`.
 
 Subnet image::
 A boot ISO that is similar to the generic image but is configured with the address of a {SmartProxyServer}.

--- a/guides/doc-Provisioning_Guide/topics/Networking.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Networking.adoc
@@ -108,8 +108,8 @@ Depending on the PXE loader option, the `filename` changes as follows:
 |PXELinux UEFI | `pxelinux.efi`|
 |iPXE Chain BIOS | `undionly.kpxe`|
 |PXEGrub2 UEFI | `grub2/grubx64.efi`| x64 can differ depending on architecture
-|iPXE UEFI HTTP | `http://_{smartproxy-example-com}_:8000/httpboot/ipxe-x64.efi` | Requires the `httpboot` feature and renders the `filename` as a full URL where _{smartproxy-example-com}_ is a known host name of {SmartProxy} in {Project}.
-|Grub2 UEFI HTTP | `http://_{smartproxy-example-com}_:8000/httpboot/grub2/grubx64.efi` | Requires the `httpboot` feature and renders the `filename` as a full URL where _{smartproxy-example-com}_ is a known host name of {SmartProxy} in {Project}.
+|iPXE UEFI HTTP | `\http://_{smartproxy-example-com}_:8000/httpboot/ipxe-x64.efi` | Requires the `httpboot` feature and renders the `filename` as a full URL where _{smartproxy-example-com}_ is a known host name of {SmartProxy} in {Project}.
+|Grub2 UEFI HTTP | `\http://_{smartproxy-example-com}_:8000/httpboot/grub2/grubx64.efi` | Requires the `httpboot` feature and renders the `filename` as a full URL where _{smartproxy-example-com}_ is a known host name of {SmartProxy} in {Project}.
 |=======
 
 === Troubleshooting DHCP Problems in {Project}

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -169,9 +169,9 @@ if exists user-class and option user-class = "iPXE" {
 If you use an isolated network, use a {SmartProxyServer} URL with TCP port `8000`, instead of the URL of {ProjectServer}.
 +
 [NOTE]
-Use `http://{foreman-example-com}/unattended/iPXE?bootstrap=1` when {SmartProxy} HTTP endpoint is disabled (installer option --foreman-proxy-http false).
+Use `\http://{foreman-example-com}/unattended/iPXE?bootstrap=1` when {SmartProxy} HTTP endpoint is disabled (installer option --foreman-proxy-http false).
 Template {SmartProxy} plug-in has the default value `8000` when enabled and can be changed with `--foreman-proxy-http-port installer` option.
-In that case, use `http://{smartproxy-example-com}:8000`.
+In that case, use `\http://{smartproxy-example-com}:8000`.
 You must update the `/etc/dhcp/dhcpd.conf` file after every upgrade.
 
 === Chainbooting {ProjectServer} to use iPXE directly
@@ -248,7 +248,7 @@ if exists user-class and option user-class = "iPXE" {
 If you use an isolated network, use a {SmartProxyServer} URL with TCP port `8000`, instead of the URL of {ProjectServer}.
 +
 [NOTE]
-For `http://{foreman-example-com}/unattended/iPXE`, you can also use a {ProjectName} {SmartProxy} `http://{smartproxy-example-com}:8000/unattended/iPXE`.
+For `\http://{foreman-example-com}/unattended/iPXE`, you can also use a {ProjectName} {SmartProxy} `\http://{smartproxy-example-com}:8000/unattended/iPXE`.
 You must update the `/etc/dhcp/dhcpd.conf` file after every upgrade.
 
 === Chainbooting {ProjectName} {SmartProxy} to use iPXE directly


### PR DESCRIPTION
This PR escapes HTTP links in inline code with a backslash.

In asciidoc, you can escape links using a backslash in inline codes as follows:

```
clickable            vs. not clickable
`http://example.com` vs. `\http://example.com`

```

This makes sense if the docs link to "foreman.example.com/pub/something" etc., as the URL such never be clicked on/resolve.