### PR TITLE
Add the Repositories and repair the content for RHEL 8

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 ifdef::foreman-el,foreman-deb,satellite[]
 // Configuring Repositories
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
 
 // Installing {SmartProxyServer} Packages

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -2,7 +2,8 @@
 = Attaching the {Project} Infrastructure Subscription
 
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
-The {ProjectName} Infrastructure subscription provides access to the {ProjectName}, {RHEL}, and Red{nbsp}Hat Software Collections (RHSCL) content.
+The {ProjectName} Infrastructure subscription provides access to the {ProjectName} and {RHEL} content.
+For {RHEL} 7, it also provides access to Red{nbsp}Hat Software Collections (RHSCL).
 This is the only subscription required.
 
 {ProjectName} Infrastructure is included with all subscriptions that include Smart Management.

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -7,8 +7,54 @@ This procedure is only for Katello plug-in and {RHEL}-based operating system use
 endif::[]
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
+Select the option that corresponds with operating system and version you want to install on:
 
-.Procedure
+ifdef::foreman-el,katello,satellite[]
+* xref:#repositories-rhel-8[{RHEL} 8]
+* xref:#repositories-rhel-7[{RHEL} 7]
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
+== [[repositories-rhel-8]]{RHEL} 8
+
+:distribution-major-version: 8
+:package-manager: dnf
+
+. Disable all repositories:
++
+[options="nowrap"]
+----
+# subscription-manager repos --disable "*"
+----
++
+endif::[]
+
+. Enable the following repositories:
+ifdef::satellite[]
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteCapsuleProductVersion} \
+--enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+
+. Enable the module:
++
+[options="nowrap"]
+----
+# dnf module enable satellite-capsule:el8
+----
++
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
+
+== [[repositories-rhel-7]]{RHEL} 7
+
+:distribution-major-version: 7
+:package-manager: yum
 
 . Disable all repositories:
 +

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -95,8 +95,7 @@ ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteServerProductVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
-endif::[]
-ifdef::satellite[]
+
 . Enable the module:
 +
 [options="nowrap"]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -74,7 +74,7 @@ ifdef::foreman-el,katello,satellite[]
 == [[repositories-rhel-8]]{RHEL} 8
 
 :distribution-major-version: 8
-:package-manager: yum, dnf
+:package-manager: dnf
 
 . Disable all repositories:
 +

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -9,6 +9,7 @@ ifdef::foreman-el,katello[]
 * xref:#repositories-centos-7[CentOS 7]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
+* xref:#repositories-rhel-8[{RHEL} 8]
 * xref:#repositories-rhel-7[{RHEL} 7]
 endif::[]
 ifdef::foreman-deb[]
@@ -70,6 +71,43 @@ include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
+== [[repositories-rhel-8]]{RHEL} 8
+
+:distribution-major-version: 8
+:package-manager: yum, dnf
+
+. Disable all repositories:
++
+[options="nowrap"]
+----
+# subscription-manager repos --disable "*"
+----
++
+endif::[]
+
+. Enable the following repositories:
+ifdef::satellite[]
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteServerProductVersion} \
+--enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+endif::[]
+ifdef::satellite[]
+. Enable the module:
++
+[options="nowrap"]
+----
+# dnf module enable satellite:el8
+----
++
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
+
 == [[repositories-rhel-7]]{RHEL} 7
 
 :distribution-major-version: 7
@@ -99,19 +137,17 @@ ifdef::foreman-el,katello[]
 # {package-manager} localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-{distribution-major-version}.noarch.rpm
 ----
 endif::[]
+
 ifdef::satellite[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable={RepoRHEL7ServerSatelliteServerProductVersion} \
---enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion} \
 --enable={RepoRHEL7ServerSoftwareCollections} \
---enable={RepoRHEL7ServerAnsible}
+--enable={RepoRHEL7ServerAnsible} \
+--enable={RepoRHEL7ServerSatelliteServerProductVersion} \
+--enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion}
 ----
