### PR TITLE
Use ProjectServer and SmartProxyServer attributes

### DIFF
--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -47,7 +47,7 @@ baseurl=file:///media/rhel7-server/
 # mkdir /media/sat6
 ----
 
-. Mount the ISO image for {ProjectName} Server to the mount point.
+. Mount the ISO image for {ProjectServer} to the mount point.
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Backup_Disaster_Recovery.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Backup_Disaster_Recovery.adoc
@@ -1,7 +1,7 @@
 [[sect-Administering-Backup_and_Disaster_Recovery-Restoring_Satellite_Server_or_Capsule_Server_from_a_Backup]]
 == Restoring {ProjectServer} or {SmartProxyServer} from a Backup
 
-You can restore {ProjectServer} or Red{nbsp}Hat {SmartProxyServer} from the backup data that you create as part of xref:backing-up-satellite-server-and-capsule-server[].
+You can restore {ProjectServer} or {SmartProxyServer} from the backup data that you create as part of xref:backing-up-satellite-server-and-capsule-server[].
 This process outlines how to restore the backup on the same server that generated the backup, and all data covered by the backup is deleted on the target system.
 If the original system is unavailable, provision a system with the same configuration settings and host name.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Backup_Disaster_Recovery.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Backup_Disaster_Recovery.adoc
@@ -1,7 +1,7 @@
 [[sect-Administering-Backup_and_Disaster_Recovery-Restoring_Satellite_Server_or_Capsule_Server_from_a_Backup]]
 == Restoring {ProjectServer} or {SmartProxyServer} from a Backup
 
-You can restore {ProjectName} Server or Red{nbsp}Hat {SmartProxyServer} from the backup data that you create as part of xref:backing-up-satellite-server-and-capsule-server[].
+You can restore {ProjectServer} or Red{nbsp}Hat {SmartProxyServer} from the backup data that you create as part of xref:backing-up-satellite-server-and-capsule-server[].
 This process outlines how to restore the backup on the same server that generated the backup, and all data covered by the backup is deleted on the target system.
 If the original system is unavailable, provision a system with the same configuration settings and host name.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -159,9 +159,9 @@ You require the following setup to configure external authentication for provisi
 * A deployed realm or domain provider such as {FreeIPA}.
 
 [id="Configuring_IdM_Realm_Support_{context}"]
-.To install and configure {FreeIPA} packages on {ProjectName} Server or {ProjectName} {SmartProxyServer}:
+.To install and configure {FreeIPA} packages on {ProjectServer} or {ProjectName} {SmartProxyServer}:
 
-To use {FreeIPA} for provisioned hosts, complete the following steps to install and configure {FreeIPA} packages on {ProjectName} Server or {ProjectName} {SmartProxyServer}:
+To use {FreeIPA} for provisioned hosts, complete the following steps to install and configure {FreeIPA} packages on {ProjectServer} or {ProjectName} {SmartProxyServer}:
 
 . Install the `ipa-client` package on {ProjectServer} or {SmartProxyServer}:
 +
@@ -216,7 +216,7 @@ If you use the integrated {SmartProxy} on {Project}, enter this command on {Proj
 --foreman-proxy-realm-provider freeipa
 ----
 +
-You can also use these options when you first configure the {ProjectName} Server.
+You can also use these options when you first configure the {ProjectServer}.
 +
 . Ensure that the most updated versions of the ca-certificates package is installed and trust the {FreeIPA} Certificate Authority:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Configuring_Identity_Management.adoc
@@ -159,9 +159,9 @@ You require the following setup to configure external authentication for provisi
 * A deployed realm or domain provider such as {FreeIPA}.
 
 [id="Configuring_IdM_Realm_Support_{context}"]
-.To install and configure {FreeIPA} packages on {ProjectServer} or {ProjectName} {SmartProxyServer}:
+.To install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}:
 
