### PR TITLE
Fix link to registration doc in Configuring_Ansible guide

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -29,7 +29,7 @@ Use one of the following methods to distribute the public SSH key from {SmartPro
 . xref:using-the-api-to-obtain-ssh-keys-for-remote-execution_{context}[].
 . xref:configuring-a-kickstart-template-to-distribute-ssh-keys-during-provisioning_{context}[].
 . For new {Project} hosts, you can deploy SSH keys to {Project} hosts during registration using the global registration template.
-For more information, see {ManagingHostsDocURL}registering-a-host-to-project-using-the-global-registration-template_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template].
+For more information, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template].
 
 {Project} distributes SSH keys for the remote execution feature to the hosts provisioned from {Project} by default.
 


### PR DESCRIPTION
Fixed only for 2.5, `nightly` and `2.4` are ok

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
