### PR TITLE
Update README setup instructions for RHEL8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ endif
 all: html
 
 prep:
-	bundle install
+	bundle install --path vendor
 	cd web
-	bundle install
+	bundle install --path ../vendor
 	cd ..
 	mkdir -p $(DEST)/nightly
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -6,12 +6,25 @@ This is a **work in progress**, an attempt to take content written by Red Hat do
 
 Contributions are welcome. Please read the [Contribution guidelines](#contribution-guidelines) before opening a Pull Request.
 
-## Building
+## Building Locally
 
 Install the required tools.
 In Fedora perform:
 
-	dnf -y install make linkchecker
+	dnf -y groupinstall development-tools
+	dnf -y install ruby ruby-devel rubygem-bundler linkchecker
+
+Then continue with the `make prep` step below.
+
+In RHEL perform:
+	
+	dnf module enable ruby:2.7
+	dnf -y groupinstall development-tools
+	dnf -y install ruby ruby-devel rubygem-bundler python3-pip
+	pip3 install linkchecker
+
+If you prefer to install python packages into home folder rather than system-wide folder (requires root), then add `--user` option to the `pip3` command.
+Then continue with the `make prep` step below.
 
 In MacOS required tools can be installed via brew but instead "make" call "gmake":
 


### PR DESCRIPTION
I was asked for give instructions for RHEL8 (CSB) owners, so I updated it. This was tested on CentOS 8 Stream which is hopefully close enough to the internal RHEL8 build in Red Hat.

Cherry-pick into:

* [ ] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->