### PR TITLE
Re-enable linkchecker and fix broken URLs

### DIFF
--- a/guides/Makefile
+++ b/guides/Makefile
@@ -20,12 +20,10 @@ clean:
 	done
 
 linkchecker:
-	echo "do not check links"
-	# find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
 
 linkchecker-tryer:
-	echo "do not check links"
-	# find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer
 
 serve:
 	python -m http.server --directory ./build 8813

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -7,7 +7,7 @@
 :InstallingProjectDocURL: {BaseURL}Installing_Server/{BaseFilenameURL}#
 :InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy/{BaseFilenameURL}#
 :ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
-:ManagingConfigurationsPuppetDocURL: {BaseURL}Managing_Configurations_Using_Puppet/{BaseFilenameURL}#
+:ManagingConfigurationsPuppetDocURL: {BaseURL}Managing_Configurations_Puppet/{BaseFilenameURL}#
 :ManagingOrganizationsLocationsDocURL: {BaseURL}Managing_Organizations_and_Locations/{BaseFilenameURL}#
 :PlanningDocURL: {BaseURL}Planning_Guide/{BaseFilenameURL}#
 :ProvisioningDocURL: {BaseURL}Provisioning_Guide/{BaseFilenameURL}#

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -10,8 +10,6 @@
 :TargetVersionMaintainUpgrade: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9
-// For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub
-:SpecialCaseProductVersion: 6.10
 
 // Use current RH Satellite release version for links to access.redhat.com
 :AccessRedHatComVersion: 6.10

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -17,3 +17,5 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
+  # This guide isn't published downstream yet
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.10/html-single/managing_configurations_using_puppet_integration/index

--- a/guides/common/modules/con_host-global-status-overview.adoc
+++ b/guides/common/modules/con_host-global-status-overview.adoc
@@ -24,7 +24,7 @@ For example, a run contains some failed resources.
 This status is highlighted with the color red.
 
 .Search syntax
-If you want to search for hosts according to their status, use the syntax for searching in {Project} that is outlined in the {AdministeringDocURL}Searching_and_Bookmarking_admin[] chapter of the _Administering {Project}_ guide, and then build your searches out using the following status-related examples:
+If you want to search for hosts according to their status, use the syntax for searching in {Project} that is outlined in the {AdministeringDocURL}Searching_and_Bookmarking_admin[Searching and Bookmarking] chapter of the _Administering {Project}_ guide, and then build your searches out using the following status-related examples:
 
 To search for hosts that have an *OK* status:
 

--- a/guides/common/modules/con_template-writing-reference.adoc
+++ b/guides/common/modules/con_template-writing-reference.adoc
@@ -17,13 +17,8 @@ Templates for partition tables::
 For more information, see {ProvisioningDocURL}creating-partition-tables_provisioning[Creating Partition Tables] in the _Provisioning Guide_.
 
 ifndef::orcharhino[]
-Smart Variables::
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/puppet_guide/chap-red_hat_satellite-puppet_guide-adding_puppet_modules_to_red_hat_satellite_6#sect-{Project_Link}-Puppet_Guide-Adding_Puppet_Modules_to_{Project_Link}_6-Configuring_Smart_Variables[Configuring Smart Variables] in the _Puppet Guide_.
-endif::[]
-
-ifndef::orcharhino[]
 Smart Class Parameters::
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/puppet_guide/chap-red_hat_satellite-puppet_guide-adding_puppet_modules_to_red_hat_satellite_6#sect-{Project_Link}-Puppet_Guide-Adding_Puppet_Modules_to_{Project_Link}_6-Configuring_Smart_Class_Parameters[Configuring Smart Class Parameters] in the _Puppet Guide_.
+For more information, see {ManagingConfigurationsPuppetDocURL}using-puppet-smart-parameters_managing-configurations-puppet[Configuring Smart Class Parameters] in the _Puppet Guide_.
 endif::[]
 
 This section provides an overview of {Project}-specific macros and variables that can be used in ERB templates along with some usage examples.

--- a/guides/common/modules/proc_salt-salt-variables.adoc
+++ b/guides/common/modules/proc_salt-salt-variables.adoc
@@ -4,4 +4,4 @@
 You can configure Salt Variables within {Project}.
 The configured values are available as Salt Pillar data.
 
-For more information, see {ManagingHostsDocURL}puppet_guide_configuring_a_puppet_class_{context}[Puppet smart class parameters] section on how to configure the variables' data.
+For more information, see {ManagingConfigurationsPuppetDocURL}using-puppet-smart-parameters_managing-configurations-puppet[Configuring Smart Class Parameters] in the _Puppet Guide_ on how to configure the variables' data.


### PR DESCRIPTION
This is an alternative to https://github.com/theforeman/foreman-documentation/pull/1057 which takes some commits, but also does something different.

Rather than disabling the linkchecker because something is unavailable in downstream, this takes the approach of ignoring those broken links.