### PR TITLE
WIP: Deprecation: remove Puppet content support

### DIFF
--- a/guides/common/modules/proc_puppet-using-puppet-classes-host-group.adoc
+++ b/guides/common/modules/proc_puppet-using-puppet-classes-host-group.adoc
@@ -9,7 +9,7 @@ Every host you deploy based on this host group has this Puppet class installed.
 . Set the following parameters:
 .. The *Lifecycle Environment* describes the stage in which certain versions of content are available to hosts.
 .. The *Content View* is comprised of products and allows for version control of content repositories.
-.. The *Puppet Environment* allows you to supply a group of hosts with their own dedicated configuration.
+.. The *Environment* allows you to supply a group of hosts with their own dedicated configuration.
 . In the {ProjectWebUI}, navigate to *Configure > Classes*.
 . Add the Puppet class to the _included classes_ or to the _included config groups_ if a Puppet config group is configured.
 . Click *Submit* to save the changes.

--- a/guides/doc-Content_Management_Guide/docinfo.xml
+++ b/guides/doc-Content_Management_Guide/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>6.9</productnumber>
 <subtitle>A guide to managing content from Red Hat and custom sources</subtitle>
 <abstract>
-    <para>Use this guide to understand and manage content in Satellite 6. Examples of such content include RPM files, ISO images, and Puppet modules. Red Hat Satellite 6 manages this content using a set of Content Views promoted across the application lifecycle. This guide demonstrates how to create an application lifecycle that suits your organization and content views that fulfils host states within lifecycle environments. These content views eventually form the basis for provisioning and updating hosts in your Red Hat Satellite 6 environment.</para>
+    <para>Use this guide to understand and manage content in Satellite 6. Examples of such content include RPM files, and ISO images. Red Hat Satellite 6 manages this content using a set of Content Views promoted across the application lifecycle. This guide demonstrates how to create an application lifecycle that suits your organization and content views that fulfils host states within lifecycle environments. These content views eventually form the basis for provisioning and updating hosts in your Red Hat Satellite 6 environment.</para>
 </abstract>
 <authorgroup id="Author_Group">
 	<author>

--- a/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
@@ -27,7 +27,7 @@ This adds extra stages to the application life cycle:
 Each stage in the application life cycle is called an _environment_ in {ProjectNameX}.
 Each environment uses a specific collection of content.
 {ProjectNameX} defines these content collections as a Content View.
-Each Content View acts as a filter where you can define what repositories, packages, and Puppet modules to include in a particular environment.
+Each Content View acts as a filter where you can define what repositories, and packages to include in a particular environment.
 This provides a method for you to define specific sets of content to designate to each environment.
 
 For example, an email server might only require a simple application life cycle where you have a production-level server for real-world use and a test server for trying out the latest mail server packages.

--- a/guides/doc-Content_Management_Guide/topics/Introduction.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Introduction.adoc
@@ -41,8 +41,4 @@ ISO and KVM Images::
   Download and manage media for installation and provisioning.
 For example, {Project} downloads, stores and manages ISO images and guest images for specific Red Hat Enterprise Linux and non-Red Hat operating systems.
 
-Puppet Modules::
-  You can upload Puppet modules alongside RPM content so that Puppet can configure the system's state after provisioning.
-Users can also manage Puppet classes and parameters as part of the provisioning process.
-
 You can use the procedure to add {customcontent} for any type of content you require, for example, SSL certificates and OVAL files.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -30,7 +30,7 @@ This ensures systems are designated to a specific environment but receive update
 The general workflow for creating Content Views for filtering and creating snapshots is as follows:
 
 . Create a Content View.
-. Add the repository and the Puppet modules that you want to the Content View.
+. Add one or more repositories that you want to the Content View.
 . Optionally, create one or more filters to refine the content of the Content View.
 . Optionally, resolve any package dependencies for a Content View.
 . Publish the Content View.
@@ -138,47 +138,6 @@ To view module streams for the repositories in your content view, complete the f
 . Click the *Module Streams* tab to view the module streams that are available for the Content View.
 . Use the *Filter* field to refine the list of modules.
 . To view the information about the module, click the module.
