### PR TITLE
Removed - in line 101 next to self-upgrade

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -98,7 +98,7 @@ Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVe
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain}-self-upgrade
+# {foreman-maintain} self-upgrade
 ----
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:


### PR DESCRIPTION
After viewing merged PR #1323, a comment mentioned a command having an extra - so it has been removed. This PR is also needed to cherry pick to 3.3, 3.2, and 3.1 since the original PR didn't get to be cherry picked.


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
