### PR TITLE
Registration - required templates on proxy

### DIFF
--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
@@ -18,7 +18,7 @@ ifdef::satellite,orcharhino[]
 * Optional: If you want to register hosts to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL7Server}` repository and make it available in the activation key that you use.
 This is required to install the `insights-client` package on hosts.
 endif::[]
-* Optional: If you want to register hosts through {SmartProxy}, ensure that the *Registration* feature is enabled on this {SmartProxy}.
+* Optional: If you want to register hosts through {SmartProxy}, ensure that the *Registration* and *Templates* features are enabled on this {SmartProxy}.
 +
 Navigate to *Infrastructure* > *{SmartProxies}*, click the {SmartProxy} that you want to use, and locate the *Registration* feature in the *Active features* list.
 +


### PR DESCRIPTION
For https://github.com/theforeman/foreman/pull/8855,
proxy must have enabled *Registration* and *Templates* features

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
