### PR TITLE
Set ISS acronym to Inter-Server Synchronization

### DIFF
--- a/guides/common/assembly_synchronizing-content-between-foreman.adoc
+++ b/guides/common/assembly_synchronizing-content-between-foreman.adoc
@@ -1,7 +1,7 @@
 [id="Synchronizing_Content_Between_Servers_{context}"]
 = Synchronizing Content Between {ProjectServer}s
 
-{ProjectName} uses Inter-{Project} Synchronization (ISS) to synchronize content between two {ProjectServer}s including those that are airgapped.
+{ProjectName} uses Inter-Server Synchronization (ISS) to synchronize content between two {ProjectServer}s including those that are airgapped.
 
 include::modules/con_iss-scenarios.adoc[leveloffset=+1]
 

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -109,7 +109,7 @@ In such case, {SmartProxies} have to integrate with those external services (see
 
 ifdef::satellite[]
 * *Is my {ProjectServer} required to be disconnected from the Internet?* – Disconnected {Project} is a common deployment scenario (see xref:sect-Architecture_Guide-Disconnected_Satellite[]).
-If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for inter-{Project} synchronization.
+If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for Inter-Server synchronization.
 endif::[]
 
 * *What compute resources do I need for my hosts?* – Apart from provisioning bare metal hosts, you can use various compute resources supported by {Project}.

--- a/guides/doc-Planning_Guide/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Scenarios.adoc
@@ -46,9 +46,9 @@ To see the products in your subscription for which content ISO images are availa
 For instructions on how to import content ISOs to a disconnected {Project}, see {ContentManagementDocURL}Configuring_Server_to_Synchronize_Content_with_a_Local_CDN_Server_content-management[Configuring {Project} to Synchronize Content with a Local CDN Server] in the _Content Management Guide_.
 Note that Content ISOs previously hosted at redhat.com for import into {ProjectServer} have been deprecated and will be removed in the next {Project} version.
 
-* *Disconnected {Project} with Inter-{Project} Synchronization* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
+* *Disconnected {Project} with Inter-Server Synchronization* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
 This allows for exporting both Red{nbsp}Hat provided and custom content at the frequency you choose, but requires deploying an additional server with a separate subscription.
-For instructions on how to configure Inter-{Project} synchronization, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in the _Content Management Guide_.
+For instructions on how to configure Inter-Server synchronization, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in the _Content Management Guide_.
 
 The above methods for importing content to a disconnected {ProjectServer} can also be used to speed up the initial population of a connected {Project}.
 endif::[]


### PR DESCRIPTION
This PR sets the `ISS` acronym from "Inter-Satellite Synchronization" to "Inter-Server Synchronization".

Example: [Issue in upstream guide](https://docs.theforeman.org/nightly/Content_Management_Guide/index-katello.html#Synchronizing_Content_Between_Servers_content-management)