### PR TITLE
Fix instructions on provisioning on vSphere

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -350,22 +350,55 @@ endif::[]
 # yum -y install cloud-init open-vm-tools perl
 ----
 +
-. Create a configuration file for `cloud-init`:
+. Disable network configuration by `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# vi /etc/cloud/cloud.cfg.d/_example_cloud-init_config_.cfg
+# cat << EOM > /etc/cloud/cloud.cfg.d/01_network.cfg
+network:
+  config: disabled
+EOM
 ----
 +
-. Add the following information to the `_example_cloud_init_config_.cfg` file:
+. Configure `cloud-init` to fetch data from {Project}:
 +
 [options="nowrap" subs="+attributes"]
 ----
+# cat << EOM > /etc/cloud/cloud.cfg.d/10_datasource.cfg
 datasource_list: [NoCloud]
 datasource:
   NoCloud:
     seedfrom: https://{foreman-example-com}/userdata/
-EOF
+EOM
+----
++
+. Configure modules to use in `cloud-init`:
++
+[options="nowrap" subs="+quotes"]
+----
+# cat << EOM > /etc/cloud/cloud.cfg
+cloud_init_modules:
+ - bootcmd
+
+cloud_config_modules:
+ - runcmd
+
+cloud_final_modules:
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - phone-home
+
+system_info:
+  distro: rhel
+  paths:
+    cloud_dir: /var/lib/cloud
+    templates_dir: /etc/cloud/templates
+  ssh_svcname: sshd
+
+# vim:syntax=yaml
+EOM
 ----
 +
 . Enable the CA certificates for the image:

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -371,7 +371,6 @@ datasource:
     seedfrom: https://{foreman-example-com}/userdata/
 EOM
 ----
-+
 . Configure modules to use in `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]
@@ -400,7 +399,6 @@ system_info:
 # vim:syntax=yaml
 EOM
 ----
-+
 . Enable the CA certificates for the image:
 +
 ----

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -395,8 +395,6 @@ system_info:
     cloud_dir: /var/lib/cloud
     templates_dir: /etc/cloud/templates
   ssh_svcname: sshd
-
-# vim:syntax=yaml
 EOM
 ----
 . Enable the CA certificates for the image:


### PR DESCRIPTION
When provisioning hosts on vSphere, using `open-vm-tools` and
`cloud-init`, one must do some extra configuration of `cloud-init` to
ensure that vSphere gets the correct callback and enables the network
conncetion before `cloud-init` attempts to fetch userdata from
Foreman/Satellite.


Cherry-pick into:

* [x] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
