### PR TITLE
correct paths for diffing -- the preview is in preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           mkdir old
           unzip -d old foreman-docs-html-base.zip
-          diff -Nrwu old/ public/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > public/diff.patch
-          diffstat -l public/diff.patch > diff.txt
+          diff -Nrwu old/ preview/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > preview/diff.patch
+          diffstat -l preview/diff.patch > diff.txt
 
       - name: Deploy to surge.sh
         run: ./node_modules/.bin/surge ./preview $PREVIEW_DOMAIN --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
not in public


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
