### PR TITLE
Remove underscore from example domain

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
@@ -117,7 +117,7 @@ If you use Puppet in your {Project} configuration, then you must complete the fo
 
 
 Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing.
-In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}_ca.example.com`.
+In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}-ca.example.com`.
 
 . Append the following option to the `{certs-generate}` command that you obtain from the output of the `katello-certs-check` command:
 +
@@ -132,10 +132,10 @@ For example:
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {certs-generate} \
---foreman-proxy-fqdn _{smart-proxy-context}_ca.example.com_ \
---certs-tar /root/{smart-proxy-context}_cert/{smart-proxy-context}_ca.tar \
---server-cert /root/{smart-proxy-context}_cert/{smart-proxy-context}_ca.pem \
---server-key /root/{smart-proxy-context}_cert/{smart-proxy-context}_ca.pem \
+--foreman-proxy-fqdn _{smart-proxy-context}-ca.example.com_ \
+--certs-tar /root/{smart-proxy-context}_cert/{smart-proxy-context}-ca.tar \
+--server-cert /root/{smart-proxy-context}_cert/{smart-proxy-context}-ca.pem \
+--server-key /root/{smart-proxy-context}_cert/{smart-proxy-context}-ca.pem \
 --server-ca-cert /root/{smart-proxy-context}_cert/ca_cert_bundle.pem \
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
@@ -149,7 +149,7 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 [options="nowrap", subs="+quotes,attributes"]
 ----
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "true" \
 --puppet-server-ca                         "true" \
 --enable-foreman-proxy-plugin-remote-execution-ssh
@@ -164,14 +164,14 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --foreman-proxy-register-in-foreman        "true" \
 --foreman-proxy-foreman-base-url           "_https://{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts              "_{foreman-example-com}_" \
---foreman-proxy-trusted-hosts              "_{smart-proxy-context}_ca.example.com_" \
+--foreman-proxy-trusted-hosts              "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-oauth-consumer-key         "oauth key" \
 --foreman-proxy-oauth-consumer-secret      "oauth secret" \
 --certs-tar-file                           "_certs.tgz_" \
 --puppet-server-foreman-url                "_https://{foreman-example-com}_" \
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "true" \
 --puppet-server-ca                         "true" \
 --enable-foreman-proxy-plugin-remote-execution-ssh
@@ -248,13 +248,13 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/ca.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/ca.pem \
 /etc/puppetlabs/puppet/ssl/certs/ca.pem
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem \
 /etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem \
 /etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem \
 /etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem
 ----
 
@@ -272,7 +272,7 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "false" \
 --puppet-server-ca                         "false" \
 --enable-foreman-proxy-plugin-remote-execution-ssh
@@ -294,7 +294,7 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 --puppet-server-foreman-url                "_https://{foreman-example-com}_" \
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "false" \
 --puppet-server-ca                         "false" \
 --enable-foreman-proxy-plugin-remote-execution-ssh

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
@@ -13,15 +13,15 @@ If you use Puppet in your {Project} configuration, you must complete the followi
 .Configuring {SmartProxyServer} to Generate and Sign Puppet Certificates
 
 Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate and sign Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing.
-In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}_ca.example.com`.
+In the examples in this procedure, the FQDN of this {SmartProxyServer} is `{smart-proxy-context}-ca.example.com`.
 
 . On {ProjectServer}, generate Katello certificates for the system where you configure {SmartProxyServer} to generate and sign Puppet certificates:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {certs-generate} \
---foreman-proxy-fqdn _{smart-proxy-context}_ca.example.com_ \
---certs-tar "/root/_{smart-proxy-context}_ca.example.com_-certs.tar" \
+--foreman-proxy-fqdn _{smart-proxy-context}-ca.example.com_ \
+--certs-tar "/root/_{smart-proxy-context}-ca.example.com_-certs.tar" \
 --foreman-proxy-cname _loadbalancer.example.com_
 ----
 +
@@ -31,8 +31,8 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# scp /root/_{smart-proxy-context}_ca.example.com_-certs.tar \
-root@_{smart-proxy-context}_ca.example.com_:__{smart-proxy-context}_ca.example.com__-certs.tar
+# scp /root/_{smart-proxy-context}-ca.example.com_-certs.tar \
+root@_{smart-proxy-context}-ca.example.com_:__{smart-proxy-context}-ca.example.com__-certs.tar
 ----
 
 . Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command:
@@ -41,7 +41,7 @@ root@_{smart-proxy-context}_ca.example.com_:__{smart-proxy-context}_ca.example.c
 ----
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "true" \
 --puppet-server-ca                         "true" \
 --enable-foreman-proxy-plugin-remote-execution-ssh
@@ -56,14 +56,14 @@ root@_{smart-proxy-context}_ca.example.com_:__{smart-proxy-context}_ca.example.c
 --foreman-proxy-register-in-foreman        "true" \
 --foreman-proxy-foreman-base-url           "_https://{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts              "_{foreman-example-com}_" \
---foreman-proxy-trusted-hosts              "_{smart-proxy-context}_ca.example.com_" \
+--foreman-proxy-trusted-hosts              "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-oauth-consumer-key         "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret      "_oauth secret_" \
---certs-tar-file          "_{smart-proxy-context}_ca.example.com-certs.tar_" \
+--certs-tar-file          "_{smart-proxy-context}-ca.example.com-certs.tar_" \
 --puppet-server-foreman-url                "_https://{foreman-example-com}_" \
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "true" \
 --puppet-server-ca                         "true" \
 --enable-foreman-proxy-plugin-remote-execution-ssh
@@ -144,13 +144,13 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/ca.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/ca.pem \
 /etc/puppetlabs/puppet/ssl/certs/ca.pem
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem \
 /etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem \
 /etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem
-# scp root@_{smart-proxy-context}_ca.example.com_:/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem \
+# scp root@_{smart-proxy-context}-ca.example.com_:/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem \
 /etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem
 ----
 
@@ -168,7 +168,7 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "false" \
 --puppet-server-ca                         "false" \
 --enable-foreman-proxy-plugin-remote-execution-ssh
@@ -189,7 +189,7 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 --puppet-server-foreman-url                "_https://{foreman-example-com}_" \
 --certs-cname                              "_loadbalancer.example.com_" \
 --puppet-dns-alt-names                     "_loadbalancer.example.com_" \
---puppet-ca-server                         "_{smart-proxy-context}_ca.example.com_" \
+--puppet-ca-server                         "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca                   "false" \
 --puppet-server-ca                         :false" \
 --enable-foreman-proxy-plugin-remote-execution-ssh


### PR DESCRIPTION
Change {smart-proxy-context}_ca.example.com to {smart-proxy-context}-ca.example.com, as a FQDN cannot contain an underscore.

Bug 1973389 - Remove " _ " underscore from the hostname which used as example in documentation and not supported

https://bugzilla.redhat.com/show_bug.cgi?id=1973389


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)


