### PR TITLE
Remove bash highlighting in code blocks

### DIFF
--- a/guides/common/modules/con_acd_architecture.adoc
+++ b/guides/common/modules/con_acd_architecture.adoc
@@ -28,7 +28,7 @@ The Ansible playbook must contain all necessary roles and tasks to execute the p
 If your Ansible playbooks are currently using Ansible collections, ensure that these Ansible collections are added manually to every {SmartProxyServer}.
 To install Ansible collections manually, enter the following command on your {ProjectServer} and {SmartProxyServer}:
 
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # ansible-galaxy collection install _namespace.collection_
 ----

--- a/guides/common/modules/proc_acd_installation.adoc
+++ b/guides/common/modules/proc_acd_installation.adoc
@@ -16,7 +16,7 @@ endif::[]
 ifdef::foreman-el,foreman-deb,katello,satellite[]
 . Create a new yum repository `/etc/yum.repos.d/foreman-plugins.repo` on your {ProjectServer}:
 +
-[source,bash,subs="+quotes,attributes"]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 [foreman-plugins]
 name=Foreman plugins
@@ -27,20 +27,20 @@ gpgcheck=0
 endif::[]
 . Install the required packages on your {ProjectServer}:
 +
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # yum install tfm-rubygem-foreman_acd tfm-rubygem-smart_proxy_acd tfm-rubygem-smart_proxy_acd_core
 ----
 . Run database migrations on your {ProjectServer}:
 +
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # foreman-rake db:migrate
 # foreman-rake db:seed
 ----
 . Restart the {ProjectName} services:
 +
-[source,bash,subs="+quotes,attributes"]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # {foreman-maintain} service restart
 ----

--- a/guides/common/modules/proc_puppet-configuring-a-puppet-class.adoc
+++ b/guides/common/modules/proc_puppet-configuring-a-puppet-class.adoc
@@ -11,14 +11,14 @@ This example overrides the default list of ntp servers.
 . Set the *Parameter Type* drop down menu to _array_.
 . Insert a list of ntp servers as *Default Value*:
 +
-[source,none]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 ["0.de.pool.ntp.org","1.de.pool.ntp.org","2.de.pool.ntp.org","3.de.pool.ntp.org"]
 ----
 +
 An alternative way to describe the array is the `yaml` syntax:
 +
-[source,yaml]
+[yaml, options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 - 0.de.pool.ntp.org
 - 1.de.pool.ntp.org

--- a/guides/common/modules/proc_puppet-importing-a-puppet-module.adoc
+++ b/guides/common/modules/proc_puppet-importing-a-puppet-module.adoc
@@ -13,7 +13,7 @@ You may typically choose between your {ProjectServer} or any attached {SmartProx
 .. Click the *Update* button to import the Puppet classes to {Project}.
 . Importing a Puppet module results in a notification as follows:
 +
-[source,none]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 Successfully updated environments and Puppet classes from the on-disk Puppet installation
 ----

--- a/guides/common/modules/proc_puppet-installing-a-puppet-module-from-puppet-forge.adoc
+++ b/guides/common/modules/proc_puppet-installing-a-puppet-module-from-puppet-forge.adoc
@@ -11,7 +11,7 @@ This example shows how to add the _ntp module_ to managed hosts.
 One of the first modules is _puppetlabs/ntp_.
 . Connect to your {ProjectServer} using SSH and install the Puppet module:
 +
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # puppet module install puppetlabs-ntp -i /etc/puppetlabs/code/environment/production/modules
 ----
@@ -20,7 +20,7 @@ Use the `-i` parameter to specify the path and Puppet environment, for example `
 +
 Once the installation is completed, the output looks as follows:
 +
-[source,none]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 Notice: Preparing to install into /etc/puppetlabs/code/environment/production/modules ...
 Notice: Created target directory /etc/puppetlabs/code/environment/production/modules

--- a/guides/common/modules/proc_puppet-updating-a-puppet-module.adoc
+++ b/guides/common/modules/proc_puppet-updating-a-puppet-module.adoc
@@ -6,20 +6,20 @@ You can update an existing Puppet module using the `puppet` command.
 .Procedure
 . Connect to your Puppet server using SSH and find out where the Puppet modules are located:
 +
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # puppet config print modulepath
 ----
 +
 This returns output as follows:
 +
-[source,none]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 /etc/puppetlabs/code/environments/production/modules:/etc/puppetlabs/code/environments/common:/etc/puppetlabs/code/modules:/opt/puppetlabs/puppet/modules:/usr/share/puppet/modules
 ----
 . If the module is located in the path as displayed above, the following command updates a module:
 +
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # puppet module upgrade _module name_
 ----

--- a/guides/common/modules/proc_puppet-using-puppet-classes-individual-host.adoc
+++ b/guides/common/modules/proc_puppet-using-puppet-classes-individual-host.adoc
@@ -15,7 +15,7 @@ If the _Puppet classes_ tab of an individual host is empty, check if it's assign
 Select the *YAML* button on the host overview page to verify the Puppet configuration.
 This produces output similar as follows:
 
-[source,yaml]
+[yaml, options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 ---
 parameters:
@@ -35,7 +35,7 @@ Other operating systems may store the ntp config file in a different path.
 ====
 You may need to run the Puppet agent on your host by executing the following command:
 
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # puppet agent -t
 ----
@@ -43,14 +43,14 @@ You may need to run the Puppet agent on your host by executing the following com
 
 Running the following command on the host checks which ntp servers are used for clock synchronization:
 
-[source,bash]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # cat /etc/ntp.conf
 ----
 
 This returns output similar as follows:
 
-[source,none]
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # ntp.conf: Managed by puppet.
 server 0.de.pool.ntp.org


### PR DESCRIPTION
This PR fixes the source highlighting for code blocks in the 'puppet for configuration management' documentation.