### PR TITLE
Adapt Admin guide for Katello and Foreman-EL

### DIFF
--- a/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
@@ -4,7 +4,7 @@ ifdef::context[:parent-context: {context}]
 = Migrating from Internal {Project} Databases to External Databases
 
 ifdef::foreman-el,katello[]
-For Red Hat systems only.
+For {RHEL} 7 systems only.
 endif::[]
 
 When you install {ProjectName}, the *{foreman-installer}* command installs PostgreSQL databases on the same server as {Project}.

--- a/guides/doc-Administering_Red_Hat_Satellite/master.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/master.adoc
@@ -9,9 +9,11 @@ include::common/header.adoc[]
 
 include::topics/Accessing_Satellite.adoc[]
 
+ifndef::foreman-deb[]
 include::topics/Starting_and_Stopping_Satellite.adoc[]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_using-satellite-ansible-content-collections.adoc[leveloffset=+1]
 
@@ -19,13 +21,18 @@ include::topics/Users_and_Roles.adoc[]
 
 include::topics/configuring-email-notifications.adoc[]
 
+ifndef::foreman-deb[]
 include::topics/Security_Compliance_Management.adoc[]
 
 include::topics/assembly_backing-up-satellite-server-and-capsule-server.adoc[]
 
+endif::[]
+
 include::topics/Backup_Disaster_Recovery.adoc[]
 
+ifdef::satellite,katello,orcharhino[]
 include::topics/Renaming_a_Server.adoc[]
+endif::[]
 
 include::topics/Maintenance.adoc[]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Accessing_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Accessing_Satellite.adoc
@@ -3,7 +3,7 @@
 
 After {ProjectName} has been installed and configured, use the web user interface to log in to {Project} for further configuration.
 
-include::Logging_in_to_Red_Hat_Satellite.adoc[]
+include::Logging_in.adoc[]
 
 include::Changing_the_Password.adoc[]
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_and_Reporting_Problems.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_and_Reporting_Problems.adoc
@@ -3,7 +3,14 @@
 
 This chapter provides information on how to log and report problems in {ProjectName} Server, including information on relevant log files, how to enable debug logging, how to open a support case and attach the relevant log tar files, and how to access support cases within the {ProjectWebUI}.
 
+ifdef::satellite[]
 You can use the log files and other information described in this chapter to do your own troubleshooting, or you can capture these and many more files, as well as diagnostic and configuration information, to send to Red{nbsp}Hat Support if you need further assistance.
+endif::[]
+
+ifndef::satellite[]
+You can use the log files and other information described in this chapter to do your own troubleshooting.
+endif::[]
+
 
 For more information about {Project} logging settings, use `{foreman-installer}` with the `--full-help` option:
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_in.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_in.adoc
@@ -1,3 +1,5 @@
+ifdef::satellite,katello,orcharhino[]
+
 [[sect-Administering-Installing_the_Katello_Root_CA_Certificate]]
 === Installing the Katello Root CA Certificate
 
@@ -47,15 +49,20 @@ _username@hostname:remotefile_
 
 . In the browser, import the `katello-server-ca.crt` certificate as a certificate authority and trust it to identify websites.
 
+endif::[]
+
 [[sect-Administering-Logging_on_to_Satellite]]
 === Logging on to {Project}
 
 Use the web user interface to log on to {Project} for further configuration.
 
+ifdef::satellite,katello,orcharhino[]
 .Prerequisites
 
 Ensure that the Katello root CA certificate is installed in your browser.
 For more information, see xref:sect-Administering-Installing_the_Katello_Root_CA_Certificate[].
+
+endif::[]
 
 .Procedure
 
@@ -85,8 +92,10 @@ Use the navigation tabs to browse the {ProjectWebUI}.
 If no organization or location is selected, the default organization is _Any Organization_ and the default location is _Any Location_.
 Use this tab to change to different values.
 | *Monitor*  | Provides summary dashboards and reports.
+ifdef::satellite,katello,orcharhino[]
 | *Content*  | Provides content management tools.
 This includes Content Views, Activation Keys, and Life Cycle Environments.
+endif::[]
 | *Hosts*  | Provides host inventory and provisioning configuration tools.
 | *Configure*  | Provides general configuration tools and data including Host Groups and Puppet data.
 | *Infrastructure*  | Provides tools on configuring how {ProjectX} interacts with the environment.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Starting_and_Stopping_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Starting_and_Stopping_Satellite.adoc
