### PR TITLE
Fix typo in release note guide's READEME file.

### DIFF
--- a/guides/doc-Release_notes/README.md
+++ b/guides/doc-Release_notes/README.md
@@ -45,7 +45,7 @@ If Katello 4.2.1 was released before Foreman 3.0.1 it would show up as:
 To generate the changelogs for Foreman 3.0.0:
 
 ```sh
-./redmine_release_notes katello 3.0.0 > topics/foreman-3.0.0.adoc
+./redmine_release_notes foreman 3.0.0 > topics/foreman-3.0.0.adoc
 ```
 
 Then edit `master.adoc` and add:


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2