### PR TITLE
Add title to link with DocURL attribute

### DIFF
--- a/guides/common/assembly_configuring-external-idm-dns.adoc
+++ b/guides/common/assembly_configuring-external-idm-dns.adoc
@@ -1,7 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
 [id="configuring-external-idm-dns_{context}"]
-
 = Configuring {ProductName} with External IdM DNS
 
 When {ProjectServer} adds a DNS record for a host, it first determines which {SmartProxy} is providing DNS for that domain.
@@ -14,7 +13,7 @@ For more information about Red{nbsp}Hat Identity Management, see the https://acc
 
 To configure {ProductName} to use a Red{nbsp}Hat Identity Management (IdM) server to provide DNS service, use one of the following procedures:
 
-*  xref:configuring-dynamic-dns-update-with-gss-tsig-authentication_{context}[]
+* xref:configuring-dynamic-dns-update-with-gss-tsig-authentication_{context}[]
 
 * xref:configuring-dynamic-dns-update-with-tsig-authentication_{context}[]
 
@@ -22,13 +21,11 @@ To revert to internal DNS service, use the following procedure:
 
 * xref:reverting-to-internal-dns-service_{context}[]
 
-
 [NOTE]
 You are not required to use {ProductName} to manage DNS.
 When you are using the realm enrollment feature of {Project}, where provisioned hosts are enrolled automatically to IdM, the `ipa-client-install` script creates DNS records for the client.
 Configuring {ProductName} with external IdM DNS and realm enrollment are mutually exclusive.
-For more information about configuring realm enrollment, see {AdministeringDocURL}External_Authentication_for_Provisioned_Hosts_admin[] in the _Administering {ProjectName}_ guide.
-
+For more information about configuring realm enrollment, see {AdministeringDocURL}External_Authentication_for_Provisioned_Hosts_admin[External Authentication for Provisioned Hosts] in the _Administering {ProjectName}_ guide.
 
 //Configuring Dynamic DNS Update with GSS-TSIG Authentication
 include::modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc[leveloffset=+1]

--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -52,7 +52,7 @@ When your host uses a configuration management system but {Project} does not rec
 Otherwise it is mapped to OK.
 
 .Search syntax
-If you want to search for hosts according to their sub-status, use the syntax for searching in {Project} that is outlined in the {AdministeringDocURL}Searching_and_Bookmarking_admin[] chapter of the _Administering {Project}_ guide, and then build your searches out using the following status-related examples:
+If you want to search for hosts according to their sub-status, use the syntax for searching in {Project} that is outlined in the {AdministeringDocURL}Searching_and_Bookmarking_admin[Searching and Bookmarking] chapter of the _Administering {Project}_ guide, and then build your searches out using the following status-related examples:
 
 You search for hosts' configuration sub-statuses based on their last reported state.
 

--- a/guides/common/modules/con_permissions-for-remote-execution.adoc
+++ b/guides/common/modules/con_permissions-for-remote-execution.adoc
@@ -15,7 +15,7 @@ You can use the `view_hosts` and `view_smart_proxies` permissions to limit which
 The `execute_template_invocation` permission is a special permission that is checked immediately before execution of a job begins.
 This permission defines which job template you can run on a particular host.
 This allows for even more granularity when specifying permissions.
-For more information on working with roles and permissions, see {AdministeringDocURL}Creating_and_Managing_Roles_admin[] in the _Administering {ProjectName}_ guide.
+For more information on working with roles and permissions, see {AdministeringDocURL}Creating_and_Managing_Roles_admin[Creating and Managing Roles] in the _Administering {ProjectName}_ guide.
 
 The following example shows filters for the `execute_template_invocation` permission:
 

--- a/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
+++ b/guides/common/modules/proc_adding-server-as-a-dynamic-inventory-item.adoc
@@ -9,7 +9,7 @@ To add {ProjectServer} to {awx} as a dynamic inventory item, you must create a c
 * If your {Project} deployment is large, for example, managing tens of thousands of hosts, using a non-admin user can negatively impact performance because of time penalties that accrue during authorization checks.
 For large deployments, consider using an admin user.
 * For non-admin users, you must assign the `{awx} Inventory Reader` role to your {ProjectServer} user.
-For more information about managing users, roles, and permission filters, see {AdministeringDocURL}Creating_and_Managing_Roles_admin[] in _Administering {ProjectName}_ guide.
+For more information about managing users, roles, and permission filters, see {AdministeringDocURL}Creating_and_Managing_Roles_admin[Creating and Managing Roles] in _Administering {ProjectName}_ guide.
 * You must host your {ProjectServer} and {awx} on the same network or subnet.
 
 .Procedure

--- a/guides/common/modules/proc_applying-errata-to-a-host.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host.adoc
@@ -9,14 +9,14 @@ ifdef::satellite[]
 For more information, see xref:Synchronizing_Repositories_{context}[].
 endif::[]
 * Register the host to an environment and Content View on {ProjectServer}.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.
 * Configure the host for remote execution.
-For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[] in the _Managing Hosts_ guide.
+For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in the _Managing Hosts_ guide.
 
 [NOTE]
 ====
 If the host is already configured to receive content updates with the deprecated Katello Agent, migrate to remote execution instead.
-For more information, see {ManagingHostsDocURL}migrating-from-katello-agent-to-remote-execution_managing-hosts[] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}migrating-from-katello-agent-to-remote-execution_managing-hosts[Migrating From Katello Agent to Remote Execution] in the _Managing Hosts_ guide.
 ====
 
 The procedure to apply an erratum to a managed host depends on its operating system.

