### PR TITLE
Fix symlink to common images (Sat Disconnected)

### DIFF
--- a/guides/doc-Installing_Satellite_Server_Disconnected/images/common
+++ b/guides/doc-Installing_Satellite_Server_Disconnected/images/common
@@ -1,1 +1,1 @@
-../common/images
+../../common/images/


### PR DESCRIPTION
Internal Sat build still breaking due to a missing image. I was advised that this might help, but I will have to test it downstream.

Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1 (required for testing)

NOTE I would cherrypick it everywhere for future compatibility, but we can wait with cherrypicking to 3.2 and 3.3 until I will have tested it properly.

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
