### PR TITLE
Rework introduction to content management guide

### DIFF
--- a/guides/common/modules/con_introduction-to-content-management.adoc
+++ b/guides/common/modules/con_introduction-to-content-management.adoc
@@ -3,7 +3,12 @@
 
 In the context of {Project}, _content_ is defined as the software installed on systems.
 This includes, but is not limited to, the base operating system, middleware services, and end-user applications.
+ifdef::satellite[]
 With {ProjectNameX}, you can manage the various types of content for Red Hat Enterprise Linux systems at every stage of the software life cycle.
+endif::[]
+ifndef::satellite[]
+With {Project}, you can manage the various types of content at every stage of the software life cycle.
+endif::[]
 
 ifdef::foreman-el,katello[]
 [IMPORTANT]
@@ -13,8 +18,20 @@ endif::[]
 
 {ProjectNameX} manages the following content:
 
+ifdef::satellite[]
 Subscription management::
 This provides organizations with a method to manage their Red Hat subscription information.
+endif::[]
+
+ifndef::satellite[]
+Red Hat Subscription management::
+This provides organizations with a method to store Red Hat content and organize it in various ways.
+
+SUSE Subscription management::
+This provides organizations with a method to store SUSE content and organize it in various ways.
+Note that this requires the Foreman SCC Manager plug-in.
+For more information, see xref:Managing_SUSE_Content_{context}[].
+endif::[]
 
 Content management::
 ifdef::satellite[]


### PR DESCRIPTION
This PR extends the introduction to the content management guide to provide information on more than RHEL content/subscriptions.