### PR TITLE
Corrected information on CV filters and dependency solving.

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -424,12 +424,14 @@ In {Project}, you can use the package dependency resolution feature to ensure th
 
 You can select to resolve package dependencies for any Content View that you want, or you can change the default setting to enable or disable resolving package dependencies for all new Content Views.
 
-Note that resolving package dependencies can cause significant delays to Content View promotion.
-The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View so `{package-update-project}` is not guaranteed to work.
+In most simple and common cases, dependency resolution is not necessary to the the correct function of the repository, and can be omitted.
+Note that resolving package dependencies can be a very expensive operation that can cause significant delays to Content View promotion.
+The package dependency resolution feature also does not consider packages that are installed on your system independently of the Content View, so even with dependency solving enabled, it is possible to use Content View filters which produce a repository for which `{package-update-project}` is not guaranteed to work.
+Therefore, caution is recommended when using complex filter combinations, even in conjunction with dependency resolution.
 
 .Resolving Package Dependencies and Filters
 
-Filters do not resolve any dependencies of the packages listed in the filters.
+Filters do not resolve any dependencies of the packages listed in the filters by default.
 This might require some level of testing to determine what dependencies are required.
 
 If you add a filter that excludes some packages that are required and the Content View has dependency resolution enabled, {Project} ignores the rules you create in your filter in favor of resolving the package dependency.
@@ -444,13 +446,12 @@ To resolve package dependencies by default, complete the following steps:
 . Locate the *Content View Dependency Solving Default*, and select *Yes*.
 
 .Considerations
-. The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `{package-update-project}` is not guaranteed to work.
-. Packages in a Content View can have conflicting dependencies, which is expected.
-* A -> B(1.1)
-* C -> B(1.2)
-Where A, B and C are example packages where package A has a dependency on version 1.1 of package B, and Package C has a dependency on Version 1.2 of package B.
+. It is  possible to use filters in such a way that the resulting Content View has broken dependencies, and dependency resolution is not always guaranteed to solve this.
+This is because the package dependency resolution feature does not consider packages that are installed on your system independently of the Content View.
+. Packages in a Content View can have conflicting dependencies.
 +
-Both B(1.1) and B (1.2) are brought in by dependency solving in the Content View to satisfy dependencies of both A and C.
+For example, imagine a scenario where A, B and C are example packages, where package A has a dependency on version 1.1 of package B, and package C has a dependency on version 1.2 of package B.
+B (1.1) and B (1.2) are both brought in by dependency solving in the Content View to satisfy dependencies of both A and C.
 . If a package in a repository has a dependency on a package outside the repository which has not been synced or added to the Content View, dependency solving will not solve dependencies for that package.
 . If you are using exclude filters on your Content View with dependency solving turned on, dependency solving takes precedence and brings in any required packages even if they were filtered out.
 . Dependency solving and filters can increase publishing times considerably.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -425,7 +425,7 @@ In {Project}, you can use the package dependency resolution feature to ensure th
 You can select to resolve package dependencies for any Content View that you want, or you can change the default setting to enable or disable resolving package dependencies for all new Content Views.
 
 Note that resolving package dependencies can cause significant delays to Content View promotion.
-The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View so `yum update` is not guaranteed to work.
+The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View so `{package-update-project}` is not guaranteed to work.
 
 .Resolving Package Dependencies and Filters
 
@@ -444,7 +444,7 @@ To resolve package dependencies by default, complete the following steps:
 . Locate the *Content View Dependency Solving Default*, and select *Yes*.
 
 .Considerations
-. The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `yum update` is not guaranteed to work.
+. The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `{package-update-project}` is not guaranteed to work.
 . Packages can have conflicting dependencies in a Content View.
 If this is the case you might have dependency issues on the client.
 * A -> B(1.1)

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -390,7 +390,7 @@ There are two types of content filters:
 | *Include* | You start with no content, then select which content to add from the selected repositories.
 Use this filter to combine multiple content items.
 | *Exclude* | You start with all content from selected repositories, then select which content to remove.
-Use this filter when you want to use most of a particular content repository but exclude certain packages, such as blacklisted packages.
+Use this filter when you want to use most of a particular content repository but exclude certain packages, such as blocklisted packages.
 The filter uses all content in the repository except for the content you select.
 |===
 
@@ -447,10 +447,11 @@ To resolve package dependencies by default, complete the following steps:
 . The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `yum update` is not guaranteed to work.
 . Packages can have conflicting dependencies in a Content View.
 If this is the case you might have dependency issues on the client.
-* A -> b 1.1
-* C -> b 1.2
+* A -> B(1.1)
+* C -> B(1.2)
+Where A, B and C are example packages where package A has a dependency on version 1.1 of package B, and Package C has a dependency on Version 1.2 of package B.
 +
-Both b 1.1 and b 1.2 are brought in by dependency solving in the Content View but dependency solving for package A or B might break, depending on which version of b is installed on the host.
+Both B(1.1) and B (1.2) are brought in by dependency solving in the Content View but dependency solving for package A or B might break, depending on which version of B is installed on the host.
 . If a package in a repository has a dependency on a package outside the repository which has not been synced or added to the Content View, dependency solving will not solve dependencies for that package.
 . If you are using exclude filters on your Content View with dependency solving turned on, dependency solving takes precedence and brings in any required packages even if they are filtered out.
 . Dependency solving and filters can increase publishing times considerably.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -444,9 +444,9 @@ To resolve package dependencies by default, complete the following steps:
 . Locate the *Content View Dependency Solving Default*, and select *Yes*.
 
 .Considerations
