### PR TITLE
Add Foreman 3.2 links

### DIFF
--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -5,6 +5,7 @@ title: Home
 == Foreman and Katello Documentation
 
 * link:/release/nightly/[Nightly build]
+* link:/release/3.2/[3.2 (RC-phase)]
 * link:/release/3.1/[3.1 (stable)]
 * link:/release/3.0/[3.0 (supported)]
 * link:/release/2.5/[2.5 (unsupported)]

--- a/web/content/js/nav.js
+++ b/web/content/js/nav.js
@@ -5,6 +5,9 @@ let navVersions = [
 		title: "Nightly",
 		href: "nightly"
 	},{
+		title: "Foreman 3.2 - Katello 4.4 (RC-phase)",
+		href: "3.2"
+	},{
 		title: "Foreman 3.1 - Katello 4.3 (stable)",
 		href: "3.1"
 	},{

--- a/web/content/release-3.2.adoc
+++ b/web/content/release-3.2.adoc
@@ -1,0 +1,31 @@
+:FOREMAN_VER: 3.2
+:KATELLO_VER: 4.4
+
+= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+
+Use the top menu bar for navigation in the following guides:
+
+* link:/{FOREMAN_VER}/Planning_Guide/index-foreman-el.html[Planning for Foreman]
+* link:/{FOREMAN_VER}/Release_notes/index-foreman-el.html[Release notes for Foreman]
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello]
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-el.html[Foreman Quickstart Guide on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-deb.html[Foreman Quickstart Guide on Debian/Ubuntu]
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-el.html[Upgrading and Updating Foreman]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
+* link:/{FOREMAN_VER}/Deploying_on_AWS/index-foreman-el.html[Deploying Foreman on AWS (reference guide)]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-foreman-el.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Provisioning_Guide/index-foreman-el.html[Provisioning Guide]
+* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+* link:/{FOREMAN_VER}/Configuring_Ansible/index-foreman-el.html[Configuring Foreman to use Ansible]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-foreman-el.html[Managing Hosts Guide]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-el.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-deb.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-foreman-el.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Application_Centric_Deployment/index-foreman-el.html[Application Centric Deployment]


### PR DESCRIPTION
I've added some changes to get the process of publishing Foreman 3.2 (and hence Katello 4.4) docs.  This process needs to happen before I can make the release announcement since Katello relies on this new documentation website.

I'm not certain I edited everything correctly, so I need some help there. Also, is it right to say 3.2 is in the "RC-phase" as I did? It didn't seem right to say it's stable yet.