--- a/guides/common/modules/proc_applying-errata-to-multiple-hosts.adoc
+++ b/guides/common/modules/proc_applying-errata-to-multiple-hosts.adoc
@@ -7,14 +7,14 @@ Use these procedures to review and apply errata to multiple RHEL 7 hosts.
 * Synchronize {ProjectName} repositories with the latest errata available from Red{nbsp}Hat.
 For more information, see xref:Synchronizing_Repositories_{context}[].
 * Register the hosts to an environment and Content View on {ProjectServer}.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.
 * Configure the host for remote execution.
-For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[] in the _Managing Hosts_ guide.
+For more information about running remote execution jobs, see {ManagingHostsDocURL}configuring-and-setting-up-remote-jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in the _Managing Hosts_ guide.
 
 [NOTE]
 ====
 If the host is already configured to receive content updates with the deprecated Katello Agent, migrate to remote execution instead.
-For more information, see {ManagingHostsDocURL}migrating-from-katello-agent-to-remote-execution_managing-hosts[] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}migrating-from-katello-agent-to-remote-execution_managing-hosts[Migrating From Katello Agent to Remote Execution] in the _Managing Hosts_ guide.
 ====
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -26,7 +26,7 @@ This can also cause errors when resolving dependencies for errata.
 You can view the Content View in the Content Views window.
 To view more information about the Content View, click the Content View name.
 
-To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
 [id="cli-creating-a-content-view_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
@@ -10,7 +10,7 @@ For more information, see xref:Creating_a_Custom_File_Type_Repository_{context}[
 * To use HTTPS you require the following certificates on the client:
 +
 . The `katello-server-ca.crt`.
-For more information, see {AdministeringDocURL}Installing_the_Katello_Root_CA_Certificate_admin[] in the _Administering {ProjectName}_ guide.
+For more information, see {AdministeringDocURL}Installing_the_Katello_Root_CA_Certificate_admin[Installing the Katello Root CA Certificate] in the _Administering {ProjectName}_ guide.
 . An Organization Debug Certificate.
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in the _Managing Organizations and Locations in {Project}_ guide.

--- a/guides/common/modules/proc_enabling-power-management-on-managed-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-managed-hosts.adoc
@@ -6,7 +6,7 @@ To perform power management tasks on managed hosts using the intelligent platfor
 .Prerequisites
 * All managed hosts must have a network interface of BMC type.
 {ProductName} uses this NIC to pass the appropriate credentials to the host.
-For more information, see {ManagingHostsDocURL}Adding_a_Baseboard_Management_Controller_Interface_managing-hosts[] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}Adding_a_Baseboard_Management_Controller_Interface_managing-hosts[Adding a Baseboard Management Controller (BMC) Interface] in the _Managing Hosts_ guide.
 
 .Procedure
 * To enable BMC, enter the following command:

--- a/guides/common/modules/proc_promoting-a-content-view.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view.adoc
@@ -57,4 +57,4 @@ Now the repository for the Content View appears in all environments.
 +
 Now the database content is available in all environments.
 
-To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -10,15 +10,13 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 * {oVirt}
 
 .Prerequisites
-
 * You must have a virtual machine created by {Project}.
 * For existing virtual machines, ensure that the *Display type* in the *Compute Resource* settings is *VNC*.
 * You must import the Katello root CA certificate into your {ProjectServer}.
 Adding a security exception in the browser is not enough for using noVNC.
-For more information, see the {AdministeringDocURL}Installing_the_Katello_Root_CA_Certificate_admin[] section in the _Administering {ProjectName}_ guide.
+For more information, see the {AdministeringDocURL}Installing_the_Katello_Root_CA_Certificate_admin[Installing the Katello Root CA Certificate] section in the _Administering {ProjectName}_ guide.
 
 .Procedure
-
 . On the VM host system, configure the firewall to allow VNC service on ports 5900 to 5930:
 +
 ifdef::satellite[]

--- a/guides/doc-Configuring_Load_Balancer/topics/Promoting_SCAP_Content_to_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Promoting_SCAP_Content_to_Clients.adoc
@@ -6,7 +6,7 @@ The following section describes how to promote Security Content Automation Proto
 .Prerequisites
 
 * Ensure that you configure the SCAP content.
-For more information, see {AdministeringDocURL}Configuring_SCAP_Content_admin[] in _Administering {ProjectName}_ guide.
+For more information, see {AdministeringDocURL}Configuring_SCAP_Content_admin[Configuring SCAP Content] in _Administering {ProjectName}_ guide.
 
 .Procedure
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
@@ -2,7 +2,7 @@
 = Registering Clients
 
 You can register a client running a {RHEL} 6, 7, or 8 operating system to {SmartProxyServer}s that you configure for load balancing.
-For more information about registering clients and configuring them to use Puppet, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+For more information about registering clients and configuring them to use Puppet, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.
 
 To register clients, proceed to one of the following procedures:
 

--- a/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Considerations.adoc
@@ -254,7 +254,7 @@ This allows users to get earlier access to information about potential upcoming 
 A good approach in case of problems is to start with a limited set of permissions, add permissions step by step, and test continuously.
 
 
-For instructions on defining roles and assigning them to users, see {AdministeringDocURL}Managing_Users_and_Roles_admin[] in the _Administering {ProjectName}_ guide.
+For instructions on defining roles and assigning them to users, see {AdministeringDocURL}Managing_Users_and_Roles_admin[Managing Users and Roles] in the _Administering {ProjectName}_ guide.
 The same guide contains information on configuring external authentication sources.
 
 [[sect-Additional_Tasks]]


### PR DESCRIPTION
Basically, empty titles only work for xrefs, but not DocURL links. See also commit message.

Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1