### PR TITLE
Add context for Planning guide

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -1,5 +1,6 @@
 include::common/attributes.adoc[]
 include::common/header.adoc[]
+:context: planning
 
 = {PlanningDocTitle}
 


### PR DESCRIPTION
* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
