### PR TITLE
Registering host links corrected

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/QuickStart.adoc
+++ b/guides/doc-Content_Management_Guide/topics/QuickStart.adoc
@@ -151,7 +151,7 @@ Use the following procedure to create an activation key that you can use to subs
 . Select your new *CentOS Stream* product in the table.
 . Click *Add Selected* to save.
 
-Use your activation key to register a host to the Content View. For more information on registering a host, see {ManagingHostsDocUR}registering-a-host-to-project-using-the-global-registration-template_managing-hosts
+Use your activation key to register a host to the Content View. For more information on registering a host, see {ManagingHostsDocURL}registering-a-host_managing-hosts
 
 ==== Registering a CentOS Stream host to consume content from published Content View
 

--- a/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
@@ -22,7 +22,7 @@ You can also register Atomic Hosts to {ProjectServer} or {SmartProxyServer}.
 
 Use one of the following procedures to register a host:
 
-* xref:registering-a-host-to-project-using-the-global-registration-template_managing-hosts[]
+* xref:registering-a-host_managing-hosts[]
 * xref:registering-a-host-to-satellite[]
 * xref:registering-an-atomic-host-to-satellite[]
 * xref:registering-a-host-to-satellite-using-the-bootstrap-script[]

--- a/guides/doc-Managing_Hosts/topics/using_insights_with_satellite_hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/using_insights_with_satellite_hosts.adoc
@@ -9,7 +9,7 @@ You can sort by category, view details of the impact and resolution, and then de
 To use Red{nbsp}Hat Insights to monitor hosts that you manage with {Project}, you must first install Red{nbsp}Hat Insights on your hosts and register your hosts with Red{nbsp}Hat Insights.
 
 For new {Project} hosts, you can install and configure {Project} hosts with Insights during registration using the global registration template.
-For more information, see {ManagingHostsDocURL}registering-a-host-to-project-using-the-global-registration-template_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
 
 To install and register your host using Puppet, or manually, see https://access.redhat.com/products/red-hat-insights/#getstarted[Red{nbsp}Hat Insights Getting Started].
 


### PR DESCRIPTION
One was already fixed, but there are others:

https://github.com/theforeman/foreman-documentation/pull/716

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)