### PR TITLE
Correct the 'userdata' url in Provisioning Guide

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -364,7 +364,7 @@ endif::[]
 datasource_list: [NoCloud]
 datasource:
   NoCloud:
-    seedfrom: https://{foreman-example-com}/userdata/
+    seedfrom: https://{foreman-example-com}/unattended/userdata/
 EOF
 ----
 +


### PR DESCRIPTION
Bug 1929003 - Incorrect 'userdata' url in the Satellite 6.8 docs
https://bugzilla.redhat.com/show_bug.cgi?id=1929003

Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
