### PR TITLE
Build docs in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM fedora:34
+
+RUN dnf upgrade -y && \
+    dnf install -y findutils \
+                   linkchecker \
+                   make \
+                   rubygem-asciidoctor \
+                   rubygem-asciidoctor-pdf
+
+WORKDIR /foreman-documentation/guides

--- a/guides/README.md
+++ b/guides/README.md
@@ -11,7 +11,7 @@ Contributions are welcome. Please read the [Contribution guidelines](#contributi
 Install the required tools.
 In Fedora perform:
 
-    dnf -y install ruby asciidoctor asciidoctor-pdf make linkchecker
+    dnf -y install rubygem-asciidoctor rubygem-asciidoctor-pdf make linkchecker
 
 In MacOS required tools can be installed via brew but instead "make" call "gmake":
 
@@ -66,6 +66,24 @@ Note that GNU Makefile tracks changes and only builds relevant artifacts, to tri
 It's also possible to check links; the following command will check all links except example.com domain:
 
 	make linkchecker
+
+## Building Locally Using a Container
+
+You can build Foreman documentation locally using a container image.
+This requires the cloned git repository plus an application such as Podman or Docker to build and run container images.
+
+1. Build container image:
+
+       podman build --tag foreman_documentation .
+
+2. Build Foreman documentation.
+   Run this command in your `foreman-documentation` repository:
+
+       rm -rf guides/build && podman run --rm -v $(pwd):/foreman-documentation foreman_documentation make html
+
+   On SELinux enabled systems, run this command:
+
+       rm -rf guides/build && podman run --rm -v $(pwd):/foreman-documentation:Z foreman_documentation make html
 
 ## Reading or Publishing
 


### PR DESCRIPTION
This PR adds a `Containerfile` to build a container image & minimal usage instructions on how to build Foreman documentation without installing any other applications apart from docker/ a docker alternative. If someone is kind enough to rerun both commands on Fedora, I would **love** to replace `docker` with `podman`.

I hope this makes it easier for everyone to try and build their branch/contribution locally first before creating a PR.

On a sidenote: We could also create a separate repo (like `foreman-documentation-container-image`) to massively speed up Github actions. It'll be faster and save resources.