### PR TITLE
Removed additional PXE-less provisioning entry

### DIFF
--- a/guides/common/modules/con_provisioning-workflow.adoc
+++ b/guides/common/modules/con_provisioning-workflow.adoc
@@ -54,9 +54,10 @@ For example:
 Discovery::
 If you use the discovery service, {Project} automatically detects the MAC address of the new host and restarts the host after you submit a request.
 Note that TCP port 8443 must be reachable by the {SmartProxy} to which the host is attached for {Project} to restart the host.
-
+ifndef::satellite[]
 PXE-less Provisioning::
 After you submit a new host request, you must boot the specific host with the boot disk that you download from {Project} and transfer using a USB port of the host.
+endif::[]
 
 Compute Resources::
 {Project} creates the virtual machine and retrieves the MAC address and stores the MAC address in {Project}.


### PR DESCRIPTION
Removed entry missing from original commit

Bug 1938633 - We have to remove those topic from documentation, which we removed functionality from new satellite version

https://issues.redhat.com/browse/SATDOC-473


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
