### PR TITLE
Disable link checker for downstream docs

### DIFF
--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -17,3 +17,5 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
+  # There are no downstream 7.1 docs
+  access.redhat.com/documentation/en-us/red_hat_satellite/7.1/


### PR DESCRIPTION
There is no corresponding Satellite release to Foreman 3.2 so there is no point in checking.