### PR TITLE
Fixed a mischaracterization of composite export.

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -100,7 +100,8 @@ This option is available for all content-export operations. You can use the `des
 === Exporting a Content View Version
 
 You can export a version of a Content View to an archive file from {ProjectServer} and use this archive file to create the same Content View version on another {ProjectServer} or on another {ProjectServer} organization.
-{Project} exports composite Content Views as a normal content view. The composite nature is not retained.
+{Project} exports composite Content Views as normal content views.
+The composite nature is not retained.
 The exported archive file contains the following data:
 
 * A JSON file containing Content View version metadata

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -100,7 +100,7 @@ This option is available for all content-export operations. You can use the `des
 === Exporting a Content View Version
 
 You can export a version of a Content View to an archive file from {ProjectServer} and use this archive file to create the same Content View version on another {ProjectServer} or on another {ProjectServer} organization.
-{Project} does not export composite Content Views.
+{Project} exports composite Content Views as a normal content view. The composite nature is not retained.
 The exported archive file contains the following data:
 
 * A JSON file containing Content View version metadata

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -102,6 +102,7 @@ This option is available for all content-export operations. You can use the `des
 You can export a version of a Content View to an archive file from {ProjectServer} and use this archive file to create the same Content View version on another {ProjectServer} or on another {ProjectServer} organization.
 {Project} exports composite Content Views as normal content views.
 The composite nature is not retained.
+On importing the exported archive, a normal content-view will get created/updated in the downstream {ProjectServer}.
 The exported archive file contains the following data:
 
 * A JSON file containing Content View version metadata

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -102,7 +102,7 @@ This option is available for all content-export operations. You can use the `des
 You can export a version of a Content View to an archive file from {ProjectServer} and use this archive file to create the same Content View version on another {ProjectServer} or on another {ProjectServer} organization.
 {Project} exports composite Content Views as normal content views.
 The composite nature is not retained.
-On importing the exported archive, a normal content-view will get created/updated in the downstream {ProjectServer}.
+On importing the exported archive, a regular Content View is created or updated on your disconnected {ProjectServer}.
 The exported archive file contains the following data:
 
 * A JSON file containing Content View version metadata


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
