### PR TITLE
Add '§' link to section titles

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -96,3 +96,4 @@
 :SmartProxy: Smart{nbsp}Proxy
 :SmartProxyServer: Smart{nbsp}Proxy{nbsp}server
 :Team: Foreman developers
+:sectanchors:

--- a/guides/common/sass/components/_asciidoc.scss
+++ b/guides/common/sass/components/_asciidoc.scss
@@ -244,7 +244,10 @@ b.button:after {
 #footnotes,
 #footer {
   @include grid-row;
-  @include grid-column($float: false);
+
+  // Padding left 1.4 for headline link anchors
+  padding-left: 1.4em;
+  padding-right: 0.9375em;
 }
 
 #content {


### PR DESCRIPTION
Useful for quick sharing of specific section in guide.

![Screenshot from 2021-10-21 13-42-42](https://user-images.githubusercontent.com/59385976/138270499-264c978b-afb8-4336-8bed-ee83f84e9150.png)

<!---


Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
