### PR TITLE
Included a pre-check step in three sections

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -35,6 +35,9 @@ ifdef::katello[]
 endif::[]
 . In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*. On the Discovered Hosts page, power off and then delete the discovered hosts. From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts. Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
+
+. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/Capsule {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
+
 . Ensure that the {Project} Maintenance repository is enabled:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -36,7 +36,7 @@ endif::[]
 . In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*. On the Discovered Hosts page, power off and then delete the discovered hosts. From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts. Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
 
-. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/Capsule {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
+. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/{SmartProxy} {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
 
 . Ensure that the {Project} Maintenance repository is enabled:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -69,7 +69,7 @@ Run the pre-upgrade check script to get a list of hosts that can be deleted afte
 
 . In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*. If there are discovered hosts available, turn them off and then delete all entries under the `Discovered hosts` page. Select all other organizations in turn using the organization setting menu and repeat this action as required. Reboot these hosts after the upgrade has completed.
 
-. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/Capsule {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
+. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/{SmartProxy} {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
 
 . Make sure all external {SmartProxyServer}s are assigned to an organization, otherwise they might get unregistered due to host-unification changes.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -69,6 +69,8 @@ Run the pre-upgrade check script to get a list of hosts that can be deleted afte
 
 . In the {Project} web UI, navigate to *Hosts* > *Discovered hosts*. If there are discovered hosts available, turn them off and then delete all entries under the `Discovered hosts` page. Select all other organizations in turn using the organization setting menu and repeat this action as required. Reboot these hosts after the upgrade has completed.
 
+. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/Capsule {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
+
 . Make sure all external {SmartProxyServer}s are assigned to an organization, otherwise they might get unregistered due to host-unification changes.
 
 . Remove old repositories:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -99,6 +99,8 @@ ifdef::satellite[]
 # grep foreman_url /etc/foreman-proxy/settings.yml
 ----
 
+. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/Capsule {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
+
 . Check the available versions to confirm the version you want is listed:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -99,7 +99,7 @@ ifdef::satellite[]
 # grep foreman_url /etc/foreman-proxy/settings.yml
 ----
 
-. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/Capsule {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
+. Ensure that the `apache::purge_configs: false` entry is either not present or commented out in the `/etc/foreman-installer/custom-hiera.yaml` file of the {Project} {ProjectVersionPrevious}/{SmartProxy} {ProjectVersionPrevious} servers which will be upgraded to {ProjectVersion}.
 
 . Check the available versions to confirm the version you want is listed:
 +


### PR DESCRIPTION
Included a new pre-check step (Ensure that "apache::purge_configs: false" entry is either not present or commented out in /etc/foreman-installer/custom-hiera.yaml file of The Red Hat Satellite 6.9\Capsule 6.9 servers which will be upgraded to 6.10)in the Updating and Upgrading in three sections.
@melcorr 

Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
