### PR TITLE
Added condition for Satellite to command in line 43

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -40,7 +40,7 @@ endif::[]
 +
 For information on backups, see {AdministeringDocURL}Backing_Up_Server_and_Proxy_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
 
-ifdef::katello[]
+ifdef::katello,satellite[]
 +
 . Regenerate certificates.
 On the main {Project} server:


### PR DESCRIPTION
Per SATDOC-6404, there was a condition ifdef:: for Katello right before the steps for "Regenerate certificates". A condition for Satellite needed to be added so it was added to ifdef::katello to appear as ifdef::katello,satellite.


Cherry-pick into:

* [**YES**] Foreman 3.2
* [**YES**] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
