### PR TITLE
Install guides: Hide invalid sections

### DIFF
--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -3,10 +3,6 @@ ifdef::context[:parent-context: {context}]
 [id="Configuring_Server_with_a_Custom_SSL_Certificate_{context}"]
 = Configuring {ProjectServer} with a Custom SSL Certificate
 
-ifndef::satellite[]
-This procedure is only for Katello plug-in users.
-endif::[]
-
 By default, {ProjectNameX} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
 If you cannot use a {Project} self-signed certificate, you can configure {ProjectServer} to use an SSL certificate signed by an external Certificate Authority.
 

--- a/guides/doc-Installing_Satellite_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Satellite_Server_Disconnected/master.adoc
@@ -34,9 +34,11 @@ include::common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
 
 include::common/modules/proc_configuring-satellite-for-outgoing-emails.adoc[leveloffset=+2]
 
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/assembly_using-external-databases.adoc[leveloffset=+2]
+endif::[]
 
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
 

--- a/guides/doc-Installing_Server_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Server_on_Red_Hat/master.adoc
@@ -46,11 +46,13 @@ include::common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
 
 include::common/modules/proc_configuring-satellite-for-outgoing-emails.adoc[leveloffset=+2]
 
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/assembly_using-external-databases.adoc[leveloffset=+2]
+endif::[]
 
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Alternative cname, custom certs and external DB are only valid on Katello scenarios. Eventually these should be written for non-Katello but for now this hides the invalid sections.