### PR TITLE
Hide Katello only note

### DIFF
--- a/guides/common/assembly_configuring-an-alternate-cname.adoc
+++ b/guides/common/assembly_configuring-an-alternate-cname.adoc
@@ -7,11 +7,8 @@ You can configure an alternate CNAME for {Project}.
 This might be useful if you want to deploy the {Project} web interface on a different domain name than the one that is used by client systems to connect to {Project}.
 You must plan the alternate CNAME configuration in advance prior to installing {SmartProxies} and registering hosts to {Project} to avoid redeploying new certificates to hosts.
 
-ifndef::satellite[]
-This procedure is only for Katello plug-in users.
-endif::[]
-
 include::modules/proc_configuring-project-with-an-alternate-cname.adoc[leveloffset=+1]
+
 include::modules/proc_configuring-hosts-to-use-an-alternate-cname-for-content-management.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -1,10 +1,6 @@
 [[Adding-Life-Cycle-Environments]]
 = Adding Life Cycle Environments to {SmartProxyServer}s
 
-ifdef::katello[]
-This procedure is only for Katello plug-in users.
-endif::[]
-
 If your {SmartProxyServer} has the content functionality enabled, you must add an environment so that {SmartProxy} can synchronize content from {ProjectServer} and provide content to host systems.
 
 Do not assign the _Library_ lifecycle environment to your {SmartProxyServer} because it triggers an automated {SmartProxy} sync every time the CDN updates a repository.


### PR DESCRIPTION
This note is unnecessary because we only show these procedures in guides for Katello users.

Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1