### PR TITLE
Remove link to closed BZ

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
@@ -27,9 +27,7 @@ For more information about importing Ansible roles, see {ConfiguringAnsibleDocUR
 . Enter a name for this policy, a description (optional), then click *Next*.
 . Select the SCAP Content and XCCDF Profile to be applied, then click *Next*.
 +
-ifndef::orcharhino[]
-Until https://bugzilla.redhat.com/show_bug.cgi?id=1704582[BZ#1704582] is resolved, note that the `Default XCCDF Profile` might return an empty report.
-endif::[]
+Note that the openSCAP plugin does not detect if a SCAP content role has no content, which means that the `Default XCCDF Profile` might return an empty report.
 . Specify the scheduled time when the policy is to be applied, then click *Next*.
 +
 Select *Weekly*, *Monthly*, or *Custom* from the *Period* list.


### PR DESCRIPTION
This PR removes a link to a closed BZ entry. It has been closed with `won't fix`, so I've reworded the sentence accordingly. IMHO it does not make sense to provide this link in our docs.

This PR is **very much up for discussion**, as I don't know how you want to handle such things.