### PR TITLE
Added location of insights host information

### DIFF
--- a/guides/common/modules/proc_using-red-hat-insights.adoc
+++ b/guides/common/modules/proc_using-red-hat-insights.adoc
@@ -15,14 +15,14 @@ To install and register your host using Puppet, or manually, see https://access.
 .{Team} Insights Information Available for Hosts
 Additional information is available about hosts through {Team} Insights.
 
-You can find this information in two places.
+You can find this information in two places:
 
-* In the {ProjectWebUI}, navigate to *Configure > Insights* where the three dots icon next to the *Remediate* button provides a *View in {Team} Insights* link to the general recommendations page.
-On each recommendation line, the three dots icon provide a *View in {Team} Insights* link to the recommendation rule, and, if one is available for that recommendation, a *Knowledgebase article* link.
+* In the {ProjectWebUI}, navigate to *Configure > Insights* where the vertical ellipsis next to the *Remediate* button provides a *View in {Team} Insights* link to the general recommendations page.
+On each recommendation line, the vertical ellipsis provide a *View in {Team} Insights* link to the recommendation rule, and, if one is available for that recommendation, a *Knowledgebase article* link.
 
 * For additional information, navigate to *Hosts > All hosts*.
 If the host has recommendations listed, click on the number of recommendations.
-On the *Insights* tab, the three dots icon next to the *Remediate* button provide a *Go To {Project} Insights page* link to information for the system, and a *View in {Team} Insights* link to host details on the console.
+On the *Insights* tab, the vertical ellipsis next to the *Remediate* button provide a *Go To {Project} Insights page* link to information for the system, and a *View in {Team} Insights* link to host details on the console.
 
 .Deploying Red{nbsp}Hat Insights using the Ansible Role
 You can automate the installation and registration of hosts with Red{nbsp}Hat Insights using the *RedHatInsights.insights-client* Ansible role.

--- a/guides/common/modules/proc_using-red-hat-insights.adoc
+++ b/guides/common/modules/proc_using-red-hat-insights.adoc
@@ -12,6 +12,18 @@ For more information, see {ManagingHostsDocURL}registering-a-host_managing-hosts
 
 To install and register your host using Puppet, or manually, see https://access.redhat.com/products/red-hat-insights/#getstarted[Red{nbsp}Hat Insights Getting Started].
 
+.{Team} Insights Information Available for Hosts
+Additional information is available about hosts through {Team} Insights.
+
+You can find this information in two places.
+
+* In the {ProjectWebUI}, navigate to *Configure > Insights* where the three dots icon next to the *Remediate* button provides a *View in {Team} Insights* link to the general recommendations page.
+On each recommendation line, the three dots icon provide a *View in {Team} Insights* link to the recommendation rule, and, if one is available for that recommendation, a *Knowledgebase article* link.
+
+* For additional information, navigate to *Hosts > All hosts*.
+If the host has recommendations listed, click on the number of recommendations.
+On the *Insights* tab, the three dots icon next to the *Remediate* button provide a *Go To {Project} Insights page* link to information for the system, and a *View in {Team} Insights* link to host details on the console.
+
 .Deploying Red{nbsp}Hat Insights using the Ansible Role
 You can automate the installation and registration of hosts with Red{nbsp}Hat Insights using the *RedHatInsights.insights-client* Ansible role.
 For more information about adding this role to your {Project}, see {ConfiguringAnsibleDocURL}getting-started-with-ansible_ansible[Getting Started with Ansible in {Project}] in _Configuring {Project} to use Ansible_.


### PR DESCRIPTION
Described how to access insights information on hosts and recommendations.

[doc] - Improved Insights adoption

https://issues.redhat.com/browse/SAT-4686


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
