### PR TITLE
Only allow the exact remote IP for Foreman

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -49,7 +49,7 @@ listen_addresses = '*'
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-  host  all   all   _{Project}_ip_/24   md5
+  host  all   all   _{Project}_ip_/32   md5
 ----
 
 . To start, and enable PostgreSQL service, enter the following commands:


### PR DESCRIPTION
There is no reason to assume a whole /24 subnet needs access. This is insecure and can create security problems. By only allowing /32 it's limited to the exact IP.