### PR TITLE
Resolved several issues preventing titles from building

### DIFF
--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -39,11 +39,6 @@ This method is performed by running the installation script with one or more com
 The command options override the corresponding default initial configuration options and are recorded in the {Project} answer file.
 You can run the script as often as needed to configure any necessary options.
 
-* xref:configuring-satellite-automatically-using-an-answer-file_{context}[].
-This method is performed by using an answer file to automate the configuration process when running the installation script.
-The default {Project} answer file is `/etc/foreman-installer/scenarios.d/{project-context}-answers.yaml`.
-The answer file in use is set by the `answer_file` directive in the `/etc/foreman-installer/scenarios.d/{project-context}.yaml` configuration file.
-
 NOTE: Depending on the options that you use when running the {Project} installer, the configuration can take several minutes to complete.
 An administrator can view the answer file to see previously used options for both methods.
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,19 +5,19 @@
 Use this procedure to enable the repositories that are required to install {ProductName}. Choose from the available list which operating system and version you are installing on:
 
 ifdef::foreman-el,katello[]
-* xref:#storage-centos-7[CentOS 7]
-* xref:#storage-centos-8[CentOS 8]
+* xref:#repositories-centos-7[CentOS 7]
+* xref:#repositories-centos-8[CentOS 8]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
-* xref:#storage-rhel-7[Red Hat Enterprise Linux 7]
+* xref:#repositories-rhel-7[Red Hat Enterprise Linux 7]
 endif::[]
 ifdef::foreman-deb[]
-* xref:#storage-debian-10[Debian 10 (Buster)]
-* xref:#storage-ubuntu-1804[Ubuntu 18.04 (Bionic)]
+* xref:#repositories-debian-10[Debian 10 (Buster)]
+* xref:#repositories-ubuntu-1804[Ubuntu 18.04 (Bionic)]
 endif::[]
 
 ifdef::foreman-el,katello[]
-== [[centos-7]]CentOS 7
+== [[repositories-centos-7]]CentOS 7
 
 :distribution-major-version: 7
 :package-manager: yum
@@ -40,7 +40,7 @@ include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
 ifdef::foreman-el,katello[]
-== [[centos-8]]CentOS 8
+== [[repositories-centos-8]]CentOS 8
 
 :distribution-major-version: 8
 :package-manager: dnf
@@ -60,7 +60,7 @@ ifdef::katello[]
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
-== [[rhel-7]]Red Hat Enterprise Linux 7
+== [[repositories-rhel-7]]Red Hat Enterprise Linux 7
 
 :distribution-major-version: 7
 :package-manager: yum
@@ -109,7 +109,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 endif::[]
 
 ifdef::foreman-deb[]
-== [[debian-10]]Debian 10 (Buster)
+== [[repositories-debian-10]]Debian 10 (Buster)
 
 :distribution-codename: buster
 include::proc_configuring-repositories-deb.adoc[]
@@ -117,7 +117,7 @@ include::proc_configuring-repositories-deb.adoc[]
 endif::[]
 
 ifdef::foreman-deb[]
-== [[ubuntu-1804]]Ubuntu 18.04 (Bionic)
+== [[repositories-ubuntu-1804]]Ubuntu 18.04 (Bionic)
 
 :distribution-codename: bionic
 include::proc_configuring-repositories-deb.adoc[]

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -167,8 +167,7 @@ For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_
 ----
 +
 . On {ProjectServer} where you want to import, create a Content View with the same name and label as the exported Content View with the `Import Only` option set.
-For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_View_CLI[].
->>>>>>> 3f93a37... Adding initial docs for the new import/export
+For more information, see xref:Managing_Content_Views-Creating_a_Simple_Content_View[].
 . Ensure that you enable the repositories that the Products in the exported Content View version include.
 For more information, see xref:Importing_Content-Selecting_Red_Hat_Repositories_to_Synchronize[].
 . In the {Project} web UI, navigate to *Content* > *Products*, click the *Yum content* tab and add the same `Yum` content that the exported Content View version includes.
@@ -235,7 +234,7 @@ To export the contents of the Library lifecycle environment of the organization,
 * Ensure that the export directory has free storage space to accommodate the export.
 * Ensure that the `/var/lib/pulp/exports` directory has free storage space equivalent to the size of the repositories being exported for temporary files created during the export process.
 * Ensure that you set download policy to *Immediate* for all repositories within the Library lifecycle environment you export.
-For more information, see xref:Importing_Red_Hat_Content-Configuring_Download_Policies[].
+For more information, see xref:Importing_Content-Configuring_Download_Policies[].
 * Ensure that you synchronize Products that you export to the required date.
 
 .To Export the Library Content of an Organization:

--- a/guides/doc-Upgrading_and_Updating/docinfo.xml
+++ b/guides/doc-Upgrading_and_Updating/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Upgrading and Updating Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.9 Beta</productnumber>
+<productnumber>6.9</productnumber>
 <subtitle>Upgrading and updating Red Hat Satellite Server and Capsule Server</subtitle>
 <abstract>
     <para>This guide describes upgrading and updating Red Hat Satellite Server, Capsule Server, and hosts.</para>


### PR DESCRIPTION
This PR resolves issues in several titles from across the suite that prevent them from building correctly.

* "guides/common/assembly_installing-satellite-server-disconnected.adoc" referred to answer-file-based installations, the main content for which was removed in 1ea86e7104a14116aeee0af2a4a4f80d82c0bcdf. Removed related content and - most importantly - the XREF, which points to a dead reference today.
* "guides/common/modules/proc_configuring-repositories.adoc" pointed to storage XREFs, which are non-existent in that title and section. I suspect this is a copy and paste from the storage docs, so updated all refs to use 'repositories' instead and point to each of the relevant sections.
* "guides/doc-Content_Management_Guide/topics/Using_ISS.adoc" contains a Git conflict notice and an XREF to a section that has since been updated to be more generic. Removed the conflict strip and updated the XREF to point to the current section.
* "guides/doc-Upgrading_and_Updating/docinfo.xml" contained a reference to 'Beta'. Updated to '6.9'.

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
