### PR TITLE
Copy landing page as index.html and improve 404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,6 +182,16 @@ jobs:
         run: hugo -v --ignoreCache
         working-directory: web
 
+      - name: Copy nightly landing page as index.html
+        if: github.repository_owner == 'theforeman' && github.ref == 'refs/heads/master'
+        run: cp -f nightly.html nightly/index.html
+        working-directory: web/public
+
+      - name: Copy stable landing page as index.html
+        if: github.repository_owner == 'theforeman' && (startsWith(github.ref, 'refs/heads/2.') || startsWith(github.ref, 'refs/heads/3.') || startsWith(github.ref, 'refs/heads/4.'))
+        run: cp -f ${{ env.BRANCH_NAME }}.html ${{ env.BRANCH_NAME }}/index.html
+        working-directory: web/public
+
       - name: Upload web
         uses: actions/upload-artifact@v2
         with:

--- a/web/content/404/index.md
+++ b/web/content/404/index.md
@@ -3,4 +3,4 @@ title: 404
 headless: true
 ---
 
-{{% guide-list version="nightly" %}}
+Continue to the [front page](https://docs.theforeman.org) to find available documentation.

--- a/web/layouts/404.html
+++ b/web/layouts/404.html
@@ -19,8 +19,6 @@
 </script>
 </p>
 
-<p>Available guides for the latest nightly build:</p>
-
 {{ with site.GetPage "/404" }}
 {{ .Content }}
 {{ end }}


### PR DESCRIPTION
This will copy landing version page (e.g. `2.5.html`) also as `2.5/index.html`. So if readers manually delete URL to:

https://docs.theforeman.org/2.5/

instead of "Page not found!" with nightly links, there will be proper 2.5 landing page instead.

To test this, download foreman-docs-nightly.zip and unpack the artifact, there should be nightly/index.html as a copy of nightly.html.

The change also removes list of nightly docs from the 404 page and only provide a link to the root for less confusion.

Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* other versions at will