### PR TITLE
Replaced the path of repository

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -5,7 +5,7 @@ You can register hosts with {Project} using the host registration feature, the {
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Log on to the host you want register and run the previously generated command.
-. Check the `/etc/yum.repos.d/redhat.conf` and ensure that the appropriate repositories have been enabled.
+. Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
 
 .CLI procedure
 . Generate the host registration command using the Hammer CLI:
@@ -24,7 +24,7 @@ ifdef::katello,satellite,orcharhino[]
 ----
 endif::[]
 . Log on to the host you want register and run the previously generated command.
-. Check the `/etc/yum.repos.d/redhat.conf` and ensure that the appropriate repositories have been enabled.
+. Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
 
 .API procedure
 . Generate the host registration command using the {Project} API:
@@ -55,4 +55,4 @@ Keep in mind this can save the password in the shell history.
 +
 For more information about registration see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName}].
 . Log on to the host you want register and run the previously generated command.
-. Check the `/etc/yum.repos.d/redhat.conf` and ensure that the appropriate repositories have been enabled.
+. Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.


### PR DESCRIPTION
Replaced the correct path of repository which will reflect in
Configuring Load Balancer, Installing Proxy, and Managing Content
section.

Replace /etc/yum.repos.d/redhat.conf with /etc/yum.repos.d/redhat.repo
in the Red Hat Capsule 6.11 installation guide and
anywhere else applicable

https://issues.redhat.com/browse/SATDOC-941


Cherry-pick into:

* [X] Foreman 3.3
* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
