### PR TITLE
Drop EL7 doc link from sync sys clock with chronyd

### DIFF
--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -5,7 +5,7 @@
 To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProductName} with Network Time Protocol (NTP) servers.
 If the base operating system clock is configured incorrectly, certificate verification might fail.
 
-For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite[Configuring NTP Using the chrony Suite] in the _{RHEL} 7 System Administrator's Guide_.
+For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings[Configuring NTP Using the chrony Suite] in the _{RHEL} 8 System Administrator's Guide_.
 
 .Procedure
 


### PR DESCRIPTION
Cherry-pick into:
none
