### PR TITLE
fixes and updates rpms

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -18,13 +18,13 @@
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-beta-rpms
-:RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-6.8-rpms
-:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-7-server-satellite-capsule-6.9-rpms
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.9-rpms
-:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-rpms
+:RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-server-7-satellite-6.9-rpms
+:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-beta-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-server-7-satellite-tools-6-beta-rpms
+:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-server-7-satellite-maintenance-6-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.
-:RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
-:RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms
+:RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-server-7-satellite-6.3-puppet4-rpms
+:RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-server-7-satellite-capsule-6.3-puppet4-rpms
 
 // Base attributes
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -21,7 +21,7 @@
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-server-7-satellite-6.9-rpms
 :RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-beta-rpms
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-beta-rpms
-:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-server-7-satellite-maintenance-6-rpms
+:RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-beta-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.
 :RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-server-7-satellite-6.3-puppet4-rpms
 :RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-server-7-satellite-capsule-6.3-puppet4-rpms

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -20,7 +20,7 @@
 :RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-beta-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-server-7-satellite-6.9-rpms
 :RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-beta-rpms
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-server-7-satellite-tools-6-beta-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-beta-rpms
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-server-7-satellite-maintenance-6-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.
 :RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-server-7-satellite-6.3-puppet4-rpms

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -23,8 +23,8 @@
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-beta-rpms
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-beta-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.
-:RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-server-7-satellite-6.3-puppet4-rpms
-:RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-server-7-satellite-capsule-6.3-puppet4-rpms
+:RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
+:RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms
 
 // Base attributes
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key


### PR DESCRIPTION
all instances of rhel-7-server changed to rhel-server-7
version numbers also updated

https://bugzilla.redhat.com/show_bug.cgi\?id\=2007353


Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)

