### PR TITLE
use the certs-generate attribute instead of foreman-proxy-certs-generate

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -42,7 +42,7 @@ Validation succeeded.
 
 To use them inside a NEW $CAPSULE, run this command:
 
-capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
+{certs-generate} --foreman-proxy-fqdn "$CAPSULE" \
     --certs-tar  "~/$CAPSULE-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
@@ -50,7 +50,7 @@ capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
 
 To use them inside an EXISTING $CAPSULE, run this command INSTEAD:
 
-  capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
+  {certs-generate} --foreman-proxy-fqdn "$CAPSULE" \
     --certs-tar "~/$CAPSULE-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
@@ -67,14 +67,14 @@ ifndef::satellite[]
 Validation succeeded.
 
 To use them inside a NEW $FOREMAN_PROXY, run this command:
-  foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" \
+  {certs-generate} --foreman-proxy-fqdn "$FOREMAN_PROXY" \
     --certs-tar  "~$FOREMAN_PROXY-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
 
 To use them inside an EXISTING $FOREMAN_PROXY, run this command INSTEAD:
-  foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY" \
+  {certs-generate} --foreman-proxy-fqdn "\$FOREMAN_PROXY" \
     --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -27,5 +27,5 @@ endif::[]
 
 ifdef::katello[]
 * To install an external Smart Proxy with content, please refer to xref:configuring-capsule-server-with-ssl-certificates[].
-Running `foreman-proxy-certs-generate` is a required prerequisite to installing an external Smart Proxy with content.
+Running `{certs-generate}` is a required prerequisite to installing an external Smart Proxy with content.
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -45,8 +45,9 @@ ifdef::katello,satellite[]
 . Regenerate certificates.
 On the main {Project} server:
 +
+[options="nowrap" subs="attributes"]
 ----
-# foreman-proxy-certs-generate --foreman-proxy-fqdn "myproxy.example.com" \
+# {certs-generate} --foreman-proxy-fqdn "myproxy.example.com" \
                        --certs-update-all \
                        --certs-tar "~/myproxy.example.com-certs.tar"
 ----


### PR DESCRIPTION
the certs-generate command is branded differently between Katello and
Satellite and it's confusing for users to see the wrong name (even if it
works equally fine *technically*)


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
