### PR TITLE
Ribbon for RC and unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Foreman documentation
 
-THIS IS A WORK IN PROGRESS. VISIT THE OFFICIAL [FOREMAN OR KATELLO DOCUMENTATION](https://theforeman.org/documentation.html) IF YOU ARE SEEKING HELP.
-
-This git repository contains PoC of improving Foreman documentation.
+This repository and `docs.theforeman.org` site contains work in progress content.
+Some guides, specifically those marked with a `DRAFT` ribbon in the top-right corner, may contain irrelevant or incorrect information.
+If you see such guide, please visit the official [Foreman documentation](https://theforeman.org/documentation.html).
+Feel free to open a PR or issue on Github.
 
 ## Foreman Guides
 

--- a/guides/common/docinfo.html
+++ b/guides/common/docinfo.html
@@ -4,5 +4,28 @@ if (rl.includes("/master/") || rl.includes("/nightly/") || rl.includes("file://"
   document.open();
   document.write("<span id=\"ribbon\"><a href=\"https://github.com/theforeman/foreman-documentation/tree/master/guides\">Nightly</a></span>");
   document.close();
+} else if (rl.includes("/3.2/")) {
+  document.open();
+  document.write("<span id=\"ribbon\"><a href=\"https://github.com/theforeman/foreman-documentation/tree/master/guides\">RC</a></span>");
+  document.close();
+} else if (
+  rl.includes("/Installing_Proxy_on_Red_Hat/index-foreman-el.html") ||
+  rl.includes("/Installing_Proxy_on_Debian/index-foreman-deb.html") ||
+  rl.includes("/Planning_Guide/index-foreman-el.html") ||
+  rl.includes("/Planning_Guide/index-foreman-deb.html") ||
+  rl.includes("/Upgrading_and_Updating/index-foreman-el.html") ||
+  rl.includes("/Upgrading_and_Updating/index-foreman-deb.html") ||
+  rl.includes("/Configuring_Load_Balancer/index-foreman-el.html") ||
+  rl.includes("/Configuring_Load_Balancer/index-foreman-deb.html")) {
+  /* draft guide builds */
+  document.open();
+  document.write("<span id=\"ribbon\"><a href=\"https://github.com/theforeman/foreman-documentation#foreman-documentation\">Draft</a></span>");
+  document.close();
+} else if (rl.includes("/3.1/") || rl.includes("/3.0/")) {
+  /* stable and supported release - no ribbon */
+} else {
+  document.open();
+  document.write("<span id=\"ribbon\"><a href=\"https://docs.theforeman.org\">Unsupported</a></span>");
+  document.close();
 }
 </script>


### PR DESCRIPTION
This add ribon "RC" and "Unsupported" according to URL. This is hacky, but it allows us to avoid forking HTML/CSS template. Unfortunately, asciidoc syntax (and attributes) cannot be used in this header "snippet", ideally, this should have been an attribute.

Fixes #695