### PR TITLE
Reformatted Port Requirement Tables

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -21,10 +21,6 @@ For more information on {Project} Topology, see {PlanningDocURL}sect-Documentati
 
 Required ports can change based on your configuration.
 
-ifdef::katello,satellite,orcharhino[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
-endif::[]
-
 The following tables indicate the destination port and the direction of network traffic:
 
 .{SmartProxy} incoming traffic
@@ -35,10 +31,9 @@ The following tables indicate the destination port and the direction of network 
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 ifdef::katello,satellite,orcharhino[]
-| 80 | TCP | HTTP | Client | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
-| 443 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
-| 443 | TCP | HTTPS | {ProjectServer} |Content Mirroring | Management
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
+| 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 
@@ -47,16 +42,16 @@ endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
-| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
-
-Uploading facts
-
-Sending installed packages and traces
 ifndef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
 ifdef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
+
+Uploading facts
+
+Sending installed packages and traces
 | 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
@@ -73,46 +68,39 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 
 |====
-| Destination Port | Protocol | Service |Source| Required For | Function
-| 7 | ICMP | ping  | {ProjectServer} | DHCP | Free IP checking (optional)
-| | TCP | echo | {ProjectServer} | DHCP | Free IP checking (optional)
+| Destination Port | Protocol | Service | Destination | Required For | Function
+| | ICMP | ping  | Client | DHCP | Free IP checking (optional)
+| 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
 | 22 | TCP | SSH | Target host | Remote execution | Run jobs
-| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Validation of DNS conflicts
-| 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
-| 443 | TCP | HTTPS | {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
+| 53 | TCP and UDP | DNS | DNS Servers on the Internet | DNS Server | Resolve DNS records (optional)
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} DNS | Validation of DNS conflicts (optional)
+| 68 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 443 | TCP | HTTPS | {Project} | {SmartProxy} | {SmartProxy}
 
-Content Mirroring
-
-Forward Request to {Project}
-
-External Node Classification
-
-Run Report
+Configuration management
 
 Template retrieval
-| 443 | TCP | HTTPS | {Project} | Power Management | iPXE chained template retrieval
-| 443 | TCP | HTTPS | {Project} | goferd message bus | Send report to {ProjectServer}
 
-Initiation
-| 443 | TCP | HTTPS | {Project} | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
-| 443 | TCP | HTTPS | {Project} | OpenSCAP | Send report from {SmartProxy} to {Project}
-| 443 | TCP | HTTPS | {Project} | Content promotion | Initiation
-| 443 | TCP | HTTPS | {Project} | Content Sync | Initiation
-| 443 | TCP | HTTPS | {Project} | Content Sync | Red{nbsp}Hat CDN
-| 443 | TCP | HTTPS | {Project}te | Remote Execution result upload |
+OpenSCAP
+
+Remote Execution result upload
+ifdef::satellite[]
+| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | Sos report | Assisting support cases (optional
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 443 | TCP | HTTPS | {Project} | Content | Sync
+| 443 | TCP | HTTPS | {Project} | Client communication | Forward requests from Client to {Project}
+endif::[]
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 ifdef::katello,satellite,orcharhino[]
-| 5646 | TCP | AMQP | {ProjectServer} | Power management for Katello agent | Forward message to Qpid dispatch router on {SmartProxy}
+| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy}
 endif::[]
 | 7911 | TCP | DHCP, OMAPI | DHCP Server| DHCP | The DHCP target is configured using `--foreman-proxy-dhcp-server` and defaults to localhost
 
 ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAPI
 
 Infoblox always uses port 443 and HTTPS
-ifdef::katello,satellite,orcharhino[]
-| 8443 | TCP | HTTPS | Discovered Node|Power management | {SmartProxy} sends reboot command to the discovered host
-| 8443 | TCP | HTTPS | cert-api.access.redhat.com |Telemetry data upload and report | Send and read data to and from the Red{nbsp}Hat portal
-endif::[]
+| 8443 | TCP | HTTPS | Client | Discovery | {SmartProxy} sends reboot command to the discovered host
 |====
 
 NOTE: ICMP to Port 7 UDP and TCP must not be rejected, but can be dropped.

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -22,7 +22,7 @@ For more information on {Project} Topology, see {PlanningDocURL}sect-Documentati
 Required ports can change based on your configuration.
 
 ifdef::katello,satellite,orcharhino[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/3904011[Red Hat Satellite 6.9 List of Network Ports].
+A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
 endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:
@@ -39,11 +39,12 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
 endif::[]
-| 443 | TCP | HTTPS | {ProjectServer}|Content Mirroring | Initiation
-ifdef::katello,satellite,orcharhino[]
+| 443 | TCP | HTTPS | {ProjectServer} |Content Mirroring | Management
+| 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
+
 Katello agent to communicate with Qpid dispatcher
-| 8000 | TCP | HTTPS | Client | Bootdisk | iPXE chained template retrieval
+| 8000 | TCP | HTTPS | Client | Provisioning Templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet |
 | 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
@@ -51,16 +52,12 @@ Katello agent to communicate with Qpid dispatcher
 Uploading facts
 
 Sending installed packages and traces
-endif::[]
-| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 ifdef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+endif::[]
 | 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
-| 9090 | TCP | HTTPS | {ProjectServer} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
-| 9090 | TCP | HTTPS | {ProjectServer} | Remote execution | Run job on VM
-| 9090 | TCP | HTTPS | {ProjectServer} | {SmartProxy} feature retrieval |
-| 9090 | TCP | HTTPS | {ProjectServer} | OpenSCAP | View SCAP report in HTML or XML format
-endif::[]
+| 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -37,28 +37,30 @@ The following tables indicate the destination port and the direction of network 
 ifdef::katello,satellite,orcharhino[]
 | 80 | TCP | HTTP | Client | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
-endif::[]
 | 443 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | {ProjectServer} |Content Mirroring | Management
-| 443 | TCP | HTTPS | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 
 Katello agent to communicate with Qpid dispatcher
+endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
-| 8140 | TCP | HTTPS | Client | Puppet |
+| 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
 | 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
 
 Uploading facts
 
 Sending installed packages and traces
-ifdef::katello,satellite,orcharhino[]
+ifndef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
+ifdef::katello,satellite,orcharhino[]
 | 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
+endif::[]
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
@@ -72,10 +74,11 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 
 |====
 | Destination Port | Protocol | Service |Source| Required For | Function
-| 7 | ICMP | ping  | {ProjectServer} | DHCP | Free IP checking
-|- (optional) | TCP | echo | {ProjectServer} | DHCP | Free IP checking
+| 7 | ICMP | ping  | {ProjectServer} | DHCP | Free IP checking (optional)
+| | TCP | echo | {ProjectServer} | DHCP | Free IP checking (optional)
 | 22 | TCP | SSH | Target host | Remote execution | Run jobs
 | 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Validation of DNS conflicts
+| 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 443 | TCP | HTTPS | {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
 
 Content Mirroring

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -36,15 +36,16 @@ The following tables indicate the destination port and the direction of network 
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 ifdef::katello,satellite,orcharhino[]
 | 80 | TCP | HTTP | Client | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
 endif::[]
+| 443 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | {ProjectServer} |Content Mirroring | Management
+| 443 | TCP | HTTPS | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 
 Katello agent to communicate with Qpid dispatcher
-| 8000 | TCP | HTTPS | Client | Provisioning Templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
+| 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet |
 | 8443 | TCP | HTTPS | Client | Content Host registration | Initiation

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -27,48 +27,43 @@ endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:
 
-.Ports for {SmartProxy} to {Project} Communication
-[cols="24%,20%,18%,38%",options="header"]
+.{SmartProxy} incoming traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
-| Port | Protocol | Service | Required For
-| 443 | TCP | HTTPS | {SmartProxy} to {Project}
+| Destination Port | Protocol | Service |Source| Required For | Function
+| 67 | UDP | DHCP | Client | PXE Boot | DHCP
+| 69 | UDP | TFTP | Client | TFTP Server |
 ifdef::katello,satellite,orcharhino[]
-| 5646   | TCP   |  amqp   |  {SmartProxy}'s Qpid dispatch router to Qpid dispatch router in {Project}
+ .3+| 80 .3+| TCP .3+| HTTP .3+| Client | Content Host registration | {SmartProxy} CA RPM registration
+                                        | PXEBoot | Installation
+                                        | Package Installation | yum execution
 endif::[]
-|====
+ .3+| 443, 80 .3+| TCP .3+| HTTPS, HTTP .3+| Client | Content Host Registration | {SmartProxy} CA RPM installation
+                                                    | PXE Boot | Installation
+                                                    | Package installation | yum extension
+ .6+| 443 .6+| TCP .6+| HTTPS .5+| {Smartproxy} | {SmartProxy} registration |  Installation/ removal/ update
+                                                | Power management | iPXE chained template retrieval
+                                                | Telemetry data upload | Send data to Red{nbsp}Hat portal
+                                                | OpenSCAP | Configure Client
+                                                | Remote Execution Upload |
+                                                | {ProjectServer}|Content Mirroring | Initiation
+//ifdef::katello,satellite,orcharhino[]
+| 5647 (optional) | TCP | AMQP | Client | goferd message bus | Forward message to client
 
-.Ports for Client to {SmartProxy} Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-|Port |Protocol |Service |Required for
-|53 | TCP and UDP | DNS | Client DNS queries to a {SmartProxy}'s DNS service (Optional)
-|67 | UDP | DHCP | Client to {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {SmartProxy} (Optional)
-|69 | UDP |TFTP | Clients downloading PXE boot image files from a {SmartProxy} for provisioning (Optional)
-ifdef::katello,satellite,orcharhino[]
-|80 | TCP | HTTP |Content (like RPMs), and for obtaining Katello certificate updates
-|443 | TCP |HTTPS |Content (like RPMs)
-|5647 |TCP |AMQP |Katello agent to communicate with {SmartProxy}'s Qpid dispatch router (Optional)
-|8000 |TCP |HTTPS |Operating System installers like Anaconda to download installation templates to hosts, and for downloading iPXE firmware (Optional)
-|8140 |TCP |HTTPS |Puppet agent to Puppet server connections (Optional)
-|8443 |TCP |HTTPS |Subscription Management Services
-|9090 |TCP |HTTPS |Sending SCAP reports to the {SmartProxy} and for the discovery image during provisioning (Optional)
-endif::[]
-ifndef::katello,satellite,orcharhino[]
-|8000 |TCP |HTTPS |Operating System installers like Anaconda to download installation templates to hosts, and for downloading iPXE firmware (Optional)
-|8140 |TCP |HTTPS |Puppet agent to Puppet server connections (Optional)
-|8443 |TCP |HTTPS |Sending SCAP reports to the {SmartProxy} and for the discovery image during provisioning (Optional)
-endif::[]
-|====
+Katello agent to communicate with Qpid dispatcher
+| 8000 | TCP | HTTPS | Client | Bootdisk | iPXE chained template retrieval
+| 8140 | TCP | HTTPS | Client | Puppet |
+| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
 
-.Ports for {SmartProxy} to Client Communication
-[cols="24%,20%,18%,38%a",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| - | ICMP | ping | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-| 7 | TCP | echo | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-| 22 | TCP | SSH | {Project} and {SmartProxy} originated communications, for Remote Execution (Rex) and Ansible. (Optional)
-| 68 | UDP | DHCP | {SmartProxy} to Client broadcasts, DHCP broadcasts for Client provisioning from a {SmartProxy} (Optional)
-| 8443 | TCP |HTTP | {SmartProxy} to Client "reboot" command to a discovered host during provisioning (Optional)
+Uploading facts
+
+Sending installed packages and traces
+ .5+| 9090 .5+| TCP .5+| HTTPS | Discovered Node|Discovery |Host discovery and provisioning
+ .4+| {ProjectServer} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
+                      | Remote execution | Run job on VM
+                      | {SmartProxy} feature retrieval |
+                      | OpenSCAP | View SCAP report in HTML or XML format
+endif::[]
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
@@ -77,12 +72,49 @@ This includes the base operating system on which a {SmartProxyServer} is running
 A DHCP {SmartProxy} performs ICMP ping and TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
 This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
-.Optional Network Ports
-[cols="24%,20%,18%,38%a",options="header"]
+.{SmartProxy} outgoing traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
+
 |====
-| Port | Protocol | Service | Required For
-| 7911 | TCP | DHCP | * {SmartProxy} originated commands for orchestration of DHCP records (local or external).
-                      * If DHCP is provided by an external service, you must open the port on the external server.
+| Destination Port | Protocol | Service |Source| Required For | Function
+| 7 | ICMP and UDP | ECHO | {ProjectServer} | DHCP | {SmartProxy} API requirement to configure TFTP, DHCP and others
+| 22 | TCP | SSH | Target host | Remote execution |Run job on  VM proxied through {SmartProxy}
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | DNS records
+ .8+| 443 .8+| TCP .8+| HTTPS .8+| {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
+
+                                                 Content Mirroring
+
+                                                 Forward Request to {Project}
+
+                                                 External Node Classification
+
+                                                 Run Report
+
+                                                 Template retrieval
+                                                 | Power Management | iPXE chained template retrieval
+                                                 | goferd message bus | Send report to {ProjectServer}
+
+                                                Initiation
+                                                 | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
+                                                 | OpenSCAP | Send report from {SmartProxy} to {Project}
+                                                 | Content promotion | Initiation
+                                                 | Content Sync | Initiation
+
+Red{nbsp}Hat CDN
+                                                 | Remote Execution result upload |
+| 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
+ifdef::katello,satellite,orcharhino[]
+| 5646 | TCP | AMQP | {ProjectServer} | Power management for Katello agent | Forward message to Qpid dispatch router on {SmartProxy}
+endif::[]
+| 7911 | TCP | DHCP, OMAPI | DHCP Server| DHCP | The DHCP target is configured using `--foreman-proxy-dhcp-server` and defaults to localhost
+
+ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAPI
+
+Infoblox always uses port 443 and HTTPS
+ifdef::katello,satellite,orcharhino[]
+ .2+| 8443 .2+| TCP .2+| HTTPS | Discovered Node|Power management | {SmartProxy} sends reboot command to the discovered host
+                               | cert-api.access.redhat.com |Telemetry data upload and report | Send and read data to and from the Red{nbsp}Hat portal
+endif::[]
 |====
 
 NOTE: A DHCP {SmartProxy} sends an ICMP ECHO to confirm an IP address is free, *no response* of any kind is expected.

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -31,24 +31,17 @@ The following tables indicate the destination port and the direction of network 
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
 | Destination Port | Protocol | Service |Source| Required For | Function
-| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Name resolution
-| 67 | UDP | TFTP (optional) | Client | PXE Boot | DHCP (optional)
+| 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
-| 69 | UDP | TFTP (optional) | Client | TFTP Server |
+| 69 | UDP | TFTP | Client | TFTP Server (optional) |
 ifdef::katello,satellite,orcharhino[]
-| 80 | TCP | HTTP | Client | Content Host registration | {SmartProxy} CA RPM registration
-| 80 | TCP | HTTP | Client | Package Installation | Content
+| 80 | TCP | HTTP | Client | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
 endif::[]
-| 443 | TCP | HTTPS | {Smartproxy} | {SmartProxy} registration |  Installation/ removal/ update
-| 443 | TCP | HTTPS | {Smartproxy} | Power management | iPXE chained template retrieval
-| 443 | TCP | HTTPS | {Smartproxy} | Telemetry data upload | Send data to Red{nbsp}Hat portal
-
 | 443 | TCP | HTTPS | {ProjectServer}|Content Mirroring | Initiation
 ifdef::katello,satellite,orcharhino[]
-| 5647 (optional) | TCP | AMQP | Client | goferd message bus | Forward message to client
-
+| 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 Katello agent to communicate with Qpid dispatcher
 | 8000 | TCP | HTTPS | Client | Bootdisk | iPXE chained template retrieval
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -26,7 +26,7 @@ The following tables indicate the destination port and the direction of network 
 .{SmartProxy} incoming traffic
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
-| Destination Port | Protocol | Service |Source| Required For | Function
+| Destination Port | Protocol | Service |Source| Required For | Description
 | 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
@@ -40,7 +40,7 @@ ifdef::katello,satellite,orcharhino[]
 Katello agent to communicate with Qpid dispatcher
 endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
-| 8000 | TCP | HTTPS | Client | PXE Boot | Installation
+| 8000 | TCP | HTTP | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
 ifndef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
@@ -68,7 +68,7 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 
 |====
-| Destination Port | Protocol | Service | Destination | Required For | Function
+| Destination Port | Protocol | Service | Destination | Required For | Description
 | | ICMP | ping  | Client | DHCP | Free IP checking (optional)
 | 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
 | 22 | TCP | SSH | Target host | Remote execution | Run jobs
@@ -85,22 +85,21 @@ OpenSCAP
 
 Remote Execution result upload
 ifdef::satellite[]
-| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | Sos report | Assisting support cases (optional
+| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 | 443 | TCP | HTTPS | {Project} | Content | Sync
 | 443 | TCP | HTTPS | {Project} | Client communication | Forward requests from Client to {Project}
 endif::[]
+| 443 | TCP | HTTPS | Infoblox DHCP Server| DHCP management | When using Infoblox for DHCP, management of the DHCP leases (optional)
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 ifdef::katello,satellite,orcharhino[]
-| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy}
+| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
 endif::[]
 | 7911 | TCP | DHCP, OMAPI | DHCP Server| DHCP | The DHCP target is configured using `--foreman-proxy-dhcp-server` and defaults to localhost
 
 ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAPI
-
-Infoblox always uses port 443 and HTTPS
-| 8443 | TCP | HTTPS | Client | Discovery | {SmartProxy} sends reboot command to the discovered host
+| 8443 | TCP | HTTPS | Client | Discovery | {SmartProxy} sends reboot command to the discovered host (optional)
 |====
 
 NOTE: ICMP to Port 7 UDP and TCP must not be rejected, but can be dropped.

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -22,7 +22,7 @@ For more information on {Project} Topology, see {PlanningDocURL}sect-Documentati
 Required ports can change based on your configuration.
 
 ifdef::katello,satellite,orcharhino[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
+A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/3904011[Red Hat Satellite 6.9 List of Network Ports].
 endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:
@@ -84,7 +84,7 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 | 7 | ICMP | ping  | {ProjectServer} | DHCP | Free IP checking
 |- (optional) | TCP | echo | {ProjectServer} | DHCP | Free IP checking
 | 22 | TCP | SSH | Target host | Remote execution | Run jobs
-| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Name resolution
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Validation of DNS conflicts
 | 443 | TCP | HTTPS | {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
 
 Content Mirroring
@@ -105,7 +105,7 @@ Initiation
 | 443 | TCP | HTTPS | {Project} | Content promotion | Initiation
 | 443 | TCP | HTTPS | {Project} | Content Sync | Initiation
 | 443 | TCP | HTTPS | {Project} | Content Sync | Red{nbsp}Hat CDN
-| 443 | TCP | HTTPS | {Project} | Remote Execution result upload |
+| 443 | TCP | HTTPS | {Project}te | Remote Execution result upload |
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 ifdef::katello,satellite,orcharhino[]
 | 5646 | TCP | AMQP | {ProjectServer} | Power management for Katello agent | Forward message to Qpid dispatch router on {SmartProxy}
@@ -121,5 +121,6 @@ ifdef::katello,satellite,orcharhino[]
 endif::[]
 |====
 
-NOTE: A DHCP {SmartProxy} sends an ICMP ECHO to confirm an IP address is free, *no response* of any kind is expected.
-ICMP can be dropped by a networked-based firewall, but *any* response prevents the allocation of IP addresses.
+NOTE: ICMP to Port 7 UDP and TCP must not be rejected, but can be dropped.
+The DHCP {SmartProxy} sends an ECHO REQUEST to the Client network to verify that an IP address is free.
+Any response will prevent IP addresses being allocated.

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -33,7 +33,7 @@ The following tables indicate the destination port and the direction of network 
 ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
-| 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
+| 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -31,34 +31,37 @@ The following tables indicate the destination port and the direction of network 
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
 | Destination Port | Protocol | Service |Source| Required For | Function
-| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | DNS records
-| 67 | UDP | DHCP | Client | PXE Boot | DHCP
-| 69 | UDP | TFTP | Client | TFTP Server |
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Name resolution
+| 67 | UDP | TFTP (optional) | Client | PXE Boot | DHCP (optional)
+| 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 69 | UDP | TFTP (optional) | Client | TFTP Server |
 ifdef::katello,satellite,orcharhino[]
 | 80 | TCP | HTTP | Client | Content Host registration | {SmartProxy} CA RPM registration
-| 80 | TCP | HTTP | Client | PXEBoot | Installation
 | 80 | TCP | HTTP | Client | Package Installation | Content
-endif::[]
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
-| 443, 80 | TCP | HTTPS, HTTP | Client | PXE Boot | Installation
 | 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
+endif::[]
 | 443 | TCP | HTTPS | {Smartproxy} | {SmartProxy} registration |  Installation/ removal/ update
 | 443 | TCP | HTTPS | {Smartproxy} | Power management | iPXE chained template retrieval
 | 443 | TCP | HTTPS | {Smartproxy} | Telemetry data upload | Send data to Red{nbsp}Hat portal
-| 443 | TCP | HTTPS | {Smartproxy} | OpenSCAP | Configure Client
-| 443 | TCP | HTTPS | {Smartproxy} | Remote Execution Upload |
+
 | 443 | TCP | HTTPS | {ProjectServer}|Content Mirroring | Initiation
 ifdef::katello,satellite,orcharhino[]
 | 5647 (optional) | TCP | AMQP | Client | goferd message bus | Forward message to client
 
 Katello agent to communicate with Qpid dispatcher
 | 8000 | TCP | HTTPS | Client | Bootdisk | iPXE chained template retrieval
+| 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet |
 | 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
 
 Uploading facts
 
 Sending installed packages and traces
+endif::[]
+| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+ifdef::katello,satellite,orcharhino[]
+| 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectServer} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
 | 9090 | TCP | HTTPS | {ProjectServer} | Remote execution | Run job on VM
@@ -78,9 +81,10 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 
 |====
 | Destination Port | Protocol | Service |Source| Required For | Function
-| 7 (optional) | ICMP and TCP | ping and echo | {ProjectServer} | DHCP | {SmartProxy} API requirement to configure TFTP, DHCP and others
-| 22 | TCP | SSH | Target host | Remote execution |Run jobs
-| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | DNS records
+| 7 | ICMP | ping  | {ProjectServer} | DHCP | Free IP checking
+|- (optional) | TCP | echo | {ProjectServer} | DHCP | Free IP checking
+| 22 | TCP | SSH | Target host | Remote execution | Run jobs
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | Name resolution
 | 443 | TCP | HTTPS | {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
 
 Content Mirroring
@@ -92,17 +96,16 @@ External Node Classification
 Run Report
 
 Template retrieval
-| 443 | TCP | HTTPS | {SmartProxy} | Power Management | iPXE chained template retrieval
-| 443 | TCP | HTTPS | {SmartProxy} | goferd message bus | Send report to {ProjectServer}
+| 443 | TCP | HTTPS | {Project} | Power Management | iPXE chained template retrieval
+| 443 | TCP | HTTPS | {Project} | goferd message bus | Send report to {ProjectServer}
 
 Initiation
-| 443 | TCP | HTTPS | {SmartProxy} | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
-| 443 | TCP | HTTPS | {SmartProxy} | OpenSCAP | Send report from {SmartProxy} to {Project}
-| 443 | TCP | HTTPS | {SmartProxy} | Content promotion | Initiation
-| 443 | TCP | HTTPS | {SmartProxy} | Content Sync | Initiation
-
-Red{nbsp}Hat CDN
-| 443 | TCP | HTTPS | {SmartProxy} | Remote Execution result upload |
+| 443 | TCP | HTTPS | {Project} | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
+| 443 | TCP | HTTPS | {Project} | OpenSCAP | Send report from {SmartProxy} to {Project}
+| 443 | TCP | HTTPS | {Project} | Content promotion | Initiation
+| 443 | TCP | HTTPS | {Project} | Content Sync | Initiation
+| 443 | TCP | HTTPS | {Project} | Content Sync | Red{nbsp}Hat CDN
+| 443 | TCP | HTTPS | {Project} | Remote Execution result upload |
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 ifdef::katello,satellite,orcharhino[]
 | 5646 | TCP | AMQP | {ProjectServer} | Power management for Katello agent | Forward message to Qpid dispatch router on {SmartProxy}

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -31,22 +31,23 @@ The following tables indicate the destination port and the direction of network 
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
 | Destination Port | Protocol | Service |Source| Required For | Function
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | DNS records
 | 67 | UDP | DHCP | Client | PXE Boot | DHCP
 | 69 | UDP | TFTP | Client | TFTP Server |
 ifdef::katello,satellite,orcharhino[]
- .3+| 80 .3+| TCP .3+| HTTP .3+| Client | Content Host registration | {SmartProxy} CA RPM registration
-                                        | PXEBoot | Installation
-                                        | Package Installation | yum execution
+| 80 | TCP | HTTP | Client | Content Host registration | {SmartProxy} CA RPM registration
+| 80 | TCP | HTTP | Client | PXEBoot | Installation
+| 80 | TCP | HTTP | Client | Package Installation | Content
 endif::[]
- .3+| 443, 80 .3+| TCP .3+| HTTPS, HTTP .3+| Client | Content Host Registration | {SmartProxy} CA RPM installation
-                                                    | PXE Boot | Installation
-                                                    | Package installation | yum extension
- .6+| 443 .6+| TCP .6+| HTTPS .5+| {Smartproxy} | {SmartProxy} registration |  Installation/ removal/ update
-                                                | Power management | iPXE chained template retrieval
-                                                | Telemetry data upload | Send data to Red{nbsp}Hat portal
-                                                | OpenSCAP | Configure Client
-                                                | Remote Execution Upload |
-                                                | {ProjectServer}|Content Mirroring | Initiation
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Host Registration | {SmartProxy} CA RPM installation
+| 443, 80 | TCP | HTTPS, HTTP | Client | PXE Boot | Installation
+| 443, 80 | TCP | HTTPS, HTTP | Client | Package installation | yum extension
+| 443 | TCP | HTTPS | {Smartproxy} | {SmartProxy} registration |  Installation/ removal/ update
+| 443 | TCP | HTTPS | {Smartproxy} | Power management | iPXE chained template retrieval
+| 443 | TCP | HTTPS | {Smartproxy} | Telemetry data upload | Send data to Red{nbsp}Hat portal
+| 443 | TCP | HTTPS | {Smartproxy} | OpenSCAP | Configure Client
+| 443 | TCP | HTTPS | {Smartproxy} | Remote Execution Upload |
+| 443 | TCP | HTTPS | {ProjectServer}|Content Mirroring | Initiation
 ifdef::katello,satellite,orcharhino[]
 | 5647 (optional) | TCP | AMQP | Client | goferd message bus | Forward message to client
 
@@ -58,11 +59,11 @@ Katello agent to communicate with Qpid dispatcher
 Uploading facts
 
 Sending installed packages and traces
- .5+| 9090 .5+| TCP .5+| HTTPS | Discovered Node|Discovery |Host discovery and provisioning
- .4+| {ProjectServer} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
-                      | Remote execution | Run job on VM
-                      | {SmartProxy} feature retrieval |
-                      | OpenSCAP | View SCAP report in HTML or XML format
+| 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
+| 9090 | TCP | HTTPS | {ProjectServer} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
+| 9090 | TCP | HTTPS | {ProjectServer} | Remote execution | Run job on VM
+| 9090 | TCP | HTTPS | {ProjectServer} | {SmartProxy} feature retrieval |
+| 9090 | TCP | HTTPS | {ProjectServer} | OpenSCAP | View SCAP report in HTML or XML format
 endif::[]
 |====
 
@@ -77,31 +78,31 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 
 |====
 | Destination Port | Protocol | Service |Source| Required For | Function
-| 7 | ICMP and UDP | ECHO | {ProjectServer} | DHCP | {SmartProxy} API requirement to configure TFTP, DHCP and others
-| 22 | TCP | SSH | Target host | Remote execution |Run job on  VM proxied through {SmartProxy}
+| 7 (optional) | ICMP and TCP | ping and echo | {ProjectServer} | DHCP | {SmartProxy} API requirement to configure TFTP, DHCP and others
+| 22 | TCP | SSH | Target host | Remote execution |Run jobs
 | 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} registration | DNS records
- .8+| 443 .8+| TCP .8+| HTTPS .8+| {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
+| 443 | TCP | HTTPS | {SmartProxy} | {SmartProxy} registration | (smart host, {SmartProxy})
 
-                                                 Content Mirroring
+Content Mirroring
 
-                                                 Forward Request to {Project}
+Forward Request to {Project}
 
-                                                 External Node Classification
+External Node Classification
 
-                                                 Run Report
+Run Report
 
-                                                 Template retrieval
-                                                 | Power Management | iPXE chained template retrieval
-                                                 | goferd message bus | Send report to {ProjectServer}
+Template retrieval
+| 443 | TCP | HTTPS | {SmartProxy} | Power Management | iPXE chained template retrieval
+| 443 | TCP | HTTPS | {SmartProxy} | goferd message bus | Send report to {ProjectServer}
 
-                                                Initiation
-                                                 | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
-                                                 | OpenSCAP | Send report from {SmartProxy} to {Project}
-                                                 | Content promotion | Initiation
-                                                 | Content Sync | Initiation
+Initiation
+| 443 | TCP | HTTPS | {SmartProxy} | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
+| 443 | TCP | HTTPS | {SmartProxy} | OpenSCAP | Send report from {SmartProxy} to {Project}
+| 443 | TCP | HTTPS | {SmartProxy} | Content promotion | Initiation
+| 443 | TCP | HTTPS | {SmartProxy} | Content Sync | Initiation
 
 Red{nbsp}Hat CDN
-                                                 | Remote Execution result upload |
+| 443 | TCP | HTTPS | {SmartProxy} | Remote Execution result upload |
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 ifdef::katello,satellite,orcharhino[]
 | 5646 | TCP | AMQP | {ProjectServer} | Power management for Katello agent | Forward message to Qpid dispatch router on {SmartProxy}
@@ -112,8 +113,8 @@ ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAP
 
 Infoblox always uses port 443 and HTTPS
 ifdef::katello,satellite,orcharhino[]
- .2+| 8443 .2+| TCP .2+| HTTPS | Discovered Node|Power management | {SmartProxy} sends reboot command to the discovered host
-                               | cert-api.access.redhat.com |Telemetry data upload and report | Send and read data to and from the Red{nbsp}Hat portal
+| 8443 | TCP | HTTPS | Discovered Node|Power management | {SmartProxy} sends reboot command to the discovered host
+| 8443 | TCP | HTTPS | cert-api.access.redhat.com |Telemetry data upload and report | Send and read data to and from the Red{nbsp}Hat portal
 endif::[]
 |====
 

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -47,7 +47,7 @@ endif::[]
                                                 | OpenSCAP | Configure Client
                                                 | Remote Execution Upload |
                                                 | {ProjectServer}|Content Mirroring | Initiation
-//ifdef::katello,satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 | 5647 (optional) | TCP | AMQP | Client | goferd message bus | Forward message to client
 
 Katello agent to communicate with Qpid dispatcher

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -16,7 +16,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
 ifdef::satellite[]
-For more information on {Project} Topology, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
+For more information on {Project} Topology and an illustration of port connections, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
 endif::[]
 
 Required ports can change based on your configuration.
@@ -27,59 +27,51 @@ endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:
 
-ifdef::satellite[]
+.{ProjectServer} incoming traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
+
+|====
+| Destination Port | Protocol | Service |Source| Required For |Function
 ifeval::["{mode}" == "connected"]
-.Ports for {Project} to Red Hat CDN Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 443 | TCP | HTTPS | Subscription Management Services (access.redhat.com) and connecting to the Red{nbsp}Hat CDN (cdn.redhat.com).
-|====
+| 7 | ICMP and UDP | ECHO | {Smartproxy} |  DHCP | ICMP ECHO to verify IP address is free (Optional)
 endif::[]
-endif::[]
+ .3+| 80 .3+| TCP .3+| HTTP .3+| Client | Content Host Registration | Capsule CA RPM Installation
+                                        | Provisioning | Template Retrieval
+                                        | Bootdisk | iPXE chained template retrieval
+ .8+| 443 .8+| TCP .8+| HTTPS .8+| {Smartproxy}| {Smartproxy} Registration | (smart host, {SmartProxy})
 
-ifdef::satellite[]
+Content Mirroring
+
+Forward Request to {Project}
+
+External Node Classification
+
+Run Report
+
+Template retrieval
+                                         | Power Management | iPXE chained template retrieval
+                                         | goferd message bus |Send report to {ProjectServer}
+
+Initiation
+                                         | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
+                                         | OpenSCAP | Send report from {SmartProxy} to {Project}
+                                         | Content promotion | Initiation
+                                         | Content Sync | Initiation
+
 ifeval::["{mode}" == "connected"]
-{ProjectServer} needs access to the Red{nbsp}Hat CDN.
-For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red Hat] on the Red{nbsp}Hat Customer Portal.
+Red{nbsp}Hat CDN
 endif::[]
-endif::[]
-
-ifdef::katello[]
-ifeval::["{mode}" == "connected"]
-If you plan to use Red{nbsp}Hat services, {ProjectServer} needs access to the Red{nbsp}Hat CDN.
-For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red Hat] on the Red{nbsp}Hat Customer Portal.
-endif::[]
-endif::[]
-
-.Ports for Browser-based User Interface Access to {Project}
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 443 | TCP | HTTPS | Browser-based UI access to {Project}
-| 80 | TCP | HTTP | Redirection to HTTPS for web UI access to {Project} (Optional)
-|====
-
-.Ports for Client to {Project} Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 80 | TCP | HTTP | Anaconda, yum, for obtaining Katello certificates, templates, and for downloading iPXE firmware
-| 443 | TCP | HTTPS | Subscription Management Services, yum, Telemetry Services and client connections
+                                         | Remote Execution result upload |
+ .3+| .3+| .3+| .3+| {Projectserver} | Content Promotion | Initiation
+                                     | Content Sync | Initiation
+                                     | Remote Install | Initiation
 ifdef::katello,satellite[]
-| 5646 | TCP | AMQP | The {SmartProxy} Qpid dispatch router to the Qpid dispatch router in {Project}
-| 5647 | TCP | AMQP | Katello Agent to communicate with {Project}'s Qpid dispatch router
+| 5646 | TCP | AMQP |{SmartProxy}| Power Management for Katello agent | Forward message to Qpid dispatch router on {Project
 endif::[]
-| 8000 | TCP | HTTP | Anaconda to download kickstart templates to hosts, and for downloading iPXE firmware
-| 8140 | TCP | HTTPS | Puppet agent to Puppet server connections
-| 9090 | TCP | HTTPS | Sending SCAP reports to the integrated {SmartProxy}, for the discovery image during provisioning, and for communicating with {ProjectServer} to copy the SSH keys for Remote Execution (Rex) configuration
-ifeval::["{mode}" == "connected"]
-| - | ICMP | ping | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-| 7 | TCP | echo | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-endif::[]
-| 53 | TCP and UDP | DNS | Client DNS queries to a {Project}'s integrated {SmartProxy} DNS service (Optional)
-| 67 | UDP | DHCP | Client to {Project}'s integrated {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {Project}'s integrated {SmartProxy} (Optional)
-| 69 | UDP |TFTP | Clients downloading PXE boot image files from a {Project}s' integrated {SmartProxy} for provisioning (Optional)
+| 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client
+
+Forward message to dispatch router on {Project}
+| 5910 - 5930 | TCP | SSL/TLS | Client | Compute Resource's virtual console
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
@@ -88,23 +80,29 @@ This includes the base operating system on which a {SmartProxyServer} is running
 A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
 This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
-.Ports for {Project} to {SmartProxy} Communication
-[cols="24%,20%,18%,38%",options="header"]
+.{ProjectServer} outgoing traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
-| Port | Protocol | Service | Required for
-| 443 | TCP | HTTPS | Connections to the Pulp server in the {SmartProxy}
-| 9090 | TCP | HTTPS | Connections to the proxy in the {SmartProxy}
-| 80 | TCP | HTTP | Downloading a bootdisk (Optional)
-|====
-
-.Optional Network Ports
-[cols="24%,20%,18%,38%a",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 22 | TCP | SSH | {Project} and {SmartProxy} originated communications, for Remote Execution (Rex) and Ansible.
-| 443 | TCP | HTTPS | {Project} originated communications, for vCenter compute resource.
-| 5000 | TCP | HTTP | {Project} originated communications, for compute resources in OpenStack.
-| 22, 16514 | TCP | SSH, SSL/TLS | {Project} originated communications, for compute resources in libvirt.
-| 389, 636 | TCP | LDAP, LDAPS | {Project} originated communications, for LDAP and secured LDAP authentication sources.
-| 5900 to 5930 | TCP | SSL/TLS | {Project} originated communications, for NoVNC console in web UI to hypervisors.
+| Destination Port | Protocol | Service |Source| Required For | Function
+| 22, 16514 | TCP | SSH SSH/TLS | Compute Resource | {Project} originated communications, for compute resources in libvirt |
+| 53 | TCP and UDP | DNS | DNS Server | Orchestration | Validation of DNS conflicts
+| 80 | TCP | HTTP | Remote repository | Content Sync | Remote yum repository
+| 389, 636 | TCP | LDAP, LDAPS | External LDAP Server | LDAP | LDAP authenticatiion, necessary only if external authentication is enabled.
+The port can be customized when `LDAPAuthSource` is defined
+ .3+| 443 .3+| TCP .3+| HTTPS | {SmartProxy} | Content mirroring | Initiation
+                              | EC2 | Compute resources | Fog interactions (query/create/destroy) |
+//ifdef::satellite[]
+//ifeval::["{mode}" == "connected"]
+                              Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN |
+                          ||| cert-api.access.redhat.com | Telemetry data upload and report |
+//endif::[]
+//endif::[]
+| 5000 | TCP | HTTP | Compute Resource | Compute resources | Fog interactions (query/create/destroy)
+ .2+| 5671 .2+|  .2+|  | Qpid |Remote install | Send install command to  client
+| Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
+| 5900 - 5930 | TCP | SSL/TLS | Hypervisor | noVNC console | Launch noVNC console
+ .4+| 9090 .4+| TCP .4+| HTTPS .4+| {SmartProxy} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
+                                                 | Remote execution | Run job on VM
+                                                 | {SmartProxy} feature retrieval |
+                                                 | OpenSCAP | View SCAP report in HTML or XML format
 |====

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -22,7 +22,7 @@ endif::[]
 Required ports can change based on your configuration.
 
 ifdef::satellite[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
+A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/3904011[Red Hat Satellite 6.9 List of Network Ports].
 endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -31,9 +31,6 @@ The following tables indicate the destination port and the direction of network 
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
-ifdef::satellite[]
-// ToDo Figure out how cloud.redhat.com connects
-endif::[]
 ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
@@ -109,7 +106,6 @@ endif::[]
 | 5000 | TCP | HTTPS | OpenStack Compute Resource | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::katello,satellite,orcharhino[]
 | 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
-//To Do Check this with Eric
 | 5671 |  |  | Qpid |Remote install | Send install command to  client
 | 5671 |  |  | Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
 | 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -21,49 +21,45 @@ endif::[]
 
 Required ports can change based on your configuration.
 
-ifdef::satellite[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
-endif::[]
-
 The following tables indicate the destination port and the direction of network traffic:
 
 .{ProjectServer} incoming traffic
-[cols="15%,15%,15%,15%,20%,20%",options="header"]
-
+[cols="15%,15%,15%,15%,20%,20%",options="header
 |====
-| Destination Port | Protocol | Service |Source| Required For |Function
-ifeval::["{mode}" == "connected"]
-| 7 | ICMP and UDP | ECHO | {Smartproxy} |  DHCP | ICMP ECHO to verify IP address is free (Optional)
+| Destination Port | Protocol | Service |Source| Required For | Description
+| 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
+| 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 69 | UDP | TFTP | Client | TFTP Server (optional) |
+| 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
+ifdef::satellite[]
+// ToDo Figure out how cloud.redhat.com connects
 endif::[]
-| 80 | TCP | HTTP | Client | Content Host Registration | Capsule CA RPM Installation
-| 80 | TCP | HTTP | Client | Provisioning | Template Retrieval
-| 80 | TCP | HTTP | Client | Bootdisk | iPXE chained template retrieval
-| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | (smart host, {SmartProxy})
-| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Content Mirroring
-| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Forward Request to {Project}
-| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | External Node Classification
-| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Run Report
-| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Template retrieval
-| 443 | TCP | HTTPS | {Smartproxy} | Power Management | iPXE chained template retrieval
-| 443 | TCP | HTTPS | {Smartproxy} | goferd message bus | Send report to {ProjectServer}
-| 443 | TCP | HTTPS | {Smartproxy} | goferd message bus | Initiation
-| 443 | TCP | HTTPS | {Smartproxy} | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
-| 443 | TCP | HTTPS | {Smartproxy} | OpenSCAP | Send report from {SmartProxy} to {Project}
-| 443 | TCP | HTTPS | {Smartproxy} | Content promotion | Initiation
-| 443 | TCP | HTTPS | {Smartproxy} | Content Sync | Initiation
-ifeval::["{mode}" == "connected"]
-| 443 | TCP | HTTPS | {Smartproxy} | Red{nbsp}Hat CDN
+ifdef::katello,satellite,orcharhino[]
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
+| 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
+| 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
+| 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
 endif::[]
-| 443 | TCP | HTTPS | {Smartproxy} | Remote Execution result upload |
-| 443 | TCP | HTTPS | {Projectserver} | Content Promotion | Initiation
-| 443 | TCP | HTTPS | {Projectserver}| Content Sync | Initiation
-| 443 | TCP | HTTPS | {Projectserver}| Remote Install | Initiation
-ifdef::katello,satellite[]
-| 5646 | TCP | AMQP |{SmartProxy}| Power Management for Katello agent | Forward message to Qpid dispatch router on {Project
+| 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console
+| 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
+| 8000 | TCP | HTTPS | Client | PXE Boot | Installation
+| 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
+ifndef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
-| 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client
-| 5671 | | | {ProjectServer} | Remote install for Katello agent | Forward message to dispatch router on {Project}
-| 5910 - 5930 | TCP | SSL/TLS | Client | Compute Resource's virtual console
+ifdef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
+
+Uploading facts
+
+Sending installed packages and traces
+| 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
+| 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
+endif::[]
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
@@ -74,27 +70,60 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 
 .{ProjectServer} outgoing traffic
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
+
 |====
-| Destination Port | Protocol | Service |Source| Required For | Function
+| Destination Port | Protocol | Service | Destination | Required For | Description
+| | ICMP | ping  | Client | DHCP | Free IP checking (optional)
+| 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
+| 22 | TCP | SSH | Target host | Remote execution | Run jobs
 | 22, 16514 | TCP | SSH SSH/TLS | Compute Resource | {Project} originated communications, for compute resources in libvirt |
+| 53 | TCP and UDP | DNS | DNS Servers on the Internet | DNS Server | Resolve DNS records (optional)
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} DNS | Validation of DNS conflicts (optional)
 | 53 | TCP and UDP | DNS | DNS Server | Orchestration | Validation of DNS conflicts
+| 68 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 80 | TCP | HTTP | Remote repository | Content Sync | Remote yum repository
 | 389, 636 | TCP | LDAP, LDAPS | External LDAP Server | LDAP | LDAP authenticatiion, necessary only if external authentication is enabled.
 The port can be customized when `LDAPAuthSource` is defined
-| 443 | TCP | HTTPS | {SmartProxy} | Content mirroring | Initiation
-| 443 | TCP | HTTPS | EC2 | Compute resources | Fog interactions (query/create/destroy)
+| 443 | TCP | HTTPS | {Project} | {SmartProxy} | {SmartProxy}
+
+Configuration management
+
+Template retrieval
+
+OpenSCAP
+
+Remote Execution result upload
+| 443 | TCP | HTTPS | Amazon EC2, Azure, Google GCE | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
+| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 | 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
 endif::[]
 endif::[]
-| 5000 | TCP | HTTP | Compute Resource | Compute resources | Fog interactions (query/create/destroy)
+ifdef::katello,satellite,orcharhino[]
+| 443 | TCP | HTTPS | {SmartProxy} | Content mirroring | Initiation
+endif::[]
+| 443 | TCP | HTTPS | Infoblox DHCP Server| DHCP management | When using Infoblox for DHCP, management of the DHCP leases (optional)
+| 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
+| 5000 | TCP | HTTPS | OpenStack Compute Resource | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
+ifdef::katello,satellite,orcharhino[]
+| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
+//To Do Check this with Eric
 | 5671 |  |  | Qpid |Remote install | Send install command to  client
 | 5671 |  |  | Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
+| 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client
+| 5671 | | | {ProjectServer} | Remote install for Katello agent | Forward message to dispatch router on {Project}
+endif::[]
 | 5900 - 5930 | TCP | SSL/TLS | Hypervisor | noVNC console | Launch noVNC console
-| 9090 | TCP | HTTPS | {SmartProxy} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
-| 9090 | TCP | HTTPS | {SmartProxy} | Remote execution | Run job on VM
-| 9090 | TCP | HTTPS | {SmartProxy} | {SmartProxy} feature retrieval |
-| 9090 | TCP | HTTPS | {SmartProxy} | OpenSCAP | View SCAP report in HTML or XML format
+| 7911 | TCP | DHCP, OMAPI | DHCP Server| DHCP | The DHCP target is configured using `--foreman-proxy-dhcp-server` and defaults to localhost
+
+ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAPI
+| 8443 | TCP | HTTPS | Client | Discovery | {SmartProxy} sends reboot command to the discovered host (optional)
+ifndef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | {SmartProxy}| {SmartProxy} API | Management of {SmartProxies}
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 9090 | TCP | HTTPS | {SmartProxy}| {SmartProxy} API | Management of {SmartProxies}
+endif::[]
 |====

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -93,6 +93,7 @@ Remote Execution result upload
 | 443 | TCP | HTTPS | Amazon EC2, Azure, Google GCE | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
+| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls
 | 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 | 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -22,7 +22,7 @@ endif::[]
 Required ports can change based on your configuration.
 
 ifdef::satellite[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/3904011[Red Hat Satellite 6.9 List of Network Ports].
+A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
 endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -35,42 +35,34 @@ The following tables indicate the destination port and the direction of network 
 ifeval::["{mode}" == "connected"]
 | 7 | ICMP and UDP | ECHO | {Smartproxy} |  DHCP | ICMP ECHO to verify IP address is free (Optional)
 endif::[]
- .3+| 80 .3+| TCP .3+| HTTP .3+| Client | Content Host Registration | Capsule CA RPM Installation
-                                        | Provisioning | Template Retrieval
-                                        | Bootdisk | iPXE chained template retrieval
- .8+| 443 .8+| TCP .8+| HTTPS .8+| {Smartproxy}| {Smartproxy} Registration | (smart host, {SmartProxy})
-
-Content Mirroring
-
-Forward Request to {Project}
-
-External Node Classification
-
-Run Report
-
-Template retrieval
-                                         | Power Management | iPXE chained template retrieval
-                                         | goferd message bus |Send report to {ProjectServer}
-
-Initiation
-                                         | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
-                                         | OpenSCAP | Send report from {SmartProxy} to {Project}
-                                         | Content promotion | Initiation
-                                         | Content Sync | Initiation
-
+| 80 | TCP | HTTP | Client | Content Host Registration | Capsule CA RPM Installation
+| 80 | TCP | HTTP | Client | Provisioning | Template Retrieval
+| 80 | TCP | HTTP | Client | Bootdisk | iPXE chained template retrieval
+| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | (smart host, {SmartProxy})
+| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Content Mirroring
+| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Forward Request to {Project}
+| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | External Node Classification
+| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Run Report
+| 443 | TCP | HTTPS | {Smartproxy} | {Smartproxy} Registration | Template retrieval
+| 443 | TCP | HTTPS | {Smartproxy} | Power Management | iPXE chained template retrieval
+| 443 | TCP | HTTPS | {Smartproxy} | goferd message bus | Send report to {ProjectServer}
+| 443 | TCP | HTTPS | {Smartproxy} | goferd message bus | Initiation
+| 443 | TCP | HTTPS | {Smartproxy} | Telemetry Data Upload | Send data to Red{nbsp}Hat Portal
+| 443 | TCP | HTTPS | {Smartproxy} | OpenSCAP | Send report from {SmartProxy} to {Project}
+| 443 | TCP | HTTPS | {Smartproxy} | Content promotion | Initiation
+| 443 | TCP | HTTPS | {Smartproxy} | Content Sync | Initiation
 ifeval::["{mode}" == "connected"]
-Red{nbsp}Hat CDN
+| 443 | TCP | HTTPS | {Smartproxy} | Red{nbsp}Hat CDN
 endif::[]
-                                         | Remote Execution result upload |
- .3+| .3+| .3+| .3+| {Projectserver} | Content Promotion | Initiation
-                                     | Content Sync | Initiation
-                                     | Remote Install | Initiation
+| 443 | TCP | HTTPS | {Smartproxy} | Remote Execution result upload |
+| 443 | TCP | HTTPS | {Projectserver} | Content Promotion | Initiation
+| 443 | TCP | HTTPS | {Projectserver}| Content Sync | Initiation
+| 443 | TCP | HTTPS | {Projectserver}| Remote Install | Initiation
 ifdef::katello,satellite[]
 | 5646 | TCP | AMQP |{SmartProxy}| Power Management for Katello agent | Forward message to Qpid dispatch router on {Project
 endif::[]
 | 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client
-
-Forward message to dispatch router on {Project}
+| 5671 | | | {ProjectServer} | Remote install for Katello agent | Forward message to dispatch router on {Project}
 | 5910 - 5930 | TCP | SSL/TLS | Client | Compute Resource's virtual console
 |====
 
@@ -89,20 +81,20 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 | 80 | TCP | HTTP | Remote repository | Content Sync | Remote yum repository
 | 389, 636 | TCP | LDAP, LDAPS | External LDAP Server | LDAP | LDAP authenticatiion, necessary only if external authentication is enabled.
 The port can be customized when `LDAPAuthSource` is defined
- .3+| 443 .3+| TCP .3+| HTTPS | {SmartProxy} | Content mirroring | Initiation
-                              | EC2 | Compute resources | Fog interactions (query/create/destroy) |
-//ifdef::satellite[]
-//ifeval::["{mode}" == "connected"]
-                              Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN |
-                          ||| cert-api.access.redhat.com | Telemetry data upload and report |
-//endif::[]
-//endif::[]
+| 443 | TCP | HTTPS | {SmartProxy} | Content mirroring | Initiation
+| 443 | TCP | HTTPS | EC2 | Compute resources | Fog interactions (query/create/destroy)
+ifdef::satellite[]
+ifeval::["{mode}" == "connected"]
+| 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
+| 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
+endif::[]
+endif::[]
 | 5000 | TCP | HTTP | Compute Resource | Compute resources | Fog interactions (query/create/destroy)
- .2+| 5671 .2+|  .2+|  | Qpid |Remote install | Send install command to  client
-| Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
+| 5671 |  |  | Qpid |Remote install | Send install command to  client
+| 5671 |  |  | Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
 | 5900 - 5930 | TCP | SSL/TLS | Hypervisor | noVNC console | Launch noVNC console
- .4+| 9090 .4+| TCP .4+| HTTPS .4+| {SmartProxy} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
-                                                 | Remote execution | Run job on VM
-                                                 | {SmartProxy} feature retrieval |
-                                                 | OpenSCAP | View SCAP report in HTML or XML format
+| 9090 | TCP | HTTPS | {SmartProxy} | Provisioning | {SmartProxy} API requirement to configure TFTP, DHCP and others
+| 9090 | TCP | HTTPS | {SmartProxy} | Remote execution | Run job on VM
+| 9090 | TCP | HTTPS | {SmartProxy} | {SmartProxy} feature retrieval |
+| 9090 | TCP | HTTPS | {SmartProxy} | OpenSCAP | View SCAP report in HTML or XML format
 |====


### PR DESCRIPTION
The port requirement tables have been redesigned and now incorporate more information on
the functions of each port. They are divided into outgoing and incoming traffic for
Satellite and Capsule

[doc] Reformat the port requirements tables

https://issues.redhat.com/browse/SAT-3277


Cherry-pick into:

* [X] Foreman 3.0
* [X] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [ ] Foreman 2.3 (Satellite 6.9)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
