### PR TITLE
Fix title and anchor in Upgrading Guide on 2.5

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 :context: upgrade-guide
 
 
-= Upgrading and Updating {ProjectServer}
+= Upgrading and Updating {ProjectName}
 
 
 // Upgrading Satellite Server overview

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
@@ -8,7 +8,7 @@ endif::[]
 Use the following procedures to upgrade your existing {ProjectName} to {ProjectName} {ProjectVersion}:
 
 ifdef::satellite[]
-. xref:upgrading_satellite_server_parent[]
+. xref:Upgrading_Server_{context}[]
 . xref:synchronizing_the_new_repositories[]
 . xref:upgrading_capsule_server[]
 . xref:upgrading_clients[]
@@ -16,7 +16,7 @@ ifdef::satellite[]
 endif::[]
 
 ifdef::katello,foreman-el[]
-. xref:upgrading_satellite_server_parent[]
+. xref:Upgrading_Server_{context}[]
 . xref:upgrading_capsule_server[]
 . xref:upgrading_clients[]
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
@@ -96,4 +96,4 @@ If your {ProjectNameX} subscription is in the {Project} Manifest, you must remov
 
 For Red Hat Enterprise Linux 6 users, proceed to the xref:migrating_from_rhel_6_to_rhel_7[].
 
-For Red Hat Enterprise Linux 7 users, proceed to xref:upgrading_satellite_server_parent[].
+For Red Hat Enterprise Linux 7 users, proceed to xref:Upgrading_Server_{context}[].

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -73,7 +73,7 @@ The high level steps in upgrading to {Project} {ProjectVersion} are as follows.
 ifdef::satellite[]
 . Clone your existing {ProjectServer}s. For more information, see xref:cloning_satellite_server[].
 endif::[]
-. Upgrade {ProjectServer} and all {SmartProxyServer}s to {Project} {ProjectVersion}. For more information, see xref:upgrading_satellite_server_parent[].
+. Upgrade {ProjectServer} and all {SmartProxyServer}s to {Project} {ProjectVersion}. For more information, see xref:Upgrading_Server_{context}[].
 . Upgrade to {project-client-name} on all {Project} clients. For more information, see xref:upgrading_clients[].
 
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -1,5 +1,4 @@
-[[upgrading_satellite_server_parent]]
-
+[id="Upgrading_Server_{context}"]
 = Upgrading {ProjectServer}
 
 This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.


### PR DESCRIPTION
No cherry picks.
This may be an intermediate fix that I need to verify in our internal Pantheon build and I don't have another way of verification than after merge. Unless we make local builds with bccutil work. Sorry!

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
