### PR TITLE
Admin guide: hide invalid sections

### DIFF
--- a/guides/common/assembly_accessing-server.adoc
+++ b/guides/common/assembly_accessing-server.adoc
@@ -1,6 +1,8 @@
 include::modules/con_accessing-server.adoc[]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_installing-the-katello-root-ca-certificate.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_logging-on.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_logging-on.adoc
+++ b/guides/common/modules/proc_logging-on.adoc
@@ -3,9 +3,11 @@
 
 Use the web user interface to log on to {Project} for further configuration.
 
+ifdef::katello,orcharhino,satellite[]
 .Prerequisites
 * Ensure that the Katello root CA certificate is installed in your browser.
 For more information, see xref:Installing_the_Katello_Root_CA_Certificate_{context}[].
+endif::[]
 
 .Procedure
 . Access {ProjectServer} using a web browser pointed to the fully qualified domain name:

--- a/guides/doc-Administering_Red_Hat_Satellite/master.adoc
+++ b/guides/doc-Administering_Red_Hat_Satellite/master.adoc
@@ -8,9 +8,11 @@ include::common/header.adoc[]
 
 include::common/assembly_accessing-server.adoc[leveloffset=+1]
 
+ifndef::foreman-deb[]
 include::common/modules/proc_starting-and-stopping-server.adoc[leveloffset=+1]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_managing-project-with-ansible-collections.adoc[leveloffset=+1]
 
@@ -18,9 +20,11 @@ include::common/assembly_managing-users-and-roles.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-email-notifications.adoc[leveloffset=+1]
 
+ifndef::foreman-deb[]
 include::common/assembly_managing-security-compliance.adoc[leveloffset=+1]
 
 include::common/assembly_running-openscap-scans.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_backing-up-server-and-proxy.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Installing the Katello root CA is, as the name suggests, a Katello only thing.

The starting and stopping guide relies on foreman-maintain which is unavailable on Debian so the whole section is hidden.

The external PostgreSQL guide is EL7 only (even incorrect on EL8 which is supported). For now it's just hidden on Debian but this needs serious work.

Additionally, OpenSCAP is unavailable on Debian so the sections are hidden.

This works towards resolving https://github.com/theforeman/foreman-documentation/issues/676.