### PR TITLE
remove pulp2 removal section for katello 4.1

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -138,15 +138,3 @@ In such a case, change directory, for example to the *_root_* user's home direct
 ----
 # {package-install-project} tfm-rubygem-smart_proxy_discovery.noarch
 ----
-. Remove all Pulp 2 content on each {SmartProxy}.
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} content remove-pulp2
-----
-. A re-sync is required for each {SmartProxy} from {ProjectServer}.
-+
-[options="nowrap"]
-----
-# hammer capsule content synchronize --id ${SMART_PROXY_ID}
-----


### PR DESCRIPTION
Cherry-pick into:

* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
