### PR TITLE
Add 'Managing SUSE Content' to Content Management Guide

### DIFF
--- a/guides/common/assembly_managing-suse-content.adoc
+++ b/guides/common/assembly_managing-suse-content.adoc
@@ -1,0 +1,18 @@
+[id="Managing_SUSE_Content_{context}"]
+= Managing SUSE Content
+
+Using the SCC Manager plug-in, you can comfortable manage content from SUSE using your {Project}.
+
+include::modules/proc_preparing-suse-installation-media.adoc[leveloffset=+1]
+
+include::modules/proc_creating-a-suse-operating-system.adoc[leveloffset=+1]
+
+include::modules/proc_installing-the-scc-manager.adoc[leveloffset=+1]
+
+include::modules/proc_adding-scc-accounts.adoc[leveloffset=+1]
+
+include::modules/proc_switching-scc-accounts.adoc[leveloffset=+1]
+
+include::modules/proc_importing-suse-products.adoc[leveloffset=+1]
+
+include::modules/proc_synchronizing-suse-content.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_adding-scc-accounts.adoc
+++ b/guides/common/modules/proc_adding-scc-accounts.adoc
@@ -1,0 +1,32 @@
+[id="Adding_SCC_Accounts_to_Server_{context}"]
+= Adding SCC Accounts to {Project}
+
+.Prerequisite
+* xref:Installing_the_SCC_Manager_Plugin_{context}[SCC Manager plug-in installed] on your {Project}
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > Content Credentials* and click *Create Content Credential*.
++
+Add the GPG public key for SLES 15 SP3 from https://www.suse.com/support/security/keys/[suse.com].
+ifdef::orcharhino[]
+For more information, see xref:sources/management_ui/the_content_menu/content_credentials.adoc#gpg_sles[content credentials].
+endif::[]
+. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions* and click *Add SCC Account*.
+** Enter your account name and password.
+** Optional: Set a *Sync interval* to periodically update the SCC authentication tokens.
+Note that this does not refer to synchronizing content to {Project}.
+** Optional: Assign a *GPG key for SUSE products* to the SCC products.
+`zypper` automatically verifies the signatures of each software package to ensure their authenticity.
++
+[NOTE]
+====
+You can also set the GPG public key for SUSE repositories at a later stage.
+However, changing it does not affect already synchronized products.
+If you already have synchronized products in {Project}, navigate to *Content > Products* and replace the GPG key in each respective product.
+====
+** Click *Test connection* to verify your account information.
+Note that you have to re-enter your password if you are trying to check the connection to an SCC account that has already been saved to {Project}.
+** Click *Submit* to save your SCC account to {Project}.
+. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*, select the previously added SCC account, and click *Sync* to fetch a list of products associated to your SCC account.
+
+Continue with xref:Importing_SUSE_Products_{context}[importing products] from your newly added SCC account.

--- a/guides/common/modules/proc_creating-a-suse-operating-system.adoc
+++ b/guides/common/modules/proc_creating-a-suse-operating-system.adoc
@@ -1,0 +1,41 @@
+[id="Creating_a_SUSE_Operating_System_{context}"]
+= Creating a SUSE Operating System
+
+{ProvisioningDocURL}adding-installation-media_provisioning[Create an installation media] and {ProvisioningDocURL}creating-operating-systems_provisioning[operating system] entry for SLES 15 SP3.
+
+.Prerequisite
+* An xref:Preparing_SUSE_Installation_Media_{context}[extracted `.iso` image] on {Project} or an HTTP server that can be reached during the host provisioning process.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts > Installation Media* and click *Create Medium*.
+. Set a *Name* for the installation medium for SLES 15 SP3.
+Add `local` to the name as the path of the extracted `.iso` image points to your {Project}.
+. Set the *Path* of the extracted `.iso` image.
+The content of `/var/www/html/pub/` is publicly available on `\http://{foreman-example-com}/pub/`.
+If you extract the `.iso` image to `/var/www/html/pub/installation_media/sles/15sp3/`, the path is `\http://{foreman-example-com}/pub/installation_media/sles/15sp3/`.
+. Set the *Operating System Family* to `SUSE` for all SLES systems.
+. Set a location and organization context for the installation media.
+. Click *Submit* to save the installation media entry for SLES 15 SP3.
+. In the {ProjectWebUI}, navigate to *Hosts > Operating Systems* and click *Create Operating System*.
+. Set the *Name* of the operating system.
+Choose a name as reported by Ansible, Puppet, or Salt as fact.
+. Set the *Major Version* of SLES, for example `15`.
+. Set the *Minor Version* of SLES, for example `3` for SLES 15 SP3.
+. Optional: Add an arbitrary *Description*.
+. Set the *Family* to `SUSE` for all SLES systems.
+. Set the *Root Password Hash* to `SHA256` for SLES 15 SP3.
+. Assign the *Architectures* to SLES 15 SP3.
+. Click *Submit* to save the operating system entry.
+. In the {ProjectWebUI}, navigate to *Hosts > Partition Tables* and click *Create Partition Table*.
+The partition tables are stored in the `/usr/share/foreman/app/views/unattended/partition_tables_templates/` directory on your {ProjectServer}.
++
+For more information, see {ProvisioningDocURL}creating-partition-tables_provisioning[Partition Tables] in the _Provisioning_ guide.
+. In the {ProjectWebUI}, navigate to *Hosts > Provisioning Templates* and click *Create Template*.
+The provisioning templates are stored in the `/usr/share/foreman/app/views/unattended/provisioning_templates/` directory on your {ProjectServer}.
++
+For more information, see {ProvisioningDocURL}provisioning-templates_provisioning[Provisioning Templates] in the _Provisioning_ guide.
+. In the {ProjectWebUI}, navigate to *Hosts > Operating Systems*.
+. Select the previously created operating system.
+. On the *Partition Table* tab, select the previously created partition table.
+. On the *Templates* tab, select the previously created provisioning template.
+. Click *Submit* to save the operating system entry.

