### PR TITLE
Update version numbers and branching instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,17 @@ When a commit is pushed into `X.Y`:
 
 ## Branching new release
 
-* Create a copy of [/web/content/nightly.md](https://github.com/theforeman/foreman-documentation/tree/master/web/content/nightly.md) as `X.Y.md` and edit it accordingly.
-* Edit [/web/content/versions.md](https://github.com/theforeman/foreman-documentation/blob/master/web/content/versions.md) and add the new version to the menu.
-* Push the changes into `master`.
-* Check the site if links and landing page appeared correctly.
 * Create a new `X.Y` branch.
-* Update `TargetVersion` and `TargetVersionMaintainUpgrade` in `guides/common/attributes.adoc`
-* Push into `X.Y` branch.
-* HTML guildes should be deployed into `/X.Y`
-* Set `DocState` to `unsupported` in `guides/common/attributes.adoc`
+  * Update `guides/common/attributes.adoc`
+    * Set `DocState` to `unsupported`
+    * Set `ProjectVersion` to `X.Y` and set the matching `KatelloVersion`
+  * Push into `X.Y` branch.
+* Update master
+  * Update `ProjectVersionPrevious` to `X.Y` in `guides/common/attributes.adoc`
+  * Create a copy of [/web/content/nightly.md](https://github.com/theforeman/foreman-documentation/tree/master/web/content/nightly.md) as `X.Y.md` and edit it accordingly.
+  * Edit [/web/content/versions.md](https://github.com/theforeman/foreman-documentation/blob/master/web/content/versions.md) and add the new version to the menu.
+  * Push the changes into `master`.
+* Check the site if links and landing page appeared correctly. HTML guides should be deployed into `/X.Y`
 
 ## License
 

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -13,8 +13,12 @@
 :PuppetDocURL: {BaseURL}puppet_guide/index#
 
 // Attributes only for satellite build
-:ProductVersionRepoTitle: 6.10
-// Change to "Red Hat Satellite Infrastructure Subscription (Beta)" for beta releases
+:ProductVersion: 7.0
+:ProductVersionPrevious: 6.10
+:TargetVersion: {ProductVersion}
+:TargetVersionMaintainUpgrade: {ProductVersion}
+// Add -beta for Beta releases
+:ProductVersionRepoTitle: {ProductVersion}
 
 // Overrides for satellite build
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
@@ -59,8 +63,6 @@
 :package-remove-project: satellite-maintain packages remove
 :package-update-project: satellite-maintain packages update
 :PIV: CAC
-:ProductVersion: 6.10
-:ProductVersionPrevious: 6.9
 :project-client-name: Satellite Tools {ProductVersionRepoTitle}
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-context: satellite
@@ -84,5 +86,3 @@
 :SmartProxy: Capsule
 :SmartProxyServer: Capsule{nbsp}Server
 :Team: Red{nbsp}Hat
-:TargetVersion: 6.9
-:TargetVersionMaintainUpgrade: 6.9

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -4,14 +4,14 @@
 
 // Version numbers
 :ProjectVersion: nightly
-:ProjectVersionPrevious: 3.0
+:ProjectVersionPrevious: 3.1
 :KatelloVersion: nightly
 :TargetVersion: {ProjectVersion}
 :TargetVersionMaintainUpgrade: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9
 // For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
-:SpecialCaseProductVersion: 6.9
+:SpecialCaseProductVersion: 6.10
 
 // Use current RH Satellite release version for links to access.redhat.com
 :AccessRedHatComVersion: 6.10


### PR DESCRIPTION
The branching instructions now first happen by creating the branch. This means the guides will be available by the time the index is created. It also explicitly mentions some steps that were previously missed.

The Satellite versions are updated and now grouped together. It reuses macros to reduce duplication.