### PR TITLE
drop old OS references that aren't supported anymore

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -10,7 +10,7 @@ For more information, see xref:sect-Administering-Using_LDAP[].
 [[br-Using-IdM-for-Authentication-prereq]]
 .Prerequisites
 
-* {ProjectServer} has to run on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6.6 or later.
+* {ProjectServer} has to run on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or later.
 * The base operating system of {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -76,7 +76,6 @@ Replace _OTP_ with the one-time password provided by the {FreeIPA} administrator
 ----
 +
 The installer is dependent on packages which, on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7, are in the optional repository `rhel-7-server-optional-rpms`.
-On Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6 all necessary packages are in the `base` repository.
 
 . Set `foreman-ipa-authentication` to true, using the following command:
 +

--- a/guides/doc-Planning_Guide/topics/Configuration_Management_Support.adoc
+++ b/guides/doc-Planning_Guide/topics/Configuration_Management_Support.adoc
@@ -9,5 +9,4 @@ Supported combinations of major versions of {RHEL} and hardware architectures fo
 |Red Hat Enterprise Linux 8 |x86_64, ppc_64, s390x
 |Red Hat Enterprise Linux 7 |x86_64, aarch64, ppc64le
 |Red Hat Enterprise Linux 6 |x86_64, i386
-|Red Hat Enterprise Linux 5 |x86_64, i386
 |====

--- a/guides/doc-Planning_Guide/topics/Content_Management_Support.adoc
+++ b/guides/doc-Planning_Guide/topics/Content_Management_Support.adoc
@@ -10,5 +10,4 @@ This includes the {project-client-name} repositories.
 |Red Hat Enterprise Linux 8 |x86_64, ppc_64, s390x
 |Red Hat Enterprise Linux 7 |x86_64, ppc64 (BE), ppc64le, aarch64, s390x
 |Red Hat Enterprise Linux 6 |x86_64, i386, s390x, ppc64 (BE)
-|Red Hat Enterprise Linux 5 |x86_64, i386, s390x
 |====

--- a/guides/doc-Planning_Guide/topics/Host_Provisioning_Support.adoc
+++ b/guides/doc-Planning_Guide/topics/Host_Provisioning_Support.adoc
@@ -9,5 +9,4 @@ Supported combinations of major versions of {RHEL} and hardware architectures fo
 |Red Hat Enterprise Linux 8 |x86_64
 |Red Hat Enterprise Linux 7 |x86_64
 |Red Hat Enterprise Linux 6 |x86_64, i386
-|Red Hat Enterprise Linux 5 |x86_64, i386
 |====


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

Only the "Foreman on EL6" commit should be picked into Satellite 6.8, or ignored.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
