### PR TITLE
Adapt managing hosts guide for orcharhino

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Configuring_Host_Collections.adoc
+++ b/guides/doc-Managing_Hosts/topics/Configuring_Host_Collections.adoc
@@ -1,7 +1,7 @@
 [[chap-Red_Hat_Satellite-Managing_Hosts-Configuring_Host_Collections]]
 = Configuring Host Collections
 
-ifndef::satellite[]
+ifdef::foreman-deb,foreman-el,katello[]
 This is for users of the Katello plug-in and hosts running RPM-based linux distributions.
 Hosts collections work via the Pulp back end.
 endif::[]

--- a/guides/doc-Managing_Hosts/topics/con_overview-of-hosts-in-satellite.adoc
+++ b/guides/doc-Managing_Hosts/topics/con_overview-of-hosts-in-satellite.adoc
@@ -4,7 +4,13 @@
 
 A host is any Linux client that {ProjectName} manages.
 Hosts can be physical or virtual.
+ifndef::orcharhino[]
 Virtual hosts can be deployed on any platform supported by {ProjectName}, such as KVM, VMware vSphere, OpenStack, Amazon EC2, Rackspace Cloud Services or Google Compute Engine.
+endif::[]
+
+ifdef::orcharhino[]
+Virtual hosts can be deployed on any platform supported by {ProjectName}, such as Amazon EC2, Google GCE, libvirt, Microsoft Azure, Oracle Linux Virtualization Manager, oVirt, Proxmox, RHV, and VMware vSphere.
+endif::[]
 
 {ProjectName} enables host management at scale, including monitoring, provisioning, remote execution, configuration management, software management, and subscription management.
 You can manage your hosts from the {ProjectWebUI} or from the command line.

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
@@ -26,7 +26,9 @@ See xref:Bonding_Modes_Available_in_{Project_Link}[] for a brief description of 
 These can be physical interfaces or VLANs.
 
 * *Bond options*: Specify a space-separated list of configuration options, for example *miimon=100*.
+ifndef::orcharhino[]
 See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/index.html[Red{nbsp}Hat Enterprise Linux 7 Networking Guide] for details of the configuration options you can specify for the bonded interface.
+endif::[]
 
 . Click *OK* to save the interface configuration.
 . Click *Submit* to apply the changes to the host.

--- a/guides/doc-Managing_Hosts/topics/proc_exporting_report_templates_api.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_exporting_report_templates_api.adoc
@@ -2,7 +2,9 @@
 = Exporting Report Templates Using the {Project} API
 
 You can use the {Project} `report_templates` API to export report templates from {Project}.
+ifndef::orcharhino[]
 For more information about using the {Project} API, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/api_guide/index[API Guide].
+endif::[]
 
 .Procedure
 . Use the following request to retrieve a list of available report templates:

--- a/guides/doc-Managing_Hosts/topics/proc_importing_report_templates_api.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_importing_report_templates_api.adoc
@@ -3,7 +3,9 @@
 
 You can use the {Project} API to import report templates into {Project}.
 Importing report templates using the {Project} API automatically parses the report template metadata and assigns organizations and locations.
+ifndef::orcharhino[]
 For more information about using the {Project} API, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/api_guide/index[API Guide].
+endif::[]
 
 .Prerequisites
 * Create a template using `.erb` syntax or export a template from another {Project}.

--- a/guides/doc-Managing_Hosts/topics/proc_managing_and_monitoring_hosts_using_red_hat_web_console.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_managing_and_monitoring_hosts_using_red_hat_web_console.adoc
@@ -18,9 +18,7 @@ ifdef::satellite[]
 endif::[]
 
 * {Project} or {SmartProxy} can authenticate to the host with SSH keys.
-ifndef::orcharhino[]
 For more information, xref:ssh-keys-for-remote-execution-overview_{context}[].
-endif::[]
 
 .Procedure
 

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
@@ -5,7 +5,7 @@ Hosts can be registered to {Project} by generating a `curl` command on {Project}
 This method uses two templates: `global registration` template and `host initial configuration` template. That gives you complete control over the host registration process.
 You can set default templates by navigating to Administer > Settings, and clicking the Provisioning tab.
 
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 Note that you can extend the parameters by plug-ins.
 For more information, see https://github.com/theforeman/foreman/blob/develop/developer_docs/how_to_create_a_plugin.asciidoc[How to Create a Plugin] and https://theforeman.github.io/foreman/?path=/docs/introduction-slot-and-fill--page[Slot and Fill]
 endif::[]
@@ -13,7 +13,7 @@ endif::[]
 .Prerequisites
 * The {Project} user that generates the `curl` command must have the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 * You must have an activation key created.
 * Optional: If you want to register hosts to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL7Server}` repository and make it available in the activation key that you use.
 This is required to install the `insights-client` package on hosts.
@@ -75,14 +75,14 @@ If you keep this field blank, {Project} uses the default network interface.
 . Optional: *Repository* - A repository to be added before the registration is performed. For example, it can be useful to make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository. For example, http://rpm.example.com/. For Debian OS families, it's the whole list file content, for example 'deb http://deb.example.com/ buster 1.0'.
 . Optional: *Repository GPG key URL* - If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header.
 
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 . In the *Activation Key(s)* field, enter one or more activation keys to assign to hosts.
 . Optional: *Lifecycle environment*
 . Optional: *Ignore errors* - Ignore subscription manager errors
 . Optional: *Force* - Remove any `katello-ca-consumer` rpms before registration and run subscription-manager with --force argument.
 endif::[]
 
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Optional: This step is for the Katello users only.
 If you register RHEL or CentOS hosts, in the *Activation Key(s)* field, enter one or more activation keys to assign to registered hosts.
 endif::[]

--- a/guides/doc-Managing_Hosts/topics/proc_upgrading-rhel7-hosts-to-rhel8.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_upgrading-rhel7-hosts-to-rhel8.adoc
@@ -5,9 +5,13 @@ You can use a job template to upgrade your Red{nbsp}Hat Enterprise{nbsp}Linux 7 
 
 .Prerequisites
 * Ensure that your RHEL 7 hosts meet the requirements for the upgrade to RHEL 8.
+ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/planning-an-upgrade_upgrading-from-rhel-7-to-rhel-8[Planning an upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
 * Prepare your hosts for the upgrade.
+ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/preparing-a-rhel-7-system-for-the-upgrade_upgrading-from-rhel-7-to-rhel-8[Preparing a RHEL 7 system for the upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
 * Enable remote execution feature on {Project}.
 For more information, see xref:configuring-and-setting-up-remote-jobs_{context}[].
 * Distribute {Project} SSH keys to the hosts that you want to upgrade.

--- a/guides/doc-Managing_Hosts/topics/ref_customizing-the-registration-templates.adoc
+++ b/guides/doc-Managing_Hosts/topics/ref_customizing-the-registration-templates.adoc
@@ -93,14 +93,14 @@ This table describes what variables are used in the `Global Registration` templa
 
 |`@activation_keys`
 |`activation_keys`
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 |Host activation keys.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 |The Host activation keys snippet is for Katello users only.
 endif::[]
 
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 |`@force`
 |`force`
 |Remove any `katello-ca-consumer*` rpms and run `subscription-manager register` command with `--force` argument.


### PR DESCRIPTION
This PR adapts the managing hosts guide for Foreman downstream product `orcharhino`. It does not make any changes to upstream or Satellite docs.