### PR TITLE
Fixed the command to install satellite-clone

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -165,12 +165,22 @@ To clone your server, complete the following steps on your target server:
 --enable=rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
 ----
 +
+ifdef::satellite[]
+. Install the `satellite-clone` package:
++
+[options="nowrap" subs="attributes"]
+----
+# yum install satellite-clone
+----
+endif::[]
+ifndef::satellite[]
 . Install the `satellite-clone` package:
 +
 [options="nowrap" subs="attributes"]
 ----
 # {package-install-project} satellite-clone
 ----
+endif::[]
 +
 After you install the `satellite-clone` tool, you can adjust any configuration to suit your own deployment in the `/etc/satellite-clone/satellite-clone-vars.yml` file.
 +


### PR DESCRIPTION
Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
