### PR TITLE
always strip exactly two levels from the diffstat output

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -60,7 +60,7 @@ jobs:
           mkdir old
           unzip -d old foreman-docs-html-base.zip
           diff -Nrwu old/ preview/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > preview/diff.patch
-          diffstat -l preview/diff.patch > diff.txt
+          diffstat -l -p2 preview/diff.patch > diff.txt
 
       - name: Deploy to surge.sh
         run: ./node_modules/.bin/surge ./preview $PREVIEW_DOMAIN --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
diffstat, by default, tries to strip as many common path prefixes as
possible. that means, if we change files that only affect one guide, it
will also happily strip the guide folder, making the output unusable.

explicitly configure it to strip two levels, which maps to
`preview/<release>/` and is something that is truly common for any given
PR


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
