### PR TITLE
Correct directory path

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/proc_estimating-the-size-of-a-backup.adoc
@@ -57,7 +57,7 @@ The following table describes the compression ratio of all data items included i
 a|`/var/lib/qpidd` +
 `/var/lib/tftpboot` +
 `/etc` +
-`/root-ssl/build` +
+`/root/ssl-build` +
 `/var/www/html/pub` +
 `/opt/puppetlabs`
 |85%


### PR DESCRIPTION
This was introduced in 9c4054406c9076db5abb2447dd09f4d4b8f135a6 so I'm assuming it should be picked to all to all branches. However, for now I'm just selecting the supported branches.

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)