### PR TITLE
BZ 2021473: Specify disk space requirement for Pulp content migration

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -19,6 +19,13 @@ In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the templ
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
 ifdef::satellite[]
 * Pulp content migration occurs at {ProjectVersionPrevious}, before the upgrade to {ProjectVersion}.
+* Ensure there is sufficient storage space for `/var/lib/pulp/published` to double in size before starting the migration process.
+Check the size of `/var/lib/pulp/published` with:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# du -sh /var/lib/pulp/published/
+----
 * Content migration can be run online, but uses processor, disk, and memory resources.
 Sync and content view publishing operations might take longer as a result.
 * If you have not pre-migrated Pulp content, the `PULP_CONTENT_PREMIGRATION_BATCH_SIZE` setting defines the number of content units processed at the same time.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2021472

Cherry-pick into:

* [x] Foreman 3.0
* [x] Foreman 2.5 (Satellite 6.10)

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
