### PR TITLE
Adapt remote execution guide

### DIFF
--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -42,7 +42,9 @@ This helps to keep the query up to date for scheduled tasks.
 You can also define a one-time future job, or set up a recurring job.
 For recurring tasks, you can define start and end dates, number and frequency of runs.
 You can also use cron syntax to define repetition.
+ifndef::orcharhino[]
 For more information about cron, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-automating_system_tasks[Automating System Tasks] section of the Red Hat Enterprise Linux 7 _System Administrator's Guide_.
+endif::[]
 
 . Click *Submit*.
 This displays the *Job Overview* page, and when the job completes, also displays the status of the job.

--- a/guides/common/modules/ref_default-job-template-categories.adoc
+++ b/guides/common/modules/ref_default-job-template-categories.adoc
@@ -1,7 +1,7 @@
 [id="default-job-template-categories_{context}"]
 = Default Job Template Categories
 
-[options="header"]
+[cols="30%,70%",options="header"]
 |====
 |Job template category |Description
 |Packages |Templates for performing package related actions.


### PR DESCRIPTION
This PR adapts remote execution files for usage in the documentation of the downstream product orcharhino.

Do you like the 30%-70% width distribution in the table? I feel like it's a small UX improvement. [original 50-50](https://docs.theforeman.org/nightly/Managing_Hosts/index-foreman-el.html#default-job-template-categories_managing-hosts)