### PR TITLE
Removed RHEL5 mention

### DIFF
--- a/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
+++ b/guides/doc-Managing_Hosts/topics/Registering_Hosts.adoc
@@ -38,7 +38,6 @@ ifdef::satellite[]
 
 Hosts must use one of the following Red{nbsp}Hat Enterprise{nbsp}Linux versions:
 
-* 5.7 or later
 * 6.1 or later*
 * 7.0 or later
 * 8.0 or later
@@ -73,4 +72,3 @@ include::../common/modules/proc_installing-the-katello-agent.adoc[leveloffset=+1
 include::proc_installing-tracer.adoc[leveloffset=+1]
 
 include::proc_installing-and-configuring-the-puppet-agent.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Removed the mention of RHEL 5 support

Bug 2062040 - Adding a note about RHEL5 and katello-host-tools on Satellite 6.10

https://bugzilla.redhat.com/show_bug.cgi?id=2062040


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
