### PR TITLE
Hide broken/unfinished variants

### DIFF
--- a/web/layouts/shortcodes/guide-list.html
+++ b/web/layouts/shortcodes/guide-list.html
@@ -1,16 +1,14 @@
 {{ $path := default "nightly" (.Get "version") }}
 
-* [Planning for Foreman](/{{ $path }}/Planning_Guide/index-foreman-el.html)
 * [Foreman Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-foreman-el.html)
 * [Foreman Quickstart Guide on Debian/Ubuntu](/{{ $path }}/Quickstart_Guide/index-foreman-deb.html)
-* [Katello Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-katello.html)
+* [Planning for Katello](/{{ $path }}/Planning_Guide/index-katello.html)
 * [Installing Foreman on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-el.html)
 * [Installing Katello on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-katello.html)
 * [Installing Smart Proxy with Content on RHEL/CentOS](/{{ $path }}/Installing_Proxy_on_Red_Hat/index-katello.html)
 * [Installing Smart Proxy on RHEL/CentOS](/{{ $path }}/Installing_Proxy_on_Red_Hat/index-foreman-el.html)
 * [Installing Foreman on Debian/Ubuntu](/{{ $path }}/Installing_Server_on_Debian/index-foreman-deb.html)
 * [Installing Smart Proxy on Debian/Ubuntu](/{{ $path }}/Installing_Proxy_on_Debian/index-foreman-deb.html)
-* [Upgrading and Updating Foreman](/{{ $path }}/Upgrading_and_Updating/index-foreman-el.html)
 * [Upgrading and Updating Katello](/{{ $path }}/Upgrading_and_Updating/index-katello.html)
 * [Deploying Foreman on AWS (reference guide)](/{{ $path }}/Deploying_on_AWS/index-foreman-el.html)
 * [Configuring Smart Proxies with a Load Balancer](/{{ $path }}/Configuring_Load_Balancer/index-foreman-el.html)


### PR DESCRIPTION
In https://github.com/theforeman/foreman-documentation/pull/728 I had to hide variants which had broken xrefs. The pages still render, but it renders to an empty page with no content, this allows our xrefs validator to pass. I forgot that we link these guides from the main menu.

Therefore I am proposing to remove these links to avoid confusion. We will add those back as soon as we fix links and in some cases also update its content.