### PR TITLE
[CP] Katello 4.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When a commit is pushed into `X.Y`:
 
 ## Branching new release
 
-* Create a new directory [/web/content/version-X.Y](https://github.com/theforeman/foreman-documentation/tree/master/web/content/version-2.3) and copy `index.md` and edit it accordingly.
+* Create a copy of [/web/content/2.3.md](https://github.com/theforeman/foreman-documentation/tree/master/web/content/version-2.3) (or older version) as `X.Y.md` and edit it accordingly.
 * Edit [/web/content/versions.md](https://github.com/theforeman/foreman-documentation/blob/master/web/content/versions.md) and add the new version to the menu.
 * Push the changes into `master`.
 * Check the site if links and landing page appeared correctly.

--- a/web/content/2.3.md
+++ b/web/content/2.3.md
@@ -3,10 +3,28 @@ title: "Foreman 2.3 and Katello 3.18 documentation"
 path: 2.3
 ---
 
-This is work-in-progress documentation site for <a href="https://www.theforeman.org">Foreman</a> open-source software.
-Official documentation [is available here](https://theforeman.org/manuals/2.3/index.html).
+## Foreman 2.3 and Katello 3.18
 
-### Headline features
+Available guides:
+
+* [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman.html)
+* [Installing Foreman on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-foreman.html)
+* [Installing Katello on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-katello.html)
+* [Installing Smart Proxy on RHEL/CentOS](/{{< param "path" >}}/Installing_Proxy_on_Red_Hat/index-foreman.html)
+* [Installing Foreman on Debian/Ubuntu](/{{< param "path" >}}/Installing_Server_on_Debian/index-foreman-deb.html)
+* [Installing Smart Proxy on Debian/Ubuntu](/{{< param "path" >}}/Installing_Proxy_on_Debian/index-foreman-deb.html)
+* [Deploying Foreman on AWS (reference guide)](/{{< param "path" >}}/Deploying_on_AWS/index-foreman.html)
+* [Configuring Smart Proxies with a Load Balancer](/{{< param "path" >}}/Configuring_Load_Balancer/index-foreman.html)
+* [Provisioning Guide](/{{< param "path" >}}/Provisioning_Guide/index-foreman.html)
+* [Content Management Guide](/{{< param "path" >}}/Content_Management_Guide/index-katello.html)
+* [Configuring Foreman to use Ansible](/{{< param "path" >}}/Configuring_Ansible/index-foreman.html)
+* [Managing Hosts Guide](/{{< param "path" >}}/Managing_Hosts/index-foreman.html)
+* [Administering Foreman](/{{< param "path" >}}/Administering_Red_Hat_Satellite/index-foreman.html)
+
+This is work-in-progress documentation site for <a href="https://www.theforeman.org">Foreman</a> open-source software and its
+plugins. Official documentation [is available here](https://theforeman.org/manuals/latest/index.html).
+
+### Foreman headline features
 
 #### Host Registration
 
@@ -23,18 +41,3 @@ When template safe mode rendering is disabled in the settings, users can now pre
 #### Show instance name in top menu
 For users managing multiple Foreman instances, a new setting (`instance_title`) has been introduced that allows setting a name for each instance. When set, an icon will appear on the top bar which will display the instance name when hovered over. ([#29024](https://projects.theforeman.org/issues/29024))
 
-Available guides for version 2.3:
-
-* [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman.html)
-* [Installing Foreman on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-foreman.html)
-* [Installing Katello on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-katello.html)
-* [Installing Smart Proxy on RHEL/CentOS](/{{< param "path" >}}/Installing_Proxy_on_Red_Hat/index-foreman.html)
-* [Installing Foreman on Debian/Ubuntu](/{{< param "path" >}}/Installing_Server_on_Debian/index-foreman-deb.html)
-* [Installing Smart Proxy on Debian/Ubuntu](/{{< param "path" >}}/Installing_Proxy_on_Debian/index-foreman-deb.html)
-* [Deploying Foreman on AWS (reference guide)](/{{< param "path" >}}/Deploying_on_AWS/index-foreman.html)
-* [Configuring Smart Proxies with a Load Balancer](/{{< param "path" >}}/Configuring_Load_Balancer/index-foreman.html)
-* [Provisioning Guide](/{{< param "path" >}}/Provisioning_Guide/index-foreman.html)
-* [Content Management Guide](/{{< param "path" >}}/Content_Management_Guide/index-katello.html)
-* [Configuring Foreman to use Ansible](/{{< param "path" >}}/Configuring_Ansible/index-foreman.html)
-* [Managing Hosts Guide](/{{< param "path" >}}/Managing_Hosts/index-foreman.html)
-* [Administering Foreman](/{{< param "path" >}}/Administering_Red_Hat_Satellite/index-foremanl.html)

--- a/web/content/2.4.md
+++ b/web/content/2.4.md
@@ -243,3 +243,60 @@ plugins. Official documentation [is available here](https://theforeman.org/manua
 * Drop deprecated disable_plugin methods ([#31303](https://projects.theforeman.org/issues/31303))
 
 *A full list of changes in 2.4.0 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12][]=1319)*
+
+
+### Katello headline features
+
+For the full release notes, see the [Changelog](https://github.com/Katello/katello/blob/KATELLO-4.0/CHANGELOG.md).
+
+#### Features
+
+* Katello repositories are now hosted at [yum.theforeman.org](https://yum.theforeman.org/katello/).
+* New Content View page user interface updates.
+* Content View Version added to Reporting Engine Template.
+* Number of Red Hat subscriptions consumed by host added to Entitlements report.
+* Added option to select Operating System in Register Content Host.
+
+
+#### Deprecations
+* katello-agent will be removed in a future Katello release. Consider migrating to use the Remote Execution plugin for managing content on your hosts
+* Removal of Puppet command support from hammer-cli-katello.
+* Pulp 3 replaced Pulp 2.
+** MongoDB was removed.
+** The Foreman installer MongoDB Storage Engine Migration Hook was removed.
+* Puppet and OSTree repository types are no longer be available.
+
+#### Notes
+* It is very important that when upgrading to Katello 4.0 that [content is migrated from Pulp 2 to Pulp 3](https://theforeman.org/plugins/katello/3.18/upgrade/index.html).
+
+### Bug Fixes
+* Almost 60 bugs were addressed in this release. Full details are available at the [release tracker](https://projects.theforeman.org/projects/katello/issues?fixed_version_id=1177&set_filter=1&status_id=%2A&tracker_id=1).
+
+### Contributors
+* Adam Růžička
+* Anand Agrawal
+* Bernhard Suttner
+* Chris Roberts
+* Eric D. Helms
+* Evgeni Golov
+* Ewoud Kohl van Wijngaarden
+* Ian Ballou
+* James Jeffers
+* Jeremy Lenz
+* John Mitsch
+* Jonathon Turel
+* Justin Sherrill
+* Leos Stejskal
+* Manisha Singhal
+* Marek Hulan
+* Nagoor Shaik
+* Oleh Fedorenko
+* Ondřej Ezr
+* Partha Aji
+* Ranjan Kumar
+* Ron Lavi
+* Samir Jha
+* Shimon Shtein
+* Tomer Brisker
+
+*A full list of changes in 4.0 is available via [Redmine](https://projects.theforeman.org/versions/1177)*

--- a/web/content/2.4.md
+++ b/web/content/2.4.md
@@ -1,0 +1,245 @@
+---
+title: "Foreman 2.4 and Katello 4.0 documentation"
+path: 2.4
+---
+
+## Foreman 2.4 and Katello 4.0
+
+Available guides:
+
+* [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman.html)
+* [Installing Foreman on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-foreman.html)
+* [Installing Katello on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-katello.html)
+* [Installing Smart Proxy on RHEL/CentOS](/{{< param "path" >}}/Installing_Proxy_on_Red_Hat/index-foreman.html)
+* [Installing Foreman on Debian/Ubuntu](/{{< param "path" >}}/Installing_Server_on_Debian/index-foreman-deb.html)
+* [Installing Smart Proxy on Debian/Ubuntu](/{{< param "path" >}}/Installing_Proxy_on_Debian/index-foreman-deb.html)
+* [Deploying Foreman on AWS (reference guide)](/{{< param "path" >}}/Deploying_on_AWS/index-foreman.html)
+* [Configuring Smart Proxies with a Load Balancer](/{{< param "path" >}}/Configuring_Load_Balancer/index-foreman.html)
+* [Provisioning Guide](/{{< param "path" >}}/Provisioning_Guide/index-foreman.html)
+* [Content Management Guide](/{{< param "path" >}}/Content_Management_Guide/index-katello.html)
+* [Configuring Foreman to use Ansible](/{{< param "path" >}}/Configuring_Ansible/index-foreman.html)
+* [Managing Hosts Guide](/{{< param "path" >}}/Managing_Hosts/index-foreman.html)
+* [Administering Foreman](/{{< param "path" >}}/Administering_Red_Hat_Satellite/index-foreman.html)
+
+This is work-in-progress documentation site for <a href="https://www.theforeman.org">Foreman</a> open-source software and its
+plugins. Official documentation [is available here](https://theforeman.org/manuals/latest/index.html).
+
+### Foreman headline features
+
+#### Foreman
+* Support vertical drag & drop ([#31689](https://projects.theforeman.org/issues/31689))
+* Kickstart template for creating bond interfaces does not work in all cases ([#31675](https://projects.theforeman.org/issues/31675))
+* Add OpenWrt icon to the OS ([#31664](https://projects.theforeman.org/issues/31664))
+* Global Registration Template - Fix for syntax error ([#31639](https://projects.theforeman.org/issues/31639))
+* Repository enable failed on http-proxy configured setup.
+ ([#31637](https://projects.theforeman.org/issues/31637))
+* Booting to anaconda with bond configured run into timeout ([#31631](https://projects.theforeman.org/issues/31631))
+* bondslaves in kickstart kernel options should be string not list ([#31626](https://projects.theforeman.org/issues/31626))
+* Deprecate flot_pie_chart ([#31569](https://projects.theforeman.org/issues/31569))
+* remove ovirt_use_v4 from oVirt compute resource attributes  ([#31551](https://projects.theforeman.org/issues/31551))
+* Improve /puppetrun error message ([#31543](https://projects.theforeman.org/issues/31543))
+* Improve os name matching for icon ([#31531](https://projects.theforeman.org/issues/31531))
+* ALTLinux icons display ([#31491](https://projects.theforeman.org/issues/31491))
+* Provisioning templates - Error message for blank template & fix resetting fields ([#31483](https://projects.theforeman.org/issues/31483))
+* allow ansible inventory template to work without Ansible plugin ([#31482](https://projects.theforeman.org/issues/31482))
+* Allow reinitialization of init values in ForemanForm ([#31461](https://projects.theforeman.org/issues/31461))
+* Clone Operating system ([#31410](https://projects.theforeman.org/issues/31410))
+* Integrate webhooks with ActiveJob ([#31243](https://projects.theforeman.org/issues/31243))
+* Extract the permitted params to a separate variable in registration controller ([#31177](https://projects.theforeman.org/issues/31177))
+* Show host name in ENC output  ([#31168](https://projects.theforeman.org/issues/31168))
+* Use single quotes in registration templates for curl ([#31143](https://projects.theforeman.org/issues/31143))
+* Developer Docs - Create plugin - host.refresh_status & subscriber ([#31139](https://projects.theforeman.org/issues/31139))
+* Add global css registration from plugins ([#30978](https://projects.theforeman.org/issues/30978))
+* Allow Ubuntu 18.04 to netboot with a VLAN tag ([#30737](https://projects.theforeman.org/issues/30737))
+* Add warning banner about puppet ENC extraction ([#30215](https://projects.theforeman.org/issues/30215))
+* Add support for Redfish to BMC Smart Proxy ([#29636](https://projects.theforeman.org/issues/29636))
+
+#### Foreman - API
+* GET "/api/v2/permissions" Is failing with 500 Internal Server Error ([#31554](https://projects.theforeman.org/issues/31554))
+* make /api/statuses output more structured data about plugins ([#31521](https://projects.theforeman.org/issues/31521))
+* External IPAM Error Handling Issue ([#31480](https://projects.theforeman.org/issues/31480))
+* nic delay not present in API responses ([#31429](https://projects.theforeman.org/issues/31429))
+* not possible to update interfaces in POST /api/hosts/:host_id ([#31311](https://projects.theforeman.org/issues/31311))
+
+#### Foreman - Compute resources - VMware
+* API errors since upgrade to 2.1.2 ([#30889](https://projects.theforeman.org/issues/30889))
+
+#### Foreman - Compute resources - libvirt
+* Libvirt hostdev network breaks entire compute resource ([#22259](https://projects.theforeman.org/issues/22259))
+
+#### Foreman - Compute resources - oVirt
+* - Storage domain from External provider not available when creating new host on Satellite ([#30835](https://projects.theforeman.org/issues/30835))
+* Add support for vNIC profiles in RHV compute resource ([#30834](https://projects.theforeman.org/issues/30834))
+* Remove API v3 from fog-ovirt ([#30793](https://projects.theforeman.org/issues/30793))
+
+#### Foreman - Development tools
+* Fix bundler not found for Storybook deploy ([#31567](https://projects.theforeman.org/issues/31567))
+* Use gem for common rubocop rules ([#30925](https://projects.theforeman.org/issues/30925))
+* Upgrade Storybook to v6 ([#30842](https://projects.theforeman.org/issues/30842))
+
+#### Foreman - Host creation
+* Add CentOS 8 Stream installation media ([#31571](https://projects.theforeman.org/issues/31571))
+* Improve provisioing token logging ([#31273](https://projects.theforeman.org/issues/31273))
+
+#### Foreman - Host registration
+* registration_facet missing on hosts ([#31669](https://projects.theforeman.org/issues/31669))
+* Global registration fails with Validation failed: Name can't be blank ([#31645](https://projects.theforeman.org/issues/31645))
+* foreman_hooks: create hook fails to render host with "You cannot call create unless the parent is saved" ([#31518](https://projects.theforeman.org/issues/31518))
+* Add insecure checkbox to the registration form ([#31503](https://projects.theforeman.org/issues/31503))
+* Global Registration Template - Exit when subscription-manager fails ([#31420](https://projects.theforeman.org/issues/31420))
+* Limit JWT used for host registration to only allow access to the register endpoint ([#31282](https://projects.theforeman.org/issues/31282))
+
+#### Foreman - JavaScript stack
+* Drop NavDropdown component ([#31688](https://projects.theforeman.org/issues/31688))
+* Deprecate using store for current taxonomies ([#31666](https://projects.theforeman.org/issues/31666))
+* fix propTypes in EmptyStatePattern  ([#31561](https://projects.theforeman.org/issues/31561))
+* cant use customBreadcrumbs in pagelayout ([#31546](https://projects.theforeman.org/issues/31546))
+* Stop using deprecated API export in common/index.js ([#31478](https://projects.theforeman.org/issues/31478))
+* Breadcrumbs story is empty ([#31365](https://projects.theforeman.org/issues/31365))
+* Use API middleware with React hooks ([#31250](https://projects.theforeman.org/issues/31250))
+* Add card template extension mechanism for host details page ([#30987](https://projects.theforeman.org/issues/30987))
+* Remove console errors from ForemanModal ([#30724](https://projects.theforeman.org/issues/30724))
+* current taxonomies and user_id are missing in ContextAPI ([#29792](https://projects.theforeman.org/issues/29792))
+* Add react-helmet to foreman ([#29324](https://projects.theforeman.org/issues/29324))
+* deprecate  per_page_options and move its logic to Pagination component ([#29292](https://projects.theforeman.org/issues/29292))
+
+#### Foreman - Organizations and Locations
+* Switching taxonomies is impossible on mobile displays ([#31600](https://projects.theforeman.org/issues/31600))
+* User without view_organization permission cannot switch organization ([#29914](https://projects.theforeman.org/issues/29914))
+* API in satellite 6.3 to view location parameter does not resolve the location name with location ID as it used to in satellite 6.2
+ ([#26871](https://projects.theforeman.org/issues/26871))
+
+#### Foreman - Packaging
+* Use Puma 5.1's feature to synthesize systemd socket binds ([#31431](https://projects.theforeman.org/issues/31431))
+
+#### Foreman - Plugin integration
+* External IPAM now fails with "mac address cannot be nil" on Compute Resource deployment. ([#31578](https://projects.theforeman.org/issues/31578))
+* Clean up deprecations for 2.4 ([#31233](https://projects.theforeman.org/issues/31233))
+* Add Hostgroup API views Facet extenstion points ([#31213](https://projects.theforeman.org/issues/31213))
+
+#### Foreman - Puppet Reports
+* WebUI spinner spins forever when clicking a column within config report ([#31526](https://projects.theforeman.org/issues/31526))
+
+#### Foreman - Puppet integration
+* Puppet Environments are not listed properly in the SCP details page ([#31625](https://projects.theforeman.org/issues/31625))
+* Each smart class parameter appears twice, when having two environments ([#31538](https://projects.theforeman.org/issues/31538))
+* TemplateInput type registry ([#31284](https://projects.theforeman.org/issues/31284))
+
+#### Foreman - Rails
+* Unset welcome flag, if the controller doesn't have welcome template ([#31111](https://projects.theforeman.org/issues/31111))
+
+#### Foreman - Rake tasks
+* rake errors:fetch_log errors when layout is not multiline_request_pattern ([#31884](https://projects.theforeman.org/issues/31884))
+* Incorrect output in rake config task ([#31584](https://projects.theforeman.org/issues/31584))
+
+#### Foreman - Reporting
+* Report template "Last Checkin" fails: ERF45-5139 [Foreman::Renderer::Errors::UnknownReportColumn] ([#31747](https://projects.theforeman.org/issues/31747))
+* Add time_to_str macro ([#31633](https://projects.theforeman.org/issues/31633))
+* Extend StatusCalculator to make use of 64 bits ([#31147](https://projects.theforeman.org/issues/31147))
+* foreman-rake reports:daily runs all reports twice ([#30670](https://projects.theforeman.org/issues/30670))
+* Add host filter to the applied errata report ([#29969](https://projects.theforeman.org/issues/29969))
+
+#### Foreman - Search
+* Simplify mount_search_bar method ([#31368](https://projects.theforeman.org/issues/31368))
+* drop unused get_search_props method ([#31367](https://projects.theforeman.org/issues/31367))
+* Search doesn't work on the models page ([#31198](https://projects.theforeman.org/issues/31198))
+
+#### Foreman - Settings
+* Settings table is not updated after making a change in the UI ([#31723](https://projects.theforeman.org/issues/31723))
+* "Can not set password with opaque" error on settings page after creating Http proxy with invalid url. ([#31722](https://projects.theforeman.org/issues/31722))
+* Unable to clear http_proxy_except_list setting ([#31719](https://projects.theforeman.org/issues/31719))
+* Remove use of {locations,organizations}_enabled in menu structure ([#31718](https://projects.theforeman.org/issues/31718))
+* Settings "Content" page disappeared after setting the http-proxy. ([#31603](https://projects.theforeman.org/issues/31603))
+* Some Settings have a blank name on Settings page ([#31587](https://projects.theforeman.org/issues/31587))
+* Deprecate setting timestamps in API responses ([#31471](https://projects.theforeman.org/issues/31471))
+* responses to /api/v2/settings/&lt;id&gt; no longer contain 'created_at' and 'updated_at' attrs ([#31285](https://projects.theforeman.org/issues/31285))
+
+#### Foreman - Templates
+* Unterminated single quote in chainloader pxeboot template breaks grub2 parser ([#31758](https://projects.theforeman.org/issues/31758))
+* Deprecate Environment in Template combination API ([#31738](https://projects.theforeman.org/issues/31738))
+* iPXE ping gateway and name server ([#31585](https://projects.theforeman.org/issues/31585))
+* Drop IPAPPEND2 completely and use 01 for the hardware prefix ([#31573](https://projects.theforeman.org/issues/31573))
+* puppetlabs_repo snippet incorrectly references puppet release files as puppetlabs-release rather than puppet-release ([#31568](https://projects.theforeman.org/issues/31568))
+* Add eject cdrom snippet and call it from preseed finish script ([#31454](https://projects.theforeman.org/issues/31454))
+* Cannot build an EL 8.3 system via Satellite Bootdisk or Discovery kexec ([#31452](https://projects.theforeman.org/issues/31452))
+* Use minimal repo requirements for Debian installer in presseed default template ([#31017](https://projects.theforeman.org/issues/31017))
+* Generating Ansible Inventory includes newlines in response ([#29111](https://projects.theforeman.org/issues/29111))
+* Default kickstart places log to /mnt/sysimage/root/install.post.log ([#28521](https://projects.theforeman.org/issues/28521))
+
+#### Foreman - Tests
+* tests fail to run with Rake 13.0.2 ([#31533](https://projects.theforeman.org/issues/31533))
+* Upgrade tests to support jest 26 ([#30799](https://projects.theforeman.org/issues/30799))
+
+#### Foreman - Unattended installations
+* Add 'snippet_if_exists' to default kickstart template ([#31440](https://projects.theforeman.org/issues/31440))
+
+#### Foreman - Users, Roles and Permissions
+* Remove usage of deprecated Net::LDAP::LdapError ([#31517](https://projects.theforeman.org/issues/31517))
+* LDAP usergroup sync makes logins very slow ([#31165](https://projects.theforeman.org/issues/31165))
+
+#### Foreman - Web Interface
+* Tables have overlaping text content ([#31855](https://projects.theforeman.org/issues/31855))
+* Simplify TaxonomySwitcher component ([#31599](https://projects.theforeman.org/issues/31599))
+* Navigating to the same page removes highlight from nav ([#31549](https://projects.theforeman.org/issues/31549))
+* Javascript error on logout page "TypeError: Cannot read property 'icon' of null" ([#31495](https://projects.theforeman.org/issues/31495))
+* Table pagination in react has extra space ([#31295](https://projects.theforeman.org/issues/31295))
+* unable to pass params to 'plugin_documentation_url' ([#31290](https://projects.theforeman.org/issues/31290))
+* Skeleton loading continue infinitely  if the value is undefined  ([#31231](https://projects.theforeman.org/issues/31231))
+* Add UI for managing Personal Access Tokens ([#31080](https://projects.theforeman.org/issues/31080))
+
+#### Hammer CLI
+* Expand path for bash completion file ([#30639](https://projects.theforeman.org/issues/30639))
+* Fix hammer list failure when defaults are set ([#31384](https://projects.theforeman.org/issues/31384))
+* Deprecating puppetrun command ([#31536](https://projects.theforeman.org/issues/31536))
+* Set new owner with host update ([#31609](https://projects.theforeman.org/issues/31609))
+* Consume structured statuses api data ([#31570](https://projects.theforeman.org/issues/31570))
+* Added missing tests to filter ([#31074](https://projects.theforeman.org/issues/31074))
+
+#### Installer
+* Enable pki-core DNF module if needed on EL8 ([#31909](https://projects.theforeman.org/issues/31909))
+* Command exceeded timeout while Installer executes foreman-rake db:migrate
+ ([#31670](https://projects.theforeman.org/issues/31670))
+* Foreman content proxy doesn't listen on port 80 anymore ([#31662](https://projects.theforeman.org/issues/31662))
+* Deploy Pulp 3 by default on Foreman server and as a mirror configuration on content proxies ([#31614](https://projects.theforeman.org/issues/31614))
+* foreman-proxy-certs-generate fails with custom certificates ([#31611](https://projects.theforeman.org/issues/31611))
+* Upgrade results in empty /var/opt/rh/rh-postgresql12/lib/pgsql/data which causes upgrade to fail ([#31486](https://projects.theforeman.org/issues/31486))
+* Ensure import/export directories are created and have proper permissions ([#31468](https://projects.theforeman.org/issues/31468))
+* Unable to set ping_free_ip in Foreman Proxy's dhcp.yml ([#31415](https://projects.theforeman.org/issues/31415))
+* Default to TLS 1.2+ ([#31386](https://projects.theforeman.org/issues/31386))
+
+#### Installer - Foreman modules
+* Remove foreman-proxy-plugin-pulp from Foreman scenario ([#31757](https://projects.theforeman.org/issues/31757))
+* Restore katello::qpid_client ([#31693](https://projects.theforeman.org/issues/31693))
+* Increase Artemis disk usage limit ([#31607](https://projects.theforeman.org/issues/31607))
+* Allow changing some Foreman Proxy and Apache hostnames on Katello-based certificates ([#31509](https://projects.theforeman.org/issues/31509))
+* Update candlepin broker.xml for jobs processing ([#31497](https://projects.theforeman.org/issues/31497))
+* Remove digital ocean plugin ([#31490](https://projects.theforeman.org/issues/31490))
+* Drop ssl_protocol parameter on foreman_proxy_content ([#31435](https://projects.theforeman.org/issues/31435))
+* Installer can't install the Ansible plugin on Debian/Ubuntu ([#31430](https://projects.theforeman.org/issues/31430))
+* Disable TLS 1.0 and 1.1 by default in Apache ([#31387](https://projects.theforeman.org/issues/31387))
+* Disable weak ciphers in qpid-router ([#31385](https://projects.theforeman.org/issues/31385))
+* Use Java 11 for Candlepin ([#31346](https://projects.theforeman.org/issues/31346))
+* Foreman Proxy HTTPBoot feature should not require tftp ([#30449](https://projects.theforeman.org/issues/30449))
+* As a developer I'd like to set the exportable paths via installer ([#30436](https://projects.theforeman.org/issues/30436))
+* Provide clearer Smart Proxy registration errors with as much context as possible based on the error ([#30284](https://projects.theforeman.org/issues/30284))
+
+#### Installer - foreman-installer script
+* Ensure postgresql-docs and postgresql-contrib are removed as part of postgresql upgrade ([#31671](https://projects.theforeman.org/issues/31671))
+* Migrate ssh_args to ansible default for current installations ([#31553](https://projects.theforeman.org/issues/31553))
+* Incorrect legacy dir in Pulpcore migration ([#31548](https://projects.theforeman.org/issues/31548))
+
+#### Packaging
+* smart_proxy_container_gateway needs to be added to foreman-packaging ([#31643](https://projects.theforeman.org/issues/31643))
+* update of DNS records fails with IPv6 address - invalid rdata format: bad dotted quad ([#31598](https://projects.theforeman.org/issues/31598))
+* rubygem-rkerberos: libkadm5clnt_mit.so will be a problem again in RHEL-8.3 ([#30653](https://projects.theforeman.org/issues/30653))
+
+#### Packaging - Debian/Ubuntu
+* Drop sysvinit scripts ([#31393](https://projects.theforeman.org/issues/31393))
+
+#### Smart Proxy - BMC
+* Expose installed BMC providers as capabilities or settings ([#31537](https://projects.theforeman.org/issues/31537))
+
+#### Smart Proxy - Plugins
+* Drop deprecated disable_plugin methods ([#31303](https://projects.theforeman.org/issues/31303))
+
+*A full list of changes in 2.4.0 is available via [Redmine](https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f[]=cf_12&op[cf_12]=%3D&v[cf_12][]=1319)*

--- a/web/content/_index.md
+++ b/web/content/_index.md
@@ -8,5 +8,6 @@ Official documentation [is available here](https://theforeman.org/manuals/nightl
 
 Available documentation sets are:
 
-* [Nightly](/nightly.html)
-* [2.3](/2.3.html)
+* [Foreman and Katello Nightly](/nightly.html)
+* [Foreman 2.3 and Katello 3.18](/2.3.html)
+* [Foreman 2.4 and Katello 4.0](/2.4.html)

--- a/web/content/versions.md
+++ b/web/content/versions.md
@@ -1,2 +1,3 @@
-[Nightly](/nightly.html)
-[2.3](/2.3.html)
+[Foreman and Katello Nightly](/nightly.html)
+[Foreman 2.3 and Katello 3.18](/2.3.html)
+[Foreman 2.4 and Katello 4.0](/2.4.html)


### PR DESCRIPTION
Cherry-pick into:
* [ ] Foreman 2.4 (Satellite 6.10)

This is a draft of release notes for the Katello 4.0 release. It is based on https://github.com/theforeman/foreman-documentation/pull/480 and will require a rebase after that is merged, AFAIK.
