### PR TITLE
add Debian 11 Bullseye to supported OSes

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -14,6 +14,7 @@ ifdef::foreman-el,katello,satellite[]
 endif::[]
 ifdef::foreman-deb[]
 * xref:#repositories-debian-10[Debian 10 (Buster)]
+* xref:#repositories-debian-11[Debian 11 (Bullseye)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
 endif::[]
 
@@ -191,9 +192,11 @@ ifdef::foreman-deb[]
 :distribution-codename: buster
 include::proc_configuring-repositories-deb.adoc[]
 
-endif::[]
+== [[repositories-debian-11]]Debian 11 (Bullseye)
 
-ifdef::foreman-deb[]
+:distribution-codename: bullseye
+include::proc_configuring-repositories-deb.adoc[]
+
 == [[repositories-ubuntu-2004]]Ubuntu 20.04 (Focal)
 
 :distribution-codename: focal

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -27,6 +27,7 @@ ifdef::satellite[]
 endif::[]
 ifdef::foreman-deb[]
 | Debian 10 (Buster) | amd64 |
+| Debian 11 (Bullseye) | amd64 |
 | Ubuntu 20.04 (Focal) | amd64 |
 endif::[]
 |====


### PR DESCRIPTION
* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
