### PR TITLE
Added statement that Pulp migration increases upgrade time

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -36,6 +36,9 @@ endif::[]
 Upgrading {Project} takes approximately 1 - 2 hours.
 +
 Upgrading {SmartProxy} takes approximately 10 - 30 minutes.
++
+However, upgrading from {ProjectVersionPrevious} to {ProjectVersion} also migrates Pulp content, this step can take some considerable time.
+For more information on preparing for Pulp migration and the upgrade process, see xref:Upgrading_Server_{context}[].
 
 * Ensure that you have sufficient storage space on your server. For more information, see {InstallingProjectDocURL}preparing-environment-for-satellite-installation[Preparing your Environment for Installation] in _Installing {ProjectServer} from a Connected Network_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 


### PR DESCRIPTION
Bug 2013267 - Need to update time required to complete the upgrade in Prerequisites section of Sat6.10

https://issues.redhat.com/browse/SATDOC-477


Cherry-pick into:

* [ ] Foreman 3.0
* [X] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
