### PR TITLE
Changed guidance for causes of corrupted content

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -104,9 +104,9 @@ There are several causes of corrupted or missing content:
 +
 You can review the list of corrupt or missing RPMs written to disk as part of the `{foreman-maintain} content migration-stats command`, `/tmp/unmigratable_content-20211025-74422-16cxfae20211120-2149-1j4pmfae` in the example above.
 +
-If there is a large percentage of missing or corrupted RPMs, for example, more than 5-10%, {Team} recommends that you review the list generated and contact support for guidance.
+For more information about determining which repository the unmigratable contents belong to, see https://access.redhat.com/solutions/6629271[How to determine the repository to run Verify Checksum on for reported corrupted RPMs].
 +
-In most cases, where the number of missing or corrupt RPMs is low, you can mark these as skipped using the following command:
+In most cases, where repositories with unmigratable contents are configured on {Project} with the *On-demand* download policy and the number of missing or corrupt RPMs are low, you can mark these as skipped using the command:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----


### PR DESCRIPTION
In the section "Preparing to Migrate Content to Pulp 3", I added some new guidance on what to do if the "content prepare" upgrade step results in unmigratable contents from Red Hat repositories using on-demand policy. I added a new paragraph for the reader to find the instructions in a Knowledge base Solution and provided the link to determine what repositories the unmigratable contents belong to. I removed a paragraph discussing a percentage of missing or corrupted RPMs and modified a paragraph discussing repositories containing unmigratable contents being configured on Satellite with the On-demand download policy.
@melcorr 

Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
