### PR TITLE
Correct version numbers for nightly

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,13 +1,13 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: stable
+:DocState: nightly
 
 // Version numbers
-:ProjectVersion: 3.0
-:ProjectVersionPrevious: 2.5
-:KatelloVersion: 4.2
-:TargetVersion: 7.0
-:TargetVersionMaintainUpgrade: 7.0
+:ProjectVersion: nightly
+:ProjectVersionPrevious: 3.0
+:KatelloVersion: nightly
+:TargetVersion: {ProjectVersion}
+:TargetVersionMaintainUpgrade: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9
 // For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub


### PR DESCRIPTION
00de02be190de55babef8d6ac23380e7682a4a81 changed this to stable versions, but this branch is still the nightly branch.

This only affects master.