### PR TITLE
Allow building on Darwin

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -22,9 +22,11 @@ CSS_STYLE = compressed
 
 ifeq ($(UNAME), Linux)
 BROWSER_OPEN = xdg-open
+CP_ARGS = -l
 endif
 ifeq ($(UNAME), Darwin)
 BROWSER_OPEN = open
+CP_ARGS =
 endif
 
 ifeq ($(LINKS), LOCAL)
@@ -69,7 +71,7 @@ $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
 
 $(IMAGES_TS): $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"
-	cp -lLrf ./images/* $(IMAGES_DIR)
+	cp -Lrf $(CP_ARGS) ./images/* $(IMAGES_DIR)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD).css $(IMAGES_TS)


### PR DESCRIPTION
It was reported to me that guides do not build on MacOS because there are no hardlinks. Poor MacOS users, let's fix that :)