### PR TITLE
Fix include path and reference 2.5

### DIFF
--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -31,7 +31,7 @@ To export the contents of a repository, ensure that {ProjectServer} from which y
 * Ensure that the export directory has enough free storage space to accommodate the export.
 * Ensure that the `/var/lib/pulp/exports` directory has enough free storage space equivalent to the size of the repositories being exported for temporary files created during the export process.
 * Ensure that you set download policy to *Immediate* for the repository within the Library lifecycle environment you export.
-For more information, see xref:Download_Policies_Overview_{context}[].
+For more information, see xref:Importing_Content-Configuring_Download_Policies[].
 * Ensure that you synchronize Products that you export to the required date.
 
 .Export a Repository

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -467,10 +467,10 @@ Note you must enter the full path `/var/lib/pulp/imports/<path>`. Relative paths
 A new Content View called `Import-Library` is created in the target organization.
 This Content View is used to facilitate the library content import.
 
-include::../../common/modules/proc_exporting-a-repository.adoc[leveloffset=+2]
+include::../common/modules/proc_exporting-a-repository.adoc[leveloffset=+2]
 
-include::../../common/modules/proc_exporting-a-repository-incrementally.adoc[leveloffset=+2]
+include::../common/modules/proc_exporting-a-repository-incrementally.adoc[leveloffset=+2]
 
-include::../../common/modules/proc_importing-a-repository.adoc[leveloffset=+2]
+include::../common/modules/proc_importing-a-repository.adoc[leveloffset=+2]
 
-include::../../common/modules/ref_iss-import-export-cheat-sheet.adoc[leveloffset=+2]
+include::../common/modules/ref_iss-import-export-cheat-sheet.adoc[leveloffset=+2]


### PR DESCRIPTION
No cherry-picks.
We need this fix for ccutil build.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
