### PR TITLE
updates AccessRedHatComVersion to 6.10-beta

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -13,8 +13,8 @@
 // For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
 :SpecialCaseProductVersion: 6.9
 
-// Use current RH Satellite GA for links to access.redhat.com
-:AccessRedHatComVersion: 6.9
+// Use current RH Satellite release version for links to access.redhat.com
+:AccessRedHatComVersion: 6.10-beta
 
 //
 // WHERE ARE MY ATTRIBUTES?


### PR DESCRIPTION
also updates inline instructions for clarity

this attribute ensures that links to the docs on the RH customer portal point to the current version, e.g. `access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/...`


Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)

