### PR TITLE
Updated various outdated Content Mgmt sections

### DIFF
--- a/guides/common/modules/con_content-filter-overview.adoc
+++ b/guides/common/modules/con_content-filter-overview.adoc
@@ -34,8 +34,8 @@ There are also five types of content to filter:
 |===
 | Content Type | Description
 
-|*Package* | Filter packages based on their name and version number.
-The *Package* option filters non-modular RPM packages and errata.
+|*RPM* | Filter packages based on their name and version number.
+The *RPM* option filters non-modular RPM packages and errata.
 |*Package Group* | Filter packages based on package groups.
 The list of package groups is based on the repositories added to the Content View.
 | *Erratum (by ID)* | Select which specific errata to add to the filter.
@@ -43,4 +43,5 @@ The list of Errata is based on the repositories added to the Content View.
 | *Erratum (by Date and Type)* | Select a issued or updated date range and errata type (Bugfix, Enhancement, or Security) to add to the filter.
 | *Module Streams* | Select whether to include or exclude specific module streams.
 The *Module Streams* option filters modular RPMs and errata, but does not filter non-modular content that is associated with the selected module stream.
+| *Container Image Tag* | Select whether to include or exclude specific container image tags.
 |===

--- a/guides/common/modules/proc_adding-repositories.adoc
+++ b/guides/common/modules/proc_adding-repositories.adoc
@@ -4,8 +4,5 @@
 Use the following procedure to add the upstream CentOS repositories to your Content view.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views* > Select *CentOS Content View* > *Yum Content* Dropdown > *Repositories*.
-. Click on *Add* section on the Repository selection page.
-. Locate the *AppStream x86_64 os* and *BaseOS x86_64 os* repositories.
-. Select both repositories
-. Click *Add Repositories*
+. In the {ProjectWebUI}, navigate to *Content* > *Content Views* > Select *CentOS Content View* > *Repositories* > Select repository(ies).
+. Click *Add Repositories*.

--- a/guides/common/modules/proc_creating-a-content-filter-for-apt-content.adoc
+++ b/guides/common/modules/proc_creating-a-content-filter-for-apt-content.adoc
@@ -18,6 +18,7 @@ Depending on what you select for the new filter's content type, different option
 . Optional: In the *Description* field, enter a description for the filter.
 . Click *Save* to create your content filter.
 . Depending on what you enter for *Content Type*, add rules to create the filter that you want.
+. On the *Filter Detail* page, click on *Apply to subset of repositories* to view the *Affected repositories* tab.
 . Click the *Affected repositories* tab to select which specific repositories use this filter.
 . Click *Publish New Version* to publish the filtered repository.
 . Optional: In the *Description* field, enter a description of the changes.

