### PR TITLE
Identify when Pulp migration is complete.

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -66,8 +66,17 @@ Note that `{foreman-maintain} content-prepare abort` can take several minutes to
 You can continue the migration process using `{foreman-maintain} content-prepare` whenever it is convenient.
 ====
 
-. The migration process is not fully complete until the upgrade of {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion} is complete.
+. The process does not confirm that migration is complete.
+You can determine how near the process is to completion by using:
 +
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# {foreman-maintain} content migration-stats
+----
++
+at intervals until the indicated migration time is at or near zero.
+. The final steps of Pulp content migration are completed when upgrading {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.
+
 [NOTE]
 ====
 If problems occur, you can restart the pre-migration process from the beginning using the following command:


### PR DESCRIPTION
Added a means of testing how complete the migration process is.

Bug 2013689 - Identify when the content migration is completed

https://issues.redhat.com/browse/SATDOC-489


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
