### PR TITLE
List CentOS 8 before CentOS 7

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,8 +5,8 @@
 Use this procedure to enable the repositories that are required to install {ProductName}. Choose from the available list which operating system and version you are installing on:
 
 ifdef::foreman-el,katello[]
-* xref:#repositories-centos-7[CentOS 7]
 * xref:#repositories-centos-8[CentOS 8]
+* xref:#repositories-centos-7[CentOS 7]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
 * xref:#repositories-rhel-7[Red Hat Enterprise Linux 7]
@@ -17,29 +17,6 @@ ifdef::foreman-deb[]
 endif::[]
 
 ifdef::foreman-el,katello[]
-== [[repositories-centos-7]]CentOS 7
-
-:distribution-major-version: 7
-:package-manager: yum
-include::proc_configuring-repositories-el.adoc[]
-
-+
-. Install the `epel-release` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} install epel-release
-----
-+
-. Install the `centos-release-scl-rh` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} install centos-release-scl-rh
-----
-endif::[]
-
-ifdef::foreman-el,katello[]
 == [[repositories-centos-8]]CentOS 8
 
 :distribution-major-version: 8
@@ -47,9 +24,6 @@ ifdef::foreman-el,katello[]
 
 include::proc_configuring-repositories-el.adoc[]
 
-endif::[]
-
-ifdef::foreman-el,katello[]
 +
 . Enable Ruby 2.7 module:
 +
@@ -84,6 +58,27 @@ ifdef::foreman-el,katello[]
 ----
 # {package-manager} module reset postgresql
 # {package-manager} module enable postgresql:12
+----
+
+== [[repositories-centos-7]]CentOS 7
+
+:distribution-major-version: 7
+:package-manager: yum
+include::proc_configuring-repositories-el.adoc[]
+
++
+. Install the `epel-release` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} install epel-release
+----
++
+. Install the `centos-release-scl-rh` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} install centos-release-scl-rh
 ----
 endif::[]
 

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -4,8 +4,8 @@ ifdef::context[:parent-context: {context}]
 = Installing {ProjectServer} Packages
 
 ifdef::foreman-el,katello[]
-* xref:#centos-7[CentOS 7]
 * xref:#centos-8[CentOS 8]
+* xref:#centos-7[CentOS 7]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
 * xref:#rhel-7[Red Hat Enterprise Linux 7]
@@ -14,19 +14,19 @@ endif::[]
 .Procedure
 
 ifdef::foreman-el,katello[]
-== [[centos-7]]CentOS 7
+== [[centos-8]]CentOS 8
 
-:context: centos7
-:package-manager: yum
+:context: centos8
+:package-manager: dnf
 include::proc_installing-server-packages-el.adoc[]
 
 endif::[]
 
 ifdef::foreman-el,katello[]
-== [[centos-8]]CentOS 8
+== [[centos-7]]CentOS 7
 
-:context: centos8
-:package-manager: dnf
+:context: centos7
+:package-manager: yum
 include::proc_installing-server-packages-el.adoc[]
 
 endif::[]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -2,8 +2,8 @@
 = Storage Requirements
 
 ifdef::foreman-el,katello[]
-* xref:#storage-centos-7[CentOS 7]
 * xref:#storage-centos-8[CentOS 8]
+* xref:#storage-centos-7[CentOS 7]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
 * xref:#storage-rhel-7[Red Hat Enterprise Linux 7]
@@ -14,32 +14,6 @@ These values are based on expected use case scenarios and can vary according to 
 
 ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
-endif::[]
-
-ifdef::foreman-el,katello[]
-== [[storage-centos-7]]CentOS 7
-
-.Storage Requirements for a {ProjectServer} Installation
-[cols="1,1,1",options="header"]
-|====
-|Directory |Installation Size |Runtime Size
-
-|/var/log/ |10 MB |10 GB
-
-|/var/opt/rh/rh-postgresql12 |100 MB |20 GB
-
-|/usr | 3 GB | Not Applicable
-
-|/opt | 3 GB | Not Applicable
-
-|/opt/puppetlabs | 500 MB | Not Applicable
-
-ifdef::katello,satellite[]
-|/var/lib/pulp/ |1 MB |300 GB
-
-|/var/lib/qpidd/ |25 MB | Not Applicable
-endif::[]
-|====
 endif::[]
 
 ifdef::foreman-el,katello[]
@@ -55,6 +29,30 @@ ifdef::foreman-el,katello[]
 |/var/lib/pgsql |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
+
+|/opt/puppetlabs | 500 MB | Not Applicable
+
+ifdef::katello,satellite[]
+|/var/lib/pulp/ |1 MB |300 GB
+
+|/var/lib/qpidd/ |25 MB | Not Applicable
+endif::[]
+|====
+
+== [[storage-centos-7]]CentOS 7
+
+.Storage Requirements for a {ProjectServer} Installation
+[cols="1,1,1",options="header"]
+|====
+|Directory |Installation Size |Runtime Size
+
+|/var/log/ |10 MB |10 GB
+
+|/var/opt/rh/rh-postgresql12 |100 MB |20 GB
+
+|/usr | 3 GB | Not Applicable
+
+|/opt | 3 GB | Not Applicable
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -17,8 +17,8 @@ The following operating systems are supported by the installer, have packages, a
 |====
 | Operating System | Architecture | Notes
 ifdef::foreman-el,katello[]
-| CentOS 7 | x86_64 only | EPEL is required.
 | CentOS 8 | x86_64 only | EPEL is not supported.
+| CentOS 7 | x86_64 only | EPEL is required.
 | {RHEL} 7 | x86_64 only | EPEL is required.
 endif::[]
 ifdef::satellite[]


### PR DESCRIPTION
It is better to list the newest first since we want to encourage users to use the latest version.

I also noticed we don't list RHEL 8 support while in upstream I think it should work. In general I've been thinking about merging some sections into just EL7 or EL8 but that can change the scope quite a bit so I won't do it in this PR.