### PR TITLE
Updated Supported Browsers List for Foreman 3.3

### DIFF
--- a/guides/common/modules/ref_supported-browsers.adoc
+++ b/guides/common/modules/ref_supported-browsers.adoc
@@ -6,12 +6,15 @@ ifdef::satellite[]
 endif::[]
 
 ifdef::foreman-el,foreman-deb,katello[]
+Using the most recent version of a major browser is highly recommended, as {Project} and the frameworks it uses offer limited support for older versions.
+
 The recommended requirements are as follows for major browsers:
 
-* Google Chrome 54 or higher
-* Microsoft Edge
-* Microsoft Internet Explorer 10 or higher
-* Mozilla Firefox 49 or higher
+* Google Chrome - latest version
+* Microsoft Edge - latest version
+* Apple Safari - latest version
+* Mozilla Firefox - latest version
+* Mozilla Firefox Extended Support Release (ESR) - latest version
 
 Other browsers may work unpredictably.
 endif::[]


### PR DESCRIPTION
Per SATDOC-652, I updated the recommended the Supported Browsers list for Foreman 3.3.


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
