### PR TITLE
Remove duplicate headers

### DIFF
--- a/web/content/2.3.md
+++ b/web/content/2.3.md
@@ -3,8 +3,6 @@ title: "Foreman 2.3 and Katello 3.18 documentation"
 path: 2.3
 ---
 
-## Foreman 2.3 and Katello 3.18
-
 Available guides:
 
 * [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman.html)

--- a/web/content/2.4.md
+++ b/web/content/2.4.md
@@ -3,8 +3,6 @@ title: "Foreman 2.4 and Katello 4.0 documentation"
 path: 2.4
 ---
 
-## Foreman 2.4 and Katello 4.0
-
 Available guides:
 
 * [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman-el.html)

--- a/web/content/2.5.md
+++ b/web/content/2.5.md
@@ -3,8 +3,6 @@ title: "Foreman 2.5 and Katello 4.1 documentation"
 path: 2.5
 ---
 
-## Foreman 2.5 and Katello 4.1
-
 Available guides:
 
 * [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman-el.html)


### PR DESCRIPTION
Prior to this it ended up as:

    Foreman 2.5 and Katello 4.1 documentation
    Foreman 2.5 and Katello 4.1

This is because the title is always printed.



Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)