### PR TITLE
Fix broken links on /nightly.html: Remove OS from navigation paths

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -337,11 +337,11 @@ const navVersions = [
           },
           {
             title: "Installing Katello Server",
-            path: "Installing_Server_on_Red_Hat"
+            path: "Installing_Server"
           },
           {
             title: "Installing Smart Proxy with Content",
-            path: "Installing_Proxy_on_Red_Hat"
+            path: "Installing_Proxy"
           },
           {
             title: "Upgrading and Updating",
@@ -405,11 +405,11 @@ const navVersions = [
           },
           {
             title: "Installing Katello Server",
-            path: "Installing_Server_on_Red_Hat"
+            path: "Installing_Server"
           },
           {
             title: "Installing Smart Proxy with Content",
-            path: "Installing_Proxy_on_Red_Hat"
+            path: "Installing_Proxy"
           },
           {
             title: "Upgrading and Updating",
@@ -473,11 +473,11 @@ const navVersions = [
           },
           {
             title: "Installing Katello Server",
-            path: "Installing_Server_on_Red_Hat"
+            path: "Installing_Server"
           },
           {
             title: "Installing Smart Proxy with Content",
-            path: "Installing_Proxy_on_Red_Hat"
+            path: "Installing_Proxy"
           },
           {
             title: "Upgrading and Updating",


### PR DESCRIPTION
I am trying to fix four broken links on [docs.theforeman.org/nightly.html](https://docs.theforeman.org/nightly.html):

* https://docs.theforeman.org/nightly/Installing_Server_on_Red_Hat/index-foreman-el.html
* https://docs.theforeman.org/nightly/Installing_Server_on_Red_Hat/index-katello.html
* https://docs.theforeman.org/nightly/Installing_Proxy_on_Red_Hat/index-katello.html
* https://docs.theforeman.org/nightly/Installing_Proxy_on_Red_Hat/index-foreman-el.html

Cherry-picking: I have no idea. I don't even know if my PR works as intended.