### PR TITLE
Removed incorect text about registering to Insights by default

### DIFF
--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -2,7 +2,7 @@
 
 = Disabling Registration to Red Hat Insights
 
-{Project} is registered to Red Hat Insights by default. After you install or upgrade {Project}, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
+After you install or upgrade {Project}, you can choose to unregister or register Red Hat Insights as needed. For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}. 
 
 .Prerequisites
 

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -27,6 +27,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 +
 . To register {ProjectServer} with Red{nbsp}Hat Insights, enter the following command:
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# insights-client --register
+# {foreman-installer} --register-with-insights
 ----


### PR DESCRIPTION
-Also updated insights registration command

Bug 1959123 - Enhancement:'Satellite now registers to Insights by default' not working as described in the documentation
https://bugzilla.redhat.com/show_bug.cgi?id=1959123


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
