### PR TITLE
correct rhel 7 server repo name

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,7 +17,7 @@
 // Repositories and subscriptions (used both upstream and Satellite guides)
 // The rest of repo IDs moved to attributes-satellite.adoc
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
-:RepoRHEL7Server: rhel-7-server-satellite
+:RepoRHEL7Server: rhel-7-server-rpms
 :RepoRHEL8BaseOS: rhel-8-for-x86_64-baseos-rpms
 :RepoRHEL8AppStream: rhel-8-for-x86_64-appstream-rpms
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms


### PR DESCRIPTION
Fixes: bfa9406ec6b2839fe086664957257fb05ac6dd03


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
