### PR TITLE
Replace recursive make

### DIFF
--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,37 +1,51 @@
 SHELL := /bin/bash
-ALL_DIRS = $(shell ls -d doc-*)
-GUIDES-HTML = $(ALL_DIRS)
+ALL_DIRS = $(wildcard doc-*)
+ALL_GUIDES = $(patsubst doc-%,%,$(ALL_DIRS))
+BUILDS=foreman-el foreman-deb katello
+BUILD_DIR := build
+COMMON_DIR := common
+DEPENDENCIES := $(shell find $(COMMON_DIR) -type f -name \*.adoc)
+DATE_MDY := $(shell LC_ALL=C date "+%b %d %Y")
+DATE_MY := $(shell LC_ALL=C date "+%b %Y")
 
-.PHONY: all html pdf linkchecker all-html all-pdf clean all-clean linkchecker-tryer $(GUIDES-HTML)
+HTML_INDEXES := $(BUILDS:%=index-%.html)
+PDFS := $(BUILDS:%=index-%.pdf)
+GUIDE_BUILDS := $(addprefix $(BUILD_DIR)/,$(ALL_GUIDES))
+
+GUIDES-HTML := $(foreach guide,$(GUIDE_BUILDS),$(addprefix $(guide)/,$(HTML_INDEXES)))
+GUIDES-PDF := $(foreach guide,$(GUIDE_BUILDS),$(addprefix $(guide)/,$(PDFS)))
+
+.PHONY: all html pdf linkchecker all-html all-pdf clean all-clean linkchecker-tryer
 
 all: html
 
-html: all-html
+html: $(GUIDES-HTML)
 
-pdf: all-pdf
+pdf: $(GUIDES-PDF)
 
-clean: all-clean
+clean:
+	rm -rf build
 
 linkchecker:
-	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
+	find $(BUILD_DIR) -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
 
 linkchecker-tryer:
-	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
+	find $(BUILD_DIR) -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
-all-html: $(GUIDES-HTML)
+# The variables only work within rules
+CURRENT_BUILD=$(patsubst index-%,%,$(notdir $(basename $@)))
+CSS_FILE=$(COMMON_DIR)/$(CURRENT_BUILD).css
 
-$(GUIDES-HTML):
-	$(MAKE) --directory=$@ html
+# TODO: copy images
+#$(BUILD_DIR)/%/%.png:
 
-all-pdf:
-	for DIR in $(ALL_DIRS) ; do \
-		$(MAKE) --directory="$$DIR" pdf ; \
-	done
+# TODO: depend on .css file
+$(addprefix $(BUILD_DIR)/%/,$(HTML_INDEXES)): doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor -a build=$(CURRENT_BUILD) -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(CSS_FILE) -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 
-$(GUIDES-PDF):
-	$(MAKE) --directory=$@ pdf
-
-all-clean:
-	for DIR in $(ALL_DIRS) ; do \
-		$(MAKE) --directory="$$DIR" clean ; \
-	done
+$(addprefix $(BUILD_DIR)/%/,$(PDFS)): doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor-pdf -a build=$(CURRENT_BUILD) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,21 +1,21 @@
 SHELL := /bin/bash
 ALL_DIRS = $(wildcard doc-*)
 ALL_GUIDES = $(patsubst doc-%,%,$(ALL_DIRS))
-BUILDS=foreman-el foreman-deb katello
+BUILDS = foreman-deb foreman-el katello satellite orcharhino
 BUILD_DIR := build
 COMMON_DIR := common
 DEPENDENCIES := $(shell find $(COMMON_DIR) -type f -name \*.adoc)
 DATE_MDY := $(shell LC_ALL=C date "+%b %d %Y")
 DATE_MY := $(shell LC_ALL=C date "+%b %Y")
 
-HTML_INDEXES := $(BUILDS:%=index-%.html)
-PDFS := $(BUILDS:%=index-%.pdf)
+HTMLS := $(BUILDS:%=%.html)
+PDFS := $(BUILDS:%=%.pdf)
 GUIDE_BUILDS := $(addprefix $(BUILD_DIR)/,$(ALL_GUIDES))
 
-GUIDES-HTML := $(foreach guide,$(GUIDE_BUILDS),$(addprefix $(guide)/,$(HTML_INDEXES)))
+GUIDES-HTML := $(foreach guide,$(GUIDE_BUILDS),$(addprefix $(guide)/,$(HTMLS)))
 GUIDES-PDF := $(foreach guide,$(GUIDE_BUILDS),$(addprefix $(guide)/,$(PDFS)))
 
