### PR TITLE
adds satellite conditional to rhel-7 section

### DIFF
--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -32,7 +32,7 @@ include::proc_installing-server-packages-el.adoc[]
 
 endif::[]
 
-ifdef::foreman-el,katello[]
+ifdef::foreman-el,katello,satellite[]
 == [[rhel-7]]Red Hat Enterprise Linux 7
 
 :context: rhel7


### PR DESCRIPTION
Satellite (Pantheon) docbook.xml is failing validation because this conditional does not include satellite


Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)
* [ ] Foreman 2.1 (Satellite 6.8)

