### PR TITLE
Rework content management guide

### DIFF
--- a/guides/common/assembly_converting-a-host-with-convert2rhel.adoc
+++ b/guides/common/assembly_converting-a-host-with-convert2rhel.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="assembly_converting-a_host-with-convert2rhel_{context}"]
 = Converting a Host to {RHEL} with Convert2RHEL
 
-Convert2RHEL enables the conversion of Red Hat Enterprise Linux derivative distributions into a supportable {RHEL} state while retaining existing applications and configurations.
+Convert2RHEL enables the conversion of {RHEL} derivative distributions into a supportable {RHEL} state while retaining existing applications and configurations.
 
 The conversion process is similar to a minor release upgrade of {RHEL} in which every RPM package on the system is replaced.
 Third-party packages and non-{Team} packages not available in {RHEL} are not replaced.

--- a/guides/common/assembly_importing-kickstart-repositories.adoc
+++ b/guides/common/assembly_importing-kickstart-repositories.adoc
@@ -4,11 +4,11 @@ ifdef::context[:parent-context: {context}]
 = Importing Kickstart Repositories
 
 Kickstart repositories are not provided by the Content ISO image.
-To use Kickstart repositories in your disconnected {Project}, you must download a binary DVD ISO file for the version of Red{nbsp}Hat Enterprise Linux that you want to use and copy the Kickstart files to {Project}.
+To use Kickstart repositories in your disconnected {Project}, you must download a binary DVD ISO file for the version of {RHEL} that you want to use and copy the Kickstart files to {Project}.
 
-To import Kickstart repositories for Red{nbsp}Hat Enterprise Linux 7, complete xref:importing-kickstart-repositories_rhel-7[].
+To import Kickstart repositories for {RHEL} 7, complete xref:importing-kickstart-repositories_rhel-7[].
 
-To import Kickstart repositories for Red{nbsp}Hat Enterprise Linux 8, complete xref:importing-kickstart-repositories_rhel-8[].
+To import Kickstart repositories for {RHEL} 8, complete xref:importing-kickstart-repositories_rhel-8[].
 
 :rhel-version: 7
 :context: rhel-7

--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -1,5 +1,4 @@
 [id="adding-life-cycle-environments_{context}"]
-
 = Adding Life Cycle Environments to {SmartProxyServer}s
 
 ifdef::katello[]
@@ -14,7 +13,6 @@ This might consume multiple system resources on {SmartProxies}, network bandwidt
 You can use Hammer CLI on {ProjectServer} or the {ProjectWebUI}.
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} that you want to add a life cycle to.
 . Click *Edit* and click the *Life Cycle Environments* tab.
 . From the left menu, select the life cycle environments that you want to add to {SmartProxy} and click *Submit*.
@@ -24,7 +22,6 @@ You can use Hammer CLI on {ProjectServer} or the {ProjectWebUI}.
 For definitions of each synchronization type, see {ContentManagementDocURL}Importing_Content-Recovering_a_Repository[Recovering a Repository].
 
 .CLI procedure
-
 . To display a list of all {SmartProxyServer}s, on {ProjectServer}, enter the following command:
 +
 [options="nowrap"]
@@ -39,14 +36,12 @@ Note the {SmartProxy} ID of the {SmartProxy} that you want to add a life cycle t
 ----
 # hammer capsule info --id _capsule_id_
 ----
-+
 . To view the life cycle environments available for your {SmartProxyServer}, enter the following command and note the ID and the organization name:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer capsule content available-lifecycle-environments --id _capsule_id_
 ----
-+
 . Add the life cycle environment to your {SmartProxyServer}:
 +
 [options="nowrap" subs="+quotes"]
@@ -57,7 +52,6 @@ Note the {SmartProxy} ID of the {SmartProxy} that you want to add a life cycle t
 ----
 +
 Repeat for each life cycle environment you want to add to {SmartProxyServer}.
-+
 . Synchronize the content from {Project} to {SmartProxy}.
 +
 * To synchronize all content from your {ProjectServer} environment to {SmartProxyServer}, enter the following command:

