### PR TITLE
6.11 version-less client repo for puppet-agent

### DIFF
--- a/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
@@ -12,7 +12,7 @@ endif::[]
 .Prerequisites
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-* The {ProjectName} Client Puppet 7.0 repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.
+* The {ProjectName} Client repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.
 endif::[]
 ifdef::orcharhino[]
 * The {Team} {project-client-name} repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.


### PR DESCRIPTION
Per SATDOC-968, in Section 1.5 of the Managing Configurations Using Puppet Integration in Red Hat Satellite guide, "The Red Hat Satellite Client Puppet 7.0 repository" was changed to "The Red Hat Satellite Client 6.11 repository."


* [x] I am familiar with the [contributing](CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
