### PR TITLE
remove update guide for smart proxy

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -80,7 +80,13 @@ include::topics/post_upgrade_template_checks.adoc[leveloffset=+2]
 //Tuning Satellite Server with Predefined Profiles
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
 
+ifdef::satellite[]
 == Updating {ProjectServer}, {SmartProxyServer}, and Content Hosts
+endif::[]
+
+ifdef::foreman-el,katello[]
+== Updating {ProjectServer} and Content Hosts
+endif::[]
 
 // Updating Red Hat Satellite Introduction
 include::topics/introduction_updating_satellite.adoc[leveloffset=+2]
@@ -88,8 +94,10 @@ include::topics/introduction_updating_satellite.adoc[leveloffset=+2]
 // Updating Satellite Minor Versions
 include::topics/updating_satellite_server_to_next_minor_version.adoc[leveloffset=+2]
 
+ifdef::satellite[]
 // Updating Capsule Minor Versions
 include::topics/updating_capsule_server_to_next_minor_version.adoc[leveloffset=+2]
+endif::[]
 
 // Updating Content Hosts Minor Versions
 include::topics/updating_content_hosts_to_next_minor_version.adoc[leveloffset=+2]

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -29,7 +29,7 @@ Use this procedure to update {SmartProxyServer}s to the next minor version.
 
 . Check the available versions to confirm the next minor version is listed:
 +
-[options="nowrap"]
+[options="nowrap" subs="attributes"]
 ----
 # {foreman-maintain} upgrade list-versions
 ----


### PR DESCRIPTION
Comments from @ekohl on IRC to fix. 


* Content relevent for downstream only
* Fix attribute


Cherry-pick into:

* [x] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
