### PR TITLE
Allow foreman-proxy user to read /etc/rndc.key

### DIFF
--- a/guides/common/modules/proc_configuring-external-dns.adoc
+++ b/guides/common/modules/proc_configuring-external-dns.adoc
@@ -46,6 +46,8 @@ endif::[]
 # chown -v root:named /etc/rndc.key
 # chmod -v 640 /etc/rndc.key
 ----
++
+Ensure the `foreman-proxy` user can read `/etc/rndc.key`.
 
 . To test the `nsupdate` utility, add a host remotely:
 +


### PR DESCRIPTION
Setting `root:named` as the owner and `0640` as the permissions is not sufficient, `foreman-proxy` has to be able to read `/etc/rndc.key`.

Cherry-pick into:

* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)
