### PR TITLE
Removed Boolean from command line

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/adding_rhel_system_roles.adoc
@@ -17,7 +17,7 @@ Complete this procedure to configure your {Project} deployment to run Ansible ro
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {installer-scenario-smartproxy} \
---enable-foreman-proxy-plugin-ansible true
+--enable-foreman-proxy-plugin-ansible
 ----
 
 . Distribute SSH keys to enable {SmartProxies} to connect to hosts using SSH. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/6.7/html-single/managing_hosts/index#sect-Managing_Hosts-Establishing_a_Secure_Connection_for_Remote_Commands[Distributing SSH Keys for Remote Execution] in the _Managing Hosts_ guide. {Project} runs Ansible roles the same way it runs remote execution jobs.


### PR DESCRIPTION
Removed the 'true' Boolean from the command line to enable the Ansible plug-in

Bug 1954530 - Command to enable ansible plugin on Capsules requires no value

https://bugzilla.redhat.com/show_bug.cgi?id=1954530


Cherry-pick into:

* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
