### PR TITLE
BZ1997503: Fix configuration with external dbs (Pulp3 and Postgres)

### DIFF
--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -21,7 +21,7 @@ To create and use external databases for {Project}, you must complete the follow
 . xref:preparing-a-host-for-external-databases_{context}[].
 Prepare a {RHEL} 7 server to host the external databases.
 . xref:installing-postgresql_{context}[].
-Prepare PostgreSQL with databases for {Project} and Candlepin and dedicated users owning them.
+Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:configuring-satellite-to-use-external-databases_{context}[].
 Edit the parameters of `{foreman-installer}` to point to the new databases, and run `{foreman-installer}`.
 

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -75,14 +75,16 @@ listen_addresses = '*'
 $ su - postgres -c psql
 ----
 +
-. Create two databases and dedicated roles, one for {Project} and one for Candlepin:
+. Create three databases and dedicated roles: one for {Project}, one for Candlepin, and one for Pulp:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 CREATE USER "foreman" WITH PASSWORD '_Foreman_Password_';
 CREATE USER "candlepin" WITH PASSWORD '_Candlepin_Password_';
+CREATE USER "pulpcore" WITH PASSWORD '_Pulpcore_Password_';
 CREATE DATABASE foreman OWNER foreman;
 CREATE DATABASE candlepin OWNER candlepin;
+CREATE DATABASE pulpcore OWNER pulpcore;
 ----
 +
 . Exit the `postgres` user:
@@ -99,4 +101,5 @@ If the connection succeeds, the commands return `1`.
 ----
 # PGPASSWORD='_Foreman_Password_' psql -h _postgres.example.com_  -p 5432 -U foreman -d foreman -c "SELECT 1 as ping"
 # PGPASSWORD='_Candlepin_Password_' psql -h _postgres.example.com_ -p 5432 -U candlepin -d candlepin -c "SELECT 1 as ping"
+# PGPASSWORD='_Pulpcore_Password_' psql -h _postgres.example.com_ -p 5432 -U pulpcore -d pulpcore -c "SELECT 1 as ping"
 ----


### PR DESCRIPTION
Add creation of Pulp database and user.

Note from developers: Foreman 2.3 (Sat 6.9) is the only version that contains both Pulp2 (MongoDB) and Pulp3 (Postgres).

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)
* [ ] Foreman 2.4
* [x] Foreman 2.3 (Satellite 6.9)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
