### PR TITLE
Apply one-sentence-per-line rule to upgrade guide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -2,7 +2,8 @@
 
 = Cloning {ProjectServer}
 
-When you upgrade {ProjectServer}, you can optionally create a clone of your {Project} to ensure that you do not lose any data while you upgrade. After your upgrade is complete, you can then decommission the earlier version of {ProjectServer}.
+When you upgrade {ProjectServer}, you can optionally create a clone of your {Project} to ensure that you do not lose any data while you upgrade.
+After your upgrade is complete, you can then decommission the earlier version of {ProjectServer}.
 
 Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
 
@@ -33,13 +34,17 @@ Ensure that you understand the following terms:
 
 To clone {ProjectServer}, ensure that you have the following resources available:
 
-* A minimal install of Red{nbsp}Hat Enterprise Linux 7 server to become the target server. Do not install Red{nbsp}Hat Enterprise Linux 7 software groups, or third-party applications. Ensure that your server complies with all the specifications of {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your Environment for Installation] in _Installing {ProjectServer}_.
-* A backup from {Project} {ProjectVersionPrevious} that you make using the `{foreman-maintain} backup` script. You can use a backup with or without Pulp data.
+* A minimal install of Red{nbsp}Hat Enterprise Linux 7 server to become the target server.
+Do not install Red{nbsp}Hat Enterprise Linux 7 software groups, or third-party applications.
+Ensure that your server complies with all the specifications of {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your Environment for Installation] in _Installing {ProjectServer}_.
+* A backup from {Project} {ProjectVersionPrevious} that you make using the `{foreman-maintain} backup` script.
+You can use a backup with or without Pulp data.
 * A {Project} subscription for the target server.
 
 Before you begin cloning, ensure the following conditions exist:
 
-* The target server is on an isolated network. This avoids unwanted communication with {SmartProxyServer}s and hosts
+* The target server is on an isolated network.
+This avoids unwanted communication with {SmartProxyServer}s and hosts
 * The target server has the capacity to store all your backup files from the source server.
 
 .Customized configuration files
@@ -48,14 +53,18 @@ If you have any customized configurations on your source server that are not man
 
 [[sec-Pulp_Data_Considerations]]
 == Pulp Data Considerations
-You can clone {Project} server without including Pulp data. However, for your cloned environment to work, you do require Pulp data. If the target server does not have Pulp data. it is not a fully working {Project}.
+
+You can clone {Project} server without including Pulp data.
+However, for your cloned environment to work, you do require Pulp data.
+If the target server does not have Pulp data. it is not a fully working {Project}.
 
 To transfer Pulp data to a target server, you have two options:
 
 * Clone using backup with Pulp data
 * Clone using backup without Pulp data and copy `/var/lib/pulp` manually from source server.
 
-If your `pulp_data.tar` file is greater than 500 GB, or if you use a slow storage system, such as NFS, and your `pulp_data.tar` file is greater than 100 GB, do not include `pulp_data.tar` in the backup because this can cause memory errors during extraction. Copy the `pulp_data.tar` file from the source server to the target server.
+If your `pulp_data.tar` file is greater than 500 GB, or if you use a slow storage system, such as NFS, and your `pulp_data.tar` file is greater than 100 GB, do not include `pulp_data.tar` in the backup because this can cause memory errors during extraction.
+Copy the `pulp_data.tar` file from the source server to the target server.
 
 .To back up without Pulp data
 
@@ -124,7 +133,8 @@ Note the _Pool ID_ for later use.
 # du -sh /var/lib/pulp/
 ----
 +
-. If you have less than 500 GB of Pulp data, perform a backup with MongoDB and PostgreSQL databases active including the Pulp data. If you have more than 500 GB of Pulp data, skip the following steps and complete the steps in xref:sec-Pulp_Data_Considerations[] before you continue.
+. If you have less than 500 GB of Pulp data, perform a backup with MongoDB and PostgreSQL databases active including the Pulp data.
+If you have more than 500 GB of Pulp data, skip the following steps and complete the steps in xref:sec-Pulp_Data_Considerations[] before you continue.
 +
 [options="nowrap"]
 ----
@@ -147,8 +157,10 @@ Proceed to xref:sec-Cloning_to_Target[].
 
 To clone your server, complete the following steps on your target server:
 
-. The `satellite-clone` tool defaults to using `/backup/` as the backup folder. If you copy to a different folder, update the `backup_dir` variable in the `/etc/satellite-clone/satellite-clone-vars.yml` file.
-. Place the backup files from the source {Project} in the `/backup/` folder on the target server. You can either mount the shared storage or copy the backup files to the `/backup/` folder on the target server.
+. The `satellite-clone` tool defaults to using `/backup/` as the backup folder.
+If you copy to a different folder, update the `backup_dir` variable in the `/etc/satellite-clone/satellite-clone-vars.yml` file.
+. Place the backup files from the source {Project} in the `/backup/` folder on the target server.
+You can either mount the shared storage or copy the backup files to the `/backup/` folder on the target server.
 . Power off the source server.
 . Enter the following commands to register to the Customer Portal, attach subscriptions, and enable only the required subscriptions:
 +
@@ -180,8 +192,10 @@ After you install the `satellite-clone` tool, you can adjust any configuration t
 # satellite-clone
 ----
 +
-. Reconfigure DHCP, DNS, TFTP and remote execution services. The cloning process disables these services on the target {ProjectServer} to avoid conflict with the source {ProjectServer}.
-. Reconfigure and enable DHCP, DNS, TFTP in the {Project} web UI. For more information, see {InstallingProjectDocURL}configuring-external-services[Configuring External Services on {ProjectServer}] in _Installing {ProjectServer}_.
+. Reconfigure DHCP, DNS, TFTP and remote execution services.
+The cloning process disables these services on the target {ProjectServer} to avoid conflict with the source {ProjectServer}.
+. Reconfigure and enable DHCP, DNS, TFTP in the {Project} web UI.
+For more information, see {InstallingProjectDocURL}configuring-external-services[Configuring External Services on {ProjectServer}] in _Installing {ProjectServer}_.
 . Enable remote execution:
 +
 [options="nowrap"]
