### PR TITLE
Disable unresolvable links

### DIFF
--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
@@ -15,12 +15,11 @@ Note that you can navigate to the following URL within your realm to obtain valu
 . Locate the *Authorize login delegation* row, and in the *Value* column, set the value to *Yes*.
 . Locate the *Authorize login delegation auth source user autocreate* row, and in the *Value* column,
 set the value to *External*.
-. Locate the *Login delegation logout URL* row, and in the *Value* column, set the value to
-*https://{foreman-example-com}/users/extlogout*.
+. Locate the *Login delegation logout URL* row, and in the *Value* column, set the value to *\https://{foreman-example-com}/users/extlogout*.
 . Locate the *OIDC Algorithm* row, and in the *Value* column, set the algorithm for encoding on {Keycloak} to *RS256*.
 . Locate the *OIDC Audience* row, and in the *Value* column, set the value to the client ID for {Keycloak}.
-. Locate the *OIDC Issuer* row, and in the *Value* column, set the value to *_https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm_*.
-. Locate the *OIDC JWKs URL* row, and in the *Value* column, set the value to *_https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/protocol/openid-connect/certs_*.
+. Locate the *OIDC Issuer* row, and in the *Value* column, set the value to *_\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm_*.
+. Locate the *OIDC JWKs URL* row, and in the *Value* column, set the value to *_\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/protocol/openid-connect/certs_*.
 . Navigate to *Administer* > *Authentication Sources* and click *External*.
 . Click *Create LDAP Authentication Source* and select the {Keycloak} server.
 . Click the *Locations* tab and add locations that can use the {Keycloak} authentication source.


### PR DESCRIPTION
This PR disables some more unresolvable links.

Reason: `X.example.com` won't ever/most likely not resolve, i.e. users cannot/should not click these kinds of links.

See also https://github.com/theforeman/foreman-documentation/pull/487

Question: is the bold and italic on purpose or "should" this be inline code?