### PR TITLE
Change reference to cloud.redhat.com with console.redhat.com

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -16,7 +16,7 @@
 
 // Overrides for satellite build
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
-:ansible-galaxy: https://cloud.redhat.com/ansible/automation-hub/redhat/satellite/docs
+:ansible-galaxy: https://console.redhat.com/ansible/automation-hub/redhat/satellite/docs
 :ansible-namespace-example: redhat.satellite._module_name_
 :ansible-namespace: redhat.satellite
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/


### PR DESCRIPTION
Part of the changes that move certain technical content to console.redhat.com. The changed  link already resolves successfully.

SATDOC-132 cloud.redhat.com changes

https://issues.redhat.com/browse/SATDOC-132


Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

