### PR TITLE
changes ProductVersion to 6.10-beta

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -57,8 +57,8 @@
 :package-remove-project: satellite-maintain packages remove
 :package-update-project: satellite-maintain packages update
 :PIV: CAC
-:ProductVersion: 6.9
-:ProductVersionPrevious: 6.8
+:ProductVersion: 6.10-beta
+:ProductVersionPrevious: 6.9
 :project-client-name: Satellite Tools {ProductVersionRepoTitle}
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-context: satellite


### PR DESCRIPTION
this happens after publishing as the link-checker requires working links

this needs to be back-ported to 2.5, where the identical attributes are in a different file.
