### PR TITLE
use HTTP not a placeholder servicename when registering for IdM

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -40,7 +40,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ipa service-add _servicename_/_hostname_
+# ipa service-add HTTP/_hostname_
 ----
 +
 ifndef::orcharhino[]


### PR DESCRIPTION
our installer hard-codes HTTP and using _servicename_ here would imply
that the user can change this, while they can not.


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
