### PR TITLE
Created module for RHEL 7 to RHEL 8 upgrade

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -6,6 +6,7 @@
 :ProjectVersion: nightly
 :ProjectVersionPrevious: 3.3
 :KatelloVersion: nightly
+:PulpcoreVersion: 3.18
 :TargetVersion: {ProjectVersion}
 :TargetVersionMaintainUpgrade: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -1,4 +1,4 @@
-[id="Upgrading-Project-from-EL7-to-EL8{context}"]
+[id="Upgrading-Project-from-EL7-to-EL8_{context}"]
 ifdef::satellite[]
 = Upgrading {Project} from {RHEL} 7 to {RHEL} 8
 endif::[]
@@ -6,38 +6,72 @@ ifdef::katello,foreman-el[]
 = Upgrading {Project} from Enterprise Linux 7 to Enterprise Linux 8
 endif::[]
 
+ifdef::satellite[]
 Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL} 8.
 LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
-
-.Prerequisites
-ifdef::katello,foreman-el[]
-* {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
-- {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8. You must have a {RHEL} compatible LEAPP build to upgrade.
 endif::[]
 
+ifdef::katello,foreman-el[]
+Use this procedure to upgrade your {Project} installation from Enterprise Linux 7 to Enterprise Linux 8.
+LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
+endif::[]
+
+
+ifdef::katello,foreman-el[]
+.Prerequisites
+* {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
+- {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8.
+You must have a {RHEL} compatible LEAPP build to upgrade.
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
-ifdef::katello,foreman-el[]
 * {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
 endif::[]
 
+ifdef::satellite[]
+.Prerequisites
+* Access to available repositories or a local mirror of repositories.
+* No outstanding updates.
+
 .Procedure
+[start=1]
+. Ensure `leapp preupgrade` has no issues.
+[start=2]
+. Run:
+----
+# leapp upgrade
+----
+[start=3]
+. Reboot the system.
+[start=4]
+. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
+[start=5]
+. After the system reboots, LEAPP finishes the upgrade, watch it with:
+----
+# journalctl -u leapp_resume -f
+----
+
+[NOTE]
+====
+If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
+====
+endif::[]
+
 ifdef::katello,foreman-el[]
+.Procedure
+[start=1]
 . Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
 
-+
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
 ----
+[start=2]
 . Install required packages:
-+
 ----
 # yum install leapp leapp-repository leapp-data-centos
 ----
 
-ifdef::katello,foreman-el[]
+[start=3]
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
-+
 ----
 [leapp-foreman]
 name=Foreman 3.2
@@ -98,46 +132,40 @@ gpgcheck=1
 ----
 endif::[]
 
+ifdef::katello,foreman-el[]
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
 endif::[]
 
 ifdef::katello,foreman-el[]
+[start=4]
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
-+
 ----
 # yum remove epel-release
 ----
-
+[start=5]
 . Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
-+
 ----
 # yum remove centos-release-scl centos-release-scl-rh
 ----
+[start=6]
 . Let LEAPP analyze your system:
-+
 ----
 # leapp preupgrade
 ----
-
 The first run is expected to fail but report issues.
 Continue to the next step for remediation.
 
 [start=7]
 . Fix issues found by LEAPP (check `/var/log/leapp/leapp-report.txt` for details):
-+
 ----
 # rmmod pata_acpi
 # echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
 # leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 ----
-+
-endif::[]
-
 ifdef::katello,foreman-el[]
 ** The `preupgrade` might fail with a dependency resolution error such as:
-+
 
 * "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
 * "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
@@ -156,30 +184,32 @@ Remove `rubygem-thor`:
 ----
 endif::[]
 
+ifdef::katello,foreman-el[]
 [start=8]
 . Ensure `leapp preupgrade` has no issues.
-+
+endif::[]
+
+ifdef::katello,foreman-el[]
+[start=9]
 . Run:
-+
 ----
 # leapp upgrade
 ----
-
-+
-
-. Reboot the system.
-+
-ifdef::satellite[]
-. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
-+
 endif::[]
+
+
 ifdef::katello,foreman-el[]
-. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
-+
+[start=10]
+. Reboot the system.
 endif::[]
 
+ifdef::katello,foreman-el[]
+[start=11]
+. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
+
+
+[start=12]
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
-+
 ----
 # journalctl -u leapp_resume -f
 ----
@@ -188,3 +218,4 @@ endif::[]
 ====
 If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
 ====
+endif::[]

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -8,13 +8,21 @@ LEAPP is the supported tool for Enterprise Linux 7 to Enterprise Linux 8 upgrade
 * {Project} {ProjectVersion} running on Enterprise Linux 7.
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
-* {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
+* {Project} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
 
 .Procedure
-. Do not perform this step on {RHEL} as this is for CentOS. Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
+. Configure the repositories to obtain LEAPP.
++
+On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
 +
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
+----
++
+On {RHEL}, enable the `rhel-7-server-extras-rpms` repository:
++
+----
+# subscription-manager repos --enable=rhel-7-server-extras-rpms
 ----
 
 . Install required packages:
@@ -23,20 +31,20 @@ LEAPP is the supported tool for Enterprise Linux 7 to Enterprise Linux 8 upgrade
 # yum install leapp leapp-repository
 ----
 
-. Install additional OS specific packages (`leapp-data-centos` for CentOS Stream, `leapp-data-rocky` for Rocky Linux, `leapp-data-almalinux` for AlmaLinux`). Not required for {RHEL}.
+. Install additional OS specific packages (`leapp-data-centos` for CentOS Stream, `leapp-data-rocky` for Rocky Linux, `leapp-data-almalinux` for AlmaLinux). Not required for {RHEL}.
 +
 ----
 # yum install leapp-data-centos
 ----
 
 +
-[options="nowrap", subs="+quotes,verbatim,attributes"]
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
 +
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 [leapp-foreman]
 name=Foreman {ProjectVersion}
-baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/3.2/el8/$basearch
+baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/el8/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
@@ -117,7 +125,8 @@ For more information, see link:https://docs.theforeman.org/nightly/Managing_Conf
 The first run is expected to fail but report issues.
 Continue to the next step for remediation.
 
-. Fix issues found by LEAPP (check `/var/log/leapp/leapp-report.txt` for details):
+. Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`) and manually resolve the other reported problems.
+The following commands show the most common steps required:
 +
 ----
 # rmmod pata_acpi

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -1,23 +1,9 @@
 [id="Upgrading-Project-from-EL7-to-EL8_{context}"]
-ifndef::satellite[]
-= Upgrading {Project} from {RHEL} 7 to {RHEL} 8
-endif::[]
-ifdef::katello,foreman-el[]
 = Upgrading {Project} from Enterprise Linux 7 to Enterprise Linux 8
-endif::[]
 
-ifdef::satellite[]
-Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL} 8.
-LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
-endif::[]
-
-ifdef::katello,foreman-el[]
 Use this procedure to upgrade your {Project} installation from Enterprise Linux 7 to Enterprise Linux 8.
-LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
-endif::[]
+LEAPP is the supported tool for Enterprise Linux 7 to Enterprise Linux 8 upgrades.
 
-
-ifdef::katello,foreman-el[]
 .Prerequisites
 * {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
 * {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8.
@@ -25,40 +11,7 @@ You must have a {RHEL} compatible LEAPP build to upgrade.
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
 * {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
-endif::[]
 
-ifdef::satellite[]
-.Prerequisites
-* Access to available repositories or a local mirror of repositories.
-* No outstanding updates.
-
-.Procedure
-[start=1]
-. Ensure `leapp preupgrade` has no issues.
-[start=2]
-. Run:
-+
-----
-# leapp upgrade
-----
-[start=3]
-. Reboot the system.
-[start=4]
-. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
-[start=5]
-. After the system reboots, LEAPP finishes the upgrade, watch it with:
-+
-----
-# journalctl -u leapp_resume -f
-----
-
-[NOTE]
-====
-If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
-====
-endif::[]
-
-ifdef::katello,foreman-el[]
 .Procedure
 [start=1]
 . Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
@@ -82,7 +35,7 @@ ifdef::katello,foreman-el[]
 name=Foreman 3.2
 baseurl=https://yum.theforeman.org/releases/3.2/el8/$basearch
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
 
@@ -94,7 +47,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
 module_hotfixes=1
-endif::[]
 
 [leapp-katello-candlepin]
 name=Candlepin: an open source entitlement management system.
@@ -111,6 +63,7 @@ gpgkey=https://yum.theforeman.org/pulpcore/3.16/GPG-RPM-KEY-pulpcore
 enabled=1
 gpgcheck=1
 module_hotfixes=1
+endif::[]
 
 [leapp-foreman-plugins]
 name=Foreman plugins 3.2
@@ -135,15 +88,11 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
 enabled=1
 gpgcheck=1
 ----
-endif::[]
 
-ifdef::katello,foreman-el[]
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
-endif::[]
 
-ifdef::katello,foreman-el[]
 [start=4]
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +
@@ -173,14 +122,14 @@ Continue to the next step for remediation.
 # echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
 # leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 ----
-ifdef::katello,foreman-el[]
+
 The `preupgrade` might fail with a dependency resolution error such as:
 
 * "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
 * "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
 
 If this happens, do the following to clean up packages that cannot automatically upgrade:
-
++
 ----
 # dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd)
 ----
@@ -188,36 +137,26 @@ If this happens, do the following to clean up packages that cannot automatically
 Check the output if it does not contain any local packages.
 
 Remove `rubygem-thor`:
-
++
 ----
 # yum remove rubygem-thor
 ----
-endif::[]
 
-ifdef::katello,foreman-el[]
 [start=8]
 . Ensure `leapp preupgrade` has no issues.
-endif::[]
 
-ifdef::katello,foreman-el[]
 [start=9]
 . Run:
 +
 ----
 # leapp upgrade
 ----
-endif::[]
 
-
-ifdef::katello,foreman-el[]
 [start=10]
 . Reboot the system.
-endif::[]
 
-ifdef::katello,foreman-el[]
 [start=11]
 . After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
-
 
 [start=12]
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
@@ -230,4 +169,3 @@ ifdef::katello,foreman-el[]
 ====
 If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
 ====
-endif::[]

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -6,8 +6,6 @@ LEAPP is the supported tool for Enterprise Linux 7 to Enterprise Linux 8 upgrade
 
 .Prerequisites
 * {Project} {ProjectVersion} running on Enterprise Linux 7.
-* {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8.
-You must have a {RHEL} compatible LEAPP build to upgrade.
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
 * {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
@@ -37,8 +35,8 @@ You must have a {RHEL} compatible LEAPP build to upgrade.
 +
 ----
 [leapp-foreman]
-name={ProjectVersion}
-baseurl=https://yum.theforeman.org/releases/3.2/el8/$basearch
+name=Foreman {ProjectVersion}
+baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/3.2/el8/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
@@ -46,16 +44,16 @@ module_hotfixes=1
 
 ifdef::katello[]
 [leapp-katello]
-name={KatelloVersion}
-baseurl=https://yum.theforeman.org/katello/4.4/katello/el8/$basearch/
+name=Katello {KatelloVersion}
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
 module_hotfixes=1
 
 [leapp-katello-candlepin]
-name={KatelloVersion}
-baseurl=https://yum.theforeman.org/katello/4.4/candlepin/el8/$basearch/
+name=Candlepin: an open source entitlement management system.
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el8/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
@@ -71,16 +69,16 @@ module_hotfixes=1
 endif::[]
 
 [leapp-foreman-plugins]
-name={ProjectVersion}
-baseurl=https://yum.theforeman.org/plugins/3.2/el8/$basearch
+name=Foreman plugins {ProjectVersion}
+baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el8/$basearch
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 module_hotfixes=1
 
 [leapp-foreman-client]
-name=Foreman client 3.2
-baseurl=https://yum.theforeman.org/client/3.2/el8/$basearch
+name=Foreman client {ProjectVersion}
+baseurl=https://yum.theforeman.org/client/{ProjectVersion}/el8/$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
@@ -130,24 +128,18 @@ Continue to the next step for remediation.
 +
 The `preupgrade` might fail with a dependency resolution error such as:
 +
-----
+
 * "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
 * "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
-----
+
 +
 If this happens, do the following to clean up packages that cannot automatically upgrade (`rubygem(thor)` and `rubygem(railties)` in the example above):
+
 +
 ----
 # yum remove rubygem-thor rubygem-railties
 ----
-+
-Check the output if it does not contain any local packages.
-+
-Remove `rubygem-thor`:
-+
-----
-# yum remove rubygem-thor
-----
+
 . Ensure `leapp preupgrade` has no issues.
 
 . Run:
@@ -158,7 +150,7 @@ Remove `rubygem-thor`:
 . Reboot the system.
 
 . After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
-. After the system reboots, LEAPP finishes the upgrade, watch it with:
+. LEAPP finishes the upgrade, watch it with:
 +
 ----
 # journalctl -u leapp_resume -f

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -9,6 +9,7 @@ LEAPP is the supported tool for Enterprise Linux 7 to Enterprise Linux 8 upgrade
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
 * {Project} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
+* {Project} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
 
 .Procedure
 . Configure the repositories to obtain LEAPP.
@@ -103,7 +104,6 @@ gpgcheck=1
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
-For more information, see link:https://docs.theforeman.org/nightly/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet].
 
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -5,14 +5,21 @@ Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL
 LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
 
 .Prerequisites
-* {Project} {ProjectVersionPrevious} running on CentOS 7.
-- Upgrading does not work on {RHEL}. You must have a {RHEL}-compatible LEAPP build to upgrade.
-* Access to a local repository server mirroring all required repositories.
+* {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
+ifdef::katello,foreman-el[]
+- {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8. You must have a {RHEL} compatible LEAPP build to upgrade.
+endif::[]
+* Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
-* You can upgrade a CentOS7 system before you upgrade {Project}.
+* {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
+ifdef::satellite[]
+* {Project} installations upgrade from {RHEL} 7 to {RHEL} 8, not from CentOS Linux 7 and {RHEL} rebuilds.
+endif::[]
 
 .Procedure
+ifdef::katello,foreman-el[]
 . Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
+
 +
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
@@ -41,6 +48,13 @@ enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 module_hotfixes=1
+
+[leapp-foreman-client]
+name=Foreman client 3.2
+baseurl=https://yum.theforeman.org/client/3.2/el8/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
 
 [leapp-puppet7]
 name=Puppet 7 Repository el 8 - $basearch
@@ -74,6 +88,7 @@ enabled=1
 gpgcheck=1
 module_hotfixes=1
 ----
+endif::[]
 
 * If you are not using {Project}, you can leave out `leapp-katello`, `leapp-katello-candlepin` and `leapp-pulpcore`.
 
@@ -81,10 +96,18 @@ module_hotfixes=1
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
 
-. We do not support EL8 installations with EPEL8 enabled, so remove `epel-release`:
+ifdef::katello,foreman-el[]
+. We do not support {RHEL} 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +
 ----
 # yum remove epel-release
+----
+endif::[]
+
+. Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
++
+----
+# yum remove centos-release-scl centos-release-scl-rh
 ----
 . Let LEAPP analyze your system:
 +
@@ -106,28 +129,33 @@ Continue to the next step for remediation.
 ----
 +
 
+ifdef::katello,foreman-el[]
 ** If `preupgrade` aborts with a dependency resolution error such as:
 +
 ----
-# package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can install
+# package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0,
 ----
-or:
+but none of the providers can install or:
 +
 ----
- # package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can install
+# package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0
 ----
+but none of the providers can install:
+endif::[]
 
-** Remove packages that are no longer available from any repository:
+ifdef::katello,foreman-el[]
+. Remove packages that are no longer available from any repository:
 +
 ----
 # dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd) –
 ----
+endif::[]
 
 +
 
-** Check the output if it does not contain any local packages.
+. Check the output if it does not contain any local packages.
 
-** Remove `rubygem-thor`:
+. Remove `rubygem-thor`:
 +
 ----
 # yum remove rubygem-thor
@@ -143,17 +171,14 @@ or:
 +
 
 . Reboot the system.
-. After the system reboots, a live system conducts the upgrade.
-. Reboot to fix SELinux labels.
-. Reboot into the final {RHEL} 8 system.
-. After the system reboots, LEAPP finishes the upgrade.
-. You can watch LEAPP finish the upgrade with:
+. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
+. After the system reboots, LEAPP finishes the upgrade, watch it with:
 +
 ----
 # journalctl -u leapp_resume -f
 ----
 
-[WARNING]
+[NOTE]
 ====
-If you installed the system and had to use `--disable-system-checks`, the last step of the upgrade will fail, and you will need to call `foreman-installer --disable-system-checks` manually once the system is booted up.
+If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
 ====

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -97,8 +97,6 @@ gpgcheck=1
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
-
-+
 For more information, see link:https://docs.theforeman.org/nightly/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet].
 
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
@@ -131,36 +129,35 @@ Continue to the next step for remediation.
 
 +
 The `preupgrade` might fail with a dependency resolution error such as:
-
++
+----
 * "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
 * "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
-
+----
++
 If this happens, do the following to clean up packages that cannot automatically upgrade (`rubygem(thor)` and `rubygem(railties)` in the example above):
++
 ----
 # yum remove rubygem-thor rubygem-railties
 ----
-
++
 Check the output if it does not contain any local packages.
-
++
 Remove `rubygem-thor`:
++
 ----
 # yum remove rubygem-thor
 ----
-[start=9]
 . Ensure `leapp preupgrade` has no issues.
-[start=10]
+
 . Run:
 +
 ----
 # leapp upgrade
 ----
-
-[start=11]
 . Reboot the system.
 
-[start=12]
 . After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
-[start=13]
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
 +
 ----

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -1,5 +1,5 @@
 [id="Upgrading-Project-from-EL7-to-EL8_{context}"]
-ifdef::satellite[]
+ifndef::satellite[]
 = Upgrading {Project} from {RHEL} 7 to {RHEL} 8
 endif::[]
 ifdef::katello,foreman-el[]
@@ -20,7 +20,7 @@ endif::[]
 ifdef::katello,foreman-el[]
 .Prerequisites
 * {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
-- {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8.
+* {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8.
 You must have a {RHEL} compatible LEAPP build to upgrade.
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
@@ -37,6 +37,7 @@ ifdef::satellite[]
 . Ensure `leapp preupgrade` has no issues.
 [start=2]
 . Run:
++
 ----
 # leapp upgrade
 ----
@@ -46,6 +47,7 @@ ifdef::satellite[]
 . After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
 [start=5]
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
++
 ----
 # journalctl -u leapp_resume -f
 ----
@@ -60,18 +62,21 @@ ifdef::katello,foreman-el[]
 .Procedure
 [start=1]
 . Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
-
++
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
 ----
 [start=2]
 . Install required packages:
++
 ----
 # yum install leapp leapp-repository leapp-data-centos
 ----
 
 [start=3]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
++
 ----
 [leapp-foreman]
 name=Foreman 3.2
@@ -141,16 +146,19 @@ endif::[]
 ifdef::katello,foreman-el[]
 [start=4]
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
++
 ----
 # yum remove epel-release
 ----
 [start=5]
 . Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
++
 ----
 # yum remove centos-release-scl centos-release-scl-rh
 ----
 [start=6]
 . Let LEAPP analyze your system:
++
 ----
 # leapp preupgrade
 ----
@@ -159,18 +167,20 @@ Continue to the next step for remediation.
 
 [start=7]
 . Fix issues found by LEAPP (check `/var/log/leapp/leapp-report.txt` for details):
++
 ----
 # rmmod pata_acpi
 # echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
 # leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 ----
 ifdef::katello,foreman-el[]
-** The `preupgrade` might fail with a dependency resolution error such as:
+The `preupgrade` might fail with a dependency resolution error such as:
 
 * "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
 * "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
 
 If this happens, do the following to clean up packages that cannot automatically upgrade:
+
 ----
 # dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd)
 ----
@@ -192,6 +202,7 @@ endif::[]
 ifdef::katello,foreman-el[]
 [start=9]
 . Run:
++
 ----
 # leapp upgrade
 ----
@@ -210,6 +221,7 @@ ifdef::katello,foreman-el[]
 
 [start=12]
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
++
 ----
 # journalctl -u leapp_resume -f
 ----

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -1,12 +1,12 @@
 [id="Upgrading-Project-from-EL7-to-EL8{context}"]
-= Upgrading {Project} from RHEL 7 to RHEL 8
+= Upgrading {Project} from {RHEL} 7 to {RHEL} 8
 
-Use this procedure to upgrade your {Project} installation from RHEL 7 to RHEL 8.
-LEAPP is the supported tool for RHEL 7 to RHEL 8 upgrades.
+Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL} 8.
+LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
 
 .Prerequisites
 * {Project} {ProjectVersionPrevious} running on CentOS 7.
-- Upgrading does not work on RHEL. You must have a RHEL-compatible LEAPP build to upgrade.
+- Upgrading does not work on {RHEL}. You must have a {RHEL}-compatible LEAPP build to upgrade.
 * Access to a local repository server mirroring all required repositories.
 * No outstanding updates.
 * You can upgrade a CentOS7 system before you upgrade {Project}.
@@ -145,7 +145,7 @@ or:
 . Reboot the system.
 . After the system reboots, a live system conducts the upgrade.
 . Reboot to fix SELinux labels.
-. Reboot into the final RHEL8 system.
+. Reboot into the final {RHEL} 8 system.
 . After the system reboots, LEAPP finishes the upgrade.
 . You can watch LEAPP finish the upgrade with:
 +

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -72,11 +72,7 @@ gpgkey=https://yum.theforeman.org/pulpcore/3.16/GPG-RPM-KEY-pulpcore
 enabled=1
 gpgcheck=1
 module_hotfixes=1
-----
-endif::[]
 
-+
-----
 [leapp-foreman-plugins]
 name=Foreman plugins 3.2
 baseurl=https://yum.theforeman.org/plugins/3.2/el8/$basearch
@@ -100,6 +96,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
 enabled=1
 gpgcheck=1
 ----
+endif::[]
 
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
 
@@ -150,18 +147,16 @@ If this happens, do the following to clean up packages that cannot automatically
 # dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd)
 ----
 
-[start=8]
-. Check the output if it does not contain any local packages.
-+
-. Remove `rubygem-thor`:
-+
+Check the output if it does not contain any local packages.
+
+Remove `rubygem-thor`:
+
 ----
 # yum remove rubygem-thor
 ----
 endif::[]
 
-+
-
+[start=8]
 . Ensure `leapp preupgrade` has no issues.
 +
 . Run:

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -1,0 +1,159 @@
+[id="Upgrading-Project-from-EL7-to-EL8{context}"]
+= Upgrading {Project} from RHEL 7 to RHEL 8
+
+Use this procedure to upgrade your {Project} installation from RHEL 7 to RHEL 8.
+LEAPP is the supported tool for RHEL 7 to RHEL 8 upgrades.
+
+.Prerequisites
+* {Project} {ProjectVersionPrevious} running on CentOS 7.
+- Upgrading does not work on RHEL. You must have a RHEL-compatible LEAPP build to upgrade.
+* Access to a local repository server mirroring all required repositories.
+* No outstanding updates.
+* You can upgrade a CentOS7 system before you upgrade {Project}.
+
+.Procedure
+. Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
++
+----
+# curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
+----
+. Install required packages:
++
+----
+# yum install leapp leapp-repository leapp-data-centos
+----
+
+. Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
++
+----
+# [leapp-foreman]
+name=Foreman 3.2
+baseurl=https://yum.theforeman.org/releases/3.2/el8/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
+
+[leapp-foreman-plugins]
+name=Foreman plugins 3.2
+baseurl=https://yum.theforeman.org/plugins/3.2/el8/$basearch
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
+
+[leapp-puppet7]
+name=Puppet 7 Repository el 8 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1
+
+[leapp-katello]
+name=Katello 4.4
+baseurl=https://yum.theforeman.org/katello/4.4/katello/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-katello-candlepin]
+name=Candlepin: an open source entitlement management system.
+baseurl=https://yum.theforeman.org/katello/4.4/candlepin/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-pulpcore]
+name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
+baseurl=https://yum.theforeman.org/pulpcore/3.16/el8/$basearch/
+gpgkey=https://yum.theforeman.org/pulpcore/3.16/GPG-RPM-KEY-pulpcore
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+----
+
+* If you are not using {Project}, you can leave out `leapp-katello`, `leapp-katello-candlepin` and `leapp-pulpcore`.
+
+* If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
+
+* You need a Puppet repository for the Puppet agent that the installer is using.
+
+. We do not support EL8 installations with EPEL8 enabled, so remove `epel-release`:
++
+----
+# yum remove epel-release
+----
+. Let LEAPP analyze your system:
++
+----
+# leapp preupgrade
+----
+
++
+
+The first run is expected to fail but report issues.
+Continue to the next step for remediation.
+
+. Fix issues found by LEAPP (check `/var/log/leapp/leapp-report.txt` for details):
++
+----
+# rmmod pata_acpi
+# echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
+# leapp answer --section remove_pam_pkcs11_module_check.confirm=True
+----
++
+
+** If `preupgrade` aborts with a dependency resolution error such as:
++
+----
+# package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can install
+----
+or:
++
+----
+ # package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can install
+----
+
+** Remove packages that are no longer available from any repository:
++
+----
+# dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd) –
+----
+
++
+
+** Check the output if it does not contain any local packages.
+
+** Remove `rubygem-thor`:
++
+----
+# yum remove rubygem-thor
+----
+
+. Ensure `leapp preupgrade` has no issues.
+. Run:
++
+----
+# leapp upgrade
+----
+
++
+
+. Reboot the system.
+. After the system reboots, a live system conducts the upgrade.
+. Reboot to fix SELinux labels.
+. Reboot into the final RHEL8 system.
+. After the system reboots, LEAPP finishes the upgrade.
+. You can watch LEAPP finish the upgrade with:
++
+----
+# journalctl -u leapp_resume -f
+----
+
+[WARNING]
+====
+If you installed the system and had to use `--disable-system-checks`, the last step of the upgrade will fail, and you will need to call `foreman-installer --disable-system-checks` manually once the system is booted up.
+====

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -1,17 +1,29 @@
 [id="Upgrading-Project-from-EL7-to-EL8{context}"]
+ifdef::satellite[]
 = Upgrading {Project} from {RHEL} 7 to {RHEL} 8
+endif::[]
+ifdef::katello,foreman-el[]
+= Upgrading {Project} from Enterprise Linux 7 to Enterprise Linux 8
+endif::[]
 
 Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL} 8.
 LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
 
 .Prerequisites
-* {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
 ifdef::katello,foreman-el[]
+* {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
+endif::[]
+
+ifdef::satellite[]
 - {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8. You must have a {RHEL} compatible LEAPP build to upgrade.
 endif::[]
+
 * Access to available repositories or a local mirror of repositories.
 * No outstanding updates.
+ifdef::katello,foreman-el[]
 * {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
+endif::[]
+
 ifdef::satellite[]
 * {Project} installations upgrade from {RHEL} 7 to {RHEL} 8, not from CentOS Linux 7 and {RHEL} rebuilds.
 endif::[]
@@ -30,17 +42,32 @@ ifdef::katello,foreman-el[]
 # yum install leapp leapp-repository leapp-data-centos
 ----
 
+ifdef::katello,foreman-el[]
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
 +
 ----
-# [leapp-foreman]
+[leapp-foreman]
 name=Foreman 3.2
 baseurl=https://yum.theforeman.org/releases/3.2/el8/$basearch
 enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+enabled=1
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
-module_hotfixes=1
 
+ifdef::katello[]
+[leapp-katello]
+name=Katello 4.4
+baseurl=https://yum.theforeman.org/katello/4.4/katello/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+endif::[]
+----
+endif::[]
+
++
+----
 [leapp-foreman-plugins]
 name=Foreman plugins 3.2
 baseurl=https://yum.theforeman.org/plugins/3.2/el8/$basearch
@@ -64,13 +91,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
 enabled=1
 gpgcheck=1
 
-[leapp-katello]
-name=Katello 4.4
-baseurl=https://yum.theforeman.org/katello/4.4/katello/el8/$basearch/
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
-enabled=1
-gpgcheck=1
-module_hotfixes=1
 
 [leapp-katello-candlepin]
 name=Candlepin: an open source entitlement management system.
@@ -88,21 +108,18 @@ enabled=1
 gpgcheck=1
 module_hotfixes=1
 ----
-endif::[]
-
-* If you are not using {Project}, you can leave out `leapp-katello`, `leapp-katello-candlepin` and `leapp-pulpcore`.
 
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
+endif::[]
 
 ifdef::katello,foreman-el[]
-. We do not support {RHEL} 8 installations with EPEL 8 enabled, so remove `epel-release`:
+. We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +
 ----
 # yum remove epel-release
 ----
-endif::[]
 
 . Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
 +
@@ -115,11 +132,10 @@ endif::[]
 # leapp preupgrade
 ----
 
-+
-
 The first run is expected to fail but report issues.
 Continue to the next step for remediation.
 
+[start=7]
 . Fix issues found by LEAPP (check `/var/log/leapp/leapp-report.txt` for details):
 +
 ----
@@ -128,40 +144,34 @@ Continue to the next step for remediation.
 # leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 ----
 +
-
-ifdef::katello,foreman-el[]
-** If `preupgrade` aborts with a dependency resolution error such as:
-+
-----
-# package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0,
-----
-but none of the providers can install or:
-+
-----
-# package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0
-----
-but none of the providers can install:
 endif::[]
 
 ifdef::katello,foreman-el[]
-. Remove packages that are no longer available from any repository:
-+
-----
-# dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd) –
-----
-endif::[]
-
+** The `preupgrade` might fail with a dependency resolution error such as:
 +
 
+* "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
+* "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
+
+If this happens, do the following to clean up packages that cannot automatically upgrade:
+----
+# dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd)
+----
+
+[start=8]
 . Check the output if it does not contain any local packages.
-
++
 . Remove `rubygem-thor`:
 +
 ----
 # yum remove rubygem-thor
 ----
+endif::[]
+
++
 
 . Ensure `leapp preupgrade` has no issues.
++
 . Run:
 +
 ----
@@ -171,7 +181,16 @@ endif::[]
 +
 
 . Reboot the system.
++
+ifdef::satellite[]
 . After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
++
+endif::[]
+ifdef::katello,foreman-el[]
+. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
++
+endif::[]
+
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
 +
 ----

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -12,9 +12,6 @@ LEAPP is the supported tool for {RHEL} 7 to {RHEL} 8 upgrades.
 .Prerequisites
 ifdef::katello,foreman-el[]
 * {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
-endif::[]
-
-ifdef::satellite[]
 - {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8. You must have a {RHEL} compatible LEAPP build to upgrade.
 endif::[]
 
@@ -22,10 +19,6 @@ endif::[]
 * No outstanding updates.
 ifdef::katello,foreman-el[]
 * {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
-endif::[]
-
-ifdef::satellite[]
-* {Project} installations upgrade from {RHEL} 7 to {RHEL} 8, not from CentOS Linux 7 and {RHEL} rebuilds.
 endif::[]
 
 .Procedure
@@ -63,6 +56,22 @@ enabled=1
 gpgcheck=1
 module_hotfixes=1
 endif::[]
+
+[leapp-katello-candlepin]
+name=Candlepin: an open source entitlement management system.
+baseurl=https://yum.theforeman.org/katello/4.4/candlepin/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-pulpcore]
+name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
+baseurl=https://yum.theforeman.org/pulpcore/3.16/el8/$basearch/
+gpgkey=https://yum.theforeman.org/pulpcore/3.16/GPG-RPM-KEY-pulpcore
+enabled=1
+gpgcheck=1
+module_hotfixes=1
 ----
 endif::[]
 
@@ -90,23 +99,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
        file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
 enabled=1
 gpgcheck=1
-
-
-[leapp-katello-candlepin]
-name=Candlepin: an open source entitlement management system.
-baseurl=https://yum.theforeman.org/katello/4.4/candlepin/el8/$basearch/
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
-enabled=1
-gpgcheck=1
-module_hotfixes=1
-
-[leapp-pulpcore]
-name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
-baseurl=https://yum.theforeman.org/pulpcore/3.16/el8/$basearch/
-gpgkey=https://yum.theforeman.org/pulpcore/3.16/GPG-RPM-KEY-pulpcore
-enabled=1
-gpgcheck=1
-module_hotfixes=1
 ----
 
 * If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -69,8 +69,8 @@ module_hotfixes=1
 
 [leapp-pulpcore]
 name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
-baseurl=https://yum.theforeman.org/pulpcore/3.16/el8/$basearch/
-gpgkey=https://yum.theforeman.org/pulpcore/3.16/GPG-RPM-KEY-pulpcore
+baseurl=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el8/$basearch/
+gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore
 enabled=1
 gpgcheck=1
 module_hotfixes=1

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -5,7 +5,7 @@ Use this procedure to upgrade your {Project} installation from Enterprise Linux 
 LEAPP is the supported tool for Enterprise Linux 7 to Enterprise Linux 8 upgrades.
 
 .Prerequisites
-* {Project} {ProjectVersionPrevious} running on CentOS Linux 7.
+* {Project} {ProjectVersion} running on Enterprise Linux 7.
 * {Project} installations running on {RHEL} 7 cannot upgrade to {RHEL} 8.
 You must have a {RHEL} compatible LEAPP build to upgrade.
 * Access to available repositories or a local mirror of repositories.
@@ -13,35 +13,40 @@ You must have a {RHEL} compatible LEAPP build to upgrade.
 * {Project} installations can be upgraded to CentOS Stream 8 and a {RHEL} rebuild.
 
 .Procedure
-[start=1]
-. Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
+. Do not perform this step on {RHEL} as this is for CentOS. Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
 +
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
 ----
-[start=2]
+
 . Install required packages:
 +
 ----
-# yum install leapp leapp-repository leapp-data-centos
+# yum install leapp leapp-repository
 ----
 
-[start=3]
+. Install additional OS specific packages (`leapp-data-centos` for CentOS Stream, `leapp-data-rocky` for Rocky Linux, `leapp-data-almalinux` for AlmaLinux`). Not required for {RHEL}.
++
+----
+# yum install leapp-data-centos
+----
+
++
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
 +
 ----
 [leapp-foreman]
-name=Foreman 3.2
+name={ProjectVersion}
 baseurl=https://yum.theforeman.org/releases/3.2/el8/$basearch
-enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
+module_hotfixes=1
 
 ifdef::katello[]
 [leapp-katello]
-name=Katello 4.4
+name={KatelloVersion}
 baseurl=https://yum.theforeman.org/katello/4.4/katello/el8/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
@@ -49,7 +54,7 @@ gpgcheck=1
 module_hotfixes=1
 
 [leapp-katello-candlepin]
-name=Candlepin: an open source entitlement management system.
+name={KatelloVersion}
 baseurl=https://yum.theforeman.org/katello/4.4/candlepin/el8/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
@@ -66,7 +71,7 @@ module_hotfixes=1
 endif::[]
 
 [leapp-foreman-plugins]
-name=Foreman plugins 3.2
+name={ProjectVersion}
 baseurl=https://yum.theforeman.org/plugins/3.2/el8/$basearch
 enabled=1
 gpgcheck=0
@@ -93,21 +98,21 @@ gpgcheck=1
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
 
++
 For more information, see link:https://docs.theforeman.org/nightly/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet].
 
-[start=4]
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +
 ----
 # yum remove epel-release
 ----
-[start=5]
+
 . Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
 +
 ----
 # yum remove centos-release-scl centos-release-scl-rh
 ----
-[start=6]
+
 . Let LEAPP analyze your system:
 +
 ----
@@ -116,7 +121,6 @@ For more information, see link:https://docs.theforeman.org/nightly/Managing_Conf
 The first run is expected to fail but report issues.
 Continue to the next step for remediation.
 
-[start=7]
 . Fix issues found by LEAPP (check `/var/log/leapp/leapp-report.txt` for details):
 +
 ----
@@ -125,42 +129,38 @@ Continue to the next step for remediation.
 # leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 ----
 
++
 The `preupgrade` might fail with a dependency resolution error such as:
 
 * "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
 * "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
 
-If this happens, do the following to clean up packages that cannot automatically upgrade:
-+
+If this happens, do the following to clean up packages that cannot automatically upgrade (`rubygem(thor)` and `rubygem(railties)` in the example above):
 ----
-# dnf remove $(dnf repoquery --extras --exclude '*katello*' --exclude '*pulp*' --exclude '*localhost*' --exclude "*$HOSTNAME*" --exclude libmodulemd)
+# yum remove rubygem-thor rubygem-railties
 ----
 
 Check the output if it does not contain any local packages.
 
 Remove `rubygem-thor`:
-+
 ----
 # yum remove rubygem-thor
 ----
-
-[start=8]
-. Ensure `leapp preupgrade` has no issues.
-
 [start=9]
+. Ensure `leapp preupgrade` has no issues.
+[start=10]
 . Run:
 +
 ----
 # leapp upgrade
 ----
 
-[start=10]
+[start=11]
 . Reboot the system.
 
-[start=11]
-. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
-
 [start=12]
+. After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
+[start=13]
 . After the system reboots, LEAPP finishes the upgrade, watch it with:
 +
 ----

--- a/guides/common/modules/proc_upgrading-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-el7-to-el8.adoc
@@ -93,6 +93,8 @@ gpgcheck=1
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
 
+For more information, see link:https://docs.theforeman.org/nightly/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet].
+
 [start=4]
 . We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -56,7 +56,7 @@ include::topics/upgrading_discovery_satellite.adoc[leveloffset=+3]
 // Configuring Subnets with a Template Capsule
 include::topics/upgrading_discovery_subnet_with_a_template_capsule.adoc[leveloffset=+3]
 
-ifdef::katello,satellite[]
+ifdef::foreman-el,katello,satellite[]
 // Upgrading Foreman/Katello from EL7 to EL8
 include::common/modules/proc_upgrading-el7-to-el8.adoc[leveloffset=+2]
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -56,6 +56,11 @@ include::topics/upgrading_discovery_satellite.adoc[leveloffset=+3]
 // Configuring Subnets with a Template Capsule
 include::topics/upgrading_discovery_subnet_with_a_template_capsule.adoc[leveloffset=+3]
 
+ifdef::katello,satellite[]
+// Upgrading Foreman/Katello from EL7 to EL8
+include::common/modules/proc_upgrading-el7-to-el8.adoc[leveloffset=+2]
+endif::[]
+
 ifndef::foreman-deb[]
 // Upgrading virt-who
 include::topics/upgrading_virt_who.adoc[leveloffset=+2]

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -56,7 +56,7 @@ include::topics/upgrading_discovery_satellite.adoc[leveloffset=+3]
 // Configuring Subnets with a Template Capsule
 include::topics/upgrading_discovery_subnet_with_a_template_capsule.adoc[leveloffset=+3]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 // Upgrading Foreman/Katello from EL7 to EL8
 include::common/modules/proc_upgrading-el7-to-el8.adoc[leveloffset=+2]
 endif::[]


### PR DESCRIPTION
Created a new module for the master.adoc for Upgrading and Updating Foreman. This module is titled proc_upgrading-el7-to-el8.adoc. The content came from an existing document and was cleaned up for minimalist purposes and grammar. The content was pulled from this link: https://hackmd.io/@evgeni/B1AT256Q5

@melcorr This is the one you needed a PR for. Needed to clean up the content to fit minimalist principles. Did not see any attributes for RHEL so let me know if I missed that.

Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
