### PR TITLE
Cleared misunderstanding between major and minor versions

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/restoring-from-a-full-backup.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/restoring-from-a-full-backup.adoc
@@ -6,7 +6,7 @@ When the restore process completes, all processes are online, and all databases 
 
 .Prerequisites
 * Ensure that you are restoring to the correct instance.
-The {ProjectName} instance must have the same host name, configuration, and be the same version as the original system.
+The {ProjectName} instance must have the same host name, configuration, and be the same minor version (X.Y) as the original system.
 * Ensure that you have an existing target directory.
 The target directory is read from the configuration files contained within the archive.
 * Ensure that you have enough space to store this data on the base system of {ProjectServer} or {SmartProxyServer} as well as enough space after the restoration to contain all the data in the `/etc/` and `/var/` directories contained within the backup.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/restoring-from-a-full-backup.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/restoring-from-a-full-backup.adoc
@@ -6,7 +6,7 @@ When the restore process completes, all processes are online, and all databases 
 
 .Prerequisites
 * Ensure that you are restoring to the correct instance.
-The {ProjectName} instance must have the same host name, configuration, and be the same major version as the original system.
+The {ProjectName} instance must have the same host name, configuration, and be the same version as the original system.
 * Ensure that you have an existing target directory.
 The target directory is read from the configuration files contained within the archive.
 * Ensure that you have enough space to store this data on the base system of {ProjectServer} or {SmartProxyServer} as well as enough space after the restoration to contain all the data in the `/etc/` and `/var/` directories contained within the backup.


### PR DESCRIPTION
Removed the word 'major' so that the text now states you should restore from the same version you backed up. Restoring
from an alternate minor version, for example 6.7 to 6.8 is not supported and may cause problems.

Bug 1846077 - misunderstanding between major and minor version

https://bugzilla.redhat.com/show_bug.cgi?id=1846077


Cherry-pick into:

* [X] Foreman 2.5 (Satellite 6.10)
* [X ] Foreman 2.4
* [X ] Foreman 2.3 (Satellite 6.9)
* [X ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
