### PR TITLE
Update 2.4 landing site

### DIFF
--- a/web/content/2.4.md
+++ b/web/content/2.4.md
@@ -7,19 +7,25 @@ path: 2.4
 
 Available guides:
 
-* [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman.html)
-* [Installing Foreman on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-foreman.html)
-* [Installing Katello on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-katello.html)
-* [Installing Smart Proxy on RHEL/CentOS](/{{< param "path" >}}/Installing_Proxy_on_Red_Hat/index-foreman.html)
-* [Installing Foreman on Debian/Ubuntu](/{{< param "path" >}}/Installing_Server_on_Debian/index-foreman-deb.html)
-* [Installing Smart Proxy on Debian/Ubuntu](/{{< param "path" >}}/Installing_Proxy_on_Debian/index-foreman-deb.html)
-* [Deploying Foreman on AWS (reference guide)](/{{< param "path" >}}/Deploying_on_AWS/index-foreman.html)
-* [Configuring Smart Proxies with a Load Balancer](/{{< param "path" >}}/Configuring_Load_Balancer/index-foreman.html)
-* [Provisioning Guide](/{{< param "path" >}}/Provisioning_Guide/index-foreman.html)
-* [Content Management Guide](/{{< param "path" >}}/Content_Management_Guide/index-katello.html)
-* [Configuring Foreman to use Ansible](/{{< param "path" >}}/Configuring_Ansible/index-foreman.html)
-* [Managing Hosts Guide](/{{< param "path" >}}/Managing_Hosts/index-foreman.html)
-* [Administering Foreman](/{{< param "path" >}}/Administering_Red_Hat_Satellite/index-foreman.html)
+* [Planning for Foreman](/{{ $path }}/Planning_Guide/index-foreman-el.html)
+* [Foreman Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-foreman-el.html)
+* [Foreman Quickstart Guide on Debian/Ubuntu](/{{ $path }}/Quickstart_Guide/index-foreman-deb.html)
+* [Katello Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-katello.html)
+* [Installing Foreman on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-el.html)
+* [Installing Katello on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-katello.html)
+* [Installing Smart Proxy on RHEL/CentOS](/{{ $path }}/Installing_Proxy_on_Red_Hat/index-foreman-el.html)
+* [Installing Foreman on Debian/Ubuntu](/{{ $path }}/Installing_Server_on_Debian/index-foreman-deb.html)
+* [Installing Smart Proxy on Debian/Ubuntu](/{{ $path }}/Installing_Proxy_on_Debian/index-foreman-deb.html)
+* [Upgrading and Updating Foreman](/{{ $path }}/Upgrading_and_Updating/index-foreman-el.html)
+* [Upgrading and Updating Katello](/{{ $path }}/Upgrading_and_Updating/index-katello.html) 
+* [Deploying Foreman on AWS (reference guide)](/{{ $path }}/Deploying_on_AWS/index-foreman-el.html)
+* [Configuring Smart Proxies with a Load Balancer](/{{ $path }}/Configuring_Load_Balancer/index-foreman-el.html)
+* [Provisioning Guide](/{{ $path }}/Provisioning_Guide/index-foreman-el.html)
+* [Content Management Guide](/{{ $path }}/Content_Management_Guide/index-katello.html)
+* [Configuring Foreman to use Ansible](/{{ $path }}/Configuring_Ansible/index-foreman-el.html)
+* [Managing Hosts Guide](/{{ $path }}/Managing_Hosts/index-foreman-el.html)
+* [Administering Foreman](/{{ $path }}/Administering_Red_Hat_Satellite/index-foreman-el.html)
+* [Application Centric Deployment](/{{ $path }}/Application_Centric_Deployment/index-foreman-el.html)
 
 This is work-in-progress documentation site for <a href="https://www.theforeman.org">Foreman</a> open-source software and its
 plugins. Official documentation [is available here](https://theforeman.org/manuals/latest/index.html).

--- a/web/layouts/shortcodes/guide-list.html
+++ b/web/layouts/shortcodes/guide-list.html
@@ -10,7 +10,7 @@
 * [Installing Foreman on Debian/Ubuntu](/{{ $path }}/Installing_Server_on_Debian/index-foreman-deb.html)
 * [Installing Smart Proxy on Debian/Ubuntu](/{{ $path }}/Installing_Proxy_on_Debian/index-foreman-deb.html)
 * [Upgrading and Updating Foreman](/{{ $path }}/Upgrading_and_Updating/index-foreman-el.html)
-* [Upgrading and Updating Katello](/{{ $path }}/Upgrading_and_Updating/index-katello.html) 
+* [Upgrading and Updating Katello](/{{ $path }}/Upgrading_and_Updating/index-katello.html)
 * [Deploying Foreman on AWS (reference guide)](/{{ $path }}/Deploying_on_AWS/index-foreman-el.html)
 * [Configuring Smart Proxies with a Load Balancer](/{{ $path }}/Configuring_Load_Balancer/index-foreman-el.html)
 * [Provisioning Guide](/{{ $path }}/Provisioning_Guide/index-foreman-el.html)


### PR DESCRIPTION
I haven't noticed that the landing site has changed dramatically and my branch had an old version of that file. This should correct it.

Cherry-pick into:

* [x] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->