### PR TITLE
Use inline images in tables

### DIFF
--- a/guides/common/modules/proc_using-the-project-content-dashboard.adoc
+++ b/guides/common/modules/proc_using-the-project-content-dashboard.adoc
@@ -15,13 +15,13 @@ The following table shows the descriptions of the possible configuration states.
 [cols="1,3,5", options="header"]
 |====
 | Icon | State | Description
-| image::common/1.png[] | *Hosts that had performed modifications without error* | Host that successfully performed modifications during the last reporting interval.
-| image::common/2.png[] | *Hosts in error state* | Hosts on which an error was detected during the last reporting interval.
-| image::common/3.png[] | *Good host reports in the last 35 minutes* | Hosts without error that did not perform any modifications in the last 35 minutes.
-| image::common/4.png[] | *Hosts that had pending changes* | Hosts on which some resources would be applied but Puppet was configured to run in the `noop` mode.
-| image::common/5.png[] | *Out of sync hosts* | Hosts that were not synchronized and the report was not received during the last reporting interval.
-| image::common/6.png[] | *Hosts with no reports* | Hosts for which no reports were collected during the last reporting interval.
-| image::common/7.png[] | *Hosts with alerts disabled* | Hosts which are not being monitored.
+| image:common/1.png[] | *Hosts that had performed modifications without error* | Host that successfully performed modifications during the last reporting interval.
+| image:common/2.png[] | *Hosts in error state* | Hosts on which an error was detected during the last reporting interval.
+| image:common/3.png[] | *Good host reports in the last 35 minutes* | Hosts without error that did not perform any modifications in the last 35 minutes.
+| image:common/4.png[] | *Hosts that had pending changes* | Hosts on which some resources would be applied but Puppet was configured to run in the `noop` mode.
+| image:common/5.png[] | *Out of sync hosts* | Hosts that were not synchronized and the report was not received during the last reporting interval.
+| image:common/6.png[] | *Hosts with no reports* | Hosts for which no reports were collected during the last reporting interval.
+| image:common/7.png[] | *Hosts with alerts disabled* | Hosts which are not being monitored.
 |====
 +
 Click the particular configuration status to view hosts associated with it.
@@ -62,11 +62,11 @@ The following table shows the possible states of subscriptions.
 [cols="1,3,5", options="header"]
 |====
 | Icon | State | Description
-| image::common/1229.png[] | *Invalid* | Hosts that have products installed, but are not correctly subscribed.
+| image:common/1229.png[] | *Invalid* | Hosts that have products installed, but are not correctly subscribed.
 These hosts need attention immediately.
-| image::common/1230.png[] | *Partial* | Hosts that have a subscription and a valid entitlement, but are not using their full entitlements.
+| image:common/1230.png[] | *Partial* | Hosts that have a subscription and a valid entitlement, but are not using their full entitlements.
 These hosts should be monitored to ensure they are configured as expected.
-| image::common/1228.png[] | *Valid* | Hosts that have a valid entitlement and are using their full entitlements.
+| image:common/1228.png[] | *Valid* | Hosts that have a valid entitlement and are using their full entitlements.
 |====
 +
 Click the subscription type to view hosts associated with subscriptions of the selected type.

--- a/guides/common/modules/ref_navigation-tabs-in-web-ui.adoc
+++ b/guides/common/modules/ref_navigation-tabs-in-web-ui.adoc
@@ -16,7 +16,7 @@ This includes Content Views, Activation Keys, and Life Cycle Environments.
 | *Configure* | Provides general configuration tools and data including Host Groups and Puppet data.
 | *Infrastructure* | Provides tools on configuring how {Project} interacts with the environment.
 | *_User Name_* | Provides user administration where users can edit their personal information.
-| image::common/notifications1.png[]
+| image:common/notifications1.png[]
  | Provides event notifications to keep administrators informed of important environment changes.
 | *Administer* | Provides advanced configuration for settings such as Users and RBAC, as well as general settings.
 |====


### PR DESCRIPTION
In tables, you cannot use `image::`, but instead, must use inline images like `image:`.

Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1