### PR TITLE
Remove outdated TODO list from main readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,3 @@ When a commit is pushed into `X.Y`:
 ## License
 
 See LICENSE files in individual subdirectories.
-
-## The process (TODO)
-
-This is what we are working on right now:
-
-* [x] Initial import of Provisioning Guide
-* [x] Provide Makefiles and Travis integration
-* [x] Replace Satellite 6 with Foreman term
-* [ ] Modularize content
-* [ ] Hide irrelevant chapters
-* [ ] [Incorporate parts from upstream docs](https://community.theforeman.org/t/foreman-manual-reboot/22606)
-* [ ] Incorporate https://community.theforeman.org/t/discovery-ipxe-efi-workflow-in-foreman-1-20/13026
-* [ ] Write a better introduction
-* [ ] Add Anaconda-image based provisioning workflow
-* [ ] Update with PXE Grub2 steps
-* [ ] Discuss with Foreman community if to continue with other guides


### PR DESCRIPTION
fixes #662


Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
