### PR TITLE
Merge installing on CentOS and RHEL

### DIFF
--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -17,7 +17,7 @@ Use the following procedures to install {ProjectServer} and perform the initial 
 endif::[]
 
 ifdef::foreman-el[]
-On CentOS, you can install {Project} with or without the Katello plug-in.
+On {EL}, you can install {Project} with or without the Katello plug-in.
 If you are a new user, consider installing {Project} with the Katello plug-in.
 endif::[]
 

--- a/guides/common/modules/con_extra-scap-content.adoc
+++ b/guides/common/modules/con_extra-scap-content.adoc
@@ -4,5 +4,5 @@
 You can upload extra SCAP content into {ProjectServer}, either content created by yourself or obtained elsewhere.
 SCAP content must be imported into {ProjectServer} before being applied in a policy.
 
-For example, the `scap-security-guide` RPM package available in the {RHEL} 7.2 repositories includes a profile for the Payment Card Industry Data Security Standard (PCI-DSS) version 3.
-You can upload this content into a {ProjectServer} even if it is not running {RHEL} 7.2 as the content is not specific to an operating system version.
+For example, the `scap-security-guide` RPM package available in the {EL} 7.2 repositories includes a profile for the Payment Card Industry Data Security Standard (PCI-DSS) version 3.
+You can upload this content into a {ProjectServer} even if it is not running {EL} 7.2 as the content is not specific to an operating system version.

--- a/guides/common/modules/con_gss-proxy.adoc
+++ b/guides/common/modules/con_gss-proxy.adoc
@@ -8,10 +8,10 @@ When using AD as an external authentication source for {Project}, it is recommen
 ifndef::orcharhino[]
 [NOTE]
 ====
-The AD integration requires {ProjectServer} to be deployed on {RHEL} 7.1 or later.
+The AD integration requires {ProjectServer} to be deployed on {EL} 7.1 or later.
 ====
 
-Perform the following procedures on {RHEL} that acts as a base operating system for your {ProjectServer}.
+Perform the following procedures on {EL} that acts as a base operating system for your {ProjectServer}.
 For the examples in this section _EXAMPLE.ORG_ is the Kerberos realm for the AD domain.
 By completing the procedures, users that belong to the EXAMPLE.ORG realm can log in to {ProjectServer}.
 endif::[]

--- a/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
@@ -1,7 +1,7 @@
 [id="Host_Management_and_Monitoring_Using_Cockpit_{context}"]
 = Host Management and Monitoring Using {Cockpit}
 
-{Cockpit} is an interactive web interface that you can use to perform actions and monitor {RHEL} hosts.
+{Cockpit} is an interactive web interface that you can use to perform actions and monitor {EL} hosts.
 You can enable a remote-execution feature to integrate {Project} with {Cockpit}.
 When you install {Cockpit} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
 You can also use the features that are integrated with {Cockpit}, for example, {LoraxCompose}.

--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -10,12 +10,7 @@ You can create an OSTree image using an image builder and expose it in an OSTree
 Then you can use your {Project} to synchronize and manage OSTree branches from the exposed OSTree repository.
 
 .Prerequisites
-ifdef::satellite[]
-* OSTree content is supported only when running {Project} on {RHEL} 8.
-endif::[]
-ifndef::satellite[]
-* OSTree content is supported only when running {Project} on {RHEL} 8 or CentOS 8.
-endif::[]
+* OSTree content is supported only when running {Project} on {EL} 8.
 * In {ProjectServer}, OSTree management tools are not enabled by default.
 To enable OSTree, enter the following command:
 +

--- a/guides/common/modules/con_using-freeipa.adoc
+++ b/guides/common/modules/con_using-freeipa.adoc
@@ -10,7 +10,7 @@ For more information, see xref:Using_LDAP_{context}[].
 ====
 
 .Prerequisites
