### PR TITLE
Fix PDF generation, exit code from make and parallelization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ env:
   RUBY_VERSION: 3.1
   PYTHON_VERSION: 2.x
   BUNDLE_WITHOUT: "nanoc"
+  MAKE_J: 3
 
 jobs:
   check-html:
@@ -55,11 +56,11 @@ jobs:
 
       - name: Build HTML with local links
         run: |
-          make html BUILD=foreman-el LINKS=LOCAL
-          make html BUILD=foreman-deb LINKS=LOCAL
-          make html BUILD=katello LINKS=LOCAL
-          make html BUILD=satellite LINKS=LOCAL
-          make html BUILD=orcharhino LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=foreman-el LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=katello LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=satellite LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=orcharhino LINKS=LOCAL
 
       - name: Check HTML links of all builds
         run: |
@@ -94,11 +95,11 @@ jobs:
       - name: Build HTML with real links
         run: |
           make clean
-          make html BUILD=foreman-el
-          make html BUILD=foreman-deb
-          make html BUILD=katello
-          make html BUILD=satellite
-          make html BUILD=orcharhino
+          make -j ${{ env.MAKE_J }} html BUILD=foreman-el
+          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb
+          make -j ${{ env.MAKE_J }} html BUILD=katello
+          make -j ${{ env.MAKE_J }} html BUILD=satellite
+          make -j ${{ env.MAKE_J }} html BUILD=orcharhino
 
       - name: Upload HTML
         uses: actions/upload-artifact@v2
@@ -107,11 +108,6 @@ jobs:
           path: guides/build/
 
   build-pdf:
-    if: >
-      github.repository_owner == 'theforeman' &&
-      (github.ref == 'refs/heads/master' ||
-      startsWith(github.ref, 'refs/heads/2.') ||
-      startsWith(github.ref, 'refs/heads/3.'))
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -140,13 +136,21 @@ jobs:
       - name: Clean the environment
         run: make clean
 
-      - name: Build PDFs
+      - name: Build PDFs (master/stable)
         run: |
-          make pdf BUILD=foreman-el
-          make pdf BUILD=foreman-deb
-          make pdf BUILD=katello
-          make pdf BUILD=satellite
-          make pdf BUILD=orcharhino
+          make -j ${{ env.MAKE_J }} pdf BUILD=foreman-el
+
+      - name: Build PDFs (PR)
+        if: >
+          github.repository_owner == 'theforeman' &&
+          (github.ref == 'refs/heads/master' ||
+          startsWith(github.ref, 'refs/heads/2.') ||
+          startsWith(github.ref, 'refs/heads/3.'))
+        run: |
+          make -j ${{ env.MAKE_J }} pdf BUILD=foreman-deb
+          make -j ${{ env.MAKE_J }} pdf BUILD=katello
+          make -j ${{ env.MAKE_J }} pdf BUILD=satellite
+          make -j ${{ env.MAKE_J }} pdf BUILD=orcharhino
 
       - name: Upload PDFs
         uses: actions/upload-artifact@v2

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gem 'asciidoctor'
 gem 'asciidoctor-pdf'
+# missing dependency for asciidoctor-pdf
+gem 'matrix'
 
 gem 'compass', '0.12.7'
 gem 'zurb-foundation', '4.3.2'

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,16 +1,23 @@
 SHELL := /bin/bash
-ALL_DIRS = $(shell ls -d doc-*)
-GUIDES-HTML = $(ALL_DIRS)
+SUBDIRS = $(shell ls -d doc-*)
 
-.PHONY: all html pdf linkchecker all-html all-pdf clean all-clean linkchecker-tryer $(GUIDES-HTML)
+.PHONY: all clean html pdf linkchecker linkchecker-tryer serve subdirs $(SUBDIRS)
 
 all: html
 
-html: all-html
+html: subdirs
 
-pdf: all-pdf
+pdf: subdirs
 
