### PR TITLE
Fix title and an anchor in upgrading guide on 2.5

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 :context: upgrade-guide
 
 
-= Upgrading and Updating {ProjectServer}
+= Upgrading and Updating {ProjectName}
 
 
 // Upgrading Satellite Server overview

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -1,5 +1,4 @@
-[[upgrading_satellite_server_parent]]
-
+[id="Upgrading_Server_{context}"]
 = Upgrading {ProjectServer}
 
 This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.


### PR DESCRIPTION
No cherry picks.
This may be an intermediate fix that I need to verify in our internal Pantheon build and I don't have another way of verification than after merge. Unless we make local builds with bccutil work. Sorry!

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