-* {ProjectServer} has to run on {RHEL} 7.1 or later.
+* {ProjectServer} has to run on {EL} 7.1 or later.
 * The base operating system of {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.

--- a/guides/common/modules/proc_assigning-an-ansible-role-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-an-ansible-role-to-a-host-group.adoc
@@ -1,7 +1,7 @@
 [id="assigning-an-ansible-role-to-a-host-group_{context}"]
 = Assigning an Ansible Role to a Host Group
 
-You can use Ansible roles for remote management of {RHEL} versions 8, 7, and 6.9 or later.
+You can use Ansible roles for remote management of {EL} versions 8, 7, and 6.9 or later.
 
 .Prerequisite
 

--- a/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
+++ b/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
@@ -1,7 +1,7 @@
 [id="adding-ansible-roles-to-an-existing-host_{context}"]
 = Assigning Ansible Roles to an Existing Host
 
-You can use Ansible roles for remote management of {RHEL} versions 8, 7, and 6.9 or later.
+You can use Ansible roles for remote management of {EL} versions 8, 7, and 6.9 or later.
 
 .Prerequisites
 

--- a/guides/common/modules/proc_building-a-discovery-image.adoc
+++ b/guides/common/modules/proc_building-a-discovery-image.adoc
@@ -8,7 +8,7 @@ ifdef::satellite[]
 The operating system image is based on {RHEL} 7.
 endif::[]
 ifndef::satellite[]
-The operating system image is based on Cent OS.
+The operating system image is based on CentOS 8 Stream.
 endif::[]
 
 ifdef::satellite[]

--- a/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
+++ b/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
@@ -6,7 +6,7 @@ In some environments, you might want to allow HTTPS only between the host and {P
 Use `--download-method` to change the download method from HTTP to HTTPS.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -20,7 +20,7 @@ Use `--download-method` to change the download method from HTTP to HTTPS.
 --download-method https
 ----
 
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_changing-the-module-stream-for-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-module-stream-for-a-host.adoc
@@ -1,12 +1,7 @@
 [id="Changing_a_Module_Stream_for_a_Host_{context}"]
 = Changing a Module Stream for a Host
 
-ifdef::satellite[]
-If you have a {RHEL} 8 host, you can modify the module stream for the repositories you install.
-endif::[]
-ifndef::satellite[]
-If you have a {RHEL} 8 or clone operating system host, you can modify the module stream for the repositories you install.
-endif::[]
+If you have a host running {EL} 8, you can modify the module stream for the repositories you install.
 
 After you create the host, you can enable, disable, install, update, and remove module streams from your host in the {ProjectWebUI}.
 

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -5,28 +5,28 @@
 You must update each virtual machine configuration so that they receive updates from the correct {Project} Server or {SmartProxyServer}.
 
 .Prerequisites
-* Hosts must be using the following Red Hat Enterprise Linux version:
+* Hosts must be using the following {EL} version:
 ** 6.4 or later
 ** 7.0 or later
-* All architectures of {RHEL} are supported (i386, x86_64, s390x, ppc_64).
+* All architectures of {EL} are supported (i386, x86_64, s390x, ppc_64).
 * Ensure that a time synchronization tool is enabled and runs on the {ProjectServer}s, any {SmartProxyServer}s, and the hosts.
-** For {RHEL} 6:
+** For {EL} 6:
 +
 ----
 # chkconfig ntpd on; service ntpd start
 ----
-** For {RHEL} 7:
+** For {EL} 7:
 +
 ----
 # systemctl enable chronyd; systemctl start chronyd
 ----
 * Ensure that the daemon `rhsmcertd` is enabled and running on the hosts.
-** For {RHEL} 6:
+** For {EL} 6:
 +
 ----
 # chkconfig rhsmcertd on; service rhsmcertd start
 ----
-** For {RHEL} 7:
+** For {EL} 7:
 +
 ----
 # systemctl start rhsmcertd

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -2,7 +2,7 @@
 
 = Configuring an External DHCP Server to Use with {ProductName}
 
-To configure an external DHCP server running {RHEL} to use with {ProductName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) packages.
+To configure an external DHCP server running {EL} to use with {ProductName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) packages.
 You must also share the DHCP configuration and lease files with {ProductName}.
 The example in this procedure uses the distributed Network File System (NFS) protocol to share the DHCP configuration and lease files.
 
@@ -14,7 +14,7 @@ include::snip_firewalld.adoc[]
 
 .Procedure
 
-. On your {RHEL} host, install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) packages:
+. On your {EL} host, install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
@@ -24,9 +24,6 @@ ifndef::foreman-deb[]
 # {package-update-project} grub2-efi
 ----
 endif::[]
-ifdef::satellite[]
-. Synchronize the {RHEL} 8 kickstart repository.
-endif::[]
-ifdef::katello,orcharhino[]
-. Synchronize the EL 8 kickstart repository.
+ifdef::katello,orcharhino,satellite[]
+. Synchronize the {EL} 8 kickstart repository.
 endif::[]

--- a/guides/common/modules/proc_configuring-the-qpid-mgmt-pub-interval-parameter.adoc
+++ b/guides/common/modules/proc_configuring-the-qpid-mgmt-pub-interval-parameter.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_the_qpid_mgmt_pub_interval_Parameter_{context}"]
 = Configuring the QPID mgmt-pub-interval Parameter
 
-You might see the following error in journal (use `journalctl` command to access it) in {RHEL} 7:
+You might see the following error in journal (use `journalctl` command to access it) in {EL} 7:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_creating-a-domain-for-a-host-during-registration.adoc
+++ b/guides/common/modules/proc_creating-a-domain-for-a-host-during-registration.adoc
@@ -5,7 +5,7 @@ To create a host record, the DNS domain of a host needs to exist in {Project} pr
 If the domain does not exist, add it using `--add-domain`.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -19,7 +19,7 @@ If the domain does not exist, add it using `--add-domain`.
 --add-domain
 ----
 
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-remote-execution-on-the-host.adoc
+++ b/guides/common/modules/proc_enabling-remote-execution-on-the-host.adoc
@@ -4,7 +4,7 @@
 Use `--rex` and `--rex-user` to enable remote execution and add the required SSH keys for the specified user.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -19,7 +19,7 @@ Use `--rex` and `--rex-user` to enable remote execution and add the required SSH
 --rex-user _root_
 ----
 
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_importing-kickstart-repositories.adoc
+++ b/guides/common/modules/proc_importing-kickstart-repositories.adoc
@@ -28,7 +28,7 @@ endif::[]
 ----
 
 ifeval::["{rhel-version}" == "8"]
-. Create directories for {RHEL}Linux 8 AppStream and BaseOS Kickstart repositories:
+. Create directories for {RHEL} 8 AppStream and BaseOS Kickstart repositories:
 +
 ----
 # mkdir --parents /var/www/html/pub/sat-import/content/dist/rhel8/8.1/x86_64/appstream/kickstart

--- a/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
@@ -53,14 +53,14 @@ environment = _My_Puppet_Environment_
 server = _{foreman-example-com}_
 ----
 . Configure the Puppet agent to start at boot:
-* On {RHEL} 6:
+* On {EL} 6:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # chkconfig puppet on
 ----
 ifdef::satellite[]
-* On {RHEL} 7 and 8:
+* On {EL} 7 and 8:
 endif::[]
 ifndef::satellite[]
 * On other operating systems:

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -3,9 +3,9 @@
 
 Before installing {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
 
-ifdef::foreman-el,katello[]
-* xref:centos-7-package[{RHEL} 7 / CentOS Linux 7]
-* xref:centos-8-package[{RHEL} 8 / CentOS Linux 8]
+ifdef::foreman-el,katello,satellite[]
+* xref:el-7-package[{EL} 7]
+* xref:el-8-package[{EL} 8]
 endif::[]
 
 .Procedure
@@ -16,17 +16,13 @@ ifdef::foreman-deb[]
 include::proc_installing-proxy-packages.adoc[]
 endif::[]
 
-ifdef::foreman-el,katello[]
-== [[centos-7-package]]{RHEL} 7 / CentOS Linux 7
-endif::[]
-
 ifdef::foreman-el,katello,satellite[]
+== [[el-7-package]]{EL} 7
+
 :package-manager: yum
 include::proc_installing-proxy-packages.adoc[]
-endif::[]
 
-ifdef::foreman-el,katello[]
-== [[centos-8-package]]{RHEL} 8 / CentOS Linux 8
+== [[el-8-package]]{EL} 8
 
 :package-manager: dnf
 include::proc_installing-proxy-packages.adoc[]

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -4,48 +4,22 @@ ifdef::context[:parent-context: {context}]
 = Installing {ProjectServer} Packages
 
 ifdef::foreman-el,katello,satellite[]
-* xref:#rhel-8[{RHEL} 8]
-* xref:#rhel-7[{RHEL} 7]
-endif::[]
-ifdef::foreman-el,katello[]
-* xref:#centos-8[CentOS 8]
-* xref:#centos-7[CentOS 7]
+* xref:#el-8[{EL} 8]
+* xref:#el-7[{EL} 7]
 endif::[]
 
 .Procedure
 
 ifdef::foreman-el,katello,satellite[]
-== [[rhel-8]]{RHEL} 8
-:context: rhel8
+== [[el-8]]{EL} 8
+:context: el8
 :package-manager: dnf
 include::proc_installing-server-packages-el.adoc[]
 
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
-== [[rhel-7]]{RHEL} 7
-:context: rhel7
+== [[el-7]]{EL} 7
+:context: el7
 :package-manager: yum
 include::proc_installing-server-packages-el.adoc[]
-
-endif::[]
-
-ifdef::foreman-el,katello[]
-== [[centos-8]]CentOS 8
-
-:context: centos8
-:package-manager: dnf
-include::proc_installing-server-packages-el.adoc[]
-
-endif::[]
-
-ifdef::foreman-el,katello[]
-== [[centos-7]]CentOS 7
-
-:context: centos7
-:package-manager: yum
-include::proc_installing-server-packages-el.adoc[]
-
 endif::[]
 
 ifdef::foreman-deb[]

--- a/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
@@ -4,7 +4,7 @@
 Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` packages on the new {Project}.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -17,7 +17,7 @@ Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` pac
 --activationkey=_activation_key_ \
 --force
 ----
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_migrating-a-host-from-red-hat-network.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-red-hat-network.adoc
@@ -8,7 +8,7 @@ To remove the legacy profile, use `--legacy-purge`, and use `--legacy-login` to 
 Enter the user account password when prompted.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -22,7 +22,7 @@ Enter the user account password when prompted.
 --legacy-purge \
 --legacy-login _rhn-user_
 ----
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -2,7 +2,7 @@
 = Preparing a Host for External Databases
 
 ifndef::orcharhino[]
-Install a freshly provisioned system with the latest {RHEL} 7 server to host the external databases.
+Install a freshly provisioned system with the latest {EL} 7 server to host the external databases.
 endif::[]
 ifdef::orcharhino[]
 Install a freshly provisioned system with the latest CentOS 7, Oracle Linux 7, or {RHEL} 7 to host the external databases.

--- a/guides/common/modules/proc_providing-an-alternative-fqdn-for-the-host.adoc
+++ b/guides/common/modules/proc_providing-an-alternative-fqdn-for-the-host.adoc
@@ -18,7 +18,7 @@ If you cannot update the host to use an FQDN that is accepted by {Project}, you 
 ----
 . Use `--fqdn` to specify the FQDN that will be reported to {Project}:
 
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -31,7 +31,7 @@ If you cannot update the host to use an FQDN that is accepted by {Project}, you 
 --fqdn _node100.example.com_
 ----
 
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_providing-the-hosts-ip-address.adoc
+++ b/guides/common/modules/proc_providing-the-hosts-ip-address.adoc
@@ -5,7 +5,7 @@ On hosts with multiple interfaces or multiple IP addresses on one interface, you
 Use `--ip`.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -19,7 +19,7 @@ Use `--ip`.
 --ip _192.x.x.x_
 ----
 
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-for-content-management-only.adoc
+++ b/guides/common/modules/proc_registering-a-host-for-content-management-only.adoc
@@ -4,7 +4,7 @@
 To register a system as a content host, and omit the provisioning and configuration management functions, use `--skip-foreman`.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -14,7 +14,7 @@ To register a system as a content host, and omit the provisioning and configurat
 --activationkey=_activation_key_ \
 --skip-foreman
 ----
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
@@ -57,13 +57,13 @@ The button name includes the FQDN of the internal or external {SmartProxy}.
 ----
 . Confirm that the script is executable by viewing the help text:
 
-* On {RHEL} 8:
+* On {EL} 8:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # /usr/libexec/platform-python bootstrap.py -h
 ----
-* On other {RHEL} versions:
+* On other {EL} versions:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -76,7 +76,7 @@ For the `--server` option, specify the FQDN of {ProjectServer} or a {SmartProxyS
 For the `--location`, `--organization`, and `--hostgroup` options, use quoted names, not labels, as arguments to the options.
 For advanced use cases, see xref:Advanced_Bootstrap_Script_Configuration_{context}[].
 
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -89,7 +89,7 @@ For advanced use cases, see xref:Advanced_Bootstrap_Script_Configuration_{contex
 --activationkey=_activation_key_
 ----
 
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-without-puppet.adoc
+++ b/guides/common/modules/proc_registering-a-host-without-puppet.adoc
@@ -5,7 +5,7 @@ By default, the bootstrap script configures the host for content management and 
 If you have an existing configuration management system and do not want to install Puppet on the host, use `--skip-puppet`.
 
 .Procedure
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -18,7 +18,7 @@ If you have an existing configuration management system and do not want to insta
 --activationkey=_activation_key_ \
 --skip-puppet
 ----
-* On {RHEL} 6, or 7, enter the following command:
+* On {EL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -51,7 +51,7 @@ This procedure includes steps to clean the virtual machine so that no unwanted i
 If you have an image with `cloud-init`, you must still follow this procedure to enable `cloud-init` to communicate with {Project} because `cloud-init` is disabled by default.
 
 ifndef::satellite[]
-These instructions are for {RHEL} or Fedora OS, follow similar steps for other Linux distributions.
+These instructions are for {EL} or Fedora, follow similar steps for other Linux distributions.
 endif::[]
 
 .Procedure

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -5,45 +5,35 @@
 The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
+ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
-
-ifdef::foreman-el,katello[]
-== [[storage-centos-8]]{RHEL} 8 / CentOS Linux 8
 endif::[]
 
-ifdef::satellite[]
-== [[storage-rhel-8]]{RHEL} 8
-endif::[]
+== [[storage-el-8]]{EL} 8
 
-ifdef::foreman-el,katello,satellite[]
 .Storage Requirements for {SmartProxyServer} Installation
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
+ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
+endif::[]
 |/var/lib/pgsql |100 MB |10 GB
 |/usr |3 GB |Not Applicable
 |/opt/puppetlabs |500 MB |Not Applicable
 |====
-endif::[]
 
-ifdef::foreman-el,katello[]
-== [[storage-centos-7]]{RHEL} 7 / CentOS Linux 7
-endif::[]
+== [[storage-el-7]]{EL} 7
 
-ifdef::satellite[]
-== [[storage-rhel-7]]{RHEL} 7
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
 .Storage Requirements for {SmartProxyServer} Installation
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
+ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
+endif::[]
 |/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |10 GB
 |/usr |3 GB | Not Applicable
 |/opt |3 GB | Not Applicable
 |/opt/puppetlabs |500 MB | Not Applicable
 |====
-endif::[]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -1,13 +1,9 @@
 [id="storage-requirements_{context}"]
 = Storage Requirements
 
-ifdef::foreman-el,katello[]
-* xref:#storage-centos-8[CentOS 8]
-* xref:#storage-centos-7[CentOS 7]
-endif::[]
 ifdef::foreman-el,katello,satellite[]
-* xref:#storage-rhel-8[{RHEL} 8]
-* xref:#storage-rhel-7[{RHEL} 7]
+* xref:#storage-el-8[{EL} 8]
+* xref:#storage-el-7[{EL} 7]
 endif::[]
 
 The following table details storage requirements for specific directories.
@@ -17,8 +13,8 @@ ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
-ifdef::foreman-el,katello[]
-== [[storage-centos-8]]CentOS 8
+ifdef::foreman-el,katello,satellite[]
+== [[storage-el-8]]{EL} 8
 
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
@@ -33,14 +29,14 @@ ifdef::foreman-el,katello[]
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 
-ifdef::katello,satellite[]
+ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp/ |1 MB |300 GB
 
 |/var/lib/qpidd/ |25 MB | Not Applicable
 endif::[]
 |====
 
-== [[storage-centos-7]]CentOS 7
+== [[storage-el-7]]{EL} 7
 
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
@@ -57,57 +53,7 @@ endif::[]
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 
-ifdef::katello,satellite[]
-|/var/lib/pulp/ |1 MB |300 GB
-
-|/var/lib/qpidd/ |25 MB | Not Applicable
-endif::[]
-|====
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
-== [[storage-rhel-8]]{RHEL} 8
-
-.Storage Requirements for a {ProjectServer} Installation
-[cols="1,1,1",options="header"]
-|====
-|Directory |Installation Size |Runtime Size
-
-|/var/log/ |10 MB |10 GB
-
-|/var/lib/pgsql |100 MB |20 GB
-
-|/usr | 3 GB | Not Applicable
-
-|/opt/puppetlabs | 500 MB | Not Applicable
-
-ifdef::katello,satellite[]
-|/var/lib/pulp/ |1 MB |300 GB
-
-|/var/lib/qpidd/ |25 MB | Not Applicable
-endif::[]
-|====
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
-== [[storage-rhel-7]]{RHEL} 7
-
-.Storage Requirements for a {ProjectServer} Installation
-[cols="1,1,1",options="header"]
-|====
-|Directory |Installation Size |Runtime Size
-
-|/var/log/ |10 MB |10 GB
-
-|/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |20 GB
-
-|/usr | 3 GB | Not Applicable
-
-|/opt | 3 GB | Not Applicable
-
-|/opt/puppetlabs | 500 MB | Not Applicable
-
-ifdef::katello,satellite[]
+ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp/ |1 MB |300 GB
 
 |/var/lib/qpidd/ |25 MB | Not Applicable

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -16,10 +16,9 @@ The following operating systems are supported by the installer, have packages, a
 .Operating Systems supported by {foreman-installer}
 |====
 | Operating System | Architecture | Notes
-ifdef::foreman-el,katello[]
-| CentOS 8 | x86_64 only | EPEL is not supported.
-| CentOS 7 | x86_64 only | EPEL is required.
-| {RHEL} 7 | x86_64 only | EPEL is required.
+ifdef::foreman-el,katello,orcharhino[]
+| {EL} 8 | x86_64 only | EPEL is not supported.
+| {EL} 7 | x86_64 only | EPEL is required.
 endif::[]
 ifdef::satellite[]
 | {RHEL} 8 | x86_64 only |

--- a/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
@@ -1,7 +1,7 @@
 [id='registering-clients']
 = Registering Clients
 
-You can register a client running a {RHEL} 6, 7, or 8 operating system to {SmartProxyServer}s that you configure for load balancing.
+You can register a client running a {EL} 6, 7, or 8 operating system to {SmartProxyServer}s that you configure for load balancing.
 For more information about registering clients and configuring them to use Puppet, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
 To register clients, proceed to one of the following procedures:
@@ -26,7 +26,7 @@ You must complete the registration procedure for each client.
 Ensure that you install the bootstrap script on the client and change the script's file permissions to executable.
 For more information, see {ManagingHostsDocURL}Registering_a_Host_Using_the_Bootstrap_Script_managing-hosts[Registering Hosts to {ProjectName} Using The Bootstrap Script] in the _Managing Hosts_ guide.
 
-* On {RHEL} 8, enter the following command:
+* On {EL} 8, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -45,7 +45,7 @@ For more information, see {ManagingHostsDocURL}Registering_a_Host_Using_the_Boot
 <2> Include the `--force` option to register the client that has been previously registered to a standalone {SmartProxy}.
 
 
-* On {RHEL} 7, 6, or 5, enter the following command:
+* On {EL} 7, 6, or 5, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Planning_for_Project/topics/Glossary.adoc
+++ b/guides/doc-Planning_for_Project/topics/Glossary.adoc
@@ -101,7 +101,7 @@ Once a content view is published, it can be promoted through the life cycle envi
 
 
 [[varl-Glossary_of_Terms-Discovery_Image]]
-*Discovery Image*:: Refers to the minimal operating system based on {RHEL} that is PXE-booted on hosts to acquire initial hardware information and to communicate with {ProjectServer} before starting the provisioning process.
+*Discovery Image*:: Refers to the minimal operating system based on {EL} that is PXE-booted on hosts to acquire initial hardware information and to communicate with {ProjectServer} before starting the provisioning process.
 
 
 [[varl-Glossary_of_Terms-Discovery_Plug-in]]

--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -7,7 +7,7 @@ If you do not plan to install the Katello plug-in, ignore these references.
 endif::[]
 
 _{ProjectName}_ is a system management solution that enables you to deploy, configure, and maintain your systems across physical, virtual, and cloud environments.
-{Project} provides provisioning, remote management and monitoring of multiple {RHEL} deployments with a single, centralized tool.
+{Project} provides provisioning, remote management and monitoring of multiple {EL} deployments with a single, centralized tool.
 _{ProjectServer}_ synchronizes the content from Red{nbsp}Hat Customer{nbsp}Portal and other sources, and provides functionality including fine-grained life cycle management, user and group role-based access control, integrated subscription management, as well as advanced GUI, CLI, or API access.
 
 _{SmartProxyServer}_ mirrors content from {ProjectServer} to facilitate content federation across various geographical locations.
@@ -217,8 +217,8 @@ ifndef::satellite[]
 [[Foreman_Server_Operating_System]]
 ==== {ProjectServer} Operating System
 
-{Project} has packages for CentOS 8 and clones, and Debian 11 and Ubuntu 20.04.
-Katello plug-in packages, which provide content management capabilities, are only available for CentOS.
+{Project} has packages for {EL} 8, Debian 11 and Ubuntu 20.04.
+Katello plug-in packages, which provide content management capabilities, are only available for {EL}.
 
 The only architecture {Project} has packages for is x86_64.
 

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -134,15 +134,15 @@ endif::[]
 ifdef::foreman-el,katello,orcharhino[]
 === Secure Boot
 
-When {Project} is installed on {RHEL} or compatible operating systems using `{foreman-installer}`, grub2 and shim bootloaders that are signed by Red Hat are deployed into the TFTP and HTTP UEFI Boot directory.
+When {Project} is installed on {EL} using `{foreman-installer}`, grub2 and shim bootloaders that are signed by Red Hat are deployed into the TFTP and HTTP UEFI Boot directory.
 PXE loader options named "SecureBoot" configure hosts to load `shim.efi`.
 
 On Debian and Ubuntu operating systems, the grub2 bootloader is created using the `grub2-mkimage` unsigned.
 To perform the Secure Boot, the bootloader must be manually signed and key enrolled into the EFI firmware.
-Alternatively, grub2 from Ubuntu or {RHEL} can be copied to perform booting.
+Alternatively, grub2 from Ubuntu or {EL} can be copied to perform booting.
 
-Grub2 in {RHEL} 8.0-8.3 were updated to mitigate https://access.redhat.com/security/vulnerabilities/grub2bootloader[Boot Hole Vulnerability] and keys of existing {RHEL} kernels were invalidated.
-To boot any of the affected {RHEL} kernel (or OS installer), you must enroll keys manually into the EFI firmware for each host:
+Grub2 in {EL} 8.0-8.3 were updated to mitigate https://access.redhat.com/security/vulnerabilities/grub2bootloader[Boot Hole Vulnerability] and keys of existing {EL} kernels were invalidated.
+To boot any of the affected {EL} kernel (or OS installer), you must enroll keys manually into the EFI firmware for each host:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -7,8 +7,8 @@ After your upgrade is complete, you can then decommission the earlier version of
 
 Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
 
-The {Project} clone tool does not support migrating a {SmartProxyServer} to {RHEL} 7.
-Instead you must backup the existing {SmartProxyServer}, restore it on {RHEL} 7, then reconfigure {SmartProxyServer}.
+The {Project} clone tool does not support migrating a {SmartProxyServer} to {EL} 7.
+Instead you must backup the existing {SmartProxyServer}, restore it on {EL} 7, then reconfigure {SmartProxyServer}.
 
 .Terminology
 Ensure that you understand the following terms:
@@ -34,8 +34,8 @@ Ensure that you understand the following terms:
 
 To clone {ProjectServer}, ensure that you have the following resources available:
 
-* A minimal install of {RHELServer} 7 to become the target server.
-Do not install {RHEL} 7 software groups, or third-party applications.
+* A minimal install of {EL} 7 to become the target server.
+Do not install {EL} 7 software groups, or third-party applications.
 Ensure that your server complies with all the specifications of {InstallingProjectDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _Installing {ProjectServer}_.
 * A backup from {Project} {ProjectVersionPrevious} that you make using the `{foreman-maintain} backup` script.
 You can use a backup with or without Pulp data.


### PR DESCRIPTION
These sections are the same. Merging this makes the entire guide shorter.

This builds on https://github.com/theforeman/foreman-documentation/pull/973 (included). I expect there to be some discussion, so marking it as a draft for now. Please don't look at the specifics right now but rather on the concept, which is:

* Use Enterprise Linux when refering to RHEL and derivatives upstream
* Use Red Hat Enterprise Linux in Satellite
* Use specific distro names when the instructions differ (like setting up repos)

Is this a direction we can agree on?