### PR TITLE
Install foreman-console instead of all plugins

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-complete-permission-table.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-complete-permission-table.adoc
@@ -10,7 +10,7 @@ Execute the following command on {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} tfm-rubygem-foreman*
+# {package-install-project} foreman-console
 ----
 
 . Start the {Project} console with the following command:


### PR DESCRIPTION
This removes the extremely dangerous instruction to install all plugins. Users who do this can easily effectively break their installation. We have no way to safely remove plugins and there is no way back.

The correct thing to do is ensure the foreman-console package is installed. That's the only thing that is needed.

This also has the benefit that it works on all supported platforms rather than just EL7.

I consider this very important and would suggest to fix it where possible.

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->