### PR TITLE
Rework "removing a host" deletion warning

### DIFF
--- a/guides/doc-Managing_Hosts/topics/proc_removing-a-host-from-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_removing-a-host-from-satellite.adoc
@@ -15,8 +15,12 @@ In both cases, {Project} removes a host completely.
 
 [WARNING]
 ====
-If a host record that is associated with a virtual machine is deleted, the virtual machine will be deleted as well.
-To avoid deleting the virtual machine in this situation, disassociate the virtual machine from {Project} without removing it from the hypervisor.
+By default, the `Destroy associated VM on host delete` setting is set to `no`.
+If a host record that is associated with a virtual machine is deleted, the virtual machine will remain on the compute resource.
+
+To delete a virtual machine on the compute resource, navigate to *Administer > Settings* and select the *Provisioning* tab.
+Setting `Destroy associated VM on host delete` to `yes` deletes the virtual machine if the host record that is associated with the virtual machine is deleted.
+To avoid deleting the virtual machine in this situation, disassociate the virtual machine from {Project} without removing it from the compute resource or change the setting.
 ====
 
 [id="disassociating-a-virtual-machine"]


### PR DESCRIPTION
The default behaviour has been changed with the release of Foreman 2.3.
See [f6fdaaf5b1f519db902e6469beda3b0f20d2411e](https://github.com/theforeman/foreman/commit/f6fdaaf5b1f519db902e6469beda3b0f20d2411e) in the foreman repository.



Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

