### PR TITLE
Re-enable link checking of RH docs site

### DIFF
--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -15,4 +15,3 @@ ignore=example.com
   keycloak.com
   rhsso.com
   sources/
-  access.redhat.com/documentation


### PR DESCRIPTION
And it is up.

https://access.redhat.com/documentation/en-us/red_hat_satellite/6.9/

Cherry-pick into:

* [x] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->