### PR TITLE
deploy diff to surge, don't embedd it

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           mkdir old
           unzip -d old foreman-docs-html-base.zip
-          diff -Nrwu old/ public/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > diff.patch
-          diffstat -l diff.patch > diff.txt
+          diff -Nrwu old/ public/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > public/diff.patch
+          diffstat -l public/diff.patch > diff.txt
 
       - name: Deploy to surge.sh
         run: ./node_modules/.bin/surge ./preview $PREVIEW_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
@@ -72,13 +72,7 @@ jobs:
           echo "The following output files are affected by this PR:" >> pr.md
           sed -E "s#(.*)#- [\1](https://${{ env.PREVIEW_DOMAIN }}/${{ fromJSON(env.PR_DATA).target_name }}/\1)#" diff.txt >> pr.md
           echo "" >> pr.md
-          echo '<details>' >> pr.md
-          echo '<summary>show diff</summary>' >> pr.md
-          echo "" >> pr.md
-          echo '```diff' >> pr.md
-          cat diff.patch >> pr.md
-          echo '```' >> pr.md
-          echo '</details>' >> pr.md
+          echo '[show diff](https://${{ env.PREVIEW_DOMAIN }}/diff.patch)' >> pr.md
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
GH only allows 65k big comments, but diffs can be bigger :(


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
