### PR TITLE
Reformatted Port Requirement Tables

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -86,7 +86,8 @@ Remote Execution result upload
 ifdef::satellite[]
 | 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 endif::[]
-[cols="15%,15%,15%,15%,20%,20%",options="header"]| 443 | TCP | HTTPS | {Project} | Content | Sync
+ifdef::katello,satellite,orcharhino[]
+| 443 | TCP | HTTPS | {Project} | Content | Sync 
 | 443 | TCP | HTTPS | {Project} | Client communication | Forward requests from Client to {Project}
 endif::[]
 | 443 | TCP | HTTPS | Infoblox DHCP Server| DHCP management | When using Infoblox for DHCP, management of the DHCP leases (optional)

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -17,90 +17,91 @@ This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
-For more information on {Project} Topology, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
+For more information on {Project} Topology and an illustration of port connections, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
 
 Required ports can change based on your configuration.
 
-ifndef::foreman-deb[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
-endif::[]
-
 The following tables indicate the destination port and the direction of network traffic:
 
-.Ports for {SmartProxy} to {Project} Communication
-[cols="24%,20%,18%,38%",options="header"]
+.{SmartProxy} incoming traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
-| Port | Protocol | Service | Required For
-| 5646   | TCP   |  amqp   |  {SmartProxy}'s Qpid dispatch router to Qpid dispatch router in {Project}
-|====
+| Destination Port | Protocol | Service |Source| Required For | Description
+| 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
+| 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 69 | UDP | TFTP | Client | TFTP Server (optional) |
+ifdef::katello,satellite,orcharhino[]
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
+| 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
+| 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
+| 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 
-ifdef::foreman-el,katello[]
-Some of the following ports apply only to deployments that use the Katello plug-in.
+Katello agent to communicate with Qpid dispatcher
 endif::[]
-
-ifdef::foreman-deb[]
-Some of the following ports apply only to deployments that use the Katello plug-in.
-For Debian deployments, ignore references to the Katello plug-in.
+| 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
+| 8000 | TCP | HTTP | Client | PXE Boot | Installation
+| 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
+ifndef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
 
-.Ports for Client to {SmartProxy} Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-ifdef::satellite[]
-|Port |Protocol |Service |Required for
-|80 |TCP |HTTP |Anaconda, yum, and for obtaining Katello certificate
-updates
-|443 |TCP |HTTPS |Anaconda, yum, Telemetry Services, and Puppet
-|5647 |TCP |AMQP |Katello agent to communicate with {SmartProxy}'s
-Qpid dispatch router
-|8000 |TCP |HTTPS |Anaconda to download kickstart templates to hosts,
-and for downloading iPXE firmware
+Uploading facts
+
+Sending installed packages and traces
+| 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
+| 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
 endif::[]
-ifdef::foreman-el,katello[]
-|Port |Protocol |Service |Required for
-|80 |TCP |HTTP |Operating System installers like Anaconda, yum, and, if you use the Katello plug-in, for obtaining Katello certificate
-updates
-|443 |TCP |HTTPS |Operating System installers like Anaconda, yum, Telemetry Services, and Puppet
-|5646 | TCP | AMQP | The {SmartProxy} Qpid dispatch router to the Qpid dispatch router in {Project}
-|5647 |TCP |amqp |For Katello plug-in users: Katello agent to communicate with {SmartProxy}'s
-Qpid dispatch router
-|8000 |TCP |HTTPS |Operating System installers like Anaconda to download kickstart templates to hosts,
-and for downloading iPXE firmware
-endif::[]
-|8140 |TCP |HTTPS |Puppet agent to Puppet master connections
-|8443 |TCP |HTTPS |Subscription Management Services and Telemetry Services
-|9090 |TCP |HTTPS |Sending SCAP reports to the {SmartProxy} and for the discovery image during provisioning
-| 53 | TCP and UDP | DNS | Client DNS queries to a {SmartProxy}'s DNS service (Optional)
-| 67 | UDP | DHCP | Client to {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {SmartProxy} (Optional)
-| 69 | UDP |TFTP | Clients downloading PXE boot image files from a {SmartProxy} for provisioning (Optional)
-|====
-
-
-.Ports for {SmartProxy} to Client Communication
-[cols="24%,20%,18%,38%a",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| - | ICMP | ping | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-| 7 | TCP | echo | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-| 68 | UDP | DHCP | {SmartProxy} to Client broadcasts, DHCP broadcasts for Client provisioning from a {SmartProxy} (Optional)
-| 8443 | TCP |HTTP | {SmartProxy} to Client "reboot" command to a discovered host during provisioning (Optional)
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
 This includes the base operating system on which a {SmartProxyServer} is running.
 
-A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
+A DHCP {SmartProxy} performs ICMP ping and TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
 This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
+.{SmartProxy} outgoing traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
 
-.Optional Network Ports
-[cols="24%,20%,18%,38%a",options="header"]
 |====
-| Port | Protocol | Service | Required For
-| 22 | TCP | SSH | {Project} and {SmartProxy} originated communications, for Remote Execution (Rex) and Ansible.
-| 7911 | TCP | DHCP | * {SmartProxy} originated commands for orchestration of DHCP records (local or external).
-                      * If DHCP is provided by an external service, you must open the port on the external server.
+| Destination Port | Protocol | Service | Destination | Required For | Description
+| | ICMP | ping  | Client | DHCP | Free IP checking (optional)
+| 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
+| 22 | TCP | SSH | Target host | Remote execution | Run jobs
+| 53 | TCP and UDP | DNS | DNS Servers on the Internet | DNS Server | Resolve DNS records (optional)
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} DNS | Validation of DNS conflicts (optional)
+| 68 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 443 | TCP | HTTPS | {Project} | {SmartProxy} | {SmartProxy}
+
+Configuration management
+
+Template retrieval
+
+OpenSCAP
+
+Remote Execution result upload
+ifdef::satellite[]
+| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 443 | TCP | HTTPS | {Project} | Content | Sync
+| 443 | TCP | HTTPS | {Project} | Client communication | Forward requests from Client to {Project}
+endif::[]
+| 443 | TCP | HTTPS | Infoblox DHCP Server| DHCP management | When using Infoblox for DHCP, management of the DHCP leases (optional)
+| 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
+ifdef::katello,satellite,orcharhino[]
+| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
+endif::[]
+| 7911 | TCP | DHCP, OMAPI | DHCP Server| DHCP | The DHCP target is configured using `--foreman-proxy-dhcp-server` and defaults to localhost
+
+ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAPI
+| 8443 | TCP | HTTPS | Client | Discovery | {SmartProxy} sends reboot command to the discovered host (optional)
 |====
 
-NOTE: A DHCP {SmartProxy} sends an ICMP ECHO to confirm an IP address is free, *no response* of any kind is expected.
-ICMP can be dropped by a networked-based firewall, but *any* response prevents the allocation of IP addresses.
+NOTE: ICMP to Port 7 UDP and TCP must not be rejected, but can be dropped.
+The DHCP {SmartProxy} sends an ECHO REQUEST to the Client network to verify that an IP address is free.
+Any response will prevent IP addresses being allocated.

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -26,7 +26,7 @@ The following tables indicate the destination port and the direction of network 
 .{SmartProxy} incoming traffic
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 |====
-| Destination Port | Protocol | Service |Source| Required For | Description
+| Destination Port | Protocol | Service | Source | Required For | Description
 | 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
@@ -66,7 +66,6 @@ This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-
 
 .{SmartProxy} outgoing traffic
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
-
 |====
 | Destination Port | Protocol | Service | Destination | Required For | Description
 | | ICMP | ping  | Client | DHCP | Free IP checking (optional)
@@ -87,8 +86,7 @@ Remote Execution result upload
 ifdef::satellite[]
 | 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 endif::[]
-ifdef::katello,satellite,orcharhino[]
-| 443 | TCP | HTTPS | {Project} | Content | Sync
+[cols="15%,15%,15%,15%,20%,20%",options="header"]| 443 | TCP | HTTPS | {Project} | Content | Sync
 | 443 | TCP | HTTPS | {Project} | Client communication | Forward requests from Client to {Project}
 endif::[]
 | 443 | TCP | HTTPS | Infoblox DHCP Server| DHCP management | When using Infoblox for DHCP, management of the DHCP leases (optional)

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -22,65 +22,41 @@ endif::[]
 
 Required ports can change based on your configuration.
 
-ifdef::satellite[]
-A matrix table of ports is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/5627751[Red Hat Satellite List of Network Ports].
-endif::[]
-
 The following tables indicate the destination port and the direction of network traffic:
 
-ifdef::satellite[]
-ifeval::["{mode}" == "connected"]
-.Ports for {Project} to Red Hat CDN Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 443 | TCP | HTTPS | Subscription Management Services (access.redhat.com) and connecting to the Red{nbsp}Hat CDN (cdn.redhat.com).
-|====
+.{ProjectServer} incoming traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header
+| Destination Port | Protocol | Service |Source| Required For | Description
+| 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
+| 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 69 | UDP | TFTP | Client | TFTP Server (optional) |
+| 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
+ifdef::katello,satellite,orcharhino[]
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
+| 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
+| 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
+| 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
 endif::[]
+| 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console
+| 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
+| 8000 | TCP | HTTPS | Client | PXE Boot | Installation
+| 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
+ifndef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
 
-ifdef::satellite[]
-ifeval::["{mode}" == "connected"]
-{ProjectServer} needs access to the Red{nbsp}Hat CDN.
-For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red Hat] on the Red{nbsp}Hat Customer Portal.
-endif::[]
-endif::[]
+Uploading facts
 
-ifdef::katello[]
-ifeval::["{mode}" == "connected"]
-If you plan to use Red{nbsp}Hat services, {ProjectServer} needs access to the Red{nbsp}Hat CDN.
-For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red Hat] on the Red{nbsp}Hat Customer Portal.
+Sending installed packages and traces
+| 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
+| 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
+| 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
 endif::[]
