### PR TITLE
Use ProductVersion macro instead of hardcoding

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -49,7 +49,7 @@ endif::[]
 
 // Load base attributes
 :SiteURL: https://docs.theforeman.org
-:BaseURL:  {SiteURL}/nightly/
+:BaseURL:  {SiteURL}/{ProjectVersion}/
 include::attributes-base.adoc[]
 
 // Load overrides for specific scenarios

--- a/guides/common/modules/proc_acd_installation.adoc
+++ b/guides/common/modules/proc_acd_installation.adoc
@@ -9,7 +9,7 @@ Running ACD on Debian and Ubuntu is currently untested.
 endif::[]
 
 ifdef::foreman-el,katello[]
-This guide assumes you already have a working https://docs.theforeman.org/nightly/Installing_Server_on_Red_Hat/index-foreman-el.html[Foreman] or https://docs.theforeman.org/nightly/Installing_Server_on_Red_Hat/index-katello.html[Foreman and Katello] installation.
+This guide assumes you already have a working {BaseURL}Installing_Server_on_Red_Hat/index-foreman-el.html[Foreman] or {BaseURL}Installing_Server_on_Red_Hat/index-katello.html[Foreman and Katello] installation.
 endif::[]
 
 .Procedure
@@ -20,7 +20,7 @@ ifdef::foreman-el,foreman-deb,katello,satellite[]
 ----
 [foreman-plugins]
 name=Foreman plugins
-baseurl=https://yum.theforeman.org/plugins/nightly/el7/x86_64/
+baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el7/x86_64/
 enabled=1
 gpgcheck=0
 ----

--- a/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_building-a-discovery-image.adoc
@@ -82,8 +82,8 @@ repo --name=centos --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$ba
 repo --name=centos-updates --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates
 repo --name=epel7 --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
 repo --name=centos-sclo-rh --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=sclo-rh
-repo --name=foreman-el7 --baseurl=http://yum.theforeman.org/nightly/el7/$basearch/
-repo --name=foreman-plugins-el7 --baseurl=http://yum.theforeman.org/plugins/nightly/el7/$basearch/
+repo --name=foreman-el7 --baseurl=http://yum.theforeman.org/{ProductVersion}/el7/$basearch/
+repo --name=foreman-plugins-el7 --baseurl=http://yum.theforeman.org/plugins/{ProductVersion}/el7/$basearch/
 endif::[]
 ----
 +


### PR DESCRIPTION
Without this you get weird bugs after branching.


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)