### PR TITLE
BZ 1993960: Fix preparing image to use cloud-init template on 2.5

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -32,7 +32,7 @@ For VMware vCenter Server version {ProductVersion}, set the following permission
     - All Privileges -> Virtual Machine -> Edit Inventory (All)
     - All Privileges -> Virtual Machine -> Provisioning (All)
 
-Note that the same steps also apply to VMware vCenter Server version 7.0.  
+Note that the same steps also apply to VMware vCenter Server version 7.0.
 
 For VMware vCenter Server version 6.5, set the following permissions:
 
@@ -350,24 +350,53 @@ endif::[]
 # yum -y install cloud-init open-vm-tools perl
 ----
 +
-. Create a configuration file for `cloud-init`:
+. Disable network configuration by `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# vi /etc/cloud/cloud.cfg.d/_example_cloud-init_config_.cfg
+# cat << EOM > /etc/cloud/cloud.cfg.d/01_network.cfg
+network:
+  config: disabled
+EOM
 ----
 +
-. Add the following information to the `_example_cloud_init_config_.cfg` file:
+. Configure `cloud-init` to fetch data from {Project}:
 +
 [options="nowrap" subs="+attributes"]
 ----
+# cat << EOM > /etc/cloud/cloud.cfg.d/10_datasource.cfg
 datasource_list: [NoCloud]
 datasource:
   NoCloud:
     seedfrom: https://{foreman-example-com}/userdata/
-EOF
+EOM
 ----
+. Configure modules to use in `cloud-init`:
 +
+[options="nowrap" subs="+quotes"]
+----
+# cat << EOM > /etc/cloud/cloud.cfg
+cloud_init_modules:
+ - bootcmd
+
+cloud_config_modules:
+ - runcmd
+
+cloud_final_modules:
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - phone-home
+
+system_info:
+  distro: rhel
+  paths:
+    cloud_dir: /var/lib/cloud
+    templates_dir: /etc/cloud/templates
+  ssh_svcname: sshd
+EOM
+----
 . Enable the CA certificates for the image:
 +
 ----
@@ -419,13 +448,11 @@ endif::[]
 # rm -f /etc/udev/rules.d/70*
 ----
 +
-. Remove the `uuid` from `ifcfg` scripts:
+. Remove the `ifcfg` scripts related to existing network configurations:
 +
 ----
-# cat > /etc/sysconfig/network-scripts/ifcfg-ens192 <<EOM
-DEVICE=ens192
-ONBOOT=yes
-EOM
+# rm -f /etc/sysconfig/network-scripts/ifcfg-ens*
+# rm -f /etc/sysconfig/network-scripts/ifcfg-eth*
 ----
 +
 . Remove the SSH host keys:
@@ -435,17 +462,17 @@ EOM
 # rm -f /etc/ssh/_SSH_keys_
 ----
 +
+. Remove root user's SSH history:
++
+----
+# rm -rf ~root/.ssh/known_hosts
+----
++
 . Remove root user's shell history:
 +
 ----
 # rm -f ~root/.bash_history
 # unset HISTFILE
-----
-+
-. Remove root user's SSH history:
-+
-----
-# rm -rf ~root/.ssh/known_hosts
 ----
 
 You can now create an image from this virtual machine.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1993960

Do not cherry-pick.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
