### PR TITLE
Remove ProjectX attribute

### DIFF
--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -21,7 +21,7 @@ On CentOS, you can install {Project} with or without the Katello plug-in.
 If you are a new user, consider installing {Project} with the Katello plug-in.
 endif::[]
 
-Note that the {ProjectX} installation script is based on Puppet, which means that if you run the installation script more than once, it might overwrite any manual configuration changes.
+Note that the {Project} installation script is based on Puppet, which means that if you run the installation script more than once, it might overwrite any manual configuration changes.
 ⁠
 To avoid this and determine which future changes apply, use the `--noop` argument when you run the installation script.
 This argument ensures that no actual changes are made.

--- a/guides/common/assembly_managing-red-hat-subscriptions.adoc
+++ b/guides/common/assembly_managing-red-hat-subscriptions.adoc
@@ -2,7 +2,7 @@
 = Managing Red Hat Subscriptions
 
 {ProjectName} can import content from the Red{nbsp}Hat Content Delivery Network (CDN).
-{ProjectX} requires a Red{nbsp}Hat Subscription Manifest to find, access, and download content from the corresponding repositories.
+{Project} requires a Red{nbsp}Hat Subscription Manifest to find, access, and download content from the corresponding repositories.
 You must have a Red{nbsp}Hat Subscription Manifest containing a subscription allocation for each organization on {ProjectServer}.
 All subscription information is available in your Red Hat Customer Portal account.
 
@@ -17,7 +17,7 @@ Use this chapter to import a Red{nbsp}Hat Subscription Manifest and manage the m
 .Subscription Allocations and Organizations
 
 You can manage more than one organization if you have more than one subscription allocation.
-{ProjectX} requires a single allocation for each organization configured in {ProjectServer}.
+{Project} requires a single allocation for each organization configured in {ProjectServer}.
 The advantage of this is that each organization maintains separate subscriptions so that you can support multiple organizations, each with their own Red Hat accounts.
 
 .Future-Dated subscriptions

--- a/guides/common/modules/con_introduction-to-content-management.adoc
+++ b/guides/common/modules/con_introduction-to-content-management.adoc
@@ -1,7 +1,7 @@
 [id="Introduction_to_Content_Management_{context}"]
 = Introduction to Content Management
 
-In the context of {ProjectX}, _content_ is defined as the software installed on systems.
+In the context of {Project}, _content_ is defined as the software installed on systems.
 This includes, but is not limited to, the base operating system, middleware services, and end-user applications.
 With {ProjectNameX}, you can manage the various types of content for Red Hat Enterprise Linux systems at every stage of the software life cycle.
 

--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -3,7 +3,7 @@
 
 To create hosts using image-based provisioning, you must add information about the image, such as access details and the image location, to your {ProjectServer}.
 
-ifdef::kvm-provisioning[Note that you can manage only directory pool storage types through {ProjectX}.]
+ifdef::kvm-provisioning[Note that you can manage only directory pool storage types through {Project}.]
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-images-to-server_{context}[].
 

--- a/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
+++ b/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
@@ -22,7 +22,7 @@ For more information about creating credentials, see http://docs.ansible.com/ans
 [cols="1a,2a"options="header"]
 |====
 |*Credential Type*: |*{ProjectNameX}*
-|*{ProjectX} URL*: |https://_{foreman-example-com}_
+|*{Project} URL*: |https://_{foreman-example-com}_
 |*Username*: |The username of the {Project} user with the integration role.
 |*Password*: |The password of the {Project} user.
 |====

