### PR TITLE
Removed recommendation on BZ1665893 from Prerequisites

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -31,8 +31,6 @@ endif::[]
 * Review this guide so that you are aware of the upgrade process and its impact.
 * Plan your upgrade path. For more information, see xref:upgrade_paths[].
 
-* Until https://bugzilla.redhat.com/show_bug.cgi?id=1665893[BZ#1665893] is resolved, read the Knowledgebase solution https://access.redhat.com/solutions/3803901[Candlepin gets stuck during startup forever, logging huge thread dump to error.log], and perform the resolution steps before beginning the upgrade.
-
 * Plan for the required downtime. {Project} services are shut down during the upgrade. The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
 +
 Upgrading {Project} takes approximately 1 - 2 hours.


### PR DESCRIPTION
BZ1665893 was moved to Errata at 6.8 so the message can be removed from Satellite 6.9 (v2.3) documentation

Bug 1961082 - [DOC] Need to remove prerequisites recommendation about BZ#1665893 in Satellite 6.9 documentation guide

https://bugzilla.redhat.com/show_bug.cgi?id=1961082


Cherry-pick into:

* [X ] Foreman 2.5 (Satellite 6.10)
* [X ] Foreman 2.4
* [X] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
