### PR TITLE
Correct the Foreman 3.2 state in navigation

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -164,7 +164,7 @@ const navVersions = [
     ]
   },
   {
-    title: "Foreman 3.2 - Katello 4.4 (stable)",
+    title: "Foreman 3.2 - Katello 4.4 (RC-phase)",
     path: "3.2",
     builds: [
       {


### PR DESCRIPTION
Fixes: 94bc6cdf7ae08ae87605ab723497ac02ba963c7b

@lzap I don't think this needs to be picked to stable releases, only the HTML part, right?


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request