### PR TITLE
Extend ACD procedures

### DIFF
--- a/guides/common/modules/proc_overwriting-ansible-group-variables-in-application-instances.adoc
+++ b/guides/common/modules/proc_overwriting-ansible-group-variables-in-application-instances.adoc
@@ -1,0 +1,16 @@
+[id="Overwriting_Ansible_Group_Variables_in_Application_Instances_{context}"]
+= Overwriting Ansible Group Variables in Application Instances
+
+You can overwrite Ansible group variables in application instances unless the parameters are locked by the application definition.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Applications > App Instances*.
+. Select an application instance.
+. To overwrite Ansible group variables for all services, click the *A* character below the table.
+. To overwrite Ansible group variables on a per service basis, click the *A* character in the action menu next to a service.
+. Click the *edit* icon to overwrite Ansible group variables from the application definition.
++
+A grayed out *edit* icon indicates that this Ansible group variable has been locked by the application definition.
+. Click *Save* to update the Ansible group variables.
+
+Note that it is not possible to add or remove parameters in the application instance.

--- a/guides/common/modules/proc_setting-host-parameters-in-application-definitions.adoc
+++ b/guides/common/modules/proc_setting-host-parameters-in-application-definitions.adoc
@@ -1,0 +1,14 @@
+[id="Setting_Host_Parameters_in_Application_Definitions_{context}"]
+= Setting Host Parameters in Application Definitions
+
+You can add and edit host parameters for individual application definitions.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Applications > Application Definitions*.
+. Select an application definition.
+. Click the _settings_ icon in the *Actions* column.
+. Click the *+* sign to add a new host parameter.
+. Optional: Using the *Actions* column, you can _edit_ an existing host parameter, _lock_ or _unlock_ host parameters, and _delete_ host parameters.
+. Click *Save* to save your application definition to {Project}.
+
+Locking parameters prevents users from changing them within an application instance.

--- a/guides/common/modules/proc_viewing-application-instance-reports.adoc
+++ b/guides/common/modules/proc_viewing-application-instance-reports.adoc
@@ -1,0 +1,9 @@
+[id="Viewing_Application_Instance_Reports_{context}"]
+= Viewing Application Instance Reports
+
+You can view reports on the last application instance deployment.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Applications > App Instances*.
+. Click on *Show Report* in the list of application instances.
+. Click on *Last deployment task* to view the last deployment task in {Project}.

--- a/guides/common/modules/proc_viewing-the-last-deployment-task.adoc
+++ b/guides/common/modules/proc_viewing-the-last-deployment-task.adoc
@@ -1,0 +1,13 @@
+[id="Viewing_the_Last_Deployment_Task_{context}"]
+= Viewing the Last Deployment Task
+
+You can view the last deployment task for each application instance.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Applications > App Instances*.
+. Click *Show Report* in the list of application instances.
+. Click *Last deployment task* to view the last deployment task in {Project}.
++
+The table shows basic information regarding the execution of the task.
+The indicator shows the state and overall status of the task, for example `100% complete`.
+The other tabs *Running Steps*, *Errors*, *Locks*, and *Raw* contain more detailed information about the task.

--- a/guides/doc-Application_Centric_Deployment/master.adoc
+++ b/guides/doc-Application_Centric_Deployment/master.adoc
@@ -31,6 +31,8 @@ include::common/modules/proc_creating_an_application_definition.adoc[leveloffset
 
 include::common/modules/proc_removing_an_application_definition.adoc[leveloffset=+2]
 
+include::common/modules/proc_setting-host-parameters-in-application-definitions.adoc[leveloffset=+2]
+
 
 include::common/modules/proc_viewing_an_application_instance.adoc[leveloffset=+2]
 
@@ -39,6 +41,12 @@ include::common/modules/proc_creating_an_application_instance.adoc[leveloffset=+
 include::common/modules/proc_deploying_an_application_instance.adoc[leveloffset=+2]
 
 include::common/modules/proc_removing_an_application_instance.adoc[leveloffset=+2]
+
+include::common/modules/proc_overwriting-ansible-group-variables-in-application-instances.adoc[leveloffset=+2]
+
+include::common/modules/proc_viewing-application-instance-reports.adoc[leveloffset=+2]
+
+include::common/modules/proc_viewing-the-last-deployment-task.adoc[leveloffset=+2]
 
 [id="{context}_developers"]
 == Developers


### PR DESCRIPTION
This PR adds four more ACD procedures:

* Add procedure to change host parameters for ACD
* Add procedure to overwrite Ansible group variables in ACD
* Add procedure to view application instance reports for ACD
* Add procedure to view last deployment task for ACD