### PR TITLE
Install *-release* packages on CentOS 7 in a single step

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -67,18 +67,11 @@ ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]
 
 +
-. Install the `epel-release` package:
+. Install the `epel-release` and `centos-release-scl-rh` packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} install epel-release
-----
-+
-. Install the `centos-release-scl-rh` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} install centos-release-scl-rh
+# {package-manager} install epel-release centos-release-scl-rh
 ----
 endif::[]
 


### PR DESCRIPTION
Yum can handle this and it's fewer steps for the user. This means a shorter guide.