-endif::[]
-ifdef::foreman-el,katello[]
-include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -7,10 +7,6 @@ ifdef::foreman-el,katello[]
 * xref:centos-7-package[{RHEL} 7 / CentOS Linux 7]
 * xref:centos-8-package[{RHEL} 8 / CentOS Linux 8]
 endif::[]
-ifdef::satellite[]
-* xref:rhel-7-package[{RHEL} 7]
-endif::[]
-
 .Procedure
 To install {SmartProxyServer}, complete the following steps:
 
@@ -21,10 +17,6 @@ endif::[]
 
 ifdef::foreman-el,katello[]
 [[centos-7-package]] == {RHEL} 7 / CentOS Linux 7
-endif::[]
-
-ifdef::satellite[]
-[[rhel-7-package]] == {RHEL} 7
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -7,7 +7,7 @@ ifdef::foreman-el,katello[]
 * xref:#centos-8[CentOS 8]
 * xref:#centos-7[CentOS 7]
 endif::[]
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 * xref:#rhel-7[{RHEL} 7]
 endif::[]
 
@@ -32,7 +32,6 @@ include::proc_installing-server-packages-el.adoc[]
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
-== [[rhel-7]]{RHEL} 7
 
 :context: rhel7
 :package-manager: yum

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -31,7 +31,8 @@ include::proc_installing-server-packages-el.adoc[]
 
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
+== [[rhel-7]]{RHEL} 7
 
 :context: rhel7
 :package-manager: yum

--- a/guides/common/modules/proc_registering-to-red-hat-subscription-management.adoc
+++ b/guides/common/modules/proc_registering-to-red-hat-subscription-management.adoc
@@ -6,7 +6,8 @@ If you use a {RHEL}-based operating system, complete the following steps.
 endif::[]
 
 Registering the host to Red Hat Subscription Management enables the host to subscribe to and consume content for any subscriptions available to the user.
-This includes content such as {RHEL}, Red Hat Software Collections (RHSCL), and {ProjectName}.
+This includes content such as {RHEL} and {ProjectName}.
+For {RHEL} 7, it also provides access to Red{nbsp}Hat Software Collections (RHSCL).
 
 .Procedure
 

--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -5,7 +5,7 @@
 To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProductName} with Network Time Protocol (NTP) servers.
 If the base operating system clock is configured incorrectly, certificate verification might fail.
 
-For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite[Configuring NTP Using the chrony Suite] in the _{RHEL} 7 System Administrator's Guide_.
+For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in the _{RHEL} 8 System Administrator's Guide_, and https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite[Configuring NTP Using the chrony Suite] in the _{RHEL} 7 System Administrator's Guide_.
 
 .Procedure
 

