### PR TITLE
Remove links to orcharhino management UI

### DIFF
--- a/guides/common/modules/con_provisioning-templates.adoc
+++ b/guides/common/modules/con_provisioning-templates.adoc
@@ -26,7 +26,3 @@ Click *Show Diff* to see information about a specific change:
 * The *Template Diff* tab displays changes in the body of a provisioning template.
 * The *Details* tab displays changes in the template description.
 * The *History* tab displays the user who made a change to the template and date of the change.
-
-ifdef::orcharhino[]
-For more information, see xref:sources/management_ui/the_hosts_menu/provisioning_templates.adoc[provisioning templates].
-endif::[]

--- a/guides/common/modules/proc_adding-scc-accounts.adoc
+++ b/guides/common/modules/proc_adding-scc-accounts.adoc
@@ -8,9 +8,6 @@
 . In the {ProjectWebUI}, navigate to *Content > Content Credentials* and click *Create Content Credential*.
 +
 Add the GPG public key for SLES 15 SP3 from https://www.suse.com/support/security/keys/[suse.com].
-ifdef::orcharhino[]
-For more information, see xref:sources/management_ui/the_content_menu/content_credentials.adoc#gpg_sles[content credentials].
-endif::[]
 . In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*.
 . Click *Add SCC Account*.
 . Enter your account name and password.

--- a/guides/common/modules/proc_creating-architectures.adoc
+++ b/guides/common/modules/proc_creating-architectures.adoc
@@ -18,27 +18,18 @@ endif::[]
 
 . In the {ProjectWebUI}, navigate to *Hosts* > *Architectures* and click *Create Architecture*.
 . In the *Name* field, enter a name for the architecture.
-ifndef::orcharhino[]
 . From the *Operating Systems* list, select an operating system.
-endif::[]
-ifdef::orcharhino[]
-. From the *Operating Systems* list, select an xref:sources/management_ui/the_hosts_menu/operating_systems.adoc[operating system].
-endif::[]
 If none are available, you can create and assign them under *Hosts* > *Operating Systems*.
 . Click *Submit*.
 
 .CLI procedure
 
 * Enter the `hammer architecture create` command to create an architecture.
-ifndef::orcharhino[]
 Specify its name and operating systems that include this architecture:
-endif::[]
-ifdef::orcharhino[]
-Specify its name and operating systems that include this xref:sources/management_ui/the_hosts_menu/architectures.adoc[architecture]:
-endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer architecture create --name "_Architecture_Name_" \
---operatingsystems "_os_"
+# hammer architecture create \
+--name "_My_Architecture_" \
+--operatingsystems "_My_Operating_System_"
 ----

--- a/guides/common/modules/proc_creating-hardware-models.adoc
+++ b/guides/common/modules/proc_creating-hardware-models.adoc
@@ -1,12 +1,7 @@
 [id="creating-hardware-models_{context}"]
 = Creating Hardware Models
 
-ifndef::orcharhino[]
 Use this procedure to create a hardware model in {Project} so that you can specify which hardware model a host uses.
-endif::[]
-ifdef::orcharhino[]
-Use this procedure to create a xref:sources/management_ui/the_hosts_menu/hardware_models.adoc[hardware model] in {Project} so that you can specify which hardware model a host uses.
-endif::[]
 
 .Procedure
 
@@ -24,6 +19,9 @@ Optionally, enter the hardware model with the `--hardware-model` option, a vendo
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer model create --name "_model_name_" --info "_description_" \
---hardware-model "_hardware_model_" --vendor-class "_vendor_class_"
+# hammer model create \
+--hardware-model "_My_Hardware_Model_" \
+--info "_My_Description_" \
+--name "_My_Hardware_Model_Name_" \
+--vendor-class "_My_Vendor_Class_"
 ----

--- a/guides/common/modules/proc_creating-partition-tables.adoc
+++ b/guides/common/modules/proc_creating-partition-tables.adoc
@@ -4,12 +4,7 @@
 A partition table is a type of template that defines the way {ProjectServer} configures the disks available on a new host.
 A Partition table uses the same ERB syntax as provisioning templates.
 {ProjectName} contains a set of default partition tables to use, including a `Kickstart default`.
-ifndef::orcharhino[]
 You can also edit partition table entries to configure the preferred partitioning scheme, or create a partition table entry and add it to the operating system entry.
-endif::[]
-ifdef::orcharhino[]
-You can also edit partition table entries to configure the preferred partitioning scheme, or create a partition table entry and add it to the xref:sources/management_ui/the_hosts_menu/operating_systems.adoc[operating system] entry.
-endif::[]
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-partition-tables_{context}[].
 
@@ -50,7 +45,11 @@ This example uses the `~/my-partition` file.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer partition-table create --name "My Partition" --snippet false \
---os-family Redhat --file ~/my-partition --organizations "_My_Organization_" \
---locations "_My_Location_"
+# hammer partition-table create \
+--file "_path/to/my_partition_table_" \
+--locations "_My_Location_" \
+--name "My Partition Table" \
+--organizations "_My_Organization_" \
+--os-family "My_OS_Family" \
+--snippet false
 ----

--- a/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
+++ b/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
@@ -7,14 +7,10 @@ endif::[]
 
 {Project} contains a set of synchronized kickstart repositories that you use to install the provisioned host's operating system.
 For more information about adding repositories, see {ContentManagementDocURL}Synchronizing_Repositories[Syncing Repositories] in the _Content Management Guide_.
