### PR TITLE
Correct the default organization name & hide debug certs in non-Katello context

### DIFF
--- a/guides/common/assembly_managing-organizations.adoc
+++ b/guides/common/assembly_managing-organizations.adoc
@@ -4,8 +4,10 @@ include::modules/proc_creating-an-organization.adoc[leveloffset=+1]
 
 include::modules/proc_setting-the-organization-context.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_creating-an-organization-debug-certificate.adoc[leveloffset=+1]
 
 include::modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_deleting-an-organization.adoc[leveloffset=+1]

--- a/guides/common/modules/con_managing-organizations.adoc
+++ b/guides/common/modules/con_managing-organizations.adoc
@@ -29,7 +29,7 @@ In this case, you can create an organization for the company's own system infras
 You can then assign content to each organization where necessary.
 
 ifndef::orcharhino[]
-A default installation of {ProjectName} has a default organization called *Default_Organization*.
+A default installation of {ProjectName} has a default organization called *Default Organization*.
 endif::[]
 
 .New Users


### PR DESCRIPTION
The default organization is named Default Organization, which results in Default_Organization as a label but this doesn't refer to labels.

I contemplated mentioning that it's affecter by the --initial-organization installer argument, but wasn't sure how to mention this clearly.

Debug certificates are a content feature, which only exists with Katello.  This means the content can be removed.

Technically this can be cherry picked but we hide all guides for non-Katello releases from the navigation so it doesn't matter that much. The other change is also pretty trivial.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request