### PR TITLE
Added vCentre 7 support inormation

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -32,6 +32,8 @@ For VMware vCenter Server version 6.7, set the following permissions:
     - All Privileges -> Virtual Machine -> Edit Inventory (All)
     - All Privileges -> Virtual Machine -> Provisioning (All)
 
+Note that the same steps also apply to VMware vCenter Server version 7.0.  
+
 For VMware vCenter Server version 6.5, set the following permissions:
 
     - All Privileges -> Datastore -> Allocate Space, Browse datastore, Update Virtual Machine files, Low level file operations


### PR DESCRIPTION
The steps for version 6.9 also apply to vCenter Server version 7.

Bug 1952970 - Red Hat Satellite 6.8 needs to include Vcenter 7 support information

https://bugzilla.redhat.com/show_bug.cgi?id=1952970


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
