### PR TITLE
Add katello 2.4 notes and contributors

### DIFF
--- a/web/content/3.0.md
+++ b/web/content/3.0.md
@@ -36,8 +36,47 @@ plugins. Official documentation [is available here](https://theforeman.org/manua
 
 ### Katello headline features
 
+For the full list of changes, see the [Changelog](https://github.com/Katello/katello/blob/KATELLO-4.2/CHANGELOG.md).
+
+* New Experimental Content View UI Features:
+  * Publish & Promote
+  * Add component CVs to composite CVs
+* Pulp's mirorred metadata is now used to speed up repo syncs
+* Upgrade to Pulp 3.14 (This was backported to Katello 4.1)
+* support deleting RH repos from the repositories details
+
+## Upgrade Warnings
+
+* upstream_subscriptions apis have been removed in favor of apis rooted at /katello/api/v2/organizations/:organization_id/simple_content_access/
+
 ## Deprecations
 
 ### Contributors to Foreman 3.0
 
 ### Contributors to Katello 4.2
+
+* Andrew Dewar
+* Andrew Lukoshko
+* Bernhard Suttner
+* Chris Roberts
+* Dominik Matoulek
+* Eric D. Helms
+* Hao Yu
+* Ian Ballou
+* James Jeffers
+* Jeremy Lenz
+* Jonathon Turel
+* Justin Sherrill
+* Leos Stejskal
+* Lucy Fu
+* Lukas Zapletal
+* lumarel
+* Marek Hulán
+* Markus Bucher
+* Oleh Fedorenko
+* Ondřej Ezr
+* Partha Aji
+* Pat Riehecky
+* Paul Donohue
+* Ryan Verdile
+* Samir Jha


### PR DESCRIPTION
Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
