### PR TITLE
Capitalize "Content View" and fix minor typos

### DIFF
--- a/guides/common/modules/con_iss-import-export-cheat-sheet.adoc
+++ b/guides/common/modules/con_iss-import-export-cheat-sheet.adoc
@@ -6,16 +6,16 @@
 |=========================================================
 |Intent | Command
 
-|Fully Export a content view version | `hammer content-export complete version --content-view="_My_Content_View_" --version=1.0 --organization="_My_Organization_"`
-|Incrementally Export a content view version (assuming you have already exported something)| `hammer content-export incremental version --content-view="_My_Content_View_" --version=2.0 --organization="_My_Organization_"`
+|Fully Export a Content View version | `hammer content-export complete version --content-view="_My_Content_View_" --version=1.0 --organization="_My_Organization_"`
+|Incrementally Export a Content View version (assuming you have already exported something)| `hammer content-export incremental version --content-view="_My_Content_View_" --version=2.0 --organization="_My_Organization_"`
 
 |Fully Export an Organization's Library| `hammer content-export complete library --organization="_My_Organization_"`
 
 |Incrementally Export an Organization's Library (assuming you have already exported something)|`hammer content-export incremental library --organization="_My_Organization_"`
 
-|Export a content view version promoted to the Dev Environment|`hammer content-export complete version --content-view="_My_Content_View_" --organization="_My_Organization_" --lifecycle-environment=’Dev’`
+|Export a Content View version promoted to the Dev Environment|`hammer content-export complete version --content-view="_My_Content_View_" --organization="_My_Organization_" --lifecycle-environment=’Dev’`
 
-|Export a content view in smaller chunks (2 gb slabs)|`hammer content-export complete version --content-view="_My_Content_View_" --version=1.0 --organization="_My_Organization_" --chunk-size-gb=2`
+|Export a Content View in smaller chunks (2 gb slabs)|`hammer content-export complete version --content-view="_My_Content_View_" --version=1.0 --organization="_My_Organization_" --chunk-size-gb=2`
 
 |Get a list of exports|`hammer content-export list --content-view="_My_Content_View_" --organization="_My_Organization_"`
 
@@ -26,7 +26,7 @@
 |=========================================================
 |Intent | Command
 
-|Import to a content view version | `hammer content-import version --organization="_My_Organization_" --path=’/var/lib/pulp/imports/dump_dir’`
+|Import to a Content View version | `hammer content-import version --organization="_My_Organization_" --path=’/var/lib/pulp/imports/dump_dir’`
 
 |Import to an Organization's Library| `hammer content-import library --organization="_My_Organization_" --path=’/var/lib/pulp/imports/dump_dir’`
 |=========================================================

--- a/guides/common/modules/con_monitoring-resources.adoc
+++ b/guides/common/modules/con_monitoring-resources.adoc
@@ -2,4 +2,4 @@
 = Monitoring Resources
 
 The following chapter details how to configure monitoring and reporting for managed systems.
-This includes host configuration, content views, compliance, subscriptions, registered hosts, promotions and synchronization.
+This includes host configuration, Content Views, compliance, subscriptions, registered hosts, promotions, and synchronization.

--- a/guides/common/modules/proc_connected-foreman-for-managing-content-view-versions.adoc
+++ b/guides/common/modules/proc_connected-foreman-for-managing-content-view-versions.adoc
@@ -30,4 +30,4 @@ For more information on performing an incremental export on Content View Version
 . Copy the exported content archive from the connected {ProjectServer}.
 . Import the content to the organization that you want.
 For more information, see xref:Importing_a_Content_View_Version_{context}[].
-This will create a content view version from the exported content archives and them import content appropriately.
+This will create a Content View Version from the exported content archives and then import content appropriately.

--- a/guides/common/modules/proc_creating-a-composite-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-composite-content-view.adoc
@@ -1,7 +1,7 @@
 [id="Creating_a_Composite_Content_View_{context}"]
 = Creating a Composite Content View
 
-Use this procedure to create a composite content view.
+Use this procedure to create a composite Content View.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-composite-content-view_{context}[].
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -26,7 +26,7 @@ This can also cause errors when resolving dependencies for errata.
 You can view the Content View in the Content Views window.
 To view more information about the Content View, click the Content View name.
 
