### PR TITLE
Fixed the link pointing to section Configuring and Setting up Remote …

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
@@ -8,7 +8,7 @@ Note that Puppet runs by default every 30 minutes.
 If you assign a new policy, the next Puppet run synchronizes the policy to the host.
 However Ansible does not perform scheduled runs.
 To add a new policy, you must run Ansible role manually or using remote execution.
-For more information about remote execution, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs] in the _Managing Hosts_ guide.
+For more information about remote execution, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/managing_hosts/index#configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs] in the _Managing Hosts_ guide.
 
 
 [[form-Red_Hat_Satellite-Host_Configuration_Guide-Compliance_Policy-Creating_a_Policy-Prerequisites]]


### PR DESCRIPTION
…Jobs

Bug 1930911 - 404 on remote execution page for satellite 6.8
https://bugzilla.redhat.com/show_bug.cgi?id=1930911


Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
