### PR TITLE
OSTree is not enabled by default

### DIFF
--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -16,8 +16,8 @@ endif::[]
 ifndef::satellite[]
 * OSTree content is supported only when running {Project} on {RHEL} 8 or CentOS 8.
 endif::[]
-* In {ProjectServer}, OSTree management tools are enabled by default.
-If you ever have a reason to enable the tool, enter the following command:
+* In {ProjectServer}, OSTree management tools are not enabled by default.
+To enable OSTree, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->

OSTree is not enabled by default: https://github.com/theforeman/puppet-foreman_proxy_content/blob/ec6f3e75476c76b3f0389873aafb02ea192e96ff/manifests/init.pp#L121