### PR TITLE
Remove all references of port 5000 for Docker

### DIFF
--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -20,8 +20,7 @@ include::snip_firewalld.adoc[]
 --add-port="5647/tcp" --add-port="8000/tcp" \
 --add-port="8140/tcp" --add-port="9090/tcp" \
 --add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" --add-port="69/udp" \
---add-port="5000/tcp"
+--add-port="67/udp" --add-port="69/udp"
 ----
 
 . Make the changes persistent:

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -15,7 +15,7 @@ include::snip_firewalld.adoc[]
 # firewall-cmd --add-port="53/udp" --add-port="53/tcp" \
 --add-port="67/udp" --add-port="69/udp" \
 --add-port="80/tcp" --add-port="443/tcp" \
---add-port="5000/tcp" --add-port="5647/tcp" \
+--add-port="5647/tcp" \
 --add-port="8000/tcp" --add-port="8140/tcp" \
 --add-port="8443/tcp" --add-port="9090/tcp"
 ----

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -73,9 +73,6 @@ endif::[]
 | 53 | TCP and UDP | DNS | Client DNS queries to a {SmartProxy}'s DNS service (Optional)
 | 67 | UDP | DHCP | Client to {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {SmartProxy} (Optional)
 | 69 | UDP |TFTP | Clients downloading PXE boot image files from a {SmartProxy} for provisioning (Optional)
-ifndef::foreman-deb[]
-| 5000   | TCP   | HTTPS | Connection to Katello for the Docker registry (Optional)
-endif::[]
 |====
 
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -45,7 +45,6 @@ You must configure sticky session on TCP port 443 to request yum metadata for RP
 | Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServer}s
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates
 | SmartProxy (_Optional for OpenScap_)| 9090 | TCP | roundrobin | port 9090 on all {SmartProxyServer}s
-| Docker (_Optional_)| 5000 | TCP | roundrobin | port 5000 on all {SmartProxyServer}s
 |====
 
 . Configure the load balancer to disable SSL offloading and allow client-side SSL certificates to pass through to back end servers.


### PR DESCRIPTION
32e6122d156671e913b152ebfbade8af0c6ba387 started this effort, but I missed a few.

This is for any Pulp 3-only install, so Katello 4, meaning Foreman 2.5 should receive this as a cherry pick.

Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)