### PR TITLE
Remove RHEL 5

### DIFF
--- a/guides/common/modules/con_registering_hosts.adoc
+++ b/guides/common/modules/con_registering_hosts.adoc
@@ -35,7 +35,6 @@ ifdef::satellite[]
 
 Hosts must use one of the following {RHEL} versions:
 
-* 5.7 or later
 * 6.1 or later*
 * 7.0 or later
 * 8.0 or later

--- a/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
+++ b/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
@@ -20,7 +20,7 @@ Use `--download-method` to change the download method from HTTP to HTTPS.
 --download-method https
 ----
 
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_creating-a-domain-for-a-host-during-registration.adoc
+++ b/guides/common/modules/proc_creating-a-domain-for-a-host-during-registration.adoc
@@ -19,7 +19,7 @@ If the domain does not exist, add it using `--add-domain`.
 --add-domain
 ----
 
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-remote-execution-on-the-host.adoc
+++ b/guides/common/modules/proc_enabling-remote-execution-on-the-host.adoc
@@ -19,7 +19,7 @@ Use `--rex` and `--rex-user` to enable remote execution and add the required SSH
 --rex-user _root_
 ----
 
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
@@ -17,7 +17,7 @@ Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` pac
 --activationkey=_activation_key_ \
 --force
 ----
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_migrating-a-host-from-red-hat-network.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-red-hat-network.adoc
@@ -22,7 +22,7 @@ Enter the user account password when prompted.
 --legacy-purge \
 --legacy-login _rhn-user_
 ----
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_providing-an-alternative-fqdn-for-the-host.adoc
+++ b/guides/common/modules/proc_providing-an-alternative-fqdn-for-the-host.adoc
@@ -31,7 +31,7 @@ If you cannot update the host to use an FQDN that is accepted by {Project}, you 
 --fqdn _node100.example.com_
 ----
 
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_providing-the-hosts-ip-address.adoc
+++ b/guides/common/modules/proc_providing-the-hosts-ip-address.adoc
@@ -19,7 +19,7 @@ Use `--ip`.
 --ip _192.x.x.x_
 ----
 
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-for-content-management-only.adoc
+++ b/guides/common/modules/proc_registering-a-host-for-content-management-only.adoc
@@ -14,7 +14,7 @@ To register a system as a content host, and omit the provisioning and configurat
 --activationkey=_activation_key_ \
 --skip-foreman
 ----
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
@@ -89,7 +89,7 @@ For advanced use cases, see xref:Advanced_Bootstrap_Script_Configuration_{contex
 --activationkey=_activation_key_
 ----
 
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-without-puppet.adoc
+++ b/guides/common/modules/proc_registering-a-host-without-puppet.adoc
@@ -18,7 +18,7 @@ If you have an existing configuration management system and do not want to insta
 --activationkey=_activation_key_ \
 --skip-puppet
 ----
-* On {RHEL} 5, 6, or 7, enter the following command:
+* On {RHEL} 6, or 7, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
I ran `find guides -iname "*.adoc" | xargs sed -i "" "s/{RHEL} 5, 6/{RHEL} 6/g"`. Note that GNU sed does not require `""` with the `-i` option.


Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1