### PR TITLE
BZ1983101 deploying capsule cert is confusing

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -22,7 +22,7 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
+-t capsule -c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
 -k __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \  <2>
 -b __/root/{smart-proxy-context}_cert/ca_cert_bundle.pem__      <3>
 ----

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -22,7 +22,7 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--t {smart-proxy-context} -c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
+-t {certs-proxy-context} -c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
 -k __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \  <2>
 -b __/root/{smart-proxy-context}_cert/ca_cert_bundle.pem__      <3>
 ----

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -22,7 +22,7 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--t capsule -c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
+-t {smart-proxy-context} -c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
 -k __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \  <2>
 -b __/root/{smart-proxy-context}_cert/ca_cert_bundle.pem__      <3>
 ----


### PR DESCRIPTION
Need to add "-t capsule" if the katello-certs-check is called with custom ssl certificates for Capsule server

Bug 1983101 - Deploying capsule certificates is confusing as per the documentation

https://bugzilla.redhat.com/show_bug.cgi?id=1983101


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