--- a/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
+++ b/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
@@ -10,7 +10,7 @@ For more information about activation keys, see xref:Managing_Activation_Keys_{c
 
 .Smart Management Subscriptions
 
-In {ProjectX}, you must maintain a Red{nbsp}Hat Enterprise Linux Smart Management subscription for every Red{nbsp}Hat Enterprise Linux host that you want to manage.
+In {Project}, you must maintain a Red{nbsp}Hat Enterprise Linux Smart Management subscription for every Red{nbsp}Hat Enterprise Linux host that you want to manage.
 
 However, you are not required to attach Smart Management subscriptions to each content host.
 Smart Management subscriptions cannot attach automatically to content hosts in {Project} because they are not associated with any product certificates.

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -34,6 +34,6 @@ Option 67: /pxelinux.0
 For more information about DHCP options, see https://tools.ietf.org/html/rfc2132[RFC 2132].
 
 [NOTE]
-{ProjectX} does not perform orchestration when a {SmartProxy} is not set for a given subnet and domain.
+{Project} does not perform orchestration when a {SmartProxy} is not set for a given subnet and domain.
 When enabling or disabling {SmartProxy} associations, orchestration commands for existing hosts can fail if the expected records and configuration files are not present.
 When associating a {SmartProxy} to turn orchestration on, make sure the required DHCP and DNS records as well as the TFTP files are in place for the existing {Project} hosts in order to prevent host deletion failures in the future.

--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -47,7 +47,7 @@ For more information, see the https://access.redhat.com/documentation/en-us/red_
 ifndef::foreman-deb[]
 [WARNING]
 ====
-Name resolution is critical to the operation of {ProjectX}.
+Name resolution is critical to the operation of {Project}.
 If {Project} cannot properly resolve its fully qualified domain name, tasks such as content management, subscription management, and provisioning will fail.
 ====
 endif::[]
@@ -55,7 +55,7 @@ endif::[]
 ifdef::foreman-deb[]
 [WARNING]
 ====
-Name resolution is critical to the operation of {ProjectX}.
+Name resolution is critical to the operation of {Project}.
 If {Project} cannot
 properly resolve its fully qualified domain name, many options fail, such as provisioning.
 ====

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -16,7 +16,7 @@ Depending on the number of Puppet clients required, the {Project} installation c
 
 If you want to scale your {SmartProxyServer} when managing Puppet clients, the following assumptions are made:
 
-* There are no external Puppet clients reporting directly to the {ProjectX} integrated {SmartProxy}.
+* There are no external Puppet clients reporting directly to the {Project} integrated {SmartProxy}.
 * All other Puppet clients report directly to an external {SmartProxy}.
 * There is an evenly distributed run-interval of all Puppet agents.
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_in_to_Red_Hat_Satellite.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Logging_in_to_Red_Hat_Satellite.adoc
@@ -89,7 +89,7 @@ Use this tab to change to different values.
 This includes Content Views, Activation Keys, and Life Cycle Environments.
 | *Hosts*  | Provides host inventory and provisioning configuration tools.
 | *Configure*  | Provides general configuration tools and data including Host Groups and Puppet data.
-| *Infrastructure*  | Provides tools on configuring how {ProjectX} interacts with the environment.
+| *Infrastructure*  | Provides tools on configuring how {Project} interacts with the environment.
 | *_User Name_*  | Provides user administration where users can edit their personal information.
 |  image:notifications1.png[]
  | Provides event notifications to keep administrators informed of important environment changes.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/Using_Active_Directory.adoc
@@ -8,7 +8,7 @@ This section shows how to use direct Active Directory (AD) as an external authen
 You can attach Active Directory as an external authentication source with no single sign-on support.
 For more information, see xref:sect-Administering-Using_LDAP[].
 ifndef::orcharhino[]
-For an example configuration, see https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with TLS on {ProjectX}].
+For an example configuration, see https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with TLS on {Project}].
 endif::[]
 ====
 

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/configuring-tls-for-secure-ldap.adoc
@@ -9,7 +9,7 @@ Use the {Project} CLI to configure TLS for secure LDAP (LDAPS).
 
 .. If you use Active Directory Certificate Services, export the Enterprise PKI CA Certificate using the Base-64 encoded X.509 format.
 ifndef::orcharhino[]
-See https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with `TLS` on {ProjectX}] for information on creating and exporting a CA certificate from an Active Directory server.
+See https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with `TLS` on {Project}] for information on creating and exporting a CA certificate from an Active Directory server.
 endif::[]
 
 .. Download the LDAP server certificate to a temporary location on the Red{nbsp}Hat Enterprise{nbsp}Linux system where {ProjectServer} is installed and remove it when finished.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/creating-a-compliance-policy.adoc
@@ -1,7 +1,7 @@
 [id='creating-a-complicance-policy_{context}']
 = Creating a Compliance Policy
 
-With {ProjectX}, you can create a compliance policy to scan your content hosts to ensure that the hosts remain compliant to your security requirements.
+With {Project}, you can create a compliance policy to scan your content hosts to ensure that the hosts remain compliant to your security requirements.
 
 You can use either Puppet or Ansible to deploy the compliance policy to your hosts.
 Note that Puppet runs by default every 30 minutes.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/scap-content.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/scap-content.adoc
