### PR TITLE
BZ1776930: Simplify the remote DNS instructions

### DIFF
--- a/guides/common/modules/proc_configuring-external-dns.adoc
+++ b/guides/common/modules/proc_configuring-external-dns.adoc
@@ -9,42 +9,26 @@ To make any changes persistent, you must enter the `{foreman-installer}` command
 .Prerequisites
 
 * You must have a configured external DNS server.
+* This guide assumes you have an existing installation.
 
 .Procedure
-
-ifndef::foreman-deb[]
-. Install the `bind-utils` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} bind bind-utils
-----
-endif::[]
-
-ifdef::foreman-deb[]
-
-. Install the `bind-utils` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} bind9
-----
-endif::[]
 
 . Copy the `/etc/rndc.key` file from the external DNS server to {ProductName}:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# scp root@_dns.example.com_:/etc/rndc.key /etc/rndc.key
+# scp root@_dns.example.com_:/etc/rndc.key /etc/foreman-proxy/rndc.key
 ----
 
 . Configure the ownership, permissions, and SELinux context:
 +
 [options="nowrap"]
 ----
-# restorecon -v /etc/rndc.key
-# chown -v root:named /etc/rndc.key
-# chmod -v 640 /etc/rndc.key
+ifndef::foreman-deb[]
+# restorecon -v /etc/foreman-proxy/rndc.key
+endif::[]
+# chown -v root:foreman-proxy /etc/foreman-proxy/rndc.key
+# chmod -v 640 /etc/foreman-proxy/rndc.key
 ----
 
 . To test the `nsupdate` utility, add a host remotely:
@@ -52,20 +36,12 @@ endif::[]
 [options="nowrap", subs="+quotes"]
 ----
 # echo -e "server _DNS_IP_Address_\n \
-update add aaa.virtual.lan 3600 IN A _Host_IP_Address_\n \
-send\n" | nsupdate -k /etc/rndc.key
-# nslookup aaa.virtual.lan _DNS_IP_Address_
+update add aaa.example.com 3600 IN A _Host_IP_Address_\n \
+send\n" | nsupdate -k /etc/foreman-proxy/rndc.key
+# nslookup aaa.example.com _DNS_IP_Address_
 # echo -e "server _DNS_IP_Address_\n \
-update delete aaa.virtual.lan 3600 IN A _Host_IP_Address_\n \
-send\n" | nsupdate -k /etc/rndc.key
-----
-
-.  Assign the `foreman-proxy` user to the `named` group manually.
-Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to the `named` UNIX group, however, in this scenario {Project} does not manage users and groups, therefore you need to assign the `foreman-proxy` user to the `named` group manually.
-+
-[options="nowrap"]
-----
-# usermod -a -G named foreman-proxy
+update delete aaa.example.com 3600 IN A _Host_IP_Address_\n \
+send\n" | nsupdate -k /etc/foreman-proxy/rndc.key
 ----
 
 . Enter the `{foreman-installer}` command to make the following persistent changes to the `/etc/foreman-proxy/settings.d/dns.yml` file:
@@ -76,15 +52,7 @@ Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to t
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate \
 --foreman-proxy-dns-server="_DNS_IP_Address_" \
---foreman-proxy-keyfile=/etc/rndc.key \
---foreman-proxy-dns-ttl=86400
-----
-
-. Restart the foreman-proxy service:
-+
-[options="nowrap"]
-----
-# systemctl restart foreman-proxy
+--foreman-proxy-keyfile=/etc/foreman-proxy/rndc.key
 ----
 
 . Log in to {ProjectServer} web UI.


### PR DESCRIPTION
By using a file in /etc/foreman-proxy, you can use it just for this service and make foreman-proxy the group. That also allows the service to read the content without needing the named group.

Now step 1 is not needed at all. You may need bind-utils for nsupdate to test, but bind itself is certainly not needed. In the current guide it's installed just for the named group but that's really overkill.

Step 7 is not needed at all and was never needed. The installer will restart the service if needed.

Step 4 (testing) is a good step but I think example.com is a better domain than virtual.lan.

Note that this instruction now only works well if you have an existing installation where the foreman-proxy group is present. So carefully review this.

I also removed restorecon on Debian where we SELinux is typically not present.

Based on https://github.com/theforeman/foreman-documentation/pull/498#pullrequestreview-640968680