### PR TITLE
Update platform links

### DIFF
--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -20,7 +20,7 @@ Ensure no other DHCP services run on this network to avoid conflicts with {Smart
 For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking[Configuring Networking].
 ifdef::satellite[]
 * A {RHEL} server running KVM virtualization tools (libvirt daemon).
-For more information, see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Virtualization_Getting_Started_Guide/index.html[Red Hat Enterprise Linux 7 Virtualization Getting Started Guide].
+For more information, see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Virtualization_Getting_Started_Guide/[Red Hat Enterprise Linux 7 Virtualization Getting Started Guide].
 endif::[]
 ifndef::satellite[]
 * A server running KVM virtualization tools (libvirt daemon).

--- a/guides/common/modules/con_types-of-provisioning-templates.adoc
+++ b/guides/common/modules/con_types-of-provisioning-templates.adoc
@@ -7,7 +7,7 @@ Provision::
 The main template for the provisioning process.
 For example, a kickstart template.
 ifndef::orcharhino[]
-For more information about kickstart template syntax, see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html[Kickstart Syntax Reference] in the _Red Hat Enterprise Linux 7 Installation Guide_.
+For more information about kickstart template syntax, see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax[Kickstart Syntax Reference] in the _Red Hat Enterprise Linux 7 Installation Guide_.
 endif::[]
 
 PXELinux, PXEGrub, PXEGrub2::

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -8,7 +8,7 @@ To configure the IdM server to use the GSS-TSIG technology, you must install the
 .Prerequisites
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
-For more information, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/installing-ipa.html#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
+For more information, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/installing-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
 * You must contact the IdM server administrator to ensure that you obtain an account on the IdM server with permissions to create zones on the IdM server.
 * You must confirm whether {ProjectServer} or {SmartProxyServer} is configured to provide DNS service for your deployment.
 * You must configure DNS, DHCP and TFTP services on the base operating system of either the {Project} or {SmartProxy} that is managing the DNS service for your deployment.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -9,7 +9,7 @@ The TSIG protocol is defined in https://tools.ietf.org/html/rfc2845[RFC2845].
 .Prerequisites
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
-For more information, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/installing-ipa.html#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
+For more information, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/installing-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
 * You must obtain `root` user access on the IdM server.
 * You must confirm whether {ProjectServer} or {SmartProxyServer} is configured to provide DNS service for your deployment.
 * You must configure DNS, DHCP and TFTP services on the base operating system of either the {Project} or {SmartProxy} that is managing the DNS service for your deployment.

--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -42,7 +42,7 @@ rtt min/avg/max/mdev = 0.019/0.019/0.019/0.000 ms
 # hostnamectl set-hostname _name_
 ----
 
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec_configuring_host_names_using_hostnamectl/[Configuring Host Names Using hostnamectl] in the _Red Hat Enterprise Linux 7 Networking Guide_.
+For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/networking_guide/index#sec_Configuring_Host_Names_Using_hostnamectl[Configuring Host Names Using hostnamectl] in the _Red Hat Enterprise Linux 7 Networking Guide_.
 
 ifndef::foreman-deb[]
 [WARNING]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -1,5 +1,5 @@
 [[sect-Administering-Configuring_External_Authentication-Using_Identity_Management]]
-=== Using {FreeIPA} 
+=== Using {FreeIPA}
 
 This section shows how to integrate {ProjectName} Server with a {FreeIPA} server and how to enable host-based access control.
 
@@ -15,7 +15,7 @@ For more information, see xref:sect-Administering-Using_LDAP[].
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
 ifndef::orcharhino[]
-However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/index.html#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].
+However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/index#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].
 endif::[]
 
 include::configuring-idm-authentication-on-satellite-server.adoc[leveloffset=+3]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/active-directory-with-cross-forest-trust.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/active-directory-with-cross-forest-trust.adoc
@@ -5,5 +5,5 @@ Kerberos can create `cross-forest trust` that defines a relationship between two
 A domain forest is a hierarchical structure of domains; both AD and {FreeIPA} constitute a forest.
 With a trust relationship enabled between AD and {FreeIPA}, users of AD can access Linux hosts and services using a single set of credentials.
 ifndef::orcharhino[]
-For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/active-directory-trust.html[Creating Cross-forest Trusts with Active Directory and Identity Management] in the _Red{nbsp}Hat Enterprise{nbsp}Linux Windows Integration_ guide.
+For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/active-directory-trust[Creating Cross-forest Trusts with Active Directory and Identity Management] in the _Red{nbsp}Hat Enterprise{nbsp}Linux Windows Integration_ guide.
 endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
@@ -6,7 +6,7 @@ HBAC rules define which machine within the domain a {FreeIPA} user is allowed to
 You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing {ProjectServer}.
 With this approach, you can prevent {Project} from creating database entries for users that are not allowed to log in.
 ifndef::orcharhino[]
-For more information on HBAC, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/configuring-host-access.html[Configuring Host-Based Access Control] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on HBAC, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/configuring-host-access[Configuring Host-Based Access Control] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 endif::[]
 
 On the {FreeIPA} server, configure Host-Based Authentication Control (HBAC).

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -33,7 +33,7 @@ The generated one-time password must be used on the client to complete {FreeIPA}
 ====
 +
 ifndef::orcharhino[]
-For more information on host configuration properties, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/host-attr.html[About Host Entry Configuration Properties] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on host configuration properties, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/host-attr[About Host Entry Configuration Properties] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 endif::[]
 
 . Create an HTTP service for {ProjectServer}, for example:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -44,7 +44,7 @@ endif::[]
 ----
 +
 ifndef::orcharhino[]
-For more information on managing services, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/services.html[Managing Services] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on managing services, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/services[Managing Services] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 endif::[]
 
 . On {ProjectServer}, install the IPA client:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
@@ -23,6 +23,6 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifndef::orcharhino[]
-For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/sssd-gpo.html[Red{nbsp}Hat Enterprise Linux Windows Integration Guide].
+For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/sssd-gpo[Red{nbsp}Hat Enterprise Linux Windows Integration Guide].
 endif::[]
 ====

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
@@ -2,7 +2,7 @@
 = Kerberos Configuration in Web Browsers
 
 ifndef::orcharhino[]
-For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/Configuring_Applications_for_SSO.html#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _Red{nbsp}Hat Enterprise{nbsp}Linux System-Level Authentication_ guide.
+For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/Configuring_Applications_for_SSO#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _Red{nbsp}Hat Enterprise{nbsp}Linux System-Level Authentication_ guide.
 endif::[]
 
 If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Container_Images.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Container_Images.adoc
@@ -3,4 +3,4 @@
 
 With {ProjectNameX}, you can import container images from various sources and distribute them to external containers using Content Views.
 
-For information about containers, see https://access.redhat.com/documentation/en/red-hat-enterprise-linux-atomic-host/7/getting-started-with-containers/getting-started-with-containers[Getting Started with Containers] in _Red Hat Enterprise Linux Atomic Host 7_.
+For information about containers, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/index[Getting Started with Containers] in _Red Hat Enterprise Linux Atomic Host 7_.

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
@@ -27,7 +27,7 @@ These can be physical interfaces or VLANs.
 
 * *Bond options*: Specify a space-separated list of configuration options, for example *miimon=100*.
 ifndef::orcharhino[]
-See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/index.html[Red{nbsp}Hat Enterprise Linux 7 Networking Guide] for details of the configuration options you can specify for the bonded interface.
+See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/index[Red{nbsp}Hat Enterprise Linux 7 Networking Guide] for details of the configuration options you can specify for the bonded interface.
 endif::[]
 
 . Click *OK* to save the interface configuration.

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -68,7 +68,7 @@ To provision machines through HTTP booting ensure that you meet the following re
 .Client requirements
 
 For HTTP booting to work, ensure that your environment has the following client-side configurations:
- 
+
 * All the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
 For more information, see xref:figu-Satellite_Topology_with_Isolated_Capsule[].
 
@@ -167,7 +167,7 @@ endif::[]
 
 === Kickstart
 You can use Kickstart to automate the installation process of a {ProjectName} or {SmartProxyServer} by creating a Kickstart file that contains all the information that is required for the installation.
-For more information about Kickstart, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-kickstart-installations.html[Kickstart Installations] in the _{RHEL} 7 Installation Guide_.
+For more information about Kickstart, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-kickstart-installations[Kickstart Installations] in the _{RHEL} 7 Installation Guide_.
 
 ==== Workflow
 When you run a {ProjectName} Kickstart script, the following workflow occurs:


### PR DESCRIPTION

RHEL Platform documentation went through an upgrade during the weekend, and this upgrade changed several urls. I have been assured that eventually redirects will work over the next week or so, but the linkchecker is causing the links to fail, which is slowing progress. It is less time consuming just to fix and move on. 

Cherry-pick into:

* [x] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
