### PR TITLE
BZ2029060: Upload default OpenSCAP content using Hammer

### DIFF
--- a/guides/common/modules/proc_loading-the-default-openscap-content.adoc
+++ b/guides/common/modules/proc_loading-the-default-openscap-content.adoc
@@ -1,10 +1,16 @@
 [id="Loading_the_Default_OpenSCAP_Content_{context}"]
 = Loading the Default OpenSCAP Content
 
-In the CLI, load the default OpenScap content.
+In the CLI, load the default OpenSCAP content using one of the following methods.
 
 .Procedure
-* Use the `foreman-rake` command:
+* Use the Hammer command:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# hammer scap-content bulk-upload --type default
+----
+* (Deprecated) Use the `foreman-rake` command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2029060

Cherry-pick into:

* [x] Foreman 3.1
* There will not be additional PRs, master and 3.1 are sufficient, because we want to deprecate it in Sat 7.0.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
