### PR TITLE
Add puppet out of sync interval

### DIFF
--- a/guides/common/assembly_using-puppet-for-configuration-management.adoc
+++ b/guides/common/assembly_using-puppet-for-configuration-management.adoc
@@ -39,6 +39,8 @@ include::modules/proc_puppet-overriding-puppet-parameters-organization-based.ado
 
 include::modules/proc_puppet-run-puppet-once-using-ssh.adoc[leveloffset=+1]
 
+include::modules/proc_puppet-setting-out-of-sync-time-for-puppet-managed-hosts.adoc[leveloffset=+1]
+
 include::modules/ref_puppet-additional-resources.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/guides/common/modules/proc_puppet-setting-out-of-sync-time-for-puppet-managed-hosts.adoc
+++ b/guides/common/modules/proc_puppet-setting-out-of-sync-time-for-puppet-managed-hosts.adoc
@@ -1,0 +1,54 @@
+[id="puppet_guide_setting_out_of_sync_time_for_puppet_managed_hosts_{context}"]
+= Setting Out of Sync Time for Puppet Managed Hosts
+
+{Project} considers hosts managed by Puppet to be out of sync if the last Puppet report is older than the combined values of `outofsync_interval` and `puppet_interval` set in minutes.
+By default, the Puppet agent on managed hosts runs every 30 minutes.
+The `puppet_interval` is set to 35 minutes and the global `outofsync_interval` is set to 30 minutes.
+
+The effective time after which hosts are considered out of sync is the sum of `outofsync_interval` and `puppet_interval`.
+Setting the global `outofsync_interval` to 30 and the `puppet_interval` to 60 results in a total of 90 minutes after which the host status changes to `out of sync`.
+
+[id="puppet_guide_setting_the_puppet_agent_run_interval{context}"]
+== Setting the Puppet Agent Run Interval
+
+Set the interval when the Puppet Agent runs and sends reports to {Project}.
+
+.Procedure
+. Connect to your managed host using SSH.
+. Add the Puppet Agent run interval to `/etc/puppetlabs/puppet/puppet.conf`, for example `runinterval = 1h`.
+
+[id="puppet_guide_setting_the_puppet_interval_{context}"]
+== Setting the Puppet Interval
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Administer > Settings*, and click the *Puppet* tab.
+. In the *Puppet interval* field, edit the value to the duration, in minutes, after which hosts reporting using Puppet are considered to be out of sync.
+Set a duration in minutes after which hosts reporting using Puppet are considered to be out of sync.
+
+[id="puppet_guide_setting_the_out_of_sync_interval_{context}"]
+== Setting the Out of Sync Interval
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Administer > Settings*.
+. On the *General* tab, edit *Out of sync interval*.
+Set a duration in minutes after which hosts are considered to be out of sync.
++
+You can also overwrite this on individual hosts or host groups by adding the `outofsync_interval` parameter.
+
+[id="puppet_guide_setting_of_of_sync_interval_for_individual_hosts_{context}"]
+== Setting Out of Sync Interval for Individual Hosts
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. Click *Edit* for a selected host.
+. On the *Parameters* tab, click *Add Parameter*.
+. In the *Name* field, enter `outofsync_interval`.
+
+[id="puppet_guide_setting_out_of_sync_interval_for_host_groups_{context}"]
+== Setting Out of Sync Interval for Host Groups
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Configure > Host Groups*.
+. Select a host group.
+. On the *Parameters* tab, click *Add Parameter*.
+. In the *Name* field, enter `outofsync_interval`.


### PR DESCRIPTION
This PR documents how the "out of sync" interval is calculated which is not intuitive. See also [Foreman Community Forum](https://community.theforeman.org/t/outofsync-interval-vs-origin-downcase-interval/24538?u=maximilian).