### PR TITLE
Updated ProductVersionRepoTitle attribute to reflect 6.9

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -11,7 +11,7 @@
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
 
 // Attributes only for satellite build
-:ProductVersionRepoTitle: Beta
+:ProductVersionRepoTitle: 6.9
 // Change to "Red Hat Satellite Infrastructure Subscription (Beta)" for beta releases
 
 // Overrides for satellite build


### PR DESCRIPTION
Satellite 6.9 managing_hosts doc mentions the Satellite Tools beta repository rather than Satellite Tools 6.9
https://bugzilla.redhat.com/show_bug.cgi?id=1952153


Cherry-pick into:

* [ ] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
