### PR TITLE
Added missing line from Pulp migration instructions

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -60,8 +60,8 @@ Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'
 # {foreman-maintain} content prepare
 ----
 +
-. As part of the final step of `{foreman-maintain} content prepare`, {Project} checks whether any content units are unmigrated.
-If `{foreman-maintain} content migration-stats` identifies corrupted or missing content, you might see something similar to the following:
+. By the end of its run, the command checks whether any content units are unmigrated.
+If the command identifies corrupted or missing content, you might see something similar to the following:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -60,8 +60,8 @@ Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'
 # {foreman-maintain} content prepare
 ----
 +
-. By the end of its run, the command checks whether any content units are unmigrated.
-If the command identifies corrupted or missing content, you might see something similar to the following:
+As part of its final step, `{foreman-maintain} content prepare` checks whether any content units are unmigrated.
+If it identifies corrupted or missing content, you might see something similar to the following:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -60,7 +60,7 @@ Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'
 # {foreman-maintain} content prepare
 ----
 +
-. When the `{foreman-maintain} content prepare` step is complete {Project} checks whether any content units are unmigrated.
+. As part of the final step of `{foreman-maintain} content prepare`, {Project} checks whether any content units are unmigrated.
 If `{foreman-maintain} content migration-stats` identifies corrupted or missing content, you might see something similar to the following:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -60,9 +60,9 @@ ifdef::satellite[]
 # {foreman-maintain} content prepare
 ----
 +
-. When the `satellite-maintain content prepare` step is complete {Project} checks whether any content units are unmigrated.
+. When the `{foreman-maintain} content prepare` step is complete {Project} checks whether any content units are unmigrated.
 endif::[]
-If `satellite-maintain content migration-stats` identifies corrupted or missing content, you might see something similar to the following:
+If `{foreman-maintain} content migration-stats` identifies corrupted or missing content, you might see something similar to the following:
 endif::[]
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -59,6 +59,10 @@ ifdef::satellite[]
 ----
 # {foreman-maintain} content prepare
 ----
++
+. When the `satellite-maintain content prepare` step is complete {Project} checks whether any content units are unmigrated.
+endif::[]
+If `satellite-maintain content migration-stats` identifies corrupted or missing content, you might see something similar to the following:
 endif::[]
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -52,7 +52,7 @@ double in size before starting the migration process.
 Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'
 [OK]
 ----
-ifdef::satellite[]
+
 . Update the file permissions before upgrading {ProjectServer} using the following command:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
@@ -61,9 +61,7 @@ ifdef::satellite[]
 ----
 +
 . When the `{foreman-maintain} content prepare` step is complete {Project} checks whether any content units are unmigrated.
-endif::[]
 If `{foreman-maintain} content migration-stats` identifies corrupted or missing content, you might see something similar to the following:
-endif::[]
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----


### PR DESCRIPTION
A missing line between two instructions was added.

Include More Information Regarding Concerns During the Pulp 2 to Pulp 3 Migration

https://issues.redhat.com/browse/SATDOC-548


Cherry-pick into:

* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
