### PR TITLE
BZ 1993960: Fix preparing image to use cloud-init template

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -32,7 +32,7 @@ For VMware vCenter Server version 6.7, set the following permissions:
     - All Privileges -> Virtual Machine -> Edit Inventory (All)
     - All Privileges -> Virtual Machine -> Provisioning (All)
 
-Note that the same steps also apply to VMware vCenter Server version 7.0.  
+Note that the same steps also apply to VMware vCenter Server version 7.0.
 
 For VMware vCenter Server version 6.5, set the following permissions:
 
@@ -448,13 +448,11 @@ endif::[]
 # rm -f /etc/udev/rules.d/70*
 ----
 +
-. Remove the `uuid` from `ifcfg` scripts:
+. Remove the `ifcfg` scripts related to existing network configurations:
 +
 ----
-# cat > /etc/sysconfig/network-scripts/ifcfg-ens192 <<EOM
-DEVICE=ens192
-ONBOOT=yes
-EOM
+# rm -f /etc/sysconfig/network-scripts/ifcfg-ens*
+# rm -f /etc/sysconfig/network-scripts/ifcfg-eth*
 ----
 +
 . Remove the SSH host keys:
@@ -464,6 +462,11 @@ EOM
 # rm -f /etc/ssh/_SSH_keys_
 ----
 +
+. Remove root user's SSH history:
++
+----
+# rm -rf ~root/.ssh/known_hosts
+----
 . Remove root user's shell history:
 +
 ----
@@ -471,11 +474,6 @@ EOM
 # unset HISTFILE
 ----
 +
-. Remove root user's SSH history:
-+
-----
-# rm -rf ~root/.ssh/known_hosts
-----
 
 You can now create an image from this virtual machine.
 


### PR DESCRIPTION
Fix to make master consistent with #847

https://bugzilla.redhat.com/show_bug.cgi?id=1993960

No cherry-picks.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
