### PR TITLE
Removed Update the file permissions before upgrading Foreman server u…

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -35,12 +35,14 @@ double in size before starting the migration process.
 Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'
 [OK]
 ----
+ifdef::satellite[]
 . Update the file permissions before upgrading {ProjectServer} using the following command:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 # {foreman-maintain} prep-{TargetVersion}-upgrade
 ----
+endif::[]
 +
 This might take some time on high latency systems.
 . Prepare your content for Pulp migration using the following command:


### PR DESCRIPTION
…sing the following command in Preparing to Migrate Content to Pulp 3 section of Katello build and made it only visible to Satellite users

closes #895


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
