### PR TITLE
Fix incorrect markup on FAM attribute

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -29,8 +29,8 @@
 // Base attributes
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
-:ansible-namespace-example: `theforeman.foreman._module_name_`
-:ansible-namespace: `theforeman.foreman`
+:ansible-namespace-example: theforeman.foreman._module_name_
+:ansible-namespace: theforeman.foreman
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/
 :awx: AWX
 :certs-generate: foreman-proxy-certs-generate

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -17,8 +17,8 @@
 // Overrides for satellite build
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
 :ansible-galaxy: https://cloud.redhat.com/ansible/automation-hub/redhat/satellite/docs
-:ansible-namespace-example: `redhat.satellite._module_name_`
-:ansible-namespace: `redhat.satellite`
+:ansible-namespace-example: redhat.satellite._module_name_
+:ansible-namespace: redhat.satellite
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
 :awx: Ansible Tower
 :certs-generate: capsule-certs-generate

--- a/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
+++ b/guides/common/modules/proc_listing-using-satellite-ansible-modules.adoc
@@ -38,7 +38,7 @@ endif::[]
 ifndef::orcharhino[]
 Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}.
 
-All modules are in the {ansible-namespace} namespace and can be referred to in the format {ansible-namespace-example}.
+All modules are in the `{ansible-namespace}` namespace and can be referred to in the format `{ansible-namespace-example}`.
 For example, to display information about the `activation_key` module, enter the following command:
 
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
@evgeni pointed out on IRC that a FAM example
was rendering incorrectly in our docs.
https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-foreman-el.html#using-satellite-ansible-content-collections_admin

The attributes files included backticks
that also appeared in the codeblocks.

Best to format on the namespace as needed 
as the formatting limited its usage. 

@maximiliankolb - I didn't touch orcharhino as you have not exposed this section in your docs yet: https://docs.theforeman.org/nightly/Administering_Red_Hat_Satellite/index-orcharhino.html#using-satellite-ansible-content-collections_admin 
I'm adding you as a reviewer as you might need me to adjust the orcharhino attributes also. 

Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