-ifdef::orcharhino[]
-For more information, see xref:sources/management_ui/the_content_menu/products_and_repositories.adoc#creating_a_repository[creating a repository].
-endif::[]
 
 Use this procedure to set up a kickstart repository.
 
 .Procedure
-
 . Add the synchronized kickstart repository that you want to use to the existing Content View, or create a new Content View and add the kickstart repository.
 +
 For {RHEL} 8, ensure that you add both *{RHEL} 8 for x86_64 - AppStream Kickstart x86_64 8* and *{RHEL} 8 for x86_64 - BaseOS Kickstart x86_64 8* repositories.
@@ -32,5 +28,5 @@ To view the kickstart tree, enter the following command:
 
 [subs="+quotes"]
 ----
-# hammer medium list --organization "_your_organization_"
+# hammer medium list --organization "_My_Organization_"
 ----

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -123,17 +123,13 @@ Confirm each aspect of the operating system.
 . Optional: Click *Resolve* in *Provisioning template* to check the new host can identify the right provisioning templates to use.
 +
 For more information about associating provisioning templates, see xref:provisioning-templates_provisioning[].
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
 ifdef::foreman-el,katello[]
 . If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
-endif::[]
-ifdef::orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an xref:sources/management_ui/the_content_menu/activation_keys.adoc#creating_an_activation_key[activation key].
 endif::[]
 . Click *Submit* to save the host details.
 +
@@ -242,9 +238,9 @@ ifdef::foreman-el,foreman-deb,katello[]
 . If you use the Katello plug-in, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
-ifdef::orcharhino[]
+ifdef::satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an xref:sources/management_ui/the_content_menu/activation_keys.adoc#creating_an_activation_key[activation key].
+If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host details.
 
@@ -370,17 +366,13 @@ Confirm each aspect of the operating system.
 . Optional: Click *Resolve* in *Provisioning template* to check the new host can identify the right provisioning templates to use.
 +
 For more information about associating provisioning templates, see xref:creating-provisioning-templates_provisioning[].
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
 ifdef::foreman-el,katello[]
 . If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
-endif::[]
-ifdef::orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an xref:sources/management_ui/the_content_menu/activation_keys.adoc#creating_an_activation_key[activation key].
 endif::[]
 . Click *Submit* to save the host details.
 +
@@ -396,15 +388,12 @@ This creates the host entry and the relevant provisioning settings.
 This also includes creating the necessary directories and files for UEFI booting the bare metal host.
 When you start the physical host and set its boot mode to UEFI HTTP, the host detects the defined DHCP service, receives HTTP endpoint of {SmartProxy} with the Kickstart tree and installs the operating system.
 
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
 ifdef::foreman-el,katello[]
 If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
-endif::[]
-ifdef::orcharhino[]
-When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
 [id="cli-creating-hosts-with-uefi-http-boot-provisioning_{context}"]

--- a/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Cloud-Amazon_EC2.adoc
@@ -176,13 +176,9 @@ ifdef::foreman-el,katello[]
 . If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
-endif::[]
-ifdef::orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an xref:sources/management_ui/the_content_menu/activation_keys.adoc#creating_an_activation_key[activation key].
 endif::[]
 . Click *Submit* to save your changes.
 
@@ -324,13 +320,9 @@ endif::[]
 In the corresponding *Value* field, enter the output of `cat /usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy.pub`.
 .. In the *Name* field, enter `remote_execution_ssh_user`.
 In the corresponding *Value* field, enter `ec2-user`.
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 .. In the *Name* field, enter `activation_keys`.
 In the corresponding *Value* field, enter your activation key.
-endif::[]
-ifdef::orcharhino[]
-.. In the *Name* field, enter `activation_keys`.
-In the corresponding *Value* field, enter your xref:sources/management_ui/the_content_menu/activation_keys.adoc[activation key].
 endif::[]
 ifdef::foreman-el,katello[]
 .. If you use the Katello plugin, in the *Name* field, enter `activation_keys`.

--- a/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Virt-VMWare.adoc
@@ -231,24 +231,16 @@ Modify these settings to suit your needs.
 ifdef::satellite[]
 * For boot-disk provisioning, click *Boot disk based*.
 endif::[]
-ifdef::orcharhino[]
-* If the `foreman_bootdisk` plug-in is installed, and you want to use boot-disk provisioning, click *Boot disk based*.
-For more information, see xref:sources/management_ui/the_hosts_menu/create_host.adoc#boot_disk_provisioning[boot-disk based provisioning].
-endif::[]
-ifdef::foreman-el,foreman-deb,katello[]
+ifdef::foreman-el,foreman-deb,katello,orcharhino[]
 * If the `foreman_bootdisk` plug-in is installed, and you want to use boot-disk provisioning, click *Boot disk based*.
 endif::[]
 +
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your requirements.
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 . Click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
-endif::[]
-ifdef::orcharhino[]
-. Click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
-If not, add an xref:sources/management_ui/the_content_menu/activation_keys.adoc#creating_an_activation_key[activation key]
 endif::[]
 ifdef::foreman-el,katello[]
 . If you use the Katello plugin, click the *Parameters* tab and ensure that a parameter exists that provides an activation key.


### PR DESCRIPTION
Hi.
This PR removes links to the management UI chapter of orcharhino docs.

It also fixes from hammer CLI commands and one potential bug where a ifdef has not been visible for satellite. See my comment.