### PR TITLE
Update project settings to reflect latest information

### DIFF
--- a/guides/common/modules/ref_project-settings.adoc
+++ b/guides/common/modules/ref_project-settings.adoc
@@ -34,6 +34,7 @@ This permits users full remote code execution on {ProjectServer}, effectively di
 This is not a safe option, especially in bigger companies.
 ifndef::orcharhino[]
 | *Exclude pattern for facts stored in {Project}* | You can use regular expressions as well as the * wildcard for excluding a pattern.
-| *Ignore interfaces with matching identifier* | You can use the * wildcard for ignoring a pattern. Regular expressions do not work with this setting.
+| *Ignore interfaces with matching identifier* | You can use the * wildcard for ignoring a pattern.
+Regular expressions do not work with this setting.
 endif::[]
 |====

--- a/guides/common/modules/ref_project-settings.adoc
+++ b/guides/common/modules/ref_project-settings.adoc
@@ -33,7 +33,7 @@ When set to `No`, any object may be accessed by a user with permission to use te
 This permits users full remote code execution on {ProjectServer}, effectively disabling all authorization.
 This is not a safe option, especially in bigger companies.
 ifndef::orcharhino[]
-| *Exclude pattern for facts stored in {Project}* | Until https://bugzilla.redhat.com/show_bug.cgi?id=1759111[BZ#1759111] is resolved, note that if you use the wildcard value, for example `docker*`, to exclude all facts beginning with `docker`, this also excludes facts that contain the excluded term in any part of the name.
-| *Ignore interfaces with matching identifier* | Until https://bugzilla.redhat.com/show_bug.cgi?id=1759111[BZ#1759111] is resolved, note that if you use the wildcard value, for example `docker*`, to ignore all facts beginning with `docker`, this also excludes facts that contain the ignored term in any part of the name.
+| *Exclude pattern for facts stored in {Project}* | You can use regular expressions as well as the * wildcard for excluding a pattern.
+| *Ignore interfaces with matching identifier* | You can use the * wildcard for ignoring a pattern. Regular expressions do not work with this setting.
 endif::[]
 |====


### PR DESCRIPTION
Since the bug related to wildcard for "Exclude pattern for facts stored" and "Ignore interfaces with matching identifier" has been resolved, updating ref_project-settings.adoc with the latest information.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
@melcorr 