### PR TITLE
Deprecation: remove Repository Background download policy references

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -90,7 +90,7 @@ Clear this field if the repository does not require authentication.
 | *Option* | *Description*
 
 | `--checksum-type` _sha_version_                 | Repository checksum, currently 'sha1' & 'sha256' are supported
-| `--download-policy` _policy_name_       | Download policy for yum repos (either 'immediate', 'on_demand', or 'background').
+| `--download-policy` _policy_name_       | Download policy for yum repos (either 'immediate' or 'on_demand').
 | `--gpg-key` _gpg_key_name_                  | Key name to search by
 | `--gpg-key-id` _gpg_key_id_                 | GPG key numeric identifier
 | `--mirror-on-sync` _boolean_         | Must this repo be mirrored from the source, and stale RPMs removed, when synced? Set to `true` or `false`, `yes` or `no`, `1` or `0`.

--- a/guides/doc-Content_Management_Guide/topics/appendix-Importing_Content_ISOs_into_Connected_Satellite.adoc
+++ b/guides/doc-Content_Management_Guide/topics/appendix-Importing_Content_ISOs_into_Connected_Satellite.adoc
@@ -5,7 +5,7 @@
 Even if {ProjectServer} can connect directly to the Red{nbsp}Hat Customer Portal, you can perform the initial synchronization from locally mounted content ISOs.
 When the initial synchronization is completed from the content ISOs, you can switch back to downloading content through the network connection.
 To accomplish this, download the Content ISOs for {ProjectName} from the Red{nbsp}Hat Customer Portal and import them into {ProjectServer}.
-For locations with bandwidth limitations, using an *On Demand* or *Background* download policy might be more efficient than downloading and importing Content ISOs.
+For locations with bandwidth limitations, using an *On Demand* download policy might be more efficient than downloading and importing Content ISOs.
 
 [IMPORTANT]
 You can only import content ISO images for Red{nbsp}Hat Enterprise Linux 8 because repodata checksum from CDN does not match the repodata checksum from the content ISO images for Red{nbsp}Hat Enterprise Linux 7 and lower.

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -125,9 +125,8 @@ Red{nbsp}Hat repositories are signed with GPG keys by default, and it is recomme
 The configuration of custom repositories depends on the type of content they hold (RPM packages, or Docker images).
 
 Repositories configured as `yum` repositories, that contain only RPM packages, can make use of the new download policy setting to save on synchronization time and storage space.
-This setting enables selecting from *Immediate*, *On demand*, and *Background*.
+This setting enables selecting from *Immediate* and *On demand*.
 The *On demand* setting saves space and time by only downloading packages when requested by clients.
-The *Background* setting saves time by completing the download after the initial synchronization.
 For detailed instructions on setting up content sources see {ContentManagementDocURL}Importing_Content[Importing Content] in the _Content Management Guide_.
 
 A custom repository within {ProjectServer} is in most cases populated with content from an external staging server.

--- a/guides/doc-Planning_Guide/topics/Glossary.adoc
+++ b/guides/doc-Planning_Guide/topics/Glossary.adoc
@@ -212,8 +212,8 @@ Every job is defined in a job template.
 *Katello*:: A Foreman plug-in responsible for subscription and repository management.
 
 
-*Lazy Sync*:: The ability to change a `yum` repository's default download policy of *Immediate* to *On Demand* or *Background*.
-The *On Demand* setting saves storage space and synchronization time by only downloading the packages when requested by a client, and the *Background* setting saves synchronization time by downloading packages after synchronizing the repository's metadata.
+*Lazy Sync*:: The ability to change a `yum` repository's default download policy of *Immediate* to *On Demand*.
+The *On Demand* setting saves storage space and synchronization time by only downloading the packages when requested by a client.
 
 
 [[varl-Glossary_of_Terms-Location]]


### PR DESCRIPTION
With the move to Pulp 3, the Background download policy has been removed from repositories.  This commit will remove references in the documentation to that download policy.

For any existing repositories that a user may have with 'Download Policy = Background', the upgrade will update them to 'Download Policy = Immediate'.  With this change, the process to fully complete a repository synchronization may appear to take longer as the sync will not be considered completed until all content in the repository is downloaded.


Cherry-pick into:

* [ ] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
