### PR TITLE
Add underscore before context in anchor

### DIFF
--- a/guides/common/modules/proc_restrict-custom-repository-RHEL9.adoc
+++ b/guides/common/modules/proc_restrict-custom-repository-RHEL9.adoc
@@ -1,4 +1,4 @@
-[id="Restricting_Custom_Repository_to_RHEL9{context}"]
+[id="Restricting_Custom_Repository_to_RHEL9_{context}"]
 = Restricting Custom Repository Sets to RHEL 9 in {Project}
 
 


### PR DESCRIPTION
FYI: I've checked; the anchor is not referenced anywhere.

Cherry-pick into:

* [x] Foreman 3.1