### PR TITLE
Mention that there are EL8 packages

### DIFF
--- a/guides/doc-Planning_Guide/topics/Introduction.adoc
+++ b/guides/doc-Planning_Guide/topics/Introduction.adoc
@@ -217,7 +217,7 @@ ifndef::satellite[]
 [[Foreman_Server_Operating_System]]
 ==== {ProjectServer} Operating System
 
-{Project} has packages for CentOS 7 and clones, and Debian and clones.
+{Project} has packages for CentOS 7 & 8 and clones, and Debian and clones.
 Katello plug-in packages, which provide content management capabilities, are only available for CentOS.
 
 The only architecture {Project} has packages for is x86_64.


### PR DESCRIPTION
While planning it's good to know that there are EL8 packages. In fact, in upstream EL7 has been deprecated already and we may drop EL7 support in this or the next release.