### PR TITLE
Corrected sequence in numbering and fixed Debian section

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -86,7 +86,6 @@ ifdef::foreman-el,katello,satellite[]
 # subscription-manager repos --disable "*"
 ----
 +
-endif::[]
 
 . Enable the following repositories:
 +
@@ -105,6 +104,7 @@ ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 endif::[]
++
 
 ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]
@@ -127,6 +127,7 @@ ifdef::satellite[]
 ----
 # dnf module enable satellite:el8
 ----
+endif::[]
 endif::[]
 +
 
@@ -174,6 +175,7 @@ ifdef::satellite[]
 --enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion}
 ----
 endif::[]
++
 
 ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]


### PR DESCRIPTION
Removed the unnecessary reference of OS to avoid confusion. Also,
organized the content to make it more clear.

https://bugzilla.redhat.com/show_bug.cgi?id=2097758


Cherry-pick into:

* [X] Foreman 3.3
* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
