### PR TITLE
Update upgrading_a_disconnected_satellite.adoc

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -25,7 +25,8 @@ If you implemented custom certificates, you must retain the content of both the 
 Failure to retain these files during an upgrade causes the upgrade to fail.
 If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
 ====
-The hammer import and export commands have been removed and replaced with `hammer content-import` and `hammer content-export` tooling. If you have scripts that are using `hammer content-view version export`, `hammer content-view version export-legacy` or `hammer repository export` and their respective import commands, they will have to be adjusted to use the `hammer content-export` command instead.
+The hammer import and export commands have been replaced with `hammer content-import` and `hammer content-export` tooling.
+If you have scripts that are using `hammer content-view version export`, `hammer content-view version export-legacy` or `hammer repository export` and their respective import commands, they will have to be adjusted to use the `hammer content-export` command instead.
 ====
 
 .Upgrade Disconnected {ProjectServer}

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -5,9 +5,28 @@
 Use this procedure for a {ProjectServer} not connected to the Red{nbsp}Hat Content Delivery Network.
 
 [WARNING]
-If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when you enter the `{foreman-maintain}` command during upgrading or updating.
+====
+* If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when you enter the `{foreman-maintain}` command during upgrading or updating.
 You can use the `--noop` option with the `{foreman-installer}` command to review the changes that are applied during upgrading or updating.
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
+
+* The hammer import and export commands have been replaced with `hammer content-import` and `hammer content-export` tooling.
++
+If you have scripts that are using: 
++
+----
+hammer content-view version export
+hammer content-view version export-legacy
+hammer repository export
+----
++
+or their respective import commands, they will have to be adjusted to use the `hammer content-export` command instead.
+
+* If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom certificates.
++
+Failure to retain these files during an upgrade causes the upgrade to fail.
+If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
+====
 
 
 .Before You Begin
@@ -18,16 +37,6 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 * Back up and remove all Foreman hooks before upgrading.
 Reinstate hooks only after {Project} is known to be working after the upgrade is complete.
 
-[WARNING]
-====
-If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom certificates.
-
-Failure to retain these files during an upgrade causes the upgrade to fail.
-If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
-====
-The hammer import and export commands have been replaced with `hammer content-import` and `hammer content-export` tooling.
-If you have scripts that are using `hammer content-view version export`, `hammer content-view version export-legacy` or `hammer repository export` and their respective import commands, they will have to be adjusted to use the `hammer content-export` command instead.
-====
 
 .Upgrade Disconnected {ProjectServer}
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -14,13 +14,21 @@ For more information, see the Red Hat Knowledgebase solution https://access.redh
 +
 If you have scripts that are using: 
 +
+[source, Bash, options="nowrap"]
 ----
-hammer content-view version export
-hammer content-view version export-legacy
-hammer repository export
+# hammer content-view version export
+# hammer content-view version export-legacy
+# hammer repository export
 ----
 +
-or their respective import commands, they will have to be adjusted to use the `hammer content-export` command instead.
+or their respective import commands, they will have to be adjusted to use the 
++
+[source, Bash, options="nowrap"]
+----
+# hammer content-export
+----
+command instead, along with it's respective import command. 
+
 
 * If you implemented custom certificates, you must retain the content of both the `/root/ssl-build` directory and the directory in which you created any source files associated with your custom certificates.
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -25,6 +25,8 @@ If you implemented custom certificates, you must retain the content of both the 
 Failure to retain these files during an upgrade causes the upgrade to fail.
 If these files have been deleted, they must be restored from a backup in order for the upgrade to proceed.
 ====
+The hammer import and export commands have been removed and replaced with `hammer content-import` and `hammer content-export` tooling. If you have scripts that are using `hammer content-view version export`, `hammer content-view version export-legacy` or `hammer repository export` and their respective import commands, they will have to be adjusted to use the `hammer content-export` command instead.
+====
 
 .Upgrade Disconnected {ProjectServer}
 


### PR DESCRIPTION
Added note that the old export and import hammer commands have been replaced.


Cherry-pick into:

* [ ] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
