### PR TITLE
Removed information from Satellite docs which is no longer supported

### DIFF
--- a/guides/common/modules/con_provisioning-overview.adoc
+++ b/guides/common/modules/con_provisioning-overview.adoc
@@ -5,20 +5,32 @@ Provisioning is a process that starts with a bare physical or virtual machine an
 Using {ProjectName}, you can define and automate fine-grained provisioning for a large number of hosts.
 
 There are many provisioning methods.
+ifndef::satellite[]
 For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using both PXE based and non-PXE based methods.
+endif::[]
+ifdef::satellite[]
+For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using non-PXE based methods.
+endif::[]
 You can also provision cloud instances from specific providers through their APIs.
 These provisioning methods are part of the {ProjectName} application life cycle to create, manage, and update hosts.
 
 {ProjectName} has different methods for provisioning hosts:
 
 Bare Metal Provisioning::
-  {Project} provisions bare metal hosts primarily through PXE boot and MAC address identification.
+ifndef::satellite[]
+{Project} provisions bare metal hosts primarily through PXE boot and MAC address identification.
+endif::[]
+ifdef::satellite[]
+{Project} provisions bare metal hosts primarily through MAC address identification.
+endif::[]
 You can create host entries and specify the MAC address of the physical host to provision.
 You can also boot blank hosts to use {Project}'s discovery service, which creates a pool of ready-to-provision hosts.
+ifndef::satellite[]
 You can also boot and provision hosts through PXE-less methods.
+endif::[]
 
 Cloud Providers::
-  {Project} connects to private and public cloud providers to provision instances of hosts from images that are stored with the Cloud environment.
+{Project} connects to private and public cloud providers to provision instances of hosts from images that are stored with the Cloud environment.
 This also includes selecting which hardware profile or flavor to use.
 
 Virtualization Infrastructure::

--- a/guides/common/modules/con_provisioning-overview.adoc
+++ b/guides/common/modules/con_provisioning-overview.adoc
@@ -9,7 +9,7 @@ ifndef::satellite[]
 For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using both PXE based and non-PXE based methods.
 endif::[]
 ifdef::satellite[]
-For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using non-PXE based methods.
+For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using PXE based methods.
 endif::[]
 You can also provision cloud instances from specific providers through their APIs.
 These provisioning methods are part of the {ProjectName} application life cycle to create, manage, and update hosts.
@@ -17,12 +17,7 @@ These provisioning methods are part of the {ProjectName} application life cycle 
 {ProjectName} has different methods for provisioning hosts:
 
 Bare Metal Provisioning::
-ifndef::satellite[]
 {Project} provisions bare metal hosts primarily through PXE boot and MAC address identification.
-endif::[]
-ifdef::satellite[]
-{Project} provisions bare metal hosts primarily through MAC address identification.
-endif::[]
 You can create host entries and specify the MAC address of the physical host to provision.
 You can also boot blank hosts to use {Project}'s discovery service, which creates a pool of ready-to-provision hosts.
 ifndef::satellite[]

--- a/guides/doc-Provisioning_Guide/master.adoc
+++ b/guides/doc-Provisioning_Guide/master.adoc
@@ -57,9 +57,7 @@ include::topics/Infoblox_Integration.adoc[]
 
 include::topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc[]
 
-ifndef::satellite[]
 include::topics/Bare_Metal.adoc[]
-endif::[]
 
 include::topics/configuring_the_discovery_service.adoc[]
 

--- a/guides/doc-Provisioning_Guide/master.adoc
+++ b/guides/doc-Provisioning_Guide/master.adoc
@@ -59,7 +59,7 @@ include::topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc[]
 
 include::topics/Bare_Metal.adoc[]
 
-include::topics/configuring_the_discovery_service.adoc[]
+include::topics/configuring-the-discovery-service.adoc[]
 
 include::topics/proc_using-an-imagebuilder-image-for-provisioning.adoc[]
 

--- a/guides/doc-Provisioning_Guide/master.adoc
+++ b/guides/doc-Provisioning_Guide/master.adoc
@@ -57,7 +57,7 @@ include::topics/Infoblox_Integration.adoc[]
 
 include::topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc[]
 
-ifndedf::satellite[]
+ifndef::satellite[]
 include::topics/Bare_Metal.adoc[]
 endif::[]
 

--- a/guides/doc-Provisioning_Guide/master.adoc
+++ b/guides/doc-Provisioning_Guide/master.adoc
@@ -57,7 +57,9 @@ include::topics/Infoblox_Integration.adoc[]
 
 include::topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc[]
 
+ifndedf::satellite[]
 include::topics/Bare_Metal.adoc[]
