### PR TITLE
Keep external db config for both Mongo and Postgres in Satellite 6.9

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -21,6 +21,10 @@ Use the `{foreman-installer}` command to configure {Project} to connect to exter
   --katello-candlepin-db-name candlepin \
   --katello-candlepin-db-password _Candlepin_Password_ \
   --katello-candlepin-manage-db false \
+  --foreman-proxy-content-pulpcore-manage-postgresql false \
+  --foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
+  --foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
+  --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
   --katello-pulp-db-username pulp \
   --katello-pulp-db-password _pulp_password_ \
   --katello-pulp-db-seeds _mongo.example.com:27017_ \


### PR DESCRIPTION
This is the follow-up in addition to [#784](https://github.com/theforeman/foreman-documentation/pull/784)

Do not cherry-pick.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
