### PR TITLE
Added information about truthy and falsy macros

### DIFF
--- a/guides/common/modules/ref_template-macros.adoc
+++ b/guides/common/modules/ref_template-macros.adoc
@@ -118,3 +118,35 @@ This macro is available only for job templates.
 +
 Using this macro, you can render a specific template.
 You can also enable and define arguments that you want to pass to the template.
+
+
+truthy::
++
+Using the `truthy` macro, you can declare if the value passed is true or false, regardless of whether the value is an integer or boolean or string.
++
+This macro helps to avoid confusion when your template contains multiple value types. For example, the boolean value `true` is not the same as the string value `"true"`. With this macro, you can declare how you want the template to interpret the value and avoid confusion. 
++
+You can use `truthy` to declare values as follows:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+truthy?(“true”) => true
+truthy?(1) => true
+truthy?(“false”) => false
+truthy?(0) => false
+----
+
+falsy::
++
+The falsy macro serves the same purpose as the truthy macro.
++
+Using the `falsy` macro, you can declare if the value passed in is true or false, regardless of whether the value is an integer or boolean or string.
++
+You can use `falsy` to declare values as follows:
++
+----
+falsy?(“true”) => false
+falsy?(1) => false
+falsy?(“false”) => true
+falsy?(0) => true
+----


### PR DESCRIPTION
Added information about the truthy and falsy macros in the Templates Macros section of the Template Writing Reference appendix in the Managing Hosts document.


Cherry-pick into:

* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->

@melcorr 