### PR TITLE
Replaced the new option in Recovering a Repository topic

### DIFF
--- a/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
+++ b/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
@@ -25,7 +25,7 @@ Use this option if you have one of the following errors:
 . Select the name of a repository you want to synchronize.
 . To perform optimized sync or complete sync, select *Advanced Sync* from the *Select Action* menu.
 . Select the required option and click *Sync*.
-. To verify the checksum, click *Verify Content Checksum* from the *Select Action* menu. (optional)
+. Optional: To verify the checksum, click *Verify Content Checksum* from the *Select Action* menu.
 
 .CLI procedure
 . Obtain a list of repository IDs:

--- a/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
+++ b/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
@@ -10,7 +10,7 @@ Complete Sync::
 Synchronizes all RPMs regardless of detected changes.
 Use this option if specific RPMs could not be downloaded to the local repository even though they exist in the upstream repository.
 
-Validate Content Sync::
+Verify Content Checksum::
 Synchronizes all RPMs and then verifies the checksum of all RPMs locally.
 If the checksum of an RPM differs from the upstream, it re-downloads the RPM.
 This option is relevant only for `yum` repositories.
@@ -23,8 +23,9 @@ Use this option if you have one of the following errors:
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
 . Select the product containing the corrupted repository.
 . Select the name of a repository you want to synchronize.
-. From the *Select Action* menu, select *Advanced Sync*.
-. Select the option and click *Sync*.
+. To perform optimized sync or complete sync, select *Advanced Sync* from the *Select Action* menu.
+. Select the required option and click *Sync*.
+. To verify the checksum, click *Verify Content Checksum* from the *Select Action* menu. (optional)
 
 .CLI procedure
 . Obtain a list of repository IDs:


### PR DESCRIPTION
A new option was replaced i.e "Verify Content Checksum" with
Validate Content Sync as it is no longer an option for an advanced
synchronization in Satellite 6.10

"Validate Content Sync" is no longer an option for "Recovering a
Repository"

https://issues.redhat.com/browse/SATDOC-728


Cherry-pick into:

* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
