### PR TITLE
Added information on configuring podman to trust the CA

### DIFF
--- a/guides/common/assembly_managing-container-images.adoc
+++ b/guides/common/assembly_managing-container-images.adoc
@@ -6,4 +6,6 @@ include::modules/proc_managing-container-name-patterns.adoc[leveloffset=+1]
 
 include::modules/proc_managing-container-registry-authentication.adoc[leveloffset=+1]
 
+include::modules/proc_configuring-podman-to-trust-the-ca.adoc[leveloffset=+1]
+
 include::modules/proc_using-container-registries.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -8,7 +8,7 @@ Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` 
 ----
 # mkdir -p /etc/containers/certs.d/hostname.example.com
 ----
-* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, either `{project-context}-server` or `{smart-proxy-context}-server`, and naming the file `ca.crt`:
+* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, for example, `{project-context}-server` or `{smart-proxy-context}-server`, and naming the file `ca.crt`:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -25,7 +25,7 @@ Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` 
 You no longer need to use the `--tls-verify=false` option when logging in to the registry:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# podman login hostname.example.com
+$ podman login hostname.example.com
 
 Username: admin
 Password:

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -1,0 +1,28 @@
+[id="Configuring_podman_to_trust_the_CA_{context}"]
+= Configuring Podman and Docker to trust the Certificate Authority
+
+Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
+
+* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, and naming the file `ca.crt`:
+
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ sudo cp rootCA.pem /etc/containers/certs.d/quay-server.example.com/ca.crt
+----
+
+* Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:
+
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ sudo cp rootCA.pem /etc/docker/certs.d/quay-server.example.com/ca.crt
+----
+
+You should no longer need to use the `--tls-verify=false` option when logging in to the registry:
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ sudo podman login quay-server.example.com
+
+Username: quayadmin
+Password:
+Login Succeeded!
+----

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -3,16 +3,17 @@
 
 Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
 
-* You might first need to create the location using:
-[options="nowrap", subs="+quotes,attributes"]
-----
-# mkdir -p /etc/containers/certs.d/hostname.example.com
-----
 * Copy the root CA file to one of these locations, with the exact path determined by the server hostname, for example, `{project-context}-server` or `{smart-proxy-context}-server`, and naming the file `ca.crt`:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # cp rootCA.pem /etc/containers/certs.d/hostname.example.com/ca.crt
+----
+
+* You might first need to create the location using:
+[options="nowrap", subs="+quotes,attributes"]
+----
+# mkdir -p /etc/containers/certs.d/hostname.example.com
 ----
 
 * Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -3,26 +3,31 @@
 
 Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
 
-* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, and naming the file `ca.crt`:
+* You might first need to create the location using:
+[options="nowrap", subs="+quotes,attributes"]
+----
+mkdir -p /etc/containers/certs.d/hostname.example.com
+----
+* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, either `{project-context}-server` or `{smart-proxy-context}-server`, and naming the file `ca.crt`:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ sudo cp rootCA.pem /etc/containers/certs.d/quay-server.example.com/ca.crt
+$ cp rootCA.pem /etc/containers/certs.d/hostname.example.com/ca.crt
 ----
 
 * Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ sudo cp rootCA.pem /etc/docker/certs.d/quay-server.example.com/ca.crt
+$ cp rootCA.pem /etc/docker/certs.d/hostname.example.com/ca.crt
 ----
 
-You should no longer need to use the `--tls-verify=false` option when logging in to the registry:
+You no longer need to use the `--tls-verify=false` option when logging in to the registry:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ sudo podman login quay-server.example.com
+$ podman login hostname.example.com
 
