### PR TITLE
Remove leftover line from cherry-pick

### DIFF
--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -7,7 +7,7 @@ You can install the Katello agent to remotely update {Project} clients.
 NOTE: The Katello agent is deprecated and will be removed in a future {Project} version.
 Migrate your processes to use the remote execution feature to update clients remotely.
 For more information, see {ManagingHostsDocURL}migrating-from-katello-agent-to-remote-execution_managing-hosts[Migrating from Katello Agent to Remote Execution] in the _Managing Hosts Guide_.
-====
+
 
 The `katello-agent` package depends on the `gofer` package that provides the `goferd` service.
 


### PR DESCRIPTION
When cherry-picking changes in #444 I had to resolve several
conflicts and one small codeline remained. This is now fixed.


Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
