### PR TITLE
Reworded Section 2.2 per SATDOC-755

### DIFF
--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -16,7 +16,7 @@ endif::[]
 This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide an integration API for managing IPv6 records, therefore the {SmartProxy} DHCP plug-in that provides DHCP management is limited to IPv4 subnets.
 
 * You must deploy an external IPv4 HTTP proxy server.
-This is required because the Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must this proxy to pull content into the {Project} on your IPv6 network.
+This is required because the Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into the {Project} on your IPv6 network.
 ifndef::satellite[]
 +
 Note that this requirement is for Katello users only.

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -1,5 +1,5 @@
 [id="requirements-for-installation-in-an-ipv6-network_{context}"]
-= Requirements for {Project} Installation in an IPv6 Network 
+= Requirements for {Project} Installation in an IPv6 Network
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
@@ -16,7 +16,7 @@ endif::[]
 This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide an integration API for managing IPv6 records, therefore the {SmartProxy} DHCP plug-in that provides DHCP management is limited to IPv4 subnets.
 
 * You must deploy an external IPv4 HTTP proxy server.
-This is required because {Project} distributes content only over IPv4 networks, therefore you must use an IPv4 proxy to redirect that content to hosts in your IPv6 network.
+This is required because the Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must this proxy to pull content into the {Project} on your IPv6 network.
 ifndef::satellite[]
 +
 Note that this requirement is for Katello users only.

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -15,8 +15,16 @@ endif::[]
 * You must deploy an external DHCP IPv6 server as a separate unmanaged service to bootstrap clients into GRUB2, which then configures IPv6 networking either using DHCPv6 or or assigning static IPv6 address.
 This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide an integration API for managing IPv6 records, therefore the {SmartProxy} DHCP plug-in that provides DHCP management is limited to IPv4 subnets.
 
+ifdef::satellite[]
 * You must deploy an external IPv4 HTTP proxy server.
 This is required because the Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into the {Project} on your IPv6 network.
+endif::[]
+
+ifdef::katello,foreman-el[]
+* You must deploy an external IPv4 HTTP proxy server.
+This is required because the Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into {Project} on your IPv6 network.
+endif::[]
+
 ifndef::satellite[]
 +
 Note that this requirement is for Katello users only.

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -17,12 +17,12 @@ This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide a
 
 ifdef::satellite[]
 * You must deploy an external IPv4 HTTP proxy server.
-This is required because the Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into the {Project} on your IPv6 network.
+This is required because Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into the {Project} on your IPv6 network.
 endif::[]
 
 ifdef::katello,foreman-el[]
-* You must deploy an external IPv4 HTTP proxy server.
-This is required because the Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into {Project} on your IPv6 network.
+* Optional: If you rely on content from IPv4 networks, you must deploy an external IPv4 HTTP proxy server.
+This is required to access Content Delivery Networks that distribute content only over IPv4 networks, therefore you must use this proxy to pull content into {Project} on your IPv6 network.
 endif::[]
 
 ifndef::satellite[]


### PR DESCRIPTION
I reworded the second to last bullet point of Section 2.2 per SATDOC-755. The IPv4 HTTP proxy is needed between the Satellite and the CDN, not the Satellite and the hosts. This was reworded based on the recommendation in the ticket.


Cherry-pick into:

* [ ] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
