### PR TITLE
Remake title attributes (definitions were wrongly overwritten)

### DIFF
--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -13,8 +13,3 @@
 :package-remove: apt-get remove
 :package-update-project: apt-get upgrade
 :package-update: apt-get upgrade
-
-// Overrides for titles
-:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server on Debian/Ubuntu
-:InstallingSmartProxyDocTitle: Installing an External Smart Proxy Server on Debian/Ubuntu
-:QuickstartDocTitle: Quickstart Guide for {Project} on Debian/Ubuntu

--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -2,7 +2,3 @@
 :foreman-installer-package: foreman-installer
 :installer-scenario-smartproxy: foreman-installer --no-enable-foreman
 :installer-scenario: foreman-installer --scenario foreman
-
-// Overrides for titles
-:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server on RHEL/CentOS
-:QuickstartDocTitle: Quickstart Guide for {Project} on RHEL/CentOS

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -4,7 +4,3 @@
 :installer-scenario: foreman-installer --scenario katello
 :installer-log-file: /var/log/foreman-installer/katello.log
 :smartproxy_port: 9090
-
-// Overrides for titles
-:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server with Katello {KatelloVersion} Plugin on RHEL/CentOS
-:QuickstartDocTitle: Quickstart Guide for {Project} with Katello on RHEL/CentOS

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -42,7 +42,3 @@
 :project-context: orcharhino
 :smart-proxy-context: orcharhino Proxy
 :smartproxy-example-com: orcharhino-proxy.example.com
-
-// Overrides for titles
-:InstallingServerDocTitle: Installing {Project} Server
-:InstallingSmartProxyDocTitle: Installing {Project} Proxy

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -109,10 +109,3 @@
 
 :project-client-name: Satellite Client {ProductVersionRepoTitle}
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
-
-// Overrides for titles
-:InstallingServerDocTitle: Installing {ProjectServerTitle} in a Connected Network Environment
-:InstallingServerDisconnectedDocTitle: Installing {ProjectServerTitle} in a Disconnected Network Environment
-:InstallingSmartProxyDocTitle: Installing Capsule Server
-:ManagingConfigurationsPuppetDocTitle: Managing Configurations Using Puppet Integration in {ProjectName}
-:PlanningDocTitle: {Project} Overview, Concepts, and Deployment Considerations

--- a/guides/common/attributes-titles-overrides.adoc
+++ b/guides/common/attributes-titles-overrides.adoc
@@ -1,0 +1,31 @@
+// Overrides for titles per product
+
+ifdef::foreman-el[]
+:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server on RHEL/CentOS
+:QuickstartDocTitle: Quickstart Guide for {Project} on RHEL/CentOS
+endif::[]
+
+ifdef::foreman-deb[]
+// Overrides for titles
+:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server on Debian/Ubuntu
+:InstallingSmartProxyDocTitle: Installing an External Smart Proxy Server on Debian/Ubuntu
+:QuickstartDocTitle: Quickstart Guide for {Project} on Debian/Ubuntu
+endif::[]
+
+ifdef::katello[]
+:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server with Katello {KatelloVersion} Plugin on RHEL/CentOS
+:QuickstartDocTitle: Quickstart Guide for {Project} with Katello on RHEL/CentOS
+endif::[]
+
+ifdef::satellite[]
+:InstallingServerDocTitle: Installing {ProjectServerTitle} in a Connected Network Environment
+:InstallingServerDisconnectedDocTitle: Installing {ProjectServerTitle} in a Disconnected Network Environment
+:InstallingSmartProxyDocTitle: Installing Capsule Server
+:ManagingConfigurationsPuppetDocTitle: Managing Configurations Using Puppet Integration in {ProjectName}
+:PlanningDocTitle: {Project} Overview, Concepts, and Deployment Considerations
+endif::[]
+
+ifdef::orcharhino[]
+:InstallingServerDocTitle: Installing {Project} Server
+:InstallingSmartProxyDocTitle: Installing {Project} Proxy
+endif::[]

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -21,7 +21,7 @@
 // Attributes are split into separate files
 // Attribute files COMMON for all builds:
 // * attributes-base.adoc (basic upstream attributes)
-// * attributes-titles-base.adoc (title attributes)
+// * attributes-titles-base.adoc (title attributes base)
 // * attributes-typography.adoc (extra typographical attributes)
 // Attribute files for SPECIFIC PRODUCTS:
 // * attributes-foreman-el.adoc (attributes overridden or unique to Red Hat Enterprise Linux and clones)
@@ -29,6 +29,7 @@
 // * attributes-katello.adoc (attributes overridden or unique to Katello)
 // * attributes-orcharhino.adoc (attributes overridden or unique to orcharhino)
 // * attributes-satellite.adoc (attributes overridden or unique to Satellite)
+// * attributes-titles-overrides.adoc (title attributes overrides per product)
 
 // Define properties to represent each build. Allows 'or' and 'and' operations in conditions.
 ifeval::["{build}" == "foreman-el"]
@@ -55,6 +56,7 @@ endif::[]
 :SiteURL: https://docs.theforeman.org
 :BaseURL:  {SiteURL}/{ProjectVersion}/
 include::attributes-base.adoc[]
+include::attributes-titles-base.adoc[]
 include::attributes-typography.adoc[]
 
 // Load overrides for specific scenarios
@@ -80,5 +82,5 @@ ifdef::orcharhino[]
 include::attributes-orcharhino.adoc[]
 endif::[]
 
-// Must be loaded last to get attribute values correctly because of ifdefs above
-include::attributes-titles-base.adoc[]
+// Must be loaded after product-specific definitions
+include::attributes-titles-overrides.adoc[]


### PR DESCRIPTION
Had to remake how title attributes are included, because the definitions were wrongly overwritten.

* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
