### PR TITLE
Correct firewall commands for non-Katello scenarios

### DIFF
--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -16,11 +16,18 @@ include::snip_firewalld.adoc[]
 [options="nowrap"]
 ----
 # firewall-cmd \
---add-port="80/tcp" --add-port="443/tcp" \
---add-port="5647/tcp" --add-port="8000/tcp" \
---add-port="8140/tcp" --add-port="9090/tcp" \
 --add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" --add-port="69/udp"
+--add-port="67/udp" \
+--add-port="69/udp" \
+--add-port="80/tcp" --add-port="443/tcp" \
+ifdef::katello,satellite,orcharhino[]
+--add-port="5647/tcp" \
+--add-port="8000/tcp" --add-port="9090/tcp" \
+endif::[]
+ifndef::katello,satellite,orcharhino[]
+--add-port="8443/tcp" \
+endif::[]
+--add-port="8140/tcp"
 ----
 
 . Make the changes persistent:

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -12,12 +12,19 @@ include::snip_firewalld.adoc[]
 +
 [options="nowrap"]
 ----
-# firewall-cmd --add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" --add-port="69/udp" \
+# firewall-cmd \
+--add-port="53/udp" --add-port="53/tcp" \
+--add-port="67/udp" \
+--add-port="69/udp" \
+ifdef::katello,satellite,orcharhino[]
 --add-port="80/tcp" --add-port="443/tcp" \
 --add-port="5647/tcp" \
---add-port="8000/tcp" --add-port="8140/tcp" \
---add-port="8443/tcp" --add-port="9090/tcp"
+endif::[]
+--add-port="8140/tcp" \
+--add-port="8443/tcp" \
+ifdef::katello,satellite,orcharhino[]
+--add-port="8000/tcp" --add-port="9090/tcp"
+endif::[]
 ----
 
 . Make the changes persistent:


### PR DESCRIPTION
This corrects the instructions for non-Katello scenarios. Port 5647 is used by Qpid (needed for katello-agent) and is not present in non-Katello setups (or setups where katello-agent is disabled).

Port 8000 (Smart Proxy HTTP) is disabled by default on Foreman setups so it doesn't need to be opened. Smart Proxy HTTPS also runs on port 8443 in a vanilla Foreman where Katello runs it on port 9090. These are put on the same line to indicate they belong together.

On Katello's content proxies (aka Capsule in downstream) port 8443 is a reverse proxy setup. This doesn't exist in non-Katello setups.  Similarly, port 80 and 443 are used for content which doesn't exist on non-Katello setups.

The order of parameters is also aligned between the two guides.

The only thing that's slightly weird is opening DHCP (port 67), DNS (port 53) and TFTP (port 69) by default while the scenario doesn't enable it. Arguably this should be moved to section 4.4 where DNS, DHCP and TFTP are configured.

Technically this applies to all releases but I don't think we should aim to making Foreman 3.0 documentation on non-Katello usable. There's too much work for that.

Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)