### PR TITLE
correct spelling of Leapp

### DIFF
--- a/guides/common/modules/proc_upgrading-project-from-el7-to-el8.adoc
+++ b/guides/common/modules/proc_upgrading-project-from-el7-to-el8.adoc
@@ -30,10 +30,10 @@ ifdef::satellite[]
 endif::[]
 
 .Procedure
-. Configure the repositories to obtain LEAPP.
+. Configure the repositories to obtain Leapp.
 ifdef::foreman-el,katello[]
 +
-On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer LEAPP packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
+On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer Leapp packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
 +
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
@@ -141,7 +141,7 @@ gpgcheck=1
 ----
 endif::[]
 
-. Let LEAPP analyze your system:
+. Let Leapp analyze your system:
 +
 ----
 # leapp preupgrade
@@ -193,7 +193,7 @@ ifdef::satellite[]
 After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
 endif::[]
 
-. LEAPP finishes the upgrade, watch it with:
+. Leapp finishes the upgrade, watch it with:
 +
 ----
 # journalctl -u leapp_resume -f


### PR DESCRIPTION
it's `Leapp` not `LEAPP`


[ ] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
