### PR TITLE
Added 2 extra steps to Reclaiming PostgreSQL Space

### DIFF
--- a/guides/common/modules/proc_reclaiming-postgresql-space.adoc
+++ b/guides/common/modules/proc_reclaiming-postgresql-space.adoc
@@ -26,3 +26,18 @@ Use this procedure to reclaim some of this disk space on {Project}.
 ----
 # {foreman-maintain} service start
 ----
+. Confirm files are present under `/var/lib/pgsql/` and check its size.
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# ls -l /var/lib/pgsql/
+
+# du -sh /var/lib/pgsq/
+----
+
+. If you are using {ProjectServer} {ProjectVersionPrevious} and higher, the data from `/var/lib/pgsql/` can be deleted.
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# rm -rf /var/lib/pgsql/*
+----


### PR DESCRIPTION
I added two steps regarding /var/lib/pgsql/ from SATDOC-606 into the Upgrading and Updating Guide. These are steps 4 and 5 in the section for Reclaiming PostgreSQL Space. These steps will confirm all data under /var/lib/pgsql/ is cleaned.
@melcorr 

Cherry-pick into:

* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
