### PR TITLE
Add link to release notes

### DIFF
--- a/web/content/3.0.md
+++ b/web/content/3.0.md
@@ -6,8 +6,10 @@ path: "3.0"
 Available guides:
 
 * [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman-el.html)
+* [Foreman Release Notes](/{{< param "path" >}}/Release_notes/index-foreman-el.html)
 * [Foreman Quickstart Guide on RHEL/CentOS](/{{< param "path" >}}/Quickstart_Guide/index-foreman-el.html)
 * [Foreman Quickstart Guide on Debian/Ubuntu](/{{< param "path" >}}/Quickstart_Guide/index-foreman-deb.html)
+* [Katello Release Notes](/{{< param "path" >}}/Release_notes/index-katello.html)
 * [Katello Quickstart Guide on RHEL/CentOS](/{{< param "path" >}}/Quickstart_Guide/index-katello.html)
 * [Installing Foreman on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-foreman-el.html)
 * [Installing Katello on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-katello.html)

--- a/web/content/3.1.md
+++ b/web/content/3.1.md
@@ -6,8 +6,10 @@ path: "3.1"
 Available guides:
 
 * [Planning for Foreman](/{{< param "path" >}}/Planning_Guide/index-foreman-el.html)
+* [Foreman Release Notes](/{{< param "path" >}}/Release_notes/index-foreman-el.html)
 * [Foreman Quickstart Guide on RHEL/CentOS](/{{< param "path" >}}/Quickstart_Guide/index-foreman-el.html)
 * [Foreman Quickstart Guide on Debian/Ubuntu](/{{< param "path" >}}/Quickstart_Guide/index-foreman-deb.html)
+* [Katello Release Notes](/{{< param "path" >}}/Release_notes/index-katello.html)
 * [Katello Quickstart Guide on RHEL/CentOS](/{{< param "path" >}}/Quickstart_Guide/index-katello.html)
 * [Installing Foreman on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-foreman-el.html)
 * [Installing Katello on RHEL/CentOS](/{{< param "path" >}}/Installing_Server_on_Red_Hat/index-katello.html)

--- a/web/layouts/shortcodes/guide-list.html
+++ b/web/layouts/shortcodes/guide-list.html
@@ -1,8 +1,10 @@
 {{ $path := default "nightly" (.Get "version") }}
 
 * [Planning for Foreman](/{{ $path }}/Planning_Guide/index-foreman-el.html)
+* [Foreman Release Notes](/{{ $path }}/Release_notes/index-foreman-el.html)
 * [Foreman Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-foreman-el.html)
 * [Foreman Quickstart Guide on Debian/Ubuntu](/{{ $path }}/Quickstart_Guide/index-foreman-deb.html)
+* [Katello Release Notes](/{{ $path }}/Release_notes/index-katello.html)
 * [Katello Quickstart Guide on RHEL/CentOS](/{{ $path }}/Quickstart_Guide/index-katello.html)
 * [Installing Foreman on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-foreman-el.html)
 * [Installing Katello on RHEL/CentOS](/{{ $path }}/Installing_Server_on_Red_Hat/index-katello.html)


### PR DESCRIPTION
This PR adds a link to the Release notes from https://github.com/theforeman/foreman-documentation/pull/699. They are currently not visible.