### PR TITLE
fixes rpm versions lacking minor release version

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,9 +17,9 @@
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
-:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6.10-rpms
+:RepoRHEL7ServerSatelliteServerProductVersion: rhel-7-server-satellite-6.10-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-server-7-satellite-6.9-rpms
-:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6.10-rpms
+:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-7-server-satellite-capsule-6.10-rpms
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.10-rpms
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,10 +17,10 @@
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
 :RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 // For Beta, change to "Beta". For GA releases, change to, for example, "6.8".
-:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6-rpms
+:RepoRHEL7ServerSatelliteServerProductVersion: rhel-server-7-satellite-6.10-rpms
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-server-7-satellite-6.9-rpms
-:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6-rpms
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6-rpms
+:RepoRHEL7ServerSatelliteCapsuleProductVersion: rhel-server-7-satellite-capsule-6.10-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-tools-6.10-rpms
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-6-rpms
 // Do not update the puppet4 repo versions. They must stay at 6.3.
 :RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms


### PR DESCRIPTION
rhel-server-7-satellite-6-rpms --> rhel-7-server-satellite-6.10-rpms
rhel-server-7-satellite-capsule-6-rpms --> rhel-7-server-satellite-capsule-6.10-rpms
rhel-7-server-satellite-tools-6-rpms --> rhel-7-server-satellite-tools-6.10-rpms

via https://bugzilla.redhat.com/show_bug.cgi?id=2023921 and https://bugzilla.redhat.com/show_bug.cgi?id=2023924