### PR TITLE
Removed Boolean from command line

### DIFF
--- a/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
+++ b/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
@@ -32,7 +32,7 @@ If you want to use custom or third party Ansible roles, ensure to configure an e
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {installer-scenario-smartproxy} \
---enable-foreman-proxy-plugin-ansible true
+--enable-foreman-proxy-plugin-ansible
 ----
 
 . Distribute SSH keys to enable {SmartProxies} to connect to hosts using SSH.


### PR DESCRIPTION
Removed the 'true' Boolean from the command line to enable the Ansible plug-in

Bug 1954530 - Command to enable ansible plugin on Capsules requires no value

https://bugzilla.redhat.com/show_bug.cgi?id=1954530
~


Cherry-pick into:

* [ ] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
