### PR TITLE
Add information about changing download policies for docker images

### DIFF
--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -2,7 +2,7 @@
 = Download Policies Overview
 
 ifdef::satellite[]
-{ProjectName} provides multiple download policies for synchronizing RPM content.
+{ProjectName} provides multiple download policies for synchronizing RPM content and docker images.
 endif::[]
 ifndef::satellite[]
 {ProjectName} provides multiple download policies for synchronizing RPM and DEB content.

--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -2,10 +2,10 @@
 = Download Policies Overview
 
 ifdef::satellite[]
-{ProjectName} provides multiple download policies for synchronizing RPM content and docker images.
+{ProjectName} provides multiple download policies for synchronizing RPM content.
 endif::[]
 ifndef::satellite[]
-{ProjectName} provides multiple download policies for synchronizing RPM and DEB content.
+{ProjectName} provides multiple download policies for synchronizing RPM and DEB content and container images.
 endif::[]
 For example, you might want to download only the content metadata while deferring the actual content download for later.
 

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -22,6 +22,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-contain
 . In the *Registry Search Parameter* field, enter any search criteria that you want to use to filter your search, and then click *Discover*.
 . Optional: To further refine the *Discovered Repository* list, in the *Filter* field, enter any additional search criteria that you want to use.
 . From the *Discovered Repository* list, select any repositories that you want to import, and then click *Create Selected*.
+. Optional: To change the download policy for this docker repository to on demand, follow xref:changing_the_download_policy_for_a_repository[].
 . Optional: If you want to create a product, from the *Product* list, select *New Product*.
 . In the *Name* field, enter a product name.
 . Optional: In the *Repository Name* and *Repository Label* columns, you can edit the repository names and labels.

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -22,7 +22,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-contain
 . In the *Registry Search Parameter* field, enter any search criteria that you want to use to filter your search, and then click *Discover*.
 . Optional: To further refine the *Discovered Repository* list, in the *Filter* field, enter any additional search criteria that you want to use.
 . From the *Discovered Repository* list, select any repositories that you want to import, and then click *Create Selected*.
-. Optional: To change the download policy for this docker repository to on demand, follow xref:changing_the_download_policy_for_a_repository[].
+. Optional: To change the download policy for this docker repository to _on demand_, see xref:changing_the_download_policy_for_a_repository[].
 . Optional: If you want to create a product, from the *Product* list, select *New Product*.
 . In the *Name* field, enter a product name.
 . Optional: In the *Repository Name* and *Repository Label* columns, you can edit the repository names and labels.


### PR DESCRIPTION
- Added xref to the changing download policy doc in the repo discovery section of "Importing Container Images" in the Content Management guide.
- Changed the description for download policies in the "Download Policies overview section".


Cherry-pick into:

* [x] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
@melcorr 