### PR TITLE
Remove Salt reactor configuration step

### DIFF
--- a/guides/common/modules/proc_salt-authenticating-salt-minions-using-salt-autosign-grains.adoc
+++ b/guides/common/modules/proc_salt-authenticating-salt-minions-using-salt-autosign-grains.adoc
@@ -27,21 +27,6 @@ If it is configured to use `/srv/salt`, create the runners folder `/srv/salt/_ru
 # mkdir -p /srv/salt/_runners
 # cp /var/lib/foreman-proxy/salt/runners/* /srv/salt/_runners/
 ----
-. Set the host name of your {ProjectServer} in `/var/lib/foreman-proxy/salt/reactors/foreman_minion_auth.sls`:
-+
-[options="nowrap" subs="attributes"]
-----
-[...]
-remove_autosign_key_custom_runner:
-  runner.foreman_https.query_cert:
-    - method: PUT
-    - host: {foreman-example-com}
-    - path: /salt/api/v2/salt_autosign_auth?name={{ data['id'] }}
-    - cert: /etc/pki/katello/puppet/puppet_client.crt
-    - key: /etc/pki/katello/puppet/puppet_client.key
-    - port: 443
-[...]
-----
 . Restart the Salt Master service:
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
From now on, the corresponding reactor file calls a runner which retrieves the parameters (that were given manually before) from `/etc/salt/foreman.yaml`.

Please review my PR @bastian-src.

Cherry-pick into:

* [x] Foreman 3.1