@@ -22,6 +22,14 @@ Alternatively, you can also use `systemctl` to start and stop services:
 # systemctl stop foreman.service foreman.socket
 ----
 
+However, services like dynflow still continue to run if you use `systemctl`.
+You must target directly, for example:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl stop dynflow-sidekiq@*
+----
+
 endif::[]
 
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Starting_and_Stopping_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Starting_and_Stopping_Satellite.adoc
@@ -5,7 +5,30 @@
 This is useful when creating a backup of {Project}.
 For more information on creating backups, see xref:backing-up-satellite-server-and-capsule-server[].
 
+ifdef::foreman-el,katello[]
+.Prerequisite
+This section uses the `{foreman-maintain}` command.
+To use the commands in this section, you must install `{foreman-maintain}`, for example:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# yum install `{foreman-maintain}`
+----
+
+Alternatively, you can also use `systemctl` to start and stop services:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl stop foreman.service foreman.socket
+----
+
+endif::[]
+
+
+ifdef::satellite,orcharhino[]
 After installing {Project} with the `{foreman-installer}` command, all {Project} services are started and enabled automatically.
+endif::[]
+
 View the list of these services by executing:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/log-files-provided-by-satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/log-files-provided-by-satellite.adoc
@@ -10,15 +10,22 @@
 [options="header"]
 |===
 | Log File Directories | Description of Log File Content
+ifndef::foreman-el,foreman-deb[]
 | `/var/log/candlepin` | Subscription management
+| `/var/log/tomcat` | Candlepin webservice logs
+endif::[]
 | `/var/log/foreman` | Foreman
 | `/var/log/foreman-proxy` | Foreman proxy
 | `/var/log/httpd` | Apache HTTP server
 | `/var/log/foreman-installer` | Installer
 | `/var/log/puppet` | Configuration management
+ifndef::foreman-deb[]
 | `/var/log/rhsm` | Subscription management
-| `/var/log/tomcat` | Candlepin webservice logs
 | `/var/log/messages` | Various other log messages
+endif::[]
+ifdef::foreman-deb[]
+| `/var/log/daemon.log` | Various other log messages
+endif::[]
 |===
 
 You can also use the `foreman-tail` command to follow many of the log files related to {Project}.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/log-files-provided-by-satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/log-files-provided-by-satellite.adoc
@@ -16,9 +16,14 @@ ifndef::foreman-el,foreman-deb[]
 endif::[]
 | `/var/log/foreman` | Foreman
 | `/var/log/foreman-proxy` | Foreman proxy
+ifndef::foreman-deb[]
 | `/var/log/httpd` | Apache HTTP server
+endif::[]
+ifdef::foreman-deb[]
+| `/var/log/apache2` | Apache HTTP server
+endif::[]
 | `/var/log/foreman-installer` | Installer
-| `/var/log/puppet` | Configuration management
+| `/var/log/puppetlabs/puppet` | Configuration management
 ifndef::foreman-deb[]
 | `/var/log/rhsm` | Subscription management
 | `/var/log/messages` | Various other log messages


### PR DESCRIPTION
Based on the comments here: https://github.com/theforeman/theforeman.org/pull/1879#discussion_r690316318

And in line with what was described in #676, this PR is to adapt the Admin guide to meet the requirements of foreman-el and katello scenarios. 

There are a few comments I need further guidance on: 

#### Admin guide, chapter 2:  I don't know what prerequisite to add: 
To use this section, you must have foreman-maintain installed (how do they do that?)
And is there an alternative method? I can add that in?
At the moment, i've just added an ifndef for foreman-deb builds for Chapter 2.

#### Chapter 5.4.5. - I'll add a new issue to address this. I don't know how to improve it. It's out of scope 

Regarding: 
>Chapter 8: again, RPM-only due to foreman-maintain usage. Mention of /root/ssl-build and various other 
> directories makes it Katello-only. /var/opt/rh/rh-postgresql12 makes it EL7 only.
>
I've ifndef'd it to stream it out of foreman-deb
I'd happily add in alternative directories if anyone can provide me with the info. 

#### Chapter 13.3.3 & Chapter 13.7 - out of scope for now - l do not know how to make it better. I'll create an issue. 

I added in the debian logs and excluded debian where I was certain. The scope of this PR is not to have it complete for Debian. I was just trying to be helpful and clean what I could. 


Cherry-pick into:

* [x] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
