### PR TITLE
Always build web from the master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,16 +124,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Get branch name (merge)
-        if: github.event_name != 'pull_request'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-
-      - name: Get branch name (pull request)
-        if: github.event_name == 'pull_request'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: master
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
@@ -147,7 +141,7 @@ jobs:
       - name: Upload web
         uses: actions/upload-artifact@v2
         with:
-          name: foreman-docs-web-${{ env.BRANCH_NAME }}
+          name: foreman-docs-web-master
           path: web/public/
 
   publish:

--- a/web/README.md
+++ b/web/README.md
@@ -13,3 +13,4 @@ Use `make` or `hugo` to build contents from markdown and layouts in `public/` di
 ## Deployment
 
 Do not commit directory public/ into git, site is generated via Github Actions.
+The site is built from `master` branch.


### PR DESCRIPTION
Ewoud noticed that we actually build the web portion from the topic/stable branch, but since we do not overwrite files (due to documentation portion of the site) files do not get deleted and we haven't noticed. This fixes it, everything under `/web` should be built from `master`.

There is another solution to create a dedicated branch just for the web/ portion, however I do not like having two different content sets in two branches. This creates unecessary long checkouts when switching over, we have this problem with foreman-packaging (rpm/develop vs deb/develop) and I ended up having two separate checkouts for that. I would rather keep this approach when all content is in the single branch - master. This is where most of the development/writing takes place.