--- a/guides/common/modules/proc_verifying-firewall-settings.adoc
+++ b/guides/common/modules/proc_verifying-firewall-settings.adoc
@@ -16,5 +16,5 @@ include::snip_firewalld.adoc[]
 ----
 
 ifndef::foreman-deb[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_firewalls#sec-Getting_started_with_firewalld[Getting Started with firewalld] in the _{RHEL} 7 Security Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and Configuring firewalld] in the _{RHEL} 8 Security Guide_, and https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_firewalls#sec-Getting_started_with_firewalld[Getting Started with firewalld] in the _{RHEL} 7 Security Guide_.
 endif::[]

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -8,6 +8,26 @@ These values are based on expected use case scenarios and can vary according to 
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 
 ifdef::foreman-el,katello[]
+== [[storage-centos-8]]{RHEL} 8 / CentOS Linux 8
+endif::[]
+
+ifdef::satellite[]
+== [[storage-rhel-8]]{RHEL} 8
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
+.Storage Requirements for {SmartProxyServer} Installation
+[cols="1,1,1",options="header"]
+|====
+|Directory |Installation Size |Runtime Size
+|/var/lib/pulp |1 MB |300 GB
+|/var/lib/pgsql |100 MB |10 GB
+|/usr |3 GB |Not Applicable
+|/opt/puppetlabs |500 MB |Not Applicable
+|====
+endif::[]
+
+ifdef::foreman-el,katello[]
 == [[storage-centos-7]]{RHEL} 7 / CentOS Linux 7
 endif::[]
 
@@ -22,18 +42,8 @@ ifdef::foreman-el,katello,satellite[]
 |Directory |Installation Size |Runtime Size
 |/var/lib/pulp |1 MB |300 GB
 |/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |10 GB
-|/opt | 500 MB | Not Applicable
-|====
-endif::[]
-
-ifdef::foreman-el,katello[]
-== [[storage-centos-8]]{RHEL} 8 / CentOS Linux 8
-
-.Storage Requirements for {SmartProxyServer} Installation
-[cols="1,1,1",options="header"]
-|====
-|Directory |Installation Size |Runtime Size
-|/var/lib/pulp |1 MB |300 GB
-|/var/lib/pgsql |100 MB |10 GB
+|/usr |3 GB | Not Applicable
+|/opt |3 GB | Not Applicable
+|/opt/puppetlabs |500 MB | Not Applicable
 |====
 endif::[]

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -39,7 +39,7 @@ ifdef::katello,satellite,orcharhino[]
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
 endif::[]
-| 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console
+| 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
@@ -93,7 +93,7 @@ Remote Execution result upload
 | 443 | TCP | HTTPS | Amazon EC2, Azure, Google GCE | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
-| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls
+| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
 | 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 | 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -6,6 +6,7 @@ ifdef::foreman-el,katello[]
 * xref:#storage-centos-7[CentOS 7]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
+* xref:#storage-rhel-8[{RHEL} 8]
 * xref:#storage-rhel-7[{RHEL} 7]
 endif::[]
 
@@ -53,6 +54,30 @@ endif::[]
 |/usr | 3 GB | Not Applicable
 
 |/opt | 3 GB | Not Applicable
+
+|/opt/puppetlabs | 500 MB | Not Applicable
+
+ifdef::katello,satellite[]
+|/var/lib/pulp/ |1 MB |300 GB
+
+|/var/lib/qpidd/ |25 MB | Not Applicable
+endif::[]
+|====
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
+== [[storage-rhel-8]]{RHEL} 8
+
+.Storage Requirements for a {ProjectServer} Installation
+[cols="1,1,1",options="header"]
+|====
+|Directory |Installation Size |Runtime Size
+
+|/var/log/ |10 MB |10 GB
+
+|/var/lib/pgsql |100 MB |20 GB
+
+|/usr | 3 GB | Not Applicable
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -3,7 +3,7 @@
 
 ifdef::satellite[]
 You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
-Red{nbsp}Hat {ProductName} is supported only on the latest versions of {RHEL} 7 Server that is available at the time when {ProductName} is installed.
+Red{nbsp}Hat {ProductName} is supported on the latest versions of {RHEL} 8, and {RHEL} 7 Server that are available at the time when {ProductName} is installed.
 Previous versions of {RHEL} including EUS or z-stream are not supported.
 endif::[]
 
@@ -22,6 +22,7 @@ ifdef::foreman-el,katello[]
 | {RHEL} 7 | x86_64 only | EPEL is required.
 endif::[]
 ifdef::satellite[]
+| {RHEL} 8 | x86_64 only |
 | {RHEL} 7 | x86_64 only |
 endif::[]
 ifdef::foreman-deb[]


### PR DESCRIPTION
Added the new repositories for Satellite and Capsule Servers v6.11
supporting RHEL 8. Also, added the new content and modified the
existing one wherever required to make the documentation more accurate.

Support Satellite and Capsule running on RHEL 7 and RHEL 8 - commands
in the installation docs should reflect RHEL 8.

https://issues.redhat.com/browse/SAT-9421


Cherry-pick into:

* [X] Foreman 3.3
* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