--- a/guides/common/modules/proc_importing-suse-products.adoc
+++ b/guides/common/modules/proc_importing-suse-products.adoc
@@ -1,0 +1,14 @@
+[id="Importing_SUSE_Products_{context}"]
+= Importing SUSE Products
+
+.Prerequisites
+* xref:Installing_the_SCC_Manager_Plugin_{context}[SCC Manager plug-in installed] on your {Project}
+* Access to the SUSE product `SUSE Linux Enterprise Server 15 SP3 x86_64`
+
+.Procedure
+. Navigate to *Content > SUSE Subscriptions* and click *Select products* on your previously synchronized SCC account.
+** Select all SUSE products you want to synchronize to {Project}.
+This guide assumes you have access to and select the `SUSE Linux Enterprise Server 15 SP3 x86_64` product.
+** Click *Submit* to create the selected SUSE products in {Project}.
+
+Continue with xref:Synchronizing_SUSE_Content_{context}[synchronizing SUSE products].

--- a/guides/common/modules/proc_installing-the-scc-manager.adoc
+++ b/guides/common/modules/proc_installing-the-scc-manager.adoc
@@ -1,0 +1,33 @@
+[id="Installing_the_SCC_Manager_Plugin_{context}"]
+= Installing the SCC Manager Plugin
+
+Perform the following steps to install the _SCC Manager_ plugin on your {Project}.
+
+.Procedure
+. Connect to your {ProjectServer} using SSH:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# ssh root@{foreman-example-com}
+----
+. Install the SCC Manager plug-in on your {Project}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {package-install-project} -y tfm-rubygem-foreman_scc_manager
+----
+. Run database migrations on your {Project}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foreman-rake db:migrate
+# foreman-rake db:seed
+----
+. Restart {Project} services:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service restart
+----
+
+Continue with xref:Adding_SCC_Accounts_to_Server_{context}[adding your SCC account] to {Project}.

--- a/guides/common/modules/proc_preparing-suse-installation-media.adoc
+++ b/guides/common/modules/proc_preparing-suse-installation-media.adoc
@@ -1,0 +1,50 @@
+[id="Preparing_SUSE_Installation_Media_{context}"]
+= Preparing SUSE Installation Media
+
+Extract the SUSE installation medium on your {ProjectServer} to perform offline installations.
+This example prepares the installation medium for SUSE Linux Enterprise Server 15 SP3.
+
+.Procedure
+. Download the `SLES 15 SP3` installation medium from https://www.suse.com/download/sles/[suse.com/download/sles].
+. Download the signature and checksum from https://www.suse.com/support/security/download-verification/[suse.com].
+. Transfer the `.iso` image, the signature, and the checksum from your local machine to {ProjectServer} using `scp`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# scp SLE-15-SP3-Full-x86_64-GM-Media1.iso root@{foreman-example-com}:/tmp/
+# scp SLE-15-SP3-Full-x86_64-GM-Media1.iso.sha256 root@{foreman-example-com}:/tmp/
+# scp sles_15_sp3.signature root@{foreman-example-com}:/tmp/
+----
+. On your {ProjectServer}, verify the integrity and authenticity of the `.iso` image using GPG public keys:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# cd /tmp
+# gpg --verify sles_15_sp3.signature SLE-15-SP3-Full-x86_64-GM-Media1.iso.sha256
+# echo '2a6259fc849fef6ce6701b8505f64f89de0d2882857def1c9e4379d26e74fa56 SLE-15-SP3-Full-x86_64-GM-Media1.iso' | sha256sum --check
+----
+. Mount the `.iso` image:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# mount SLE-15-SP3-Full-x86_64-GM-Media1.iso /mnt
+----
+. Copy the content of the mounted installation medium to the `pub` directory:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# mkdir -p /var/www/html/pub/installation_media/sles/15sp3
+# cp -a /mnt/* /var/www/html/pub/installation_media/sles/15sp3/
+----
+. Unmount and delete the `.iso` image:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# cd
+# umount /mnt
+# rm -f /tmp/SLE-15-SP3-Full-x86_64-GM-Media1.iso
+# rm -f /tmp/SLE-15-SP3-Full-x86_64-GM-Media1.iso.sha256
+# rm -f /tmp/sles_15_sp3.signature
+----
+
+Use the path to the local installation media files when {ProvisioningDocURL}adding-installation-media_provisioning[creating an installation medium], for example `\http://{foreman-example-com}/pub/installation_media/sles/15sp3/`.

