### PR TITLE
Remove context from xref

### DIFF
--- a/guides/common/modules/ref_performing-configuration-management.adoc
+++ b/guides/common/modules/ref_performing-configuration-management.adoc
@@ -15,4 +15,5 @@ For more information, see {AdministeringDocURL}Monitoring_Resources_admin[Monito
 . Configuring email notifications.
 For more information, see {AdministeringDocURL}Configuring_Email_Notifications_admin[Configuring Email Notifications] in _Administering {ProjectName}_.
 
-After assigning Puppet classes or config groups, {Project} runs configuration management automatically in the configured intervals to enforce Puppet configuration on the managed hosts, or you can initiate it manually on demand with the xref:running-puppet-once-using-ssh_managing-configurations-puppet[*Run Puppet Once* feature].
+After assigning Puppet classes or config groups, {Project} runs configuration management automatically in the configured intervals to enforce Puppet configuration on the managed hosts, or you can initiate it manually on demand with the *Run Puppet Once* feature.
+For more information, see xref:running-puppet-once-using-ssh_{context}[].


### PR DESCRIPTION
For xrefs, we should not hard-code the context but use the `{context}` attribute instead.

Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1