@@ -14,5 +14,5 @@ ifndef::orcharhino[]
 The creation of SCAP content is outside the scope of this guide, but see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/security_guide/[Red Hat Enterprise Linux 7 Security Guide] for information on how to download, deploy, modify, and create your own content.
 endif::[]
 
-The default SCAP content provided with the OpenSCAP components of {ProjectX} depends on the version of Red{nbsp}Hat Enterprise{nbsp}Linux.
+The default SCAP content provided with the OpenSCAP components of {Project} depends on the version of Red{nbsp}Hat Enterprise{nbsp}Linux.
 On Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7, content for both Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}6 and Red{nbsp}Hat Enterprise{nbsp}Linux{nbsp}7 is installed.

--- a/guides/doc-Administering_Red_Hat_Satellite/topics/xccdf-profile.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/topics/xccdf-profile.adoc
@@ -4,4 +4,4 @@
 An XCCDF profile is a checklist against which a host or host group is evaluated.
 Profiles are created to verify compliance with an industry standard or custom standard.
 
-The profiles provided with {ProjectX} are obtained from the https://www.open-scap.org/[OpenSCAP project].
+The profiles provided with {Project} are obtained from the https://www.open-scap.org/[OpenSCAP project].

--- a/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
@@ -4,7 +4,7 @@
 There are three main methods for registering hosts to {ProjectServer} or {SmartProxyServer}:
 
 . *(Default method)* Generate a `curl` command from {Project} and run this command from unlimited number of hosts to register them using the global registration template.
-This method is suited for both freshly installed hosts and hosts that have been previously registered, for example, to {Project} 5 or another {ProjectX}.
+This method is suited for hosts that haven't been registered to {Project} yet.
 +
 By using this method you can also deploy {Project} SSH keys to hosts during registration to {Project} to enable hosts for remote execution jobs.
 For more information about the remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting up Remote Jobs].
@@ -13,10 +13,10 @@ By using this method you can also configure hosts with Red{nbsp}Hat Insights dur
 For more information about using Insights with {Project} hosts, see {ManagingHostsDocURL}Using_Red_Hat_Insights_with_Hosts_managing-hosts[Monitoring Hosts Using Red{nbsp}Hat Insights].
 
 . Download and install the consumer RPM `_server.example.com_/pub/katello-ca-consumer-latest.noarch.rpm` and then run Subscription Manager.
-This method is suited for freshly installed hosts.
+This method is suited for hosts that haven't been provisioned through {Project}.
 
 . *(Deprecated)* Download and run the bootstrap script (_server.example.com_/pub/bootstrap.py).
-This method is suited for both freshly installed hosts and hosts that have been previously registered, for example, to {Project} 5 or another {ProjectX}.
+This method is suited for hosts that haven't been provisioned through {Project}.
 
 You can also register Atomic Hosts to {ProjectServer} or {SmartProxyServer}.
 

--- a/guides/doc-Managing_Hosts/topics/creating-an-insights-plan.adoc
+++ b/guides/doc-Managing_Hosts/topics/creating-an-insights-plan.adoc
@@ -1,7 +1,7 @@
 [id="creating-an-insights-plan"]
 = Creating an Insights Plan for Hosts
 
-With {ProjectX}, you can create a Red{nbsp}Hat Insights remediation plan and run the plan on {Project} hosts.
+With {Project}, you can create a Red{nbsp}Hat Insights remediation plan and run the plan on {Project} hosts.
 
 .Procedure
 

--- a/guides/doc-Managing_Hosts/topics/ref_advanced-bootstrap-script-configuration.adoc
+++ b/guides/doc-Managing_Hosts/topics/ref_advanced-bootstrap-script-configuration.adoc
@@ -10,7 +10,7 @@ If this is not acceptable to your security policy, create a new role with the mi
 For more information, see xref:Setting_Permissions_for_the_Bootstrap_Script_{context}[].
 ====
 
-== Migrating a host from one {ProjectX} to another {ProjectX}
+== Migrating a host from one {Project} to another {Project}
 
 Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` packages on the new {Project}.
 
@@ -41,7 +41,7 @@ Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` pac
 --force
 ----
 
