### PR TITLE
Replace the command in the topic Configuring Satellite to use Externa…

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -27,7 +27,7 @@ Use the `{foreman-installer}` command to configure {Project} to connect to an ex
   --foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
   --foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
   --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_
-  --foreman-proxy-content-pulpcore-postgresql-user pulpcore
+  --foreman-proxy-content-pulpcore-postgresql-user pulp
 ----
 +
 
@@ -42,6 +42,3 @@ To enable the Secure Sockets Layer (SSL) protocol for these external databases, 
 --foreman-proxy-content-pulpcore-postgresql-ssl true
 --foreman-proxy-content-pulpcore-postgresql-ssl-root-ca <path_to_CA>
 ----
-
-
-


### PR DESCRIPTION
Replace the command in the topic Configuring Satellite to use External Databases

The installer flags need to be updated as they should have the
correct username. The command replacement is applicable to
connected and disconnected networks both.

External database documentation needs modification for user

https://issues.redhat.com/browse/SATDOC-751

Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
