### PR TITLE
Declare Foreman 2.5 unsupported

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: nightly
+:DocState: unsupported
 
 // Version numbers
 :ProjectVersion: 2.5


### PR DESCRIPTION
With the release of Foreman 3.1 version 2.5 became unsupported.