### PR TITLE
Changed word order

### DIFF
--- a/guides/common/modules/proc_inspecting-available-errata.adoc
+++ b/guides/common/modules/proc_inspecting-available-errata.adoc
@@ -10,7 +10,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-inspecting-availa
 +
 * Select the repository to be inspected from the list.
 *All Repositories* is selected by default.
-* The *Applicable* check box is selected by default to view only errata applicable to the selected repository.
+* The *Applicable* check box is selected by default to view only applicable errata in the selected repository.
 Select the *Installable* check box to view only errata marked as installable.
 * To search the table of errata, type the query in the *Search* field in the form of:
 +


### PR DESCRIPTION
Corrected confusing word order for Applicable check box

Confusing word order in description of Applicable check box

https://issues.redhat.com/browse/SATDOC-250


Cherry-pick into:

* [X ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