-endif::[]
-
-.Ports for Browser-based User Interface Access to {Project}
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 443 | TCP | HTTPS | Browser-based UI access to {Project}
-| 80 | TCP | HTTP | Redirection to HTTPS for web UI access to {Project} (Optional)
-|====
-
-.Ports for Client to {Project} Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required For
-| 80 | TCP | HTTP | Anaconda, yum, for obtaining Katello certificates, templates, and for downloading iPXE firmware
-| 443 | TCP | HTTPS | Subscription Management Services, yum, Telemetry Services and client connections
-ifdef::katello,satellite[]
-| 5646 | TCP | AMQP | The {SmartProxy} Qpid dispatch router to the Qpid dispatch router in {Project}
-| 5647 | TCP | AMQP | Katello Agent to communicate with {Project}'s Qpid dispatch router
-endif::[]
-| 8000 | TCP | HTTP | Anaconda to download kickstart templates to hosts, and for downloading iPXE firmware
-| 8140 | TCP | HTTPS | Puppet agent to Puppet master connections
-| 9090 | TCP | HTTPS | Sending SCAP reports to the integrated {SmartProxy}, for the discovery image during provisioning, and for communicating with {ProjectServer} to copy the SSH keys for Remote Execution (Rex) configuration
-ifeval::["{mode}" == "connected"]
-| - | ICMP | ping | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-| 7 | TCP | echo | DHCP {SmartProxy} to Client network, to verify non-active IP address (Optional)
-endif::[]
-| 53 | TCP and UDP | DNS | Client DNS queries to a {Project}'s integrated {SmartProxy} DNS service (Optional)
-| 67 | UDP | DHCP | Client to {Project}'s integrated {SmartProxy} broadcasts, DHCP broadcasts for Client provisioning from a {Project}'s integrated {SmartProxy} (Optional)
-| 69 | UDP |TFTP | Clients downloading PXE boot image files from a {Project}s' integrated {SmartProxy} for provisioning (Optional)
 |====
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
@@ -89,24 +65,62 @@ This includes the base operating system on which a {SmartProxyServer} is running
 A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
 This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
