### PR TITLE
Added port 8443 to Table 1.5. Ports for Satellite to Capsule Communic…

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -96,6 +96,7 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 | 443 |  TCP | HTTPS | Connections to the Pulp server in the {SmartProxy}
 | 9090 | TCP | HTTPS | Connections to the proxy in the {SmartProxy}
 | 80 | TCP | HTTP | Downloading a bootdisk (Optional)
+| 8443 | TCP | HTTPS | Subscription Management Services and host registration
 |====
 
 


### PR DESCRIPTION
…ation

Bug 1921423 - Documentation missing : Ports for Client to Capsule Communication
https://bugzilla.redhat.com/show_bug.cgi?id=1921423


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
