### PR TITLE
Drop Ubuntu 18.04 support (#969)

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -13,7 +13,6 @@ ifdef::foreman-el,katello,satellite[]
 endif::[]
 ifdef::foreman-deb[]
 * xref:#repositories-debian-10[Debian 10 (Buster)]
-* xref:#repositories-ubuntu-1804[Ubuntu 18.04 (Bionic)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
 endif::[]
 
@@ -141,14 +140,6 @@ ifdef::foreman-deb[]
 == [[repositories-debian-10]]Debian 10 (Buster)
 
 :distribution-codename: buster
-include::proc_configuring-repositories-deb.adoc[]
-
-endif::[]
-
-ifdef::foreman-deb[]
-== [[repositories-ubuntu-1804]]Ubuntu 18.04 (Bionic)
-
-:distribution-codename: bionic
 include::proc_configuring-repositories-deb.adoc[]
 
 endif::[]

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -26,7 +26,6 @@ ifdef::satellite[]
 endif::[]
 ifdef::foreman-deb[]
 | Debian 10 (Buster) | amd64 |
-| Ubuntu 18.04 (Bionic) | amd64 |
 | Ubuntu 20.04 (Focal) | amd64 |
 endif::[]
 |====


### PR DESCRIPTION
Foreman 3.1 dropped Ubuntu 18.04 as a platform. This reflects the
change.

(cherry picked from commit 345045d50ab737b41e9c0e15ef2bf3f39114750b)
