### PR TITLE
Setup authentication token from SCC Manager

### DIFF
--- a/guides/common/modules/proc_installing-the-scc-manager.adoc
+++ b/guides/common/modules/proc_installing-the-scc-manager.adoc
@@ -22,6 +22,7 @@ Perform the following steps to install the _SCC Manager_ plug-in on your {Projec
 ----
 # foreman-rake db:migrate
 # foreman-rake db:seed
+# foreman-rake foreman_scc_manager:setup_authentication_tokens
 ----
 . Restart {Project} services:
 +


### PR DESCRIPTION
This is necessary on instances running Katello 4.3+ and Foreman SCC
Manager plugin 1.8.20+.

cc @nadjaheitmann

Cherry-pick into:

* [x] Foreman 3.3