### PR TITLE
Add procedure to create API-only user

### DIFF
--- a/guides/common/assembly_managing-users-and-roles.adoc
+++ b/guides/common/assembly_managing-users-and-roles.adoc
@@ -8,6 +8,8 @@ include::modules/proc_assigning-roles-to-a-user.adoc[leveloffset=+2]
 
 include::modules/proc_impersonating-a-different-user-account.adoc[leveloffset=+2]
 
+include::modules/proc_creating-an-api-only-user.adoc[leveloffset=+2]
+
 include::modules/con_ssh-key-management.adoc[leveloffset=+1]
 
 include::modules/proc_managing-ssh-keys-for-a-user.adoc[leveloffset=+2]

--- a/guides/common/modules/proc_creating-an-api-only-user.adoc
+++ b/guides/common/modules/proc_creating-an-api-only-user.adoc
@@ -1,0 +1,26 @@
+[id="Creating_an_API_Only_User_{context}"]
+= Creating an API-Only User
+
+You can create users that can interact only with the {Project} API.
+
+.Prerequisite
+. You have created a user and assigned roles to them.
+Note that this user must be authorized internally.
+For more information, see xref:Creating_a_User_{context}[] and xref:Assigning_Roles_to_a_User_{context}[].
+
+.Procedure
+. Log in to your {Project} as admin.
+. Navigate to *Administer > Users* and select a user.
+. On the *User* tab, set a password.
+Do not save or communicate this password with others.
+You can create pseudo-random strings on your console:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# openssl rand -hex 32
+----
+. On the *Personal Access Tokens* tab, click *Add Personal Access Token*.
+. Enter a name for the token.
+. Optional: Set an expiration date.
+. Click *Submit* to create the API token.
+. Copy the API token.


### PR DESCRIPTION
You can create a user with a secret password that you don't save to disable log-in to the Foreman Web UI.


Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1