### PR TITLE
Fix release name of Debian Bullseye repo

### DIFF
--- a/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
@@ -25,7 +25,7 @@ For more information, see xref:Creating_a_Custom_Product_{context}[].
 ** *Architecture*: `amd64`
 * *Debian 11 security*
 ** *URL*: `\http://deb.debian.org/debian-security/`
-** *Releases*: `bullseye/updates`
+** *Releases*: `bullseye-security`
 ** *Component*: `main`
 ** *Architecture*: `amd64`
 . Click *Create Product* to create a product named `Debian 11 client`.


### PR DESCRIPTION
broken link: http://deb.debian.org/debian-security/dists/bullseye/updates
fixed link: http://deb.debian.org/debian-security/dists/bullseye-security

Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1