-Username: quayadmin
+Username: admin
 Password:
 Login Succeeded!
 ----

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -6,26 +6,26 @@ Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` 
 * You might first need to create the location using:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-mkdir -p /etc/containers/certs.d/hostname.example.com
+# mkdir -p /etc/containers/certs.d/hostname.example.com
 ----
 * Copy the root CA file to one of these locations, with the exact path determined by the server hostname, either `{project-context}-server` or `{smart-proxy-context}-server`, and naming the file `ca.crt`:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ cp rootCA.pem /etc/containers/certs.d/hostname.example.com/ca.crt
+# cp rootCA.pem /etc/containers/certs.d/hostname.example.com/ca.crt
 ----
 
 * Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ cp rootCA.pem /etc/docker/certs.d/hostname.example.com/ca.crt
+# cp rootCA.pem /etc/docker/certs.d/hostname.example.com/ca.crt
 ----
 
 You no longer need to use the `--tls-verify=false` option when logging in to the registry:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ podman login hostname.example.com
+# podman login hostname.example.com
 
 Username: admin
 Password:

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -3,21 +3,33 @@
 
 Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
 
-* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, for example, `{project-context}-server` or `{smart-proxy-context}-server`, and naming the file `ca.crt`:
+Copy the root CA file to one of these locations, with the exact path determined by the server hostname, and naming the file `ca.crt`
 
-[options="nowrap", subs="+quotes,attributes"]
-----
-# cp rootCA.pem /etc/containers/certs.d/hostname.example.com/ca.crt
-----
+In the following examples, replace `hostname.example.com` with `{project-context}-server.example.com` or `{smart-proxy-context}-server.example.com`, depending on your use case.
 
-* You might first need to create the location using:
+* You might first need to create the relevant location using:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # mkdir -p /etc/containers/certs.d/hostname.example.com
 ----
++
+or
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# mkdir -p /etc/docker/certs.d/hostname.example.com
+----
 
-* Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:
+* For podman, use:
++
+[options="nowrap", subs="+quotes,"]
+----
+# cp rootCA.pem /etc/containers/certs.d/hostname.example.com/ca.crt
+----
 
+* Alternatively, if you are using Docker, copy the root CA file to the equivalent Docker directory:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # cp rootCA.pem /etc/docker/certs.d/hostname.example.com/ca.crt

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -3,34 +3,6 @@
 
 Podman and Docker can be used to fetch content from container registries.
 
-.Configuring Docker and Podman to trust the Certificate Authority
-
-Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
-
-* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, and naming the file `ca.crt`:
-
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ sudo cp rootCA.pem /etc/containers/certs.d/quay-server.example.com/ca.crt
-----
-
-* Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:
-
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ sudo cp rootCA.pem /etc/docker/certs.d/quay-server.example.com/ca.crt
-----
-
-You should no longer need to use the `--tls-verify=false` option when logging in to the registry:
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ sudo podman login quay-server.example.com
-
-Username: quayadmin
-Password:
-Login Succeeded!
-----
-
 ifndef::orcharhino[]
 .Container Registries on {SmartProxies}
 

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -3,6 +3,34 @@
 
 Podman and Docker can be used to fetch content from container registries.
 
+.Configuring Docker and Podman to trust the Certificate Authority
+
+Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
+
+* Copy the root CA file to one of these locations, with the exact path determined by the server hostname, and naming the file `ca.crt`:
+
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ sudo cp rootCA.pem /etc/containers/certs.d/quay-server.example.com/ca.crt
+----
+
+* Alternatively, if you are using Docker, you can copy the root CA file to the equivalent Docker directory:
+
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ sudo cp rootCA.pem /etc/docker/certs.d/quay-server.example.com/ca.crt
+----
+
+You should no longer need to use the `--tls-verify=false` option when logging in to the registry:
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ sudo podman login quay-server.example.com
+
+Username: quayadmin
+Password:
+Login Succeeded!
+----
+
 ifndef::orcharhino[]
 .Container Registries on {SmartProxies}
 


### PR DESCRIPTION
Added text

Bug 2052838 - Podman login fails with : x509: certificate signed by unknown authority

https://bugzilla.redhat.com/show_bug.cgi?id=2052838


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
