### PR TITLE
Fix usage of attributes (ProjectName)

### DIFF
--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="Configuring_Server_with_a_Custom_SSL_Certificate_{context}"]
 = Configuring {ProjectServer} with a Custom SSL Certificate
 
-By default, {ProjectNameX} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
+By default, {ProjectName} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
 If you cannot use a {Project} self-signed certificate, you can configure {ProjectServer} to use an SSL certificate signed by an external Certificate Authority.
 
 To configure your {ProjectServer} with a custom certificate, complete the following procedures:

--- a/guides/common/modules/con_content-management-types-overview.adoc
+++ b/guides/common/modules/con_content-management-types-overview.adoc
@@ -1,7 +1,7 @@
 [id="Content_Management_Types_Overview_{context}"]
 = Content Management Types Overview
 
-With {ProjectNameX}, you can manage the following Red Hat content types:
+With {ProjectName}, you can manage the following Red Hat content types:
 
 ifdef::satellite[]
 RPM Packages::
@@ -27,7 +27,7 @@ ifdef::satellite[]
 Kickstart Trees::
 Import the kickstart trees for creating a system.
 New systems access these kickstart trees over a network to use as base content for their installation.
-{ProjectNameX} also contains some predefined kickstart templates as well as the ability to create your own, which are used to provision systems and customize the installation.
+{ProjectName} also contains some predefined kickstart templates as well as the ability to create your own, which are used to provision systems and customize the installation.
 endif::[]
 
 ifndef::satellite[]

--- a/guides/common/modules/con_introduction-to-content-management.adoc
+++ b/guides/common/modules/con_introduction-to-content-management.adoc
@@ -4,7 +4,7 @@
 In the context of {Project}, _content_ is defined as the software installed on systems.
 This includes, but is not limited to, the base operating system, middleware services, and end-user applications.
 ifdef::satellite[]
-With {ProjectNameX}, you can manage the various types of content for Red Hat Enterprise Linux systems at every stage of the software life cycle.
+With {ProjectName}, you can manage the various types of content for Red Hat Enterprise Linux systems at every stage of the software life cycle.
 endif::[]
 ifndef::satellite[]
 With {Project}, you can manage the various types of content at every stage of the software life cycle.
@@ -16,7 +16,7 @@ The Katello plug-in provides content management features to Foreman.
 You can only use this guide if you have the Katello plug-in installed.
 endif::[]
 
-{ProjectNameX} manages the following content:
+{ProjectName} manages the following content:
 
 ifdef::satellite[]
 Subscription management::

--- a/guides/common/modules/con_iss-scenarios.adoc
+++ b/guides/common/modules/con_iss-scenarios.adoc
@@ -18,4 +18,4 @@ endif::[]
 
 You cannot use ISS to synchronize content from {ProjectServer} to {SmartProxyServer}.
 {SmartProxyServer} supports synchronization natively.
-For more information, see {PlanningDocURL}chap-Documentation-Architecture_Guide-Capsule_Server_Overview[{SmartProxyServer} Overview] in _Planning for {ProjectNameX}_.
+For more information, see {PlanningDocURL}chap-Documentation-Architecture_Guide-Capsule_Server_Overview[{SmartProxyServer} Overview] in _Planning for {ProjectName}_.

--- a/guides/common/modules/con_managing-content-views.adoc
+++ b/guides/common/modules/con_managing-content-views.adoc
@@ -1,7 +1,7 @@
 [id="Managing_Content_Views_{context}"]
 = Managing Content Views
 
-{ProjectNameX} uses Content Views to create customized repositories from the repositories.
+{ProjectName} uses Content Views to create customized repositories from the repositories.
 To do this, you must define which repositories to use and then apply certain filters to the content.
 These filters include both package filters, package group filters, errata filters, and module stream filters.
 You can use Content Views to define which software versions a particular environment uses.

--- a/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
@@ -7,7 +7,7 @@
 
 {OpenStack} provides the foundation to build a private or public Infrastructure-as-a-Service (IaaS) cloud.
 It offers a massively scalable, fault-tolerant platform for the development of cloud-enabled workloads.
