### PR TITLE
Remove foreman-rails repository

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
@@ -82,7 +82,6 @@ repo --name=centos --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$ba
 repo --name=centos-updates --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates
 repo --name=epel7 --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
 repo --name=centos-sclo-rh --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=sclo-rh
-repo --name=foreman-rails-el7 --baseurl=https://yum.theforeman.org/rails/foreman-nightly/el7/$basearch/
 repo --name=foreman-el7 --baseurl=http://yum.theforeman.org/nightly/el7/$basearch/
 repo --name=foreman-plugins-el7 --baseurl=http://yum.theforeman.org/plugins/nightly/el7/$basearch/
 endif::[]


### PR DESCRIPTION
This repository has been removed with Foreman 2.0.



Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)