@@ -191,12 +205,18 @@ After you install the `satellite-clone` tool, you can adjust any configuration t
 --enable-foreman-proxy-plugin-remote-execution-ssh
 ----
 +
-. Log on to the {Project} web UI, with the username `admin` and the password `changeme`. Immediately update the admin password to secure credentials.
+. Log on to the {Project} web UI, with the username `admin` and the password `changeme`.
+Immediately update the admin password to secure credentials.
 . Ensure that the correct organization is selected.
 . Navigate to *Content* > *Subscriptions*, then click *Manage Manifest*.
 . Click the *Refresh* button, then click *Close* to return to the list of subscriptions.
 . Verify that the available subscriptions are correct.
 . Follow the instructions in the `/usr/share/satellite-clone/logs/reassociate_capsules.txt` file to restore the associations between {SmartProxies} and their lifecycle environments.
-. Update your network configuration, for example, DNS, to match the target server’s IP address with its new host name. The `satellite-clone` tool changes the hostname to the source server's hostname. If you want to change the hostname to something different, you can use the `satellite-change-hostname` tool. For more information, see {AdministeringDocURL}sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Renaming_a_Server[Renaming a {Project} or {SmartProxyServer}] in _Administrating {ProjectName}_.
-. If the source server uses the `virt-who` daemon, install and configure it on the target server. Copy all the `virt-who` configuration files in the `/etc/virt-who.d/` directory from the source server to the same directory on the target server.  For more information, see {BaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index[_Configuring Virtual Machine Subscriptions in {ProjectName}_].
+. Update your network configuration, for example, DNS, to match the target server’s IP address with its new host name.
+The `satellite-clone` tool changes the hostname to the source server's hostname.
+If you want to change the hostname to something different, you can use the `satellite-change-hostname` tool.
+For more information, see {AdministeringDocURL}sect-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Renaming_a_Server[Renaming a {Project} or {SmartProxyServer}] in _Administrating {ProjectName}_.
+. If the source server uses the `virt-who` daemon, install and configure it on the target server.
+Copy all the `virt-who` configuration files in the `/etc/virt-who.d/` directory from the source server to the same directory on the target server.
+For more information, see {BaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index[_Configuring Virtual Machine Subscriptions in {ProjectName}_].
 After you perform an upgrade using the following chapters, you can safely decommission the source server.

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
@@ -4,4 +4,5 @@ Use this chapter to update your existing {ProjectServer}, {SmartProxyServer}, an
 
 Updates patch security vulnerabilities and minor issues discovered after code is released, and are often fast and non-disruptive to your operating environment.
 
-Before updating, back up your {ProjectServer} and all {SmartProxyServer}s. For more information, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName}_ guide.
+Before updating, back up your {ProjectServer} and all {SmartProxyServer}s.
+For more information, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName}_ guide.

--- a/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
@@ -2,7 +2,8 @@
 
 = Migrating Self-Registered {Project}s
 
-{ProjectNameX}.3 does not support self-registered {Project}s. You must migrate self-registered {ProjectServer}s to the Red Hat Content Delivery Network.
+{ProjectNameX}.3 does not support self-registered {Project}s.
+You must migrate self-registered {ProjectServer}s to the Red Hat Content Delivery Network.
 
 To migrate a self-registered {Project} to the Red Hat Content Delivery Network, complete the following steps.
 
@@ -25,7 +26,8 @@ To migrate a self-registered {Project} to the Red Hat Content Delivery Network, 
 # yum remove 'katello-ca-consumer*'
 ----
 +
-. The katello agent is used only for clients of {Project} and must be removed. To remove the `katello-agent`, stop and disable the `goferd` service, then enter the remove command:
+. The katello agent is used only for clients of {Project} and must be removed.
+To remove the `katello-agent`, stop and disable the `goferd` service, then enter the remove command:
 +
 [options="nowrap"]
 ----
@@ -46,7 +48,10 @@ To migrate a self-registered {Project} to the Red Hat Content Delivery Network, 
 . Register your {ProjectServer} to the Red Hat Customer Portal:
 +
 [NOTE]
-If your {ProjectNameX} subscription is in the {Project} Manifest, you must remove the subscription. This makes the {ProjectNameX} subscription available to attach to the target server. To locate the manifest, log on to the Customer{nbsp}Portal, click *Subscriptions*, click *{Project} Organizations*, then click the *All Subscription Management Applications* tab. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/content_management_guide/managing_subscriptions[Managing Subscriptions] in the _{ProjectName} {ProjectVersionPrevious} Content Management Guide_.
+If your {ProjectNameX} subscription is in the {Project} Manifest, you must remove the subscription.
+This makes the {ProjectNameX} subscription available to attach to the target server.
+To locate the manifest, log on to the Customer{nbsp}Portal, click *Subscriptions*, click *{Project} Organizations*, then click the *All Subscription Management Applications* tab.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/content_management_guide/managing_subscriptions[Managing Subscriptions] in the _{ProjectName} {ProjectVersionPrevious} Content Management Guide_.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/post_upgrade_tasks.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/post_upgrade_tasks.adoc
@@ -1,5 +1,6 @@
 [[post-upgrade_tasks]]
 
-Some of the procedures in this section are optional. You can choose to perform only those procedures that are relevant to your installation.
+Some of the procedures in this section are optional.
+You can choose to perform only those procedures that are relevant to your installation.
 
 If you use the PXE-based discovery process, then you must complete the discovery upgrade procedure on {Project} and on any {SmartProxyServer} with hosts that you want to be listed in {Project} on the *Hosts* > *Discovered hosts* page.

--- a/guides/doc-Upgrading_and_Updating/topics/post_upgrade_template_checks.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/post_upgrade_template_checks.adoc
@@ -1,6 +1,7 @@
 [[post_upgrade-updating-templates-parameters]]
 = Updating Templates, Parameters, Lookup Keys and Values
