### PR TITLE
Red Hat, not Red Han (v2)

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
@@ -9,7 +9,7 @@ This method is suited for both freshly installed hosts and hosts that have been 
 By using this method you can also deploy {Project} SSH keys to hosts during registration to {Project} to enable hosts for remote execution jobs.
 For more information about the remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs].
 +
-By using this method you can also configure hosts with Red{nbsp}Han Insights during registration to {Project}.
+By using this method you can also configure hosts with Red{nbsp}Hat Insights during registration to {Project}.
 For more information about using Insights with {Project} hosts, see {ManagingHostsDocURL}using-insights-with-satellite-hosts[Monitoring Hosts Using Red Hat Insights].
 
 . Download and install the consumer RPM `_server.example.com_/pub/katello-ca-consumer-latest.noarch.rpm` and then run Subscription Manager.


### PR DESCRIPTION
Bug 1963222 - Typo in the documentation

https://bugzilla.redhat.com/show_bug.cgi?id=1963222

Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
