### PR TITLE
Katello upgrade docs improvement for EL 8

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -85,7 +85,7 @@ ifdef::katello[]
 ----
 # foreman-rake katello:upgrade_check
 ----
-. Update operating system packages
+. Update operating system packages:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -93,15 +93,27 @@ ifdef::katello[]
 ----
 . Update repositories
 +
-.For Centos 7 or {RHEL} Users:
+.For Centos 7 or {RHEL} 7 Users:
 [options="nowrap" subs="attributes"]
 ----
-# yum update -y https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
-# yum update -y https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
+# yum update -y https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm \
+                https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 # yum install -y centos-release-scl-rh
 ----
-. Update packages
-Clean the yum cache and update the required packages:
++
+.For Enterprise Linux 8 or {RHEL} 8 Users:
+[options="nowrap" subs="attributes"]
+----
+# dnf update -y https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
+                https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
+----
+. Ensure the module streams are enabled for Enterprise Linux 8 and {RHEL} 8:
++
+[options="nowrap" subs="attributes"]
+----
+# dnf module enable -y foreman katello pulpcore
+----
+. Clean the yum cache and update the required packages:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -115,7 +127,7 @@ Clean the yum cache and update the required packages:
 # {foreman-maintain} service stop
 ----
 +
-. Run the installer
+. Run the installer:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -55,30 +55,27 @@ On the main {Project} server:
 . Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
 endif::[]
 ifdef::katello[]
-. Update repositories for EL7
+. Update repositories
++
+.For Centos 7 or {RHEL} 7 Users:
+[options="nowrap" subs="attributes"]
+----
+# yum update -y https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm \
+                https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
+----
++
+.For Enterprise Linux 8 or {RHEL} 8 Users:
+[options="nowrap" subs="attributes"]
+----
+# dnf update -y https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
+                https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
+----
+. Clean the yum cache and update the required packages:
 +
 [options="nowrap" subs="attributes"]
 ----
-# yum update -y https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm \
-                https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
-----
-. Update repositories for EL8
-+
-[options="nowrap" subs="attributes"]
-----
-# yum update -y https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm \
-                https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
-----
-. Clean yum cache:
-+
-----
-# yum clean metadata
-----
-+
-. Update Packages:
-+
-----
-# yum update -y
+# yum clean all
+# yum -y update
 ----
 +
 . Run the installer:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -70,6 +70,12 @@ ifdef::katello[]
 # dnf update -y https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
                 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
 ----
+. Ensure the module streams are enabled for Enterprise Linux 8 and {RHEL} 8:
++
+[options="nowrap" subs="attributes"]
+----
+# dnf module enable -y foreman katello pulpcore
+----
 . Clean the yum cache and update the required packages:
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
This PR adds the missing guideline for Enterprise Linux 8 to the upgrade docs for the server part (including the breaking change for 4.5, where the Module Streams have to be enabled before running `foreman-installer`),
but also streamlines it then a bit to make sure the wording is the same for server and smart proxy.

This is my first PR against the documentation repo, I hope I didn't write total nonsense, and break every possible guideline for the docs 🙂 (I tried to look for recent changes and comply to these as guidelines)
Any help and comment is very welcome!
Thank you!

Fixes #1317

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.