### PR TITLE
Remove redundant endif

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -96,7 +96,6 @@ include::proc_configuring-repositories-el.adoc[]
 # {package-manager} module reset postgresql
 # {package-manager} module enable postgresql:12
 ----
-endif::[]
 
 ifdef::foreman-el,katello,satellite[]
 == [[repositories-rhel-8]]{RHEL} 8


### PR DESCRIPTION
One extra endif was in the file. 


Cherry-pick into:

* [ ] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
