### PR TITLE
Add encrypt_grub global param and rephrase description of grub_pass on 2.5

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Template_Writing.adoc
+++ b/guides/doc-Managing_Hosts/topics/Template_Writing.adoc
@@ -39,7 +39,7 @@ This process is referred to as *rendering*.
 [[appe-Red_Hat_Satellite-Managing_Hosts-Template_Writing_Reference-ui]]
 === Accessing the Template Writing Reference in the {Project} web UI
 
-You can access the template writing reference document in the {Project} web UI. 
+You can access the template writing reference document in the {ProjectWebUI}.
 
 . Log in to the {Project} web UI.
 . Navigate to *Administer* > *About*.
@@ -243,7 +243,7 @@ Can be inherited from the operating system.
 |@host.environment |The Puppet environment of the host.
 |@host.facts |Returns a Ruby hash of facts from Facter.
 For example to access the 'ipaddress' fact from the output, specify @host.facts['ipaddress'].
-|@host.grub_pass |Returns the host's GRUB password.
+|@host.grub_pass |Returns the host's bootloader password.
 |@host.hostgroup |The host group of the host.
 |host_enc['parameters'] |Returns a Ruby hash containing information on host parameters.
 For example, use host_enc['parameters']['lifecycle_environment'] to get the life cycle environment of a host.
@@ -294,7 +294,7 @@ Not recommended, as it does not interpolate variables, prefer boot_files_uri.
 |@provisioning_type |Equals to 'host' or 'hostgroup' depending on type of provisioning.
 |@static |Returns `true` if the network configuration is static.
 |@template_name |Name of the template being rendered.
-|grub_pass |Returns the GRUB password wrapped in md5pass argument, that is *--md5pass=#{@host.grub_pass}*.
+|grub_pass |Returns a bootloader argument to set the encrypted bootloader password, such as *--md5pass=#{@host.grub_pass}*.
 |ks_console |Returns a string assembled using the port and the baud rate of the host which can be added to a kernel line.
 For example *console=ttyS1,9600*.
 |root_pass |Returns the root password configured for the system.

--- a/guides/doc-Managing_Hosts/topics/ref_customizing-the-registration-templates.adoc
+++ b/guides/doc-Managing_Hosts/topics/ref_customizing-the-registration-templates.adoc
@@ -33,6 +33,9 @@ endif::[]
 * The `host_packages` parameter is for installing packages on the host.
 
 * The `remote_execution_ssh_keys`, `remote_execution_ssh_user`, `remote_execution_create_user` and `remote_execution_effective_user_method` parameters are used in the `remote_execution_ssh_keys`. For more details se the details of the snippet.
+* The `encrypt_grub` parameter is to enable setting of an encrypted bootloader password for the host, the default value is `false`.
++
+To actually set the password, use the `grub_pass` macro in your template.
 
 .Snippets
 


### PR DESCRIPTION
Follow-up to #817 

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
