### PR TITLE
Fix title of 2.3 content

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -36,6 +36,7 @@
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy
 :Cockpit: Cockpit
+:customcontenttitle: Content
 :customcontent: content
 :customfiletype: file type
 :customfiletypetitle: File Type

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -24,6 +24,7 @@
 :certs-generate: capsule-certs-generate
 :certs-proxy-context: capsule
 :Cockpit: Red{nbsp}Hat web console
+:customcontenttitle: Custom Content
 :customcontent: custom content
 :customfiletype: custom file type
 :customfiletypetitle: Custom File Type


### PR DESCRIPTION
I'd say some cherry-pick introduced some trouble here. 

as part of

https://bugzilla.redhat.com/show_bug.cgi?id=1974361


Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
