### PR TITLE
Resolved an issue with XREFs in the Content Management Guide.

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
@@ -22,7 +22,7 @@ After an initial synchronization, you can create a synchronization plan that che
 You can perform an initial synchronization using ISO images.
 For more information about using content ISOs, see xref:Importing_Content_ISOs_into_Connected_Satellite[].
 
-[[Importing_Red_Hat_Content-Configuring_Download_Policies]]
+[[Importing_Content-Configuring_Download_Policies]]
 === Download Policies Overview
 
 {ProjectName} provides multiple download policies for synchronizing RPM content.

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -62,7 +62,7 @@ To export a Content View, ensure that the {ProjectServer} where you want to expo
 * Ensure that the `/var/lib/pulp/` directory has free storage space equivalent to the size of the repositories being exported for temporary files created during the export process.
 * Ensure that the `/var/cache/pulp` directory has free storage space equivalent to twice of the size of the repository being exported for temporary files created during the export process.
 * Ensure that you set download policy to *Immediate* for all repositories within the Content View you export.
-For more information, see xref:Importing_Red_Hat_Content-Configuring_Download_Policies[].
+For more information, see xref:Importing_Content-Configuring_Download_Policies[].
 * Ensure that you clear the *Mirror on Sync* check box for the repositories that you import on the repository settings page.
 * Ensure that you synchronize Products that you export to the required date.
 
@@ -112,7 +112,7 @@ For more information, see xref:configuring-satellite-to-synchronize-content-with
 endif::[]
 
 * Ensure that you set download policy to *Immediate* for all repositories within the Content View you export.
-For more information, see xref:Importing_Red_Hat_Content-Configuring_Download_Policies[].
+For more information, see xref:Importing_Content-Configuring_Download_Policies[].
 * Ensure that you clear the *Mirror on Sync* check box for the repositories that you import on the repository settings page.
 
 .Procedure


### PR DESCRIPTION
It's not evident from the changes in this PR, but there was a mismatch in XREFs - one pointed to an ID with 'Red_Hat' in it, two without. Because the more generic version is already on master, updated all refs to point to the one without 'Red_Hat' in it, resolving this issue and allowing the CMG to build.

Cherry-pick into:

* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
