### PR TITLE
Require PRs for backporting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 Cherry-pick into:
 
 * [ ] Foreman 3.0
-* [ ] Foreman 2.5 (Satellite 6.10)
+* For Foreman 2.5, file a separate PR request
 
 <!---
 Thank you for contributing to Foreman documentation. Make sure to read README


### PR DESCRIPTION
We had issues with backporting some of the changes. Cherry picking is mostly seamless process, but due to amount of changes recently and also due to the fact that Red Hat Documentation team requires backporting into one year old branch, we very often encounter conflicts breaking the builds.

This patch removes the checkbox from the PR template and asks authors to file PRs on their own. This way we can ensure good quality by running builds via Github Actions.

I would suggest that Red Hat Documentation team would work earier in the process, e.g. when features are being completed rather than after beta Satellite release to avoid extra work of backporting changes.

https://github.com/theforeman/foreman-documentation/pull/816

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->