### PR TITLE
Put F2.4/K4.0 back and improve version switcher

### DIFF
--- a/web/content/css/_nav.scss
+++ b/web/content/css/_nav.scss
@@ -82,6 +82,10 @@ nav .dropdown-menu {
   background-color: #fff;
   width: max-content;
 }
+nav .dropdown-menu-left {
+  left: auto;
+  right: 0;
+}
 nav .dropdown.show .dropdown-menu {
   display: block;
 }

--- a/web/content/js/nav.js
+++ b/web/content/js/nav.js
@@ -5,14 +5,17 @@ let navVersions = [
 		title: "Nightly",
 		href: "nightly"
 	},{
-		title: "3.1 (stable)",
+		title: "Foreman 3.1 - Katello 4.3 (stable)",
 		href: "3.1"
 	},{
-		title: "3.0 (supported)",
+		title: "Foreman 3.0 - Katello 4.2 (supported)",
 		href: "3.0"
 	},{
-		title: "2.5 (unsupported)",
+		title: "Foreman 2.5 - Katello 4.1 (unsupported)",
 		href: "2.5"
+	},{
+		title: "Foreman 2.4 - Katello 4.0 (unsupported)",
+		href: "2.4"
 	}]
     }
 ]

--- a/web/layouts/nav.html.erb
+++ b/web/layouts/nav.html.erb
@@ -36,7 +36,7 @@ var Navbar = `<nav>
   + navVersions.map(function(navItem){ return(
     `<li id="nav-id-`+ navId++ +`" class="nav-item dropdown">
         <a href="#" data-action="dropdown-toggle">Version `+currentVer+`</a>
-        <div class="dropdown-menu">`
+        <div class="dropdown-menu dropdown-menu-left">`
         + navItem.items.map(function(item){
             if (document.location.pathname == "/") {
                 var dl = "/release/" + item.href;


### PR DESCRIPTION
So Mel had a good point that with removal of 2.4 we lost Katello 4.0 docs. That was not intentional, I will backport the nanoc/JS/CSS changes also into 2.4 and re-publish it.

I am also trying to improve the version switcher so it is more clear what Foreman/Katello version are you on. However, the box is running from screen.

H.E.L.P.