### PR TITLE
Use modularity on EL8

### DIFF
--- a/guides/common/modules/con_troubleshooting.adoc
+++ b/guides/common/modules/con_troubleshooting.adoc
@@ -1,6 +1,63 @@
 [id="Troubleshooting_{context}"]
 = Troubleshooting
 
+ifdef::foreman-el,katello[]
+[id="troubleshooting_dnf_modules"]
+== DNF modules
+
+If the module fails to enable, it can mean an incorrect module is enabled. In that case, you have to resolve dependencies manually as follows. List the enabled modules:
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module list --enabled
+----
+
+=== Ruby
+
+If the Ruby 2.5 module has already been enabled, perform a module reset:
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module reset ruby
+----
+
+=== PostgreSQL
+
+If the PostgreSQL 10 module has already been enabled, perform a module reset:
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module reset postgresql
+----
+
+If a database was previously created using PostgreSQL 10, perform an upgrade:
+
+. Enable the module:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+ifdef::katello[]
+# dnf module enable katello:el8 pulpcore:el8
+endif::[]
+ifndef::katello[]
+# dnf module enable foreman:el8
+endif::[]
+----
+
+. Install the PostgreSQL upgrade package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf install postgresql-upgrade
+----
+
++
+. Perform the upgrade:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# postgresql-setup --upgrade
+----
+endif::[]
+
+ifdef::katello[]
 == "[Errno 1] Operation not permitted: ..." during repository syncing:
 
 [options="nowrap" subs="+quotes,attributes"]
@@ -30,3 +87,4 @@ If you see values greater than 0 returned from the dry-run:
 ----
 # sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' pulpcore-manager datarepair-2327
 ----
+endif::[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -24,13 +24,13 @@ ifdef::foreman-el,katello[]
 
 include::proc_configuring-repositories-el.adoc[]
 
+ifdef::foreman-el[]
 +
-. Enable Ruby 2.7 module:
+. Enable the Foreman module:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} module reset ruby
-# {package-manager} module enable ruby:2.7
+# {package-manager} module enable foreman:el8
 ----
 endif::[]
 
@@ -42,23 +42,17 @@ ifdef::katello[]
 ----
 # {package-manager} config-manager --set-enabled powertools
 ----
+
++
+. Enable the Katello and Pulpcore modules:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} module enable katello:el8 pulpcore:el8
+----
 endif::[]
-ifdef::foreman-el,katello[]
-+
-. Enable the PostgreSQL 12 module:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} module enable postgresql:12
-----
-+
-. If the PostgreSQL 10 module has already been enabled, a module reset will need to be performed.
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} module reset postgresql
-# {package-manager} module enable postgresql:12
-----
+
+If this fails to enable, see {InstallingProjectDocURL}troubleshooting_dnf_modules[DNF module enablement troubleshooting].
 
 == [[repositories-centos-7]]CentOS 7
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -52,7 +52,7 @@ include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
 
 :numbered!:
 
-ifdef::katello[]
+ifdef::foreman-el,katello[]
 [appendix]
 include::common/modules/con_troubleshooting.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
Now that there's a proper module on EL8 this should be used.

In practice a user may see conflicts if the Ruby 2.5 or PostgreSQL module has been enabled. Those are the default modules but foreman (and thus katello) pulls in ruby:2.7 and postgresql:12. This means a user must run that version.

In case of PostgreSQL it can be that there's already a version 10 database. In that case an upgrade must be performed, but this is not documented. This can be considered unsupported for installations.

However, there are essentially no real upgrade instructions anyway. It's all part of foreman-maintain but that may result in a chicken-and-egg situation where you would need updated modules to update. So for now I'm not touching that.

This is only relevant for nightly now. Ideally speaking this goes into 3.2 but there are some blockers on the infra side to be resolved.