### PR TITLE
New module explaining how to Filter and remove Facts

### DIFF
--- a/guides/common/assembly_configuring-networking.adoc
+++ b/guides/common/assembly_configuring-networking.adoc
@@ -2,6 +2,8 @@ include::modules/con_configuring-networking.adoc[]
 
 include::modules/con_network-resources.adoc[leveloffset=+1]
 
+include::modules/proc_filtering-and-removing-facts.adoc[leveloffset=+1]
+
 include::modules/con_dhcp-options.adoc[leveloffset=+1]
 
 include::modules/proc_troubleshooting-dhcp-problems.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_filtering-and-removing-facts.adoc
+++ b/guides/common/modules/proc_filtering-and-removing-facts.adoc
@@ -1,0 +1,59 @@
+////
+Base the file name and the ID on the module title. For example:
+* file name: proc-doing-procedure-a.adoc
+* ID: [id="proc-doing-procedure-a_{context}"]
+* Title: = Doing procedure A
+
+The ID is an anchor that links to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
+
+The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
+////
+
+////
+Indicate the module type in one of the following
+ways:
+Add the prefix proc- or proc_ to the file name.
+Add the following attribute before the module ID:
+////
+:_content-type: PROCEDURE
+
+[id="proc_filtering-and-removing-facts_{context}"]
+= Facts and NIC filtering
+
+Facts are host parameters such as total memory, operating system version, or architecture. You can find Facts in *Monitor* > *Facts*. You can search hosts via facts or use facts in templates.
+
+In {Project}, you can collect facts from following various sources:
+
+* `subscription manager`
+* `ansible`
+* `puppet`
+
+{Project} is an inventory system for hosts and network interfaces. For hypervisors or container hosts, it does not make any value to add thousands of interfaces per host into the inventory and update it every few minutes. For each individual NIC reported, Foreman creates a NIC entry and those entries are never removed from the database. Parsing all the facts and comparing all records in the database makes {Project} extremely slow and unusable. To optimize the performance of various actions, most importantly fact import, you can use options available in *Administer* > *Settings* > *Facts*.
+
+Filter and exclude the connections using the `Exclude pattern for facts stored in {Project}` and  `Ignore interfaces with matching identifier` option. By default, these options are set to a reasonable list for hypervisors such as, `libvirt`, `ovirt`, `RHV`, or `VMWare`. If you name the virtual interfaces differently, you may update this filter to use it according to your requirements.
+
+.Procedure
+
+. Login to your {Project} instance.
+
+.. Go to *Administer* > *Settings* > *Facts*.
+.. To filter out all interfaces starting with specific names, for example, `blu`, add `blu*` to the `Ignore interfaces with matching identifier` option.
+.. To prevent databases from storing facts related to interfaces starting with specific names, for example, `blu`, add `blu*` to the `Exclude pattern for facts stored in {Project}` option.
++
+By default, it contains the same list as the `Ignore interfaces with matching identifier` option. You can override it based on the requirements. This filters out facts completely without storing them.
+
+. To optimize performance and cleanup facts and interfaces matching filters set above, open terminal:
+
+.. To remove matching facts from the database (as added in *Administer* > *Settings* > *Facts* > the `Exclude pattern for facts stored in {Project}` option):
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foreman-rake facts:clean
+----
+
+.. To remove matching interfaces from the database (as added in *Administer* > *Settings* > *Facts* > the `Ignore interfaces with matching identifier` option):
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foreman-rake interfaces:clean
+----


### PR DESCRIPTION
Added a new module (Facts and NIC filtering) that explains how to
filter facts and NICs in order to optimize the performance and remove
unwanted facts and NICs from the database and system.
This module is added under Provisioning Hosts > Network Resources.

https://bugzilla.redhat.com/show_bug.cgi?id=2009649


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
