### PR TITLE
Provided more information for adding an HTTP Proxy

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -510,8 +510,6 @@ The following host names are available:
 | subscription.rhsm.redhat.com | 443 | HTTPS
 | subscription.rhn.redhat.com | 443 | HTTPS
 | cdn.redhat.com |  443 | HTTPS
-| *.akamaiedge.net | 443 | HTTPS
-| *.akamaitechnologies.com |  443 | HTTPS
 ifdef::satellite[]
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -493,6 +493,8 @@ Use this option if you have one of the following errors:
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for Products, repositories, and supported compute resources.
 
+If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com or subscription.rhn.redhat.com, and cdn.redhat.com then the proxy must not perform SSL inspection on these communications.
+
 To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy_{context}[].
 
 .Procedure
@@ -510,8 +512,10 @@ The following host names are available:
 | cdn.redhat.com |  443 | HTTPS
 | *.akamaiedge.net | 443 | HTTPS
 | *.akamaitechnologies.com |  443 | HTTPS
+ifdef::satellite[]
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
+endif::[]
 |====
 +
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
@@ -532,11 +536,6 @@ The following host names are available:
 ----
 +
 If your HTTP proxy requires authentication, add the `--username _name_` and `--password _password_` options.
-
-[WARNING]
-====
-If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com (or subscription.rhn.redhat.com) and cdn.redhat.com then the proxy must not perform SSL inspection on these communications.
-====
 
 For further information, see the Knowledgebase article https://access.redhat.com/solutions/65300[How to access Red{nbsp}Hat Subscription Manager (RHSM) through a firewall or proxy] on the Red{nbsp}Hat Customer Portal.
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -500,6 +500,20 @@ To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy_{
 . In the {Project} web UI, navigate to *Infrastructure* > *HTTP Proxies* and select *New HTTP Proxy*.
 . In the *Name* field, enter a name for the HTTP proxy.
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
+The following host names are available:
++
+[cols="2,1,1",options="header"]
+|====
+| Host name | Port | Protocol
+| subscription.rhsm.redhat.com | 443 | HTTPS
+| subscription.rhn.redhat.com | 443 | HTTPS
+| cdn.redhat.com |  443 | HTTPS
+| *.akamaiedge.net | 443 | HTTPS
+| *.akamaitechnologies.com |  443 | HTTPS
+| api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
+| cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
+|====
++
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
 . Click the *Locations* tab and add a location.
@@ -519,6 +533,12 @@ To use the CLI instead of the web UI, see the xref:cli-adding-a-new-http-proxy_{
 +
 If your HTTP proxy requires authentication, add the `--username _name_` and `--password _password_` options.
 
+[WARNING]
+====
+If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com (or subscription.rhn.redhat.com) and cdn.redhat.com then the proxy must not perform SSL inspection on these communications.
+====
+
+For further information, see the Knowledgebase article https://access.redhat.com/solutions/65300[How to access Red{nbsp}Hat Subscription Manager (RHSM) through a firewall or proxy] on the Red{nbsp}Hat Customer Portal.
 
 [[Changing_the_HTTP_Proxy_Policy_for_a_Product]]
 === Changing the HTTP Proxy Policy for a Product


### PR DESCRIPTION
A table of the hostnames available and portnumbers, plus a warning not to perform SSL inspections
on these communications was added.

Bug 1921928 - Satellite documentation needs more information on proxy part if it use to sync repositories

https://bugzilla.redhat.com/show_bug.cgi?id=1921928


Cherry-pick into:

* [X] Foreman 2.5 (Satellite 6.10)
* [X] Foreman 2.4
* [X] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
