### PR TITLE
Adapt administering Foreman guide for orcharhino

### DIFF
--- a/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-authentication.adoc
+++ b/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-authentication.adoc
@@ -10,7 +10,11 @@ Before configuring {Project} with {Keycloak} external authentication, ensure tha
 * Users imported or added to {Keycloak}.
 +
 If you have an existing user database configured such as LDAP or Kerberos, you can import users from it by configuring user federation.
+ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user-storage-federation[User Storage Federation] in the _Red{nbsp}Hat Single Sign-On Server Administration Guide_.
+endif::[]
 +
 If you do not have an existing user database configured, you can manually create users in {Keycloak}.
+ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.4/html/server_administration_guide/user_management#create-new-user[Creating New Users] in the _Red{nbsp}Hat Single Sign-On Server Administration Guide_.
+endif::[]

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -37,7 +37,7 @@ ifdef::satellite[]
 [options="nowrap", subs="+quotes,attributes"]
 ----
 _output omitted_
-satellite-installer \
+{foreman-installer} \
 --scenario capsule \
 --certs-tar-file                              "_/root/capsule_certs.tar_"\
 --foreman-proxy-content-parent-fqdn           "_satellite.example.com_"\

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -81,7 +81,7 @@ Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to t
 # usermod -a -G named foreman-proxy
 ----
 
-. On {ProjectServer}, enter the following `satellite-installer` command to configure {Project} to use the external DNS server:
+. On {ProjectServer}, enter the following `{foreman-installer}` command to configure {Project} to use the external DNS server:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -99,17 +99,17 @@ ifdef::satellite[]
 [options="nowrap", subs="+quotes,attributes"]
 ----
 _output omitted_
-satellite-installer \
+{foreman-installer} \
 --scenario capsule \
 --certs-tar-file                              "_/root/capsule_certs.tar_"\
---foreman-proxy-content-parent-fqdn           "_satellite.example.com_"\
+--foreman-proxy-content-parent-fqdn           "_{foreman-example-com}_"\
 --foreman-proxy-register-in-foreman           "true"\
---foreman-proxy-foreman-base-url              "https://_satellite.example.com_"\
---foreman-proxy-trusted-hosts                 "_satellite.example.com_"\
---foreman-proxy-trusted-hosts                 "_capsule.example.com_"\
+--foreman-proxy-foreman-base-url              "_https://{foreman-example-com}_"\
+--foreman-proxy-trusted-hosts                 "_{foreman-example-com}_"\
+--foreman-proxy-trusted-hosts                 "_{smartproxy-example-com}_"\
 --foreman-proxy-oauth-consumer-key            "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_"\
 --foreman-proxy-oauth-consumer-secret         "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"\
---puppet-server-foreman-url                   "https://_satellite.example.com_"
+--puppet-server-foreman-url                   "_https://{foreman-example-com}_"
 ----
 endif::[]
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -32,14 +32,14 @@ Validation succeeded.
 
 To install the Red Hat Satellite Server with the custom certificates, run:
 
-  satellite-installer --scenario satellite \
+  {foreman-installer} --scenario satellite \
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
 
 To update the certificates on a currently running Red Hat Satellite installation, run:
 
-  satellite-installer --scenario satellite \
+  {foreman-installer} --scenario satellite \
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \

--- a/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
+++ b/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
@@ -2,7 +2,7 @@
 [id="listing-using-satellite-ansible-modules_{context}"]
 = Viewing the {Project} Ansible Modules
 
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 You can view the installed {Project} Ansible modules by listing the content of the following directory:
 
 [options="nowrap" subs="+quotes,attributes"]
@@ -17,7 +17,7 @@ At the time of writing, the `ansible-doc -l` command does not list collections y
 
 endif::[]
 
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 
 Starting with Ansible 2.10, you can view the installed {Project} Ansible modules by running:
 