--- a/guides/common/modules/proc_creating-a-content-filter-for-apt-content.adoc
+++ b/guides/common/modules/proc_creating-a-content-filter-for-apt-content.adoc
@@ -10,16 +10,14 @@ For examples of how to build a filter, see xref:Content_Filter_Examples_{context
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views* and select a Content View.
-. Select *APT Content* > *Filters* and click *New Filter*.
-. In the *Name* field, enter a name for your filter.
-. From the *Content Type* list, select the content type that you want to filter.
-Depending on what you select for the new filter's content type, different options appear.
-. From the *Inclusion Type* list, select either *Include* or *Exclude*.
+. On the *Filters* tab, click *Create filter*.
+. Enter a name.
+. From the *Content type* list, select a content type.
+. From the *Inclusion Type* list, select either *Include filter* or *Exclude filter*.
 . Optional: In the *Description* field, enter a description for the filter.
-. Click *Save* to create your content filter.
+. Click *Create filter* to create your content filter.
 . Depending on what you enter for *Content Type*, add rules to create the filter that you want.
-. On the *Filter Detail* page, click on *Apply to subset of repositories* to view the *Affected repositories* tab.
-. Click the *Affected repositories* tab to select which specific repositories use this filter.
+. Select if you want the filter to *Apply to subset of repositories* or *Apply to all repositories*.
 . Click *Publish New Version* to publish the filtered repository.
 . Optional: In the *Description* field, enter a description of the changes.
 . Click *Save* to publish a new version of the Content View.

--- a/guides/common/modules/proc_creating-a-content-filter-for-yum-content.adoc
+++ b/guides/common/modules/proc_creating-a-content-filter-for-yum-content.adoc
@@ -18,6 +18,7 @@ Depending on what you select for the new filter's content type, different option
 . Optional: In the *Description* field, enter a description for the filter.
 . Click *Save* to create your content filter.
 . Depending on what you enter for *Content Type*, add rules to create the filter that you want.
+. On the *Filter Detail* page, click on *Apply to subset of repositories* to view the *Affected repositories* tab.
 . Click the *Affected repositories* tab to select which specific repositories use this filter.
 . Click *Publish New Version* to publish the filtered repository.
 . Optional: In the *Description* field, enter a description of the changes.

--- a/guides/common/modules/proc_creating-a-content-filter-for-yum-content.adoc
+++ b/guides/common/modules/proc_creating-a-content-filter-for-yum-content.adoc
@@ -10,16 +10,14 @@ For examples of how to build a filter, see xref:Content_Filter_Examples_{context
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views* and select a Content View.
-. Select *Yum Content* > *Filters* and click *New Filter*.
-. In the *Name* field, enter a name for your filter.
-. From the *Content Type* list, select the content type that you want to filter.
-Depending on what you select for the new filter's content type, different options appear.
-. From the *Inclusion Type* list, select either *Include* or *Exclude*.
+. On the *Filters* tab, click *Create filter*.
+. Enter a name.
+. From the *Content type* list, select a content type.
+. From the *Inclusion Type* list, select either *Include filter* or *Exclude filter*.
 . Optional: In the *Description* field, enter a description for the filter.
-. Click *Save* to create your content filter.
+. Click *Create filter* to create your content filter.
 . Depending on what you enter for *Content Type*, add rules to create the filter that you want.
-. On the *Filter Detail* page, click on *Apply to subset of repositories* to view the *Affected repositories* tab.
-. Click the *Affected repositories* tab to select which specific repositories use this filter.
+. Select if you want the filter to *Apply to subset of repositories* or *Apply to all repositories*.
 . Click *Publish New Version* to publish the filtered repository.
 . Optional: In the *Description* field, enter a description of the changes.
 . Click *Save* to publish a new version of the Content View.

--- a/guides/common/modules/proc_creating-a-content-view-short.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-short.adoc
@@ -6,6 +6,6 @@ Use the following procedure to create a Content View.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create Content View*.
 . In the *Name* field, enter *CentOS Content View*.
-. In the *Description* field, enter a description for the Content View.
-. In the *Type* field, choose a *Component content view* or a *Composite content view*.
+. In the *Description* field, enter a description for the content view.
+. In the *Type* field, select a Content View or a Composite Content View.
 . Click *Create Content View*.

--- a/guides/common/modules/proc_creating-a-content-view-short.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-short.adoc
@@ -4,7 +4,8 @@
 Use the following procedure to create a Content View.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create New View*.
+. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create Content View*.
 . In the *Name* field, enter *CentOS Content View*.
 . In the *Description* field, enter a description for the Content View.
-. Click *Save*.
+. In the *Type* field, choose a *Component content view* or a *Composite content view*.
+. Click *Create Content View*.

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -10,31 +10,33 @@ While you can stipulate whether you want to resolve any package dependencies on 
 For more information, see xref:Resolving_Package_Dependencies_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create Content View*.
+. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create content view*.
 . In the *Name* field, enter a name for the view.
 {Project} automatically completes the *Label* field from the name you enter.
 . In the *Description* field, enter a description of the view.
-. In the *Type* field, choose a *Component content view* or a *Composite content view*.
-. Optional: if you want to solve dependencies automatically every time you publish this Content View, select the *Solve Dependencies* check box.
+. In the *Type* field, select a Content View or a Composite Content View.
+. Optional: if you want to solve dependencies automatically every time you publish this Content View, select the *Solve dependencies* check box.
 Dependency solving slows the publishing time and might ignore any Content View filters you use.
 This can also cause errors when resolving dependencies for errata.
+. Optional: if you want to designate this Content View for importing from an upstream server, select the *Import only* check box.
+Import-only content views cannot be published directly.
 . Click *Create Content View*.
 
-.Component Content View Steps
-. Click *Create Content View* to create the Content View.
+.Content View Steps
+. Click *Create content view* to create the Content View.
 . In the *Repositories* tab, select the repository from the *Type* list that you want to add to your Content View, select the checkbox next to the available repositories you want to add, then click *Add repositories*.
 . Click *Publish new version* and in the *Description* field, enter information about the version to log changes.
 . Optional: You can enable a promotion path by clicking *Promote* to *Select a lifecycle environment from the available promotion paths to promote new version*.
 . Click *Next*.
 . On the *Review* page, you can review the environments you are trying to publish.
 . Click *Finish*.
-. Optional: In the *Versions* tab after publishing, you can *Promote*, *Remove*, and *Delete* versions of the Content View under the options menu.
 [NOTE]
-*Remove* and *Delete* are similar but the *Delete* option will delete an entire Content View and the versions associated with that lifecycle environment. The *Remove* option allows you to choose which version you want removed from the lifecycle environment.
+*Remove* and *Delete* are similar but the *Delete* option will delete an entire Content View and the versions associated with that lifecycle environment.
+The *Remove* option allows you to choose which version you want removed from the lifecycle environment.
 
 You can view the Content View in the Content Views window.
 To view more information about the Content View, click the Content View name.
-To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
+To register a host to your Content View, see {ManagingHostsDocURL}[Registering Hosts] in the _Managing Hosts_ guide.
 
 [id="cli-creating-a-content-view_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -10,23 +10,31 @@ While you can stipulate whether you want to resolve any package dependencies on 
 For more information, see xref:Resolving_Package_Dependencies_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create New View*.
+. In the {ProjectWebUI}, navigate to *Content* > *Content Views* and click *Create Content View*.
 . In the *Name* field, enter a name for the view.
 {Project} automatically completes the *Label* field from the name you enter.
 . In the *Description* field, enter a description of the view.
+. In the *Type* field, choose a *Component content view* or a *Composite content view*.
 . Optional: if you want to solve dependencies automatically every time you publish this Content View, select the *Solve Dependencies* check box.
 Dependency solving slows the publishing time and might ignore any Content View filters you use.
 This can also cause errors when resolving dependencies for errata.
-. Click *Save* to create the Content View.
-. In the *Repository Selection* area, select the repositories that you want to add to your Content View, then click *Add Repositories*.
-. Click *Publish New Version* and in the *Description* field, enter information about the version to log changes.
-. Click *Save*.
-. Optional: to force metadata regeneration on Yum repositories, from the *Actions* list for your Content View versions, select *Regenerate Repository Metadata*.
+. Click *Create Content View*.
+
+.Component Content View Steps
+. Click *Create Content View* to create the Content View.
+. In the *Repositories* tab, select the repository from the *Type* list that you want to add to your Content View, select the checkbox next to the available repositories you want to add, then click *Add repositories*.
+. Click *Publish new version* and in the *Description* field, enter information about the version to log changes.
+. Optional: You can enable a promotion path by clicking *Promote* to *Select a lifecycle environment from the available promotion paths to promote new version*.
+. Click *Next*.
+. On the *Review* page, you can review the environments you are trying to publish.
+. Click *Finish*.
+. Optional: In the *Versions* tab after publishing, you can *Promote*, *Remove*, and *Delete* versions of the Content View under the options menu.
+[NOTE]
+*Remove* and *Delete* are similar but the *Delete* option will delete an entire Content View and the versions associated with that lifecycle environment. The *Remove* option allows you to choose which version you want removed from the lifecycle environment.
 
 You can view the Content View in the Content Views window.
 To view more information about the Content View, click the Content View name.
-
-To register a host to your Content View, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts_ guide.
+To register a host to your content view, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[] in the _Managing Hosts_ guide.
 
 [id="cli-creating-a-content-view_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -14,13 +14,13 @@ For more information, see xref:Resolving_Package_Dependencies_{context}[].
 . In the *Name* field, enter a name for the view.
 {Project} automatically completes the *Label* field from the name you enter.
 . In the *Description* field, enter a description of the view.
-. In the *Type* field, select a Content View or a Composite Content View.
-. Optional: if you want to solve dependencies automatically every time you publish this Content View, select the *Solve dependencies* check box.
+. In the *Type* field, select a *Content view* or a *Composite content view*.
+. Optional: If you want to solve dependencies automatically every time you publish this Content View, select the *Solve dependencies* check box.
 Dependency solving slows the publishing time and might ignore any Content View filters you use.
 This can also cause errors when resolving dependencies for errata.
-. Optional: if you want to designate this Content View for importing from an upstream server, select the *Import only* check box.
+. Optional: If you want to designate this Content View for importing from an upstream server, select the *Import only* check box.
 Import-only content views cannot be published directly.
-. Click *Create Content View*.
+. Click *Create content view*.
 
 .Content View Steps
 . Click *Create content view* to create the Content View.
@@ -30,13 +30,14 @@ Import-only content views cannot be published directly.
 . Click *Next*.
 . On the *Review* page, you can review the environments you are trying to publish.
 . Click *Finish*.
++
 [NOTE]
-*Remove* and *Delete* are similar but the *Delete* option will delete an entire Content View and the versions associated with that lifecycle environment.
+*Remove* and *Delete* are similar but the *Delete* option deletes an entire Content View and the versions associated with that lifecycle environment.
 The *Remove* option allows you to choose which version you want removed from the lifecycle environment.
 
 You can view the Content View in the Content Views window.
 To view more information about the Content View, click the Content View name.
-To register a host to your Content View, see {ManagingHostsDocURL}[Registering Hosts] in the _Managing Hosts_ guide.
+To register a host to your Content View, see {ManagingHostsDocURL}[Registering Hosts] in _{ManagingHostsDocTitle}_.
 
 [id="cli-creating-a-content-view_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_managing-the-lifecycle-of-the-content-view.adoc
+++ b/guides/common/modules/proc_managing-the-lifecycle-of-the-content-view.adoc
@@ -3,10 +3,10 @@
 
 The default location of any new Content View is in the Library Environment.
 Optionally, you can add a new environment and promote your Content View to it.
-Use the following procedure to create a new Lifecycle Enviroment.
+Use the following procedure to create a new Lifecycle Environment.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle Environment* and click *Create Environment Path*.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle Environments* and click *Create Environment Path*.
 . In the *Name* field, enter *Production* or the name of your new environment to add to the end of Library environment.
 . In the *Description* field, add an optional description for your new lifecycle environment.
-. Click *Save*
+. Click *Save*.

--- a/guides/common/modules/proc_promoting-your-content-view-to-the-new-lifecycle-environment.adoc
+++ b/guides/common/modules/proc_promoting-your-content-view-to-the-new-lifecycle-environment.adoc
@@ -4,8 +4,8 @@
 You can now promote your new Content View to the *Production* environment using the following procedure.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views* > *Select your Content View*
-. On the *Versions* tab Click *Promote* for desired version under the Actions column.
+. In the {ProjectWebUI}, navigate to *Content* > *Content Views* > *Select your Content View*.
+. On the *Versions* tab, click *Promote* for desired version under the Actions column.
 . Select *Production* lifecycle environment from the available promotion paths.
-. Add an optional *Description*
-. Click *Promote Version*
+. Add an optional *Description*.
+. Click *Promote Version*.

--- a/guides/common/modules/proc_viewing-module-streams.adoc
+++ b/guides/common/modules/proc_viewing-module-streams.adoc
@@ -4,8 +4,6 @@
 In {Project}, you can view the module streams of the repositories in your Content Views.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Content Views*, and select the Content View that contains the modules you want to view.
-. Click the *Versions* tab and select the Content View version that you want to view.
-. Click the *Module Streams* tab to view the module streams that are available for the Content View.
-. Use the *Filter* field to refine the list of modules.
-. To view the information about the module, click the module.
+. In the {ProjectWebUI}, navigate to a published version of a *Content View* > *Module Streams* to view the module streams that are available for the Content Types.
+. Use the *Search* field to search for specific modules.
+. To view the information about the module, click the module and its corresponding tabs to include *Details*, *Repositories*, *Profiles*, and *Artifacts*.


### PR DESCRIPTION
Per SATDOC-6389, the Content Management workflow had some outdated information in certain sections specifying the CM workflow. Some steps needed to be updated to reflect the changes to the UI including fields. Following files and their changes include:

In common/modules/con_content-filter-overview.adoc, table was updated to reflect RPM and Container Image Tag.

In common/modules/proc_adding-repositories.adoc, steps were updated to reflect latest changes to UI.

In common/modules/proc_creating-a-content-filter-for-apt-content.adoc, new step was added in the procedure for Filter Detail Page access before clicking on Affected Repositories.

In common/modules/proc_creating-a-content-filter-for-yum-content.adoc, new step was added in the procedure for Filter Detail Page access before clicking on Affected Repositories.

In common/modules/proc_creating-a-content-view-short.adoc, steps in procedure were updated to reflect changes in UI.

In common/modules/proc_creating-a-content-view.adoc,steps in procedure were updated to reflect changes in UI.

In common/modules/proc_managing-the-lifecycle-of-the-content-view.adoc, steps in procedure were updated to reflect changes in UI. Environment was misspelled.

In common/modules/proc_viewing-module-streams.adoc, steps in procedure were updated to reflect changes in UI.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
