### PR TITLE
Use installer options to set up DHCP multi homing

### DIFF
--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -14,28 +14,7 @@ endif::[]
 
 .Adding Multihomed DHCP details
 
-If you want to use Multihomed DHCP, you must update the network interface file.
-
-. In the `/etc/systemd/system/dhcpd.service.d/interfaces.conf` file, edit the following line to add Multihomed DHCP:
-+
-[options="nowrap" subs="+quotes"]
-----
-[Service]
-ExecStart=/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid eth0 eth1 eth2
-----
-+
-If this file does not exist already, create it.
-. Enter the following command to perform a daemon reload:
-+
-----
-# systemctl --system daemon-reload
-----
-+
-. Enter the following command to restart the *dhcpd* service:
-+
-----
-# systemctl restart dhcpd.service
-----
+If you want to use Multihomed DHCP, you must inform the installer.
 
 .Prerequisites
 
@@ -75,6 +54,8 @@ ifeval::["{context}" == "{project-context}"]
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed true \
 --foreman-proxy-dhcp-interface __eth0__ \
+--foreman-proxy-dhcp-additional-interfaces __eth1__ \
+--foreman-proxy-dhcp-additional-interfaces __eth2__ \
 --foreman-proxy-dhcp-range "__192.0.2.100__ __192.0.2.150__" \
 --foreman-proxy-dhcp-gateway __192.0.2.1__ \
 --foreman-proxy-dhcp-nameservers __192.0.2.2__ \
@@ -101,6 +82,8 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-managed true \
 --foreman-proxy-dhcp-interface _eth0_ \
+--foreman-proxy-dhcp-additional-interfaces _eth1_ \
+--foreman-proxy-dhcp-additional-interfaces _eth2_ \
 --foreman-proxy-dhcp-range "_192.0.2.100_ _192.0.2.150_" \
 --foreman-proxy-dhcp-gateway _192.0.2.1_ \
 --foreman-proxy-dhcp-nameservers _192.0.2.2_ \


### PR DESCRIPTION
The installer can set this up since [Foreman 1.18](https://github.com/theforeman/puppet-foreman_proxy/commit/fcf6d82fde29527bf063d6cb60199339fd4a6266).

Technically it should be safe to cherry pick this into all branches, but I must admit I haven't tested this. That's why I'd only pick it into upstream supported branches, but if the docs team is confident, I won't hold you back :)

Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)