### PR TITLE
Add context to anchors

### DIFF
--- a/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
@@ -1,4 +1,4 @@
-[id="Adding_Custom_DEB_Repository_Example_for_Debian_11"]
+[id="Adding_Custom_DEB_Repository_Example_for_Debian_11_{context}"]
 = Adding {customdebtitle} Repository Example for Debian 11
 
 This example creates a product and repositories for Debian 11.

--- a/guides/common/modules/proc_installing-proxy-packages.adoc
+++ b/guides/common/modules/proc_installing-proxy-packages.adoc
@@ -1,4 +1,4 @@
-[id="installing-foreman-proxy-packages-{package-manager}"]
+[id="installing-foreman-proxy-packages-{package-manager}_{context}"]
 
 . Update all packages:
 +

--- a/guides/common/modules/proc_installing-server-packages-el.adoc
+++ b/guides/common/modules/proc_installing-server-packages-el.adoc
@@ -1,4 +1,4 @@
-[id="configuring-foreman-repositories-el-{package-manager}-{context}"]
+[id="configuring-foreman-repositories-el-{package-manager}_{context}"]
 
 . Update all packages:
 +

--- a/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
+++ b/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
@@ -1,4 +1,4 @@
-[id="using-a-synced-kickstart-repository"]
+[id="using-a-synced-kickstart-repository_{context}"]
 = Using a Synced Kickstart Repository for a Host's Operating System
 
 ifdef::foreman-el,katello[]

--- a/guides/common/modules/proc_using-shellhook-arguments.adoc
+++ b/guides/common/modules/proc_using-shellhook-arguments.adoc
@@ -1,4 +1,4 @@
-[id="using-shellhook_arguments{context}"]
+[id="using-shellhook_arguments_{context}"]
 = Using Shellhook Arguments
 
 .Procedure

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
@@ -9,7 +9,7 @@ Use the following procedures to upgrade your existing {ProjectName} to {ProjectN
 
 . xref:Upgrading_Server_{context}[]
 ifdef::satellite[]
-. xref:synchronizing_the_new_repositories[]
+. xref:synchronizing_the_new_repositories_{context}[]
 endif::[]
 . xref:upgrading_capsule_server[]
 ifdef::katello,satellite[]

--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -1,4 +1,4 @@
-[id="synchronizing_the_new_repositories"]
+[id="synchronizing_the_new_repositories_{context}"]
 = Synchronizing the New Repositories
 
 You must enable and synchronize the new {ProjectVersion} repositories before you can upgrade {SmartProxyServer}s and {Project} clients.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -12,7 +12,7 @@ For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context
 ifdef::satellite[]
 * Ensure the {ProjectName} {SmartProxy} {ProjectVersion} repository is enabled in {ProjectServer} and synchronized.
 * Ensure that you synchronize the required repositories on {ProjectServer}.
-For more information, see xref:synchronizing_the_new_repositories[].
+For more information, see xref:synchronizing_the_new_repositories_{context}[].
 endif::[]
 * If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories and publish their updated versions.
 For more information, see {ContentManagementDocURL}Managing_Content_Views_content-management[Managing Content Views] in the _Content Management Guide_.


### PR DESCRIPTION
For consistency and to allow for easier anchor/xref parsing.

I know this PR breaks one anchor for downstream, but another one is already broken 🤷 
I think we need a more permanent solution on how to handle this.
See also https://github.com/theforeman/foreman-documentation/issues/746
cc @melcorr 

````
diff --git a/guides/common/modules/proc_installing-proxy-packages.adoc b/guides/common/modules/proc_installing-proxy-packages.adoc
index e84ada79..afbb8ad2 100644
--- a/guides/common/modules/proc_installing-proxy-packages.adoc
+++ b/guides/common/modules/proc_installing-proxy-packages.adoc
@@ -1,4 +1,4 @@
-[id="installing-foreman-proxy-packages-{package-manager}"]
+[id="installing-foreman-proxy-packages-{package-manager}_{context}"]

diff --git a/guides/common/modules/proc_installing-server-packages-el.adoc b/guides/common/modules/proc_installing-server-packages-el.adoc
index 6a069b26..87c945b8 100644
--- a/guides/common/modules/proc_installing-server-packages-el.adoc
+++ b/guides/common/modules/proc_installing-server-packages-el.adoc
@@ -1,4 +1,4 @@
-[id="configuring-foreman-repositories-el-{package-manager}-{context}"]
+[id="configuring-foreman-repositories-el-{package-manager}_{context}"]
````

If this is a problem for now, I would simply revert the changes to those two files.

Cherry-pick into:

* [x] Foreman 3.1