### PR TITLE
fix previous version of nightly being 3.2 not 3.1

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -4,7 +4,7 @@
 
 // Version numbers
 :ProjectVersion: nightly
-:ProjectVersionPrevious: 3.1
+:ProjectVersionPrevious: 3.2
 :KatelloVersion: nightly
 :TargetVersion: {ProjectVersion}
 :TargetVersionMaintainUpgrade: {ProjectVersion}


### PR DESCRIPTION
Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
