### PR TITLE
Correct Satellite versions

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -13,8 +13,8 @@
 :ReleaseNotesURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/release_notes/index#
 
 // Attributes only for satellite build
-:ProductVersion: 7.0
-:ProductVersionPrevious: 6.10
+:ProductVersion: 6.12
+:ProductVersionPrevious: 6.11
 :TargetVersion: {ProductVersion}
 :TargetVersionMaintainUpgrade: {ProductVersion}
 // Add -beta for Beta releases

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,5 +18,6 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
-  # This guide isn't published downstream yet
+  # This isn't published downstream yet
   access.redhat.com/documentation/en-us/red_hat_satellite/6.10/html-single/managing_configurations_using_puppet_integration/index
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.11/html/upgrading_and_updating_red_hat_satellite/


### PR DESCRIPTION
Current development is tracking what will become Satellite 6.12.

https://github.com/theforeman/foreman-documentation/pull/1166 already corrects 3.1 but I wasn't quite sure what to with 3.2. Technically it doesn't map to any Satellite. You could do something like 3.12-pre but it's probably best to ignore it altogether.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request