### PR TITLE
Wrap the Debian reference for exclusion from Sat

### DIFF
--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
@@ -72,7 +72,11 @@ If you keep this field blank, {Project} uses the default network interface.
 . Optional: *Install packages* - Install packages on the host when registered. Can be set by `host_packages` parameter
 
 . Optional: *Update packages* - Update packages on the host when registered. Can be set by `host_update_packages` parameter
-. Optional: *Repository* - A repository to be added before the registration is performed. For example, it can be useful to make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository. For example, http://rpm.example.com/. For Debian OS families, it's the whole list file content, for example 'deb http://deb.example.com/ buster 1.0'.
+. Optional: *Repository* - A repository to be added before the registration is performed. For example, it can be useful to make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository.
+For example, http://rpm.example.com/.
+ifndef::satellite[]
+For Debian OS families, it's the whole list file content, for example 'deb http://deb.example.com/ buster 1.0'.
+endif::[]
 . Optional: *Repository GPG key URL* - If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header.
 
 ifdef::satellite,orcharhino[]


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [x] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
