### PR TITLE
Update capsule repo name for 6.9 release

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -19,7 +19,7 @@
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.9-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
-:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6.9-rpms
+:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-7-server-satellite-capsule-6.9-rpms
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.9-rpms
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.


### PR DESCRIPTION
Satellite 6.9 installation doc seems to show the wrong satellite 6.9 repo to be enabled
https://bugzilla.redhat.com/show_bug.cgi?id=1952165


Cherry-pick into:

* [ ] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
