### PR TITLE
Correction to warming in Renaming Casule Server section

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
@@ -5,19 +5,21 @@ The host name of {SmartProxyServer} is referenced by {ProjectServer} components,
 This procedure ensures that you update all references to the new host name.
 
 .Prerequisites
-
++
 [WARNING]
 ====
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1829115[BZ#1829115] is resolved, you must edit the `usr/share/katello/hostname-change.rb` file on {SmartProxyServer} and comment out the following lines before attempting to rename {SmartProxyServer}:
 
-[options="nowrap" subs="+quotes,attributes"]`
+[options="nowrap" subs="+quotes,attributes"]
 ----
 STDOUT.puts "updating hostname in hammer configuration"
-self.run_cmd("sed -i.bak -e 's/#{@old_hostname}/#{@new_hostname}/g' #{hammer_root_config_path}/*.yml")
-self.run_cmd("sed -i.bak -e 's/#{@old_hostname}/#{@new_hostname}/g' #{hammer_config_path}/#.yml")
+self.run_cmd("sed -i.bak -e 's/#{@old_hostname} \
+/#{@new_hostname}/g' #{hammer_root_config_path}/*.yml")
+self.run_cmd("sed -i.bak -e 's/#{@old_hostname} \
+/#{@new_hostname}/g' #{hammer_config_path}/#.yml")
 ----
 ====
-
++
 * Backup {SmartProxyServer}.
 The `{project-change-hostname}` script makes irreversible changes to {SmartProxyServer}.
 If the renaming process is not successful, you must restore it from a backup.


### PR DESCRIPTION
The text has been corrected to remove the 'Prerequisites' title from the warning block, tidy the command
lines and remove a superfuous asciidoc command from the text.

Bug 1931714 - Add WARNING in renaming capsule section untill BZ# 1829115 is not getting fixed

https://bugzilla.redhat.com/show_bug.cgi?id=1931714


Cherry-pick into:

* [X ] Foreman 2.5 (Satellite 6.10)
* [X] Foreman 2.4
* [X] Foreman 2.3 (Satellite 6.9)
* [X] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
