### PR TITLE
Document new APT download policy "on-demand"

### DIFF
--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -20,7 +20,12 @@ On Demand::
 This setting has no effect if you set a corresponding repository on a {SmartProxy} to *Immediate* because {ProjectServer} is forced to download all the packages.
 
 The *On Demand* policy acts as a _Lazy Synchronization_ feature because they save time synchronizing content.
+ifdef::satellite[]
 The lazy synchronization feature must be used only for `yum` repositories.
+endif::[]
+ifndef::satellite[]
+The lazy synchronization feature must be used only for `deb` and `yum` repositories.
+endif::[]
 You can add the packages to Content Views and promote to life cycle environments as normal.
 
 {SmartProxyServer} has the following policies:

--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -28,6 +28,15 @@ The lazy synchronization feature must be used only for `deb` and `yum` repositor
 endif::[]
 You can add the packages to Content Views and promote to life cycle environments as normal.
 
+Note that some repositories such as EPEL not only add packages to their upstream repository, but also remove older versions of packages.
+You should enable *Mirror on Sync* and use download policy *immediate* for such repositories.
+ifdef::satellite[]
+For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
+endif::[]
+ifndef::satellite[]
+For more information, see xref:Adding_Custom_RPM_Repositories_{context}[] and xref:Adding_Custom_DEB_Repositories_{context}[].
+endif::[]
+
 {SmartProxyServer} has the following policies:
 
 Immediate::

--- a/guides/common/modules/proc_adding-custom-deb-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repositories.adoc
@@ -40,6 +40,8 @@ endif::[]
 Clear this field if the repository does not require authentication.
 . In the *Upstream Password* field, enter the corresponding password for the upstream repository.
 Clear this field if the repository does not require authentication.
+. From the *Download Policy* list, select the type of synchronization {ProjectServer} performs.
+For more information, see xref:Download_Policies_Overview_{context}[].
 . Ensure to select the *Mirror on Sync* check box.
 This ensures that the content that is no longer part of the upstream repository is removed during synchronization.
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.


### PR DESCRIPTION
With Katello 4.1, it is also possible to download APT content "on-demand".

I am unsure about the second commit. The whole wording sounds off to me but I didn't come up with something better, so I just added `deb`.

Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1