### PR TITLE
Update installer commands for REX plugin

### DIFF
--- a/guides/common/modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc
+++ b/guides/common/modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc
@@ -39,7 +39,7 @@ ifeval::["{context}" == "managing-hosts"]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-plugin-remote-execution-ssh-remote-working-dir _/remote_working_dir_
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-remote-working-dir _/remote_working_dir_
 ----
 
 endif::[]

--- a/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
+++ b/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
@@ -15,7 +15,7 @@ You can use Kerberos authentication to establish an SSH connection for remote ex
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {installer-scenario} \
- --foreman-proxy-plugin-remote-execution-ssh-ssh-kerberos-auth true
+ --foreman-proxy-plugin-remote-execution-script-ssh-kerberos-auth true
 ----
 +
 . To edit the default user for remote execution, in the {ProjectWebUI}, navigate to *Administer* > *Settings* and click the *RemoteExecution* tab.


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
Follows up on https://github.com/theforeman/foreman-documentation/pull/1301

```
#  rpm -q foreman
foreman-3.3.0-0.5.rc1.el7.noarch

# foreman-installer --full-help | grep remote-execution-ssh

# foreman-installer --full-help | grep remote-execution-script
    --[no-]enable-foreman-proxy-plugin-remote-execution-script Enable 'foreman_proxy_plugin_remote_execution_script' puppet module (default: true)
    --foreman-proxy-plugin-remote-execution-script-cockpit-integration  Enables/disables Cockpit integration (current: true)
    --reset-foreman-proxy-plugin-remote-execution-script-cockpit-integration Reset cockpit_integration to the default value (true)
    --foreman-proxy-plugin-remote-execution-script-mode  Operation Mode of the plugin. (current: "pull-mqtt")
    --reset-foreman-proxy-plugin-remote-execution-script-mode Reset mode to the default value ("ssh")
    --foreman-proxy-plugin-remote-execution-script-enabled  Enables/disables the plugin (current: true)
    --reset-foreman-proxy-plugin-remote-execution-script-enabled Reset enabled to the default value (true)
    --foreman-proxy-plugin-remote-execution-script-listen-on  Proxy feature listens on https, http, or both (current: "https")
    --reset-foreman-proxy-plugin-remote-execution-script-listen-on Reset listen_on to the default value ("https")
    --foreman-proxy-plugin-remote-execution-script-generate-keys  Automatically generate SSH keys (current: true)
    --reset-foreman-proxy-plugin-remote-execution-script-generate-keys Reset generate_keys to the default value (true)
    --foreman-proxy-plugin-remote-execution-script-install-key  Automatically install generated SSH key to root authorized keys
    --reset-foreman-proxy-plugin-remote-execution-script-install-key Reset install_key to the default value (false)
    --foreman-proxy-plugin-remote-execution-script-local-working-dir  Local working directory on the smart proxy (current: "/var/tmp")
    --reset-foreman-proxy-plugin-remote-execution-script-local-working-dir Reset local_working_dir to the default value ("/var/tmp")
    --foreman-proxy-plugin-remote-execution-script-remote-working-dir  Remote working directory on clients (current: "/var/tmp")
    --reset-foreman-proxy-plugin-remote-execution-script-remote-working-dir Reset remote_working_dir to the default value ("/var/tmp")
    --foreman-proxy-plugin-remote-execution-script-ssh-identity-dir  Directory where SSH keys are stored (current: "/var/lib/foreman-proxy/ssh")
    --reset-foreman-proxy-plugin-remote-execution-script-ssh-identity-dir Reset ssh_identity_dir to the default value ("/var/lib/foreman-proxy/ssh")
    --foreman-proxy-plugin-remote-execution-script-ssh-identity-file  Provide an alternative name for the SSH keys (current: "id_rsa_foreman_proxy")
    --reset-foreman-proxy-plugin-remote-execution-script-ssh-identity-file Reset ssh_identity_file to the default value ("id_rsa_foreman_proxy")
    --foreman-proxy-plugin-remote-execution-script-ssh-kerberos-auth  Enable kerberos authentication for SSH (current: false)
    --reset-foreman-proxy-plugin-remote-execution-script-ssh-kerberos-auth Reset ssh_kerberos_auth to the default value (false)
    --foreman-proxy-plugin-remote-execution-script-ssh-keygen  Location of the ssh-keygen binary (current: "/usr/bin/ssh-keygen")
    --reset-foreman-proxy-plugin-remote-execution-script-ssh-keygen Reset ssh_keygen to the default value ("/usr/bin/ssh-keygen")
    --foreman-proxy-plugin-remote-execution-script-ssh-log-level  Configure ssh client LogLevel (current: UNDEF)
    --reset-foreman-proxy-plugin-remote-execution-script-ssh-log-level Reset ssh_log_level to the default value (UNDEF)


```
