### PR TITLE
Replaced the URLs for Firefox and CURL users

### DIFF
--- a/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
+++ b/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
@@ -36,11 +36,11 @@ $ openssl pkcs12 -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -export -in cert.p
 . In the Firefox browser, navigate to *Edit* > *Preferences* > *Advanced Tab*.
 . Select *View Certificates*, and click the *Your Certificates* tab.
 . Click *Import* and select the `.pfx` file to load.
-. In the address bar, enter a URL in the following format to browse for repositories:
+. Enter the following URL in the address bar to browse the accessible paths for all the repositories and check their contents:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-http://_{foreman-example-com}_/pulp/repos/_organization_label_
+https://_{foreman-example-com}_/pulp/content/
 ----
 +
 Pulp uses the organization label, therefore, you must enter the organization label into the URL.
@@ -51,6 +51,6 @@ To use the organization debug certificate with CURL, enter the following command
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ curl -k --cert cert.pem --key key.pem \
-http://_{foreman-example-com}_/pulp/repos/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/sat-tools/{ProductVersion}/os/
+https://_{foreman-example-com}_/pulp/content/_organization_label_/Library/content/dist/rhel/server/7/7Server/x86_64/os/
 ----
 Ensure that the paths to `cert.pem` and `key.pem` are the correct absolute paths otherwise the command fails silently.

--- a/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
+++ b/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
@@ -30,7 +30,7 @@ To use an organization debug certificate in Firefox, complete the following step
 +
 [subs="+quotes"]
 ----
-$ openssl pkcs12 -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -export -in cert.pem -inkey key.pem -out _organization_label_.pfx -name _My_Organization_
+$ openssl pkcs12 -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -export -in cert.pem -inkey key.pem -out _My_Organization_Label_.pfx -name _My_Organization_
 ----
 +
 . In the Firefox browser, navigate to *Edit* > *Preferences* > *Advanced Tab*.
@@ -51,6 +51,6 @@ To use the organization debug certificate with CURL, enter the following command
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ curl -k --cert cert.pem --key key.pem \
-https://_{foreman-example-com}_/pulp/content/_organization_label_/Library/content/dist/rhel/server/7/7Server/x86_64/os/
+https://_{foreman-example-com}_/pulp/content/_My_Organization_Label_/Library/content/dist/rhel/server/7/7Server/x86_64/os/
 ----
 Ensure that the paths to `cert.pem` and `key.pem` are the correct absolute paths otherwise the command fails silently.


### PR DESCRIPTION
The URLs that are mentioned at present are incorrect and return
the 404 error because of http:// instead of https://. Updated 
both URLs with the new ones along with https:// as shared by the reporter.
Also, added the type of URL in the address bar of Firefox users.

Fix the url protocol and end points in Section 3.4 Browsing Repository
Content Using an Organization Debug Certificate

https://bugzilla.redhat.com/show_bug.cgi?id=2097382


Cherry-pick into:

* [X] Foreman 3.3
* [X] Foreman 3.2
* [X] Foreman 3.1
* For Foreman 3.0 or older, file a separate PR request

<!---
Thank you for contributing to Foreman documentation. Make sure to read README
for the documentation standards. Set cherry-pick github label to mark this
contribution for cherry picking and check which version do you need with [x].
-->