-To use {FreeIPA} for provisioned hosts, complete the following steps to install and configure {FreeIPA} packages on {ProjectServer} or {ProjectName} {SmartProxyServer}:
+To use {FreeIPA} for provisioned hosts, complete the following steps to install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}:
 
 . Install the `ipa-client` package on {ProjectServer} or {SmartProxyServer}:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_and_Reporting_Problems.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_and_Reporting_Problems.adoc
@@ -1,7 +1,7 @@
 [[chap-Administering-Logging_and_Reporting_Problems]]
 == Logging and Reporting Problems
 
-This chapter provides information on how to log and report problems in {ProjectName} Server, including information on relevant log files, how to enable debug logging, how to open a support case and attach the relevant log tar files, and how to access support cases within the {ProjectWebUI}.
+This chapter provides information on how to log and report problems in {ProjectServer}, including information on relevant log files, how to enable debug logging, how to open a support case and attach the relevant log tar files, and how to access support cases within the {ProjectWebUI}.
 
 You can use the log files and other information described in this chapter to do your own troubleshooting, or you can capture these and many more files, as well as diagnostic and configuration information, to send to Red{nbsp}Hat Support if you need further assistance.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Maintenance.adoc
@@ -1,7 +1,7 @@
 [id="Maintaining_Server_{context}"]
 == Maintaining {ProjectServer}
 
-This chapter provides information on how to maintain a {ProjectName} Server, including information on how to work with audit records, how to clean unused tasks, and how to recover Pulp from a full disk.
+This chapter provides information on how to maintain a {ProjectServer}, including information on how to work with audit records, how to clean unused tasks, and how to recover Pulp from a full disk.
 
 [[sect-Administering-Deleting_Audit_Records]]
 === Deleting Audit Records

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_IdM.adoc
@@ -1,7 +1,7 @@
 [[sect-Administering-Configuring_External_Authentication-Using_Identity_Management]]
 === Using {FreeIPA}
 
-This section shows how to integrate {ProjectName} Server with a {FreeIPA} server and how to enable host-based access control.
+This section shows how to integrate {ProjectServer} with a {FreeIPA} server and how to enable host-based access control.
 
 [NOTE]
 You can attach {FreeIPA} as an external authentication source with no single sign-on support.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
@@ -19,7 +19,7 @@ The filename extensions `.cer` and `.crt` are only conventions and can refer to 
 
 . Trust the Certificate from the LDAP Server.
 +
-{ProjectName} Server requires the CA certificates for LDAP authentication to be individual files in `/etc/pki/tls/certs/` directory.
+{ProjectServer} requires the CA certificates for LDAP authentication to be individual files in `/etc/pki/tls/certs/` directory.
 
 .. Use the `install` command to install the imported certificate into the `/etc/pki/tls/certs/` directory with the correct permissions:
 +

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/gss-proxy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/gss-proxy.adoc
@@ -8,6 +8,6 @@ When using AD as an external authentication source for {Project}, it is recommen
 ifndef::orcharhino[]
 [NOTE]
 ====
-The AD integration requires {ProjectName} Server to be deployed on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or later.
+The AD integration requires {ProjectServer} to be deployed on Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7.1 or later.
 ====
 endif::[]

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/utilities-for-collecting-log-information.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/utilities-for-collecting-log-information.adoc
@@ -36,6 +36,6 @@ If your {ProjectServer} has large log files or many {Project} tasks, support eng
 [IMPORTANT]
 ====
 Both `foreman-debug` and `sosreport` remove security information such as passwords, tokens, and keys while collecting information.
-However, the tar files can still contain sensitive information about the {ProjectName} Server.
+However, the tar files can still contain sensitive information about the {ProjectServer}.
 Red{nbsp}Hat recommends that you send this information directly to the intended recipient and not to a public target.
 ====

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 [[sect-Satellite_Server_Configuration]]
 === {ProjectServer} Configuration
 
