### PR TITLE
Removes xref to missing file and fixes broken links

### DIFF
--- a/guides/common/modules/con_types-of-provisioning-templates.adoc
+++ b/guides/common/modules/con_types-of-provisioning-templates.adoc
@@ -7,7 +7,7 @@ Provision::
 The main template for the provisioning process.
 For example, a kickstart template.
 ifndef::orcharhino[]
-For more information about kickstart template syntax, see the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax[Kickstart Syntax Reference] in the _Red Hat Enterprise Linux 7 Installation Guide_.
+For more information about kickstart template syntax, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/indexsect-kickstart-syntax[Kickstart Syntax Reference] in the _Red Hat Enterprise Linux 7 Installation Guide_.
 endif::[]
 
 PXELinux, PXEGrub, PXEGrub2::

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -8,7 +8,7 @@ To configure the IdM server to use the GSS-TSIG technology, you must install the
 .Prerequisites
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
-For more information, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/installing-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/indexinstalling-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
 * You must contact the IdM server administrator to ensure that you obtain an account on the IdM server with permissions to create zones on the IdM server.
 * You must confirm whether {ProjectServer} or {SmartProxyServer} is configured to provide DNS service for your deployment.
 * You must configure DNS, DHCP and TFTP services on the base operating system of either the {Project} or {SmartProxy} that is managing the DNS service for your deployment.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -9,7 +9,7 @@ The TSIG protocol is defined in https://tools.ietf.org/html/rfc2845[RFC2845].
 .Prerequisites
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
-For more information, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/installing-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/indexinstalling-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
 * You must obtain `root` user access on the IdM server.
 * You must confirm whether {ProjectServer} or {SmartProxyServer} is configured to provide DNS service for your deployment.
 * You must configure DNS, DHCP and TFTP services on the base operating system of either the {Project} or {SmartProxy} that is managing the DNS service for your deployment.

