### PR TITLE
Implement asciidoctor-reducer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'asciidoctor'
+gem 'asciidoctor-reducer'
 gem 'asciidoctor-pdf'
 # missing dependency for asciidoctor-pdf
 gem 'matrix'

--- a/guides/.gitignore
+++ b/guides/.gitignore
@@ -6,3 +6,4 @@
 /scripts/docs-Red_Hat_Satellite_6/
 /scripts/foreman-documentation/
 *.diff
+*/master-*.adoc

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -9,6 +9,8 @@ html: subdirs
 
 pdf: subdirs
 
+reduced: subdirs
+
 subdirs: $(SUBDIRS)
 
 $(SUBDIRS):

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -12,7 +12,7 @@ IMAGES_DIR = $(DEST_DIR)/images
 IMAGES_TS = $(DEST_DIR)/.timestamp-images
 CSS_SOURCES = $(shell find $(COMMON_DIR)/css -type f)
 DOCINFO_SOURCES = $(shell find $(COMMON_DIR)/ -type f -name docinfo\*.html)
-SOURCES = master.adoc $(shell find . -type f -name \*.adoc)
+SOURCES = master.adoc $(shell find . -type f -name \*.adoc -and ! -name master-\*.adoc)
 DEPENDENCIES = $(shell find $(COMMON_DIR) -type f -name \*.adoc)
 IMAGES = $(shell find ./images ./common/images -type f 2>/dev/null || true)
 UNAME = $(shell uname)
@@ -50,7 +50,7 @@ html: prepare $(IMAGES_TS) $(DEST_HTML)
 pdf: prepare $(DEST_PDF)
 
 clean:
-	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)"
+	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)" master-*.adoc
 
 browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
@@ -64,6 +64,8 @@ linkchecker: html
 open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"
 
+reduced: master-$(BUILD).adoc
+
 $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
 	bundle exec sass --cache-location $(DEST_DIR)/sass-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 
@@ -71,6 +73,9 @@ $(IMAGES_TS): $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"
 	cp -lLrf ./images/* $(IMAGES_DIR)
 	@touch $(IMAGES_TS)
+
+master-$(BUILD).adoc: $(SOURCES) $(DEPENDENCIES)
+	bundle exec asciidoctor-reducer -a build=$(BUILD) -a imagesdir=./images -o $@ $<
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD).css $(IMAGES_TS)
 	bundle exec asciidoctor -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2


### PR DESCRIPTION
This uses [asciidoctor-reducer](https://github.com/asciidoctor/asciidoctor-reducer) to generate a complete adoc file for the particular build. This can make it easier to review a complete doc.

It's mostly research to find out if we can write some automated rules for common errors. asciidoctor looks like a parser you can plug into and get context like line numbers. This commit itself may not go anywhere. It's mostly here for demonstration purposes.