### PR TITLE
Build and check with local HTML links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,8 +52,21 @@ jobs:
       - name: Clean the environment
         run: make clean
 
-      - name: Build HTML
+      - name: Build HTML with local links
         run: |
+          make html BUILD=foreman-el LINKS=LOCAL
+          make html BUILD=foreman-deb LINKS=LOCAL
+          make html BUILD=katello LINKS=LOCAL
+          make html BUILD=satellite LINKS=LOCAL
+          make html BUILD=orcharhino LINKS=LOCAL
+
+      - name: Check HTML links of all builds
+        run: |
+          make linkchecker-tryer
+
+      - name: Rebuild HTML with real links
+        run: |
+          make clean
           make html BUILD=foreman-el
           make html BUILD=foreman-deb
           make html BUILD=katello
@@ -65,14 +78,6 @@ jobs:
         with:
           name: foreman-docs-html-${{ env.BRANCH_NAME }}
           path: guides/build/
-
-      - name: Check HTML links
-        run: |
-          make linkchecker-tryer BUILD=foreman-el
-          make linkchecker-tryer BUILD=foreman-deb
-          make linkchecker-tryer BUILD=katello
-          make linkchecker-tryer BUILD=satellite
-          make linkchecker-tryer BUILD=orcharhino
 
   build-pdf:
     runs-on: ubuntu-latest

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 BUILD = foreman-el
 BUILD_DIR = ../build
+BUILD_DIRA = $(realpath $(BUILD_DIR))/
 COMMON_DIR = ../common
 ROOTDIR = $(realpath .)
 NAME = $(notdir $(ROOTDIR))
@@ -22,6 +23,10 @@ BROWSER_OPEN = xdg-open
 endif
 ifeq ($(UNAME), Darwin)
 BROWSER_OPEN = open
+endif
+
+ifeq ($(LINKS), LOCAL)
+BASEURL_ATTR = "-a BaseURL=file://$(BUILD_DIRA)"
 endif
 
 all: html
@@ -60,7 +65,7 @@ $(IMAGES_TS): $(IMAGES)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES)
-	bundle exec asciidoctor -a build=$(BUILD) -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
+	bundle exec asciidoctor -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(BUILD).css -a linkcss=true -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log
 	@echo CHECKING FOR ASCIIDOCTOR ERRORS AND WARNINGS
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 	@echo CHECKING FOR ORPHAN XREFS HTML LINKS


### PR DESCRIPTION
Our Github Action builds HTML pages for all variants and then it calls linkchecker on them. So far so good.

Now, we build with BaseURL that points to real sites:

* docs.foreman.org
* Red Hat Docs
* ATIX docs

Problem is, real sites are often out of date.

This patch solves it, it builds all HTML pages with BaseURL set to `file:///absolute/path/to/build/dir/` which then correctly maps all links. Link validation is more relevant as it checks links of the actual pull request. It is also faster.

And I also found that we call the linkchecker 5 times instead of just one. This will dramatically speed up pull request tests.