--- a/guides/common/modules/proc_registering-project-as-a-keycloak-client.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-keycloak-client.adoc
@@ -45,7 +45,7 @@ Then, configure {Project} to use {Keycloak} as an authentication source:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# satellite-installer --foreman-keycloak true \
+# {foreman-installer} --foreman-keycloak true \
 --foreman-keycloak-app-name "foreman-openidc" \
 --foreman-keycloak-realm "_{Project}_Realm_"
 ----

--- a/guides/common/modules/snip_firewalld.adoc
+++ b/guides/common/modules/snip_firewalld.adoc
@@ -1,3 +1,3 @@
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 If you do not use `firewall-cmd` to configure the Linux firewall, implement using the command of your choice.
 endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -41,7 +41,7 @@ For more information, see xref:configuring-project-with-keycloak-authentication_
 * Using {Keycloak} as an OpenID provider for external authentication to {Project} with TOTP.
 For more information, see xref:configuring-keycloak-authentication-with-totp_admin[].
 
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 * Using {Keycloak} as an OpenID provider for external authentication to {Project} with {PIV} cards.
 For more information, see xref:configuring-keycloak-authentication-with-cac-cards_admin[].
 endif::[]
@@ -323,7 +323,7 @@ When a system is added to {ProjectServer}'s _hostgroup_name_ host group, it is a
 
 include::../common/assembly_configuring-keycloak-external-authentication.adoc[leveloffset=+2]
 include::../common/assembly_configuring-keycloak-external-authentication-with-totp.adoc[leveloffset=+2]
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 include::../common/assembly_configuring-keycloak-external-authentication-with-cac-cards.adoc[leveloffset=+2]
 endif::[]
 include::../common/modules/proc_disabling-keycloak-authentication.adoc[leveloffset=+2]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_LDAP_Authentication_for_Red_Hat_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_LDAP_Authentication_for_Red_Hat_Satellite.adoc
@@ -15,7 +15,9 @@ Though direct LDAP integration is covered in this section, Red{nbsp}Hat recommen
 SSSD improves the consistency of the authentication process.
 For more information about the preferred configurations, see xref:sect-Administering-Configuring_External_Authentication-Using_Active_Directory[].
 You can also cache the SSSD credentials and use them for LDAP authentication.
+ifndef::orcharhino[]
 For more information on SSSD, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/sssd[Configuring SSSD] in the _Red{nbsp}Hat{nbsp}Enterprise{nbsp}Linux 7 System-Level Authentication Guide_.
+endif::[]
 
 
 include::configuring-tls-for-secure-ldap.adoc[leveloffset=+3]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Notifications.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Notifications.adoc
@@ -7,16 +7,21 @@ To view {Project} event notification alerts, click the *Notifications* icon in t
 ifdef::satellite[]
 By default, the Notifications area displays RSS feed events published in the https://access.redhat.com/blogs/1169563[{ProjectName} Blog].
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 By default, the Notifications area displays RSS feed events published in the https://theforeman.org/blog/[Foreman Blog].
+endif::[]
+ifdef::orcharhino[]
+By default, the Notifications area displays RSS feed events published in the https://orcharhino.com/feed/[orcharhino news].
 endif::[]
 
 The feed is refreshed every 12 hours and the Notifications area is updated whenever new events become available.
 
 You can configure the RSS feed notifications by changing the URL feed.
 The supported feed format is RSS 2.0 and Atom.
+ifndef::orcharhino[]
 For an example of the RSS 2.0 feed structure, see the https://access.redhat.com/blogs/1169563/feed[{ProjectName} Blog feed].
 For an example of the Atom feed structure, see the https://theforeman.org/feed.xml[Foreman blog feed].
+endif::[]
 
 [[proc-Administering-Configuring_the_Notifications_Drawer-To_Configure_an_RSS_Feed_to_Notifications]]
 .To Configure RSS Feed Notifications:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
@@ -47,7 +47,9 @@ By default, {Project} executes a cron job that cleans tasks every day at 19:45.
 *  All tasks that are older than a year
 
 .For {Project}s Upgraded from Previous Versions
