### PR TITLE
Add Config SELinux for Repos on Custom Ports

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -36,6 +36,10 @@ include::modules/proc_changing-the-download-policy-for-a-repository.adoc[levelof
 
 include::modules/proc_uploading-content-to-custom-rpm-repositories.adoc[leveloffset=+1]
 
+ifdef::katello,satellite,orcharhino[]
+include::modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_recovering-a-corrupted-repository.adoc[leveloffset=+1]
 
 include::modules/proc_adding-an-http-proxy.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc
+++ b/guides/common/modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc
@@ -1,0 +1,21 @@
+[id="configuring-selinux-to-permit-content-synchronization-on-custom-ports_{context}"]
+= Configuring SELinux to Permit Content Synchronization on Custom Ports
+
+SELinux permits access of {Project} for content synchronization only on specific ports.
+By default, connecting to web servers running on the following ports is permitted: 80, 81, 443, 488, 8008, 8009, 8443, and 9000.
+
+.Procedure
+. On {Project}, to verify the ports that are permitted by SELinux for content synchronization, enter a command as follows:
++
+[options="nowrap",subs="+quotes"]
+----
+# semanage port -l | grep ^http_port_t
+http_port_t     tcp      80, 81, 443, 488, 8008, 8009, 8443, 9000
+----
+
+. To configure SELinux to permit a port for content synchronization, for example 10011, enter a command as follows:
++
+[options="nowrap",subs="+quotes"]
+----
+# semanage port -a -t http_port_t -p tcp 10011
+----


### PR DESCRIPTION
Hello

Changes as discussed in: 

[ BZ#2012250 SELinux: denied name_connect comm="pulpcore-worker"](https://bugzilla.redhat.com/show_bug.cgi?id=2012250)


Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
