### PR TITLE
Added new step for /var/lib/pgsql as a prerequisite

### DIFF
--- a/guides/common/modules/proc_upgrading-project-from-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-project-from-el7-to-el8.adoc
@@ -26,7 +26,7 @@ ifdef::satellite[]
 .Prerequisites
 * {Project} {ProjectVersion} running on {RHEL} 7.
 * Access to available repositories or a local mirror of repositories.
-
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 endif::[]
 
 .Procedure

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -14,6 +14,7 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
+* If you previously upgraded {Project} from 6.7 or an earlier version, or if the `/var/lib/pgsql` directory has any content, ensure it is empty before proceeding. {Project} {ProjectVersionPrevious}'s migrated `postgres` database content will be stored in this directory.
 
 .{SmartProxy} Considerations
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -14,6 +14,7 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 
 .{SmartProxy} Considerations
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -14,7 +14,6 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
-* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 
 .{SmartProxy} Considerations
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -15,7 +15,7 @@ To confirm if a template has been edited, you can view its *History* before you 
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
 ifdef::satellite[]
-* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` directory contains any content, as it does when upgrading from older versions, empty it before proceeding.
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` directory contains any content, empty `/var/lib/pgsql` before proceeding.
 * {Project} {ProjectVersionPrevious}'s migrated `postgres` database content is stored in this directory.
 endif::[]
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -15,7 +15,7 @@ To confirm if a template has been edited, you can view its *History* before you 
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
 ifdef::satellite[]
-* If you previously upgraded {Project} from an earlier version, or if the `/var/lib/pgsql` directory has any content, ensure it is empty before proceeding.
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` directory contains any content, as it does when upgrading from older versions, empty it before proceeding.
 * {Project} {ProjectVersionPrevious}'s migrated `postgres` database content is stored in this directory.
 endif::[]
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -14,10 +14,8 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
-ifdef::satellite[]
-* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` directory contains any content, empty `/var/lib/pgsql` before proceeding.
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 * {Project} {ProjectVersionPrevious}'s migrated `postgres` database content is stored in this directory.
-endif::[]
 
 .{SmartProxy} Considerations
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -14,7 +14,12 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
-* If you previously upgraded {Project} from 6.7 or an earlier version, or if the `/var/lib/pgsql` directory has any content, ensure it is empty before proceeding. {Project} {ProjectVersionPrevious}'s migrated `postgres` database content will be stored in this directory.
+ifdef::satellite[]
+* If you previously upgraded {Project} from an earlier version, or if the `/var/lib/pgsql` directory has any content, ensure it is empty before proceeding.
+endif::[]
+ifdef::satellite[]
+* {Project} {ProjectVersionPrevious}'s migrated `postgres` database content will be stored in this directory.
+endif::[]
 
 .{SmartProxy} Considerations
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -16,9 +16,7 @@ In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the templ
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
 ifdef::satellite[]
 * If you previously upgraded {Project} from an earlier version, or if the `/var/lib/pgsql` directory has any content, ensure it is empty before proceeding.
-endif::[]
-ifdef::satellite[]
-* {Project} {ProjectVersionPrevious}'s migrated `postgres` database content will be stored in this directory.
+* {Project} {ProjectVersionPrevious}'s migrated `postgres` database content is stored in this directory.
 endif::[]
 
 .{SmartProxy} Considerations

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -14,8 +14,6 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
-* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
-* {Project} {ProjectVersionPrevious}'s migrated `postgres` database content is stored in this directory.
 
 .{SmartProxy} Considerations
 


### PR DESCRIPTION
Per SATDOC-660, I added a step in Before You Begin in the Upgrading Satellite Server section. The step added is "If you previously upgraded Satellite from 6.7 or an earlier version, or if the /var/lib/pgsql directory has any content, ensure it is empty before proceeding. Satellite 6.11’s migrated postgres database content will be stored in this directory."


Cherry-pick into:

* [YES] Foreman 3.2
* [YES] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
