### PR TITLE
make "I am familiar" a real checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 
-[ ] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.
+* [ ] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.
 
 Please cherry-pick my commits into:
 


### PR DESCRIPTION
`[ ]` doesn't render as a checkbox inside github, but `* [ ]` does :woman_shrugging:


[ ] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
