### PR TITLE
Removed port 5646

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -51,7 +51,6 @@ ifdef::satellite[]
 |80 |TCP |HTTP |Anaconda, yum, and for obtaining Katello certificate
 updates
 |443 |TCP |HTTPS |Anaconda, yum, Telemetry Services, and Puppet
-| 5646 | TCP | AMQP | The {SmartProxy} Qpid dispatch router to the Qpid dispatch router in {Project}
 |5647 |TCP |AMQP |Katello agent to communicate with {SmartProxy}'s
 Qpid dispatch router
 |8000 |TCP |HTTPS |Anaconda to download kickstart templates to hosts,


### PR DESCRIPTION
Removed port 5646 from Table 1.3 of the Installing Capsule Server Guide
This is a PR to master as requested by Melanie

Bug 1890876 - [BUG] Remove port 5646 from table 1.3 of capsule installation documentation

https://bugzilla.redhat.com/show_bug.cgi?id=1890876




Cherry-pick into:

* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