+ifndef::orcharhino[]
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1788615[BZ#1788615] is resolved, this functionality works only on fresh installations of {ProjectXY} and later.
+endif::[]
 If you upgrade {Project} from previous versions, this functionality is disabled by default.
 To enable {Project} to perform regular cleaning, enter the following command:
 
@@ -89,9 +91,13 @@ Here are some ways to achieve that:
 +
 This is run weekly so it will not free much space.
 .. Change the download policy from *Immediate* to *On Demand* for as many repositories as possible and remove already downloaded packages.
+ifndef::orcharhino[]
 See the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/2785021[How to change syncing policy for Repositories on Satellite from "Immediate" to "On-Demand"] on the Red{nbsp}Hat Customer Portal for instructions.
+endif::[]
 .. Grow the file system on the LV with the `/var/lib/pulp` directory on it.
+ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/logical_volume_manager_administration/fsgrow_overview[Growing a File System on a Logical Volume] in the _Red{nbsp}Hat Enterprise Linux 7 Logical Volume Manager Administration Guide_.
+endif::[]
 +
 [NOTE]
 ====
@@ -160,7 +166,9 @@ If you want to check for updates using `yum`, enter the command to install and u
 # {foreman-maintain} packages lock
 ----
 Updating packages individually can lead to package inconsistencies in {Project} or {SmartProxy}.
+ifndef::orcharhino[]
 For more information about updating packages in {Project}, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/upgrading_and_updating_red_hat_satellite/updating_satellite_server_capsule_server_and_content_hosts#updating_satellite_server_to_next_minor_version[Updating {ProjectServer}].
+endif::[]
 
 .Enabling yum for {Project} or {SmartProxy} Package Management
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Capsule_Server.adoc
@@ -28,9 +28,9 @@ Until https://bugzilla.redhat.com/show_bug.cgi?id=1829115[BZ#1829115] is resolve
 ----
 STDOUT.puts "updating hostname in hammer configuration"
 self.run_cmd("sed -i.bak -e 's/\#_{@old_hostname}_ \
-/_#{@new_hostname}_/g' _\#{hammer_root_config_path}_/\*.yml")
+/_#{@new_hostname}_/g' _\#\{hammer_root_config_path}_/\*.yml")
 self.run_cmd("sed -i.bak -e 's/#_{@old_hostname}_ \
-/#_{@new_hostname>_/g' #_{hammer_config_path}_/*.yml")
+/#_{@new_hostname>_/g' #_\{hammer_config_path}_/*.yml")
 ----
 ====
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
@@ -7,7 +7,9 @@ This section shows how to use direct Active Directory (AD) as an external authen
 ====
 You can attach Active Directory as an external authentication source with no single sign-on support.
 For more information, see xref:sect-Administering-Using_LDAP[].
+ifndef::orcharhino[]
 For an example configuration, see https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with TLS on {ProjectX}].
