### PR TITLE
Add procedures to delete report and task records

### DIFF
--- a/guides/common/assembly_maintaining-server.adoc
+++ b/guides/common/assembly_maintaining-server.adoc
@@ -4,6 +4,8 @@ include::modules/proc_deleting-audit-records.adoc[leveloffset=+1]
 
 include::modules/proc_anonymizing-audit-records.adoc[leveloffset=+1]
 
+include::modules/proc_deleting-report-records.adoc[leveloffset=+1]
+
 include::modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc[leveloffset=+1]
 
 include::modules/proc_deleting_a_task_by_id.adoc[leveloffset=+1]

--- a/guides/common/assembly_maintaining-server.adoc
+++ b/guides/common/assembly_maintaining-server.adoc
@@ -8,6 +8,8 @@ include::modules/proc_deleting-report-records.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc[leveloffset=+1]
 
+include::modules/proc_deleting-task-records.adoc[leveloffset=+1]
+
 include::modules/proc_deleting_a_task_by_id.adoc[leveloffset=+1]
 
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_deleting-report-records.adoc
+++ b/guides/common/modules/proc_deleting-report-records.adoc
@@ -1,0 +1,15 @@
+[id="Deleting_Report_Records_{context}"]
+= Deleting Report Records
+
+Report records are created automatically in {Project}.
+You can use the `foreman-rake reports:expire` command to remove reports at any time.
+You can also use a cron job to schedule report record deletions at the set interval that you want.
+
+By default, using the `foreman-rake reports:expire` command removes report records that are older than 90 days.
+You can specify the number of days to keep the report records by adding the *days* option and add the number of days.
+
+For example, if you want to delete report records that are older than seven days, enter the following command:
+
+----
+# foreman-rake reports:expire days=7
+----

--- a/guides/common/modules/proc_deleting-task-records.adoc
+++ b/guides/common/modules/proc_deleting-task-records.adoc
@@ -1,0 +1,12 @@
+[id="Deleting_Task_Records_{context}"]
+= Deleting Task Records
+
+Task records are created automatically in {Project}.
+You can use the `foreman-rake foreman_tasks:cleanup` command to remove tasks at any time.
+You can also use a cron job to schedule Task record deletions at the set interval that you want.
+
+For example, if you want to delete task records from successful repository synchronizations, enter the following command:
+
+----
+# foreman-rake foreman_tasks:cleanup TASK_SEARCH='label = Actions::Katello::Repository::Sync' STATES='stopped'
+----


### PR DESCRIPTION
Both procedures are based on `guides/common/modules/proc_deleting-audit-records.adoc`.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
