### PR TITLE
Bump orcharhino version

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,18 +1,18 @@
 // Overrides for orcharhino build
-:KatelloVersion: Katello 3.18
-:ProductVersion: 5.12
-:ProductVersionPrevious: 5.11
+:KatelloVersion: Katello 4.1
+:ProductVersion: 6.0
+:ProductVersionPrevious: 5.12
 :Project: orcharhino
 :ProjectName: orcharhino
 :ProjectNameX: orcharhino
-:ProjectNameXY: orcharhino 5.12
+:ProjectNameXY: orcharhino 6.0
 :ProjectServer: orcharhino Server
 :ProjectServerTitle: {Project}{nbsp}Server
 :ProjectVersion: {ProductVersion}
 :ProjectVersionPrevious: {ProductVersionPrevious}
 :ProjectWebUI: {Project} management UI
 :ProjectX: orcharhino
-:ProjectXY: orcharhino 5.12
+:ProjectXY: orcharhino 6.0
 :Project_Link: orcharhino
 :RHEL: Red Hat Enterprise Linux
 :RHELServer: Red Hat Enterprise Linux Server
@@ -20,8 +20,8 @@
 :SmartProxies: orcharhino Proxies
 :SmartProxy: orcharhino Proxy
 :SmartProxyServer: orcharhino Proxy
-:TargetVersion: 5.12
-:TargetVersionMaintainUpgrade: 5.12
+:TargetVersion: 6.0
+:TargetVersionMaintainUpgrade: 6.0
 :Team: ATIX AG
 :customcontent: custom content
 :customcontenttitle: Custom Content
@@ -44,5 +44,5 @@
 :smartproxy-example-com: orcharhino-proxy.example.com
 
 // Overrides for titles
-:InstallingServerDocTitle: Installing {Project}
+:InstallingServerDocTitle: Installing {Project} Server
 :InstallingSmartProxyDocTitle: Installing {Project} Proxy


### PR DESCRIPTION
For inspiration: we restructured our downstream documentation: [all guides are now split by OS](https://docs.orcharhino.com/or/docs/sources/guides.html). cc @melcorr @Lennonka 

Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1