### PR TITLE
Use FQDN for registration cmd

### DIFF
--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -29,7 +29,7 @@ endif::[]
 +
 In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, click the {SmartProxy} that you want to use, and locate the *Registration* feature in the *Active features* list.
 +
-Optional: If the *Registration* feature is not enabled on your {SmartProxy}, enter the following command on the {SmartProxy} to enable it:
+Optional: If the *Registration* feature is not enabled on your {SmartProxy}, enter the following command on the {SmartProxy} to enable it (use a FQDN, not an IP address):
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
Cherry-pick into past versions where the line exists.


Registration templates must use domain name of Satellite not IP address.

Ref: [Bug 2054044](https://bugzilla.redhat.com/show_bug.cgi?id=2054044) - Registering hosts with Setup REX is not copying Satellite's foreman-proxy public keys on the host.
