### PR TITLE
Adding individual email chapter

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/master.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/master.adoc
@@ -17,6 +17,8 @@ include::common/assembly_using-satellite-ansible-content-collections.adoc[levelo
 
 include::topics/Users_and_Roles.adoc[]
 
+include::topics/configuring-email-notifications.adoc[]
+
 include::topics/Security_Compliance_Management.adoc[]
 
 include::topics/Disabling_Weak_Encryption.adoc[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Users_and_Roles.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Users_and_Roles.adoc
@@ -32,18 +32,6 @@ include::ssh-keys.adoc[leveloffset=+3]
 
 include::managing-ssh-keys-for-a-user.adoc[leveloffset=+3]
 
-[[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Creating_and_Managing_Users-Configuring_Email_Notifications]]
-
-include::email-notifications.adoc[leveloffset=+3]
-
-include::configuring-email-notifications.adoc[leveloffset=+3]
-
-include::testing-email-delivery.adoc[leveloffset=+3]
-
-include::testing-email-notifications.adoc[leveloffset=+3]
-
-include::notification-types.adoc[leveloffset=+3]
-
 
 [[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Users_and_Roles-Creating_and_Managing_User_Groups]]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-email-for-a-host.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-email-for-a-host.adoc
@@ -1,0 +1,18 @@
+[id='changing-email-notifications-for-a-host_{context}']
+= Changing email notification settings for a host
+
+{Project} can send event notifications for a host to the host’s registered owner.
+
+You can configure {Project} to send email notifications either to an individual user or a user group. When set to a user group, all group members who are subscribed to the email type receive a message.
+
+To view the notification status for a host, navigate to *Hosts* > *All Hosts* and click the host you want to view.
+In the host details page, click the *Additional Information* tab, you can view the email notification status. 
+
+Receiving email notifications for a host can be useful, but also overwhelming if you are expecting to receive frequent errors, for example, because of a known issue or error you are working around.
+
+To change the email notification settings for a host, complete the following steps.
+
+.Procedure
+
+. In the {Project} web UI, navigate to *Hosts* > *All Hosts*, and select the host with the notification setting you want to change.
+. Select the host's check box, and from the *Select Action* list, select *Enable Notifications* or *Disable Notifcations*, depending on what you want.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-email-notifications.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-email-notifications.adoc
@@ -1,5 +1,7 @@
 [id='configuring-email-notifications_{context}']
-= Configuring Email Notifications
+== Configuring Email Notifications
+
+You can configure {Project} to send email messages to individual users registered to {Project}. {Project} sends the email to the email address that has beed added to the account, if present. Users can edit the email address by clicking on their name in the top-right of the {Project} web UI and selecting **My account**.
 
 Configure email notifications for a user from the {Project} web UI.
 
@@ -22,3 +24,11 @@ The *Audit Summary* notification can be filtered by entering the required query 
 . Click *Submit*.
 +
 The user will start receiving the notification emails.
+
+include::testing-email-delivery.adoc[leveloffset=+2]
+
+include::testing-email-notifications.adoc[leveloffset=+2]
+
+include::notification-types.adoc[leveloffset=+2]
+
+include::configuring-email-for-a-host.adoc[leveloffset=+2]


### PR DESCRIPTION
Problem: 
I am trying to get through the list identified here: https://community.theforeman.org/t/foreman-manual-reboot/22606?u=mcorr

As I was comparing users and roles, I found email buried in there in a way that you can't even really see in the docs navigation https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Users_and_Roles

This is extremely poor user experience for someone looking to find email management info. 
I looked at the Foreman manual vs upstream Sat docs and found one section missing, so added it. 

This takes ages but trying to get as many done this week as possible. 


Cherry-pick into:

* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
