### PR TITLE
Changed word order

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Errata.adoc
@@ -49,7 +49,7 @@ To use the CLI instead of the web UI, see the xref:cli-inspecting-available-erra
 +
 * Select the repository to be inspected from the list.
 *All Repositories* is selected by default.
-* The *Applicable* check box is selected by default to view only errata applicable to the selected repository.
+* The *Applicable* check box is selected by default to view only applicable errata in the selected repository.
 Select the *Installable* check box to view only errata marked as installable.
 * To search the table of errata, type the query in the *Search* field in the form of:
 +


### PR DESCRIPTION
Corrected confusng word order of Applicable check box

Confusing word order in description of Applicable check box

https://issues.redhat.com/browse/SATDOC-250


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
