### PR TITLE
Links with context

### DIFF
--- a/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
@@ -7,7 +7,7 @@ You can install and use {Project} in an IPv6 network.
 Before installing {Project} in an IPv6 network, view the limitations and ensure that you meet the requirements.
 
 To provision hosts in an IPv6 network, after installing {Project}, you must also configure {Project} for the UEFI HTTP boot provisioning.
-For more information, see {InstallingProjectDocURL}configuring-for-uefi-http-boot-provisioning-in-an-ipv6-network_{context}[Configuring {Project} for UEFI HTTP Boot Provisioning in an IPv6 Network].
+For more information, see xref:configuring-for-uefi-http-boot-provisioning-in-an-ipv6-network_{context}[].
 
 include::modules/con_limitations-of-installation-in-an-ipv6-network.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_adding-network-interfaces.adoc
+++ b/guides/common/modules/con_adding-network-interfaces.adoc
@@ -19,7 +19,7 @@ For more information about adding a virtual interface, see xref:Adding_a_Virtual
 * *Bond*: Creates a bonded interface.
 NIC bonding is a way to bind multiple network interfaces together into a single interface that appears as a single device and has a single MAC address.
 This enables two or more network interfaces to act as one, increasing the bandwidth and providing redundancy.
-For more information, see {ManagingHostsDocURL}Adding_a_Bonded_Interface_{context}[Adding a Bonded Interface] in the _Managing Hosts_ guide.
+For more information, see xref:Adding_a_Bonded_Interface_{context}[].
 
 * *BMC*: Baseboard Management Controller (BMC) allows you to remotely monitor and manage the physical state of machines.
 For more information about BMC, see {InstallingProjectDocURL}enabling-power-management-on-managed-hosts_{project-context}[Enabling Power Management on Managed Hosts] in _{project-installation-guide-title}_.

--- a/guides/common/modules/con_applying-custom-configuration.adoc
+++ b/guides/common/modules/con_applying-custom-configuration.adoc
@@ -4,7 +4,7 @@
 When you install and configure {Project} for the first time using `{foreman-installer}`, you can specify that the DNS and DHCP configuration files are not to be managed by Puppet using the installer flags `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false`.
 If these flags are not specified during the initial installer run, rerunning of the installer overwrites all manual changes, for example, rerun for upgrade purposes.
 If changes are overwritten, you must run the restore procedure to restore the manual changes.
-For more information, see {InstallingProjectDocURL}restoring-manual-changes-overwritten-by-a-puppet-run_{context}[Restoring Manual Changes Overwritten by a Puppet Run].
+For more information, see {InstallingProjectDocURL}restoring-manual-changes-overwritten-by-a-puppet-run_{project-context}[Restoring Manual Changes Overwritten by a Puppet Run].
 
 To view all installer flags available for custom  configuration, run `{installer-scenario} --full-help`.
 Some Puppet classes are not exposed to the {Project} installer.

--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -44,7 +44,7 @@ By default, {ProjectServer} is installed with the Puppet agent running as a serv
 If required, you can disable Puppet agent on {ProjectServer} using the `--puppet-runmode=none` option.
 
 * If you want to manage DNS files and DHCP files manually, use the `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false` options so that Puppet does not manage the files related to the respective services.
-For more information on how to apply custom configuration on other services, see {InstallingProjectDocURL}applying-custom-configuration_{context}[Applying Custom Configuration to {Project}].
+For more information on how to apply custom configuration on other services, see {InstallingProjectDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
 
 .Procedure
 

--- a/guides/common/modules/proc_creating-a-webhook.adoc
+++ b/guides/common/modules/proc_creating-a-webhook.adoc
@@ -28,5 +28,5 @@ The application does not attempt to convert the content to match the specified c
 ERB is also allowed.
 
 ifndef::foreman-deb[]
-When configuring webhooks with endpoints with non-standard HTTP or HTTPS ports, an SELinux port must be assigned, see {InstallingProjectDocURL}configuring-selinux-to-ensure-access-on-custom-ports_{context}[Configuring SELinux to Ensure Access to {Project} on Custom Ports] in _{project-installation-guide-title}_.
+When configuring webhooks with endpoints with non-standard HTTP or HTTPS ports, an SELinux port must be assigned, see {InstallingProjectDocURL}configuring-selinux-to-ensure-access-on-custom-ports_{project-context}[Configuring SELinux to Ensure Access to {Project} on Custom Ports] in _{project-installation-guide-title}_.
 endif::[]

--- a/guides/common/modules/proc_salt-importing-salt-states.adoc
+++ b/guides/common/modules/proc_salt-importing-salt-states.adoc
@@ -13,7 +13,7 @@ This only removes the Salt State from {Project}, not from the disk of your Salt 
 . Click *Submit* to import the Salt States.
 
 After you have imported Salt States, you can assign them to hosts or Host Groups.
-Salt applies these Salt States to any hosts they are assigned to every time you {ManagingHostsDocURL}salt_guide_running_salt_{context}[run] `state.highstate`.
+Salt applies these Salt States to any hosts they are assigned to every time you xref:salt_guide_running_salt_{context}[run] `state.highstate`.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_salt-running-salt.adoc
+++ b/guides/common/modules/proc_salt-running-salt.adoc
@@ -19,7 +19,7 @@ If you select a host from the list, you can see the output of the remote job in 
 
 To view remote jobs, in the {ProjectWebUI}, navigate to *Monitor > Jobs*.
 
-Running `state.highstate` generates a {ManagingHostsDocURL}salt_guide_viewing_salt_reports_{context}[Salt report].
+Running `state.highstate` generates a xref:salt_guide_viewing_salt_reports_{context}[Salt report].
 Note that reports are uploaded to {Project} every ten minutes.
 
 You can use {Project}'s remote execution features to run arbitrary Salt functions.

--- a/guides/common/modules/proc_salt-salt-example.adoc
+++ b/guides/common/modules/proc_salt-salt-example.adoc
@@ -33,7 +33,7 @@ Welcome to {{ grains['fqdn'] }} Powered by {{ salt['pillar.get']('vendor_name') 
 ----
 +
 Access the `fqdn` Salt Grain from within this template and retrieve the `vendor_name` parameter from the Salt Pillar.
-. Import the `motd` {ManagingHostsDocURL}salt_guide_importing_salt_states_{context}[Salt State] into {Project}.
+. Import the `motd` xref:salt_guide_importing_salt_states_{context}[Salt State] into {Project}.
 . Verify that Salt has been given access to the `vendor_name` parameter by running either of the following commands on your Salt Master:
 +
 [options="nowrap" subs="attributes"]
@@ -49,7 +49,7 @@ If the output does not include the value of the `vendor_name` parameter, you mus
 # salt '*' saltutil.refresh_pillar
 ----
 +
-For information about how to refresh Salt Pillar data, see {ManagingHostsDocURL}salt_guide_viewing_enc_parameters_{context}[Salt ENC parameters].
+For information about how to refresh Salt Pillar data, see xref:salt_guide_viewing_enc_parameters_{context}[Salt ENC parameters].
 . Add the `motd` Salt State to your Salt Minions or a host group.
-. Apply the Salt State by {ManagingHostsDocURL}salt_guide_running_salt_{context}[running] `state.highstate`.
+. Apply the Salt State by xref:salt_guide_running_salt_{context}[running] `state.highstate`.
 . Optional: Verify the contents of `/etc/motd` on a Salt Minion.


### PR DESCRIPTION
This PR fixes various broken xrefs and simplifies (use xref directly without attribute containing the path to the guide) where possible.

Cherry-pick into:

* [x] Foreman 3.1