### PR TITLE
render leapp upgrade docs for foreman 3.1/katello 4.3

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -57,7 +57,7 @@ include::topics/upgrading_discovery_capsule.adoc[leveloffset=+3]
 // Configuring Subnets with a Template Capsule
 include::topics/upgrading_discovery_subnet_with_a_template_capsule.adoc[leveloffset=+3]
 
-ifdef::satellite[]
+ifdef::foreman-el,katello,satellite[]
 // Upgrading Foreman/Katello from Enterprise Linux 7 to Enterprise Linux 8
 include::common/modules/proc_upgrading-project-from-el7-to-el8.adoc[leveloffset=+2]
 endif::[]


### PR DESCRIPTION
we originally said this would not be supported, but after some testing,
it does work and would make users lifes easier


Cherry-pick into:

* [ ] Foreman 3.3
* [ ] Foreman 3.2
* [ ] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