--- a/guides/common/modules/proc_configuring-satellite-to-synchronize-content-with-a-local-cdn-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-synchronize-content-with-a-local-cdn-server.adoc
@@ -8,63 +8,48 @@ You can host the local CDN server on the base operating system of {ProjectServer
 Next, you must configure {ProjectServer} to synchronize content with the local CDN server.
 
 .Procedure
-
 . Log on to the Red{nbsp}Hat Customer Portal at https://access.redhat.com.
-
 . In the upper left of the window, click *Downloads* and select *{ProjectName}*.
-
 . Click the *Content ISOs* tab.
 This page lists all the products that are available in your subscription.
-
 . Click the link for the product name, such as *Red Hat Enterprise Linux 7 Server (x86_64)* to download the ISO image.
-
 . Copy all of {Project} Content ISO images to a system that you want to use as a local CDN server.
 For example, the `/root/isos` directory on {ProjectServer}.
 +
 Note that storing the content on the same system where {Project} is installed is not a requirement.
 The CDN can be hosted on a different system inside the same disconnected network as long as it is accessible to {ProjectServer} over HTTP.
-
 . On the system that you want to use as your local CDN server, create a local directory that is accessible over httpd.
 For example, `/var/www/html/pub/sat-import/`:
 +
 ----
 # mkdir -p /var/www/html/pub/sat-import/
 ----
-
 . Create a mount point and temporarily mount the ISO image at that location:
 +
 ----
 # mkdir /mnt/iso
 # mount -o loop /root/isos/first_iso /mnt/iso
 ----
-
 . Recursively copy content of the first ISO image to the local directory:
 +
 ----
 # cp -ruv /mnt/iso/* /var/www/html/pub/sat-import/
 ----
-
 . If you do not plan to use the mounted binary DVD ISO image, unmount and remove the mount point:
 +
 ----
 # umount /mnt/iso
 # rmdir /mnt/iso
 ----
-
 . Repeat the above step for each ISO image until you have copied all the data from the Content ISO images into `/var/www/html/pub/sat-import/`.
-
 . Ensure that the SELinux context for the directory is correct:
 +
 ----
 # restorecon -rv /var/www/html/pub/sat-import/
 ----
-
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*.
-
 . Click *Manage Manifest*.
-
 . Edit the *Red Hat CDN URL* field to point to the host name of the system that you use as a local CDN server with the newly created directory, for example:
 +
 `\http://server.example.com/pub/sat-import/`
-
 . Click *Update* and then upload your manifest into {Project}.

--- a/guides/common/modules/proc_creating-a-host-activation-key.adoc
+++ b/guides/common/modules/proc_creating-a-host-activation-key.adoc
@@ -4,7 +4,7 @@
 Use this procedure to create an activation key for the hosts to use.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* *>* *{Team} Repositories*.
+. In the {ProjectWebUI}, navigate to *Content* *>* *Red Hat Repositories*.
 . Enable the {RHEL} 7 Server repository.
 . In the {ProjectWebUI}, navigate to *Content* *>* *Activation keys* and click *Create Activation Key*.
 . In the *Name* field, enter the name of the host activation key.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc
@@ -9,7 +9,6 @@ This is for users of the Katello plug-in and Red Hat operating systems only.
 endif::[]
 
 .Prerequisites
-
 * You must have a Subscription Manifest file exported from the Customer Portal.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/using_red_hat_subscription_management/using_manifests_con[Using Manifests] in the _Using Red Hat Subscription Management_ guide.
 ifeval::["{mode}" == "disconnected"]
@@ -18,7 +17,6 @@ For more information, see xref:enabling-the-disconnected-mode_{project-context}[
 endif::[]
 
 .Procedure
-
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.
 . Navigate to *Content* > *Subscriptions* and click *Manage Manifest*.
 . In the Manage Manifest window, click *Browse*.
@@ -26,14 +24,12 @@ endif::[]
 If the Manage Manifest window does not close automatically, click *Close* to return to the Subscriptions window.
 
 .CLI procedure
-
 . Copy the Subscription Manifest file from your client to {ProjectServer}:
 +
 [subs="+quotes,attributes"]
 ----
 $ scp ~/_manifest_file_.zip root@_{foreman-example-com}_:~/.
 ----
-+
 . Log in to {ProjectServer} as the `root` user and import the Subscription Manifest file:
 +
 [subs="+quotes"]

--- a/guides/common/modules/proc_importing-kickstart-repositories.adoc
+++ b/guides/common/modules/proc_importing-kickstart-repositories.adoc
@@ -1,30 +1,24 @@
 [id="importing-kickstart-repositories_{context}"]
-= Importing Kickstart Repositories for Red{nbsp}Hat Enterprise Linux{nbsp}{rhel-version}
+= Importing Kickstart Repositories for {RHEL}{nbsp}{rhel-version}
 
 To import Kickstart repositories for Red{nbsp}Hat Enterprise Linux{nbsp}{rhel-version}, complete the following steps on {Project}.
 
 .Procedure
-
 . Navigate to the Red{nbsp}Hat Customer Portal at https://access.redhat.com/ and log in.
-
 . In the upper left of the window, click *Downloads*.
 
 ifeval::["{rhel-version}" == "8"]
 . Click *Red Hat Enterprise Linux 8*.
-
 . In the Download Red Hat Enterprise Linux window, locate the binary DVD version of the ISO image, for example, *Red Hat Enterprise Linux 8.1 Binary DVD*, and click *Download Now*.
 endif::[]
 
 ifeval::["{rhel-version}" == "7"]
 . To the right of *Red Hat Enterprise Linux 7*, click *Versions 7 and below*.
-
 . From the *Version* list, select the required version of the Red Hat Enterprise Linux 7, for example 7.7.
-
 . In the Download Red Hat Enterprise Linux window, locate the binary DVD version of the ISO image, for example, *Red Hat Enterprise Linux 7.7 Binary DVD*, and click *Download Now*.
 endif::[]
 
 . When the download completes, copy the ISO image to {ProjectServer}.
-
 . On {ProjectServer}, create a mount point and temporarily mount the ISO image at that location:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_installing-convert2rhel.adoc
+++ b/guides/common/modules/proc_installing-convert2rhel.adoc
@@ -11,19 +11,18 @@ The following procedure makes Convert2RHEL available to the hosts you are conver
 . Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the product.
 . You do not need to complete *SSL Client Cert* or *SSL Client Key*.
 . Optional: From the *Sync Plan* list, select an existing sync plan or click *Create Sync Plan* to create a sync plan for your product requirements.
-. In the *Description* field, enter a description of the product.
+. Optional: In the *Description* field, enter a description of the product.
 . Click *Save*.
 . Click the *Repositories* tab.
 . To add a repository, click *New Repository*.
 . In the *Name* field, enter the name of the repository.
 . From the *Type* list, set the content type to Yum.
 . Do not restrict the architecture or the OS version.
-. Use https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/ as the upstream URL.
+. Use `\https://cdn.redhat.com/content/public/convert2rhel/7/x86_64/os/` as the *Upstream URL*.
 . Disable the *Verify SSL* checkbox.
 . Optional: From the *GPG Key* list, select the GPG key for the product.
 . Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the product.
 +
 You do not need to complete *SSL Client Cert* or *SSL Client Key*.
-+
 . Click *Save*.
 . Click the checkbox next to the new repository, then click *Sync Now*.

--- a/guides/common/modules/proc_preparing-the-host-group.adoc
+++ b/guides/common/modules/proc_preparing-the-host-group.adoc
@@ -12,10 +12,10 @@ Use this procedure to prepare a host group to convert CentOS 7 machines.
 . For Steps 7 - 10, {Team} does not recommend setting values for this scenario as they might modify the host in ways that are not intended.
 . Optional: In the *Puppet Environment* field, select value the Puppet Environment.
 . The *Deploy on* field can be safely ignored.
-. Optional: In the *Puppet Capsule* field, select the name of the Puppet server configured for this {smart-proxy-context}.
-. Optional: In the *Puppet CA Capsule* field, select the Puppet Server CA configured for this {smart-proxy-context}.
+. Optional: In the *Puppet Proxy* field, select the name of the Puppet server configured for this {smart-proxy-context}.
+. Optional: In the *Puppet CA Proxy* field, select the Puppet Server CA configured for this {smart-proxy-context}.
 . Switch to the *Activation Keys* tab.
-. Optional: In the *OpenSCAP Capsule* field, select the OpenSCAP capsule to use for fetching SCAP content and uploading ARF reports.
+. Optional: In the *OpenSCAP Proxy* field, select the OpenSCAP {SmartProxy} to use for fetching SCAP content and uploading ARF reports.
 . Click *Submit*.
 . Switch to the *Activation Keys* tab.
 . In the *Activation Keys* field, enter the name of the product activation key.

--- a/guides/common/modules/proc_reverting-satellite-to-download-content-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_reverting-satellite-to-download-content-from-red-hat-cdn.adoc
@@ -5,15 +5,11 @@
 If your environment changes from disconnected to connected, you can reconfigure a disconnected {Project} to download content directly from the Red Hat CDN.
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*.
-
 . Click *Manage Manifest*.
-
 . Edit the *Red Hat CDN URL* field to point to the Red Hat CDN URL:
 +
 `https://cdn.redhat.com`
-
 . Click *Save*.
 
 {ProjectServer} is now configured to download content from the CDN the next time that it synchronizes repositories.

--- a/guides/doc-Content_Management_Guide/master.adoc
+++ b/guides/doc-Content_Management_Guide/master.adoc
@@ -14,37 +14,27 @@ ifdef::foreman-el,katello[]
 include::topics/QuickStart.adoc[]
 endif::[]
 
-include::topics/Managing_Organizations.adoc[]
+include::topics/Managing_Organizations.adoc[leveloffset=+1]
 
-include::topics/Managing_Locations.adoc[]
+include::topics/Managing_Locations.adoc[leveloffset=+1]
 
-include::topics/Managing_Subscriptions.adoc[]
+include::topics/Managing_Subscriptions.adoc[leveloffset=+1]
 
-ifdef::satellite[]
+include::topics/Importing_Content.adoc[leveloffset=+1]
 
-include::topics/Importing_Content.adoc[]
-
-endif::[]
-
-ifndef::satellite[]
-
-include::topics/Importing_Content.adoc[]
-
-endif::[]
-
-include::topics/Creating_an_Application_Life_Cycle.adoc[]
+include::topics/Creating_an_Application_Life_Cycle.adoc[leveloffset=+1]
 
 include::common/modules/proc_adding-life-cycle-environments.adoc[leveloffset=+2]
 
-include::topics/Managing_Content_Views.adoc[]
+include::topics/Managing_Content_Views.adoc[leveoffset=+1]
 
-include::topics/Using_ISS.adoc[]
+include::topics/Using_ISS.adoc[leveloffset=+1]
 
-include::topics/Managing_Activation_Keys.adoc[]
+include::topics/Managing_Activation_Keys.adoc[leveloffset=+1]
 
 include::common/assembly_converting-a-host-with-convert2rhel.adoc[leveloffset=+1]
 
-include::topics/Managing_Errata.adoc[]
+include::topics/Managing_Errata.adoc[leveoffset=+1]
 
 include::topics/Managing_Container_Images.adoc[leveloffset=+1]
 
@@ -56,11 +46,12 @@ include::topics/Containers_managing_authentication.adoc[leveloffset=+2]
 
 include::topics/Containers_interacting_with_registry.adoc[leveloffset=+2]
 
-include::topics/Managing_ISOs_and_Files.adoc[]
+include::topics/Managing_ISOs_and_Files.adoc[leveloffset=+1]
 
-include::topics/Managing_Custom_File_Type_Content.adoc[]
+include::topics/Managing_Custom_File_Type_Content.adoc[leveoffset=+1]
 
-include::topics/appendix-NFS_Share.adoc[]
+[appendix]
+include::topics/appendix-NFS_Share.adoc[leveloffset=+1]
 
 ifdef::satellite[]
 [appendix]
@@ -73,4 +64,5 @@ include::common/assembly_importing-kickstart-repositories.adoc[leveloffset=+1]
 include::common/modules/proc_reverting-satellite-to-download-content-from-red-hat-cdn.adoc[leveloffset=+1]
 endif::[]
 
-include::topics/appendix-Importing_Content_ISOs_into_Connected_Satellite.adoc[]
+[appendix]
+include::topics/appendix-Importing_Content_ISOs_into_Connected_Satellite.adoc[leveloffset=+1]

--- a/guides/doc-Content_Management_Guide/topics/Bulk_Updating_Content_Hosts_Subscriptions.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Bulk_Updating_Content_Hosts_Subscriptions.adoc
@@ -1,12 +1,9 @@
 [[Bulk_Updating_Content_Hosts_Subscriptions]]
-=== Bulk Updating Content Hosts' Subscriptions
+= Bulk Updating Content Hosts' Subscriptions
 
 Use this procedure for post-installation changes to multiple content hosts at the same time.
 
 .Procedure
-
-To update multiple content hosts, complete the following steps:
-
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.
 . Navigate to *Hosts* > *Content Hosts*.
 . On the row of each content host whose subscription you want to change, select the corresponding check box.

--- a/guides/doc-Content_Management_Guide/topics/Containers_importing_container_images.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Containers_importing_container_images.adoc
@@ -35,7 +35,6 @@ From the list, you can also remove any manifests that you do not require.
 
 [id="cli-importing-container-images_{context}"]
 .CLI procedure
-
 . Create the custom `Red Hat Container Catalog` product:
 +
 [options="nowrap" subs="+quotes"]
@@ -46,7 +45,6 @@ From the list, you can also remove any manifests that you do not require.
 --description "Red Hat Container Catalog content" \
 --organization "_My_Organization_"
 ----
-+
 . Create the repository for the container images:
 +
 [options="nowrap" subs="+quotes"]
@@ -59,7 +57,6 @@ From the list, you can also remove any manifests that you do not require.
 --product "Red Hat Container Catalog" \
 --organization "_My_Organization_"
 ----
-+
 . Synchronize the repository:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/doc-Content_Management_Guide/topics/Containers_interacting_with_registry.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Containers_interacting_with_registry.adoc
@@ -3,32 +3,36 @@
 
 Podman and Docker can be used to fetch content from Katello container registries.
 
-.Container Registries on Smart Proxies
+.Container Registries on {SmartProxies}
 
-On {SmartProxies} with content, the https://github.com/Katello/smart_proxy_container_gateway[Container Gateway] {SmartProxy} plugin acts as the container registry.  It caches authentication information from Katello and proxies incoming requests to Pulp.  The Container Gateway comes default on {SmartProxies} with content.
+On {SmartProxies} with content, the https://github.com/Katello/smart_proxy_container_gateway[Container Gateway] {SmartProxy} plugin acts as the container registry.
+It caches authentication information from Katello and proxies incoming requests to Pulp.
+The Container Gateway comes default on {SmartProxies} with content.
 
 .Procedure
 
 Logging in to the container registry:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-podman login {foreman-example-com}
+# podman login {foreman-example-com}
 ----
 
 Listing container images:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-podman search {foreman-example-com}/
+# podman search {foreman-example-com}/
 ----
 
 Pulling container images:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-podman pull {foreman-example-com}/my-image:<optional_tag>
+# podman pull {foreman-example-com}/my-image:<optional_tag>
 ----
 
 ifdef::katello[]
 .Limitations
 
-With the Katello 4.0 release, the Container Gateway does not support pulling container images that require authentication.  Until it does, ensure that *Unauthenticated Pull* is checked for all Lifecycle Environments that have container repositories that are expected to be served by {SmartProxies}.  https://projects.theforeman.org/issues/32085[Related issue]
+With the Katello 4.0 release, the Container Gateway does not support pulling container images that require authentication.
+Until it does, ensure that *Unauthenticated Pull* is checked for all Lifecycle Environments that have container repositories that are expected to be served by {SmartProxies}.
+See also https://projects.theforeman.org/issues/32085[Foreman Issue #32085]
 endif::[]

--- a/guides/doc-Content_Management_Guide/topics/Containers_interacting_with_registry.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Containers_interacting_with_registry.adoc
@@ -1,13 +1,13 @@
 [[using_container_registries]]
-= Using Katello Container Registries
+= Using Container Registries
 
-Podman and Docker can be used to fetch content from Katello container registries.
+Podman and Docker can be used to fetch content from container registries.
 
 .Container Registries on {SmartProxies}
 
 On {SmartProxies} with content, the https://github.com/Katello/smart_proxy_container_gateway[Container Gateway] {SmartProxy} plugin acts as the container registry.
 It caches authentication information from Katello and proxies incoming requests to Pulp.
-The Container Gateway comes default on {SmartProxies} with content.
+The Container Gateway is available by default on {SmartProxies} with content.
 
 .Procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Containers_managing_authentication.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Containers_managing_authentication.adoc
@@ -1,16 +1,15 @@
 [[Managing_Container_Authentication]]
 = Managing Container Registry Authentication
 
+You can manage the authentication settings for accessing containers images from {Project}.
 By default, users must authenticate to access containers images in {Project}.
 
 You can specify whether you want users to authenticate to access container images in {Project} in a lifecycle environment.
 For example, you might want to permit users to access container images from the `Production` lifecycle without any authentication requirement and restrict access the `Development` and `QA` environments to authenticated users.
 
 .Procedure
-
-To manage the authentication settings for accessing containers images from {Project}, complete the following steps:
-
-. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle Environments* and select the lifecycle environment that you want to manage authentication for.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle Environments*.
+. Select the lifecycle environment that you want to manage authentication for.
 . To permit unauthenticated access to the containers in this lifecycle environment, select the *Unauthenticated Pull* check box.
 To restrict unauthenticated access, clear the *Unauthenticated Pull* check box.
 . Click *Save*.

--- a/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Creating_an_Application_Life_Cycle.adoc
@@ -1,10 +1,10 @@
 [[Creating_an_Application_Life_Cycle]]
-== Managing Application Life Cycles
+= Managing Application Life Cycles
 
 This chapter outlines the application life cycle in {Project} and how to create and remove application life cycles for {Project} and {SmartProxy}.
 
 [[Introduction-App_Life_Cycle]]
-=== Application Life Cycle Overview
+== Application Life Cycle Overview
 
 The _application life cycle_ is a concept central to {ProjectNameX}'s content management functions.
 The application life cycle defines how a particular system and its software look at a particular stage.
@@ -43,7 +43,8 @@ endif::[]
 [[img-Application_Life_Lycle]]
 image::001-Application_Life_Cycle.png[title="The {ProjectNameX} Application Life Cycle", alt="The {ProjectNameX} Application Life Cycle"]
 
-=== Promoting Content across the Application Life Cycle
+[[promoting_content_across_the_application_life_cycle]]
+== Promoting Content across the Application Life Cycle
 
 In the application life cycle chain, when content moves from one environment to the next, this is called _promotion_.
 
@@ -108,7 +109,7 @@ After a successful review, promote the package to the _Production_ environment:
 For more information, see xref:Managing_Content_Views-Promoting_a_Content_View[].
 
 [[Creating_an_Application_Life_Cycle-Creating_a_New_Application_Life_Cycle]]
-=== Creating a Life Cycle Environment Path
+== Creating a Life Cycle Environment Path
 
 To create an application life cycle for developing and releasing software, use the _Library_ environment as the initial environment to create environment paths.
 Then optionally add additional environments to the environment paths.
@@ -154,7 +155,7 @@ Then optionally add additional environments to the environment paths.
 ----
 
 [[Creating_an_Application_Life_Cycle-Removing_Life_Cycle_Environments]]
-=== Removing Life Cycle Environments from {ProjectServer}
+== Removing Life Cycle Environments from {ProjectServer}
 
 Use this procedure to remove a life cycle environment.
 
@@ -184,7 +185,7 @@ Use this procedure to remove a life cycle environment.
 
 
 [[Creating_an_Application_Life_Cycle-Removing_Life_Cycle_Environments_from_the_Red_Hat_Satellite_Capsule_Server]]
-=== Removing Life Cycle Environments from {SmartProxyServer}
+== Removing Life Cycle Environments from {SmartProxyServer}
 
 When life cycle environments are no longer relevant to the host system or environments are added incorrectly to {SmartProxyServer}, you can remove the life cycle environments from {SmartProxyServer}.
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -1,5 +1,5 @@
 [[Importing_Content]]
-== Importing Content
+= Importing Content
 
 This chapter outlines how you can import different types of {customcontent} to {Project}.
 If you want to import Rpms, Files, or different content types to {Project}, it is done with largely the same procedures in this chapter.
@@ -10,7 +10,7 @@ For example, you can use the following chapters for information on specific type
 * xref:Managing_Custom_File_Type_Content[]
 
 [[Using_Custom_Products_in_Satellite]]
-=== Using Products and Repositories in {Project}
+== Using Products and Repositories in {Project}
 
 ifdef::satellite[]
 Both Red Hat content and {customcontent} in {Project} have similarities:
@@ -33,7 +33,7 @@ Other {customcontent} can be organized into Products however you want.  For exam
 For more information about creating and packaging RPMs, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/rpm_packaging_guide/[RPM Packaging Guide] in the Red{nbsp}Hat Enterprise Linux documentation.
 
 [[Importing_Content-Importing_Custom_SSL_Certificates]]
-=== Importing {customssltitle} Certificates
+== Importing {customssltitle} Certificates
 
 Before you synchronize {customcontent} from an external source, you might need to import SSL certificates into your {customproduct}. This might include client certs and keys or CA certificates for the upstream repositories you want to synchronize.
 
@@ -47,7 +47,7 @@ In the Content Credentials window, click *Create Content Credential*.
 . Click *Save*.
 
 [[Importing_Content-Creating_a_Custom_Product]]
-=== Creating a {customproducttitle}
+== Creating a {customproducttitle}
 
 Use this procedure to create a {customproduct} that you can then add repositories to.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-custom-product_{context}[].
@@ -80,7 +80,7 @@ To create the product, enter the following command:
 ----
 
 [[Importing_Content-Creating_a_Custom_RPM_Repository]]
-=== Adding {customrpmtitle} Repositories
+== Adding {customrpmtitle} Repositories
 
 Use this procedure to add {customrpm} repositories in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-rpm-repositories_{context}[].
@@ -139,7 +139,7 @@ This ensures that the content that is no longer part of the upstream repository 
 Continue to xref:Importing_Content-Synchronizing_Repositories[] to sync the repository
 
 [[Importing_Content-Selecting_Red_Hat_Repositories_to_Synchronize]]
-=== Enabling Red{nbsp}Hat Repositories
+== Enabling Red{nbsp}Hat Repositories
 
 If outside network access requires usage of an HTTP Proxy, configure a default HTTP Proxy for your server.  See {InstallingProjectDocURL}adding-a-default-http-proxy_{build}[Adding a default HTTP Proxy]
 
@@ -205,7 +205,7 @@ For example:
 
 
 [[Importing_Content-Synchronizing_Repositories]]
-=== Syncing Repositories
+== Syncing Repositories
 
 .Procedure
 
@@ -271,7 +271,7 @@ done
 ----
 
 [[Importing_Content-Configuring_Download_Policies]]
-=== Download Policies Overview
+== Download Policies Overview
 
 {ProjectName} provides multiple download policies for synchronizing RPM content.
 For example, you might want to download only the content metadata while deferring the actual content download for later.
@@ -304,7 +304,7 @@ When you use an *On Demand* download policy, content is downloaded from {Project
 Inherit::
 {SmartProxyServer} inherits the download policy for the repository from the corresponding repository on {ProjectServer}.
 
-=== Changing the Default Download Policy
+== Changing the Default Download Policy
 
 You can set the default download policy that {Project} applies to repositories that you create in all organizations.
 
@@ -353,7 +353,7 @@ endif::[]
 ----
 
 [[changing_the_download_policy_for_a_repository]]
-=== Changing the Download Policy for a Repository
+== Changing the Download Policy for a Repository
 
 You can set the download policy for a repository.
 
@@ -387,7 +387,7 @@ You can set the download policy for a repository.
 
 
 [[uploading-content-to-a-custom-rpm-repository]]
-=== Uploading Content to {customrpmtitle} Repositories
+== Uploading Content to {customrpmtitle} Repositories
 
 You can upload individual RPMs and source RPMs to {customrpm} repositories.
 You can upload RPMs using the {ProjectWebUI} or the Hammer CLI.
@@ -427,7 +427,7 @@ To view all RPMs in this repository, click the number next to *Packages* under *
 When the upload is complete, you can view information about a source RPM by using the commands `hammer srpm list` and `hammer srpm info --id _srpm_ID_`.
 
 [[Importing_Content-Recovering_a_Repository]]
-=== Recovering a Repository
+== Recovering a Repository
 In the case of repository corruption, you can recover it by using an advanced synchronization, which has three options:
 
 Optimized Sync::
@@ -488,7 +488,7 @@ Use this option if you have one of the following errors:
 ----
 
 [[Adding_a_New_HTTP_Proxy]]
-=== Adding a New HTTP Proxy
+== Adding a New HTTP Proxy
 
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for Products, repositories, and supported compute resources.
@@ -538,7 +538,7 @@ If your HTTP proxy requires authentication, add the `--username _name_` and `--p
 For further information, see the Knowledgebase article https://access.redhat.com/solutions/65300[How to access Red{nbsp}Hat Subscription Manager (RHSM) through a firewall or proxy] on the Red{nbsp}Hat Customer Portal.
 
 [[Changing_the_HTTP_Proxy_Policy_for_a_Product]]
-=== Changing the HTTP Proxy Policy for a Product
+== Changing the HTTP Proxy Policy for a Product
 
 For granular control over network traffic, you can set an HTTP proxy policy for each Product.
 A Product's HTTP proxy policy applies to all repositories in the Product, unless you set a different policy for individual repositories.
@@ -558,7 +558,7 @@ For more information, see xref:Adding_a_New_HTTP_Proxy[].
 . Click *Update*.
 
 [[Changing_the_HTTP_Proxy_Policy_for_a_Repository]]
-=== Changing the HTTP Proxy Policy for a Repository
+== Changing the HTTP Proxy Policy for a Repository
 
 For granular control over network traffic, you can set an HTTP proxy policy for each repository.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-changing-the-http-proxy-policy-for-a-repository_{context}[].
@@ -598,7 +598,7 @@ To add a new HTTP proxy to {Project}, see xref:Adding_a_New_HTTP_Proxy[].
 
 
 [[Importing_Content-Creating_a_Synchronization_Plan]]
-=== Creating a Synchronization Plan
+== Creating a Synchronization Plan
 
 A synchronization plan checks and updates the content at a scheduled date and time.
 In {ProjectNameX}, you can create a synchronization plan and assign products to the plan.
@@ -650,7 +650,7 @@ Select the *Red{nbsp}Hat Enterprise Linux Server* product and click *Add Selecte
 ----
 
 [[Importing_Content-Assigning_a_Synchronization_Plan_to_Multiple_Products]]
-=== Assigning a Synchronization Plan to Multiple Products
+== Assigning a Synchronization Plan to Multiple Products
 
 Use this procedure to assign a synchronization plan to the products in an organization that have been synchronized at least once and contain at least one repository
 
@@ -681,7 +681,7 @@ done
 
 [[Importing_Content-Limiting_Synchronization_Speed]]
 
-=== Limiting Synchronization Concurrency
+== Limiting Synchronization Concurrency
 
 By default each Repository Synchronization job can fetch up to 10 files at a time.  This can be adjusted on a per repository basis.
 
@@ -695,7 +695,7 @@ To do so from the CLI:
 ----
 
 [[Importing_Content-Importing_a_Custom_GPG_Key]]
-=== Importing a {customgpgtitle} Key
+== Importing a {customgpgtitle} Key
 
 When clients are consuming signed {customcontent}, ensure that the clients are configured to validate the installation of RPMs with the appropriate GPG Key.  This helps to ensure that only packages from authorized sources can be installed.
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Activation_Keys.adoc
@@ -1,5 +1,5 @@
 [[Managing_Activation_Keys]]
-== Managing Activation Keys
+= Managing Activation Keys
 
 Activation keys provide a method to automate system registration and subscription attachment.
 You can create multiple keys and associate them with different environments and Content Views.
@@ -19,7 +19,6 @@ Activation keys can define the following properties for content hosts:
 * System purpose
 
 .Content View Conflicts between Host Creation and Registration
-
 When you provision a host, {Project} uses provisioning templates and other content from the Content View that you set in the host group or host settings.
 When the host is registered, the Content View from the activation key overwrites the original Content View from the host group or host settings.
 Then {Project} uses the Content View from the activation key for every future task, for example, rebuilding a host.
@@ -45,7 +44,7 @@ $ hammer hostgroup set-parameter \
 ----
 
 [[Managing_Activation_Keys-Creating_an_Activation_Key]]
-=== Creating an Activation Key
+== Creating an Activation Key
 
 You can use activation keys to define a specific set of subscriptions to attach to hosts during registration.
 The subscriptions that you add to an activation key must be available within the associated Content View.
@@ -165,7 +164,7 @@ To enable, enter the following command:
 ----
 
 [[Managing_Activation_Keys-Updating_Subscriptions_Associated_with_an_Activation_Key]]
-=== Updating Subscriptions Associated with an Activation Key
+== Updating Subscriptions Associated with an Activation Key
 
 Use this procedure to change the subscriptions associated with an activation key.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-updating-subscriptions-associated-with-an-activation-key_{context}[].
@@ -242,7 +241,7 @@ For the `--subscription-id` option, you can use either the UUID or the ID of the
 For the `--value` option, enter `1` for enable, `0` for disable.
 
 [[Managing_Activation_Keys-Using_Activation_Keys]]
-=== Using Activation Keys for Host Registration
+== Using Activation Keys for Host Registration
 
 You can use activation keys to complete the following tasks:
 
@@ -301,7 +300,7 @@ If there are conflicting settings in activation keys, the rightmost key takes pr
 * Settings that influence the behavior of the key itself and not the host configuration: *Content Host Limit* and *Auto-Attach*.
 
 [[Managing_Activation_Keys-Enabling_Auto_Attach]]
-=== Enabling Auto-Attach
+== Enabling Auto-Attach
 
 When auto-attach is enabled on an activation key and there are subscriptions associated with the key, the subscription management service selects and attaches the best-matched associated subscriptions based on a set of criteria like currently installed products, architecture, and preferences like service level.
 
@@ -334,7 +333,7 @@ Disable the option if you want to force attach all subscriptions associated with
 ----
 
 [[Managing_Activation_Keys-Setting_the_Service_Level]]
-=== Setting the Service Level
+== Setting the Service Level
 
 You can configure an activation key to define a default service level for the new host created with the activation key.
 Setting a default service level selects only the matching subscriptions to be attached to the host.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -1,5 +1,5 @@
 [[Managing_Content_Views]]
-== Managing Content Views
+= Managing Content Views
 
 {ProjectNameX} uses Content Views to create customized repositories from the repositories.
 To do this, you must define which repositories to use and then apply certain filters to the content.
@@ -49,7 +49,7 @@ Package dependency is a complication of package management.
 For more information about how to manage package dependencies within Content Views, see xref:Managing_Content_Views-Resolving_Package_Dependencies[].
 
 [[Managing_Content_Views-Creating_a_Simple_Content_View]]
-=== Creating a Content View
+== Creating a Content View
 
 Use this procedure to create a simple Content View.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-content-view_{context}[].
@@ -125,7 +125,7 @@ For the `--repository-ids` option, you can find the IDs in the output of the `ha
 {ProjectServer} creates the new version of the view and publishes it to the Library environment.
 
 [[Managing_Content_Views-Viewing_Module_Streams]]
-=== Viewing Module Streams
+== Viewing Module Streams
 
 In {Project}, you can view the module streams of the repositories in your Content Views.
 
@@ -140,7 +140,7 @@ To view module streams for the repositories in your content view, complete the f
 . To view the information about the module, click the module.
 
 [[Managing_Content_Views-Promoting_a_Content_View]]
-=== Promoting a Content View
+== Promoting a Content View
 
 Use this procedure to promote Content Views across different lifecycle environments.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-promoting-a-content-view_{context}[].
@@ -203,7 +203,7 @@ Now the database content is available in all environments.
 To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
 [[Managing_Content_Views-Promoting_a_Content_View_Across_All_Life_Cycle_Environments_within_an_Organization]]
-=== Promoting a Content View Across All Life Cycle Environments within an Organization
+== Promoting a Content View Across All Life Cycle Environments within an Organization
 
 Use this procedure to promote Content Views across all lifecycle environments within an organization.
 
@@ -232,7 +232,7 @@ done
 ----
 
 [[Managing_Content_Views-Defining_Composite_Content_Views]]
-=== Composite Content Views Overview
+== Composite Content Views Overview
 
 A Composite Content View combines the content from several Content Views.
 For example, you might have separate Content Views to manage an operating system and an application individually.
@@ -289,7 +289,7 @@ For example, if you attempt to include two Content Views using the same reposito
 
 
 [[Managing_Content_Views-Creating_a_Composite_Content_View]]
-=== Creating a Composite Content View
+== Creating a Composite Content View
 
 Use this procedure to create a composite content view.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-composite-content-view_{context}[].
@@ -376,7 +376,7 @@ To include multiple component Content Views to the Composite Content View, repea
 ----
 
 [[Managing_Content_Views-Defining_Content_Filters]]
-=== Content Filter Overview
+== Content Filter Overview
 
 Content Views also use filters to include or restrict certain RPM content.
 Without these filters, a Content View includes everything from the selected repositories.
@@ -418,7 +418,7 @@ The *Module Streams* option filters modular RPMs and errata, but does not filter
 |===
 
 [[Managing_Content_Views-Resolving_Package_Dependencies]]
-=== Resolving Package Dependencies
+== Resolving Package Dependencies
 
 In {Project}, you can use the package dependency resolution feature to ensure that any dependencies that packages have within a Content View are added to the dependent repository as part of the Content View publication process.
 
@@ -456,7 +456,7 @@ To set the default level of dependency resolution, complete the following steps:
 
 
 [[Managing_Content_Views-Content_Filter_Examples]]
-=== Content Filter Examples
+== Content Filter Examples
 
 Use any of the following examples with the procedure that follows to build custom content filters.
 
@@ -524,7 +524,7 @@ Add a rule to exclude all `*` packages, or specify the package names that you wa
 For another example of how content filters work, see the following article: https://access.redhat.com/solutions/1564953["How do content filters work in Satellite 6"].
 
 [[Managing_Content_Views-Creating_a_Content_Filter]]
-=== Creating a Content Filter
+== Creating a Content Filter
 
 Use this procedure to create a content filter.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-content-filter_{context}[].

--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -1,5 +1,5 @@
 [[Managing_Custom_File_Type_Content]]
-== Managing {customfiletypetitle} Content
+= Managing {customfiletypetitle} Content
 
 In {Project}, you might require methods of managing and distributing SSH keys and source code files or larger files such as virtual machine images and ISO files.
 To achieve this, (customproduct)s in {ProjectName} include repositories for {customfiletype}s.
@@ -14,7 +14,7 @@ You can create an independent file type repository in a directory on the system 
 This method is useful when you have multiple files to add to a {Project} repository.
 
 [[Importing_Content-Creating_a_Custom_File_Type_Repository]]
-=== Creating a {customfiletypetitle} Repository in {ProjectName}
+== Creating a {customfiletypetitle} Repository in {ProjectName}
 
 The procedure for creating a {customfiletype} repository is the same as the procedure for creating any {customcontent}, except that when you create the repository, you select the *file* type.
 You must create a product and then add a {customrepo}.
@@ -103,7 +103,7 @@ Clear this field if the repository does not require authentication.
 
 
 [[Importing_Content-Creating_a_Custom_File_Type_Repository_Local_Directory]]
-=== Creating a {customfiletypetitle} Repository in a Local Directory
+== Creating a {customfiletypetitle} Repository in a Local Directory
 
 You can create a {customfiletype} repository, from a directory of files, on the base system where {Project} is installed using the `pulp-manifest` command.
 You can then synchronize the files into {ProjectServer}.
@@ -190,7 +190,7 @@ To update the file type repository, complete the following steps:
 . Visit the URL where the repository is published to see the files.
 
 [[Managing_Custom_File_Type_Content-Creating_a_Remote_File_Type_Repository]]
-=== Creating a Remote File Type Repository
+== Creating a Remote File Type Repository
 
 You can create a {customfiletype} repository from a directory of files that is external to {ProjectServer} using the `pulp-manifest` command.
 You can then synchronize the files into {ProjectServer} over HTTP or HTTPS.
@@ -287,7 +287,7 @@ Select the name of a product that contains the repository that you want to updat
 Visit the URL where the repository is published to view the files.
 
 [[Importing_Content-Uploading_Files_To_a_Custom_File_Type_Repository]]
-=== Uploading Files To a {customfiletypetitle} Repository in {ProjectName}
+== Uploading Files To a {customfiletypetitle} Repository in {ProjectName}
 
 Use this procedure to upload files to a {customfiletype} repository.
 
@@ -314,7 +314,7 @@ The `--path` option can indicate a file, a directory of files, or a glob express
 Globs must be escaped by single or double quotes.
 
 [[Importing_Content-Downloading_Files_From_a_Custom_File_Type_Repository]]
-=== Downloading Files to a Host From a {customfiletypetitle} Repository in {ProjectName}
+== Downloading Files to a Host From a {customfiletypetitle} Repository in {ProjectName}
 
 You can download files to a client over HTTPS using `curl -O`, and optionally over HTTP if the *Publish via HTTP* repository option is selected.
 

--- a/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
@@ -1,5 +1,5 @@
 [[Managing_Errata]]
-== Managing Errata
+= Managing Errata
 
 As a part of Red Hat's quality control and release process, we provide customers with updates for each release of official Red Hat RPMs.
 Red Hat compiles groups of related package into an *erratum* along with an advisory that provides a description of the update.
@@ -36,7 +36,7 @@ Installable errata are available to a content host from life cycle environment a
 This chapter shows how to manage errata and apply them to either a single host or multiple hosts.
 
 [[Managing_Errata-Inspecting_Available_Errata]]
-=== Inspecting Available Errata
+== Inspecting Available Errata
 
 The following procedure describes how to view and filter the available errata and how to display metadata of the selected advisory.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-inspecting-available-errata_{context}[].
@@ -132,14 +132,14 @@ You can use the same formats as with the `issued` parameter.|_updated = "6 days 
 |====
 
 [[Managing_Errata-Subscribing_to_Errata_Notifications]]
-=== Subscribing to Errata Notifications
+== Subscribing to Errata Notifications
 
 You can configure email notifications for {Project} users.
 Users receive a summary of applicable and installable errata, notifications on Content View promotion or after synchronizing a repository.
 For more information, see {AdministeringDocURL}email-notifications_admin[Configuring Email Notifications] in the _Administering {ProjectName}_ guide.
 
 [[Managing_Errata-Limitations_to_Repository_Dependency_Resolution]]
-=== Limitations to Repository Dependency Resolution
+== Limitations to Repository Dependency Resolution
 
 With {Project}, using incremental updates to your Content Views solves some repository dependency problems.
 However, dependency resolution at a repository level still remains problematic on occasion.
@@ -165,7 +165,7 @@ There is currently no workaround for this problem.
 The larger the time frame, and major _Y_ releases between the base set of RPMs and the errata being applied, the higher the chance of a problem with dependency resolution.
 
 [[Managing_Errata-Creating_a_Content_View_Filter_for_Errata]]
-=== Creating a Content View Filter for Errata
+== Creating a Content View Filter for Errata
 
 You can use content filters to limit errata.
 Such filters include:
@@ -259,7 +259,7 @@ This means the filter successfully excluded the all non-security errata from the
 ----
 
 [[Managing_Errata-Adding-Errata-To-An-Incremental-Content-View]]
-=== Adding Errata to an Incremental Content View
+== Adding Errata to an Incremental Content View
 
 If errata are available but not installable, you can create an incremental Content View version to add the errata to your content hosts.
 For example, if the Content View is version 1.0, it becomes Content View version 1.1, and when you publish, it becomes Content View version 2.0.
@@ -310,7 +310,8 @@ You can add more IDs in a comma-separated list.
 --content-view-version-id 319 --errata-ids 34068b
 ----
 
-=== Applying Errata to a Host
+[[Managing_Errata-applying_errata_to_a_host]]
+== Applying Errata to a Host
 
 Use these procedures to review and apply errata to a host.
 
@@ -355,7 +356,7 @@ To apply an erratum to a RHEL 8 host, complete the following steps:
 # yum update _Module_Stream_Name_
 ----
 
-.For Red{nbsp}Hat Enterprise Linux 7
+.For {RHEL} 7
 To apply an erratum to a RHEL 7 host, complete the following steps:
 
 . In the {ProjectWebUI}, navigate to *Hosts* > *Content Hosts* and select the host you want to apply errata to.
@@ -397,7 +398,7 @@ Using `Katello Agent` (deprecated)
 ----
 
 [[Managing_Errata-Applying_Errata_to_Multiple_Hosts]]
-=== Applying Errata to Multiple Hosts
+== Applying Errata to Multiple Hosts
 
 Use these procedures to review and apply errata to multiple RHEL 7 hosts.
 
@@ -487,8 +488,9 @@ This command identifies all hosts with _erratum_IDs_ as an applicable erratum an
 ----
 
 [[Managing_Errata-Applying_Errata_to_a_Host_Collection]]
-=== Applying Errata to a Host Collection
-Using `Remote Execution`
+== Applying Errata to a Host Collection
+
+.Using `Remote Execution`
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # hammer job-invocation create \
@@ -496,7 +498,8 @@ Using `Remote Execution`
 --inputs errata=_ERRATUM_ID1_,_ERRATUM_ID2_,... \
 --search-query "host_collection = _HOST_COLLECTION_NAME_"
 ----
-Using `Katello Agent` (deprecated)
+
+.Using `Katello Agent` (deprecated)
 [options="nowrap" subs="+quotes"]
 ----
 # hammer host-collection erratum install \

--- a/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_ISOs_and_Files.adoc
@@ -1,10 +1,11 @@
 [[Managing_ISO_Images]]
-== Managing ISO Images
+= Managing ISO Images
 
-You can use {ProjectNameX} to store ISO images, either from Red Hat's Content Delivery Network or other sources.
+You can use {ProjectNameX} to store ISO images, either from Red{nbsp}Hat's Content Delivery Network or other sources.
 You can also upload other files, such as virtual machine images, and publish them in repositories.
 
-=== Importing ISO Images from Red Hat
+[[importing_iso_images_from_red_hat]]
+== Importing ISO Images from Red Hat
 
 The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
 The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
@@ -12,22 +13,19 @@ The procedure for importing this content is similar to the procedure for enablin
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-images-from-red-hat_{context}[].
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Content* > *Red{nbsp}Hat Repositories*.
 . In the *Search* field, enter an image name, for example, `Red{nbsp}Hat Enterprise Linux 7 Server (ISOs)`.
 . In the Available Repositories window, expand *Red{nbsp}Hat Enterprise Linux 7 Server (ISOs)*.
 . For the *x86_64 7.2* entry, click the *Enable* icon to enable the repositories for the image.
 . Navigate to *Content* > *Products* and click *Red{nbsp}Hat Enterprise Linux Server*.
-. Click the *Repositories* tab of the Red{nbsp}Hat Enterprise Linux Server window, and click *Red{nbsp}Hat Enterprise Linux 7 Server ISOs x86_64 7.2*.
-. In the upper right of the Red{nbsp}Hat Enterprise Linux 7 Server ISOs x86_64 7.2 window, click *Select Action* and select *Sync Now*.
+. Click the *Repositories* tab of the {RHEL} Server window, and click *{RHEL} 7 Server ISOs x86_64 7.2*.
+. In the upper right of the {RHEL} 7 Server ISOs x86_64 7.2 window, click *Select Action* and select *Sync Now*.
 
 .To view the Synchronization Status
-
 * In the {ProjectWebUI}, navigate to *Content* > *Sync Status* and expand *Red Hat Enterprise Linux Server*.
 
 [id="cli-importing-iso-images-from-red-hat_{context}"]
 .CLI procedure
-
 . Locate the Red{nbsp}Hat Enterprise Linux Server product for `file` repositories:
 +
 [options="nowrap" subs="+quotes"]
@@ -36,7 +34,6 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 --product "Red Hat Enterprise Linux Server" \
 --organization "_My_Organization_" | grep "file"
 ----
-+
 . Enable the `file` repository for Red{nbsp}Hat Enterprise Linux 7.2 Server ISO:
 +
 [options="nowrap" subs="+quotes"]
@@ -48,7 +45,6 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 --basearch x86_64 \
 --organization "_My_Organization_"
 ----
-+
 . Locate and synchronize the repository in the product:
 +
 [options="nowrap" subs="+quotes"]
@@ -63,7 +59,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 ----
 
 [[importing_individual_iso_images_and_files]]
-=== Importing Individual ISO Images and Files
+== Importing Individual ISO Images and Files
 
 Use this procedure to manually import ISO content and other files to {ProjectServer}.
 To import files, you can complete the following steps in the {ProjectWebUI} or using the Hammer CLI.
@@ -72,7 +68,6 @@ However, if the size of the file that you want to upload is larger than 15 MB, y
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-individual-iso-images-and-files_{context}[].
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Content* > *Products*, and in the Products window, click *Create Product*.
 . In the *Name* field, enter a name to identify the product.
 This name populates the *Label* field.
@@ -93,7 +88,6 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 
 [id="cli-importing-individual-iso-images-and-files_{context}"]
 .CLI procedure
-
 . Create the {customproduct}:
 +
 [options="nowrap" subs="+quotes"]
@@ -104,7 +98,6 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 --description "_My_Product_" \
 --organization "_My_Organization_"
 ----
-+
 . Create the repository:
 +
 [options="nowrap" subs="+quotes"]
@@ -115,7 +108,6 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 --product "_My_Product_" \
 --organization "_My_Organization_"
 ----
-+
 . Upload the ISO file to the repository:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/doc-Content_Management_Guide/topics/Managing_Locations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Locations.adoc
@@ -1,5 +1,5 @@
 [[Managing_Locations]]
-== Managing Locations
+= Managing Locations
 
 Locations function similar to organizations: they provide a method to group resources and assign hosts.
 Organizations and locations have the following conceptual differences:
@@ -8,7 +8,7 @@ Organizations and locations have the following conceptual differences:
 * Locations have a hierarchical structure.
 
 [[Managing_Locations-Creating_a_Location]]
-=== Creating a Location
+== Creating a Location
 
 Use this procedure to create a location so that you can manage your hosts and resources by location.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-location_{context}[].
@@ -30,7 +30,6 @@ You can return to this page at any time by navigating to *Administer* > *Locatio
 
 [id="cli-creating-a-location_{context}"]
 .CLI procedure
-
 * Enter the following command to create a location:
 +
 [subs="+quotes"]
@@ -42,7 +41,7 @@ You can return to this page at any time by navigating to *Administer* > *Locatio
 ----
 
 [[Managing_Locations-Creating_Multiple_Locations]]
-=== Creating Multiple Locations
+== Creating Multiple Locations
 
 The following example Bash script creates three locations - London, Munich, Boston - and assigns them to the Example Organization.
 [source, Bash, subs="+quotes"]
@@ -58,7 +57,7 @@ done
 ----
 
 [[Managing_Locations-Setting_the_Location_Context]]
-=== Setting the Location Context
+== Setting the Location Context
 
 A location context defines the location to use for a host and its associated resources.
 
@@ -81,7 +80,7 @@ For example:
 This command outputs subscriptions allocated for the _Default_Location_.
 
 [[Managing_Locations-Deleting_a_Location]]
-=== Deleting a Location
+== Deleting a Location
 
 You can delete a location if the location is not associated with any life cycle environments or host groups.
 If there are any life cycle environments or host groups associated with the location you are about to delete, remove them by navigating to *Administer* > *Locations* and clicking the relevant location.
@@ -106,7 +105,6 @@ To delete a location, complete the following steps:
 ----
 +
 From the output, note the ID of the location that you want to delete.
-+
 . Enter the following command to delete the location:
 +
 [subs="+quotes"]

--- a/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
@@ -1,5 +1,5 @@
 [[Managing_Organizations]]
-== Managing Organizations
+= Managing Organizations
 
 Organizations divide {ProjectNameX} resources into logical groups based on ownership, purpose, content, security level, or other divisions.
 You can create and manage multiple organizations through {ProjectNameX}, then divide and assign your Red Hat subscriptions to each individual organization.
@@ -31,13 +31,12 @@ To grant systems rights to users, assign them to a default organization.
 The next time the user logs on to {Project}, the user's account has the correct system rights.
 
 [[Managing_Organizations-Creating_an_Organization]]
-=== Creating an Organization
+== Creating an Organization
 
 Use this procedure to create an organization.
 To use the CLI instead of the {ProjectWebUI}, see xref:cli-creating-an-organization_{context}[].
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Administer* > *Organizations*.
 . Click *New Organization*.
 . In the *Name* field, enter a name for the organization.
@@ -54,7 +53,6 @@ You can return to this page at any time by navigating to *Administer* > *Organiz
 
 [id="cli-creating-an-organization_{context}"]
 .CLI procedure
-
 . To create an organization, enter the following command:
 +
 [subs="+quotes"]
@@ -64,7 +62,6 @@ You can return to this page at any time by navigating to *Administer* > *Organiz
 --label "_your_organization_label_ \
 --description "_your_organization_description_"
 ----
-
 . Optional: To edit an organization, enter the `hammer organization update` command.
 For example, the following command assigns a compute resource to the organization:
 +
@@ -76,7 +73,7 @@ For example, the following command assigns a compute resource to the organizatio
 ----
 
 [[Managing_Organizations-Setting_the_Organization_Context]]
-=== Setting the Organization Context
+== Setting the Organization Context
 
 An organization context defines the organization to use for a host and its associated resources.
 
@@ -99,7 +96,7 @@ For example:
 This command outputs subscriptions allocated for the Default_Organization.
 
 [[Managing_Organizations-Creating_an_Organization_Debug_Certificate]]
-=== Creating an Organization Debug Certificate
+== Creating an Organization Debug Certificate
 
 If you require a debug certificate for your organization, use the following procedure.
 
@@ -116,12 +113,11 @@ To create a debug certificate for an organization, complete the following steps:
 Debug Certificates are automatically generated for provisioning template downloads if they do not already exist in the organization for which they are being downloaded.
 
 [[Managing_Organizations-Browsing_Repository_Content_Using_an_Organization_Debug_Certificate]]
-=== Browsing Repository Content Using an Organization Debug Certificate
+== Browsing Repository Content Using an Organization Debug Certificate
 
 You can view an organization's repository content using a web browser or using the API if you have a debug certificate for that organization.
 
 .Prerequisites
-
 . Create and download an organization certificate as described in xref:Managing_Organizations-Creating_an_Organization_Debug_Certificate[].
 . Open the X.509 certificate, for example, for the default organization:
 +
@@ -169,7 +165,7 @@ http://_{foreman-example-com}_/pulp/repos/Default_Organization/Library/content/d
 Ensure that the paths to `cert.pem` and `key.pem` are the correct absolute paths otherwise the command fails silently.
 
 [[Managing_Organizations-Deleting_an_Organization]]
-=== Deleting an Organization
+== Deleting an Organization
 
 You can delete an organization if the organization is not associated with any life cycle environments or host groups.
 If there are any life cycle environments or host groups associated with the organization you are about to delete, remove them by navigating to *Administer* > *Organizations* and clicking the relevant organization.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Subscriptions.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Subscriptions.adoc
@@ -1,5 +1,5 @@
 [[Managing_Subscriptions]]
-== Managing Subscriptions
+= Managing Subscriptions
 
 {ProjectNameX} can import content from the Red Hat Content Delivery Network (CDN).
 {ProjectX} requires a Subscription Manifest to find, access, and download content from the corresponding repositories.
@@ -28,13 +28,13 @@ Do not rely on the auto-attach method because this method is designed for a diff
 For more information, see xref:Managing_Subscriptions-Attaching_Subscriptions[].
 
 //Importing a Subscription Manifest into {ProjectServer}
-include::../common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc[leveloffset=+2]
+include::../common/modules/proc_importing-a-subscription-manifest-into-satellite-server.adoc[leveloffset=+1]
 
 You can now enable repositories and import Red Hat content.
 For more information, see xref:Importing_Content[].
 
 [[Managing_Subscriptions-Locating_a_Manifest]]
-=== Locating a Subscription in the {ProjectWebUI}
+== Locating a Subscription in the {ProjectWebUI}
 
 When you import a Subscription Manifest into {ProjectServer}, the subscriptions from your manifest are listed in the Subscriptions window.
 If you have a high volume of subscriptions, you can filter the results to find a specific subscription.
@@ -59,7 +59,7 @@ If you select *>* and press the space bar, another list of automatic options app
 You can also enter your own criteria.
 
 [[Managing_Subscriptions-Adding_Subscriptions_in_the_Satellite_web_UI]]
-=== Adding Subscriptions to Subscription Allocations in the {ProjectWebUI}
+== Adding Subscriptions to Subscription Allocations in the {ProjectWebUI}
 
 Use the following procedure to add subscriptions to a subscription allocation in the {ProjectWebUI}.
 
@@ -83,7 +83,7 @@ To add subscriptions to a subscription allocation, complete the following steps:
 . Click *Submit*.
 
 [[Managing_Subscriptions-Removing_Subscriptions_in_the_Satellite_web_UI]]
-=== Removing Subscriptions from Subscription Allocations in the  {ProjectWebUI}
+== Removing Subscriptions from Subscription Allocations in the  {ProjectWebUI}
 
 Use the following procedure to remove subscriptions from a subscription allocation in the {ProjectWebUI}.
 
@@ -108,7 +108,7 @@ To remove subscriptions, complete the following steps:
 . Click *Delete*, and then confirm deletion.
 
 [[Managing_Subscriptions-Updating_a_Manifest]]
-=== Updating and Refreshing Subscription Manifests
+== Updating and Refreshing Subscription Manifests
 
 Every time that you change a subscription allocation, you must refresh the manifest to reflect these changes.
 For example, you must refresh the manifest if you take any of the following actions:
@@ -128,7 +128,7 @@ Alternatively, you can import an updated manifest that contains the changes.
 . In the Manage Manifest window, click *Refresh*.
 
 [[Managing_Subscriptions-Attaching_Subscriptions]]
-=== Attaching Subscriptions to Content Hosts
+== Attaching Subscriptions to Content Hosts
 
 Using activation keys is the main method to attach subscriptions to content hosts during the provisioning process.
 However, an activation key cannot update an existing host.
@@ -180,4 +180,4 @@ You must have a Subscription Manifest file imported to {ProjectServer}.
 --subscription-id _subscription_id_
 ----
 
-include::Bulk_Updating_Content_Hosts_Subscriptions.adoc[]
+include::Bulk_Updating_Content_Hosts_Subscriptions.adoc[leveloffset=+1]

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -1,10 +1,10 @@
 [[Using_ISS]]
-== Synchronizing Content Between {ProjectServer}s
+= Synchronizing Content Between {ProjectServer}s
 
 {ProjectName} uses Inter-{Project} Synchronization (ISS) to synchronize content between two {ProjectServer}s including those that are airgapped.
 
+== Scenarios
 
-=== Scenarios
 * If you want to copy some but not all content from your {ProjectServer} to other {ProjectServer}s.
 For example, you have Content Views that your IT department consumes content from {ProjectServer}, and you want to copy content from those Content Views to other {ProjectServer}s.
 
@@ -26,7 +26,8 @@ You cannot use ISS to synchronize content from {ProjectServer} to {SmartProxySer
 {SmartProxyServer} supports synchronization natively.
 For more information, see {PlanningDocURL}chap-Documentation-Architecture_Guide-Capsule_Server_Overview[{SmartProxyServer} Overview] in _Planning for {ProjectNameX}_.
 
-=== Configuration Definitions
+== Configuration Definitions
+
 There are different ways of using ISS to synchronize content between two {ProjectServer}s.
 
 .Connected
@@ -47,7 +48,6 @@ ifndef::satellite[]
 image::Non-Airgapped-Disconnected.png[title="The {Project} ISS Non Airgapped Disconnected use case", alt="The {Project} ISS Airgapped Disconnected use case"]
 endif::[]
 
-
 .Air-gapped Disconnected
 In this setup, both {ProjectServer}s are isolated from each other.
 The only way for air-gapped {ProjectServer}s to receive content updates is through the import/export workflow.
@@ -56,9 +56,9 @@ ifndef::satellite[]
 image::Airgapped-Disconnected.png[title="The {Project} ISS Airgapped Disconnected use case", alt="The {Project} ISS Airgapped Disconnected use case"]
 endif::[]
 
-=== Exporting from a Connected {ProjectServer}
+== Exporting from a Connected {ProjectServer}
 
-==== Connected {ProjectServer} as a Content Store
+=== Connected {ProjectServer} as a Content Store
 
 In this scenario, you have one connected {ProjectServer} that is receiving content from an external source like the CDN.
 The rest of your infrastructure is completely isolated, including another disconnected {ProjectServer}.
@@ -81,14 +81,13 @@ This generates leaner content archives that contain changes only from the recent
 For example, if you enable and synchronize a new repository, the next exported content archive contains content only from the newly enabled repository.
 For more information on performing an incremental Library export, see xref:Using_ISS-Exporting-Library-Incremental[].
 
-
 .On the disconnected {ProjectServer}
 
 . Copy the exported content archive that you want from the connected {ProjectServer}.
 . Import content to an organization using the procedure outlined in xref:Using_ISS-Importing-Library[].
 You can then manage content using Content Views or Lifecycle Environments as you require on the disconnected {ProjectServer}.
 
-==== Connected {ProjectServer} for managing Content View Versions
+=== Connected {ProjectServer} for managing Content View Versions
 
 In this scenario, your connected {ProjectServer} is receiving content from an external source like the CDN. The rest of your infrastructure is completely isolated, including a disconnected {ProjectServer}.
 However, the connected {ProjectServer} is not only used as a content store, but also is used to manage content.
@@ -118,7 +117,7 @@ For more information on performing an incremental export on Content View Version
 For more information, see xref:Using_ISS-Importing-Content-View-Version[].
 This will create a content view version from the exported content archives and them import  content appropriately.
 
-=== Keeping track of your exports
+== Keeping track of your exports
 
 If you are exporting content to several disconnected {ProjectServer}s then using a `--destination-server` option  provides a way to organize or maintain a record of what versions got exported to a given destination.
 For more information, see xref:Using_ISS-Destination-Server[].
@@ -129,7 +128,7 @@ This option is available for all content-export operations. You can use the `des
 * Generate incremental exports automatically to the given destination server.
 
 [[Using_ISS-Exporting-a-Content-View-Version]]
-=== Exporting a Content View Version
+== Exporting a Content View Version
 
 You can export a version of a Content View to an archive file from {ProjectServer} and use this archive file to create the same Content View version on another {ProjectServer} or on another {ProjectServer} organization.
 {Project} exports composite Content Views as normal content views.
@@ -202,7 +201,6 @@ Get the version number of desired version. The following example targets version
 
 In many cases, the exported archive content can be several gigabytes in size. You might want to split it smaller sizes or chunks. You can use the `--chunk-size-gb` option with in the `hammer content-export` command to handle this. The following example uses the `--chunk-size-gb=2` to split the archives into `2 GB` chunks.
 
-
 [options="nowrap" subs="+quotes"]
 ----
 # hammer content-export complete version --content-view=view --version=1.0 --organization=export-21527 --chunk-size-gb=2
@@ -211,7 +209,7 @@ In many cases, the exported archive content can be several gigabytes in size. Yo
 ----
 
 [[Using_ISS-Destination-Server]]
-=== Keeping track of your exports
+== Keeping track of your exports
 
 When importing content to several {ProjectServer}s, the --destination-server option is especially useful for keeping track of which content was exported and to where.
 
@@ -250,7 +248,7 @@ To use incremental export, complete the following steps.
 # ls -lh /var/lib/pulp/exports/export-21527/view/2.0/2021-02-25T21-45-34-00-00/
 ----
 
-=== Examining the exports
+== Examining the exports
 
 You can query on the exports that you previously have created via the `hammer content-export list` command.
 
@@ -267,7 +265,7 @@ ID | DESTINATION SERVER | PATH                                                  
 ----
 
 [[Using_ISS-Importing-Content-View-Version]]
-=== Importing a Content View Version
+== Importing a Content View Version
 
 You can use the archive that the `hammer content-export` command outputs to create a version of a Content View with the same content as the exported Content View version.
 For more information about exporting a Content View version, see xref:Using_ISS-Exporting-a-Content-View-Version[].
@@ -284,9 +282,7 @@ To import a Content View, ensure that {ProjectServer} where you want to import m
 . If there are any Red Hat repositories in the export archive, the importing organization's manifest must contain subscriptions for the products contained within the export.
 . The user importing the content view version must have the 'Content Importer' Role.
 
-
 .Procedure
-
 . Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on {ProjectServer} where you want to import.
 . Set the user:group permission of the archive files to `pulp:pulp`.
 +
@@ -294,15 +290,12 @@ To import a Content View, ensure that {ProjectServer} where you want to import m
 ----
 # chown -R pulp:pulp /var/lib/pulp/imports/2021-02-25T21-15-22-00-00/
 ----
-+
 . Verify that the permission change occurs:
 +
 [subs="+quotes"]
 ----
 # ls -lh  /var/lib/pulp/imports/2021-02-25T21-15-22-00-00/
-
 ----
-
 . To import the Content View version to {ProjectServer}, enter the following command:
 +
 [subs="+quotes"]
@@ -312,7 +305,6 @@ To import a Content View, ensure that {ProjectServer} where you want to import m
 ----
 +
 Note that you must enter the full path `/var/lib/pulp/imports/<path>`. Relative paths do not work.
-+
 . To verify that you import the Content View version successfully, list Content Views for your organization:
 +
 [subs="+quotes"]
@@ -326,11 +318,8 @@ ID | NAME     | VERSION | DESCRIPTION | LIFECYCLE ENVIRONMENTS
 ---|----------|---------|-------------|-----------------------
 ----
 
-
-
-
 [[Using_ISS-Exporting-Library]]
-=== Exporting the Library Environment
+== Exporting the Library Environment
 
 You can export contents of all Yum repositories in the Library environment of an organization to an archive file from {ProjectServer} and use this archive file to create the same repositories in another {ProjectServer} or in another {ProjectServer} organization.
 The exported archive file contains the following data:
@@ -416,7 +405,7 @@ total 172K
 . Since nothing changed between the previous export and now in the Organization's library environment the change files are really small.
 
 [[Using_ISS-Importing-Library]]
-=== Importing into the Library Environment
+== Importing into the Library Environment
 
 You can use the archive that the `hammer content-export` command outputs to import into the Library lifecycle environment of another organization
 For more information about exporting contents from the Library environment, see xref:Using_ISS-Exporting-Library[].
@@ -432,7 +421,6 @@ within the export.
 . The user importing the content must have the 'Content Importer' Role.
 
 .Procedure
-
 . Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on {ProjectServer} where you want to import.
 . Set the permission of the archive files to `pulp:pulp`.
 +
@@ -446,7 +434,6 @@ total 68M
 -rw-r--r--. 1 pulp pulp 443 Mar  2 04:29 metadata.json
 
 ----
-+
 . On {ProjectServer} where you want to import, create/enable repositories the same name and label as the exported content.
 . In the {ProjectWebUI}, navigate to *Content* > *Products*, click the *Yum content* tab and add the same `Yum` content that the exported Content View version includes.
 . Identify the Organization that you wish to import into.
@@ -465,7 +452,7 @@ Note you must enter the full path `/var/lib/pulp/imports/<path>`. Relative paths
 A new Content View called `Import-Library` is created in the target organization.
 This Content View is used to facilitate the library content import.
 
-=== Import/Export Cheat Sheet
+== Import/Export Cheat Sheet
 
 .Export
 [width="100%",cols="4, 10",options="header"]

--- a/guides/doc-Content_Management_Guide/topics/appendix-Importing_Content_ISOs_into_Connected_Satellite.adoc
+++ b/guides/doc-Content_Management_Guide/topics/appendix-Importing_Content_ISOs_into_Connected_Satellite.adoc
@@ -1,6 +1,5 @@
-[appendix]
-[[Importing_Content_ISOs_into_Connected_Satellite]]
-== Importing Content ISOs into a Connected {Project}
+[[Importing_Content_ISOs_into_Connected_{Project}]]
+= Importing Content ISOs into a Connected {Project}
 
 Even if {ProjectServer} can connect directly to the Red{nbsp}Hat Customer Portal, you can perform the initial synchronization from locally mounted content ISOs.
 When the initial synchronization is completed from the content ISOs, you can switch back to downloading content through the network connection.

--- a/guides/doc-Content_Management_Guide/topics/appendix-NFS_Share.adoc
+++ b/guides/doc-Content_Management_Guide/topics/appendix-NFS_Share.adoc
@@ -1,6 +1,5 @@
-[appendix]
 [[NFS_Share]]
-== Using an NFS Share for Content Storage
+= Using an NFS Share for Content Storage
 
 Your environment requires adequate hard disk space to fulfill content storage.
 In some situations, it is useful to use an NFS share to store this content.


### PR DESCRIPTION
* Set headings to level 1
* Add anchors
* Remove unnecessary whitespace
* Use 'RHEL' attribute
* Make anchors and headings more downstream friendly
* Replace 'capsule' with 'Proxy'
* Move 'appendix' directive to parent pages

In a follow up PR, I want to split up content into different files. This will result in one heading per file.