### PR TITLE
Add Ansible variables from different namespaces to ACD

### DIFF
--- a/guides/common/modules/proc_creating_an_application_instance.adoc
+++ b/guides/common/modules/proc_creating_an_application_instance.adoc
@@ -24,8 +24,14 @@ Refer to the list of services in the top right corner.
 ... click the *edit* icon to edit an entry;
 ... click the *settings* icon to add or edit existing {ProjectName} parameters.
 Every hierarchy level of {ProjectName} parameters can be overwritten.
-... click the *A* character to edit, add, lock, or delete Ansible group variables;
-... click the *delete* icon to delete an entry.
+... Click the *A* character to edit, add, lock, or delete Ansible group variables.
++
+You can refer to any {Project} parameter using `PARAM[_name_of_your_parameter_]`, for example, based on an operating system or a host group.
+The {Project} parameter name cannot contain whitespace.
++
+When the host is configured, ACD gets the value for the variable `_name_of_your_parameter_`.
+When you deploy your application instance or reconfigure it afterwards, navigate to the *Preview templates* tab to check if the parameters are resolved correctly.
+... Click the *delete* icon to delete an entry.
 . Click the *A* character to view and edit the corresponding Ansible group variables.
 You may edit unlocked values.
 . Click *Submit* to save your application instance.


### PR DESCRIPTION
This PR documents using Ansible variables from different namespaces in ACD.
This allows you to refer to Foreman Host Parameters from Host Groups, Operating Systems, Locations, and Organizations.