### PR TITLE
Add 3.0 to CP template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 
 Cherry-pick into:
 
+* [ ] Foreman 3.0
 * [ ] Foreman 2.5 (Satellite 6.10)
 * [ ] Foreman 2.4
 * [ ] Foreman 2.3 (Satellite 6.9)


### PR DESCRIPTION
I have added 3.0 as a cherry-pick option as we have branched. 
I have not removed 2.1 because I will wait until the downstream 
release of 2.5, otherwise we might face some backlash. 