### PR TITLE
Removed reference to Foreman Hooks per SATDOC-918

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -9,11 +9,6 @@ For more information, see {InstallingProjectDocURL}Preparing_your_Environment_fo
 ifdef::katello,orcharhino,satellite[]
 * Ensure that you do not delete the manifest from the Customer Portal or in the {ProjectWebUI} because this removes all the entitlements of your content hosts.
 endif::[]
-* Back up and remove all Foreman hooks before upgrading.
-Restore any hooks only after {Project} is known to be working after the upgrade is complete.
-ifdef::satellite[]
-Note that Foreman Hooks functionality is deprecated and will be removed in the next {Project} version.
-endif::[]
 * If you have edited any of the default templates, back up the files either by cloning or exporting them.
 Cloning is the recommended method because that prevents them being overwritten in future updates or upgrades.
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.


### PR DESCRIPTION
In Section 3.1 in Before You Begin, I removed any and all references to Foreman Hooks because they have been deprecated for future versions.


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
