### PR TITLE
Replace Foreman with Project attribute

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_the_Red_Hat_Satellite_Content_Dashboard.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_the_Red_Hat_Satellite_Content_Dashboard.adoc
@@ -101,7 +101,7 @@ The following table shows the possible states.
 [cols="2,7", options="header"]
 |====
 | State | Description
-| *No Reports* | No report has been received because either an error occurred during the virt-who configuration deployment, or the configuration has not been deployed yet, or virt-who cannot connect to Foreman during the scheduled interval.
+| *No Reports* | No report has been received because either an error occurred during the virt-who configuration deployment, or the configuration has not been deployed yet, or virt-who cannot connect to {Project} during the scheduled interval.
 | *No Change* | No report has been received because hypervisor did not detect any changes on the virtual machines, or virt-who failed to upload the reports during the scheduled interval.
 If you added a virtual machine but the configuration is in the *No Change* state, check that virt-who is running.
 | *OK* | The report has been received without any errors during the scheduled interval.


### PR DESCRIPTION
Use `{Project}` attribute instead of Foreman to make it more downstream friendly.