### PR TITLE
move preview deployment and commenting to a dedicated workflow

### DIFF
--- a/.github/download_workflow_run_artifact.js
+++ b/.github/download_workflow_run_artifact.js
@@ -1,0 +1,17 @@
+module.exports = async ({github, context, core, fs, artifact_name}) => {
+  let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+     owner: context.repo.owner,
+     repo: context.repo.repo,
+     run_id: context.payload.workflow_run.id,
+  });
+  let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+    return artifact.name == artifact_name
+  })[0];
+  let download = await github.rest.actions.downloadArtifact({
+     owner: context.repo.owner,
+     repo: context.repo.repo,
+     artifact_id: matchArtifact.id,
+     archive_format: 'zip',
+  });
+  fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifact_name}.zip`, Buffer.from(download.data));
+};

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,26 @@ jobs:
           name: foreman-docs-html-${{ env.BRANCH_NAME }}
           path: guides/build/
 
+      - name: Set target name (master)
+        if: github.base_ref == 'master'
+        run: echo "TARGET_NAME=nightly" >> $GITHUB_ENV
+
+      - name: Set target name (stable branch)
+        if: github.base_ref != 'master'
+        run: echo "TARGET_NAME=$(echo ${GITHUB_BASE_REF} | tr / -)" >> $GITHUB_ENV
+
+      - name: Save PR metadata
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p ./pr
+          echo '{"pr_number": ${{ github.event.number }}, "branch_name": "${{ env.BRANCH_NAME }}", "target_name": "${{ env.TARGET_NAME }}", "head_sha": "${{ github.event.pull_request.head.sha }}"}' > ./pr/pr.json
+
+      - uses: actions/upload-artifact@v3
+        if: github.event_name == 'pull_request'
+        with:
+          name: pr
+          path: pr/
+
   build-pdf:
     runs-on: ubuntu-latest
     defaults:
@@ -206,53 +226,6 @@ jobs:
         with:
           name: foreman-docs-web-master
           path: web/output/
-
-  preview:
-    if: github.event_name == 'pull_request'
-    needs:
-      - check-html
-      - build-html
-      - build-web
-      - build-ccutil
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install surge
-        run: npm install surge
-
-      - name: Get source branch name
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
-      - name: Set target name (master)
-        if: github.base_ref == 'master'
-        run: echo "TARGET_NAME=nightly" >> $GITHUB_ENV
-
-      - name: Set target name (stable branch)
-        if: github.base_ref != 'master'
-        run: echo "TARGET_NAME=$(echo ${GITHUB_BASE_REF} | tr / -)" >> $GITHUB_ENV
-
-      - name: Set preview domain
-        run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ github.event.number }}.surge.sh" >> $GITHUB_ENV
-
-      - name: Create public directory
-        run: mkdir -p public/${{ env.TARGET_NAME }}
-
-      - name: Download web
-        uses: actions/download-artifact@v3
-        with:
-          name: foreman-docs-web-master
-          path: public
-
-      - name: Download HTML
-        uses: actions/download-artifact@v3
-        with:
-          name: foreman-docs-html-${{ env.BRANCH_NAME }}
-          path: public/${{ env.TARGET_NAME }}
-
-      - name: Deploy to surge.sh
-        run: ./node_modules/.bin/surge ./public $PREVIEW_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
-
-      - name: Generate summary
-        run: echo "The PR preview is available at [$PREVIEW_DOMAIN](https://$PREVIEW_DOMAIN)" >> $GITHUB_STEP_SUMMARY
 
   publish:
     if: >

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,59 @@
+name: preview
+
+on:
+  workflow_run:
+    workflows:
+      - deploy
+    types:
+      - completed
+
+jobs:
+  preview:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download metadata artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/download_workflow_run_artifact.js');
+            let fs = require('fs');
+            await script({github, context, core, fs, artifact_name: 'pr'});
+
+      - name: Unzip artifact
+        run: unzip pr.zip
+
+      - name: Read PR data
+        run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
+
+      - name: Download other artifacts
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/download_workflow_run_artifact.js');
+            let fs = require('fs');
+            await script({github, context, core, fs, artifact_name: 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}'});
+            await script({github, context, core, fs, artifact_name: 'foreman-docs-web-master'});
+
+      - name: Set preview domain
+        run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV
+
+      - name: Install surge
+        run: npm install surge
+
+      - name: Create preview layout
+        run: |
+          mkdir -p preview/${{ fromJSON(env.PR_DATA).target_name }}
+          unzip -d preview foreman-docs-web-master.zip
+          unzip -d preview/${{ fromJSON(env.PR_DATA).target_name }} foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}.zip
+
+      - name: Deploy to surge.sh
+        run: ./node_modules/.bin/surge ./preview $PREVIEW_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ fromJSON(env.PR_DATA).pr_number }}
+          message: "The PR preview for ${{ fromJSON(env.PR_DATA).head_sha }} is available at [$PREVIEW_DOMAIN](https://$PREVIEW_DOMAIN)"


### PR DESCRIPTION
`pull_request` triggered workflows are lacking permissions to
- create comments
- access secrets

by preparing the data in the original workflow, but moving the actual
deployment to one that is triggered on `workflow_run`, we can avoid this
issue.

background: github (rightfully) limits the permissions as in a PR an
external attacker could craft a malicious update to the workflow and
gain more access than they should. `workflow_run` workflows run the code
from the default branch, not the PR, avoiding this attack vector.


* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
