### PR TITLE
Fix spelling of separate

### DIFF
--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -76,7 +76,7 @@ Running the installer will revert this change back.
 == Increasing the Logging Level For Candlepin
 
 You can find the log for Candlepin in `/var/log/candlepin/candlepin.log`.
-Errors are also logged to a seperate file for easier debugging `/var/log/candlepin/error.log`
+Errors are also logged to a separate file for easier debugging `/var/log/candlepin/error.log`.
 
 Extend `/etc/candlepin/candlepin.conf`:
 


### PR DESCRIPTION
`git blame`: @maximiliankolb  🙈 