+endif::[]
 
 include::topics/configuring_the_discovery_service.adoc[]
 

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -71,17 +71,18 @@ endif::[]
 
 [[Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process]]
 === Configuring the Security Token Validity Duration
+
 ifndef::satellite[]
 When performing unattended and PXE-less provisioning, as a security measure, {Project} automatically generates a unique token and adds this token to the {provision-script} URL in the PXE configuration file (PXELinux, Grub2).
 By default, the token is valid for 360 minutes.
 When you provision a host, ensure that you reboot the host within this time frame.
 If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
 
-To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
+To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *Administer* *>* *Settings*, and click the *Provisioning* tab.
 Find the *Token duration* option, and click the edit icon and edit the duration, or enter `0` to disable token generation.
 
 If token generation is disabled, an attacker can spoof client IP address and download {provision-script} from {ProjectServer}, including the encrypted root password.
-endif:[]
+endif::[]
 
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_Unattended_Provisioning]]
 === Creating Hosts with Unattended Provisioning
@@ -167,6 +168,7 @@ endif::[]
 # hammer host interface update --host "test1" --managed true \
 --primary true --provision true
 ----
+
 ifndef::satellite[]
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_PXE-less_Provisioning]]
 === Creating Hosts with PXE-less Provisioning
@@ -207,19 +209,15 @@ This image is generic to all hosts with a provisioning NIC on the same subnet.
 For more information about configuring security tokens, read xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
 
 [NOTE]
-ifdef::satellite[]
-The *Full host image* is based on SYSLINUX and works with all {RHEL} certified hardware.
-endif::[]
-ifndef::satellite[]
 The *Full host image* is based on SYSLINUX and works with most hardware.
-endif::[]
+
 When using a *Host image*, *Generic image*, or *Subnet image*, see https://ipxe.org/appnote/hardware_drivers[supported hardware on ipxe.org] for a list of hardware drivers expected to work with an iPXE-based boot disk.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-with-pxe-less-provisioning_{context}[].
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* > *Create Host*.
+. In the {ProjectWebUI}, navigate to *Hosts* *>* *Create Host*.
 . In the *Name* field, enter a name that you want to become the provisioned system's host name.
 . Click the *Organization* and *Location* tabs and change the context to match your requirements.
 . From the *Host Group* list, select a host group that you want to use to populate the form.
@@ -241,10 +239,6 @@ For more information about associating provisioning templates, see xref:provisio
 +
 ifdef::foreman-el,foreman-deb,katello[]
 . If you use the Katello plug-in, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
-ifdef::satellite[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
 ifdef::orcharhino[]
@@ -314,7 +308,7 @@ Write the ISO to a USB storage device using the *dd* utility or *livecd-tools* i
 
 When you start the physical host and boot from the ISO or the USB storage device, the host connects to {ProjectServer} and starts installing operating system from its kickstart tree.
 
-ifdef::satellite,orcharhino[]
+ifdef::orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{project-client-name}* repository.
 endif::[]
 endif::[]

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -11,6 +11,7 @@ New hosts use PXE boot to load the {Project} Discovery service.
 This service identifies hardware information about the host and lists it as an available host to provision.
 For more information, see xref:configuring-the-discovery-service[].
 
+ifndef::satellite[]
 PXE-less Provisioning::
 New hosts are provisioned with a boot disk or PXE-less discovery image that {ProjectServer} generates.
 
@@ -18,6 +19,7 @@ PXE-less Provisioning with Discovery::
 New hosts use an ISO boot disk that loads the {Project} Discovery service.
 This service identifies hardware information about the host and lists it as an available host to provision.
 For more information, see xref:implementing-pxe-less-discovery[].
+endif::[]
 
 ifndef::satellite[]
 NOTE: Discovery workflows are only available when the Discovery plug-in is installed.
@@ -63,13 +65,14 @@ For more information about the Discovery service, xref:configuring-the-discovery
 * A bare metal host or a blank VM.
 include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 
+ifndef::satellite[]
 For information about the security token for unattended and PXE-less provisioning, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
+endif::[]
 
 [[Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process]]
 === Configuring the Security Token Validity Duration
-
+ifndef::satellite[]
 When performing unattended and PXE-less provisioning, as a security measure, {Project} automatically generates a unique token and adds this token to the {provision-script} URL in the PXE configuration file (PXELinux, Grub2).
-
 By default, the token is valid for 360 minutes.
 When you provision a host, ensure that you reboot the host within this time frame.
 If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
@@ -78,6 +81,7 @@ To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *
 Find the *Token duration* option, and click the edit icon and edit the duration, or enter `0` to disable token generation.
 
 If token generation is disabled, an attacker can spoof client IP address and download {provision-script} from {ProjectServer}, including the encrypted root password.
+endif:[]
 
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_Unattended_Provisioning]]
 === Creating Hosts with Unattended Provisioning