-.Ports for {Project} to {SmartProxy} Communication
-[cols="24%,20%,18%,38%",options="header"]
-|====
-| Port | Protocol | Service | Required for
-| 443 |  TCP | HTTPS | Connections to the Pulp server in the {SmartProxy}
-| 9090 | TCP | HTTPS | Connections to the proxy in the {SmartProxy}
-| 80 | TCP | HTTP | Downloading a bootdisk (Optional)
-|====
+.{ProjectServer} outgoing traffic
+[cols="15%,15%,15%,15%,20%,20%",options="header"]
 
-
-.Optional Network Ports
-[cols="24%,20%,18%,38%a",options="header"]
 |====
-| Port | Protocol | Service | Required For
-| 22 | TCP | SSH | {Project} and {SmartProxy} originated communications, for Remote Execution (Rex) and Ansible.
-| 443 | TCP | HTTPS | {Project} originated communications, for vCenter compute resource.
-| 5000 | TCP | HTTP | {Project} originated communications, for compute resources in OpenStack or for running containers.
-| 22, 16514 | TCP | SSH, SSL/TLS | {Project} originated communications, for compute resources in libvirt.
-| 389, 636 | TCP | LDAP, LDAPS | {Project} originated communications, for LDAP and secured LDAP authentication sources.
-| 5900 to 5930 | TCP | SSL/TLS | {Project} originated communications, for NoVNC console in web UI to hypervisors.
+| Destination Port | Protocol | Service | Destination | Required For | Description
+| | ICMP | ping  | Client | DHCP | Free IP checking (optional)
+| 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
+| 22 | TCP | SSH | Target host | Remote execution | Run jobs
+| 22, 16514 | TCP | SSH SSH/TLS | Compute Resource | {Project} originated communications, for compute resources in libvirt |
+| 53 | TCP and UDP | DNS | DNS Servers on the Internet | DNS Server | Resolve DNS records (optional)
+| 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} DNS | Validation of DNS conflicts (optional)
+| 53 | TCP and UDP | DNS | DNS Server | Orchestration | Validation of DNS conflicts
+| 68 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
+| 80 | TCP | HTTP | Remote repository | Content Sync | Remote yum repository
+| 389, 636 | TCP | LDAP, LDAPS | External LDAP Server | LDAP | LDAP authenticatiion, necessary only if external authentication is enabled.
+The port can be customized when `LDAPAuthSource` is defined
+| 443 | TCP | HTTPS | {Project} | {SmartProxy} | {SmartProxy}
+
+Configuration management
+
+Template retrieval
+
+OpenSCAP
+
+Remote Execution result upload
+| 443 | TCP | HTTPS | Amazon EC2, Azure, Google GCE | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
+ifdef::satellite[]
+ifeval::["{mode}" == "connected"]
+| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls
+| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
+| 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
+| 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
+endif::[]
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 443 | TCP | HTTPS | {SmartProxy} | Content mirroring | Initiation
+endif::[]
+| 443 | TCP | HTTPS | Infoblox DHCP Server| DHCP management | When using Infoblox for DHCP, management of the DHCP leases (optional)
+| 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
+| 5000 | TCP | HTTPS | OpenStack Compute Resource | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
+ifdef::katello,satellite,orcharhino[]
+| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
+| 5671 |  |  | Qpid |Remote install | Send install command to  client
+| 5671 |  |  | Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
+| 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client
+| 5671 | | | {ProjectServer} | Remote install for Katello agent | Forward message to dispatch router on {Project}
+endif::[]
+| 5900 - 5930 | TCP | SSL/TLS | Hypervisor | noVNC console | Launch noVNC console
+| 7911 | TCP | DHCP, OMAPI | DHCP Server| DHCP | The DHCP target is configured using `--foreman-proxy-dhcp-server` and defaults to localhost
+
+ISC and `remote_isc` use a configurable port that defaults to 7911 and uses OMAPI
+| 8443 | TCP | HTTPS | Client | Discovery | {SmartProxy} sends reboot command to the discovered host (optional)
+ifndef::katello,satellite,orcharhino[]
+| 8443 | TCP | HTTPS | {SmartProxy}| {SmartProxy} API | Management of {SmartProxies}
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+| 9090 | TCP | HTTPS | {SmartProxy}| {SmartProxy} API | Management of {SmartProxies}
+endif::[]
 |====

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -25,7 +25,8 @@ Required ports can change based on your configuration.
 The following tables indicate the destination port and the direction of network traffic:
 
 .{ProjectServer} incoming traffic
