### PR TITLE
Added missing ports

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -27,11 +27,15 @@ endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:
 
-.Ports for {SmartProxy} to {Project} Communication
+Ports for {SmartProxy} to {Project} Communication
 [cols="24%,20%,18%,38%",options="header"]
 |====
 | Port | Protocol | Service | Required For
+| 80 | TCP | HTTP | Anaconda, yum, and for obtaining Katello certificate updates
+| 443    | TCP   |  HTTPS  |  Connections to Katello, {Project}, {Project} API, and Pulp
+| 5000   | TCP   | HTTPS | Connection to Katello for the Docker registry
 | 5646   | TCP   |  amqp   |  {SmartProxy}'s Qpid dispatch router to Qpid dispatch router in {Project}
+| 5647   | TCP   |  amqp   |  Katello agent to communicate with {Project}'s Qpid dispatch router
 |====
 
 ifeval::["{build}" == "foreman"]

--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -27,7 +27,7 @@ endif::[]
 
 The following tables indicate the destination port and the direction of network traffic:
 
-Ports for {SmartProxy} to {Project} Communication
+.Ports for {SmartProxy} to {Project} Communication
 [cols="24%,20%,18%,38%",options="header"]
 |====
 | Port | Protocol | Service | Required For


### PR DESCRIPTION
Ports had been removed from table 1.2 after Satellite 6.5. This change puts them back.
The information is current for Satellite 6.9. Note that the information in satellite 6.1/Foreman 2.5
is expanded and corrected.

Bug 1958092 - [Doc] Firewall documentation missing ports

https://bugzilla.redhat.com/show_bug.cgi?id=1958092


Cherry-pick into:

* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