-The first step to a working {Project} infrastructure is installing an instance of {ProjectName} Server on a dedicated {RHEL} 7 Server.
+The first step to a working {Project} infrastructure is installing an instance of {ProjectServer} on a dedicated {RHEL} 7 Server.
 
 * For more information about installing {ProjectServer} from a connected network, see {InstallingProjectDocURL}[_{project-installation-guide-title}_] and {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your Environment for Installation] in the same guide.
 +

--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -8,9 +8,9 @@ endif::[]
 
 _{ProjectName}_ is a system management solution that enables you to deploy, configure, and maintain your systems across physical, virtual, and cloud environments.
 {Project} provides provisioning, remote management and monitoring of multiple {RHEL} deployments with a single, centralized tool.
-_{ProjectName} Server_ synchronizes the content from Red{nbsp}Hat Customer{nbsp}Portal and other sources, and provides functionality including fine-grained life cycle management, user and group role-based access control, integrated subscription management, as well as advanced GUI, CLI, or API access.
+_{ProjectServer}_ synchronizes the content from Red{nbsp}Hat Customer{nbsp}Portal and other sources, and provides functionality including fine-grained life cycle management, user and group role-based access control, integrated subscription management, as well as advanced GUI, CLI, or API access.
 
-_{ProjectName} {SmartProxyServer}_ mirrors content from {ProjectName} Server to facilitate content federation across various geographical locations.
+_{ProjectName} {SmartProxyServer}_ mirrors content from {ProjectServer} to facilitate content federation across various geographical locations.
 Host systems can pull content and configuration from {SmartProxyServer} in their location and not from the central {ProjectServer}.
 {SmartProxyServer} also provides localized services such as Puppet server, DHCP, DNS, or TFTP.
 {SmartProxyServer}s assist you in scaling your {Project} environment as the number of your managed systems increases.
@@ -36,13 +36,13 @@ image::satellite_6_system_architecture.png[{ProjectName} System Architecture]
 There are four stages through which content flows in this architecture:
 
 [[varl-Architecture_System_Architecture-External_Content_Sources]]
-*External Content Sources*:: The _{ProjectName} Server_ can consume diverse types of content from various sources.
+*External Content Sources*:: The _{ProjectServer}_ can consume diverse types of content from various sources.
 The Red{nbsp}Hat Customer Portal is the primary source of software packages, errata, and container images.
 In addition, you can use other supported content sources (Git repositories, Docker Hub, Puppet Forge, SCAP repositories) as well as your organization's internal data store.
 
 
 [[varl-Architecture_System_Architecture-RednbspHat_Satellite_Server]]
-*{ProjectName} Server*:: The {ProjectName} Server enables you to plan and manage the content life cycle and the configuration of {SmartProxyServer}s and hosts through GUI, CLI, or API.
+*{ProjectServer}*:: The {ProjectServer} enables you to plan and manage the content life cycle and the configuration of {SmartProxyServer}s and hosts through GUI, CLI, or API.
 +
 {ProjectServer} organizes the life cycle management by using organizations as principal division units.
 Organizations isolate content for groups of hosts with specific requirements and administration tasks.
@@ -164,7 +164,7 @@ SELinux must be either in enforcing or permissive mode, installation with disabl
 [[form-Architecture_Supported_Usage-Puppet]]
 *Puppet*:: {ProjectName} includes supported Puppet packages.
 The installation program allows users to install and configure Puppet servers as a part of {ProjectName} {SmartProxyServer}s.
-A Puppet module, running on a Puppet server on the {ProjectName} Server or {Project} {SmartProxyServer}, is also supported by Red{nbsp}Hat.
+A Puppet module, running on a Puppet server on the {ProjectServer} or {Project} {SmartProxyServer}, is also supported by Red{nbsp}Hat.
 For information on what versions of Puppet are supported, see the Red{nbsp}Hat Knowledgebase article https://access.redhat.com/articles/1343683[Satellite 6 Component Versions].
 +
 Red{nbsp}Hat supports many different scripting and other frameworks, including Puppet modules.

