### PR TITLE
Add Puppet disablement procedure (unplaced)

### DIFF
--- a/guides/common/modules/proc_disabling-puppet.adoc
+++ b/guides/common/modules/proc_disabling-puppet.adoc
@@ -1,0 +1,24 @@
+[id="Disabling_Puppet_Integration_{context}"]
+= Disabling Puppet Integration with {Project}
+
+To discontinue using Puppet in your {Project}, follow this procedure.
+
+.Prerequisite
+* Puppet is enabled on {Project}.
+
+.Procedure
+. Disable Puppet server on all external {SmartProxies} before you disable it on {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} plugin purge-puppet
+----
+. Disable Puppet server on {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} plugin purge-puppet [--remove-all-data]
+----
++
+The command without arguments will remove all Puppet-related data in {Project}.
+To remove Puppet server data files, including Puppet environments, add the `--remove-all-data` argument to the command.


### PR DESCRIPTION
Disabling Puppet -- currently unincluded, but will be included only for Satellite, Katello and orcharhino in future.

Cherry-pick into:

* [x] Foreman 3.1

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
