### PR TITLE
Rework "Mirroring Policy" for Katello 4.1+

### DIFF
--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -28,15 +28,6 @@ The lazy synchronization feature must be used only for `deb` and `yum` repositor
 endif::[]
 You can add the packages to Content Views and promote to life cycle environments as normal.
 
-Note that some repositories such as EPEL not only add packages to their upstream repository, but also remove older versions of packages.
-You should enable *Mirror on Sync* and use download policy *immediate* for such repositories.
-ifdef::satellite[]
-For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
-endif::[]
-ifndef::satellite[]
-For more information, see xref:Adding_Custom_RPM_Repositories_{context}[] and xref:Adding_Custom_DEB_Repositories_{context}[].
-endif::[]
-
 {SmartProxyServer} has the following policies:
 
 Immediate::

--- a/guides/common/modules/proc_adding-custom-deb-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repositories.adoc
@@ -45,8 +45,8 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs.
 For more information, see xref:Download_Policies_Overview_{context}[].
-. Ensure to select the *Mirror on Sync* check box.
-This ensures that the content that is no longer part of the upstream repository is removed during synchronization.
+. From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
+For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.
 . Optional: If you want, you can clear the *Publish via HTTP* check box to disable this repository from publishing through HTTP.
 . Optional: From the *GPG Key* list, select the GPG key if you want to verify the signatures of the `Release` files associated with the Debian repository.

--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -34,8 +34,8 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs.
 For more information, see xref:Download_Policies_Overview_{context}[].
-. Ensure to select the *Mirror on Sync* check box.
-This ensures that the content that is no longer part of the upstream repository is removed during synchronization.
+. From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
+For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.
 . From the *Checksum* list, select the checksum type for the repository.
 . Optional: If you want, you can clear the *Publish via HTTP* check box to disable this repository from publishing through HTTP.

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -32,8 +32,8 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . Optional: In the *Upstream Authentication Token* field, provide the token of the upstream repository user for authentication.
 Leave this field empty if the repository does not require authentication.
-. Optional: Check the *Mirror on Sync* checkbox to have this repository mirror the source repository during synchronization.
-It defaults to `true` (checked).
+. From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
+For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select the desired HTTP proxy.
 The default value is `Global Default`.
 . Optional: Check the *Publish via HTTP* to have this repository published using HTTP during synchronization.

--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -70,8 +70,8 @@ To import files from a file type repository in a local directory, complete the f
 . Optional: In the *Upstream Password* field, enter the corresponding password for your upstream user name.
 . Optional: In the *Upstream Authentication Token* field, provide the token of the upstream repository user for authentication.
 Leave this field empty if the repository does not require authentication.
-. Optional: Check the *Mirror on Sync* checkbox to have this repository mirror the source repository during synchronization.
-It defaults to `true` (checked).
+. From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
+For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select the desired HTTP proxy.
 The default value is `Global Default`.
 . Optional: Check the *Publish via HTTP* to have this repository published using HTTP during synchronization.

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -86,8 +86,8 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . Optional: In the *Upstream Authentication Token* field, provide the token of the upstream repository user for authentication.
 Leave this field empty if the repository does not require authentication.
-. Optional: Check the *Mirror on Sync* checkbox to have this repository mirror the source repository during synchronization.
-It defaults to `true` (checked).
+. From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
+For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select the desired HTTP proxy.
 The default value is `Global Default`.
 . Optional: Check the *Publish via HTTP* to have this repository published using HTTP during synchronization.


### PR DESCRIPTION
I am open for better wordings to differentiate between "Download Policy" and "Mirror Policy".

Cherry-pick into:

* [x] Foreman 3.2
* [x] Foreman 3.1