### PR TITLE
Remove mentions of Passenger

### DIFF
--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -20,7 +20,7 @@ If you want to scale your {SmartProxyServer} when managing Puppet clients, the f
 * All other Puppet clients report directly to an external {SmartProxy}.
 * There is an evenly distributed run-interval of all Puppet agents.
 
-NOTE: Deviating from the even distribution increases the risk of filling the passenger request queue.
+NOTE: Deviating from the even distribution increases the risk of overloading {ProjectServer}.
 The limit of 100 concurrent requests applies.
 
 The following table describes the scalability limits using the recommended 4 CPUs.

--- a/guides/doc-Quickstart_Guide/master.adoc
+++ b/guides/doc-Quickstart_Guide/master.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 The Foreman installer is a collection of Puppet modules that installs everything required for a full working Foreman setup. It uses native OS packaging (e.g. RPM and .deb packages) and adds necessary configuration for the complete installation.
 
-Components include the Foreman web UI, Smart Proxy, a Puppet server, and optionally Passenger, TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in “no-op” mode to see what changes it will make.
+Components include the Foreman web UI, Smart Proxy, a Puppet server, TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in “no-op” mode to see what changes it will make.
 
 include::common/modules/ref_supported-operating-systems.adoc[]
 


### PR DESCRIPTION
Passenger support was dropped in Foreman 2.5.

Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)