### PR TITLE
Remove puppet options from loadbalancing guide for puppet disabled sc…

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_without_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_without_Puppet_for_Load_Balancing.adoc
@@ -141,17 +141,10 @@ root@_{smartproxy-example-com}_:__{smartproxy-example-com}__-certs.tar
 ----
 
 . Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.
-Set the `--puppet-ca-server` option to point to {SmartProxyServer} where you enter the command.
-You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not.
-Puppet is configured in its default single-node configuration.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 --certs-cname "_loadbalancer.example.com_" \
---puppet-dns-alt-names "_loadbalancer.example.com_" \
---puppet-ca-server "_{smartproxy-example-com}_" \
---foreman-proxy-puppetca "true" \
---puppet-server-ca "true" \
 --enable-foreman-proxy-plugin-remote-execution-script
 ----
 
@@ -167,11 +160,6 @@ Puppet is configured in its default single-node configuration.
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
 --certs-tar-file "_{smartproxy-example-com}-certs.tar_" \
---puppet-server-foreman-url "_https://{foreman-example-com}_" \
 --certs-cname "_loadbalancer.example.com_" \
---puppet-dns-alt-names "_loadbalancer.example.com_" \
---puppet-ca-server "_{smartproxy-example-com}_" \
---foreman-proxy-puppetca "true" \
---puppet-server-ca "true" \
 --enable-foreman-proxy-plugin-remote-execution-script
 ----

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet.adoc
@@ -28,17 +28,10 @@ root@_{smartproxy-example-com}_:/root/__{smartproxy-example-com}__-certs.tar
 ----
 
 . Append the following options to the `{foreman-installer}` command that you obtain from the output of the `{certs-generate}` command.
-Set the `--puppet-ca-server` option to point to {SmartProxyServer} where you enter the command.
-You must install Puppet CA on your {SmartProxyServer}s, regardless of whether you intend to use it or not.
-Puppet is configured in its default single-node configuration.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 --certs-cname "_loadbalancer.example.com_" \
---puppet-dns-alt-names "_loadbalancer.example.com_" \
---puppet-ca-server "_{smartproxy-example-com}_" \
---foreman-proxy-puppetca "true" \
---puppet-server-ca "true" \
 --enable-foreman-proxy-plugin-remote-execution-script
 ----
 
@@ -54,11 +47,6 @@ Puppet is configured in its default single-node configuration.
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
 --certs-tar-file "_{smartproxy-example-com}-certs.tar_" \
---puppet-server-foreman-url "_https://{foreman-example-com}_" \
 --certs-cname "_loadbalancer.example.com_" \
---puppet-dns-alt-names "_loadbalancer.example.com_" \
---puppet-ca-server "_{smartproxy-example-com}_" \
---foreman-proxy-puppetca "true" \
---puppet-server-ca "true" \
 --enable-foreman-proxy-plugin-remote-execution-script
 ----


### PR DESCRIPTION
…enarios

Dropped puppet opions from the installer when setting up the loadbalancer, in scenarios where puppet is disabled.


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
Hi @ekohl, Ron Lavi has suggested that I reach out to you and check if these changes are valid. Could you give it a look over once?