### PR TITLE
Added postgresql space requirement to migration-stats output

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -70,6 +70,10 @@ Estimated migration time based on yum content: 47 hours, 23 minutes
 Note: ensure there is sufficient storage space for /var/lib/pulp/published to
 double in size before starting the migration process.
 Check the size of /var/lib/pulp/published with 'du -sh /var/lib/pulp/published/'
+Note: ensure there is sufficient storage space for postgresql.
+You will need additional space for your postgresql database.
+The partition holding '/var/opt/rh/rh-postgresql12/lib/pgsql/data/' will need
+additional free space equivalent to the size of your Mongo db database (/var/lib/mongodb/).
 [OK]
 ----
 


### PR DESCRIPTION
Postgresql requiremtn missing from migration-stats output. Added to example output

Bug 2043696 - [RFE] add doc message regarding the need for additional psql space

https://bugzilla.redhat.com/show_bug.cgi?id=2043696


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