-
-[[Managing_Content_Views-Creating_a_Content_View_with_a_Puppet_Module]]
-=== Creating a Content View with a Puppet Module
-
-Use this procedure to create a Content View using one repository and no filters.
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-puppet-module-to-a-content-view_{context}[].
-
-.Prerequisites
-
-Before you begin, upload the required Puppet module to a repository within a {customproduct}.
-ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/puppet_guide/chap-red_hat_satellite-puppet_guide-adding_puppet_modules_to_red_hat_satellite_6[Adding Puppet Modules to {ProjectNameX}] in the _Puppet Guide_.
-endif::[]
-
-.Procedure
-
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create New View*.
-. In the *Name* field, enter a name for the view.
-{ProjectNameX} automatically completes the *Label* field from the name you enter.
-. In the *Description* field, enter a description of the view.
-. Click *Save* to complete.
-. In the *Repository Selection* area, select the repositories that you want to add to your Content View, then click *Add Repositories*.
-. Click the *Puppet Modules* tab, then click *Add New Module*.
-. Search for the module that you want to add and click *Select a Version*.
-. Navigate to the entry for *Use Latest* and click *Select Version* in the *Actions* column.
-. To publish, click the *Versions* tab and click *Publish New Version*.
-In the *Description* field, enter a description to log the changes and click *Save*.
-
-To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
-
-[id="cli-adding-a-puppet-module-to-a-content-view_{context}"]
-.CLI procedure
-
-* Enter the following command to add a Puppet module to a Content View:
-+
-[options="nowrap" subs="+quotes"]
-----
-# hammer content-view puppet-module add \
---content-view _cv_name_ \
---name _module_name_
-----
 
 [[Managing_Content_Views-Promoting_a_Content_View]]
 === Promoting a Content View

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -109,7 +109,6 @@ The exported archive file contains the following data:
 {ProjectServer} exports only RPM and kickstart files added to a version of a Content View.
 {Project} does not export the following content:
 
-* Puppet content
 * Docker content
 * Content View definitions and metadata, such as package filters.
 
@@ -308,7 +307,6 @@ The exported archive file contains the following data:
 {ProjectServer} exports only RPM and kickstart files included in a Content View  version.
 {Project} does not export the following content:
 
-* Puppet content
 * Docker content
 
 .Prerequisites

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -122,7 +122,7 @@ The Subscription Manifest determines what Red{nbsp}Hat repositories are accessib
 Once you enable a Red{nbsp}Hat repository, an associated {Project} Product is created automatically.
 For distributing content from custom sources you need to create products and repositories manually.
 Red{nbsp}Hat repositories are signed with GPG keys by default, and it is recommended to create GPG keys also for your custom repositories.
-The configuration of custom repositories depends on the type of content they hold (RPM packages, Puppet modules, or Docker images).
+The configuration of custom repositories depends on the type of content they hold (RPM packages, or Docker images).
 
 Repositories configured as `yum` repositories, that contain only RPM packages, can make use of the new download policy setting to save on synchronization time and storage space.
 This setting enables selecting from *Immediate*, *On demand*, and *Background*.
@@ -183,8 +183,8 @@ However, it prevents sharing content across host types as well as separation bas
 With critical updates every content view has to be updated, which increases maintenance efforts.
 
 * *Host specific composite content view* – a dedicated combination of content views for each host type.
-This approach enables separating host specific and shared content, for example you can have a dedicated content view for Puppet configuration.
-By including this content view into composite content views for several host types, you can update Puppet configuration with higher frequency than other host content.
+This approach enables separating host specific and shared content, for example you can have dedicated content views for the operating system and application content.
+By using a composite, you can manage your operating system and applications separately and at different frequencies.
 
 * *Component based content view* – a dedicated content view for a specific application.
 For example a database content view can be included into several composite content views.

--- a/guides/doc-Planning_Guide/topics/Glossary.adoc
+++ b/guides/doc-Planning_Guide/topics/Glossary.adoc
@@ -79,7 +79,7 @@ Examples include {oVirt}, {OpenStack}, EC2, and VMWare.
 
 [[varl-Glossary_of_Terms-Content]]
 *Content*:: A general term for everything {Project} distributes to hosts.
-Includes software packages (RPM files), Puppet Modules, or Docker images.
+Includes software packages (RPM files), or Docker images.
 Content is synchronized into the Library and then promoted into life cycle environments using content views so that they can be consumed by hosts.
 
 

--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -37,7 +37,7 @@ There are four stages through which content flows in this architecture:
 
 [[varl-Red_Hat_Satellite-Architecture_Guide-Red_Hat_Satellite_6_System_Architecture-External_Content_Sources]]
 *External Content Sources*:: The _{ProjectName} Server_ can consume diverse types of content from various sources.
-The Red{nbsp}Hat Customer Portal is the primary source of software packages, errata, Puppet modules, and container images.
+The Red{nbsp}Hat Customer Portal is the primary source of software packages, errata, and container images.
 In addition, you can use other supported content sources (Git repositories, Docker Hub, Puppet Forge, SCAP repositories) as well as your organization's internal data store.
 
 


### PR DESCRIPTION
Content management of the Puppet content type was deprecated in a previous release.
This commit is intended to remove all references to the Puppet content type.


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
