### PR TITLE
Update global reg procedure text

### DIFF
--- a/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
+++ b/guides/doc-Managing_Hosts/topics/proc_registering-a-host.adoc
@@ -44,9 +44,6 @@ Optional: If the *Registration* feature is not enabled on your {SmartProxy}, ent
 . Optional: From the *Host Group* list, select the host group to associate the hosts with.
 Fields that inherit value from *Host group*: *Operating system*, *Activation Keys* and *Lifecycle environment*.
 . Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
-ifdef::satellite[]
-You must select the internal {SmartProxy} if you do not want to use an external {SmartProxy}.
-endif::[]
 . Optional: From the *Operating system* list, select the operating system of hosts that you want to register.
 ifndef::satellite[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.


### PR DESCRIPTION
Hello

for Sat7, minor text change as the menu is now greyed to prevent this bug:

Bug 2014251 - Global Registration: Selecting Satellite URL as the proxy fails to register hosts with default config

Using the internal Capsule is the default option, as it always was, its just that if you explicitly selected it you would have port 9090  appended. 


Thank you


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
