### PR TITLE
Document how to enable Katello Agent infrastructure

### DIFF
--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -7,8 +7,8 @@ ifdef::context[:parent-context: {context}]
 Use this chapter to configure additional settings on your {SmartProxyServer}.
 
 ifdef::katello,satellite[]
-// Installing the Katello Agent
-include::modules/proc_installing-the-katello-agent.adoc[leveloffset=+1]
+// Enabling Katello Agent Infrastructure
+include::modules/proc_enabling-katello-agent.adoc[leveloffset=+1]
 endif::[]
 
 // Enabling OpenSCAP

--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -35,6 +35,10 @@ An internal label that matches the value is also created and cannot be changed a
 If you do not specify a value, an organization called *Default Organization* with the label *Default_Organization* is created.
 You can rename the organization name but not the label.
 
+ifdef::satellite,katello[]
+* Remote Execution is the primary method of managing packages on Content Hosts. If you want to use the deprecated Katello Agent instead of Remote Execution SSH, use the `--foreman-proxy-content-enable-katello-agent=true` option to enable it. The same option should be given on any {SmartProxyServer} as well as {ProjectServer}.
+endif::[]
+
 * By default, all configuration files configured by the installer are managed by Puppet.
 When `{foreman-installer}` runs, it overwrites any manual changes to the Puppet managed files with the initial values.
 By default, {ProjectServer} is installed with the Puppet agent running as a service.

--- a/guides/common/modules/proc_enabling-katello-agent.adoc
+++ b/guides/common/modules/proc_enabling-katello-agent.adoc
@@ -1,0 +1,15 @@
+[id="enabling-katello-agent_{context}"]
+
+= Enabling Katello Agent on External {SmartProxies}
+
+Remote Execution is the primary method of managing packages on Content Hosts. To be able to use the deprecated Katello Agent it must be enabled on each {SmartProxy}.
+
+.Procedure
+
+* To enable Katello Agent infrastructure, enter the following command:
++
+[options="nowrap" subs="quotes,attributes"]
+----
+# {installer-scenario-smartproxy} \
+--foreman-proxy-content-enable-katello-agent=true
+----


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
