### PR TITLE
Add Puppet enablement and management guide

### DIFF
--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -1,0 +1,27 @@
+[id="enabling-puppet_{context}"]
+= Enabling Puppet Integration with {Project}
+
+The installation of {Project} does not have any Puppet integration configured by default.
+Users will need enable the approprite integration for their situation.
+{Project} can be configured to manage and deploy Puppet Server on the {ProjectServer} or on a {SmartProxy}.
+Additionally, Puppet Server can be deployed externally to {Project} and integrated for reporting, facts and ENC.
+
+.Prerequisites
+
+* Puppet integration must be first enabled on {Project} before being enabled on any {SmartProxy}.
+
+.Procedure
+
+. On {Project}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --enable-foreman-plugin-puppet --enable-foreman-cli-puppet --foreman-proxy-puppet true --foreman-proxy-puppetca true --foreman-proxy-content-puppet true --enable-puppet --puppet-server true --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt --puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+----
+
+. On a {SmartProxy}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-proxy-puppet true --foreman-proxy-puppetca true --foreman-proxy-content-puppet true --enable-puppet --puppet-server true --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt --puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+----

--- a/guides/doc-Installing_Server_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Server_on_Red_Hat/master.adoc
@@ -54,8 +54,11 @@ include::common/assembly_using-external-databases.adoc[leveloffset=+2]
 
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
 
-
 include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
+
+ifdef::katello,satellite[]
+include::common/modules/proc_enabling-puppet.adoc[leveloffset=+2]
+endif::[]
 
 :numbered!:
 


### PR DESCRIPTION
This is *very* rough start. The intent is for me to get started on this since we are dropping installation by default for Katello and Satellite, to gather input from some key stakeholders and to ask about some existing documentation in the Foreman guide and whether to pull this in. Now for a few opening questions:

 a) Should this be a stand-alone guide?
 b) Should this pull in any of the following:
   - https://theforeman.org/manuals/3.0/index.html#3.5.4PuppetReports
   - https://theforeman.org/manuals/3.0/index.html#3.5.5FactsandtheENC
   - https://theforeman.org/manuals/3.0/index.html#4.2ManagingPuppet
   - https://theforeman.org/manuals/3.0/index.html#4.3.6Puppet
 
 c) Some of the wording used -- Puppet integration? Puppet enablement? 
 d) Thoughts on how to tackle "on board" Puppet vs. external Puppet server?
