### PR TITLE
Update to Ruby 3.1 in building

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
       - master
       - "[0-9]+.[0-9]+"
 env:
-  RUBY_VERSION: 2.7
+  RUBY_VERSION: 3.1
   PYTHON_VERSION: 2.x
   BUNDLE_WITHOUT: "nanoc"
 


### PR DESCRIPTION
Nanoc has started to require Psych 3.1 or newer. This is shipped in Ruby 3. Ruby 3.1 actually has 4.0 and nanoc master has started to require that.