### PR TITLE
Add existing hosts when creating an app instance

### DIFF
--- a/guides/common/modules/proc_creating_an_application_instance.adoc
+++ b/guides/common/modules/proc_creating_an_application_instance.adoc
@@ -6,10 +6,15 @@ You can create xref:{context}_application_instances[application instances] as a 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Application > App Instances* and click the *New Application Instance* button.
 . In the *Name* field, enter the name of the new application instance.
-. In the *Description* field, enter an arbitrary description.
+. Optional: In the *Description* field, enter an arbitrary description.
 . From the *Application Definition* menu, select an existing application definition.
-. In the table, connect the hosts and necessary services:
-.. In the *Hostname* field, enter a unique name for the host.
+. In the table, connect the hosts and necessary services.
+You can either assign existing hosts to your application instance or deploy new hosts.
+.. To assign an existing host to a service, click on the *Server* icon.
+Select both a service and existing host, and click *Save*.
+.. Optional: Click the *A* character to edit, add, lock, or delete Ansible group variables.
+Note that you cannot change host parameters as existing hosts are not redeployed but only reconfigured using Ansible.
+.. Alternatively, in the *Hostname* field, enter a unique name for the host.
 You can enter lowercase characters, digits, and hyphens.
 Hosts cannot start with a hyphen.
 .. In the *Description* field, enter a description.


### PR DESCRIPTION
This PR documents a new feature for ACD: Adding existing hosts to your app instance.