### PR TITLE
Some guides in nightly are empty

### DIFF
--- a/guides/doc-Planning_Guide/master.adoc
+++ b/guides/doc-Planning_Guide/master.adoc
@@ -2,9 +2,6 @@ include::common/attributes.adoc[]
 :imagesdir: images
 include::common/header.adoc[]
 
-// Render only for relevant and finished contexts
-ifdef::katello,satellite,orcharhino[]
-
 = Planning for {ProjectName}
 
 [[part-Architecture]]
@@ -32,5 +29,3 @@ include::topics/Deployment_Scenarios.adoc[]
 include::topics/Required_Technical_Users.adoc[]
 
 include::topics/Glossary.adoc[]
-
-endif::[]

--- a/guides/doc-Quickstart_Guide/master.adoc
+++ b/guides/doc-Quickstart_Guide/master.adoc
@@ -10,9 +10,6 @@ endif::[]
 :mode: connected
 :ProductName: {ProjectServer}
 
-// Render only for relevant and finished contexts
-ifdef::foreman-el,foreman-deb[]
-
 = {project-installation-guide-title}
 
 The Foreman installer is a collection of Puppet modules that installs everything required for a full working Foreman setup. It uses native OS packaging (e.g. RPM and .deb packages) and adds necessary configuration for the complete installation.
@@ -50,5 +47,3 @@ ifdef::katello[]
 endif::[]
 
 When the installer has completed, details will be printed about where to find Foreman and the Smart Proxy.
-
-endif::[]

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -8,9 +8,6 @@ endif::[]
 :numbered:
 :context: upgrade-guide
 
-// Render only for relevant and finished contexts
-ifdef::katello,satellite[]
-
 = Upgrading and Updating {ProjectServer}
 
 // Upgrading Satellite Server overview
@@ -103,5 +100,3 @@ endif::[]
 
 // Updating Content Hosts Minor Versions
 include::topics/updating_content_hosts_to_next_minor_version.adoc[leveloffset=+2]
-
-endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -14,7 +14,6 @@ For more information, see the Red Hat Knowledgebase solution https://access.redh
 +
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
-ifndef::orcharhino[]
 +
 For more information about backups, see {AdministeringDocURL}#backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
 


### PR DESCRIPTION
Three guides are currently empty:

- [Planning for Foreman](https://docs.theforeman.org/nightly/Planning_Guide/index-foreman-el.html)
- [QuickStart Guide](https://docs.theforeman.org/nightly/Quickstart_Guide/index-katello.html)
- [Upgrading and Updating Foreman](https://docs.theforeman.org/nightly/Upgrading_and_Updating/index-foreman-el.html)

This PR removes the conditionals to show content again.