### PR TITLE
Updated the repo names in attribute file for 6.9 GA

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,11 +17,11 @@
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
-:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-beta-rpms
+:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6.9-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
-:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-beta-rpms
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-beta-rpms
-:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-beta-rpms
+:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6.9-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.9-rpms
+:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.
 :RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
 :RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms


### PR DESCRIPTION
Update attributes.adoc and docinfo files for 6.9
https://bugzilla.redhat.com/show_bug.cgi?id=1951584



Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
