### PR TITLE
Fixed link in sendmail configuration

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -59,7 +59,7 @@ The `SMTP username` and `SMTP password` specify the login credentials for the SM
 For security reasons, both Sendmail location and Sendmail argument settings are read-only and can be only set in `/etc/foreman/settings.yaml`.
 Both settings currently cannot be set via `{foreman-installer}`.
 ifdef::foreman,katello,orcharhino[]
-This is being tracked in [issue #33543](https://projects.theforeman.org/issues/33543).
+This is being tracked in https://projects.theforeman.org/issues/33543[issue #33543].
 endif::[]
 For more information see the *sendmail 1* man page.
 


### PR DESCRIPTION
Fixed the hyperlink for issue #33543 in section 4.6 Configuring Foreman server for Outgoing Emails.


Cherry-pick into:

* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->

@melcorr 