### PR TITLE
Add alternative to pulp-manifest package

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Custom_File_Type_Content.adoc
@@ -130,9 +130,21 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} python-pulp-manifest
+# {package-install-project} python3-pulp-manifest
 ----
 +
+Note that this command stops the {Project} service and re-runs {foreman-installer}.
+Alternatively, to prevent downtime caused by stopping the service, you can use the following:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable {RepoRHEL7ServerSatelliteToolsProductVersion}
+# {foreman-maintain} packages unlock
+# yum install install python-pulp-manifest -y
+# {foreman-maintain} packages lock
+# subscription-manager repos --disable {RepoRHEL7ServerSatelliteToolsProductVersion}
+----
+This installs the package without downtime.
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +
 [options="nowrap" subs="+quotes"]
@@ -228,7 +240,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# yum install python-pulp-manifest
+# yum install python3-pulp-manifest
 ----
 +
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:


### PR DESCRIPTION
Separate PR for 3.0 which is not modularized. Changed to python3 where necessary.
Added the alternative method. Python3 step stops the server and increases downtime.
The alternative method does not.

calling satellite-installer in order to install the package python-pulp-manifest

https://issues.redhat.com/browse/SATDOC-244


Cherry-pick into:

* [ ] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
