### PR TITLE
Swapped sections 2.6 and 2.7 in Capsule Installation Doc per SATDOC-5…

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -32,9 +32,6 @@ endif::[]
 // Synchronizing the System Clock With chronyd
 include::modules/proc_synchronizing-the-system-clock-with-chronyd.adoc[leveloffset=+1]
 
-// Assigning the Correct Organization and Location to {SmartProxyServer} in the {ProjectWebUI}
-include::modules/proc_enabling-capsule-in-UI.adoc[leveloffset=+1]
-
 ifdef::katello,satellite[]
 [id="configuring-capsule-server-with-ssl-certificates"]
 == Configuring {SmartProxyServer} with SSL Certificates
@@ -62,3 +59,6 @@ ifndef::parent-context[:!context:]
 ifdef::katello[]
 include::modules/proc_configuring-capsule-container-gateway.adoc[leveloffset=+1]
 endif::[]
+
+// Assigning the Correct Organization and Location to {SmartProxyServer} in the {ProjectWebUI}
+include::modules/proc_enabling-capsule-in-UI.adoc[leveloffset=+1]


### PR DESCRIPTION
…41. Capsule Install Doc is located in Installing_Proxy module upstream
@melcorr 

Cherry-pick into:

* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