--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -10,7 +10,7 @@ _{ProjectName}_ is a system management solution that enables you to deploy, conf
 {Project} provides provisioning, remote management and monitoring of multiple {RHEL} deployments with a single, centralized tool.
 _{ProjectServer}_ synchronizes the content from Red{nbsp}Hat Customer{nbsp}Portal and other sources, and provides functionality including fine-grained life cycle management, user and group role-based access control, integrated subscription management, as well as advanced GUI, CLI, or API access.
 
-_{ProjectName} {SmartProxyServer}_ mirrors content from {ProjectServer} to facilitate content federation across various geographical locations.
+_{SmartProxyServer}_ mirrors content from {ProjectServer} to facilitate content federation across various geographical locations.
 Host systems can pull content and configuration from {SmartProxyServer} in their location and not from the central {ProjectServer}.
 {SmartProxyServer} also provides localized services such as Puppet server, DHCP, DNS, or TFTP.
 {SmartProxyServer}s assist you in scaling your {Project} environment as the number of your managed systems increases.
@@ -163,7 +163,7 @@ SELinux must be either in enforcing or permissive mode, installation with disabl
 
 [[form-Architecture_Supported_Usage-Puppet]]
 *Puppet*:: {ProjectName} includes supported Puppet packages.
-The installation program allows users to install and configure Puppet servers as a part of {ProjectName} {SmartProxyServer}s.
+The installation program allows users to install and configure Puppet servers as a part of {SmartProxyServer}s.
 A Puppet module, running on a Puppet server on the {ProjectServer} or {Project} {SmartProxyServer}, is also supported by Red{nbsp}Hat.
 For information on what versions of Puppet are supported, see the Red{nbsp}Hat Knowledgebase article https://access.redhat.com/articles/1343683[Satellite 6 Component Versions].
 +

--- a/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
@@ -351,7 +351,7 @@ For more information about enabling {project-client-name}, see {ManagingHostsDoc
 
 
 Use this section to install and configure the Puppet agent on a host.
-When you have correctly installed and configured the Puppet agent, you can navigate to *Hosts* > *All hosts* to list all hosts visible to {ProjectName} Server.
+When you have correctly installed and configured the Puppet agent, you can navigate to *Hosts* > *All hosts* to list all hosts visible to {ProjectServer}.
 
 . Install the Puppet agent RPM package using the following command:
 +

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -193,7 +193,7 @@ You can choose to either load `ipxe.lkrn` or `undionly-ipxe.0` file depending on
 . iPXE chainloads the iPXE template from the template {SmartProxy}
 . iPXE loads the kernel and initial RAM disk of the installer
 
-.Configuring {ProjectName} Server to use iPXE
+.Configuring {ProjectServer} to use iPXE
 
 You can use the default template to configure iPXE booting for hosts.
 If you want to change the default values in the template, clone the template and edit the clone.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -2,7 +2,7 @@
 = Upgrading {ProjectServer}
 
 This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.
-You can upgrade from any minor version of {ProjectName} Server {ProjectVersionPrevious}.
+You can upgrade from any minor version of {ProjectServer} {ProjectVersionPrevious}.
 ifdef::satellite[]
 However, to access the latest migration and tooling fixes, upgrade to the latest minor version of {ProjectServer} before upgrading from {ProjectVersionPrevious} to {ProjectVersion}.
 


### PR DESCRIPTION
This PR replaces `{ProjectName} Server` and `{ProjectName} {SmartProxyServer}` with proper attributes:

    find guides -iname "*.adoc" | xargs sed -i 's/{ProjectName} Server/{ProjectServer}/g'
    find guides -iname "*.adoc" | xargs sed -i '' 's/{ProjectName} {SmartProxyServer}/{SmartProxyServer}/g'
