### PR TITLE
Add installer options for setting external database users

### DIFF
--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -48,12 +48,15 @@ PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d
     --foreman-db-password _Foreman_Password_ \
     --foreman-db-database foreman \
     --foreman-db-manage false \
+    --foreman-db-username foreman \
     --katello-candlepin-db-host _postgres.example.com_ \
     --katello-candlepin-db-name candlepin \
     --katello-candlepin-db-password _Candlepin_Password_ \
     --katello-candlepin-manage-db false \
+    --katello-candlepin-db-user candlepin \
     --foreman-proxy-content-pulpcore-manage-postgresql false \
     --foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
     --foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
-    --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_
+    --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
+    --foreman-proxy-content-pulpcore-postgresql-user pulp
 ----


### PR DESCRIPTION
* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
