### PR TITLE
drop Buster from nightly - it's unsupported now

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -13,7 +13,6 @@ ifdef::foreman-el,katello,satellite[]
 * xref:#repositories-rhel-7[{RHEL} 7]
 endif::[]
 ifdef::foreman-deb[]
-* xref:#repositories-debian-10[Debian 10 (Buster)]
 * xref:#repositories-debian-11[Debian 11 (Bullseye)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
 endif::[]
@@ -187,11 +186,6 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 endif::[]
 
 ifdef::foreman-deb[]
-== [[repositories-debian-10]]Debian 10 (Buster)
-
-:distribution-codename: buster
-include::proc_configuring-repositories-deb.adoc[]
-
 == [[repositories-debian-11]]Debian 11 (Bullseye)
 
 :distribution-codename: bullseye

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -26,7 +26,6 @@ ifdef::satellite[]
 | {RHEL} 7 | x86_64 only |
 endif::[]
 ifdef::foreman-deb[]
-| Debian 10 (Buster) | amd64 |
 | Debian 11 (Bullseye) | amd64 |
 | Ubuntu 20.04 (Focal) | amd64 |
 endif::[]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Nightly only, includes #1362 to make the diff sane.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
