### PR TITLE
Mods beta rpm attribute

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,7 +17,7 @@
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
-:RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.9-rpms
+:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-beta-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
 :RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-7-server-satellite-capsule-6.9-rpms
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.9-rpms


### PR DESCRIPTION
SATDOC-462 beta RPM name is incorrect

https://issues.redhat.com/browse/SATDOC-462


Cherry-pick into:

* [ ] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
