### PR TITLE
Restore linkchecker

### DIFF
--- a/guides/Makefile
+++ b/guides/Makefile
@@ -13,12 +13,10 @@ pdf: all-pdf
 clean: all-clean
 
 linkchecker:
-	echo "do not check links"
-	# find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
 
 linkchecker-tryer:
-	echo "do not check links"
-	# find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
 all-html: $(GUIDES-HTML)
 


### PR DESCRIPTION
We temporarily disabled linkchecker because adding a new guide
causes the linkchecker to fail the new builds.
The new guide builds just fine, so now re-enabling our checker.


Cherry-pick into:

* [ ] Foreman 3.0
* For Foreman 2.5, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
