### PR TITLE
Updated Product Version attribute in steps 7 & 9

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -60,7 +60,7 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade check --target-version {ProductVersion}
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -75,7 +75,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade run --target-version {ProductVersion}
 ----
 endif::[]
 ifdef::katello[]


### PR DESCRIPTION
SATDOC-919 specified that the Target version in the Upgrading and Updating Guide in Section 3.1.1 was incorrect in steps 7 and 9. The Target version was 6.10 and needed to be 6.11. I updated the attribute to reflect version 6.11.


Cherry-pick into:

* [X] Foreman 3.3
* [X] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
