### PR TITLE
Set --foreman-db-manage false in ext DBs

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -18,6 +18,7 @@ Use the `{foreman-installer}` command to configure {Project} to connect to an ex
   --foreman-db-host _postgres.example.com_ \
   --foreman-db-password _Foreman_Password_ \
   --foreman-db-database foreman \
+  --foreman-db-manage false \
   --katello-candlepin-db-host _postgres.example.com_ \
   --katello-candlepin-db-name candlepin \
   --katello-candlepin-db-password _Candlepin_Password_ \
@@ -26,12 +27,4 @@ Use the `{foreman-installer}` command to configure {Project} to connect to an ex
   --foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
   --foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
   --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_
-----
-
-. Verify the status of the databases:
-* For PostgreSQL, enter the following command:
-+
-[options="nowrap" subs="quotes,attributes"]
-----
-# {foreman-maintain} service status --only postgresql
 ----


### PR DESCRIPTION
This matches proc_migrating-to-external-databases.adoc and ensures that PostgreSQL doesn't run on the system, which is the entire point of using an external database in the first place.

I have removed the Verify the status part since PostgreSQL shouldn't be running at all. It could also be changed to verify it isn't running. I'm not sure what's best here.

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)