### PR TITLE
Add section on host status and substatus

### DIFF
--- a/guides/common/assembly_host-status-overview.adoc
+++ b/guides/common/assembly_host-status-overview.adoc
@@ -1,0 +1,9 @@
+[id="host-status-overview_{context}"]
+= Host Status in {Project}
+
+In {Project}, each host has a global status that indicates which hosts need attention.
+Each host also has sub-statuses that represents status of a particular feature.
+With any change of a sub-status, the global status is recalculated and the result is determined by statuses of all sub-statuses.
+
+include::modules/con_host-global-status-overview.adoc[leveloffset=+1]
+include::modules/con_host-substatus-overview.adoc[leveloffset=+1]

--- a/guides/common/modules/con_host-global-status-overview.adoc
+++ b/guides/common/modules/con_host-global-status-overview.adoc
@@ -1,0 +1,43 @@
+[id="host-global-status-overview_{context}"]
+= Host Global Status Overview
+
+The global status represents the overall status of a particular host.
+The status can have one of three possible values: *OK*, *Warning* or *Error*.
+You can find global status on the Hosts Overview page.
+The status displays as a small icon next to host name and has a color that corresponds with the status.
+Hovering over the icon renders a tooltip with sub-status information to quickly find out more details.
+To view the global status for a host, in the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+
+OK::
+No errors were reported by any sub-status.
+This status is highlighted with the color green.
+
+Warning::
+While no error was detected, some sub-status raised a warning.
+For example, there are no configuration management reports for the host even though the host is configured to send reports.
+It is a good practice to investigate any warnings to ensure that your deployment remains healthy.
+This status is highlighted with the color yellow.
+
+Error::
+Some sub-status reports a failure.
+For example, a run contains some failed resources.
+This status is highlighted with the color red.
+
+.Search syntax
+
+If you want to search for hosts according to their status, use the syntax for searching in {Project} that is outlined in the {AdministeringDocURL}chap-Administering-Searching_and_Bookmarking[Searching and Bookmarking] chapter of the _Administering {Project}_ guide, and then build your searches out using the following status-related examples:
+
+To search for hosts that have an *OK* status:
+
+[options="nowrap" subs="+quotes"]
+----
+
+global_status = ok
+----
+
+To search for all hosts that deserves some attention:
+
+[options="nowrap" subs="+quotes"]
+----
+global_status = error or global_status = warning
+----

--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -1,0 +1,77 @@
+[id="host-substatus-overview_{context}"]
+= Host Sub-status Overview
+
+A sub-status monitors only part of a host's capabilities.
+
+Currently, {Project} ships only with *Build* and *Configuration* sub-statuses. There can be more sub-statuses depending on which plugins you add to your {Project} deployment.
+
+The *build* sub-status is relevant for managed hosts and when {Project} runs in unattended mode.
+
+The *configuration* sub-status is only relevant if {Project} uses a configuration management system like Ansible, Puppet, or Salt.
+
+To view the sub-status for a host, in the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and click the host whose full status you want to inspect. You can also view substatus information in the hover help for each host.
+
+In the *Properties* table of the host details' page, you can view both the global host status with all sub-statuses.
+
+Each sub-status can define its own set of possible values that are mapped to the three global status values.
+
+The *Build* sub-status has two possible values - *pending* and *built* that are both mapped to global *OK* value.
+
+The *Configuration* status has more possible values that map to the global status as follows:
+
+.sub-statuses that map to the global *OK* status:
+
+Active::
+During the last run, some resources were applied.
+
+Pending::
+During the last run, some resources would be applied but your configuration management integration was configured to run in `noop` mode.
+
+No changes::
+During the last run, nothing changed.
+
+No reports::
+This can be both a *Warning* or *OK* sub-status.
+This occurs when there are no reports but the host uses, for example, an associated configuration management proxy or `always_show_configuration_status` setting is set to `true`, it maps to *Warning*.
+
+.Sub-status that maps to the global *Error* status:
+
+Error::
+This indicates an error during configuration, for example, a run failed to install a package.
+
+.sub-statuses that map to the global *Warning* status:
+
+Out of sync::
+A configuration report was not received within the expected interval, based on the `outofsync_interval`.
+Reports are identified by an origin and can have different intervals based upon it.
+
+No reports::
+When there are no reports but the host uses configuration management system, for example, proxy is associated or `always_show_configuration_status` setting is set to true, it maps to *Warning*. Otherwise it is mapped to OK.
+
+
+.Search syntax
+
+If you want to search for hosts according to their sub-status, use the syntax for searching in {Project} that is outlined in the {AdministeringDocURL}chap-Administering-Searching_and_Bookmarking[Searching and Bookmarking] chapter of the _Administering {Project}_ guide, and then build your searches out using the following status-related examples:
+
+You search for hosts' configuration sub-statuses based on their last reported state.
+
+For example, to find hosts that have at least one pending resource:
+
+[options="nowrap" subs="+quotes"]
+----
+status.pending > 0
+----
+
+To find hosts that restarted some service during last run:
+
+[options="nowrap" subs="+quotes"]
+----
+status.restarted > 0
+----
+
+To find hosts that have an interesting last run that might indicate something has happened:
+
+[options="nowrap" subs="+quotes"]
+----
+status.interesting = true
+----

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -39,6 +39,8 @@ endif::[]
 
 include::common/assembly_configuring-and-setting-up-remote-jobs.adoc[leveloffset=+1]
 
+include::common/assembly_host-status-overview.adoc[leveloffset=+1]
+
 include::topics/Host_Management_without_Goferd.adoc[leveloffset=+1]
 
 include::topics/Synchronizing_Templates.adoc[leveloffset=+1]


### PR DESCRIPTION
As part of the work to migrate the Foreman manual to our new site
docs.theforeman.org and make this site the official docs. 

The main change from https://theforeman.org/manuals/2.5/index.html#4.10Monitoring

1. I have tried to keep it config management option agnostic. 
2. I have not referred to it as monitoring specifically, as we have many chapters called monitoring already. It's more of an explanation as to how to interpret status. 

These changes are not new and there are no equivalent docs for Satellite, so will leave in master for now.


Cherry-pick into:

* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