-clean: all-clean
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C "$@" $(MAKECMDGOALS)
+
+clean:
+	@for DIR in $(SUBDIRS) ; do \
+		$(MAKE) -s --directory="$$DIR" clean ; \
+	done
 
 linkchecker:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
@@ -18,20 +25,5 @@ linkchecker:
 linkchecker-tryer:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
-all-html: $(GUIDES-HTML)
-
-$(GUIDES-HTML):
-	$(MAKE) --directory=$@ html
-
-all-pdf:
-	for DIR in $(ALL_DIRS) ; do \
-		$(MAKE) --directory="$$DIR" pdf ; \
-	done
-
-$(GUIDES-PDF):
-	$(MAKE) --directory=$@ pdf
-
-all-clean:
-	for DIR in $(ALL_DIRS) ; do \
-		$(MAKE) --directory="$$DIR" clean ; \
-	done
+serve:
+	python -m http.server --directory ./build 8813

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -31,19 +31,22 @@ ifeq ($(LINKS), LOCAL)
 BASEURL_ATTR = "-a BaseURL=file://$(BUILD_DIRA)"
 endif
 
+.SHELLFLAGS = -o pipefail -c
+.PHONY = all prepare css html pdf clean browser server linkchecker open-pdf
+
 all: html
 
 prepare:
-	@mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(IMAGES_DIR) $(DEST_DIR)/common/images
+	@mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(DEST_DIR)/sass-cache
 
 css: prepare $(DEST_DIR)/$(BUILD).css
 
 html: css $(IMAGES_TS) $(DEST_HTML)
 
-pdf: prepare $(DEST_PDF)
+pdf: prepare $(IMAGES_TS) $(DEST_PDF)
 
 clean:
-	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)" "$(BUILD_DIR)/default.css"
+	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)"
 
 browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
@@ -57,15 +60,11 @@ linkchecker: html
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"
 
-$(BUILD_DIR)/default.css: $(CSS_SOURCES)
-	bundle exec sass -C --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
-
-$(DEST_DIR)/$(BUILD).css: $(BUILD_DIR)/default.css
-	cp $< $@
+$(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
+	bundle exec sass --cache-location $(DEST_DIR)/sass-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 
 $(IMAGES_TS): $(IMAGES)
-	cp $? $(IMAGES_DIR)/
-	pushd "$(IMAGES_DIR)" >/dev/null && for IMG in *.*; do ln -fs ../../images/$$IMG ../common/images/$$IMG; done && popd >/dev/null
+	cp -lrf $? $(IMAGES_DIR)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES)
@@ -76,6 +75,6 @@ $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES)
 	@! grep -RE '<a href="#[a-zA-Z0-9_-]+">\[[a-zA-Z0-9_-]+\]</a>' $@
 
 $(DEST_PDF): $(SOURCES) $(IMAGES) $(DEPENDENCIES)
-	bundle exec asciidoctor-pdf -a build=$(BUILD) -d book --trace -o $@ $< 2>&1 | tee $@.log
+	bundle exec asciidoctor-pdf -a build=$(BUILD) -a imagesdir=$(IMAGES_DIR) -d book --trace -o $@ $< 2>&1 | tee $@.log
 	@echo CHECKING FOR ASCIIDOCTOR-PDF ERRORS AND WARNINGS
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -1,5 +1,5 @@
 include::common/attributes.adoc[]
-:imagesdir: common/images
+:imagesdir: images
 include::common/header.adoc[]
 
 :configuring-ansible:

--- a/guides/doc-Configuring_Ansible/master.adoc
+++ b/guides/doc-Configuring_Ansible/master.adoc
@@ -1,5 +1,5 @@
 include::common/attributes.adoc[]
-:imagesdir: common/images
+:imagesdir: images
 include::common/header.adoc[]
 
 :configuring-ansible:

