### PR TITLE
Remove Satellite 6.8 from GHT

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Cherry-pick into:
 * [ ] Foreman 2.5 (Satellite 6.10)
 * [ ] Foreman 2.4
 * [ ] Foreman 2.3 (Satellite 6.9)
-* [ ] Foreman 2.1 (Satellite 6.8)
 
 <!---
 Thank you for contributing to Foreman documentation. Make sure to read README


### PR DESCRIPTION
That's gone for us, RHD team should file PRs for "master" and cherry pick into older releases themselves. We will continue doing 6.9 but long term, I would like only to cherry pick into last two upstream release. What you think?