### PR TITLE
Fix description of a Smart Proxy

### DIFF
--- a/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_Guide/topics/Capsule_Server_Overview.adoc
@@ -21,20 +21,20 @@ endif::[]
 
 Infrastructure and host management services:
 
-* *DHCP* – {SmartProxy} can act as a DHCP server or it can integrate with an existing solution, including ISC DHCP servers, Active Directory, and Libvirt instances.
+* *DHCP* – {SmartProxy} can manage a DHCP server, including integration with an existing solution such as ISC DHCP servers, Active Directory, and Libvirt instances.
 
-* *DNS* – {SmartProxy} can act as a DNS server or it can integrate with an existing solution, including ISC BIND and Active Directory.
+* *DNS* – {SmartProxy} can manage a DNS server, including integration with an existing solution such as ISC BIND and Active Directory.
 
-* *TFTP* – {SmartProxy} can act as a TFTP server or integrate with any UNIX-based TFTP server.
+* *TFTP* – {SmartProxy} can integrate with any UNIX-based TFTP server.
 
 * *Realm* – {SmartProxy} can manage Kerberos realms or domains so that hosts can join them automatically during provisioning.
 {SmartProxy} can integrate with an existing infrastructure, including {FreeIPA} and Active Directory.
 
 * *Puppet server* – {SmartProxy} can act as a configuration management server by running Puppet server.
 
-* *Puppet Certificate Authority* – {SmartProxy} can act as a Puppet CA to provide certificates to hosts.
+* *Puppet Certificate Authority* – {SmartProxy} can integrate with Puppet's CA to provide certificates to hosts.
 
-* *Baseboard Management Controller (BMC)* – {SmartProxy} can provide power management for hosts.
+* *Baseboard Management Controller (BMC)* – {SmartProxy} can provide power management for hosts using IPMI or Redfish.
 
 * *Provisioning template proxy* – {SmartProxy} can serve provisioning templates to hosts.
 


### PR DESCRIPTION
The Smart Proxy can not act as a DHCP, DNS, or TFTP server. It can only integrate with one. I wrote this before I saw a real world example, but yesterday we had a user who had the impression Foreman Proxy actually was the service.

For downstream it's a bit more murky where the Capsule concept is arguably different from just Smart Proxy. Still, if anything it still deploys ISC DHCP or ISC BIND on the Capsule and integrates with it. This should be made clear to the reader.

IMHO this is true for all versions, but soon we'll only support 3.0 and 2.5 upstream. Downstream 6.9 is GA so I'd rather not change that.

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)