### PR TITLE
Added admonition to check the status of hostname

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
@@ -11,6 +11,15 @@ This procedure ensures that you update all references to the new host name.
 * If the `hostname` command returns the shortname of {SmartProxyServer} instead of the FQDN, use `hostnamectl set-hostname _<old_fqdn>_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
 ====
 
+.Prerequisites
+
+* Backup {SmartProxyServer}.
+The `{project-change-hostname}` script makes irreversible changes to {SmartProxyServer}.
+If the renaming process is not successful, you must restore it from a backup.
++
+{ProjectName} does not provide a native backup method for {SmartProxyServer}.
+For more information, see xref:backing-up-satellite-server-and-capsule-server[].
+
 [WARNING]
 ====
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1829115[BZ#1829115] is resolved, you must edit the `usr/share/katello/hostname-change.rb` file on {SmartProxyServer} and comment out the following lines before attempting to rename {SmartProxyServer}:
@@ -23,15 +32,7 @@ self.run_cmd("sed -i.bak -e 's/\#_@<old_hostname>_ \
 self.run_cmd("sed -i.bak -e 's/#_@<old_hostname>_ \
 /#_@<new_hostname>_/g' #_<hammer_config_path>_/*.yml")
 ----
-
-.Prerequisites
-
-* Backup {SmartProxyServer}.
-The `{project-change-hostname}` script makes irreversible changes to {SmartProxyServer}.
-If the renaming process is not successful, you must restore it from a backup.
-+
-{ProjectName} does not provide a native backup method for {SmartProxyServer}.
-For more information, see xref:backing-up-satellite-server-and-capsule-server[].
+====
 
 .Procedure
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
@@ -4,11 +4,11 @@
 The host name of {SmartProxyServer} is referenced by {ProjectServer} components, and all hosts registered to it.
 This procedure ensures that you update all references to the new host name.
 
-[IMPORTANT]
+[NOTE]
 ====
 * Both the `hostname` and `hostname -f` commands must return the FQDN of {SmartProxyServer} or the `{project-change-hostname}` script will fail to complete.
 
-* If the `hostname` command returns the shortname of {SmartProxyServer} instead of the FQDN, use `hostnamectl set-hostname _<old_fqdn>_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
+* If the `hostname` command returns the shortname of {SmartProxyServer} instead of the FQDN, use `hostnamectl set-hostname _old_fqdn_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
 ====
 
 .Prerequisites
@@ -17,7 +17,7 @@ This procedure ensures that you update all references to the new host name.
 The `{project-change-hostname}` script makes irreversible changes to {SmartProxyServer}.
 If the renaming process is not successful, you must restore it from a backup.
 +
-{ProjectName} does not provide a native backup method for {SmartProxyServer}.
+Perform a backup before changing a host name.
 For more information, see xref:backing-up-satellite-server-and-capsule-server[].
 
 [WARNING]
@@ -27,10 +27,10 @@ Until https://bugzilla.redhat.com/show_bug.cgi?id=1829115[BZ#1829115] is resolve
 [options='nowrap', subs="+quotes,verbatim,attributes"]
 ----
 STDOUT.puts "updating hostname in hammer configuration"
-self.run_cmd("sed -i.bak -e 's/\#_@<old_hostname>_ \
-/_#@<new_hostname>_/g' _\#<hammer_root_config_path>_/\*.yml")
-self.run_cmd("sed -i.bak -e 's/#_@<old_hostname>_ \
-/#_@<new_hostname>_/g' #_<hammer_config_path>_/*.yml")
+self.run_cmd("sed -i.bak -e 's/\#_{@old_hostname}_ \
+/_#{@new_hostname}_/g' _\#{hammer_root_config_path}_/\*.yml")
+self.run_cmd("sed -i.bak -e 's/#_{@old_hostname}_ \
+/#_{@new_hostname>_/g' #_{hammer_config_path}_/*.yml")
 ----
 ====
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
@@ -4,22 +4,28 @@
 The host name of {SmartProxyServer} is referenced by {ProjectServer} components, and all hosts registered to it.
 This procedure ensures that you update all references to the new host name.
 
-.Prerequisites
-+
+[IMPORTANT]
+====
+* Both the `hostname` and `hostname -f` commands must return the FQDN of {SmartProxyServer} or the `{project-change-hostname}` script will fail to complete.
+
+* If the `hostname` command returns the shortname of {SmartProxyServer} instead of the FQDN, use `hostnamectl set-hostname _<old_fqdn>_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
+====
+
 [WARNING]
 ====
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1829115[BZ#1829115] is resolved, you must edit the `usr/share/katello/hostname-change.rb` file on {SmartProxyServer} and comment out the following lines before attempting to rename {SmartProxyServer}:
 
-[options="nowrap" subs="+quotes,attributes"]
+[options='nowrap', subs="+quotes,verbatim,attributes"]
 ----
 STDOUT.puts "updating hostname in hammer configuration"
-self.run_cmd("sed -i.bak -e 's/#{@old_hostname} \
-/#{@new_hostname}/g' #{hammer_root_config_path}/*.yml")
-self.run_cmd("sed -i.bak -e 's/#{@old_hostname} \
-/#{@new_hostname}/g' #{hammer_config_path}/#.yml")
+self.run_cmd("sed -i.bak -e 's/\#_@<old_hostname>_ \
+/_#@<new_hostname>_/g' _\#<hammer_root_config_path>_/\*.yml")
+self.run_cmd("sed -i.bak -e 's/#_@<old_hostname>_ \
+/#_@<new_hostname>_/g' #_<hammer_config_path>_/*.yml")
 ----
-====
-+
+
+.Prerequisites
+
 * Backup {SmartProxyServer}.
 The `{project-change-hostname}` script makes irreversible changes to {SmartProxyServer}.
 If the renaming process is not successful, you must restore it from a backup.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
@@ -8,13 +8,6 @@ If you use external authentication, you must reconfigure {ProjectServer} for ext
 The `{project-change-hostname}` script breaks external authentication for {ProjectServer}.
 For more information about configuring external authentication, see xref:chap-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication[].
 
-[IMPORTANT]
-====
-* Both the `hostname` and `hostname -f` commands must return the FQDN of {ProjectServer} or the `{project-change-hostname}` script will fail to complete.
-
-* If the `hostname` command returns the shortname of {ProjectServer} instead of the FQDN, use `hostnamectl set-hostname _old_fqdn_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
-====
-
 If you use virt-who, you must update the virt-who configuration files with the new host name after you run the `{project-change-hostname}` script.
 ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/configuring_virtual_machine_subscriptions_in_red_hat_satellite/troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _Configuring Virtual Machine Subscriptions in {ProjectName}_.
@@ -22,8 +15,10 @@ endif::[]
 
 .Prerequisites
 
-* Backup {ProjectServer}.
-The `{project-change-hostname}` script makes irreversible changes to {ProjectServer}.
+* Both the `hostname` and `hostname -f` commands must return the FQDN of {ProjectServer} or the `{project-change-hostname}` script will fail to complete.
+If the `hostname` command returns the shortname of {ProjectServer} instead of the FQDN, use `hostnamectl set-hostname _old_fqdn_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
+
+* Perform a backup of {ProjectServer} before changing a host name.
 If the renaming process is not successful, you must restore it from a backup.
 For more information, see xref:backing-up-satellite-server-and-capsule-server[].
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
@@ -8,6 +8,13 @@ If you use external authentication, you must reconfigure {ProjectServer} for ext
 The `{project-change-hostname}` script breaks external authentication for {ProjectServer}.
 For more information about configuring external authentication, see xref:chap-{Project_Link}-Administering_{Project_Link}-Configuring_External_Authentication[].
 
+[IMPORTANT]
+====
+* Both the `hostname` and `hostname -f` commands must return the FQDN of {ProjectServer} or the `{project-change-hostname}` script will fail to complete.
+
+* If the `hostname` command returns the shortname of {ProjectServer} instead of the FQDN, use `hostnamectl set-hostname _old_fqdn_` to set the old FQDN correctly before attempting to use the `{project-change-hostname}` script.
+====
+
 If you use virt-who, you must update the virt-who configuration files with the new host name after you run the `{project-change-hostname}` script.
 ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/configuring_virtual_machine_subscriptions_in_red_hat_satellite/troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _Configuring Virtual Machine Subscriptions in {ProjectName}_.


### PR DESCRIPTION
In both Renaming Satellite Server and Renaming Casule Server sections an admonition has been added to check the
value retured by the hostname command for satellite-change-hostname to work correctly.

I have also moved a warning in the Renaming Capsule server section to avoid asciidoc formatting problems caused
when the admonition occurs directly after the Prerequisites title.

Bug 1922300 - A must prerequisite should be mentioned in "RENAMING SATELLITE SERVER OR CAPSULE SERVER" chapter

https://bugzilla.redhat.com/show_bug.cgi?id=1922300




Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