-In {ProjectNameX}, you can interact with {OpenStack} REST API to create cloud instances and control their power management states.
+In {ProjectName}, you can interact with {OpenStack} REST API to create cloud instances and control their power management states.
 
 .Prerequisites
 include::snip_common-compute-resource-prereqs.adoc[]

--- a/guides/common/modules/con_provisioning-contexts.adoc
+++ b/guides/common/modules/con_provisioning-contexts.adoc
@@ -4,8 +4,8 @@
 A provisioning context is the combination of an organization and location that you specify for {Project} components.
 The organization and location that a component belongs to sets the ownership and access for that component.
 
-Organizations divide {ProjectNameX} components into logical groups based on ownership, purpose, content, security level, and other divisions.
-You can create and manage multiple organizations through {ProjectNameX} and assign components to each individual organization.
+Organizations divide {ProjectName} components into logical groups based on ownership, purpose, content, security level, and other divisions.
+You can create and manage multiple organizations through {ProjectName} and assign components to each individual organization.
 This ensures {ProjectServer} provisions hosts within a certain organization and only uses components that are assigned to that organization.
 For more information about organizations, see {ContentManagementDocURL}Managing_Organizations[Managing Organizations] in the _Content Management Guide_.
 

--- a/guides/common/modules/con_provisioning-virtual-machines-in-vmware.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-in-vmware.adoc
@@ -2,4 +2,4 @@
 = Provisioning Virtual Machines in VMware vSphere
 
 VMware vSphere is an enterprise-level virtualization platform from VMware.
-{ProjectNameX} can interact with the vSphere platform, including creating new virtual machines and controlling their power management states.
+{ProjectName} can interact with the vSphere platform, including creating new virtual machines and controlling their power management states.

