### PR TITLE
Visually separate the abort and reset commands in the Pulp migration p…

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -51,21 +51,29 @@ This might take some time on high latency systems.
 # {foreman-maintain} content prepare
 ----
 +
-You cannot use `*Ctrl*` *+* `*C*` to terminate this process.
-If a user attempts to halt the process using CTRL + C or by disconnecting their SSH session, the process does not terminate but continues in the background.
+[Note]
+====
+You cannot use *`Ctrl` + `C`* to terminate this process.
+If you attempt to halt the process using *`Ctrl` + `C`* or by disconnecting your SSH session, the process does not terminate but continues in the background.
 You can use the following command to terminate the process gracefully, whenever necessary, so that you can continue later.
-+
+
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # {foreman-maintain} content prepare-abort
 ----
-+
+
 Note that `{foreman-maintain} content-prepare abort` can take several minutes to terminate the process.
-. Continue the migration process using `{foreman-maintain} content-prepare` whenever it is convenient.
-. If problems occur, you can restart the pre-migration process from the beginning:
+You can continue the migration process using `{foreman-maintain} content-prepare` whenever it is convenient.
+====
 +
+. The migration process is not fully complete until the upgrade of {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion} is complete.
++
+[Note]
+====
+If problems occur, you can restart the pre-migration process from the beginning using the following command:
+
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # {foreman-maintain} content migration-reset
 ----
-. The migration process is not fully complete until the upgrade of {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion} is complete.
+====

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -57,7 +57,6 @@ You cannot use *`Ctrl` + `C`* to terminate this process.
 If you attempt to halt the process using *`Ctrl` + `C`* or by disconnecting your SSH session, the process does not terminate but continues in the background.
 You can use the following command to terminate the process gracefully, whenever necessary, so that you can continue later.
 
-
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # {foreman-maintain} content prepare-abort
@@ -66,7 +65,7 @@ You can use the following command to terminate the process gracefully, whenever 
 Note that `{foreman-maintain} content-prepare abort` can take several minutes to terminate the process.
 You can continue the migration process using `{foreman-maintain} content-prepare` whenever it is convenient.
 ====
-+
+
 . The migration process is not fully complete until the upgrade of {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion} is complete.
 +
 [NOTE]

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -51,11 +51,12 @@ This might take some time on high latency systems.
 # {foreman-maintain} content prepare
 ----
 +
-[Note]
+[NOTE]
 ====
 You cannot use *`Ctrl` + `C`* to terminate this process.
 If you attempt to halt the process using *`Ctrl` + `C`* or by disconnecting your SSH session, the process does not terminate but continues in the background.
 You can use the following command to terminate the process gracefully, whenever necessary, so that you can continue later.
+
 
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
@@ -68,7 +69,7 @@ You can continue the migration process using `{foreman-maintain} content-prepare
 +
 . The migration process is not fully complete until the upgrade of {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion} is complete.
 +
-[Note]
+[NOTE]
 ====
 If problems occur, you can restart the pre-migration process from the beginning using the following command:
 


### PR DESCRIPTION
…rocess

Separated using notes.

Bug 2013682 - Remove satellite-maintain content migration-reset as a step

https://issues.redhat.com/browse/SATDOC-490


Cherry-pick into:

* [ ] Foreman 3.0
* [ ] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
