### PR TITLE
Added note on enabling kickstart.

### DIFF
--- a/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
+++ b/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
@@ -13,6 +13,9 @@ endif::[]
 
 Use this procedure to set up a kickstart repository.
 
+.Prerequisites
+You must enable both *BaseOS* and *Appstream Kickstart* before provisioning.
+
 .Procedure
 
 . Add the synchronized kickstart repository that you want to use to the existing Content View, or create a new Content View and add the kickstart repository.


### PR DESCRIPTION
Note on enabling BaseOS and AppStreamm kickstart added.

Bug 2027484 - Provide info about AppStream unmanaged content

https://bugzilla.redhat.com/show_bug.cgi?id=2027484


Cherry-pick into:

* [ ] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