--- a/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
+++ b/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
@@ -15,7 +15,7 @@ For more information about managing users, roles, and permission filters, see {A
 .Procedure
 
 . In the {awx} web UI, create a credential for your {Project}.
-For more information about creating credentials, see http://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#add-a-new-credential[Add a New Credential] and http://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#red-hat-satellite-6[{ProjectNameX} Credentials] in the _{awx} User Guide_.
+For more information about creating credentials, see http://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#add-a-new-credential[Add a New Credential] and http://docs.ansible.com/ansible-tower/latest/html/userguide/credentials.html#red-hat-satellite-6[{ProjectName} Credentials] in the _{awx} User Guide_.
 +
 [[tabl-Managing_Hosts-Integrating_Satellite_and_Ansible_Tower-Satellite_Credentials]]
 .{Project} Credentials

--- a/guides/common/modules/proc_configuring-selinux-to-ensure-access-on-custom-ports.adoc
+++ b/guides/common/modules/proc_configuring-selinux-to-ensure-access-on-custom-ports.adoc
@@ -2,13 +2,13 @@
 = Configuring SELinux to Ensure Access to {Project} on Custom Ports
 
 ifdef::satellite[]
-SELinux ensures access of {ProjectNameX} and Subscription Manager only to specific ports.
+SELinux ensures access of {ProjectName} and Subscription Manager only to specific ports.
 In the case of the HTTP cache, the TCP ports are 8080, 8118, 8123, and 10001 - 10010.
 If you use a port that does not have SELinux type `http_cache_port_t`, complete the following steps.
 endif::[]
 
 ifdef::foreman-el,katello[]
-SELinux ensures access of {ProjectNameX} only to specific ports.
+SELinux ensures access of {ProjectName} only to specific ports.
 In the case of the HTTP cache, the TCP ports are 8080, 8118, 8123, and 10001 - 10010.
 If you use a port that does not have SELinux type `http_cache_port_t`, complete the following steps.
 endif::[]

--- a/guides/common/modules/proc_creating-a-composite-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-composite-content-view.adoc
@@ -7,7 +7,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-compos
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create New View*.
 . In the *Name* field, enter a name for the view.
-{ProjectNameX} automatically completes the *Label* field from the name you enter.
+{ProjectName} automatically completes the *Label* field from the name you enter.
 . In the *Description* field, enter a description of the view.
 . Select the *Composite View?* check box to create a Composite Content View.
 . Optional: select the *Auto Publish* check box if you want the Composite Content View to be republished automatically when a Content View is republished.

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -76,7 +76,7 @@ For more information see xref:Creating_a_Custom_File_Type_Repository_{context}[]
 . Select the name of a product.
 . Click the *Repositories* tab and select *New Repository*.
 . In the *Name* field, enter a name for the repository.
-{ProjectNameX} automatically completes this field based on what you enter for *Name*.
+{ProjectName} automatically completes this field based on what you enter for *Name*.
 . From the *Type* list, select *file*.
 . In the *Upstream URL* field, enter the URL of the upstream repository to use as a source.
 . Select the *Verify SSL* check box if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.

--- a/guides/common/modules/proc_promoting-content-across-the-application-life-cycle.adoc
+++ b/guides/common/modules/proc_promoting-content-across-the-application-life-cycle.adoc
@@ -5,7 +5,7 @@ In the application life cycle chain, when content moves from one environment to 
 
 .Example Content Promotion Across {Project} Life Cycle Environments
 
-Each environment contains a set of systems registered to {ProjectNameX}.
+Each environment contains a set of systems registered to {ProjectName}.
 These systems only have access to repositories relevant to their environment.
 When you promote packages from one environment to the next, the target environment's repositories receive new package versions.
 As a result, each system in the target environment can update to the new package versions.

--- a/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
@@ -4,7 +4,7 @@
 **Deprecated** Use registration via Global registration feature.
 
 Use the bootstrap script to automate content registration and Puppet configuration.
-You can use the bootstrap script to register new hosts, or to migrate existing hosts to {ProjectNameX} from {Project} 5, RHN, SAM, or RHSM.
+You can use the bootstrap script to register new hosts, or to migrate existing hosts from RHN, SAM, RHSM, or another {ProjectName} instance.
 
 The `katello-client-bootstrap` package is installed by default on {ProjectServer}'s base operating system.
 The `bootstrap.py` script is installed in the `/var/www/html/pub/` directory to make it available to hosts at `_{foreman-example-com}_/pub/bootstrap.py`.

--- a/guides/common/modules/proc_registering-an-atomic-host.adoc
+++ b/guides/common/modules/proc_registering-an-atomic-host.adoc
@@ -1,7 +1,7 @@
 [id="Registering_an_Atomic_Host_{context}"]
 = Registering an Atomic Host to {ProjectName}
 
-Use the following procedure to register an Atomic Host to {ProjectNameX}.
+Use the following procedure to register an Atomic Host to {ProjectName}.
 
 .Procedure
 . Log in to the Atomic Host as the `root` user.

--- a/guides/common/modules/proc_using-activation-keys-for-host-registration.adoc
+++ b/guides/common/modules/proc_using-activation-keys-for-host-registration.adoc
@@ -3,8 +3,8 @@
 
 You can use activation keys to complete the following tasks:
 
-* Registering new hosts during provisioning through {ProjectNameX}.
-The kickstart provisioning templates in {ProjectNameX} contain commands to register the host using an activation key that is defined when creating a host.
+* Registering new hosts during provisioning through {ProjectName}.
+The kickstart provisioning templates in {ProjectName} contain commands to register the host using an activation key that is defined when creating a host.
 * Registering existing Red Hat Enterprise Linux hosts.
 Configure Subscription Manager to use {ProjectServer} for registration and specify the activation key when running the `subscription-manager register` command.
 

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -17,7 +17,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
-For more information on {Project} Topology, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
+For more information on {Project} Topology, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectName}_.
 
 Required ports can change based on your configuration.
 

--- a/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
+++ b/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
@@ -6,7 +6,7 @@ NOTE: The following chapter describes Red Hat content management provided by Kat
 Deployments without the plugin use Installation Media to fetch content from remote or local mirrors.
 endif::[]
 
