### PR TITLE
Update support information on bootdisks

### DIFF
--- a/guides/common/modules/con_provisioning-overview.adoc
+++ b/guides/common/modules/con_provisioning-overview.adoc
@@ -5,12 +5,7 @@ Provisioning is a process that starts with a bare physical or virtual machine an
 Using {ProjectName}, you can define and automate fine-grained provisioning for a large number of hosts.
 
 There are many provisioning methods.
-ifndef::satellite[]
 For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using both PXE based and non-PXE based methods.
-endif::[]
-ifdef::satellite[]
-For example, you can use {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} to provision bare metal hosts using PXE based methods.
-endif::[]
 You can also provision cloud instances from specific providers through their APIs.
 These provisioning methods are part of the {ProjectName} application life cycle to create, manage, and update hosts.
 

--- a/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
+++ b/guides/doc-Provisioning_Guide/topics/Bare_Metal.adoc
@@ -11,15 +11,18 @@ New hosts use PXE boot to load the {Project} Discovery service.
 This service identifies hardware information about the host and lists it as an available host to provision.
 For more information, see xref:configuring-the-discovery-service[].
 
-ifndef::satellite[]
 PXE-less Provisioning::
+ifndef::satellite[]
 New hosts are provisioned with a boot disk or PXE-less discovery image that {ProjectServer} generates.
-endif::[]
 
 PXE-less Provisioning with Discovery::
 New hosts use an ISO boot disk that loads the {Project} Discovery service.
 This service identifies hardware information about the host and lists it as an available host to provision.
 For more information, see xref:implementing-pxe-less-discovery[].
+endif::[]
+ifdef::satellite[]
+New hosts are provisioned with a boot disk image that {ProjectServer} generates.
+endif::[]
 
 ifndef::satellite[]
 NOTE: Discovery workflows are only available when the Discovery plug-in is installed.
@@ -65,19 +68,15 @@ For more information about the Discovery service, xref:configuring-the-discovery
 * A bare metal host or a blank VM.
 include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
 
-ifndef::satellite[]
 For information about the security token for unattended and PXE-less provisioning, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
-endif::[]
 
 [[Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process]]
 === Configuring the Security Token Validity Duration
 
-ifndef::satellite[]
-When performing unattended and PXE-less provisioning, as a security measure, {Project} automatically generates a unique token and adds this token to the {provision-script} URL in the PXE configuration file (PXELinux, Grub2).
+When performing any kind of provisioning, as a security measure, {Project} automatically generates a unique token and adds this token to the {provision-script} URL in the PXE configuration file (PXELinux, Grub2).
 By default, the token is valid for 360 minutes.
 When you provision a host, ensure that you reboot the host within this time frame.
 If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
-endif::[]
 To adjust the token's duration of validity, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
 
 Find the *Token duration* option, and click the edit icon and edit the duration, or enter `0` to disable token generation.
@@ -166,7 +165,6 @@ endif::[]
 --primary true --provision true
 ----
 
-ifndef::satellite[]
 [[Provisioning_Bare_Metal_Hosts-Creating_New_Hosts_with_PXE-less_Provisioning]]
 === Creating Hosts with PXE-less Provisioning
 
@@ -182,33 +180,39 @@ For more information, see xref:implementing-pxe-less-discovery[].
 
 There are four types of boot ISOs:
 
-Host image::
-A boot ISO for the specific host.
-This image contains only the boot files that are necessary to access the installation media on {ProjectServer}.
-The user defines the subnet data in {Project} and the image is created with static networking.
-
 Full host image::
 A boot ISO that contains the kernel and initial RAM disk image for the specific host.
 This image is useful if the host fails to chainload correctly.
 The provisioning template still downloads from {ProjectServer}.
+
+Subnet image::
+A boot ISO that is similar to the generic image but is configured with the address of a {SmartProxyServer}.
+This image is generic to all hosts with a provisioning NIC on the same subnet.
+THe image is based on iPXE boot firmware, only limited hardware is supported.
+
+ifndef::satellite[]
+Host image::
+A boot ISO for the specific host.
+This image contains only the boot files that are necessary to access the installation media on {ProjectServer}.
+The user defines the subnet data in {Project} and the image is created with static networking.
+THe image is based on iPXE boot firmware, only limited hardware is supported.
 
 Generic image::
 A boot ISO that is not associated with a specific host.
 The ISO sends the host's MAC address to {ProjectServer}, which matches it against the host entry.
 The image does not store IP address details, and requires access to a DHCP server on the network to bootstrap.
 This image is also available from the `/bootdisk/disks/generic` URL on your {ProjectServer}, for example, `\https://{foreman-example-com}/bootdisk/disks/generic`.
+endif::[]
 
-Subnet image::
-A boot ISO that is similar to the generic image but is configured with the address of a {SmartProxyServer}.
-This image is generic to all hosts with a provisioning NIC on the same subnet.
+[NOTE]
+ifdef::satellite[]
+Host and Generic images are no longer available in Satellite.
+endif::[]
+The *Full host image* is based on SYSLINUX and Grub and works with most hardware.
+When using a *Host image*, *Generic image*, or *Subnet image*, see https://ipxe.org/appnote/hardware_drivers[supported hardware on ipxe.org] for a list of hardware drivers expected to work with an iPXE-based boot disk.
 
 *Host image* and *Full host image* contain provisioning tokens, therefore the generated image has limited lifespan.
 For more information about configuring security tokens, read xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
-
-[NOTE]
-The *Full host image* is based on SYSLINUX and Grub and works with most hardware.
-
-When using a *Host image*, *Generic image*, or *Subnet image*, see https://ipxe.org/appnote/hardware_drivers[supported hardware on ipxe.org] for a list of hardware drivers expected to work with an iPXE-based boot disk.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-with-pxe-less-provisioning_{context}[].
 
@@ -305,9 +309,8 @@ Write the ISO to a USB storage device using the *dd* utility or *livecd-tools* i
 
 When you start the physical host and boot from the ISO or the USB storage device, the host connects to {ProjectServer} and starts installing operating system from its kickstart tree.
 
-ifdef::orcharhino[]
+ifdef::satellite,katello,orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the *{project-client-name}* repository.
-endif::[]
 endif::[]
 
 [id="creating-hosts-with-uefi-http-boot-provisioning_{context}"]

--- a/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_creating-hosts-from-discovered-hosts.adoc
@@ -17,9 +17,7 @@ For more information, see xref:installing-the-discovery-service[].
 * A bare metal host or a blank VM.
 
 include::../common/modules/snip_common-compute-resource-prereqs.adoc[]
-ifndef::satellite[]
-For information about the security token for unattended and PXE-less provisioning, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
-endif::[]
+For information about the security tokens, see xref:Provisioning_Bare_Metal_Hosts-Security_Token_in_the_Boot_Process[].
 
 .Procedure
 


### PR DESCRIPTION
There are two PXE less methods in Satellite: one is bootdisk which was limited in 6.10 (only supported bootdisks are Full Host and Subnet disk), that is the change that was supposed to be made. Then we have Discovery PXE less which is still present in Satellite, however, it is technical preview and the feature is not leaving this state until it is fully removed and replaced by something more reliable.

This PR fixes what was introduced in

https://github.com/theforeman/foreman-documentation/pull/794

I should have been more careful when doing the review.

Cherry-pick into:

* [x] Foreman 3.1