### PR TITLE
correctly hide the whole centos section for Satellite builds

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -49,8 +49,6 @@ ifdef::foreman-el,katello[]
 
 include::proc_configuring-repositories-el.adoc[]
 
-endif::[]
-
 ifdef::foreman-el,katello[]
 +
 . Enable Ruby 2.7 module:
@@ -96,6 +94,7 @@ include::proc_configuring-repositories-el.adoc[]
 # {package-manager} module reset postgresql
 # {package-manager} module enable postgresql:12
 ----
+endif::[]
 
 ifdef::foreman-el,katello,satellite[]
 == [[repositories-rhel-8]]{RHEL} 8

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -49,7 +49,6 @@ ifdef::foreman-el,katello[]
 
 include::proc_configuring-repositories-el.adoc[]
 
-ifdef::foreman-el,katello[]
 +
 . Enable Ruby 2.7 module:
 +
@@ -58,27 +57,6 @@ ifdef::foreman-el,katello[]
 # {package-manager} module reset ruby
 # {package-manager} module enable ruby:2.7
 ----
-endif::[]
-
-ifdef::katello[]
-+
-. Enable `powertools` repository:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} config-manager --set-enabled powertools
-----
-endif::[]
-
-If this fails to enable, see {InstallingProjectDocURL}troubleshooting_dnf_modules[DNF module enablement troubleshooting].
-
-== [[repositories-centos-7]]CentOS 7
-
-:distribution: el
-:distribution-major-version: 7
-:package-manager: yum
-include::proc_configuring-repositories-el.adoc[]
-
 +
 . Enable the PostgreSQL 12 module:
 +
@@ -93,6 +71,16 @@ include::proc_configuring-repositories-el.adoc[]
 ----
 # {package-manager} module reset postgresql
 # {package-manager} module enable postgresql:12
+----
+endif::[]
+
+ifdef::katello[]
++
+. Enable `powertools` repository:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} config-manager --set-enabled powertools
 ----
 endif::[]
 


### PR DESCRIPTION
also fix centos8 section for foreman/katello

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
