### PR TITLE
BZ 2008947: Procedure to rename Satellite Server

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
@@ -78,10 +78,9 @@ For more information, see {ManagingHostsDocURL}configuring-and-setting-up-remote
 # {foreman-installer} \
 --foreman-proxy-content-parent-fqdn _new-{foreman-example-com}_ \
 --foreman-proxy-foreman-base-url https://_new-{foreman-example-com}_ \
---foreman-proxy-trusted-hosts _new-{foreman-example-com}_
+--foreman-proxy-trusted-hosts _new-{foreman-example-com}_ \
+--puppet-server-foreman-url _new-{foreman-example-com}_
 ----
-
-. Update `:url:` in `/etc/puppetlabs/puppet/foreman.yaml` to point to the new {Project} host name.
 
 . On {ProjectServer}, list all {SmartProxyServer}s:
 +


### PR DESCRIPTION
Add parameter to update host name URL in Puppet after renaming Satellite Server

https://bugzilla.redhat.com/show_bug.cgi?id=2008947

Cherry-pick into:

* [ ] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)
* [x] Foreman 2.1 (Satellite 6.8)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
