### PR TITLE
Set versions to nightly

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -3,9 +3,9 @@
 :DocState: nightly
 
 // Version numbers
-:ProjectVersion: 2.4
-:ProjectVersionPrevious: 2.3
-:KatelloVersion: 4.0
+:ProjectVersion: nightly
+:ProjectVersionPrevious: 2.5
+:KatelloVersion: nightly
 :TargetVersion: 6.9
 :TargetVersionMaintainUpgrade: 6.9
 // The above attribute should point to the GA version number (x.y) for all releases including Beta


### PR DESCRIPTION
This guide is for nightly and it should point to that. Without this, it falsely gives the impression it's for 2.4.