### PR TITLE
Provided more information for adding an HTTP Proxy

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Red_Hat_Content.adoc
@@ -439,11 +439,28 @@ To add a new HTTP proxy to {Project}, see xref:Adding_a_New_HTTP_Proxy[].
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for Products, repositories, and supported compute resources.
 
+If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com or subscription.rhn.redhat.com, and cdn.redhat.com then the proxy must not perform SSL inspection on these communications.
+
+
 .Procedure
 
 . In the {Project} web UI, navigate to *Infrastructure* > *HTTP Proxies* and select *New HTTP Proxy*.
 . In the *Name* field, enter a name for the HTTP proxy.
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
+The following host names are available:
++
+[cols="2,1,1",options="header"]
+|====
+| Host name | Port | Protocol
+| subscription.rhsm.redhat.com | 443 | HTTPS
+| subscription.rhn.redhat.com | 443 | HTTPS
+| cdn.redhat.com |  443 | HTTPS
+ifdef::satellite[]
+| api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
+| cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
+endif::[]
+|====
++
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
 . Click the *Locations* tab and add a location.
@@ -461,6 +478,8 @@ You can then specify which HTTP proxy to use for Products, repositories, and sup
 ----
 +
 If your HTTP proxy requires authentication, add the `--username _name_` and `--password _password_` options.
+
+For further information, see the Knowledgebase article https://access.redhat.com/solutions/65300[How to access Red{nbsp}Hat Subscription Manager (RHSM) through a firewall or proxy] on the Red{nbsp}Hat Customer Portal.
 
 [[Importing_Red_Hat_Content-Limiting_Synchronization_Speed]]
 === Limiting Synchronization Speed


### PR DESCRIPTION
Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [X ] Foreman 2.3 (Satellite 6.9)
* [X] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
