### PR TITLE
ACD: allow Ansible parameters in yaml

### DIFF
--- a/guides/common/modules/con_acd_architecture.adoc
+++ b/guides/common/modules/con_acd_architecture.adoc
@@ -13,7 +13,7 @@ You do not have to manually add Ansible playbooks to {SmartProxyServer}s.
 Ansible playbooks provide the configuration of deployed applications.
 They are required along with to an xref:{context}_application_definitions[application definition] to create xref:{context}_application_instances[application instances].
 
-Ansible group variables are mandatory and only supported as `key:value`, that is lists and dictionaries are currently not allowed and cannot be edited via management UI.
+Ansible group variables are mandatory and support any valid YAML data.
 
 Ansible playbooks need to contain Ansible group variables for each provided service.
 


### PR DESCRIPTION
ACD supports now adding and editing arbitrary YAML data instead of only `key:value`.