### PR TITLE
CMG for Foreman 2.5 - fixed broken bullet list in section Configuring…

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -38,9 +38,10 @@ endif::[]
 
 .Disconnected
 In a disconnected scenario, there is the following setup:
+
 * Two {ProjectServer}s are connected to each other.
 * One {ProjectServer} is connected to the Internet while the other {ProjectServer} is not connected to the Internet.
-This is referred to as the disconnected {ProjectServer}.
+** This is referred to as the disconnected {ProjectServer}.
 * The disconnected {ProjectServer} is completely isolated from all external networks but can communicate with a connected {ProjectServer}.
 
 ifndef::satellite[]


### PR DESCRIPTION
… definitions under Synchronizing content between Foreman servers.


Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