+endif::[]
 ====
 
 Direct AD integration means that {ProjectServer} is joined directly to the AD domain where the identity is stored.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -14,7 +14,9 @@ For more information, see xref:sect-Administering-Using_LDAP[].
 * The base operating system of {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
+ifndef::orcharhino[]
 However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/index.html#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].
+endif::[]
 
 include::configuring-idm-authentication-on-satellite-server.adoc[leveloffset=+3]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/active-directory-with-cross-forest-trust.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/active-directory-with-cross-forest-trust.adoc
@@ -4,4 +4,6 @@
 Kerberos can create `cross-forest trust` that defines a relationship between two otherwise separate domain forests.
 A domain forest is a hierarchical structure of domains; both AD and {FreeIPA} constitute a forest.
 With a trust relationship enabled between AD and {FreeIPA}, users of AD can access Linux hosts and services using a single set of credentials.
+ifndef::orcharhino[]
 For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/active-directory-trust.html[Creating Cross-forest Trusts with Active Directory and Identity Management] in the _Red{nbsp}Hat Enterprise{nbsp}Linux Windows Integration_ guide.
+endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/assembly_backing-up-satellite-server-and-capsule-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/assembly_backing-up-satellite-server-and-capsule-server.adoc
@@ -24,7 +24,9 @@ You must encrypt or move the backup to a secure location to minimize the risk of
 .Conventional Backup Methods
 
 You can also use conventional backup methods.
+ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/part-system_backup_and_recovery[System Backup and Recovery] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 System Administrator's Guide_.
+endif::[]
 
 NOTE: If you plan to use the `{foreman-maintain} backup` command to create a backup, do not stop the `{foreman-maintain}` services.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configure-logging-to-journal.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configure-logging-to-journal.adoc
@@ -8,7 +8,7 @@ Note that after this change the log messages do not appear in `/var/log/foreman/
 ifdef::satellite[]
 For more information about Journal, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-viewing_and_managing_log_files#s1-Using_the_Journal[Using the Journal] in the _Red{nbsp}Hat Enterprise{nbsp}Linux 7 System Administrator's guide_.
 endif::[]
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 For more information about Journal, see https://github.com/lzap/foreman-elasticsearch[].
 endif::[]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
@@ -5,7 +5,9 @@
 HBAC rules define which machine within the domain a {FreeIPA} user is allowed to access.
 You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing {ProjectServer}.
 With this approach, you can prevent {Project} from creating database entries for users that are not allowed to log in.
+ifndef::orcharhino[]
 For more information on HBAC, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/configuring-host-access.html[Configuring Host-Based Access Control] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+endif::[]
 
 On the {FreeIPA} server, configure Host-Based Authentication Control (HBAC).
 
@@ -55,7 +57,9 @@ Alternatively, host groups and user groups can be added to the _allow_{project-c
 ----
 
 . Ensure the allow_all rule is disabled on the {FreeIPA} server.
+ifndef::orcharhino[]
 For instructions on how to do so without disrupting other services see the https://access.redhat.com/solutions/67895[How to configure HBAC rules in IdM] article on the Red{nbsp}Hat Customer Portal.
+endif::[]
 
 . Configure the {FreeIPA} integration with {ProjectServer} as described in xref:configuring-idm-authentication-on-satellite-server_{context}[].
 On {ProjectServer}, define the PAM service as root:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -32,7 +32,9 @@ In the {Project} CLI, configure {FreeIPA} authentication by first creating a hos
 The generated one-time password must be used on the client to complete {FreeIPA}-enrollment.
 ====
 +
+ifndef::orcharhino[]
 For more information on host configuration properties, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/host-attr.html[About Host Entry Configuration Properties] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+endif::[]
 
 . Create an HTTP service for {ProjectServer}, for example:
 +
@@ -41,7 +43,9 @@ For more information on host configuration properties, see https://access.redhat
 # ipa service-add _servicename_/_hostname_
 ----
 +
+ifndef::orcharhino[]
 For more information on managing services, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/services.html[Managing Services] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+endif::[]
 
 . On {ProjectServer}, install the IPA client:
 ifdef::satellite[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
@@ -8,7 +8,9 @@ Use the {Project} CLI to configure TLS for secure LDAP (LDAPS).
 . Obtain the Certificate from the LDAP Server.
 
 .. If you use Active Directory Certificate Services, export the Enterprise PKI CA Certificate using the Base-64 encoded X.509 format.
+ifndef::orcharhino[]
 See https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with `TLS` on {ProjectX}] for information on creating and exporting a CA certificate from an Active Directory server.
+endif::[]
 
 .. Download the LDAP server certificate to a temporary location on the Red{nbsp}Hat Enterprise{nbsp}Linux system where {ProjectServer} is installed and remove it when finished.
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-complete-permission-table.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-complete-permission-table.adoc
@@ -27,7 +27,7 @@ Insert the following code into the console:
 f = File.open('/tmp/table.html', 'w')
 
 result = Foreman::AccessControl.permissions {|a,b| a.security_block <=> b.security_block}.collect do |p|
-      actions = p.actions.collect { |a| "<li>#{a}</li>" }
+      actions = p.actions.collect { |a| "<li>#\{a}</li>" }
       "<tr><td>#{p.name}</td><td><ul>#{actions.join('')}</ul></td><td>#{p.resource_type}</td></tr>"
 end.join("\n")
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
@@ -19,7 +19,7 @@ Before you begin, you must decide whether you want to use a Puppet or Ansible de
 * For Puppet deployment, ensure that each host that you want to audit is associated with a Puppet environment.
 For more information, see xref:importing-openscap-puppet-modules_{context}[].
 * For Ansible deployment, ensure that you import the `theforeman.foreman_scap_client` Ansible role.
-For more information about importing Ansible roles, see {ConfiguringAnsibleDocURL}getting-started-with-ansible_ansible[Getting Started with Ansible in Satellite] in _Configuring Satellite to use Ansible_.
+For more information about importing Ansible roles, see {ConfiguringAnsibleDocURL}getting-started-with-ansible_ansible[Getting Started with Ansible in {Project}] in _Configuring {Project} to use Ansible_.
 
 .Procedure
 
@@ -27,7 +27,9 @@ For more information about importing Ansible roles, see {ConfiguringAnsibleDocUR
 . Enter a name for this policy, a description (optional), then click *Next*.
 . Select the SCAP Content and XCCDF Profile to be applied, then click *Next*.
 +
+ifndef::orcharhino[]
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1704582[BZ#1704582] is resolved, note that the `Default XCCDF Profile` might return an empty report.
+endif::[]
 . Specify the scheduled time when the policy is to be applied, then click *Next*.
 +
 Select *Weekly*, *Monthly*, or *Custom* from the *Period* list.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/gss-proxy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/gss-proxy.adoc
@@ -5,7 +5,9 @@ The traditional process of Kerberos authentication in Apache requires the Apache
 GSS-Proxy allows you to implement stricter privilege separation for the Apache server by removing access to the keytab file while preserving Kerberos authentication functionality.
 When using AD as an external authentication source for {Project}, it is recommended to implement GSS-proxy, because the keys in the keytab file are the same as the host keys.
 
+ifndef::orcharhino[]
 [NOTE]
 ====
 The AD integration requires {ProjectName} Server to be deployed on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or later.
 ====
+endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
@@ -1,7 +1,9 @@
 [id='kerberos-configuration-in-web-browsers_{context}']
 = Kerberos Configuration in Web Browsers
 
+ifndef::orcharhino[]
 For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/Configuring_Applications_for_SSO.html#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _Red{nbsp}Hat Enterprise{nbsp}Linux System-Level Authentication_ guide.
+endif::[]
 
 If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.
 See the Internet Explorer documentation for details.
@@ -20,5 +22,7 @@ ad_gpo_map_service = +foreman
 ----
 
 Here, _foreman_ is the PAM service name.
+ifndef::orcharhino[]
 For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/sssd-gpo.html[Red{nbsp}Hat Enterprise Linux Windows Integration Guide].
+endif::[]
 ====

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/proc_estimating-the-size-of-a-backup.adoc
@@ -2,7 +2,7 @@
 
 = Estimating the Size of a Backup
 
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 Note that estimations in this section are for the installations that use the Katello plug-in.
 endif::[]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/satellite-settings.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/satellite-settings.adoc
@@ -33,6 +33,8 @@ The default and recommended option `Yes` denies the access to variables and any 
 When set to `No`, any object may be accessed by a user with permission to use templating features, either via editing of templates, parameters or smart variables.
 This permits users full remote code execution on {ProjectServer}, effectively disabling all authorization.
 This is not a safe option, especially in bigger companies.
+ifndef::orcharhino[]
 | *Exclude pattern for facts stored in {Project}* | Until https://bugzilla.redhat.com/show_bug.cgi?id=1759111[BZ#1759111] is resolved, note that if you use the wildcard value, for example `docker*`, to exclude all facts beginning with `docker`, this also excludes facts that contain the excluded term in any part of the name.
 | *Ignore interfaces with matching identifier* | Until https://bugzilla.redhat.com/show_bug.cgi?id=1759111[BZ#1759111] is resolved, note that if you use the wildcard value, for example `docker*`, to ignore all facts beginning with `docker`, this also excludes facts that contain the ignored term in any part of the name.
+endif::[]
 |====

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/scap-content.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/scap-content.adoc
@@ -10,7 +10,9 @@ SCAP content consists of both rules and profiles.
 
 You can either create SCAP content or obtain it from a vendor.
 Supported profiles are provided for Red{nbsp}Hat Enterprise{nbsp}Linux in the scap-security-guide package.
+ifndef::orcharhino[]
 The creation of SCAP content is outside the scope of this guide, but see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/[Red Hat Enterprise Linux 7 Security Guide] for information on how to download, deploy, modify, and create your own content.
+endif::[]
 
 The default SCAP content provided with the OpenSCAP components of {ProjectX} depends on the version of Red{nbsp}Hat Enterprise{nbsp}Linux.
 On Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7, content for both Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6 and Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 is installed.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/security-content-automation-protocol.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/security-content-automation-protocol.adoc
@@ -4,4 +4,6 @@
 {ProjectX} uses the Security Content Automation Protocol (SCAP) to define security configuration policies.
 For example, a security policy might specify that for hosts running Red{nbsp}Hat Enterprise{nbsp}Linux, login via SSH is not permitted for the `root` account.
 With {ProjectX} you can schedule compliance auditing and reporting on all hosts under management.
+ifndef::orcharhino[]
 For more information about SCAP, see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/[Red Hat Enterprise Linux 7 Security Guide].
+endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/ssh-keys.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/ssh-keys.adoc
@@ -5,4 +5,6 @@ Adding SSH keys to a user allows deployment of SSH keys during provisioning.
 
 For information on deploying SSH keys during provisioning, see {ProvisioningDocURL}Configuring_Provisioning_Resources-Creating_Provisioning_Templates-Deploying_SSH_Keys_during_Provisioning[Deploying SSH Keys during Provisioning] in the _Provisioning Guide_.
 
+ifndef::orcharhino[]
 For information on SSH keys and SSH key creation, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-getting_started#sec-SSH[Using SSH-based Authentication] in the _Red{nbsp}Hat Enterprise Linux 7 System Administrator's Guide_.
+endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/utilities-for-collecting-log-information.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/utilities-for-collecting-log-information.adoc
@@ -22,7 +22,12 @@ There is no timeout when running this command.
 The command also runs external programs (for example: `foreman-debug -g`) to collect {Project}-specific information, and stores this output in a tar file.
 
 By default, the output tar file is located at `/var/tmp/__sosreport-XXX-20171002230919.tar.xz__`.
+ifndef::orcharhino[]
 For more information, run `sosreport --help` or see https://access.redhat.com/solutions/3592[_What is a sosreport and how can I create one?_].
+endif::[]
+ifdef::orcharhino[]
+For more information, run `sosreport --help`.
+endif::[]
 
 The `sosreport` command calls the `foreman-debug -g` and times out after 500 seconds.
 If your {ProjectServer} has large log files or many {Project} tasks, support engineers may require the output of `sosreport` and `foreman-debug` when you open a support case.


### PR DESCRIPTION
Hey everyone!
This PR adapt the "Administering Foreman" guide to our downstream product orcharhino.

It adds  various`ifndef::orcharhino[]`, replaces `satellite-installer` with `{foreman-installer}`, and prefixes two instances for curly brackets with a backslash due to Antora otherwise interpreting this as an attribute. The backslash is not visible.

There's still an open isse that I'm unsure how to handle: `--scenario capsule|satellite`: `git grep -i -n "\-\-scenario"`. I think we need to have `:Project:` in lowercase as well for such use case. For me, this is good enough for now. I would like to handle this (globally) in a new PR.

Cheers!