--- a/guides/common/modules/proc_verifying-firewall-settings.adoc
+++ b/guides/common/modules/proc_verifying-firewall-settings.adoc
@@ -16,5 +16,5 @@ include::snip_firewalld.adoc[]
 ----
 
 ifndef::foreman-deb[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_firewalls#sec-Getting_started_with_firewalld[Getting Started with firewalld] in the _Red Hat Enterprise Linux 7 Security Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/indexsec-using_firewalls#sec-Getting_started_with_firewalldsec-using_firewalls#sec-Getting_started_with_firewalld[Getting Started with firewalld] in the _Red Hat Enterprise Linux 7 Security Guide_.
 endif::[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -90,5 +90,5 @@ Installation with disabled SELinux is not supported.
 
 .FIPS Mode
 You can install {ProductName} on a {RHEL} system that is operating in FIPS mode.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/indexsec-using_firewalls#sec-Getting_started_with_firewalldchap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/security_guide/index#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
 endif::[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -90,5 +90,5 @@ Installation with disabled SELinux is not supported.
 
 .FIPS Mode
 You can install {ProductName} on a {RHEL} system that is operating in FIPS mode.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/indexsec-using_firewalls#sec-Getting_started_with_firewalldchap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
 endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -15,7 +15,7 @@ For more information, see xref:sect-Administering-Using_LDAP[].
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
 ifndef::orcharhino[]
-However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/index#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].
+However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/indexindex#ldi-install[Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy Guide].
 endif::[]
 
 include::configuring-idm-authentication-on-satellite-server.adoc[leveloffset=+3]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/active-directory-with-cross-forest-trust.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/active-directory-with-cross-forest-trust.adoc
@@ -5,5 +5,5 @@ Kerberos can create `cross-forest trust` that defines a relationship between two
 A domain forest is a hierarchical structure of domains; both AD and {FreeIPA} constitute a forest.
 With a trust relationship enabled between AD and {FreeIPA}, users of AD can access Linux hosts and services using a single set of credentials.
 ifndef::orcharhino[]
-For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/active-directory-trust[Creating Cross-forest Trusts with Active Directory and Identity Management] in the _Red{nbsp}Hat Enterprise{nbsp}Linux Windows Integration_ guide.
+For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/windows_integration_guide/index#active-directory-trust[Creating Cross-forest Trusts with Active Directory and Identity Management] in the _Red{nbsp}Hat Enterprise{nbsp}Linux Windows Integration_ guide.
 endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-host-based-authentication-control.adoc
@@ -6,7 +6,7 @@ HBAC rules define which machine within the domain a {FreeIPA} user is allowed to
 You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing {ProjectServer}.
 With this approach, you can prevent {Project} from creating database entries for users that are not allowed to log in.
 ifndef::orcharhino[]
-For more information on HBAC, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/configuring-host-access[Configuring Host-Based Access Control] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on HBAC, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/indexconfiguring-host-access[Configuring Host-Based Access Control] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 endif::[]
 
 On the {FreeIPA} server, configure Host-Based Authentication Control (HBAC).

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-idm-authentication-on-satellite-server.adoc
@@ -33,7 +33,7 @@ The generated one-time password must be used on the client to complete {FreeIPA}
 ====
 +
 ifndef::orcharhino[]
-For more information on host configuration properties, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/host-attr[About Host Entry Configuration Properties] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/indexhost-attr[About Host Entry Configuration Properties] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 endif::[]
 
 . Create an HTTP service for {ProjectServer}, for example:
@@ -44,7 +44,7 @@ endif::[]
 ----
 +
 ifndef::orcharhino[]
-For more information on managing services, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/services[Managing Services] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/indexservices[Managing Services] in the _Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
 endif::[]
 
 . On {ProjectServer}, install the IPA client:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/kerberos-configuration-in-web-browsers.adoc
@@ -2,7 +2,7 @@
 = Kerberos Configuration in Web Browsers
 
 ifndef::orcharhino[]
-For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/Configuring_Applications_for_SSO#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _Red{nbsp}Hat Enterprise{nbsp}Linux System-Level Authentication_ guide.
+For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/system-level_authentication_guide/index#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _Red{nbsp}Hat Enterprise{nbsp}Linux System-Level Authentication_ guide.
 endif::[]
 
 If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.
@@ -23,6 +23,6 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifndef::orcharhino[]
-For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Windows_Integration_Guide/sssd-gpo[Red{nbsp}Hat Enterprise Linux Windows Integration Guide].
+For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/windows_integration_guide/index#sssd-gpo[Red{nbsp}Hat Enterprise Linux Windows Integration Guide].
 endif::[]
 ====

--- a/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
@@ -22,7 +22,6 @@ You can also register Atomic Hosts to {ProjectServer} or {SmartProxyServer}.
 
 Use one of the following procedures to register a host:
 
-* xref:registering-a-host-to-project-using-the-global-registration-template_managing-hosts[]
 * xref:registering-a-host-to-satellite[]
 * xref:registering-an-atomic-host-to-satellite[]
 * xref:registering-a-host-to-satellite-using-the-bootstrap-script[]

--- a/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_adding-a-bonded-interface.adoc
@@ -27,7 +27,7 @@ These can be physical interfaces or VLANs.
 
 * *Bond options*: Specify a space-separated list of configuration options, for example *miimon=100*.
 ifndef::orcharhino[]
-See the https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/index[Red{nbsp}Hat Enterprise Linux 7 Networking Guide] for details of the configuration options you can specify for the bonded interface.
+See the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/networking_guide/index[Red{nbsp}Hat Enterprise Linux 7 Networking Guide] for details of the configuration options you can specify for the bonded interface.
 endif::[]
 
 . Click *OK* to save the interface configuration.

--- a/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_Guide/topics/Provisioning_Concepts.adoc
@@ -167,7 +167,7 @@ endif::[]
 
 === Kickstart
 You can use Kickstart to automate the installation process of a {ProjectName} or {SmartProxyServer} by creating a Kickstart file that contains all the information that is required for the installation.
-For more information about Kickstart, see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/chap-kickstart-installations[Kickstart Installations] in the _{RHEL} 7 Installation Guide_.
+For more information about Kickstart, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index#chap-kickstart-installations[Kickstart Installations] in the _{RHEL} 7 Installation Guide_.
 
 ==== Workflow
 When you run a {ProjectName} Kickstart script, the following workflow occurs:


### PR DESCRIPTION
Both of these commits are addressing validation errors caught by the web-based tool that prepares titles for the Red Hat Customer Portal and which block publication.

It's not ideal to catch these problems at the final stage of pre-publication. A command-line validator is in development that may allow writers themselves to catch and fix these issues far in advance of future releases.