### PR TITLE
Unlock packages before installing bind-utils 2.5

### DIFF
--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -97,26 +97,6 @@ Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to t
 
 .Testing External Updates to the DNS Zone in the IdM Server
 
-ifndef::foreman-deb[]
-. Install the `bind-utils` utility:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} bind-utils
-----
-
-endif::[]
-
-ifdef::foreman-deb[]
-
-. Install the `bind-utils` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} bind9
-----
-endif::[]
-
 . Ensure that the key in the `/etc/rndc.key` file on {ProjectServer} is the same key file that is used on the IdM server:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-external-dns.adoc
+++ b/guides/common/modules/proc_configuring-external-dns.adoc
@@ -13,17 +13,30 @@ To make any changes persistent, you must enter the `{foreman-installer}` command
 .Procedure
 
 ifndef::foreman-deb[]
-. Install the `bind-utils` package:
+. Unlock packages to enable installation of new packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages unlock
+----
+
+. Install BIND and the utility packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install} bind bind-utils
 ----
+
+. Lock the packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages lock
+----
 endif::[]
 
 ifdef::foreman-deb[]
-
-. Install the `bind-utils` package:
+. Install BIND:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2060420

Do not cherry-pick. There will be a separate PR for master+3.1+3.2.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
