### PR TITLE
Update load balanced Capsule port reference from 8443 to 443

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -38,7 +38,7 @@ For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg`
 | HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServer}s
 //| Anaconda | 8000 | TCP | roundrobin | port 8000 on all {SmartProxies}
 | HTTPS | 443 | TCP | source | port 443 on all {SmartProxyServer}s
-| RHSM | 8443 | TCP | roundrobin | port 8443 on all {SmartProxyServer}s
+| RHSM | 443 | TCP | roundrobin | port 443 on all {SmartProxyServer}s
 | AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServer}s
 | Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServer}s
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates

--- a/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
@@ -90,5 +90,5 @@ To register clients manually, complete the following procedure on each client th
 --activationkey=_My_Activation_Key_ \
 --baseurl=https://_loadbalancer.example.com_/pulp/content/ \
 --org=_Your_Organization_ \
---serverurl=https://_loadbalancer.example.com_:8443/rhsm
+--serverurl=https://_loadbalancer.example.com_/rhsm
 ----


### PR DESCRIPTION
Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
