### PR TITLE
Extend ACD documentation

### DIFF
--- a/guides/common/modules/con_acd_architecture.adoc
+++ b/guides/common/modules/con_acd_architecture.adoc
@@ -96,7 +96,17 @@ Refer to the https://docs.ansible.com/ansible/latest/user_guide/playbooks_variab
 The ACD plugin requires the specific {ProjectName} permissions.
 Depending on your environment, there might be two different groups of users in regard to _managing_ an application and _deploying_ an application:
 
+You can interact with three different resources for ACD:
+
+.ACD Resources
+* Ansible playbooks: *Applications > Ansible Playbooks*
+* Application definitions: *Applications > App Definitions*
+* Application instances: *Applications > App Instances*
+
+You can create custom roles in the {ProjectWebUI} based on existing user role filters for these resources.
+
 * An administrative group of users might be responsible for providing the tools to deploy an application, that is an Ansible playbook and application definition.
+Note that the *Ansible playbook* is not related to the Ansible plugin for configuration management.
 * An end user group might be using {ProjectName} to deploy applications, that is creating and deploying application instances based on application definitions within their organization and location context.
 Many application instances can be created based on the same application definition.
 

--- a/guides/common/modules/proc_adding_an_ansible_playbook.adoc
+++ b/guides/common/modules/proc_adding_an_ansible_playbook.adoc
@@ -8,12 +8,21 @@ You can add xref:{context}_ansible_playbooks[Ansible playbooks] used for applica
 . Click *New Ansible Playbook*.
 . In the *Name* field, enter the name of new Ansible playbook.
 . In the *Description* field, enter an arbitrary description.
-. In the *Path* field, enter the location of the Ansible playbook on your {ProjectServer}.
+. In the *SCM Type* list, select either _directory_ if the Ansible playbook is located on your {ProjectServer} or _git_ to reference a remote git repository.
+* If you select *directory*, enter the location of the Ansible playbook on your {ProjectServer} in the *Directory Path* field.
 +
-To avoid SELinux issues, add the Ansible playbook to the `/etc/foreman/plugins/foreman_acd/ansible-playbooks/` directory.
+To avoid SELinux issues, add the Ansible playbook to the `/var/lib/foreman/foreman_acd/ansible-playbooks/` directory.
+* If you select *git*, enter the remote location in the *Git Url* field and a git branch, commit, or tag in the *Git Branch/Commit/Tag* field.
++
+Click *Sync Repository* to fetch the remote git repository.
 . In the *Playfile* field, enter the name of the Ansible playbook.
 . Click *Submit* to save your Ansible playbook.
 . Once submitted, click the *Import groups* button to import Ansible group variables before this Ansible playbook can be used for an application definition.
+
+[NOTE]
+====
+You can only edit the directory path or git URL as long as it is not used by any application definition.
+====
 
 [TIP]
 ====


### PR DESCRIPTION
* Fix path for ACD Ansible playbooks
* Add git support to Ansible playbook
* Extend ACD user roles
* Git branch commit tag no longer optional