-. The package dependency resolution feature does not connsider packages that are installed on your ssystem independently of the Content View, so `yum update` is not guaranteed to work.
+. The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `yum update` is not guaranteed to work.
 . Packages can have conflicting dependencies in a Content View.
-If this is the case you might haave dependency isses on the client.
+If this is the case you might have dependency issues on the client.
 * A -> b 1.1
 * C -> b 1.2
 +

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -445,13 +445,12 @@ To resolve package dependencies by default, complete the following steps:
 
 .Considerations
 . The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `{package-update-project}` is not guaranteed to work.
-. Packages in a Content View can have conflicting dependencies.
-If this is the case you might have dependency issues on the client.
+. Packages in a Content View can have conflicting dependencies, which is expected.
 * A -> B(1.1)
 * C -> B(1.2)
 Where A, B and C are example packages where package A has a dependency on version 1.1 of package B, and Package C has a dependency on Version 1.2 of package B.
 +
-Both B(1.1) and B (1.2) are brought in by dependency solving in the Content View but dependency solving for package A or B might break, depending on which version of B is installed on the host.
+Both B(1.1) and B (1.2) are brought in by dependency solving in the Content View to satisfy dependencies of both A and C.
 . If a package in a repository has a dependency on a package outside the repository which has not been synced or added to the Content View, dependency solving will not solve dependencies for that package.
 . If you are using exclude filters on your Content View with dependency solving turned on, dependency solving takes precedence and brings in any required packages even if they were filtered out.
 . Dependency solving and filters can increase publishing times considerably.

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -445,7 +445,7 @@ To resolve package dependencies by default, complete the following steps:
 
 .Considerations
 . The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View, so `{package-update-project}` is not guaranteed to work.
-. Packages can have conflicting dependencies in a Content View.
+. Packages in a Content View can have conflicting dependencies.
 If this is the case you might have dependency issues on the client.
 * A -> B(1.1)
 * C -> B(1.2)
@@ -453,7 +453,7 @@ Where A, B and C are example packages where package A has a dependency on versio
 +
 Both B(1.1) and B (1.2) are brought in by dependency solving in the Content View but dependency solving for package A or B might break, depending on which version of B is installed on the host.
 . If a package in a repository has a dependency on a package outside the repository which has not been synced or added to the Content View, dependency solving will not solve dependencies for that package.
-. If you are using exclude filters on your Content View with dependency solving turned on, dependency solving takes precedence and brings in any required packages even if they are filtered out.
+. If you are using exclude filters on your Content View with dependency solving turned on, dependency solving takes precedence and brings in any required packages even if they were filtered out.
 . Dependency solving and filters can increase publishing times considerably.
 
 [[Managing_Content_Views-Content_Filter_Examples]]

--- a/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Content_Views.adoc
@@ -425,7 +425,7 @@ In {Project}, you can use the package dependency resolution feature to ensure th
 You can select to resolve package dependencies for any Content View that you want, or you can change the default setting to enable or disable resolving package dependencies for all new Content Views.
 
 Note that resolving package dependencies can cause significant delays to Content View promotion.
-The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View or solve dependencies across repositories.
+The package dependency resolution feature does not consider packages that are installed on your system independently of the Content View so `yum update` is not guaranteed to work.
 
 .Resolving Package Dependencies and Filters
 
@@ -443,17 +443,17 @@ To resolve package dependencies by default, complete the following steps:
 . In the {Project} web UI, navigate to *Administer* > *Settings* and click the *Content* tab.
 . Locate the *Content View Dependency Solving Default*, and select *Yes*.
 
-You can also set the default level of dependency resolution that you want.
-You can select between adding packages to solve dependencies only if the required package does not exist, or to add the latest packages to resolve the dependency even if the package exists in the repository.
-
-To set the default level of dependency resolution, complete the following steps:
-
-. In the {Project} web UI, navigate to *Administer* > *Settings* and click the *Content* tab.
-. Locate the *Content View Dependency Solving Algorithm* and select one of the following options:
+.Considerations
+. The package dependency resolution feature does not connsider packages that are installed on your ssystem independently of the Content View, so `yum update` is not guaranteed to work.
+. Packages can have conflicting dependencies in a Content View.
+If this is the case you might haave dependency isses on the client.
+* A -> b 1.1
+* C -> b 1.2
 +
-* To add the package that resolves the dependency only if it does not exist in the repository, select *Conservative*.
-* To add the package that resolves the dependency regardless of whether or not it exists in the repository, select *Greedy*.
-
+Both b 1.1 and b 1.2 are brought in by dependency solving in the Content View but dependency solving for package A or B might break, depending on which version of b is installed on the host.
+. If a package in a repository has a dependency on a package outside the repository which has not been synced or added to the Content View, dependency solving will not solve dependencies for that package.
+. If you are using exclude filters on your Content View with dependency solving turned on, dependency solving takes precedence and brings in any required packages even if they are filtered out.
+. Dependency solving and filters can increase publishing times considerably.
 
 [[Managing_Content_Views-Content_Filter_Examples]]
 === Content Filter Examples


### PR DESCRIPTION
Added supplied information on Content View filters and Dependency Solving.

Bug 2034804 - Document (un)supported combinations of CV filters and dependency solving

https://bugzilla.redhat.com/show_bug.cgi?id=2034804


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
