### PR TITLE
include "HTTP Proxy to Connect to Red Hat CDN" for Katello

### DIFF
--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -7,7 +7,7 @@ Use the following procedures to configure {Project} with an HTTP proxy.
 
 include::modules/proc_adding-a-default-http-proxy.adoc[leveloffset=+1]
 
-ifdef::satellite[]
+ifdef::satellite,katello,orcharhino[]
 include::modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
this applies equally to Satellite *and* Katello installs


Cherry-pick into:

* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
