### PR TITLE
Add alternative to installing pulp-manifest package

### DIFF
--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -27,6 +27,19 @@ endif::[]
 ----
 # {package-install-project} python3-pulp_manifest
 ----
++
+Note that this command stops the {Project} service and re-runs {foreman-installer}.
+Alternatively, to prevent downtime caused by stopping the service, you can use the following:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable {RepoRHEL7ServerSatelliteToolsProductVersion}
+# {foreman-maintain} packages unlock
+# yum install install python-pulp-manifest -y
+# {foreman-maintain} packages lock
+# subscription-manager repos --disable {RepoRHEL7ServerSatelliteToolsProductVersion}
+----
+This installs the package without downtime.
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
Added an alternative to the existing method which avoids downtime

calling satellite-installer in order to install the package python-pulp-manifest

https://issues.redhat.com/browse/SATDOC-244


Cherry-pick into:

* [X ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
