### PR TITLE
Replaced the new option in Recovering a Repository topic

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -436,7 +436,6 @@ Complete Sync::
 Synchronizes all RPMs regardless of detected changes.
 Use this option if specific RPMs could not be downloaded to the local repository even though they exist in the upstream repository.
 
-//Validate Content Sync::
 Verify Content Checksum::
 Synchronizes all RPMs and then verifies the checksum of all RPMs locally.
 If the checksum of an RPM differs from the upstream, it re-downloads the RPM.
@@ -453,7 +452,10 @@ Use this option if you have one of the following errors:
 . Select the product containing the corrupted repository.
 . Select the name of a repository you want to synchronize.
 . To verify the checksum, click *Verify Content Checksum* from the *Action* menu.
-. To perform optimised sync and complete sync, select *Advanced Sync* from the *Select Action* menu. And then, select the option and click *Sync*.
+. To perform optimised sync and complete sync, select *Advanced Sync*, perform the following:
+.. Select *Advanced Sync* from the *Select Action* menu.
+.. Select the desired option.
+. Click *Sync*.
 
 .CLI procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -451,11 +451,9 @@ Use this option if you have one of the following errors:
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select the product containing the corrupted repository.
 . Select the name of a repository you want to synchronize.
-. To verify the checksum, click *Verify Content Checksum* from the *Action* menu.
-. To perform optimised sync and complete sync, select *Advanced Sync*, perform the following:
-.. Select *Advanced Sync* from the *Select Action* menu.
-.. Select the desired option.
-. Click *Sync*.
+. To perform optimized sync or complete sync, select *Advanced Sync* from the *Select Action* menu.
+. Select the required option and click *Sync*.
+. To verify the checksum, click *Verify Content Checksum* from the *Select Action* menu. (optional)
 
 .CLI procedure
 

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -436,7 +436,8 @@ Complete Sync::
 Synchronizes all RPMs regardless of detected changes.
 Use this option if specific RPMs could not be downloaded to the local repository even though they exist in the upstream repository.
 
-Validate Content Sync::
+//Validate Content Sync::
+Verify Content Checksum::
 Synchronizes all RPMs and then verifies the checksum of all RPMs locally.
 If the checksum of an RPM differs from the upstream, it re-downloads the RPM.
 This option is relevant only for `yum` repositories.
@@ -451,8 +452,8 @@ Use this option if you have one of the following errors:
 . In the {Project} web UI, navigate to *Content* > *Products*.
 . Select the product containing the corrupted repository.
 . Select the name of a repository you want to synchronize.
-. From the *Select Action* menu, select *Advanced Sync*.
-. Select the option and click *Sync*.
+. To verify the checksum, click *Verify Content Checksum* from the *Action* menu.
+. To perform optimised sync and complete sync, select *Advanced Sync* from the *Select Action* menu. And then, select the option and click *Sync*.
 
 .CLI procedure
 


### PR DESCRIPTION
A new option was replaced i.e "Verify Content Checksum" with
Validate Content Sync as it is no longer an option for an advanced
synchronization in Satellite 6.10

"Validate Content Sync" is no longer an option for "Recovering a
Repository"

https://issues.redhat.com/browse/SATDOC-728


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
