### PR TITLE
Update version number in attributes.adoc for 6.9 GA release

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -6,14 +6,14 @@
 :ProjectVersion: 2.4
 :ProjectVersionPrevious: 2.3
 :KatelloVersion: 4.0
-:TargetVersion: 6.8
-:TargetVersionMaintainUpgrade: 6.8
+:TargetVersion: 6.9
+:TargetVersionMaintainUpgrade: 6.9
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
-:ProductVersion: 6.9-beta
+:ProductVersion: 6.9
 :ProductVersionPrevious: 6.8
 :SatelliteAnsibleVersion: 2.9
 // For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
-:SpecialCaseProductVersion: 6.8
+:SpecialCaseProductVersion: 6.9
 
 //
 // WHERE ARE MY ATTRIBUTES?


### PR DESCRIPTION
Update attributes.adoc and docinfo files for 6.9
https://bugzilla.redhat.com/show_bug.cgi?id=1951584



Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
