### PR TITLE
Added REX section from 6.9 to 6.10 per SATDOC-645

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -187,7 +187,7 @@ For information on backups, see {AdministeringDocURL}backing-up-satellite-server
 +
 [options="nowrap"]
 ----
-# {satellite-installer --foreman-proxy-dns-managed=false \
+# {satellite-installer} --foreman-proxy-dns-managed=false \
 --foreman-proxy-dhcp-managed=false
 ----
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -33,6 +33,7 @@ the upgrade to proceed.
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 +
+
 For information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
 
 ifdef::katello[]
@@ -171,14 +172,14 @@ This removes Pulp 2 RPMs, content in `/var/lib/pulp/content/`, the mongo databas
 # hammer capsule content synchronize --name ${{SmartProxy}} --skip-metadata-check true --async
 ----
 
-.Upgrading Capsule Servers Using Remote Execution in the Satellite web UI
+.Upgrading {SmartProxy} Servers Using Remote Execution in the {Project} web UI
 
 . Create a backup.
 +
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 +
-For information on backups, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/administering_red_hat_satellite/backing-up-satellite-server-and-capsule-server[Backing Up Satellite Server and Capsule Server] in the _Administering Red Hat Satellite {ProductVersion}_ guide.
+For information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
 
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
 
@@ -186,11 +187,11 @@ For information on backups, see https://access.redhat.com/documentation/en-us/re
 +
 [options="nowrap"]
 ----
-# satellite-installer --foreman-proxy-dns-managed=false \
+# {satellite-installer --foreman-proxy-dns-managed=false \
 --foreman-proxy-dhcp-managed=false
 ----
 
-. In the Satellite web UI, navigate to *Monitor* > *Jobs*.
+. In the {Project} web UI, navigate to *Monitor* > *Jobs*.
 
 . Click *Run Job*.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -172,7 +172,7 @@ This removes Pulp 2 RPMs, content in `/var/lib/pulp/content/`, the mongo databas
 # hammer capsule content synchronize --name ${{SmartProxy}} --skip-metadata-check true --async
 ----
 
-.Upgrading {SmartProxy} Servers Using Remote Execution in the {Project} web UI
+.Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI}
 
 . Create a backup.
 +
@@ -187,7 +187,7 @@ For information on backups, see {AdministeringDocURL}backing-up-satellite-server
 +
 [options="nowrap"]
 ----
-# {satellite-installer} --foreman-proxy-dns-managed=false \
+# {foreman-installer} --foreman-proxy-dns-managed=false \
 --foreman-proxy-dhcp-managed=false
 ----
 
@@ -199,14 +199,13 @@ For information on backups, see {AdministeringDocURL}backing-up-satellite-server
 
 . From the *Job template* list, select *Capsule Upgrade Playbook*.
 
-. In the *Search Query* field, enter the host name of the Capsule.
+. In the *Search Query* field, enter the host name of the {SmartProxy}.
 
 . Ensure that *Resolves to* shows *1 host*.
 
-. In the *target_version* field, enter the target version of the Capsule.
+. In the *target_version* field, enter the target version of the {SmartProxy}.
 
 . In the *whitelist_options* field, enter the whitelist options.
 
 . For *Type of query*, click *Static Query* or *Dynamic Query* depending on the type of query.
-
 . Select the schedule for the job execution in *Schedule*.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -170,3 +170,42 @@ This removes Pulp 2 RPMs, content in `/var/lib/pulp/content/`, the mongo databas
 ----
 # hammer capsule content synchronize --name ${{SmartProxy}} --skip-metadata-check true --async
 ----
+
+.Upgrading Capsule Servers Using Remote Execution in the Satellite web UI
+
+. Create a backup.
++
+* On a virtual machine, take a snapshot.
+* On a physical machine, create a backup.
++
+For information on backups, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/administering_red_hat_satellite/backing-up-satellite-server-and-capsule-server[Backing Up Satellite Server and Capsule Server] in the _Administering Red Hat Satellite {ProductVersion}_ guide.
+
+. Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
+
+. Optional: If you made manual edits to DNS or DHCP configuration files and do not want to overwrite the changes, enter the following command:
++
+[options="nowrap"]
+----
+# satellite-installer --foreman-proxy-dns-managed=false \
+--foreman-proxy-dhcp-managed=false
+----
+
+. In the Satellite web UI, navigate to *Monitor* > *Jobs*.
+
+. Click *Run Job*.
+
+. From the *Job category* list, select *Maintenance Operations*.
+
+. From the *Job template* list, select *Capsule Upgrade Playbook*.
+
+. In the *Search Query* field, enter the host name of the Capsule.
+
+. Ensure that *Resolves to* shows *1 host*.
+
+. In the *target_version* field, enter the target version of the Capsule.
+
+. In the *whitelist_options* field, enter the whitelist options.
+
+. For *Type of query*, click *Static Query* or *Dynamic Query* depending on the type of query.
+
+. Select the schedule for the job execution in *Schedule*.


### PR DESCRIPTION
Per SATDOC-645, I added the steps for remote execution in Upgrading Capsule Servers from 6.9 Upgrading and Updating Guide into the same section in 6.10.
@melcorr 

Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
