### PR TITLE
Removed mention of sticky sessions

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -7,7 +7,7 @@ endif::[]
 ifdef::satellite[]
 The following example provides general guidance for configuring an HAProxy load balancer.
 endif::[]
-However, you can install any suitable load balancing software solution that supports TCP forwarding and sticky sessions.
+However, you can install any suitable load balancing software solution that supports TCP forwarding.
 
 . On a {RHEL} 7 host, install HAProxy:
 +
@@ -29,8 +29,6 @@ However, you can install any suitable load balancing software solution that supp
 
 . Configure the load balancer to balance the network load for the ports as described in xref:ports-configuration-for-the-load-balancer[].
 For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg` file to correspond with the table.
-+
-You must configure sticky session on TCP port 443 to request yum metadata for RPM repositories from different {SmartProxyServer}s that you configure for load balancing.
 +
 [id='ports-configuration-for-the-load-balancer']
 .Ports Configuration for the Load Balancer


### PR DESCRIPTION
Removed two mentions of sticky sessions

[doc] - Load balanced content with Capsules without sticky sessions  

https://issues.redhat.com/browse/SAT-6400


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
