### PR TITLE
linkchecker.ini to ignore links to Satellite 6.11

### DIFF
--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -20,4 +20,4 @@ ignore=example.com
   atixservice.zendesk.com
   # This isn't published downstream yet
   access.redhat.com/documentation/en-us/red_hat_satellite/6.10/html-single/managing_configurations_using_puppet_integration/index
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.11/html/upgrading_and_updating_red_hat_satellite/
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.11


### PR DESCRIPTION
I've updated the linkchecker.ini  file to ignore all links that include the following string: access.redhat.com/documentation/en-us/red_hat_satellite/6.11" 
The reason is that the docs for Satellite 6.11 are not published yet.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
