### PR TITLE
Add initial Katello 4.4.0 changelog entries

### DIFF
--- a/guides/doc-Release_notes/topics/katello-4.4.0.adoc
+++ b/guides/doc-Release_notes/topics/katello-4.4.0.adoc
@@ -1,0 +1,88 @@
+= Katello 4.4.0
+
+A full list of changes is available via https://projects.theforeman.org/projects/katello/issues?utf8=%E2%9C%93&set_filter=1&sort=id%3Adesc%2C%2C&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1517&f%5B%5D=&c%5B%5D=tracker&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=subject&c%5B%5D=author&c%5B%5D=assigned_to&c%5B%5D=updated_on&c%5B%5D=category&c%5B%5D=fixed_version&group_by=[Redmine]
+
+= 4.4.0 Habanero (2022-02-11)
+
+== Features
+
+=== Repositories
+ * Use the APT verbatim publisher for deb content on Pulp 3 foreman-proxy syncs (https://projects.theforeman.org/issues/34279[#34279], https://github.com/Katello/katello.git/commit/4a363fd945d56ad48f6a30446d9c16320819d4a5[4a363fd9])
+
+=== Hosts
+ * Hosts - Change content source (https://projects.theforeman.org/issues/34211[#34211], https://github.com/Katello/katello.git/commit/c5f8e9532e61f9e5c7ec648decf81660628dd4ba[c5f8e953])
+ * Katello host detail tabs should accept URL params for search (https://projects.theforeman.org/issues/34157[#34157], https://github.com/Katello/katello.git/commit/a12116ef4cb843c87ca9f149b1b573cd14afb03c[a12116ef])
+ * Packages - Filter by status (https://projects.theforeman.org/issues/34131[#34131], https://github.com/Katello/katello.git/commit/38e14d1e02d73b430ca97fd813c6ac397ac707ee[38e14d1e])
+
+=== Content Views
+ * Extend CV API to support bulk removing versions (https://projects.theforeman.org/issues/34168[#34168], https://github.com/Katello/katello.git/commit/9e6b0d07ef198f7a0d55399e536844cb0908150b[9e6b0d07])
+
+=== Web UI
+ * New Host details overview - Installable errata card (https://projects.theforeman.org/issues/33083[#33083])
+
+=== Foreman Proxy Content
+ * Provide RHSM and content URL as info providers (https://projects.theforeman.org/issues/32835[#32835], https://github.com/Katello/katello.git/commit/f3daacdb4f2cb5d13e11401db708b41a0ed1644d[f3daacdb])
+
+=== Other
+ * Add remote download rate limit (https://projects.theforeman.org/issues/34345[#34345], https://github.com/Katello/katello.git/commit/7776b81ba39ded5eee3d7cc60dd793640b56132f[7776b81b])
+ * Allow "on_demand" download policy for repositories of content_type docker (https://projects.theforeman.org/issues/34217[#34217], https://github.com/Katello/katello.git/commit/d2c20af6911adb02ca9005350a9f2c1ad1f8140b[d2c20af6])
+ * Add default download policy for deb content (https://projects.theforeman.org/issues/34119[#34119], https://github.com/Katello/katello.git/commit/48c128db02a1d9e95a81e371f4d9229ae25ebb5b[48c128db])
+ * When choosing what capsule to use for Remote Execution into a host, use the host's "Registered through" capsule (https://projects.theforeman.org/issues/33425[#33425], https://github.com/Katello/katello.git/commit/840cbe6ff546582272ebacf479c25f03c3946c7a[840cbe6f])
+
+== Bug Fixes
+
+=== Repositories
+ * exclude source redhat containers by default (https://projects.theforeman.org/issues/34398[#34398], https://github.com/Katello/katello.git/commit/9375ebb3f9c9a2ae5a1467ac4c6f937a2d3092c3[9375ebb3])
+ * test_resync_limit_tags_deletes_proper_repo_association_meta_tags fails with VCR error (https://projects.theforeman.org/issues/34294[#34294], https://github.com/Katello/katello.git/commit/fd541f5d384c619e76ce2a4c5533a64ad0d8044f[fd541f5d])
+ * reindex repos after recreating them as part of correct_repositories (https://projects.theforeman.org/issues/34235[#34235], https://github.com/Katello/katello.git/commit/d60fb2b3bc6cc087afec8822cf8ff45cb33b7f6a[d60fb2b3])
+ * Restrict to Architecture setting in yum type repos has no effect (https://projects.theforeman.org/issues/34041[#34041], https://github.com/Katello/katello.git/commit/68ec6706a796181c9bc57bc73b75002f616f334e[68ec6706])
+ * Capsule sync task failed to refresh repo that doesn't have feed url (https://projects.theforeman.org/issues/33966[#33966])
+ * In rare cases upstream APT (deb content) repos can exceed size limited DB fields (https://projects.theforeman.org/issues/33804[#33804], https://github.com/Katello/katello.git/commit/e75900ae6383ed62bf2a2b02039e9eaf46bfb78c[e75900ae])
+ * Many Postgres ERRORs (duplicate key) especially on RedHat repo sync (https://projects.theforeman.org/issues/33451[#33451], https://github.com/Katello/katello.git/commit/215b0401dcdda07ecf300d1751b43c2062f461e3[215b0401])
+ * revert monkey patch for pulp_rpm_client 3.13.3 (https://projects.theforeman.org/issues/32976[#32976], https://github.com/Katello/katello.git/commit/4897c73c45f375077b41316e301c44348e5a776e[4897c73c])
+
+=== Tests
+ * host collection test failure (https://projects.theforeman.org/issues/34390[#34390], https://github.com/Katello/katello.git/commit/7c635a798248703d1c5f4f8bcc99e2c1e60e8a23[7c635a79])
+ * add generic test framework for more easily testing new content types (https://projects.theforeman.org/issues/34178[#34178], https://github.com/Katello/katello.git/commit/d5ac4b66dc4928c681e59a25a3a6f46019b3fb61[d5ac4b66])
+
+=== Web UI
+ * CV UI -  Content view version list API being called multiple times (https://projects.theforeman.org/issues/34347[#34347], https://github.com/Katello/katello.git/commit/97a0bd4b93653978a475403b3a1bc3f502922388[97a0bd4b])
+ * Fix inconsistent Katello test failures on CI (https://projects.theforeman.org/issues/34285[#34285], https://github.com/Katello/katello.git/commit/86565c03d852369fa0fa40106d7340b3a8cee51f[86565c03])
+ * Sync status showing never synced even though the repositories has been synced successfully (https://projects.theforeman.org/issues/34143[#34143], https://github.com/Katello/katello.git/commit/72756ada8c9382b25e4b03d2aaa5ce3b996077c2[72756ada])
+ * Katello - Nightly failures due to package availability (https://projects.theforeman.org/issues/33953[#33953], https://github.com/Katello/katello.git/commit/fd833f23e9a69ee8ba035660c339b6e25c1a6d64[fd833f23])
+ * New Content View details: Switching autopublish switch reloads entire page (https://projects.theforeman.org/issues/32379[#32379], https://github.com/Katello/katello.git/commit/8ca9d36efa44b8f2fa0982b066e7483989407fec[8ca9d36e])
+
+=== Hosts
+ * Incorrect layout of new host details overview cards (https://projects.theforeman.org/issues/34258[#34258], https://github.com/Katello/katello.git/commit/bafada6dd069a3f1715b936cf9d1053a94b06bd9[bafada6d])
+ * "Confirm services restart" modal window grammatically does not respect that multiple systems are selected for a reboot (https://projects.theforeman.org/issues/34037[#34037], https://github.com/Katello/katello.git/commit/30e6fe7d91d6296bb02830e4afaa3f66bee38795[30e6fe7d])
+
+=== Tooling
+ * faraday 1.9 and greater breaks tests (https://projects.theforeman.org/issues/34229[#34229], https://github.com/Katello/katello.git/commit/64b10e968117c79a441e3f9f1f253605722b2557[64b10e96])
+ * Re-enable disabled Rubocop cops that were turned off when fixing Rubocop Jenkins failure step (https://projects.theforeman.org/issues/31436[#31436], https://github.com/Katello/katello.git/commit/89230c545f5775c347d3bb259cacf89c665e5790[89230c54])
+
+=== Inter Server Sync
+ *  [RFE] Need a way to sync from a specific content view lifecycle environment of the upstream organization (https://projects.theforeman.org/issues/34144[#34144], https://github.com/Katello/katello.git/commit/0cda22e6c989d5897bd19b936dead485d7290b73[0cda22e6])
+ * RH Repos page should not access CDN on 'disconnected' mode (https://projects.theforeman.org/issues/33951[#33951], https://github.com/Katello/katello.git/commit/3e8f26961ff2a84a1de0b5dea197ea49a514d391[3e8f2696], https://github.com/Katello/katello.git/commit/b09ddee2f2c395c86f2f8c6cc862cc680f9debea[b09ddee2])
+
+=== Lifecycle Environments
+ * Katello should notify about published content view while removing Lifecycle environment (https://projects.theforeman.org/issues/33978[#33978], https://github.com/Katello/katello.git/commit/b8ac863c19f28d000ecd503e5cba359639240dd3[b8ac863c])
+
+=== Organizations and Locations
+ * Creating Organization produces two Audit logs (https://projects.theforeman.org/issues/33952[#33952], https://github.com/Katello/katello.git/commit/f83c785650bf03d7f2db00e3aabd7faac9448983[f83c7856], https://github.com/Katello/katello.git/commit/33994b57ed3e28a09ed9974fe58108f856287790[33994b57])
+
+=== Content Views
+ * Versions API with wrong/deleted CV id shows all versions in the org (https://projects.theforeman.org/issues/33860[#33860], https://github.com/Katello/katello.git/commit/211af427cb65d74f8ef4d892d1d29c61a191bd84[211af427])
+
+=== Client/Agent
+ * Old ApplicableContentHelper references cause `rake katello:import_applicability` to fail (https://projects.theforeman.org/issues/33554[#33554], https://github.com/Katello/katello.git/commit/15ec6dab54333667ed1a98b3556445f2b56ce57f[15ec6dab])
+
+=== Other
+ * Docker download policy test failure (https://projects.theforeman.org/issues/34295[#34295], https://github.com/Katello/katello.git/commit/d4f2976f4d28e574d291dcbb793afa02b7b8a363[d4f2976f])
+ * stop using 'mirror=true' for smart proxy rpm repo syncs  (https://projects.theforeman.org/issues/34216[#34216], https://github.com/Katello/katello.git/commit/bc1bcf41a559006e3ac96b9cb1ef0b24a0be9e19[bc1bcf41])
+ * Generic content units don't have the endpoint to filter out CV or CV-Version specific content (https://projects.theforeman.org/issues/34184[#34184], https://github.com/Katello/katello.git/commit/efb05fd6236b9036a037e0a607c2d45d1fd5a7b9[efb05fd6])
+ * hammer content-view component list does not list content-view ID (https://projects.theforeman.org/issues/34174[#34174], https://github.com/Katello/hammer-cli-katello.git/commit/701d938830cc54357bafe19a4be6c857f58cc9dd[701d9388])
+ * support new foreman tasks (https://projects.theforeman.org/issues/34097[#34097], https://github.com/Katello/katello.git/commit/d10534ae36aef9843a7a200cf651062d0628e630[d10534ae])
+ * Enable debian architecture support (https://projects.theforeman.org/issues/34087[#34087], https://github.com/Katello/katello.git/commit/52d20ee20cf1865bbafb2e5bc3a6d05864217920[52d20ee2])
+ * Error Can't join 'Katello::ContentFacetRepository' to association named 'hostgroup' when clicking on "Errata Installation" inside a host_collection as a non-admin user (https://projects.theforeman.org/issues/33940[#33940], https://github.com/Katello/katello.git/commit/276371854df4323200b9b9414a9f7fea36fe5162[27637185])
+ * pr template is a little harsh (https://projects.theforeman.org/issues/33927[#33927], https://github.com/Katello/katello.git/commit/0a512b242eaa92c03bb0c0d956b88f61c6c88e68[0a512b24])
+ * Python backend remote options are not cleared after deleting the field in Katello (https://projects.theforeman.org/issues/33685[#33685], https://github.com/Katello/katello.git/commit/5a7dd4147919010540fc8ea402cc1d072ffc5572[5a7dd414])

--- a/guides/doc-Release_notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_notes/topics/katello-contributors.adoc
@@ -1,0 +1,24 @@
+* Adam Ruzicka
+* Amir Fefer
+* Andrew
+* Bastian Schmidt
+* Chris Roberts
+* Evgeni Golov
+* Ewoud Kohl van Wijngaarden
+* Ian Ballou
+* Jeremy Lenz
+* Jonathon Turel
+* Justin Sherrill
+* Lucy Fu
+* Manisha Singhal
+* Nadja Heitmann
+* Oleh Fedorenko
+* Ondřej Ezr
+* Partha Aji
+* Ron Lavi
+* Samir Jha
+* Stejskal Leos
+* Tomer Brisker
+* William Bradford Clark
+* hao-yu
+* rverdile

--- a/guides/doc-Release_notes/topics/katello.adoc
+++ b/guides/doc-Release_notes/topics/katello.adoc
@@ -4,8 +4,27 @@
 [id="katello-headline-features"]
 == Headline Features
 
+For the full list of changes, see the https://github.com/Katello/katello/blob/KATELLO-{KatelloVersion}/CHANGELOG.md[Changelog].
+
+* The repository indexing code has been rewritten and is now much faster. A 6x indexing speed improvement for the RHEL 7 RPMs repository was reported on the pull request.
+* Docker repositories can now use the "On Demand" download policy.
+* Docker repositories can now have tags both limited and included at sync time, as opposed to only included.
+  - Source container images are now excluded by default, but that may be changed by editing the "exclude tags".
+* When syncing Debian content to smart proxies, the "APT Verbatim" publisher is used in Pulp for more efficient metadata mirroring.
+* A sync download rate limit setting has been introduced under the "Content" tab.
+* Content view versions may now be removed from a content view in bulk.
+* Work on the new host details page has progressed, specifically the packages and errata overview pages:
+  - An Installable Errata card has been added to the overview, with links to pre-filtered errata views on the Errata tab.
+  - The Packages tab now offers filter dropdowns for up-to-date / upgradable status.
+* The Inter-Server Sync interface (in Content > Subscriptions > Manage Manifest) has been rewritten completely, featuring a new CDN Configuration tab with three clear options for where Katello gets its content.
+  - As part of the above, the 'content_disconnected' setting has been renamed to 'subscription_connection_enabled'.
+* The Red Hat repositories page no longer contacts the CDN when in Airgapped mode.
+* Fixed errata installation raising errors when using Remote Execution.
+* Numerous improvements to Content View exporting and importing have been included.
+
 [id="katello-upgrade-warnings"]
 == Upgrade Warnings
 
 [id="katello-deprecations"]
 == Deprecations
+* The 'docker_tags_whitelist' parameter for Docker repositories is now deprecated.  Please switch to using 'include_tags' instead.


### PR DESCRIPTION
The changelog will be updated after the first RC and so on.