-.PHONY: all html pdf linkchecker all-html all-pdf clean all-clean linkchecker-tryer
+.PHONY: all html pdf clean linkchecker linkchecker-tryer
 
 all: html
 
@@ -24,28 +24,66 @@ html: $(GUIDES-HTML)
 pdf: $(GUIDES-PDF)
 
 clean:
-	rm -rf build
+	rm -rf $(BUILD_DIR)
 
 linkchecker:
-	find $(BUILD_DIR) -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
+	find $(BUILD_DIR) -type f -name \*.html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
 
 linkchecker-tryer:
-	find $(BUILD_DIR) -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
-
-# The variables only work within rules
-CURRENT_BUILD=$(patsubst index-%,%,$(notdir $(basename $@)))
-CSS_FILE=$(COMMON_DIR)/$(CURRENT_BUILD).css
+	find $(BUILD_DIR) -type f -name \*.html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
 # TODO: copy images
 #$(BUILD_DIR)/%/%.png:
 
-# TODO: depend on .css file
-$(addprefix $(BUILD_DIR)/%/,$(HTML_INDEXES)): doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+# TODO: combining the build rules into one appear to break
+# It only executes one per run rather than all. Multiple runs does work
+
+$(BUILD_DIR)/%/foreman-deb.html: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(COMMON_DIR)/foreman-deb.css $(DEPENDENCIES)
 	@mkdir -p "$(@D)"
-	asciidoctor -a build=$(CURRENT_BUILD) -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(CSS_FILE) -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	asciidoctor -a build=$(notdir $(basename $@)) -a stylesheet=$(COMMON_DIR)/$(notdir $(basename $@)).css -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 
-$(addprefix $(BUILD_DIR)/%/,$(PDFS)): doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+$(BUILD_DIR)/%/foreman-el.html: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(COMMON_DIR)/foreman-el.css $(DEPENDENCIES)
 	@mkdir -p "$(@D)"
-	asciidoctor-pdf -a build=$(CURRENT_BUILD) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	asciidoctor -a build=$(notdir $(basename $@)) -a stylesheet=$(COMMON_DIR)/$(notdir $(basename $@)).css -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/katello.html: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(COMMON_DIR)/katello.css $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor -a build=$(notdir $(basename $@)) -a stylesheet=$(COMMON_DIR)/$(notdir $(basename $@)).css -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/satellite.html: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(COMMON_DIR)/satellite.css $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor -a build=$(notdir $(basename $@)) -a stylesheet=$(COMMON_DIR)/$(notdir $(basename $@)).css -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/orcharhino.html: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(COMMON_DIR)/orcharhino.css $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor -a build=$(notdir $(basename $@)) -a stylesheet=$(COMMON_DIR)/$(notdir $(basename $@)).css -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/foreman-deb.pdf: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor-pdf -a build=$(notdir $(basename $@)) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/foreman-el.pdf: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor-pdf -a build=$(notdir $(basename $@)) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/katello.pdf: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor-pdf -a build=$(notdir $(basename $@)) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/satellite.pdf: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor-pdf -a build=$(notdir $(basename $@)) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
+
+$(BUILD_DIR)/%/orcharhino.pdf: doc-%/master.adoc $(wildcard doc-%/topics/*.adoc) $(DEPENDENCIES)
+	@mkdir -p "$(@D)"
+	asciidoctor-pdf -a build=$(notdir $(basename $@)) -d book --trace -o $@ $< 2>&1 | tee $@.log
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -30,7 +30,7 @@ html: prepare $(DEST_DIR)/$(BUILD).css $(IMAGES_TS) $(DEST_HTML)
 pdf: prepare $(DEST_PDF)
 
 prepare:
-	mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(IMAGES_DIR) $(DEST_DIR)/common/images
+	mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(DEST_DIR)/common/images
 
 clean:
 	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)"


### PR DESCRIPTION
[Recursive make is considered harmful](https://web.archive.org/web/20150330111905/http://miller.emu.id.au/pmiller/books/rmch/). This declares exact rules which means a single Makefile is sufficient.

Right now this is incomplete and there's a weird issue that it doesn't create all builds at once. For some reason, I need to run `make` multiple times. Maybe @lzap has an idea.