### PR TITLE
Introduce macros of the pgsql lib paths on EL7 & EL8

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -30,6 +30,10 @@
 :RepoRHEL7ServerSatelliteServerPuppetVersion: rhel-7-server-satellite-6.3-puppet4-rpms
 :RepoRHEL7ServerSatelliteCapsulePuppetVersion: rhel-7-server-satellite-capsule-6.3-puppet4-rpms
 
+// Paths
+:el7-pgsql: /var/opt/rh/rh-postgresql12/lib/pgsql
+:el8-pgsql: /var/lib/pgsql
+
 // Base attributes
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman

--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -18,8 +18,8 @@ A full backup requires space to store the following data:
 . Enter the `du` command to estimate the size of uncompressed directories containing {Project} database and configuration files:
 +
 ----
-# du -sh /var/opt/rh/rh-postgresql12/lib/pgsql/data /var/lib/pulp
-100G    /var/opt/rh/rh-postgresql12/lib/pgsql/data
+# du -sh {el7-pgsql} /data /var/lib/pulp
+100G    {el7-pgsql}/data
 100G	/var/lib/pulp
 
 # du -csh /var/lib/qpidd /var/lib/tftpboot /etc /root/ssl-build \
@@ -42,7 +42,7 @@ The following table describes the compression ratio of all data items included i
 |Data type |Directory |Ratio |Example results
 
 |PostgreSQL database files
-|`/var/opt/rh/rh-postgresql12/lib/pgsql/data`
+|`{el7-pgsql}/data`
 |80 - 85%
 |100 GB -> 20 GB
 

--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -33,7 +33,7 @@ ifndef::foreman-deb[]
 COMPONENT  | AUTO-DETECTED BY EXISTENCE OF       | DESTINATIONS
 -----------|-------------------------------------|-------------------------------------
 dhcpd      | /etc/dhcp/dhcpd.conf                | syslog /var/log/dhcpd-debug.log
-postgresql | /var/lib/pgsql/data/postgresql.conf | syslog /var/lib/pgsql/data/pg_log/
+postgresql | {el8-pgsql}/data/postgresql.conf    | syslog {el8-pgsql}/data/pg_log/
 proxy      | /etc/foreman-proxy/settings.yml     | /var/log/foreman-proxy/proxy.log
 qpidd      | /etc/qpid/qpidd.conf                | syslog
 rails      | /etc/foreman/settings.yaml          | /var/log/foreman/production.log
@@ -214,8 +214,8 @@ Ensure to restart the Redis service afterwards:
 
 == Increasing the Logging Level For Postgres
 
-You can find the log for Postgres in `/var/opt/rh/rh-postgresql12/lib/pgsql/data/log/`.
-Uncomment the `log_statement` in `/var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf`:
+You can find the log for Postgres in `{el7-pgsql}/data/log/`.
+Uncomment the `log_statement` in `{el7-pgsql}/data/postgresql.conf`:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -24,11 +24,11 @@ rh-postgresql12-postgresql-evr
 # postgresql-setup initdb
 ----
 +
-. Edit the `/var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf` file:
+. Edit the `{el7-pgsql}/data/postgresql.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# vi /var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf
+# vi {el7-pgsql}/data/postgresql.conf
 ----
 +
 . Remove the `#` and edit to listen to inbound connections:
@@ -38,11 +38,11 @@ rh-postgresql12-postgresql-evr
 listen_addresses = '*'
 ----
 +
-. Edit the `/var/opt/rh/rh-postgresql12/lib/pgsql/data/pg_hba.conf` file:
+. Edit the `{el7-pgsql}/data/pg_hba.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes"]
 -----
-# vi /var/opt/rh/rh-postgresql12/lib/pgsql/data/pg_hba.conf
+# vi {el7-pgsql}/data/pg_hba.conf
 -----
 +
 . Add the following line to the file:

--- a/guides/common/modules/proc_performing-a-snapshot-backup.adoc
+++ b/guides/common/modules/proc_performing-a-snapshot-backup.adoc
@@ -19,7 +19,7 @@ Ensure no other tasks are scheduled for the same time as the backup.
 ====
 
 .Prerequisites
-* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/`, and `/var/opt/rh/rh-postgresql12/lib/pgsql`.
+* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/`, and `{el7-pgsql}`.
 * The free disk space in the relevant volume group (VG) is three times the size of the snapshot.
 More precisely, the VG must have enough space unreserved by the member logical volumes (LVs) to accommodate new snapshots.
 In addition, one of the LVs must have enough free space for the backup directory.

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -21,7 +21,7 @@ ifdef::foreman-el,katello,satellite[]
 |====
 |Directory |Installation Size |Runtime Size
 |/var/lib/pulp |1 MB |300 GB
-|/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |10 GB
+|{el7-pgsql} |100 MB |10 GB
 |/opt | 500 MB | Not Applicable
 |====
 endif::[]
@@ -34,6 +34,6 @@ ifdef::foreman-el,katello[]
 |====
 |Directory |Installation Size |Runtime Size
 |/var/lib/pulp |1 MB |300 GB
-|/var/lib/pgsql |100 MB |10 GB
+|{el8-pgsql} |100 MB |10 GB
 |====
 endif::[]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -26,7 +26,7 @@ ifdef::foreman-el,katello[]
 
 |/var/log/ |10 MB |10 GB
 
-|/var/lib/pgsql |100 MB |20 GB
+|{el8-pgsql} |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
 
@@ -48,7 +48,7 @@ endif::[]
 
 |/var/log/ |10 MB |10 GB
 
-|/var/opt/rh/rh-postgresql12 |100 MB |20 GB
+|{el7-pgsql} |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
 
@@ -74,7 +74,7 @@ ifdef::foreman-el,katello,satellite[]
 
 |/var/log/ |10 MB |10 GB
 
-|/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |20 GB
+|{el7-pgsql} |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
 

--- a/guides/doc-Planning_Guide/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_Guide/topics/Required_Technical_Users.adoc
@@ -29,7 +29,7 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |qdrouterd |N/A |qdrouterd |N/A |yes |N/A |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin
 |unbound |N/A |unbound |N/A |yes |/etc/unbound |/sbin/nologin
-|postgres |26 |postgres |26 |no |/var/lib/pgsql |/bin/bash
+|postgres |26 |postgres |26 |no |{el8-pgsql} |/bin/bash
 |apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
 |tomcat |53 |tomcat |53 |no |/usr/share/tomcat |/bin/nologin
 |saslauth |N/A |saslauth |76 |no |N/A |/sbin/nologin


### PR DESCRIPTION
Currently the installer is very EL7 focused while in nightly it's about to be dropped. The idea behind this is to make it clear what EL 7 and 8 is, thus preparing for the future.

It also makes one other change. In the CentOS 7 storage requirements the path is aligned with RHEL 7.

Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request