### PR TITLE
Correct installation links for Debian

### DIFF
--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -4,8 +4,8 @@
 :ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/{BaseFilenameURL}#
 :ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
 :ContentManagementDocURL: {BaseURL}Content_Management_Guide/{BaseFilenameURL}#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/{BaseFilenameURL}#
-:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/{BaseFilenameURL}#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Debian/{BaseFilenameURL}#
+:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Debian/{BaseFilenameURL}#
 :ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
 :PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
 :ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->