--- a/guides/doc-Installing_Proxy_on_Debian/master.adoc
+++ b/guides/doc-Installing_Proxy_on_Debian/master.adoc
@@ -1,4 +1,4 @@
-:imagesdir: common/images
+:imagesdir: images
 :installing-capsule-server:
 :numbered:
 :toc:

--- a/guides/doc-Installing_Proxy_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Proxy_on_Red_Hat/master.adoc
@@ -1,4 +1,4 @@
-:imagesdir: common/images
+:imagesdir: images
 :numbered:
 ifndef::satellite[]
 :toc:

--- a/guides/doc-Installing_Satellite_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Satellite_Server_Disconnected/master.adoc
@@ -1,5 +1,5 @@
 include::common/attributes.adoc[]
-:imagesdir: common/images
+:imagesdir: images
 :installing-satellite-server-disconnected:
 include::common/header.adoc[]
 :context: satellite

--- a/guides/doc-Installing_Server_on_Debian/master.adoc
+++ b/guides/doc-Installing_Server_on_Debian/master.adoc
@@ -1,4 +1,4 @@
-:imagesdir: common/images
+:imagesdir: images
 :numbered:
 :toc:
 :toc-placement: left

--- a/guides/doc-Installing_Server_on_Red_Hat/master.adoc
+++ b/guides/doc-Installing_Server_on_Red_Hat/master.adoc
@@ -1,5 +1,5 @@
 include::common/attributes.adoc[]
-:imagesdir: common/images
+:imagesdir: images
 :numbered:
 ifdef::foreman-el,foreman-deb,katello[]
 :toc:

--- a/guides/doc-Quickstart_Guide/master.adoc
+++ b/guides/doc-Quickstart_Guide/master.adoc
@@ -1,5 +1,5 @@
 include::common/attributes.adoc[]
-:imagesdir: common/images
+:imagesdir: images
 :numbered:
 ifdef::foreman-el,foreman-deb,katello[]
 :toc:


### PR DESCRIPTION
So it turns out we have several issues.

Asciidoctor PDF now has a missing dependency "matrix". Without this gem, PDF generation simply fails, probably a bug usptream.

Second problem actually hid the first one - I added `asciidoctor ... | tee LOGFILE; grep LOGFILE` to search for warnings which were never returned via exit code by asciidoctor, but I haven't realized that the pipe always returns zero exit code so even when HTML/PDF generation was broken (we had brokens links), makefile was still returning zero.

After I fixed the tee problem, a third appeared - recursive make implementation did not care about return codes from the submakes at all, therefore when targets "all-html" or "all-pdf" were called, it always returned zero even if we had issues (warnings via the grep command).

Finally, I am making small improvement - for PR CI runs, let's simply build just one PDF to speed things up just to see if it actually builds. For deployments, let's build all of them, this creates a huge ZIP file and takes much longer. I think this is a good solution, previously we were building no PDFs for PR CI runs.

The root cause for PDF generation failing was because I was giving it the wrong images directory. I am going to fix all problems in separate commits. On top of that, since I am looking into this, I reimplemented the parallel make after reading GNU Makefile manual now in a proper way so it is `-j` friendly. Now we can use it on CI to even further speedups builds, for example PDF generation on my Intel NUC 8thgen:

```
# make clean; make html
real	0m14,125s
user	0m12,568s
sys	0m1,552s

# make clean; make html -j5
real	0m2,578s
user	0m8,955s
sys	0m0,897s

# make clean; make pdf
real	0m49,084s
user	0m46,572s
sys	0m2,375s

# make clean; make pdf -j5
real	0m23,316s
user	1m16,476s
sys	0m3,601s
```

For parallelization, I had to drop the clunky images symlinking, now we use simply `cp` to copy images over to the destination dir for each guide. I actually have a hard-link option to make it even faster. I also had to solve the common/images vs images/ directories problem which I run into when I was working on https://github.com/theforeman/foreman-documentation/pull/977. We used to have images/ subdirectory for some guides, now we have it for all of them and images are copied from both directories into a single one.