--- a/guides/common/modules/proc_switching-scc-accounts.adoc
+++ b/guides/common/modules/proc_switching-scc-accounts.adoc
@@ -1,0 +1,19 @@
+[id="Switching_SCC_Accounts_{context}"]
+= Switching SCC Accounts
+
+You can switch your SCC account by changing the SCC credentials saved on {Project}.
+
+[WARNING]
+====
+If you want to switch your SCC account and retain the synchronized content, do not immediately delete your old SCC account, even if it is expired.
+If you delete your old SCC account, you cannot reuse existing repositories, products, content views, and composite content views.
+====
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*.
+. Select your SCC account.
+. Enter a new *Login* and *Password*.
+. Click *Submit* to change your SCC account.
+
+Your new SCC account reuses existing products and repositories from SUSE.
+Content that is no longer available for your new SCC account cannot be synchronized anymore.

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -1,0 +1,26 @@
+[id="Synchronizing_SUSE_Content_{context}"]
+= Synchronizing SUSE Content
+
+You can use {Project} to synchronize SUSE content to deploy, attach, and serve content to managed hosts.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > Products*, select the `SUSE Linux Enterprise Server 15 SP3 x86_64` product, and click *Sync Now* to synchronize the SUSE repositories for SLES 15 SP3 to {Project}.
+. In the {ProjectWebUI}, navigate to *Content > Content Views* and click *Create Content View*.
+. Create a content view called `SLES 15 SP3` comprising the SLES repositories created in the `SLES 15 SP3` product.
+. Create a content view called `SLES 15 SP3 {Project} client` comprising the {Project} client repository created in the `SLES 15 SP3 {Project} client` product.
+. Publish a new version of both xref:Promoting_a_Content_View_{context}[content views].
+. In the {ProjectWebUI}, navigate to *Content > Content Views* and click *Create Content View*.
+. Create a composite content view called `Composite SLES 15 SP3` comprising the previously published `SLES 15 SP3` content view, the `SLES 15 SP3 {Project} client` content view, and optionally further content views of your choice, for example a content view containing Puppet.
+ifdef::orcharhino[]
+Refer to xref:sources/installation_and_maintenance/orcharhino_client_upgrade_guide.adoc#ocug_adding_orcharhino_clients[adding an {Project} client] on how to synchronize the {Project} client repository for SLES 15 SP3 and the https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal] for the necessary upstream URL.
+endif::[]
+For more information, see xref:Creating_a_Composite_Content_View_{context}[creating a composite content view].
+. Publish a new version and promote this version to the lifecycle environment of your choice.
+. In the {ProjectWebUI}, navigate to *Content > Activation Keys* and click *Create Activation Key*.
++
+xref:Creating_an_Activation_Key_{context}[Create an Activation Key] called `sles-15-sp3` and configure it as follows:
++
+. On the *Details* tab, select a Life Cycle Environment and Composite Content View.
+. On the **Subscriptions** tab, select the necessary subscriptions, for example `SLES 15 SP3`, `SLES 15 SP3 {Project} client`, and `Puppet`.
+
+You can now xref:{ManagingHostsDocURL}creating-a-host-group[create a Host Group] and assign the previously created Activation Key to it to deploy hosts running SLES 15 SP3 more comfortably.

--- a/guides/doc-Content_Management_Guide/master.adoc
+++ b/guides/doc-Content_Management_Guide/master.adoc
@@ -37,6 +37,10 @@ include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
 
 include::common/assembly_converting-a-host-with-convert2rhel.adoc[leveloffset=+1]
 
+ifndef::satellite[]
+include::common/assembly_managing-suse-content.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_managing-errata.adoc[leveloffset=+1]
 
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR add procedures on how to use the [SCC Manager plug-in](https://github.com/ATIX-AG/foreman_scc_manager) to manage content from SUSE.