### PR TITLE
Use Puppet 7 to install

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -36,10 +36,10 @@ endif::[]
 endif::[]
 ifdef::foreman-el,katello[]
 +
-. Install the `puppet6-release-el-{distribution-major-version}.noarch.rpm` package:
+. Install the `puppet7-release-el-{distribution-major-version}.noarch.rpm` package:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} localinstall https://yum.puppet.com/puppet6-release-el-{distribution-major-version}.noarch.rpm
+# {package-manager} localinstall https://yum.puppet.com/puppet7-release-el-{distribution-major-version}.noarch.rpm
 ----
 endif::[]


### PR DESCRIPTION
While Puppet 6 is still supported, it's better to use Puppet 7.



Cherry-pick into:

* [x] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request