### PR TITLE
Make ssh section more distinct

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Users_and_Roles.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Users_and_Roles.adoc
@@ -28,7 +28,10 @@ include::assigning-roles-to-a-user.adoc[leveloffset=+3]
 
 include::impersonating-a-different-user-account.adoc[leveloffset=+3]
 
-include::ssh-keys.adoc[leveloffset=+3]
+[[sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Managing_SSH_Keys]]
+
+
+include::ssh-keys.adoc[leveloffset=+2]
 
 include::managing-ssh-keys-for-a-user.adoc[leveloffset=+3]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/ssh-keys.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/ssh-keys.adoc
@@ -1,5 +1,5 @@
 [id='ssh-keys_{context}']
-= SSH Keys
+= SSH Keys Management
 
 Adding SSH keys to a user allows deployment of SSH keys during provisioning.
 


### PR DESCRIPTION
As per the effort outlined in https://community.theforeman.org/t/foreman-manual-reboot/22606

I reviewed https://theforeman.org/manuals/2.3/index.html#4.1.2RolesandPermissions
against https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Users_and_Roles

And think we are good. The only addition in this PR is to separate user ssh key management into a section discoverable in the TOC. 

Cherry-pick into:

* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