-During the upgrade process, {Project} attempts to locate macros that are deprecated for {Project} {ProjectVersion} and converts old syntax to new syntax for the default {Project} templates, parameters, and lookup keys and values. However, {Project} does not convert old syntax in the custom templates that you have created and in the cloned templates.
+During the upgrade process, {Project} attempts to locate macros that are deprecated for {Project} {ProjectVersion} and converts old syntax to new syntax for the default {Project} templates, parameters, and lookup keys and values.
+However, {Project} does not convert old syntax in the custom templates that you have created and in the cloned templates.
 
 The process uses simple text replacement, for example:
 ----
@@ -11,7 +12,9 @@ The process uses simple text replacement, for example:
 ----
 
 [WARNING]
-If you use cloned templates in {Project}, verify whether the cloned templates have diverged from the latest version of the original templates in {Project}. The syntax for the same template can differ between versions of {Project}. If your cloned templates contain outdated syntax, update the syntax to match the latest version of the template.
+If you use cloned templates in {Project}, verify whether the cloned templates have diverged from the latest version of the original templates in {Project}.
+The syntax for the same template can differ between versions of {Project}.
+If your cloned templates contain outdated syntax, update the syntax to match the latest version of the template.
 
 To ensure that this text replacement does not break or omit any variables in your files during the upgrade, check all templates, parameters, and lookup keys and values for the old syntax and replace manually.
 

--- a/guides/doc-Upgrading_and_Updating/topics/removing_satellite_tools_repository.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/removing_satellite_tools_repository.adoc
@@ -10,4 +10,5 @@ Disable Version {ProjectVersionPrevious} of the {Project} Tools Repository:
 . In the *Enabled Repositories* area, locate *{ProjectName} Tools {ProjectVersionPrevious} for RHEL 7 Server RPMs x86_64*.
 . Click the *Disable* icon to the right.
 
-If the repository is still contained in a Content View then you cannot disable it. Packages from a disabled repository are removed automatically by a scheduled task.
+If the repository is still contained in a Content View then you cannot disable it.
+Packages from a disabled repository are removed automatically by a scheduled task.

--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -24,7 +24,8 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 +
 [NOTE]
 ====
-If the {ProjectVersion} repositories are not available, refresh the Subscription Manifest. Navigate to *Content* > *Subscriptions*, click *Manage Manifest*, then click *Refresh*.
+If the {ProjectVersion} repositories are not available, refresh the Subscription Manifest.
+Navigate to *Content* > *Subscriptions*, click *Manage Manifest*, then click *Refresh*.
 ====
 +
 . Navigate to *Content* > *Sync Status*.
@@ -34,7 +35,10 @@ If the {ProjectVersion} repositories are not available, refresh the Subscription
 +
 [IMPORTANT]
 ====
-If an error occurs when you try to synchronize a repository, refresh the manifest. If the problem persists, raise a support request. Do not delete the manifest from the Customer Portal or in the {Project} web UI; this removes all the entitlements of your content hosts.
+If an error occurs when you try to synchronize a repository, refresh the manifest.
+If the problem persists, raise a support request.
+Do not delete the manifest from the Customer Portal or in the {Project} web UI; this removes all the entitlements of your content hosts.
 ====
 +
-. If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories, publish, and promote their updated versions. For more information, see {ContentManagementDocURL}Managing_Content_Views[Managing Content Views] in the _Content Management Guide_.
+. If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories, publish, and promote their updated versions.
+For more information, see {ContentManagementDocURL}Managing_Content_Views[Managing Content Views] in the _Content Management Guide_.

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -43,7 +43,9 @@ Use this procedure to update {SmartProxyServer}s to the next minor version.
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -5,13 +5,13 @@
 
 .Prerequisites
 
-* Ensure that you have synchronized {ProjectServer} repositories for
-{Project}, {SmartProxy}, and {project-client-name}.
-* Ensure each external {SmartProxy} and Content Host can be updated by
-promoting the updated repositories to all relevant Content Views.
+* Ensure that you have synchronized {ProjectServer} repositories for {Project}, {SmartProxy}, and {project-client-name}.
+* Ensure each external {SmartProxy} and Content Host can be updated by promoting the updated repositories to all relevant Content Views.
 
 [WARNING]
-If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating. You can use the `--noop` option with the {foreman-installer} script to test for changes. For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
+If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating.
+You can use the `--noop` option with the {foreman-installer} script to test for changes.
+For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
 
 *Updating {ProjectServer} to the Next Minor Version*
 
@@ -32,7 +32,8 @@ If you customize configuration files, manually or use a tool such as Hiera, thes
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Use the health check option to determine if the system is ready for upgrade. On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
+. Use the health check option to determine if the system is ready for upgrade.
+On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -41,7 +42,9 @@ If you customize configuration files, manually or use a tool such as Hiera, thes
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 
@@ -72,7 +75,8 @@ ifdef::satellite[]
 
 .Prerequisites
 
-* Before syncing the following repositories, set the download policy to *Immediate*. This is required because {Project} downloads all packages only during synchronization of repositories with the immediate download policy.
+* Before syncing the following repositories, set the download policy to *Immediate*.
+This is required because {Project} downloads all packages only during synchronization of repositories with the immediate download policy.
 +
 * Ensure that you have synchronized the following {ProjectServer} repositories for {Project}, {SmartProxy}, and {project-client-name}:
 ** rhel-7-server-rpms
@@ -145,7 +149,8 @@ To obtain the organization label, enter the command:
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Use the health check option to determine if the system is ready for the upgrade. On the first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
+. Use the health check option to determine if the system is ready for the upgrade.
+On the first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -154,7 +159,9 @@ To obtain the organization label, enter the command:
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -4,7 +4,9 @@
 Use this procedure for a {ProjectServer} with access to the public internet
 
 [WARNING]
-If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when the installation script runs during upgrading or updating. You can use the `--noop` option with the {foreman-installer} script to test for changes. For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
+If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when the installation script runs during upgrading or updating.
+You can use the `--noop` option with the {foreman-installer} script to test for changes.
+For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
 
 .Upgrade {ProjectServer}
 
@@ -33,7 +35,10 @@ ifdef::katello[]
 # yum install rh-postgresql12-postgresql-evr
 ----
 endif::[]
