### PR TITLE
Changed upgrade steps in Upgrading Capsule Servers

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -92,11 +92,13 @@ ifdef::satellite[]
 # yum clean metadata
 ----
 +
-. Ensure that the `rubygem-foreman_maintain` package that provides `{foreman-maintain}` is installed and up to date:
+. The `rubygem-foreman_maintain` is installed from the {Project} {ProjectVersion} maintenance repository or upgraded from the {Project} {ProjectVersion} maintenance repository if currently installed.
++
+Ensure {SmartProxy} has access to repository `{RHEL}-7-server-satellite-maintenance-{ProjectVersion}-rpms` and execute:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {package-install} rubygem-foreman_maintain
+# {project-context}-maintain self-upgrade
 ----
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -92,13 +92,13 @@ ifdef::satellite[]
 # yum clean metadata
 ----
 +
-. The `rubygem-foreman_maintain` is installed from the {Project} {ProjectVersion} maintenance repository or upgraded from the {Project} {ProjectVersion} maintenance repository if currently installed.
+. The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
-Ensure {SmartProxy} has access to repository `{RHEL}-7-server-satellite-maintenance-{ProjectVersion}-rpms` and execute:
+Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVersion}` and execute:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {project-context}-maintain self-upgrade
+# {foreman-maintain}-self-upgrade
 ----
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:


### PR DESCRIPTION
Per SATDOC-944, upgrade step was changed in Upgrading Capsule Servers to reflect the required repository containing the next version of Satellite.


Cherry-pick into:

* [ ] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
