### PR TITLE
Fix indentation on FIPS mode

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -67,6 +67,7 @@ ifeval::["{build}" != "foreman-deb"]
 .SELinux Mode
 SELinux must be enabled, either in enforcing or permissive mode.
 Installation with disabled SELinux is not supported.
+
 .FIPS Mode
 You can install {ProductName} on a {RHEL} system that is operating in FIPS mode.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.


### PR DESCRIPTION
Lack of indentation separating the two sections reported. 

Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
