### PR TITLE
Added a note for Shortname Support Policy

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -41,6 +41,10 @@ endif::[]
 * A system umask of 0022
 * Full forward and reverse DNS resolution using a fully-qualified domain name
 
+NOTE: The shortnames in the hostnames are no longer supported for the {Project} and {SmartProxy} server.
+Also, the custom certificate's Common Name (CN) must have a fully qualified domain name (FQDN) instead of shortnames.
+This does NOT apply to the clients of a {Project} and they can continue to use shortnames if required by the user.
+
 Before you install {ProductName}, ensure that your environment meets the requirements for installation.
 
 {ProductName} must be installed on a freshly provisioned system that serves no other function except to run {ProductName}.


### PR DESCRIPTION
Added the note in the System Requirements section for the
Shortname Support Policy.

Official support policy for shortnames on Satellite and Capsule

https://issues.redhat.com/browse/SAT-9550


Cherry-pick into:

* [X] Foreman 3.3
* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