-If you have not followed the examples in the {ProjectNameX} Content Management Guide, you can use the following initialization script to create an environment for provisioning examples.
+If you have not followed the examples in the {ProjectName} Content Management Guide, you can use the following initialization script to create an environment for provisioning examples.
 
 .Procedure
 . Create a script file (`content-init.sh`) and include the following:

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -16,7 +16,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
 ifdef::satellite[]
-For more information on {Project} Topology and an illustration of port connections, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectNameX}_.
+For more information on {Project} Topology and an illustration of port connections, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _Planning for {ProjectName}_.
 endif::[]
 
 Required ports can change based on your configuration.

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -265,8 +265,8 @@ This section provides a short overview of selected {Project} capabilities that c
 ifdef::satellite[]
 * *Importing existing hosts* – if you have existing hosts that have not been managed by {Project} in the past, you can import those hosts to {ProjectServer}.
 This procedure is usually a step in transitioning from {ProjectName} 5.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/transitioning_from_red_hat_satellite_5_to_red_hat_satellite_6/index[_Transitioning from {ProjectName} 5 to {ProjectNameX}_] for detailed documentation.
-A high level overview of the transition process is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/articles/1187643[Transitioning from Red Hat Satellite 5 to Satellite 6].
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/transitioning_from_red_hat_satellite_5_to_red_hat_satellite_6/index[_Transitioning from {ProjectName} 5 to {ProjectName} 6_] for detailed documentation.
+A high level overview of the transition process is available in the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/articles/1187643[Transitioning from {ProjectName} 5 to Satellite 6].
 endif::[]
 
 * *Discovering bare metal hosts* – the {Project} Discovery plug-in enables automatic bare-metal discovery of unknown hosts on the provisioning network.

--- a/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
@@ -1,12 +1,12 @@
 [id="Migrating_a_Self_Registered_Server_{context}"]
 = Migrating Self-Registered {Project}s
 
-{ProjectNameX} does not support self-registered {Project}s.
+{ProjectName} does not support self-registered {Project}s.
 You must migrate self-registered {ProjectServer}s to the Red Hat Content Delivery Network.
 
 To migrate a self-registered {Project} to the Red Hat Content Delivery Network, complete the following steps.
 
-. Verify whether {ProjectServer} is being managed by Foreman:
+. Verify whether {ProjectServer} is being managed by {Project}:
 .. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 .. On the host that you want to migrate, click *Edit*.
 .. In the upper right of the screen, if you can view the *Unmanage host* button, click *Unmanage host*.
@@ -47,8 +47,8 @@ To remove the `katello-agent`, stop and disable the `goferd` service, then enter
 . Register your {ProjectServer} to the Red Hat Customer Portal:
 +
 [NOTE]
-If your {ProjectNameX} subscription is in the {Project} Manifest, you must remove the subscription.
-This makes the {ProjectNameX} subscription available to attach to the target server.
+If your {ProjectName} subscription is in the {Project} Manifest, you must remove the subscription.
+This makes the {ProjectName} subscription available to attach to the target server.
 To locate the manifest, log on to the Customer{nbsp}Portal, click *Subscriptions*, click *{Project} Organizations*, then click the *All Subscription Management Applications* tab.
 For more information, see {ContentManagementDocURL}Managing_Red_Hat_Subscriptions_content-management[Managing Red Hat Subscriptions] in the _Content Management_ guide.
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -2,7 +2,7 @@
 = Upgrade Overview
 
 This chapter details the prerequisites and available upgrade paths to {ProjectName} {ProjectVersion}.
-Review this information before upgrading your current {ProjectNameX} installation.
+Review this information before upgrading your current {ProjectName} installation.
 
 In this guide, the terms update, upgrade, and migrate have the following meanings:
 


### PR DESCRIPTION
Cosmetic fine tuning. An attempt to remove version number from the project name, i.e. replacing {ProjectNameX} with {ProjectName}, where (hopefully) applicable.

Cherry-pick to:

* [x] Foreman 3.1

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
