### PR TITLE
BZ 2008947: Condition host name update in Puppet config…

### DIFF
--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Renaming_a_Satellite_Server.adoc
@@ -78,7 +78,13 @@ For more information, see {ManagingHostsDocURL}configuring-and-setting-up-remote
 # {foreman-installer} \
 --foreman-proxy-content-parent-fqdn _new-{foreman-example-com}_ \
 --foreman-proxy-foreman-base-url https://_new-{foreman-example-com}_ \
---foreman-proxy-trusted-hosts _new-{foreman-example-com}_ \
+--foreman-proxy-trusted-hosts _new-{foreman-example-com}_
+----
++
+If Puppet is enabled on the {SmartProxyServer}, add the following to the installation command:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
 --puppet-server-foreman-url _new-{foreman-example-com}_
 ----
 


### PR DESCRIPTION
… after renaming Satellite Server (Puppet possibly disabled)

Follow-up to #774

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
