### PR TITLE
mark 3.1 as unsupported upstream

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: stable
+:DocState: unsupported
 
 // Version numbers
 :ProjectVersion: 3.1


### PR DESCRIPTION
marking 3.1 as an unsupported version upstream