### PR TITLE
Remove Red Hat Satellite from anchor

### DIFF
--- a/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
@@ -22,7 +22,7 @@ For more information on manifests and repositories, see {ContentManagementDocURL
 * You must configure the host and network-based firewalls accordingly.
 For more information, see {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements].
 * You must have a {ProjectServer} user name and password.
-For more information, see {AdministeringDocURL}chap-Red_Hat_Satellite-Administering_Red_Hat_Satellite-Configuring_External_Authentication[Configuring External Authentication] in _Administering {ProjectName}_.
+For more information, see {AdministeringDocURL}Configuring_External_Authentication_admin[Configuring External Authentication] in _Administering {ProjectName}_.
 
 .Procedure
 

--- a/guides/common/modules/proc_registering-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-to-satellite-server.adoc
@@ -20,7 +20,7 @@ endif::[]
 * You must configure the host and network-based firewalls accordingly.
 For more information, see {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements].
 * You must have a {ProjectServer} user name and password.
-For more information, see {AdministeringDocURL}chap-Administering-Configuring_External_Authentication[Configuring External Authentication] in _Administering {ProjectName}_.
+For more information, see {AdministeringDocURL}Configuring_External_Authentication_admin[Configuring External Authentication] in _Administering {ProjectName}_.
 
 .Procedure
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Accessing_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Accessing_Satellite.adoc
@@ -1,4 +1,4 @@
-[[chap-Administering-Accessing_Red_Hat_Satellite]]
+[id="Accessing_Server_{context}"]
 == Accessing {ProjectName}
 
 After {ProjectName} has been installed and configured, use the web user interface to log in to {Project} for further configuration.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -1,4 +1,4 @@
-[[chap-Administering-Configuring_External_Authentication]]
+[id="Configuring_External_Authentication_{context}"]
 == Configuring External Authentication
 
 By using external authentication you can derive user and user group permissions from user group membership in an external identity provider.
@@ -88,7 +88,7 @@ When using external user groups from an LDAP source, you cannot use the `$login`
 You must use either an anonymous or dedicated service user.
 
 * If you use a {FreeIPA} or AD server, configure {Project} to use {FreeIPA} or AD authentication.
-For more information, see xref:chap-Administering-Configuring_External_Authentication[].
+For more information, see xref:Configuring_External_Authentication_{context}[].
 
 * Ensure that at least one external user authenticates for the first time.
 
@@ -158,7 +158,7 @@ You require the following setup to configure external authentication for provisi
 
 * A deployed realm or domain provider such as {FreeIPA}.
 
-[[proc-Administering-Configuring_a_Red_Hat_Satellite_Server_or_Capsule_Server_for_IdM_Realm_Support-To_configure_the_Satellite_Server_or_Capsule_Server_for_IdM_Realm_Support]]
+[id="Configuring_IdM_Realm_Support_{context}"]
 .To install and configure {FreeIPA} packages on {ProjectName} Server or {ProjectName} {SmartProxyServer}:
 
 To use {FreeIPA} for provisioned hosts, complete the following steps to install and configure {FreeIPA} packages on {ProjectName} Server or {ProjectName} {SmartProxyServer}:

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
@@ -1,4 +1,4 @@
-[[chap-Administering-Maintaining_a_Red_Hat_Satellite_Server]]
+[id="Maintaining_Server_{context}"]
 == Maintaining {ProjectServer}
 
 This chapter provides information on how to maintain a {ProjectName} Server, including information on how to work with audit records, how to clean unused tasks, and how to recover Pulp from a full disk.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
@@ -6,7 +6,7 @@ This procedure ensures that you update all references to the new host name.
 
 If you use external authentication, you must reconfigure {ProjectServer} for external authentication after you run the `{project-change-hostname}` script.
 The `{project-change-hostname}` script breaks external authentication for {ProjectServer}.
-For more information about configuring external authentication, see xref:chap-Administering-Configuring_External_Authentication[].
+For more information about configuring external authentication, see xref:Configuring_External_Authentication_{context}[].
 
 If you use virt-who, you must update the virt-who configuration files with the new host name after you run the `{project-change-hostname}` script.
 ifndef::orcharhino[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Starting_and_Stopping_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Starting_and_Stopping_Satellite.adoc
@@ -1,4 +1,4 @@
-[[chap-Administering-Starting_and_Stopping_Red_Hat_Satellite]]
+[id="Starting_and_Stopping_Server_{context}"]
 == Starting and Stopping {ProjectName}
 
 {Project} provides the `{foreman-maintain} service` command to manage {Project} services from the command line.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_the_Red_Hat_Satellite_Content_Dashboard.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_the_Red_Hat_Satellite_Content_Dashboard.adoc
@@ -1,4 +1,4 @@
-[[chap-Administering-Using_the_Red_Hat_Satellite_Content_Dashboard]]
+[id="Using_the_Content_Dashboard_{context}"]
 === Using the {ProjectName} Content Dashboard
 
 The {ProjectName} content dashboard contains various widgets which provide an overview of the host configuration, Content Views, compliance reports, subscriptions and hosts currently registered, promotions and synchronization, and a list of the latest notifications.
@@ -136,7 +136,7 @@ The possible risk levels are: Low, Medium, High, and Critical.
 It is not possible to change the date format displayed in the {ProjectWebUI}.
 ====
 
-[[sect-Administering-Using_the_Red_Hat_Satellite_Content_Dashboard-Managing_Tasks]]
+[id="Using_the_Content_Dashboard-Managing_Tasks_{context}"]
 ==== Managing Tasks
 
 {ProjectName} keeps a complete log of all planned or performed tasks, such as repositories synchronised, errata applied, and Content Views published.
@@ -148,7 +148,7 @@ You can also cancel and resume one or more tasks.
 The tasks are managed using the Dynflow engine.
 Remote tasks have a timeout which can be adjusted as needed.
 
-[[proc-Administering-Using_the_Red_Hat_Satellite_Content_Dashboard-Managing_Tasks-To_Adjust_Timeout_Settings]]
+[id="Using_the_Content_Dashboard-Managing_Tasks-To_Adjust_Timeout_Settings_{context}"]
 .To Adjust Timeout Settings:
 
 . Navigate to *Administer* > *Settings*.
@@ -173,7 +173,7 @@ There was an issue with the backend service candlepin: Connection refused – co
 
 If the back-end service checking feature turns out to be causing any trouble, it can be disabled as follows.
 
-[[proc-Administering-Using_the_Red_Hat_Satellite_Content_Dashboard-Managing_Tasks-To_Disable_Checking_For_Services]]
+[id="Using_the_Content_Dashboard-Managing_Tasks-To_Disable_Checking_For_Services_{context}"]
 .To Disable Checking for Services:
 
 . Navigate to *Administer* > *Settings*.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-user.adoc
@@ -22,7 +22,7 @@ By default, {ProjectServer} uses the language and timezone settings of the userâ
 . Set a password for the user:
 .. From the *Authorized by* list, select the source by which the user is authenticated.
 ** *INTERNAL*: to enable the user to be managed inside {ProjectServer}.
-** *EXTERNAL*: to configure external authentication as described in xref:chap-Administering-Configuring_External_Authentication[].
+** *EXTERNAL*: to configure external authentication as described in xref:Configuring_External_Authentication_{context}[].
 
 .. Enter an initial password for the user in the *Password* field and the *Verify* field.
 

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -136,7 +136,8 @@ Such servers lie outside of the {Project} infrastructure, however, it is recomme
 
 {Project} provides features for precise management of the content life cycle.
 A *life cycle environment* represents a stage in the content life cycle, a *Content View* is a filtered set of content, and can be considered as a defined subset of content.
-By associating Content Views with life cycle environments, you make content available to hosts in a defined way (see xref:figu-Architecture_System_Architecture-Content_Life_Cycle_in_Red_Hat_Satellite_6[] for visualization of the process).
+By associating Content Views with life cycle environments, you make content available to hosts in a defined way.
+See xref:figu-Content_Life_Cycle_{context}[] for visualization of the process.
 For a detailed overview of the content management process see {ContentManagementDocURL}Importing_Custom_Content[Importing Custom Content] in the _Content Management Guide_.
 The following section provides general scenarios for deploying content views as well as life cycle environments.
 

--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -1,4 +1,4 @@
-[[chap-Architecture_Guide-Introduction_to_Red_Hat_Satellite]]
+[id="Introduction_to_Server_{context}"]
 == Introduction to {ProjectName}
 
 ifndef::satellite[]
@@ -18,7 +18,7 @@ Host systems can pull content and configuration from {SmartProxyServer} in their
 {SmartProxyServer}s decrease the load on the central server, increase redundancy, and reduce bandwidth usage.
 For more information, see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
 
-[[sect-Architecture_Guide-Introduction_to_Red_Hat_Satellite-System_Architecture]]
+[id="System_Architecture_{context}"]
 === System Architecture
 
 The following diagram represents the high-level architecture of {ProjectName}.
@@ -57,7 +57,7 @@ This enables host systems to pull content and configuration from {SmartProxyServ
 The recommended minimum number of {SmartProxyServer}s is therefore given by the number of geographic regions where the organization that uses {Project} operates.
 +
 Using Content Views, you can specify the exact subset of content that {SmartProxyServer} makes available to hosts.
-See xref:figu-Architecture_System_Architecture-Content_Life_Cycle_in_Red_Hat_Satellite_6[] for a closer look at life cycle management with the use of Content Views.
+See xref:figu-Content_Life_Cycle_{context}[] for a closer look at life cycle management with the use of Content Views.
 +
 The communication between managed hosts and {ProjectServer} is routed through {SmartProxyServer} that can also manage multiple services on behalf of hosts.
 Many of these services use dedicated network ports, but {SmartProxyServer} ensures that a single source IP address is used for all communications from the host to {ProjectServer}, which simplifies firewall administration.
@@ -76,7 +76,7 @@ ifndef::satellite[]
 include::../common/modules/snip_red-hat-images.adoc[]
 endif::[]
 
-[[figu-Architecture_System_Architecture-Content_Life_Cycle_in_Red_Hat_Satellite_6]]
+[id="figu-Content_Life_Cycle_{context}"]
 .Content Life Cycle in {ProjectName}
 
 image::satellite_6_life_cycle.png[Content Life Cycle in {ProjectName}]

--- a/guides/doc-Planning_Guide/topics/Org_Loc_and_Life_Cycle_Environments.adoc
+++ b/guides/doc-Planning_Guide/topics/Org_Loc_and_Life_Cycle_Environments.adoc
@@ -12,7 +12,7 @@ ifndef::satellite[]
 include::../common/modules/snip_red-hat-images.adoc[]
 endif::[]
 
-[[figu-Example_Topology_for_Red_Hat_Satellite_6]]
+[id="figu-Example_Topology_for_Server_{context}"]
 .Example Topology for {ProjectName}
 
 image::satellite_6_topology.png[Example Topology for {ProjectName}]

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
@@ -8,7 +8,7 @@ endif::[]
 Use the following procedures to upgrade your existing {ProjectName} to {ProjectName} {ProjectVersion}:
 
 ifdef::satellite[]
-. xref:upgrading_satellite_server_parent[]
+. xref:Upgrading_Server_{context}[]
 . xref:synchronizing_the_new_repositories[]
 . xref:upgrading_capsule_server[]
 . xref:upgrading_clients[]
@@ -16,7 +16,7 @@ ifdef::satellite[]
 endif::[]
 
 ifdef::katello,foreman-el[]
-. xref:upgrading_satellite_server_parent[]
+. xref:Upgrading_Server_{context}[]
 . xref:upgrading_capsule_server[]
 . xref:upgrading_clients[]
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
@@ -1,8 +1,7 @@
-[[migrating_a_self_registered_satellite]]
-
+[id="Migrating_a_Self_Registered_Server_{context}"]
 = Migrating Self-Registered {Project}s
 
-{ProjectNameX}.3 does not support self-registered {Project}s.
+{ProjectNameX} does not support self-registered {Project}s.
 You must migrate self-registered {ProjectServer}s to the Red Hat Content Delivery Network.
 
 To migrate a self-registered {Project} to the Red Hat Content Delivery Network, complete the following steps.
@@ -101,4 +100,4 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 
 For Red Hat Enterprise Linux 6 users, proceed to the xref:migrating_from_rhel_6_to_rhel_7[].
 
-For Red Hat Enterprise Linux 7 users, proceed to xref:upgrading_satellite_server_parent[].
+For Red Hat Enterprise Linux 7 users, proceed to xref:Upgrading_Server_{context}[].

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -88,7 +88,7 @@ ifdef::satellite[]
 . Clone your existing {ProjectServer}s. For more information, see xref:cloning_satellite_server[].
 endif::[]
 . Upgrade {ProjectServer} and all {SmartProxyServer}s to {Project} {ProjectVersion}.
-For more information, see xref:upgrading_satellite_server_parent[].
+For more information, see xref:Upgrading_Server_{context}[].
 . Upgrade to {project-client-name} on all {Project} clients.
 For more information, see xref:upgrading_clients[].
 
@@ -98,7 +98,7 @@ ifdef::satellite[]
 
 You cannot upgrade a self-registered {Project}.
 You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade.
-To migrate a self-registered {Project} to the CDN, see {BaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite[Upgrading {ProjectName}] in the _{ProjectXY} Upgrading and Updating {ProjectName}_ guide.
+To migrate a self-registered {Project} to the CDN, see {UpgradingDocURL}Upgrading_Server_upgrade-guide[Upgrading {ProjectName}] in the _Upgrading and Updating {ProjectName}_ guide.
 endif::[]
 
 [[following_the_progress_of_the_upgrade]]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -1,5 +1,4 @@
-[[upgrading_satellite_server_parent]]
-
+[id="Upgrading_Server_{context}"]
 = Upgrading {ProjectServer}
 
 This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.
@@ -22,7 +21,7 @@ ifdef::satellite[]
 
 You cannot upgrade a self-registered {Project}.
 You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade.
-To migrate a self-registered {Project} to the CDN, see {BaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite#migrating_a_self_registered_satellite[Migrating Self-Registered {Project}s] in the _{ProjectXY} Upgrading and Updating {ProjectName}_ guide.
+To migrate a self-registered {Project} to the CDN, see {UpgradingDocURL}Migrating_a_Self_Registered_Server_upgrade-guide[Migrating Self-Registered {Project}s] in the _Upgrading and Updating {ProjectName}_ guide.
 endif::[]
 
 .FIPS mode


### PR DESCRIPTION
This PR remove `Red_Hat_Satellite` from anchors and links to make the docs more upstream & downstream friendly.