### PR TITLE
Add missing endif that broke the satellite build

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -73,7 +73,7 @@ When performing unattended and PXE-less provisioning, as a security measure, {Pr
 By default, the token is valid for 360 minutes.
 When you provision a host, ensure that you reboot the host within this time frame.
 If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
-
+endif::[]
 To adjust the token's duration of validity, in the {Project} web UI, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
 Find the *Token duration* option, and click the edit icon and edit the duration, or enter `0` to disable token generation.
 


### PR DESCRIPTION
Half the provisioning guide was missing as an ifndef was never closed. 

Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
