### PR TITLE
Added reminder that certificates must be signed by the same CA

### DIFF
--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -19,6 +19,7 @@ To configure your {ProjectServer} with a custom certificate, complete the follow
 . xref:deploying-a-custom-ssl-certificate-to-satellite-server_{project-context}[]
 . xref:deploying-a-custom-ssl-certificate-to-hosts_{project-context}[]
 . If you have external {SmartProxyServer}s registered to {ProjectServer}, you must configure them with custom SSL certificates.
+The same Certificate Authority must sign certificates for {ProjectServer} and {SmartProxyServer}.
 For more information, see {InstallingSmartProxyDocURL}configuring-capsule-custom-server-certificate_{smart-proxy-context}[Configuring {SmartProxyServer} with a Custom SSL Certificate] in _Installing {SmartProxyServer}_.
 
 //Creating a Custom SSL Certificate for {ProjectServer}


### PR DESCRIPTION
Added reminder that certificates for satellite server and capsule server must be signed by the same certificate authority.

Bug 1848730 - Highlight that custom certs on Sat and Caps must be signed by the same CA

https://bugzilla.redhat.com/show_bug.cgi?id=1848730


Cherry-pick into:

* [x ] Foreman 2.5 (Satellite 6.10)
* [x ] Foreman 2.4
* [x ] Foreman 2.3 (Satellite 6.9)
* [x ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
