### PR TITLE
Corrected package-cleanup command line

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -394,7 +394,7 @@ endif::[]
 ----
 # systemctl stop rsyslog
 # systemctl stop auditd
-# package-cleanup -oldkernels -count=1
+# package-cleanup --oldkernels --count=1
 # {package-clean} all
 ----
 +


### PR DESCRIPTION
Corrected the 'package-cleanup' command line in 'Using the VMWare vSphere
Cloud-init and Userdata Templates for Provisioning'

Bug 1820129 - [DDF] package-cleanup --oldkernels -count=1

https://bugzilla.redhat.com/show_bug.cgi?id=1820129


Cherry-pick into:

* [ X] Foreman 2.5 (Satellite 6.10)
* [ X] Foreman 2.4
* [ X] Foreman 2.3 (Satellite 6.9)
* [ X] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
