### PR TITLE
fix artifact path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           name: pr
-          path: pr/
+          path: guides/pr/
 
   build-pdf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
we run stuff with a basedir of `guides`, so we need to upload the
artifact from there too


* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
