### PR TITLE
Define katello for satellite and orcharhino

### DIFF
--- a/guides/common/assembly_configuring-an-alternate-cname.adoc
+++ b/guides/common/assembly_configuring-an-alternate-cname.adoc
@@ -7,7 +7,7 @@ You can configure an alternate CNAME for {Project}.
 This might be useful if you want to deploy the {Project} web interface on a different domain name than the one that is used by client systems to connect to {Project}.
 You must plan the alternate CNAME configuration in advance prior to installing {SmartProxies} and registering hosts to {Project} to avoid redeploying new certificates to hosts.
 
-ifndef::satellite[]
+ifndef::katello[]
 This procedure is only for Katello plug-in users.
 endif::[]
 

--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -6,7 +6,7 @@ ifdef::context[:parent-context: {context}]
 
 = Configuring {ProjectServer} with a Custom SSL Certificate
 
-ifndef::satellite[]
+ifndef::katello[]
 This procedure is only for Katello plug-in users.
 endif::[]
 

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -7,7 +7,7 @@ ifdef::context[:parent-context: {context}]
 Before you install {SmartProxyServer}, you must ensure that your environment meets the requirements for installation.
 For more information, see {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation].
 
-ifdef::satellite,katello[]
+ifdef::katello[]
 // Registering {SmartProxyServer} to {ProjectServer}
 include::modules/proc_registering-capsule-to-satellite-server.adoc[leveloffset=+1]
 
@@ -38,12 +38,12 @@ include::modules/proc_synchronizing-the-system-clock-with-chronyd.adoc[leveloffs
 // Assigning the Correct Organization and Location to {SmartProxyServer} in the {ProjectWebUI}
 include::modules/proc_enabling-capsule-in-UI.adoc[leveloffset=+1]
 
-ifdef::katello,satellite[]
+ifdef::katello[]
 [id="configuring-capsule-server-with-ssl-certificates"]
 == Configuring {SmartProxyServer} with SSL Certificates
 endif::[]
 
-ifdef::katello,satellite[]
+ifdef::katello[]
 {ProjectName} uses SSL certificates to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
 Depending on the requirements of your organization, you must configure your {SmartProxyServer} with a default or custom certificate.
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -42,9 +42,11 @@ ifeval::["{build}" == "satellite"]
 :ProjectVersion: {ProductVersion}
 :ProjectVersionPrevious: {ProductVersionPrevious}
 :satellite:
+:katello:
 endif::[]
 ifeval::["{build}" == "orcharhino"]
 :orcharhino:
+:katello:
 endif::[]
 
 // Load base attributes

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -17,7 +17,7 @@ This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide a
 
 * You must deploy an external IPv4 HTTP proxy server.
 This is required because {Project} distributes content only over IPv4 networks, therefore you must use an IPv4 proxy to redirect that content to hosts in your IPv6 network.
-ifndef::satellite[]
+ifndef::katello[]
 +
 Note that this requirement is for Katello users only.
 endif::[]

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -38,7 +38,7 @@ ifndef::satellite[]
 # {package-install} foreman-proxy-content
 ----
 
-ifdef::foreman-el,katello[]
+ifndef::satellite[]
 == [[centos-7-package]]Red Hat Enterprise Linux 7 / CentOS Linux 7
 endif::[]
 

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -4,7 +4,7 @@
 
 .Procedure
 
-ifdef::foreman-el,foreman-deb[]
+ifndef::katello[]
 * To install an external {SmartProxy}, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -16,7 +16,7 @@ ifeval::["{context}" == "{project-context}"]
 endif::[]
 endif::[]
 
-ifdef::katello,satellite[]
+ifdef::katello[]
 ifeval::["{context}" == "{project-context}"]
 * A minimum of 20 GB RAM is required for {ProjectServer} to function.
 In addition, a minimum of 4 GB RAM of swap space is also recommended.
@@ -30,7 +30,7 @@ In addition, a minimum of 4 GB RAM of swap space is also recommended.
 endif::[]
 endif::[]
 
-ifdef::katello,satellite[]
+ifdef::katello[]
 * A unique host name, which can contain lower-case letters, numbers, dots (.) and hyphens (-)
 endif::[]
 
@@ -50,20 +50,20 @@ The freshly provisioned system must not have the following users provided by ext
 * foreman
 * foreman-proxy
 * postgres
-ifdef::katello,satellite[]
+ifdef::katello[]
 * pulp
 endif::[]
 * puppet
 * puppetserver
-ifdef::katello,satellite[]
+ifdef::katello[]
 * qdrouterd
 endif::[]
-ifdef::katello,satellite[]
+ifdef::katello[]
 ifeval::["{context}" == "{project-context}"]
 * qpidd
 endif::[]
 endif::[]
-ifdef::katello,satellite[]
+ifdef::katello[]
 ifeval::["{context}" == "{project-context}"]
 * tomcat
 endif::[]
@@ -83,7 +83,7 @@ For more information about certified hypervisors, see https://access.redhat.com/
 
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 .SELinux Mode
 SELinux must be enabled, either in enforcing or permissive mode.
 Installation with disabled SELinux is not supported.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/proc_estimating-the-size-of-a-backup.adoc
@@ -2,7 +2,7 @@
 
 = Estimating the Size of a Backup
 
-ifndef::satellite,orcharhino[]
+ifndef::katello[]
 Note that estimations in this section are for the installations that use the Katello plug-in.
 endif::[]
 

--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
@@ -13,7 +13,7 @@ endif::[]
 .Prerequisites
 * The {Project} user that generates the `curl` command must have the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
-ifdef::satellite,orcharhino[]
+ifdef::katello[]
 * You must have an activation key created.
 * Optional: If you want to register hosts to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL7Server}` repository and make it available in the activation key that you use.
 This is required to install the `insights-client` package on hosts.
@@ -75,7 +75,7 @@ If you keep this field blank, {Project} uses the default network interface.
 . Optional: *Repository* - A repository to be added before the registration is performed. For example, it can be useful to make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository. For example, http://rpm.example.com/. For Debian OS families, it's the whole list file content, for example 'deb http://deb.example.com/ buster 1.0'.
 . Optional: *Repository GPG key URL* - If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header.
 
-ifdef::satellite,orcharhino[]
+ifdef::katello[]
 . In the *Activation Key(s)* field, enter one or more activation keys to assign to hosts.
 . Optional: *Lifecycle environment*
 . Optional: *Ignore errors* - Ignore subscription manager errors


### PR DESCRIPTION
This allows ifdef::katello for Katello-plugin-only installs while still including those in Satellite and Orcharhino builds. It also allows ifndef::katello for vanilla Foreman installations.

Right now this PR is incomplete, but I want to submit it for consideration just as an idea (rather than the exact implementation). What do you think?