### PR TITLE
Remove mention of testing on EL 5 & 6

### DIFF
--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -237,7 +237,7 @@ For example:
 
 {Project} is actively tested with the following client operating systems:
 
-* CentOS 5, 6, 7 and 8
+* CentOS 7 and 8
 * Debian stable
 * Ubuntu LTS
 


### PR DESCRIPTION
These are end of life and since Foreman 3.0 there are no more EL 6
client packages. EL 5 has been dropped earlier.



Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request