### PR TITLE
Cherry-pick: Add troubleshooting section for Katello

### DIFF
--- a/guides/common/modules/con_troubleshooting.adoc
+++ b/guides/common/modules/con_troubleshooting.adoc
@@ -1,0 +1,25 @@
+[id="Troubleshooting_{context}"]
+= Troubleshooting
+
+== "[Errno 1] Operation not permitted: ..." during repository syncing:
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+# chown --recursive pulp.pulp /var/lib/pulp/media/
+----
+
+== 500 API error during syncing with "cryptography.fernet.InvalidToken" in /var/log/messages traceback:
+
+Run this on the Katello server and every smart proxy.
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+# sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' pulpcore-manager datarepair-2327 --dry-run
+----
+
+If you see values greater than 0 returned from the dry-run:
+
+[options="nowrap" subs="+quotes,attributes"]
+----
+# sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' pulpcore-manager datarepair-2327
+----

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -52,6 +52,11 @@ include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
 
 :numbered!:
 
+ifdef::katello[]
+[appendix]
+include::common/modules/con_troubleshooting.adoc[leveloffset=+1]
+endif::[]
+
 [appendix]
 include::common/modules/con_applying-custom-configuration.adoc[leveloffset=+1]
 


### PR DESCRIPTION
I've removed the Debian-related fix because it's not cherry-picked into Katello 4.3 yet.