### PR TITLE
Corrected value in the Load Balancing guides

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
@@ -120,7 +120,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # scp /root/_{smartproxy-example-com}_-certs.tar \
-root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
+root@_{smartproxy-example-com}_:/root/__{smartproxy-example-com}__-certs.tar
 ----
 
 . On {SmartProxyServer}, install the `puppetserver` package:
@@ -189,6 +189,6 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 --puppet-dns-alt-names "_loadbalancer.example.com_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca "false" \
---puppet-server-ca :false" \
+--puppet-server-ca "false" \
 --enable-foreman-proxy-plugin-remote-execution-script
 ----

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
@@ -24,7 +24,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # scp /root/_{smartproxy-example-com}_-certs.tar \
-root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
+root@_{smartproxy-example-com}_:/root/__{smartproxy-example-com}__-certs.tar
 ----
 
 . Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.


### PR DESCRIPTION
Fixed one of the value in the load balancing guide -
Configuring capsule server with default SSL certificates
for Load Balancing with puppet. Also, fixed the suggestion provided in
the first comment in BZ#2097378.

This is the same PR as PR#1329. Creating this one for the master branch
as per the suggestions provided in the comments on PR#1329 by @maximiliankolb 

[BUG] In the Load Balancing Guide for Satellite 6.10
and foreman upstream, :false" should be replaced with "false"

https://bugzilla.redhat.com/show_bug.cgi?id=2097378

Cherry-pick into:
* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