-== Migrating a host from Red Hat Network (RHN) or {Project} 5 to {ProjectX}
+== Migrating a host from Red Hat Network (RHN) or {Project} 5 to {Project}
 
 The bootstrap script detects the presence of `/etc/syconfig/rhn/systemid` and a valid connection to RHN as an indicator that the system is registered to a legacy platform.
 The script then calls `rhn-classic-migrate-to-rhsm` to migrate the system from RHN.
@@ -78,7 +78,7 @@ Enter the user account password when prompted.
 --legacy-login _rhn-user_
 ----
 
-== Registering a host to {ProjectX}, omitting Puppet setup
+== Registering a host to {Project}, omitting Puppet setup
 
 By default, the bootstrap script configures the host for content management and configuration management.
 If you have an existing configuration management system and do not want to install Puppet on the host, use `--skip-puppet`.
@@ -110,7 +110,7 @@ If you have an existing configuration management system and do not want to insta
 --skip-puppet
 ----
 
-== Registering a host to {ProjectX} for content management only
+== Registering a host to {Project} for content management only
 
 To register a system as a content host, and omit the provisioning and configuration management functions, use `--skip-foreman`.
 

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -48,7 +48,7 @@ For BIOS provisioning, you must associate a PXELinux template with the operating
 
 For UEFI provisioning, you must associate a PXEGrub2 template with the operating system.
 
-If you associate both PXELinux and PXEGrub2 templates, {ProjectX} can deploy configuration files for both on a TFTP server, so that you can switch between PXE loaders easily.
+If you associate both PXELinux and PXEGrub2 templates, {Project} can deploy configuration files for both on a TFTP server, so that you can switch between PXE loaders easily.
 
 [[Provisioning_Bare_Metal_Hosts-Prerequisites_for_Bare_Metal_Provisioning]]
 === Prerequisites for Bare Metal Provisioning

--- a/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
+++ b/guides/doc-Provisioning_Guide/topics/app_create_images.adoc
@@ -322,7 +322,7 @@ NOTE: The Katello agent is deprecated and will be removed in a future {Project} 
 Migrate your workloads to use the remote execution feature to update clients remotely.
 For more information, see {ManagingHostsDocURL}installing-the-katello-agent_managing-hosts[Installing the Katello Agent] in the _Managing Hosts Guide_.
 
-Use the following procedure to install the Katello agent on a host registered to {ProjectX}.
+Use the following procedure to install the Katello agent on a host registered to {Project}.
 The `katello-agent` package depends on the gofer package that provides the `goferd service`.
 
 .Prerequisites

--- a/guides/doc-Provisioning_Guide/topics/ref_discovery-template-and-snippets.adoc
+++ b/guides/doc-Provisioning_Guide/topics/ref_discovery-template-and-snippets.adoc
@@ -46,7 +46,7 @@ For katello scenario deployment, use port 9090.
 endif::[]
 
 .Rendering the {SmartProxy}'s Host Name
-{ProjectX} deploys the same template to all TFTP {SmartProxies} and there is no variable or macro available to render the {SmartProxy}'s host name.
+{Project} deploys the same template to all TFTP {SmartProxies} and there is no variable or macro available to render the {SmartProxy}'s host name.
 The hard-coded `proxy.url` does not not work with two or more TFTP {SmartProxies}.
 As a workaround, every time you click *Build PXE Defaults*, edit the configuration file in the TFTP directory using SSH, or use a common DNS alias for appropriate subnets.
 

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
@@ -2,7 +2,7 @@
 
 ifdef::satellite[]
 [WARNING]
-If you have {ProjectX} installed in a high availability configuration, contact Red{nbsp}Hat Support before upgrading to {Project} {ProjectVersion}.
+If you have {Project} installed in a high availability configuration, contact Red{nbsp}Hat Support before upgrading to {Project} {ProjectVersion}.
 endif::[]
 
 Use the following procedures to upgrade your existing {ProjectName} to {ProjectName} {ProjectVersion}:


### PR DESCRIPTION
Previously, Satellite was branded as "Satellite 6" to differentiate between "Satellite 5". The product is no longer supported and Satellite marketing is moving towards simply using "Red Hat Satellite". Therefore the attribute `{ProjectX}` which rendered as `Satellite 6` or `Foreman` is not needed.

This patch removes the attribute and all uses:

    find guides -iname "*.adoc" | xargs sed -i 's/{ProjectX}/{Project}/g'

I would like blessing from @ares for this.