@@ -92,7 +96,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-wi
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* > *Create Host*.
+. In the {ProjectWebUI}, navigate to *Hosts* *>* *Create Host*.
 . In the *Name* field, enter a name for the host.
 . Click the *Organization* and *Location* tabs and change the context to match your requirements.
 . From the *Host Group* list, select a host group that you want to use to populate the form.
@@ -163,7 +167,7 @@ endif::[]
 # hammer host interface update --host "test1" --managed true \
 --primary true --provision true
 ----
-
+ifndef::satellite[]
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_PXE-less_Provisioning]]
 === Creating Hosts with PXE-less Provisioning
 
@@ -313,6 +317,7 @@ When you start the physical host and boot from the ISO or the USB storage device
 ifdef::satellite,orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{project-client-name}* repository.
 endif::[]
+endif::[]
 
 [id="creating-hosts-with-uefi-http-boot-provisioning_{context}"]
 === Creating Hosts with UEFI HTTP Boot Provisioning
@@ -346,7 +351,7 @@ For more information, see {PlanningDocURL}http-booting-requirements[HTTP Booting
 --foreman-proxy-tftp true
 ----
 
-. In the {ProjectWebUI}, navigate to *Hosts* > *Create Host*.
+. In the {ProjectWebUI}, navigate to *Hosts* *>* *Create Host*.
 . In the *Name* field, enter a name for the host.
 . Click the *Organization* and *Location* tabs and change the context to match your requirements.
 . From the *Host Group* list, select a host group that you want to use to populate the form.
@@ -481,7 +486,7 @@ For information on adding SSH keys to a user, see {AdministeringDocURL}managing-
 
 To deploy SSH keys during provisioning, complete the following steps:
 
-. In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Templates*.
+. In the {ProjectWebUI}, navigate to *Hosts* *>* *Provisioning Templates*.
 . Create a provisioning template, or clone and edit an existing template.
 For more information, see xref:creating-provisioning-templates_provisioning[].
 . In the template, click the *Template* tab.

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -78,7 +78,7 @@ By default, the token is valid for 360 minutes.
 When you provision a host, ensure that you reboot the host within this time frame.
 If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
 
-To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *Administer* *>* *Settings*, and click the *Provisioning* tab.
+To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
 Find the *Token duration* option, and click the edit icon and edit the duration, or enter `0` to disable token generation.
 
 If token generation is disabled, an attacker can spoof client IP address and download {provision-script} from {ProjectServer}, including the encrypted root password.
@@ -97,7 +97,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-wi
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* *>* *Create Host*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Create Host*.
 . In the *Name* field, enter a name for the host.
 . Click the *Organization* and *Location* tabs and change the context to match your requirements.
 . From the *Host Group* list, select a host group that you want to use to populate the form.
@@ -217,7 +217,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-wi
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* *>* *Create Host*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Create Host*.
 . In the *Name* field, enter a name that you want to become the provisioned system's host name.
 . Click the *Organization* and *Location* tabs and change the context to match your requirements.
 . From the *Host Group* list, select a host group that you want to use to populate the form.
@@ -345,7 +345,7 @@ For more information, see {PlanningDocURL}http-booting-requirements[HTTP Booting
 --foreman-proxy-tftp true
 ----
 
-. In the {ProjectWebUI}, navigate to *Hosts* *>* *Create Host*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Create Host*.
 . In the *Name* field, enter a name for the host.
 . Click the *Organization* and *Location* tabs and change the context to match your requirements.
 . From the *Host Group* list, select a host group that you want to use to populate the form.
@@ -480,7 +480,7 @@ For information on adding SSH keys to a user, see {AdministeringDocURL}managing-
 
 To deploy SSH keys during provisioning, complete the following steps:
 
-. In the {ProjectWebUI}, navigate to *Hosts* *>* *Provisioning Templates*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Templates*.
 . Create a provisioning template, or clone and edit an existing template.
 For more information, see xref:creating-provisioning-templates_provisioning[].
 . In the template, click the *Template* tab.

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -14,12 +14,12 @@ For more information, see xref:configuring-the-discovery-service[].
 ifndef::satellite[]
 PXE-less Provisioning::
 New hosts are provisioned with a boot disk or PXE-less discovery image that {ProjectServer} generates.
+endif::[]
 
 PXE-less Provisioning with Discovery::
 New hosts use an ISO boot disk that loads the {Project} Discovery service.
 This service identifies hardware information about the host and lists it as an available host to provision.
 For more information, see xref:implementing-pxe-less-discovery[].
-endif::[]
 
 ifndef::satellite[]
 NOTE: Discovery workflows are only available when the Discovery plug-in is installed.
@@ -77,12 +77,13 @@ When performing unattended and PXE-less provisioning, as a security measure, {Pr
 By default, the token is valid for 360 minutes.
 When you provision a host, ensure that you reboot the host within this time frame.
 If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
-
+endif::[]
 To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
+
 Find the *Token duration* option, and click the edit icon and edit the duration, or enter `0` to disable token generation.
 
 If token generation is disabled, an attacker can spoof client IP address and download {provision-script} from {ProjectServer}, including the encrypted root password.
-endif::[]
+
 
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_Unattended_Provisioning]]
 === Creating Hosts with Unattended Provisioning
@@ -209,7 +210,7 @@ This image is generic to all hosts with a provisioning NIC on the same subnet.
 For more information about configuring security tokens, read xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
 
 [NOTE]
-The *Full host image* is based on SYSLINUX and works with most hardware.
+The *Full host image* is based on SYSLINUX and Grub and works with most hardware.
 
 When using a *Host image*, *Generic image*, or *Subnet image*, see https://ipxe.org/appnote/hardware_drivers[supported hardware on ipxe.org] for a list of hardware drivers expected to work with an iPXE-based boot disk.
 

--- a/guides/doc-Provisioning_Guide/topics/configuring-the-discovery-service.adoc
+++ b/guides/doc-Provisioning_Guide/topics/configuring-the-discovery-service.adoc
@@ -10,7 +10,7 @@ If you select `discovery` to boot the Discovery image, after a few minutes, the 
 
 The Discovery service is enabled by default on {ProjectServer}.
 However, the default setting of the global templates is to boot from the local hard drive.
-To change the default setting, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
+To change the default setting, in the {ProjectWebUI}, navigate to *Administer* *>* *Settings*, and click the *Provisioning* tab.
 Locate the *Default PXE global template entry* row, and in the *Value* column, enter *discovery*.
 
 ifdef::foreman-el,foreman-deb,katello[]

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -52,7 +52,7 @@ For more information, see https://ipxe.org/appnote/hardware_drivers[supported ha
 To prepare iPXE environment, you must perform this procedure on all {SmartProxies}.
 
 .Procedure
-+
+
 . Enable the *tftp* and *httpboot* services:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -141,8 +141,8 @@ You can use the default template to configure iPXE booting for hosts.
 If you want to change the default values in the template, clone the template and edit the clone.
 
 .Procedure
-+
-. In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Templates*, enter `Kickstart default iPXE` and click *Search*.
+
+. In the {ProjectWebUI}, navigate to *Hosts* *>* *Provisioning Templates*, enter `Kickstart default iPXE` and click *Search*.
 . Optional: If you want to change the template, click *Clone*, enter a unique name, and click *Submit*.
 . Click the name of the template you want to use.
 . If you clone the template, you can make changes you require on the *Template* tab.

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -105,7 +105,7 @@ endif::[]
 
 . Optionally, configure Foreman discovery.
 For more information, see xref:configuring-the-discovery-service[].
-* In the {ProjectWebUI}, navigate to *Administer* *>* *Settings*, and click the *Provisioning* tab.
+* In the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
 * Locate the *Default PXE global template entry* row and in the *Value* column, change the value to *discovery*.
 
 === Booting virtual machines
@@ -142,7 +142,7 @@ If you want to change the default values in the template, clone the template and
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* *>* *Provisioning Templates*, enter `Kickstart default iPXE` and click *Search*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Templates*, enter `Kickstart default iPXE` and click *Search*.
 . Optional: If you want to change the template, click *Clone*, enter a unique name, and click *Submit*.
 . Click the name of the template you want to use.
 . If you clone the template, you can make changes you require on the *Template* tab.

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -103,8 +103,9 @@ endif::[]
 # cp /usr/share/ipxe/undionly.kpxe /var/lib/tftpboot/undionly-ipxe.0
 ----
 
-. Optionally, configure Foreman discovery. For more information, see xref:configuring-the-discovery-service[].
-* In the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
+. Optionally, configure Foreman discovery.
+For more information, see xref:configuring-the-discovery-service[].
+* In the {ProjectWebUI}, navigate to *Administer* *>* *Settings*, and click the *Provisioning* tab.
 * Locate the *Default PXE global template entry* row and in the *Value* column, change the value to *discovery*.
 
 === Booting virtual machines

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -52,7 +52,6 @@ For more information, see https://ipxe.org/appnote/hardware_drivers[supported ha
 To prepare iPXE environment, you must perform this procedure on all {SmartProxies}.
 
 .Procedure
-
 . Enable the *tftp* and *httpboot* services:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -141,7 +140,6 @@ You can use the default template to configure iPXE booting for hosts.
 If you want to change the default values in the template, clone the template and edit the clone.
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Templates*, enter `Kickstart default iPXE` and click *Search*.
 . Optional: If you want to change the template, click *Clone*, enter a unique name, and click *Submit*.
 . Click the name of the template you want to use.

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -74,6 +74,4 @@ Set a new host name with the `--new-name` option:
 This removes the host from the discovered host listing and creates a host entry with the provisioning settings.
 The Discovery image automatically resets the host so that it can boot to PXE.
 The host detects the DHCP service on {ProjectServer}'s integrated {SmartProxy} and starts installing the operating system.
-ifndef::satellite[]
 The rest of the process is identical to normal PXE workflow described in xref:Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_Unattended_Provisioning[].
-endif::[]

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* > *Discovered host*.
+. In the {ProjectWebUI}, navigate to *Hosts* *>* *Discovered host*.
 Select the host you want to use and click *Provision* to the right of the list.
 . Select from one of the two following options:
 * To provision a host from a host group, select a host group, organization, and location, and then click *Create Host*.
@@ -49,7 +49,7 @@ For more information about associating provisioning templates, see xref:provisio
 . Click *Submit* to save the host details.
 
 When the host provisioning is complete, the discovered host becomes a content host.
-To view the host, navigate to *Hosts* > *Content Hosts*.
+To view the host, navigate to *Hosts* *>* *Content Hosts*.
 
 [id="cli-creating-hosts-from-discovered-hosts_{context}"]
 .CLI procedure

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -15,9 +15,11 @@ For more information about networking requirements, see xref:Configuring_Network
 For more information, see xref:installing-the-discovery-service[].
 
 * A bare metal host or a blank VM.
-include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 
+include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
+ifndef::satellite[]
 For information about the security token for unattended and PXE-less provisioning, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
+endif::[]
 
 .Procedure
 
@@ -72,4 +74,6 @@ Set a new host name with the `--new-name` option:
 This removes the host from the discovered host listing and creates a host entry with the provisioning settings.
 The Discovery image automatically resets the host so that it can boot to PXE.
 The host detects the DHCP service on {ProjectServer}'s integrated {SmartProxy} and starts installing the operating system.
+ifndef::satellite[]
 The rest of the process is identical to normal PXE workflow described in xref:Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_Unattended_Provisioning[].
+endif::[]

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* *>* *Discovered host*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Discovered host*.
 Select the host you want to use and click *Provision* to the right of the list.
 . Select from one of the two following options:
 * To provision a host from a host group, select a host group, organization, and location, and then click *Create Host*.
@@ -49,7 +49,7 @@ For more information about associating provisioning templates, see xref:provisio
 . Click *Submit* to save the host details.
 
 When the host provisioning is complete, the discovered host becomes a content host.
-To view the host, navigate to *Hosts* *>* *Content Hosts*.
+To view the host, navigate to *Hosts* > *Content Hosts*.
 
 [id="cli-creating-hosts-from-discovered-hosts_{context}"]
 .CLI procedure

--- a/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -45,7 +45,5 @@ endif::[]
 . Click *Submit* to save your changes.
 
 You can use this image for bare metal provisioning and provisioning using a compute resource.
-ifndef::satellite[]
 For more information about bare metal provisioning, see xref:Using_PXE_to_Provision_Hosts[].
-endif::[]
 For more information about provisioning with different compute resources, see the relevant chapter for the compute resource that you want to use.

--- a/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -45,6 +45,7 @@ endif::[]
 . Click *Submit* to save your changes.
 
 You can use this image for bare metal provisioning and provisioning using a compute resource.
-
+ifndef::satellite[]
 For more information about bare metal provisioning, see xref:Using_PXE_to_Provision_Hosts[].
+endif::[]
 For more information about provisioning with different compute resources, see the relevant chapter for the compute resource that you want to use.


### PR DESCRIPTION
Where relevant ifndef and ifdef statement s have been used to remove material from Satellite documentation

Bug 1938633 - We have to remove those topic from documentation, which we removed functionality from new satellite version

https://issues.redhat.com/browse/SATDOC-473


Cherry-pick into:

* [X] Foreman 3.0
* [X] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
