### PR TITLE
Added Port 443 to Capsule incoming traffic table

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -35,6 +35,11 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
+| 443 | TCP | HTTPS | Client | Content Host registration | Initiation
+
+Uploading facts
+
+Sending installed packages and traces
 | 5647 | TCP | AMQP | Client | goferd message bus | Forward message to client (optional)
 
 Katello agent to communicate with Qpid dispatcher
@@ -47,11 +52,7 @@ ifndef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
 ifdef::katello,satellite,orcharhino[]
-| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
-
-Uploading facts
-
-Sending installed packages and traces
+| 8443 | TCP | HTTPS | Client | Content Host registration | Deprecated and only needed for Client hosts deployed before upgrades
 | 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality


### PR DESCRIPTION
Per SAT-6405, I added port 443 in the Destination Port of the Capsule incoming traffic table where port 8443 is mentioned.


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
