### PR TITLE
Fix incorrect attribute

### DIFF
--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -24,12 +24,13 @@ To configure dynamic DNS update with TSIG authentication, complete the following
 
 . On the IdM Server, add the following to the top of the `/etc/named.conf` file:
 +
-[options="nowrap" subs="+quotes,attributes"]
+[options="nowrap" subs="+attributes"]
 ----
 ########################################################################
+
 include "/etc/rndc.key";
 controls  {
-inet _IdM_Server_IP_Address_ port 953 allow { _Satellite_IP_Address_; } keys { "rndc-key"; };
+inet _IdM_Server_IP_Address_ port 953 allow { _{Project}_IP_Address_; } keys { "rndc-key"; };
 };
 ########################################################################
 ----

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -7,19 +7,19 @@
 ifdef::foreman-el,foreman-deb[]
 * To install an external {SmartProxy}, enter the following command:
 +
-[options="nowrap", subs="+quotes,attributes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 {foreman-installer} \
   --no-enable-foreman \
   --no-enable-foreman-cli \
   --enable-puppet \
   --puppet-server-ca=false \
-  --puppet-server-foreman-url=https://{foreman.example.com} \
+  --puppet-server-foreman-url=https://__{foreman-example-com}__ \
   --enable-foreman-proxy \
   --foreman-proxy-puppetca=false \
   --foreman-proxy-tftp=false \
-  --foreman-proxy-foreman-base-url=https://{foreman.example.com} \
-  --foreman-proxy-trusted-hosts={foreman.example.com} \
+  --foreman-proxy-foreman-base-url=https://__{foreman-example-com}__ \
+  --foreman-proxy-trusted-hosts=__{foreman-example-com}__ \
   --foreman-proxy-oauth-consumer-key=_oAuth_Consumer_Key_ \
   --foreman-proxy-oauth-consumer-secret=_oAuth_Consumer_Secret_
 ----


### PR DESCRIPTION
Remove "quotes" attribute
The "quotes" attribute is what is causing the yellow highlighting
in our docs on occasions
I also added italic markers as per our doc style to indicated that foreman.example.com is a variable.


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
