### PR TITLE
Add alternative to installing pulp-manifest package

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -144,6 +144,18 @@ endif::[]
 # {package-install-project} python3-pulp_manifest
 ----
 +
+Note that this command stops the {Project} service and re-runs {foreman-installer}.
+Alternatively, to prevent downtime caused by stopping the service, you can use the following:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable rhel-7-server-satellite-tools-6.7-rpms
+# {foreman-maintain} packages unlock
+# yum install install python-pulp-manifest -y
+# {foreman-maintain} packages lock
+# subscription-manager repos --disable rhel-7-server-satellite-tools-6.7-rpms
+----
+This installs the package without downtime.
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
Added an alternative to the existing method which avoids downtime

calling satellite-installer in order to install the package python-pulp-manifest

https://issues.redhat.com/browse/SATDOC-244


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
