### PR TITLE
fix performing_a_standard_rhel_installation links

### DIFF
--- a/guides/common/modules/con_migrating-project-to-el8.adoc
+++ b/guides/common/modules/con_migrating-project-to-el8.adoc
@@ -30,6 +30,6 @@ endif::[]
 * Do not install any operating system software groups or third-party applications.
 ifdef::satellite[]
 +
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/index[Performing a standard {RHEL} installation].
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/index[Performing a standard {RHEL} installation].
 endif::[]
 . Restore the backup on the target server.

--- a/guides/common/modules/proc_creating-a-host.adoc
+++ b/guides/common/modules/proc_creating-a-host.adoc
@@ -55,7 +55,7 @@ When you create a {RHEL} 8 host, you can set system purpose attributes.
 System purpose attributes define what subscriptions to attach automatically on host creation.
 In the *Host Parameters* area, enter the following parameter names with the corresponding values.
 ifndef::orcharhino[]
-For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
 endif::[]
 +
 * `syspurpose_role`

--- a/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
+++ b/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
@@ -4,7 +4,7 @@
 You can edit the system purpose attributes for a {RHEL} host.
 System purpose attributes define which subscriptions to attach automatically to this host.
 ifndef::orcharhino[]
-For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
 endif::[]
 
 .Prerequisites
@@ -22,7 +22,7 @@ endif::[]
 . Log in to the host and edit the required system purpose attributes.
 For example, set the usage type to `Production`, the role to `{RHELServer}`, and add the `addon` add on.
 ifndef::orcharhino[]
-For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
 endif::[]
 +
 [subs="+quotes"]

--- a/guides/common/modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc
+++ b/guides/common/modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc
@@ -4,7 +4,7 @@
 You can edit the system purpose attributes of {RHEL} hosts.
 System purpose attributes define which subscriptions to attach automatically to hosts.
 ifndef::orcharhino[]
-For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
 endif::[]
 
 .Prerequisites


### PR DESCRIPTION
seems they have been renamed on access.redhat.com


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
