### PR TITLE
Fixed repo name

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,7 +17,7 @@
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
-:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6.9-rpms
+:RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.9-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
 :RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6.9-rpms
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.9-rpms


### PR DESCRIPTION
Satellite 6.9 installation doc seems to show the wrong satellite 6.9 repo to be enabled
https://bugzilla.redhat.com/show_bug.cgi?id=1952165


Cherry-pick into:

* [ ] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
