### PR TITLE
Remove Application Centric Deployment on Debian

### DIFF
--- a/web/content/js/nav.js
+++ b/web/content/js/nav.js
@@ -74,9 +74,6 @@ let navItems = [
 	},{
 		title: "Administering Foreman",
 		href: "/Administering_Red_Hat_Satellite/index-foreman-deb.html"
-	},{
-		title: "Application Centric Deployment",
-		href: "/Application_Centric_Deployment/index-foreman-deb.html"
 	}]
 },{
 	title: "Katello on EL", items: [


### PR DESCRIPTION
This guide does not exist for Debian and shouldn't be linked.