### PR TITLE
Added steps for disabling katello-agent

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/post_upgrade_tasks.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/post_upgrade_tasks.adoc
@@ -4,11 +4,11 @@ Some of the procedures in this section are optional. You can choose to perform o
 
 If you use the PXE-based discovery process, then you must complete the discovery upgrade procedure on {Project} and on any {SmartProxyServer} with hosts that you want to be listed in {Project} on the *Hosts* > *Discovered hosts* page.
 
-* The `katello-agent` method is disabled with a new installation of {Project} {ProjectVersion}, making both the `qpidd` and `qdroutered` services unavailable.
+* The `katello-agent` is disabled with a new installation of {Project} {ProjectVersion}, making both the `qpidd` and `qdroutered` services unavailable.
 
-* If a {Project} {ProjectVersionPrevious} is upgraded to a {Project} {ProjectVersion}, the `katello-agent` method, as well as the `qpidd` and `qdroutered` services, remain enabled.
+* If {Project} {ProjectVersionPrevious} is upgraded to {Project} {ProjectVersion}, the `katello-agent`, as well as the `qpidd` and `qdroutered` services, remain enabled.
 
-* If you are not using `katello-agent` and transitioned to remote execution, you can optionally disable the `katello-agent` method properly as a post-upgrade task for both {Project} {ProjectVersion} and {SmartProxy} {ProjectVersion}:
+* If you are not using `katello-agent` and transitioned to remote execution, you can optionally disable the `katello-agent` as a post-upgrade task for both {Project} {ProjectVersion} and {SmartProxy} {ProjectVersion}:
 
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/post_upgrade_tasks.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/post_upgrade_tasks.adoc
@@ -3,3 +3,14 @@
 Some of the procedures in this section are optional. You can choose to perform only those procedures that are relevant to your installation.
 
 If you use the PXE-based discovery process, then you must complete the discovery upgrade procedure on {Project} and on any {SmartProxyServer} with hosts that you want to be listed in {Project} on the *Hosts* > *Discovered hosts* page.
+
+* The `katello-agent` method is disabled with a new installation of {Project} {ProjectVersion}, making both the `qpidd` and `qdroutered` services unavailable.
+
+* If a {Project} {ProjectVersionPrevious} is upgraded to a {Project} {ProjectVersion}, the `katello-agent` method, as well as the `qpidd` and `qdroutered` services, remain enabled.
+
+* If you are not using `katello-agent` and transitioned to remote execution, you can optionally disable the `katello-agent` method properly as a post-upgrade task for both {Project} {ProjectVersion} and {SmartProxy} {ProjectVersion}:
+
+[options="nowrap" subs="attributes"]
+----
+# satellite-installer --foreman-proxy-content-enable-katello-agent false
+----


### PR DESCRIPTION
Per SATDOC-657, added steps to disable katello-agent in installed versions of Satellite 6.10 and Capsule 6.10 due to deprecation of the katello-agent for future releases after 6.10. The request was to have these steps at the beginning of Chapter 4.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