-[cols="15%,15%,15%,15%,20%,20%",options="header
+[cols="15%,15%,15%,15%,20%,20%",options="header]
+|===
 | Destination Port | Protocol | Service |Source| Required For | Description
 | 53 | TCP and UDP | DNS | DNS Servers and clients | Name resolution | DNS (optional)
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
@@ -39,7 +40,7 @@ ifdef::katello,satellite,orcharhino[]
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
 endif::[]
-| 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console
+| 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
@@ -57,7 +58,7 @@ Sending installed packages and traces
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
 endif::[]
-|====
+|===
 
 Any managed host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.
 This includes the base operating system on which a {SmartProxyServer} is running.
@@ -66,9 +67,8 @@ A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts 
 This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
 .{ProjectServer} outgoing traffic
-[cols="15%,15%,15%,15%,20%,20%",options="header"]
-
-|====
+[cols="15%,15%,15%,15%,20%,20%",options="header]
+|===
 | Destination Port | Protocol | Service | Destination | Required For | Description
 | | ICMP | ping  | Client | DHCP | Free IP checking (optional)
 | 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
@@ -93,7 +93,7 @@ Remote Execution result upload
 | 443 | TCP | HTTPS | Amazon EC2, Azure, Google GCE | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
-| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls
+| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
 | 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 | 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
@@ -123,4 +123,4 @@ endif::[]
 ifdef::katello,satellite,orcharhino[]
 | 9090 | TCP | HTTPS | {SmartProxy}| {SmartProxy} API | Management of {SmartProxies}
 endif::[]
-|====
+|===


### PR DESCRIPTION
Organised into satellite incoming and outgoing, capsule incoming and outgoing
PR for 2.5 branch

[doc] Reformat the port requirements tables

https://issues.redhat.com/browse/SAT-3277


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