-. In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*. On the Discovered Hosts page, power off and then delete the discovered hosts. From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts. Make a note to reboot these hosts when the upgrade is complete.
+. In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*.
+On the Discovered Hosts page, power off and then delete the discovered hosts.
+From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
+Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
 . Ensure that the {Project} Maintenance repository is enabled:
 +
@@ -50,7 +55,9 @@ ifdef::satellite[]
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Use the health check option to determine if the system is ready for upgrade. When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials. These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
+. Use the health check option to determine if the system is ready for upgrade.
+When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials.
+These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -59,7 +66,9 @@ ifdef::satellite[]
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -5,23 +5,25 @@
 Use this procedure for a {ProjectServer} not connected to the Red{nbsp}Hat Content Delivery Network.
 
 [WARNING]
-If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when you enter the `{foreman-maintain}` command during upgrading or updating. You can use the `--noop` option with the `{foreman-installer}` command to review the changes that are applied during upgrading or updating. For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
+If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when you enter the `{foreman-maintain}` command during upgrading or updating.
+You can use the `--noop` option with the `{foreman-installer}` command to review the changes that are applied during upgrading or updating.
+For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
 
 
 .Before You Begin
 
-* Review and update your firewall configuration before upgrading your {ProjectServer}. For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/index#satellite-ports-and-firewalls-requirements_satellite[Ports and Firewalls Requirements] in _Installing {ProjectServer} from a Disconnected Network_.
-* Ensure that you do not delete the manifest from the Customer Portal or in the {Project} Web UI because this removes all the entitlements of your content hosts.
-* Back up and remove all Foreman hooks before upgrading. Reinstate hooks only after {Project} is known to be working after the upgrade is complete.
+* Review and update your firewall configuration before upgrading your {ProjectServer}.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/index#satellite-ports-and-firewalls-requirements_satellite[Ports and Firewalls Requirements] in _Installing {ProjectServer} from a Disconnected Network_.
+* Ensure that you do not delete the manifest from the Customer Portal or in the {Project} web UI because this removes all the entitlements of your content hosts.
+* Back up and remove all Foreman hooks before upgrading.
+Reinstate hooks only after {Project} is known to be working after the upgrade is complete.
 
 [WARNING]
 ====
-If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom
-certificates.
+If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom certificates.
 
-Failure to retain these files during an upgrade causes the upgrade to fail. If
-these files have been deleted, they must be restored from a backup in order for
-the upgrade to proceed.
+Failure to retain these files during an upgrade causes the upgrade to fail.
+If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
 ====
 
 .Upgrade Disconnected {ProjectServer}
@@ -31,16 +33,21 @@ the upgrade to proceed.
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 
-. A pre-upgrade script is available to detect conflicts and list hosts which have duplicate entries in {ProjectServer} that can be unregistered and deleted after upgrade. In addition, it will detect hosts which are not assigned to an organization. If a host is listed under *Hosts* > *All hosts* without an organization association and if a content host with same name has an organization already associated with it then the content host will automatically be unregistered. This can be avoided by associating such hosts to an organization before upgrading.
+. A pre-upgrade script is available to detect conflicts and list hosts which have duplicate entries in {ProjectServer} that can be unregistered and deleted after upgrade.
+In addition, it will detect hosts which are not assigned to an organization.
+If a host is listed under *Hosts* > *All hosts* without an organization association and if a content host with same name has an organization already associated with it then the content host will automatically be unregistered.
+This can be avoided by associating such hosts to an organization before upgrading.
 +
-Run the pre-upgrade check script to get a list of hosts that can be deleted after upgrading. If any unassociated hosts are found, associating them to an organization before upgrading is recommended.
+Run the pre-upgrade check script to get a list of hosts that can be deleted after upgrading.
+If any unassociated hosts are found, associating them to an organization before upgrading is recommended.
 +
 [options="nowrap"]
 ----
 # foreman-rake katello:upgrade_check
 ----
 +
-If the upgrade check reports a failure due to running tasks, then it is recommended that you wait for the tasks to complete. It is possible to cancel some tasks, but you should follow the guidance in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/2089951[How to manage paused tasks on {ProjectNameX}] to understand which tasks are safe to cancel and which are not safe to cancel.
+If the upgrade check reports a failure due to running tasks, then it is recommended that you wait for the tasks to complete.
+It is possible to cancel some tasks, but you should follow the guidance in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/2089951[How to manage paused tasks on {ProjectNameX}] to understand which tasks are safe to cancel and which are not safe to cancel.
 
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
 
@@ -59,7 +66,10 @@ If the upgrade check reports a failure due to running tasks, then it is recommen
 # yum install rh-postgresql12-postgresql-evr
 ----
 
-. In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*. If there are discovered hosts available, turn them off and then delete all entries under the `Discovered hosts` page. Select all other organizations in turn using the organization setting menu and repeat this action as required. Reboot these hosts after the upgrade has completed.
+. In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*.
+If there are discovered hosts available, turn them off and then delete all entries under the `Discovered hosts` page.
+Select all other organizations in turn using the organization setting menu and repeat this action as required.
+Reboot these hosts after the upgrade has completed.
 
 . Make sure all external {SmartProxyServer}s are assigned to an organization, otherwise they might get unregistered due to host-unification changes.
 
@@ -79,7 +89,8 @@ If the upgrade check reports a failure due to running tasks, then it is recommen
 
 . Obtain the latest ISO files by following the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in the _Installing {ProjectServer} from a Disconnected Network_ guide.
 
-. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` repository by following the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#configuring-the-base-operating-system-with-offline-repositories_satellite[Configuring the Base System with Offline Repositories] procedure in the _Installing {ProjectServer} from a Disconnected Network_ guide. Do not install or update any packages at this stage.
+. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` repository by following the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#configuring-the-base-operating-system-with-offline-repositories_satellite[Configuring the Base System with Offline Repositories] procedure in the _Installing {ProjectServer} from a Disconnected Network_ guide.
+Do not install or update any packages at this stage.
 
 . Configure the {Project} {ProjectVersion} repository from the ISO file.
 
@@ -172,7 +183,8 @@ baseurl=file:///media/sat6/sat-maintenance/
 
 . Optional: If you have applied custom Apache server configurations, note that the custom configurations are reverted to the installation defaults when you perform the upgrade.
 +
