### PR TITLE
Added the missing brackets with reference to last commit

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -168,5 +168,5 @@ This removes Pulp 2 RPMs, content in `/var/lib/pulp/content/`, the mongo databas
 +
 [options="nowrap" subs="attributes"]
 ----
-# hammer capsule content synchronize --name ${SmartProxy} --skip-metadata-check true --async
+# hammer capsule content synchronize --name ${{SmartProxy}} --skip-metadata-check true --async
 ----


### PR DESCRIPTION
Although, the brackets were present in last modification but there should be two brackets for the attributes that we
mentioned in the command. I removed it earlier considering the normal attribute instead command one.

Capsule 6.10 Upgrade Guide Step 14 to do Complete Capsule sync using hammer correction

https://issues.redhat.com/browse/SATDOC-717


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
