### PR TITLE
Do not use link dereferencing on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ guides/common/default.css
 /web/crash.log
 /web/.byebug_history
 /web/output/
+/vendor

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -22,7 +22,7 @@ CSS_STYLE = compressed
 
 ifeq ($(UNAME), Linux)
 BROWSER_OPEN = xdg-open
-CP_ARGS = -l
+CP_ARGS = -lL
 endif
 ifeq ($(UNAME), Darwin)
 BROWSER_OPEN = open
@@ -71,7 +71,7 @@ $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
 
 $(IMAGES_TS): $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"
-	cp -Lrf $(CP_ARGS) ./images/* $(IMAGES_DIR)
+	cp -rf $(CP_ARGS) ./images/* $(IMAGES_DIR)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD).css $(IMAGES_TS)


### PR DESCRIPTION
Turns out MacOS/BSD does not support dereferencing. It is not a hard requirement, it looks like recursive copy does dereference `images/common` symlink anyway when making hard links on Linux. On MacOS (tested) it also dereference by default so it works as expected.

Cherry-pick into:

* [x] Foreman 3.2