-To preview the changes that are applied during the upgrade, enter the `{foreman-installer}` command with the `--noop` (no operation) option. These changes are applied when you enter the `{foreman-maintain} upgrade` command in a following step.
+To preview the changes that are applied during the upgrade, enter the `{foreman-installer}` command with the `--noop` (no operation) option.
+These changes are applied when you enter the `{foreman-maintain} upgrade` command in a following step.
 
 .. Add the following line to the `/etc/httpd/conf/httpd.conf` configuration file.
 +
@@ -202,7 +214,9 @@ Include /etc/httpd/conf.modules.d/*.conf
 ----
 # {installer-scenario} --upgrade --verbose --noop
 ----
-Review the `{installer-log-file}` to preview the changes that are applied during the upgrade. Locate the `\+++` and `---` symbols that indicate the changes to the configurations files. Although entering the `{foreman-installer}` command with the `--noop` option does not apply any changes to your {Project}, some Puppet resources in the module expect changes to be applied and might display failure messages.
+Review the `{installer-log-file}` to preview the changes that are applied during the upgrade.
+Locate the `\+++` and `---` symbols that indicate the changes to the configurations files.
+Although entering the `{foreman-installer}` command with the `--noop` option does not apply any changes to your {Project}, some Puppet resources in the module expect changes to be applied and might display failure messages.
 
 .. Stop the `{foreman-maintain}` services:
 +
@@ -211,7 +225,9 @@ Review the `{installer-log-file}` to preview the changes that are applied during
 # {foreman-maintain} service stop
 ----
 
-. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running you can see the logs in `{installer-log-file}` to check if the process completed successfully.
 
@@ -222,7 +238,9 @@ If you lose connection to the command shell where the upgrade command is running
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Use the health check option to determine if the system is ready for upgrade. When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials. These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
+. Use the health check option to determine if the system is ready for upgrade.
+When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials.
+These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -249,7 +267,8 @@ ERROR: Scenario (config/satellite.yaml) was not found, can not continue.
 In such a case, change directory, for example to the *_root_* user's home directory, and run the command again.
 ====
 +
-If the script fails due to missing or outdated packages, you must download and install these separately. For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] section in the _Installing {ProjectServer} from a Disconnected Network_ guide.
+If the script fails due to missing or outdated packages, you must download and install these separately.
+For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] section in the _Installing {ProjectServer} from a Disconnected Network_ guide.
 
 . If using a BASH shell, after a successful or failed upgrade, enter:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -6,24 +6,27 @@ This section describes how to upgrade {SmartProxyServer}s from {ProjectVersionPr
 
 .Before You Begin
 
-* You must upgrade {ProjectServer} before you can upgrade any {SmartProxyServer}s. Note that you can upgrade {SmartProxies} separately from {Project}. For more information, see xref:upgrading_capsules-separately-from-satellite_upgrade-guide[].
+* You must upgrade {ProjectServer} before you can upgrade any {SmartProxyServer}s.
+Note that you can upgrade {SmartProxies} separately from {Project}.
+For more information, see xref:upgrading_capsules-separately-from-satellite_upgrade-guide[].
 ifdef::satellite[]
 * Ensure the {ProjectName} {SmartProxy} {ProjectVersion} repository is enabled in {ProjectServer} and synchronized.
-* Ensure that you synchronize the required repositories on {ProjectServer}. For more information, see xref:synchronizing_the_new_repositories[].
+* Ensure that you synchronize the required repositories on {ProjectServer}.
+For more information, see xref:synchronizing_the_new_repositories[].
 endif::[]
-* If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories and publish their updated versions. For more information, see {ContentManagementDocURL}Managing_Content_Views[Managing Content Views] in the _Content Management Guide_.
+* If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories and publish their updated versions.
+For more information, see {ContentManagementDocURL}Managing_Content_Views[Managing Content Views] in the _Content Management Guide_.
 * Ensure the {SmartProxy}'s base system is registered to the newly upgraded {ProjectServer}.
 * Ensure the {SmartProxy} has the correct organization and location settings in the newly upgraded {ProjectServer}.
-* Review and update your firewall configuration prior to upgrading your {SmartProxyServer}. For more information, see {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing Your Environment for {SmartProxy} Installation] in _Installing {SmartProxyServer}_.
+* Review and update your firewall configuration prior to upgrading your {SmartProxyServer}.
+For more information, see {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing Your Environment for {SmartProxy} Installation] in _Installing {SmartProxyServer}_.
 
 [WARNING]
 ====
-If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom
-certificates.
+If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom certificates.
 
-Failure to retain these files during an upgrade causes the upgrade to fail. If
-these files have been deleted, they must be restored from a backup in order for
-the upgrade to proceed.
+Failure to retain these files during an upgrade causes the upgrade to fail.
+If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
 ====
 
 .Upgrading {SmartProxyServer}s
@@ -37,7 +40,7 @@ For information on backups, see {AdministeringDocURL}backing-up-satellite-server
 
 ifdef::katello[]
 +
-. Regenerate certificates.  On the main Foreman/Katello server:
+. Regenerate certificates.  On the main {Project} server:
 +
 ----
 # foreman-proxy-certs-generate --foreman-proxy-fqdn "myproxy.example.com" \
@@ -120,7 +123,9 @@ ifdef::satellite[]
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsules_separately_from_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsules_separately_from_satellite.adoc
@@ -3,10 +3,12 @@
 
 You can upgrade {Project} to the version {ProjectVersion} and keep {SmartProxies} at the version {ProjectVersionPrevious} until you have bandwidth to upgrade them too.
 
-All the functionality that worked previously works on {ProjectVersionPrevious} {SmartProxies}. However, the functionality added in the {ProjectVersion} release will not work until you upgrade {SmartProxies} to {ProjectVersion}.
+All the functionality that worked previously works on {ProjectVersionPrevious} {SmartProxies}.
+However, the functionality added in the {ProjectVersion} release will not work until you upgrade {SmartProxies} to {ProjectVersion}.
 
 Upgrading {SmartProxies} after upgrading {Project} can be useful in the following example scenarios:
 
 . If you want to have several smaller outage windows instead of one larger window.
 . If {SmartProxies} in your organization are managed by several teams and are located in different locations.
-. If you use a load-balanced configuration, you can upgrade one load-balanced {SmartProxy} and keep other load-balanced {SmartProxies} at 1 version lower. This allows you to upgrade all {SmartProxies} one after another without any outage.
+. If you use a load-balanced configuration, you can upgrade one load-balanced {SmartProxy} and keep other load-balanced {SmartProxies} at 1 version lower.
+This allows you to upgrade all {SmartProxies} one after another without any outage.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_clients.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_clients.adoc
@@ -4,27 +4,30 @@
 
 The {project-client-name} repository provides `katello-agent` and `katello-host-tools`, which provide communication services for managing Errata.
 
-Note that the Katello agent is deprecated and will be removed in a future {Project} version. Migrate your workloads to use the remote execution feature to update clients remotely. For more information, see {ManagingHostsDocURL}host-management-without-goferd-and-katello-agent_managing-hosts[Host Management Without Goferd and Katello Agent] in the _Managing Hosts Guide_.
+Note that the Katello agent is deprecated and will be removed in a future {Project} version.
+Migrate your workloads to use the remote execution feature to update clients remotely.
+For more information, see {ManagingHostsDocURL}host-management-without-goferd-and-katello-agent_managing-hosts[Host Management Without Goferd and Katello Agent] in the _Managing Hosts Guide_.
 
 Currently, the {Project} {ProjectVersionPrevious} version of `katello-agent` and other client libraries in the {project-client-name} repository are not formally tested or supported against {Project} {ProjectVersion}.
 
-For deployments using `katello-agent` and *goferd*, update all clients to the new version of `katello-agent`. For deployments not using `katello-agent` and *goferd*, update all clients to the new version of `katello-host-tools`. Complete this action as soon as possible so that your clients are fully compatible with {ProjectServer}.
+For deployments using `katello-agent` and *goferd*, update all clients to the new version of `katello-agent`.
+For deployments not using `katello-agent` and *goferd*, update all clients to the new version of `katello-host-tools`.
+Complete this action as soon as possible so that your clients are fully compatible with {ProjectServer}.
 
 .Prerequisites
 
 * You must have upgraded {ProjectServer}.
 * You must have enabled the new {project-client-name} repositories on the {Project}.
 * You must have synchronized the new repositories in the {Project}.
-* If you have not previously installed `katello-agent` on your clients and you want to install, use the manual method. For more information, see xref:upgrading_clients_manually[].
+* If you have not previously installed `katello-agent` on your clients and you want to install, use the manual method.
+For more information, see xref:upgrading_clients_manually[].
 
 [WARNING]
 ====
-If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom
-certificates.
+If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom certificates.
 
-Failure to retain these files during an upgrade causes the upgrade to fail. If
-these files have been deleted, they must be restored from a backup in order for
-the upgrade to proceed.
+Failure to retain these files during an upgrade causes the upgrade to fail.
+If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
 ====
 
 .Upgrade {Project} Clients Using the Bulk Repository Set UI:
@@ -42,7 +45,9 @@ the upgrade to proceed.
 * If your deployment uses `katello-agent` and *goferd*, enter `katello-agent`.
 * If your deployment does not use `katello-agent` and *goferd*, enter `katello-host-tools`.
 +
-. Until https://bugzilla.redhat.com/show_bug.cgi?id=1649764[BZ#1649764] is resolved, from the *Update* list, you must select *via remote execution*. This is required because if you update the package using the Katello agent, the package update disrupts the communication between the client and {Project} or {SmartProxyServer}, which causes the update to fail. For more information, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in the _Managing Hosts_ guide.
+. Until https://bugzilla.redhat.com/show_bug.cgi?id=1649764[BZ#1649764] is resolved, from the *Update* list, you must select *via remote execution*.
+This is required because if you update the package using the Katello agent, the package update disrupts the communication between the client and {Project} or {SmartProxyServer}, which causes the update to fail.
+For more information, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in the _Managing Hosts_ guide.
 
 
 [[upgrading_clients_manually]]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_capsule.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_capsule.adoc
@@ -31,7 +31,8 @@
 # service foreman-proxy restart
 ----
 
-. In the {Project} web UI, go to *Infrastructure* > *{SmartProxies}* and verify that the relevant {SmartProxy} lists *Discovery* in the features column. Select *Refresh* from the *Actions* drop-down menu if necessary.
+. In the {Project} web UI, go to *Infrastructure* > *{SmartProxies}* and verify that the relevant {SmartProxy} lists *Discovery* in the features column.
+Select *Refresh* from the *Actions* drop-down menu if necessary.
 
 . Go to *Infrastructure* > *Subnets* and for each subnet on which you want to use discovery:
 .. Click the subnet name.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_parent.adoc
@@ -4,8 +4,10 @@
 
 This section describes updating the PXELinux template and the boot image passed to hosts that use PXE booting to register themselves with {ProjectServer}.
 
-From {ProjectXY}, provisioning templates now have a separate association with a subnet, and do not default to using the TFTP {SmartProxy} for that subnet. If you create subnets after the upgrade, you must specifically enable the {Project} or a {SmartProxy} to provide a proxy service for discovery templates and then configure all subnets with discovered hosts to use a specific _template {SmartProxy}_.
+From {ProjectXY}, provisioning templates now have a separate association with a subnet, and do not default to using the TFTP {SmartProxy} for that subnet.
+If you create subnets after the upgrade, you must specifically enable the {Project} or a {SmartProxy} to provide a proxy service for discovery templates and then configure all subnets with discovered hosts to use a specific _template {SmartProxy}_.
 
-During the upgrade, for every subnet with a TFTP proxy enabled, the template {SmartProxy} is set to be the same as the TFTP {SmartProxy}. After the upgrade, check all subnets to verify this was set correctly.
+During the upgrade, for every subnet with a TFTP proxy enabled, the template {SmartProxy} is set to be the same as the TFTP {SmartProxy}.
+After the upgrade, check all subnets to verify this was set correctly.
 
 These procedures are not required if you do not use PXE booting of hosts to enable {Project} to discover new hosts.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -31,8 +31,6 @@ endif::[]
 * Review this guide so that you are aware of the upgrade process and its impact.
 * Plan your upgrade path. For more information, see xref:upgrade_paths[].
 
-* Until https://bugzilla.redhat.com/show_bug.cgi?id=1665893[BZ#1665893] is resolved, read the Knowledgebase solution https://access.redhat.com/solutions/3803901[Candlepin gets stuck during startup forever, logging huge thread dump to error.log], and perform the resolution steps before beginning the upgrade.
-
 * Plan for the required downtime. {Project} services are shut down during the upgrade. The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
 +
 Upgrading {Project} takes approximately 1 - 2 hours.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -1,7 +1,8 @@
 [[upgrading_process_overview]]
 = Upgrade Overview
 
-This chapter details the prerequisites and available upgrade paths to {ProjectName} {ProjectVersion}. Review this information before upgrading your current {ProjectNameX} installation.
+This chapter details the prerequisites and available upgrade paths to {ProjectName} {ProjectVersion}.
+Review this information before upgrading your current {ProjectNameX} installation.
 
 In this guide, the terms update, upgrade, and migrate have the following meanings:
 
@@ -12,14 +13,19 @@ The process of advancing your {ProjectServer} and {SmartProxyServer} installatio
 Migrating::
 The process of moving an existing {Project} installation to another Red{nbsp}Hat Enterprise{nbsp}Linux server.
 
-For interactive upgrade instructions, you can also use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal. This application provides you with an exact guide to match your current version number. You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues. For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the customer portal.
+For interactive upgrade instructions, you can also use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
+This application provides you with an exact guide to match your current version number.
+You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
+For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the customer portal.
 
-Note that you can upgrade {SmartProxies} separately from {Project}. For more information, see xref:upgrading_capsules-separately-from-satellite_upgrade-guide[].
+Note that you can upgrade {SmartProxies} separately from {Project}.
+For more information, see xref:upgrading_capsules-separately-from-satellite_upgrade-guide[].
 
 [[upgrading_prerequisites]]
 == Prerequisites
 
-Upgrading to {Project} {ProjectVersion} affects your entire {Project} infrastructure. Before proceeding, complete the following:
+Upgrading to {Project} {ProjectVersion} affects your entire {Project} infrastructure.
+Before proceeding, complete the following:
 
 
 ifdef::satellite[]
@@ -29,33 +35,42 @@ ifndef::satellite[]
 * Read the {ProjectName} {ProjectVersion} Release Notes.
 endif::[]
 * Review this guide so that you are aware of the upgrade process and its impact.
-* Plan your upgrade path. For more information, see xref:upgrade_paths[].
+* Plan your upgrade path.
+For more information, see xref:upgrade_paths[].
 
-* Plan for the required downtime. {Project} services are shut down during the upgrade. The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
+* Plan for the required downtime. {Project} services are shut down during the upgrade.
+The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
 +
 Upgrading {Project} takes approximately 1 - 2 hours.
 +
 Upgrading {SmartProxy} takes approximately 10 - 30 minutes.
 
-* Ensure that you have sufficient storage space on your server. For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your Environment for Installation] in _Installing {ProjectServer} from a Connected Network_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
+* Ensure that you have sufficient storage space on your server.
+For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your Environment for Installation] in _Installing {ProjectServer} from a Connected Network_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 
-* Back up your {ProjectServer} and all {SmartProxyServer}s. For more information, see {AdministeringDocURL}#backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProductVersionPrevious}_ guide.
+* Back up your {ProjectServer} and all {SmartProxyServer}s.
+For more information, see {AdministeringDocURL}#backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProductVersionPrevious}_ guide.
 
-* Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}. For more information about changes in the API, see the Knowledgebase article https://access.redhat.com/articles/4396911[API Changes Between {Project} Versions] on the Red{nbsp}Hat Customer Portal.
+* Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
+For more information about changes in the API, see the Knowledgebase article https://access.redhat.com/articles/4396911[API Changes Between {Project} Versions] on the Red{nbsp}Hat Customer Portal.
 
 [WARNING]
-If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating. You can use the `--noop` option with the {foreman-installer} script to test for changes. For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
+If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating.
+You can use the `--noop` option with the {foreman-installer} script to test for changes.
+For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
 
 
 [[upgrade_paths]]
 == Upgrade Paths
 
 ifdef::satellite[]
-You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}. {ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}. For more details, see the {Project} {ProjectVersionPrevious} https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/upgrading_and_updating_red_hat_satellite/[Upgrading and Updating {ProjectName}] guide.
+You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}. {ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
+For more information, see the {Project} {ProjectVersionPrevious} https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/upgrading_and_updating_red_hat_satellite/[Upgrading and Updating {ProjectName}] guide.
 endif::[]
 
 ifndef::satellite[]
-You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}. {ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}. For more details, see the {Project} {ProjectVersionPrevious} Upgrade documentation.
+You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}. {ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
+For more information, see the {Project} {ProjectVersionPrevious} Upgrade documentation.
 endif::[]
 
 .Overview of {Project} {ProjectVersion} Upgrade Paths
@@ -70,19 +85,26 @@ The high level steps in upgrading to {Project} {ProjectVersion} are as follows.
 ifdef::satellite[]
 . Clone your existing {ProjectServer}s. For more information, see xref:cloning_satellite_server[].
 endif::[]
-. Upgrade {ProjectServer} and all {SmartProxyServer}s to {Project} {ProjectVersion}. For more information, see xref:upgrading_satellite_server_parent[].
-. Upgrade to {project-client-name} on all {Project} clients. For more information, see xref:upgrading_clients[].
+. Upgrade {ProjectServer} and all {SmartProxyServer}s to {Project} {ProjectVersion}.
+For more information, see xref:upgrading_satellite_server_parent[].
+. Upgrade to {project-client-name} on all {Project} clients.
+For more information, see xref:upgrading_clients[].
 
 
 ifdef::satellite[]
 .Self-Registered {Project}s
 
-You cannot upgrade a self-registered {Project}. You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade. To migrate a self-registered {Project} to the CDN, see {BaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite[Upgrading {ProjectName}] in the _{ProjectXY} Upgrading and Updating {ProjectName}_ guide.
+You cannot upgrade a self-registered {Project}.
+You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade.
+To migrate a self-registered {Project} to the CDN, see {BaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite[Upgrading {ProjectName}] in the _{ProjectXY} Upgrading and Updating {ProjectName}_ guide.
 endif::[]
 
 [[following_the_progress_of_the_upgrade]]
 == Following the Progress of the Upgrade
 
-Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session. You can then check the upgrade progress without staying connected to the command shell continuously. For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_. You can also see the `screen` manual page for more information.
+Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
+For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
+You can also see the `screen` manual page for more information.
 
 If you lose connection to the command shell where the upgrade command is running you can see the logs in `{installer-log-file}` to check if the process completed successfully.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -2,7 +2,8 @@
 
 = Upgrading {ProjectServer}
 
-This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}. You can upgrade from any minor version of {ProjectName} Server {ProjectVersionPrevious}.
+This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.
+You can upgrade from any minor version of {ProjectName} Server {ProjectVersionPrevious}.
 
 include::upgrading_satellite_server_prerequisites.adoc[leveloffset=+3]
 
@@ -11,11 +12,14 @@ ifdef::satellite[]
 - To upgrade a {ProjectServer} connected to the Red{nbsp}Hat Content Delivery Network, proceed to xref:upgrading_a_connected_satellite_server[].
 - To upgrade a {ProjectServer} not connected to the Red{nbsp}Hat Content Delivery Network, proceed to xref:upgrading_a_disconnected_satellite[].
 
-You cannot upgrade a self-registered {Project}. You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade. To migrate a self-registered {Project} to the CDN, see {BaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite#migrating_a_self_registered_satellite[Migrating Self-Registered {Project}s] in the _{ProjectXY} Upgrading and Updating {ProjectName}_ guide.
+You cannot upgrade a self-registered {Project}.
+You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade.
+To migrate a self-registered {Project} to the CDN, see {BaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite#migrating_a_self_registered_satellite[Migrating Self-Registered {Project}s] in the _{ProjectXY} Upgrading and Updating {ProjectName}_ guide.
 endif::[]
 
 .FIPS mode
 
 You cannot upgrade {ProjectServer} from a RHEL base system that is not operating in FIPS mode to a RHEL base system that is operating in FIPS mode.
 
-To run {ProjectServer} on a {RHEL} base system operating in FIPS mode, you must install {Project} on a freshly provisioned RHEL base system operating in FIPS mode. For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your environment for installation] in _Installing {ProjectServer}_.
+To run {ProjectServer} on a {RHEL} base system operating in FIPS mode, you must install {Project} on a freshly provisioned RHEL base system operating in FIPS mode.
+For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your environment for installation] in _Installing {ProjectServer}_.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -2,11 +2,18 @@
 
 .Before You Begin
 
-* Note that you can upgrade {SmartProxies} separately from {Project}. For more information, see xref:upgrading_capsules-separately-from-satellite_upgrade-guide[].
-* Review and update your firewall configuration prior to upgrading your {ProjectServer}. For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your environment for installation] in _Installing {ProjectServer}_.
+* Note that you can upgrade {SmartProxies} separately from {Project}.
+For more information, see xref:upgrading_capsules-separately-from-satellite_upgrade-guide[].
+* Review and update your firewall configuration prior to upgrading your {ProjectServer}.
+For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your environment for installation] in _Installing {ProjectServer}_.
 * Ensure that you do not delete the manifest from the Customer Portal or in the {Project} Web UI because this removes all the entitlements of your content hosts.
-* Back up and remove all Foreman hooks before upgrading. Restore any hooks only after {Project} is known to be working after the upgrade is complete.
-* If you have edited any of the default templates, back up the files either by cloning or exporting them. Cloning is the recommended method because that prevents them being overwritten in future updates or upgrades. To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade. In the web UI, Navigate to *Monitor* > *Audits* and search for the template to see a record of changes made. If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
+* Back up and remove all Foreman hooks before upgrading.
+Restore any hooks only after {Project} is known to be working after the upgrade is complete.
+* If you have edited any of the default templates, back up the files either by cloning or exporting them.
+Cloning is the recommended method because that prevents them being overwritten in future updates or upgrades.
+To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
+In the web UI, Navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
+If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
 
 .{SmartProxy} Considerations
 
@@ -18,7 +25,6 @@
 If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom
 certificates.
 
-Failure to retain these files during an upgrade causes the upgrade to fail. If
-these files have been deleted, they must be restored from a backup in order for
-the upgrade to proceed.
+Failure to retain these files during an upgrade causes the upgrade to fail.
+If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
 ====

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_virt_who.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_virt_who.adoc
@@ -1,11 +1,14 @@
 [[upgrading_virt_who]]
 = Upgrading virt-who
 
-If virt-who is installed on {ProjectServer} or a {SmartProxyServer}, it will be upgraded when they are upgraded. No further action is required. If virt-who is installed elsewhere, it must be upgraded manually.
+If virt-who is installed on {ProjectServer} or a {SmartProxyServer}, it will be upgraded when they are upgraded.
+No further action is required.
+If virt-who is installed elsewhere, it must be upgraded manually.
 
 .Before You Begin
 
-If virt-who is installed on a host registered to {ProjectServer} or a {SmartProxyServer}, first upgrade the host to the latest packages available in the {project-client-name} repository. For information about upgrading hosts, see xref:upgrading_clients[].
+If virt-who is installed on a host registered to {ProjectServer} or a {SmartProxyServer}, first upgrade the host to the latest packages available in the {project-client-name} repository.
+For information about upgrading hosts, see xref:upgrading_clients[].
 
 .Upgrade virt-who Manually
 


### PR DESCRIPTION
As agreed, upstream docs must adhere to a one-sentence-per-line rule. 
The recently upstreamised wip upgrade guide did not follow this. 
This is my attempt to right that wrong. 

Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
