### PR TITLE
Remove use of port 5000 for running containers

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -105,7 +105,7 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 | Port | Protocol | Service | Required For
 | 22 | TCP | SSH | {Project} and {SmartProxy} originated communications, for Remote Execution (Rex) and Ansible.
 | 443 | TCP | HTTPS | {Project} originated communications, for vCenter compute resource.
-| 5000 | TCP | HTTP | {Project} originated communications, for compute resources in OpenStack or for running containers.
+| 5000 | TCP | HTTP | {Project} originated communications, for compute resources in OpenStack.
 | 22, 16514 | TCP | SSH, SSL/TLS | {Project} originated communications, for compute resources in libvirt.
 | 389, 636 | TCP | LDAP, LDAPS | {Project} originated communications, for LDAP and secured LDAP authentication sources.
 | 5900 to 5930 | TCP | SSL/TLS | {Project} originated communications, for NoVNC console in web UI to hypervisors.


### PR DESCRIPTION
I suspect this was previously used for Crane (which ran on port 5000) but Crane is gone and replaced by Pulp 3 which uses port 443.