### PR TITLE
Add missing ansible repo in the upgrade guide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -173,6 +173,7 @@ You can either mount the shared storage or copy the backup files to the `/backup
 --enable=rhel-7-server-rpms \
 --enable=rhel-server-rhscl-7-rpms \
 --enable=rhel-7-server-satellite-maintenance-6-rpms \
+--enable={RepoRHEL7ServerAnsible} \
 --enable=rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
 ----
 +


### PR DESCRIPTION
Added ansible repo to the list of repos enabled on the clone system, without which the cloning will fail.


Cherry-pick into:

* [x] Foreman 3.3
* [x] Foreman 3.2
* [x] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
