### PR TITLE
Make the drop downs fit the width of the content

### DIFF
--- a/web/content/css/_nav.scss
+++ b/web/content/css/_nav.scss
@@ -80,6 +80,7 @@ nav .dropdown-menu {
   border: 1px solid rgba(0, 0, 0, 0.3);
   border-radius: 0.5em;
   background-color: #fff;
+  width: max-content;
 }
 nav .dropdown.show .dropdown-menu {
   display: block;


### PR DESCRIPTION
Many guide names are longer than the width of the title. This resizes the nav to fix the content. According to [caniuse](https://caniuse.com/mdn-css_properties_flex-basis_max-content) it's not available on all browsers, but at least on most. On unsupported browsers I'd expect it to behave as it previously did.