### PR TITLE
Always use the build to refer to documents

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -1,15 +1,16 @@
 // URLs
-:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/index-foreman-el.html#
-:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/index-foreman-el.html#
-:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/index-foreman-el.html#
-:ContentManagementDocURL: {BaseURL}Content_Management_Guide/index-foreman-el.html#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/index-foreman-el.html#
-:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/index-foreman-el.html#
-:ManagingHostsDocURL: {BaseURL}Managing_Hosts/index-foreman-el.html#
-:ManagingOrganizationsLocationsDocURL: {BaseURL}Managing_Organizations_and_Locations/index-foreman-el.html#
-:PlanningDocURL: {BaseURL}Planning_Guide/index-foreman-el.html#
-:ProvisioningDocURL: {BaseURL}Provisioning_Guide/index-foreman-el.html#
-:UpgradingDocURL: {BaseURL}Upgrading_and_Updating/index-foreman-el.html#
+:BaseFilenameURL: index-{build}.html
+:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/{BaseFilenameURL}#
+:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/{BaseFilenameURL}#
+:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
+:ContentManagementDocURL: {BaseURL}Content_Management_Guide/{BaseFilenameURL}#
+:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/{BaseFilenameURL}#
+:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/{BaseFilenameURL}#
+:ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
+:ManagingOrganizationsLocationsDocURL: {BaseURL}Managing_Organizations_and_Locations/{BaseFilenameURL}#
+:PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
+:ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#
+:UpgradingDocURL: {BaseURL}Upgrading_and_Updating/{BaseFilenameURL}#
 
 // Repositories and subscriptions (used both in Katello and Satellite guides)
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -1,14 +1,6 @@
 // URLs
-:BaseFilenameURL: index-{build}.html
-:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/{BaseFilenameURL}#
-:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/{BaseFilenameURL}#
-:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
-:ContentManagementDocURL: {BaseURL}Content_Management_Guide/{BaseFilenameURL}#
 :InstallingProjectDocURL: {BaseURL}Installing_Server_on_Debian/{BaseFilenameURL}#
 :InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Debian/{BaseFilenameURL}#
-:ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
-:PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
-:ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#
 
 // Attributes only for foreman-deb build
 :smart-proxy-installation-guide-title: Installing an External Smart Proxy Server on Debian

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -1,15 +1,3 @@
-// URLs
-:BaseFilenameURL: index-{build}.html
-//:AdministeringDocURL: {BaseURL}Administering_Red_Hat_Satellite/{BaseFilenameURL}#
-//:ConfiguringAnsibleDocURL: {BaseURL}Configuring_Ansible/{BaseFilenameURL}#
-//:ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
-//:ContentManagementDocURL: {BaseURL}Content_Management_Guide/{BaseFilenameURL}#
-:InstallingProjectDocURL: {BaseURL}Installing_Server_on_Red_Hat/{BaseFilenameURL}#
-//:InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy_on_Red_Hat/{BaseFilenameURL}#
-//:ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
-//:PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
-//:ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#
-
 // Overrides for katello build
 :foreman-installer-package: foreman-installer-katello
 :installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content


### PR DESCRIPTION
This unifies the linking structure and prevents documents from linking back to foreman-el instructions when using Debian or Katello.