### PR TITLE
Hide tuning profiles on foreman-{el,deb}

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -73,8 +73,10 @@ include::common/modules/proc_reclaiming-postgresql-space.adoc[leveloffset=2]
 // Updating Templates, Parameters, Lookup Keys and Values
 include::topics/post_upgrade_template_checks.adoc[leveloffset=+2]
 
+ifdef::katello,orcharhino,satellite[]
 //Tuning Satellite Server with Predefined Profiles
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
+endif::[]
 
 ifdef::satellite[]
 == Updating {ProjectServer}, {SmartProxyServer}, and Content Hosts


### PR DESCRIPTION
The tuning profiles only exist within Katello so they must be otherwise.

I started going through the rest of the document, but it needs a LOT of work. This is just the tip of the ice berg.