### PR TITLE
Drop unnecessary bundle install from GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        run: bundle install --jobs=3 --retry=3
-        working-directory: .
-
       - name: Install linkchecker and tryer
         run: pip install linkchecker linkchecker-tryer
 
@@ -94,10 +90,6 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-
-      - name: Install dependencies
-        run: bundle install --jobs=3 --retry=3
-        working-directory: .
 
       - name: Build HTML with real links
         run: |
@@ -144,10 +136,6 @@ jobs:
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
-
-      - name: Install dependencies
-        run: bundle install --jobs=3 --retry=3
-        working-directory: .
 
       - name: Clean the environment
         run: make clean


### PR DESCRIPTION
And I think we do not need to run `bundle install` even, this is done by setup-ruby automatically.