### PR TITLE
Remove 3.2 feature

### DIFF
--- a/guides/common/modules/proc_changing-the-host-group-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-host-group-of-a-host.adoc
@@ -3,8 +3,6 @@
 
 Use this procedure to change the Host Group of a host.
 
-If you reprovision a host after changing the host group, the fresh values that the host inherits from the host group will be applied.
-
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All hosts*.
 . Select the check box of the host you want to change.


### PR DESCRIPTION
This got included as part of the modularization effort for the managing hosts.
Removing here is the easiest option available.

@maximiliankolb how did you avoid this in the provisioning guide as that is not in 3.1 but it is on master? 