### PR TITLE
Corrected AccessRedHatComVersion attribute for 3.1

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -15,7 +15,7 @@
 :SpecialCaseProductVersion: 6.9
 
 // Use current RH Satellite release version for links to access.redhat.com
-:AccessRedHatComVersion: 6.10
+:AccessRedHatComVersion: 6.11
 
 //
 // WHERE ARE MY ATTRIBUTES?


### PR DESCRIPTION
* [ ] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
