### PR TITLE
Update MacOS build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifeq ($(UNAME), Darwin)
 CP_ARGS =
 endif
 
-all: serve
+all: html
 
 prep:
 	bundle install

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DEST := result
 PORT := 5000
 VERSION_LINKS := 3.3 3.2 3.1 3.0 2.5 2.4
 
-.PHONY: all clean html web compile serve
+.PHONY: all clean html web compile serve prep
 
 UNAME = $(shell uname)
 ifeq ($(UNAME), Linux)
@@ -16,6 +16,10 @@ endif
 all: serve
 
 prep:
+	bundle install
+	cd web
+	bundle install
+	cd ..
 	mkdir -p $(DEST)/nightly
 
 clean:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ To build both static site and guides for easy local testing, there is the global
 * `compile`: compiles all content into a single directory `./result`
 * `serve`: serves the result directory via a python web server (the default target)
 
-To test the whole site locally, perform `make` command and open up `http://localhost:5000`.
+To test the whole site locally, perform `make serve` command and open up `http://localhost:5000`.
+Use `PORT=5008` to change the web server port (5000 by default).
 It builds all contexts so the initial build can be slow, make sure to use `-j` option for faster builds on modern multi-core machines.
 Stable versions are symlink to the nightly (current) version, this can cause issues for deleted (or renamed) guides.
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -15,15 +15,17 @@ In Fedora perform:
 
 In MacOS required tools can be installed via brew but instead "make" call "gmake":
 
-	brew install make
+	brew install ruby make
+	# brew will ask to perform this after ruby installation, do it and restart the terminal
+	echo 'export PATH="/opt/homebrew/opt/ruby/bin:$PATH"' >> ~/.zshrc
 
-Alternatively, XCode development environment can be installed to have make utility available on PATH, however this takes about an hour to download and install and requires several gigabytes of HDD space:
+Alternatively, XCode development environment can be installed to have make utility available on PATH, however, this takes about an hour to download and install and requires several gigabytes of HDD space:
 
 	xcode-select --install
 
-Install ruby gems in `foreman-documentation` folder:
+Install ruby gems, in the `foreman-documentation` folder:
 
-	bundle install
+	make prep
 
 Then simply run `make` or `make html` which builds HTML artifacts.
 Generating PDF output is slow, therefore command `make pdf` must be used separately.


### PR DESCRIPTION
It looks our `bundle install` must be done both in the root and web/ directories. This moves this into a new make target. Also Ruby is marked as deprecated on MacOS now and will not be updated from the legacy 2.6 version, so use brew Ruby instead.

Also serve is the default makefile target, that is confusing. Perhaps html is a better target.