-To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
 
 [id="cli-creating-a-content-view_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
@@ -8,7 +8,7 @@ Use the following procedure to create an activation key that you can use to subs
 . In the *Name* field, enter *CentOS* or the name of your new activation key.
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the *Library*.
-. From the *Content View* list, select *Centos content view*.
+. From the *Content View* list, select *Centos Content View*.
 . Click *Save*.
 . Click the *Subscriptions* tab on the Activation Key's details page.
 . Click the *Add* tab.

--- a/guides/common/modules/proc_exporting-a-content-view-version.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version.adoc
@@ -2,7 +2,7 @@
 = Exporting a Content View Version
 
 You can export a version of a Content View to an archive file from {ProjectServer} and use this archive file to create the same Content View version on another {ProjectServer} or on another {ProjectServer} organization.
-{Project} exports composite Content Views as normal content views.
+{Project} exports composite Content Views as normal Content Views.
 The composite nature is not retained.
 On importing the exported archive, a regular Content View is created or updated on your disconnected {ProjectServer}.
 The exported archive file contains the following data:

--- a/guides/common/modules/proc_exporting-the-library-environment.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment.adoc
@@ -44,7 +44,7 @@ total 68M
 
 . You require all three files, for example, the `tar.gz`, the `toc.json` and the `metadata.json` file to be able to import.
 . A new Content View **Export-Library** is created in the organization.
-This content view contains all the repositories belonging to this organization.
+This Content View contains all the repositories belonging to this organization.
 A new version of this Content View is published and exported automatically.
 
 .Export with chunking

--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -11,7 +11,7 @@ The Custom Repositories, Products and Content Views are automatically created if
 . The exported archive must be in a directory under `/var/lib/pulp/imports`.
 . The directory must have `pulp:pulp` permissions so that Pulp can read and write the `.json` files in that directory.
 . If there are any Red Hat repositories in the export archive, the importing organization's manifest must contain subscriptions for the products contained within the export.
-. The user importing the content view version must have the 'Content Importer' Role.
+. The user importing the Content View Version must have the 'Content Importer' Role.
 
 .Procedure
 . Copy the archived file with the exported Content View version to the `/var/lib/pulp/imports` directory on {ProjectServer} where you want to import.

--- a/guides/common/modules/proc_prerequisites-for-puppet.adoc
+++ b/guides/common/modules/proc_prerequisites-for-puppet.adoc
@@ -11,7 +11,7 @@ endif::[]
 +
 For example, https://yum.puppet.com/puppet6/el/7/x86_64/[Puppet 6 for CentOS 7 on x86_64] or https://apt.puppet.com/[Puppet 6 for Ubuntu 20.04] with release `focal`, component `puppet6`, and architecture `amd64`.
 +
-Manage these repositories by using products, sync plans, content views, composite content views, and lifecycle environments.
+Manage these repositories by using products, sync plans, Content Views, composite Content Views, and Lifecycle Environments.
 ifdef::katello[]
 For more information, see {ContentManagementDocURL}basic-content-management-workflow[basic content management workflow] in the _Content Management Guide_.
 endif::[]

--- a/guides/common/modules/proc_promoting-a-content-view.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view.adoc
@@ -57,4 +57,4 @@ Now the repository for the Content View appears in all environments.
 +
 Now the database content is available in all environments.
 
-To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.

--- a/guides/common/modules/proc_switching-scc-accounts.adoc
+++ b/guides/common/modules/proc_switching-scc-accounts.adoc
@@ -6,7 +6,7 @@ You can switch your SCC account by changing the SCC credentials saved on {Projec
 [WARNING]
 ====
 If you want to switch your SCC account and retain the synchronized content, do not immediately delete your old SCC account, even if it is expired.
-If you delete your old SCC account, you cannot reuse existing repositories, products, content views, and composite content views.
+If you delete your old SCC account, you cannot reuse existing repositories, products, Content Views, and composite Content Views.
 ====
 
 .Procedure

--- a/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
+++ b/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
@@ -78,7 +78,7 @@ hammer content-view create \
 
 hammer content-view publish \
 --name "Base" \
---description "Initial content view for our operating system" \
+--description "Initial Content View for our operating system" \
 --organization "ACME"
 
 hammer content-view version promote \

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -11,7 +11,7 @@ Some events are marked as *custom*, in that case, the payload is an object objec
 [cols="40%,30%,30%",options="header"]
 |====
 |Event name |Description|Payload
-|Actions Katello Content View Promote Succeeded |A content view was successfully promoted.|Actions::Katello::ContentView::Promote
+|Actions Katello Content View Promote Succeeded |A Content View was successfully promoted.|Actions::Katello::ContentView::Promote
 |Actions Katello Content View Publish Succeeded |A repository was successfully synchronized.|Actions::Katello::ContentView::Publish
 |Actions Remote Execution Run Host Job Succeeded |A generic remote execution job succeeded for a host. This event is emitted for all Remote Execution jobs, when complete.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Katello Errata Install Succeeded |Install errata using the Katello interface.|Actions::RemoteExecution::RunHostJob
@@ -38,7 +38,7 @@ endif::[]
 |Actions Remote Execution Run Host Job Leapp Upgrade Succeeded |Run Leapp upgrade job for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
 |Build Entered |A host entered the build mode.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
 |Build Exited |A host build mode was canceled, either it was successfully provisioned or the user canceled the build manually.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
-|Content View Created/Updated/Destroyed |Common database operations on a content view.|Katello::ContentView
+|Content View Created/Updated/Destroyed |Common database operations on a Content View.|Katello::ContentView
 |Domain Created/Updated/Destroyed |Common database operations on a domain.|Domain
 |Host Created/Updated/Destroyed |Common database operations on a host.|Host
 |Hostgroup Created/Updated/Destroyed |Common database operations on a hostgroup.|Hostgroup


### PR DESCRIPTION
- Fixed instances where "Content Views" have been mentioned as "content views".
- Added an oxford comma in con_monitoring-resources.adoc.
- Capitalized "Lifecycle Environment" in proc_prerequisites-for-puppet.adoc
- Replaced "them" with "then" in proc_connected-foreman-for-managing-content-view-versions.adoc


Cherry-pick into:

* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->

@melcorr 