### PR TITLE
Disconnected installation instructions on RHEL 8.6

### DIFF
--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -17,7 +17,9 @@ NOTE: You cannot register {ProjectServer} to itself.
 
 include::modules/proc_downloading-the-binary-dvd-images.adoc[leveloffset=+1]
 
-include::modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc[leveloffset=+1]
+include::modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-7.adoc[leveloffset=+1]
+
+include::modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc[leveloffset=+1]
 
 include::modules/proc_installing-from-the-offline-repositories.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-7.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-7.adoc
@@ -1,7 +1,7 @@
-[id="configuring-the-base-operating-system-with-offline-repositories_{context}"]
-= Configuring the Base Operating System with Offline Repositories
+[id="configuring-the-base-operating-system-with-offline-repositories-in-rhel-7{context}"]
+= Configuring the Base Operating System with Offline Repositories in RHEL 7
 
-Use this procedure to configure offline repositories for the {RHEL} and {ProjectName} ISO images.
+Use this procedure to configure offline repositories for the {RHEL} 7 and {ProjectName} ISO images.
 
 .Procedure
 
@@ -19,11 +19,12 @@ Use this procedure to configure offline repositories for the {RHEL} and {Project
 # mount -o loop _rhel7-Server-DVD_.iso /media/rhel7-server
 ----
 +
-. Copy the ISO file's repository data file.
+. To copy the ISO file's repository data file and change permissions, enter:
 +
 [options="nowrap"]
 ----
 # cp /media/rhel7-server/media.repo /etc/yum.repos.d/rhel7-server.repo
+# chmod u+w /etc/yum.repos.d/rhel7-server.repo
 ----
 
 . Edit the repository data file and add the `baseurl` directive.

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-7.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-7.adoc
@@ -1,4 +1,4 @@
-[id="configuring-the-base-operating-system-with-offline-repositories-in-rhel-7{context}"]
+[id="configuring-the-base-operating-system-with-offline-repositories-in-rhel-7_{context}"]
 = Configuring the Base Operating System with Offline Repositories in RHEL 7
 
 Use this procedure to configure offline repositories for the {RHEL} 7 and {ProjectName} ISO images.

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
@@ -16,14 +16,14 @@ Use this procedure to configure offline repositories for the {RHEL} 8 and {Proje
 +
 [options="nowrap" subs="+quotes"]
 ----
-# mount -o loop _rhel8-Server-DVD_.iso /media/rhel8-server
+# mount -o loop _rhel8-DVD_.iso /media/rhel8-
 ----
 +
 . To copy the ISO file's repository data file and change permissions, enter:
 +
 [options="nowrap"]
 ----
-# cp /media/rhel8-server/media.repo /etc/yum.repos.d/rhel8-server.repo
+# cp /media/rhel8/media.repo /etc/yum.repos.d/rhel8.repo
 # chmod u+w /etc/yum.repos.d/rhel8-server.repo
 ----
 
@@ -37,7 +37,7 @@ mediaid=None
 metadata_expire=-1
 gpgcheck=0
 cost=500
-baseurl=file:///media/rhel8-server/BaseOS/
+baseurl=file:///media/rhel8/BaseOS/
 
 [RHEL8-AppStream]
 name=Red Hat Enterprise Linux Appstream
@@ -45,7 +45,7 @@ mediaid=None
 metadata_expire=-1
 gpgcheck=0
 cost=500
-baseurl=file:///media/rhel8-server/AppStream/
+baseurl=file:///media/rhel8/AppStream/
 ----
 +
 . Verify that the repository has been configured.

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
@@ -1,0 +1,70 @@
+[id="configuring-the-base-operating-system-with-offline-repositories-in-rhel-8_{context}"]
+= Configuring the Base Operating System with Offline Repositories in RHEL 8
+
+Use this procedure to configure offline repositories for the {RHEL} 8 and {ProjectName} ISO images.
+
+.Procedure
+
+. Create a directory to serve as the mount point for the ISO file corresponding to the base operating system's version.
++
+[options="nowrap"]
+----
+# mkdir /media/rhel8-server
+----
+
+. Mount the ISO image for {RHEL} to the mount point.
++
+[options="nowrap" subs="+quotes"]
+----
+# mount -o loop _rhel8-Server-DVD_.iso /media/rhel8-server
+----
++
+. To copy the ISO file's repository data file and change permissions, enter:
++
+[options="nowrap"]
+----
+# cp /media/rhel8-server/media.repo /etc/yum.repos.d/rhel8-server.repo
+# chmod u+w /etc/yum.repos.d/rhel8-server.repo
+----
+
+. Edit the repository data file and add the `baseurl` directive.
++
+[options="nowrap"]
+----
+[RHEL8-BaseOS]
+name=Red Hat Enterprise Linux BaseOS 8.6.0
+mediaid=None
+metadata_expire=-1
+gpgcheck=0
+cost=500
+baseurl=file:///media/rhel8-server/BaseOS/
+
+[RHEL8-AppStream]
+name=Red Hat Enterprise Linux Appstream 8.6.0
+mediaid=None
+metadata_expire=-1
+gpgcheck=0
+cost=500
+baseurl=file:///media/rhel8-server/AppStream/
+----
++
+. Verify that the repository has been configured.
++
+[options="nowrap"]
+----
+# yum repolist
+----
+
+. Create a directory to serve as the mount point for the ISO file of {ProjectServer}.
++
+[options="nowrap"]
+----
+# mkdir /media/sat6
+----
+
+. Mount the ISO image for {ProjectServer} to the mount point.
++
+[options="nowrap" subs="+quotes"]
+----
+# mount -o loop _sat6-DVD_.iso /media/sat6
+----

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
@@ -5,7 +5,7 @@ Use this procedure to configure offline repositories for the {RHEL} 8 and {Proje
 
 .Procedure
 
-. Create a directory to serve as the mount point for the ISO file corresponding to the base operating system's version.
+. Create a directory to serve as the mount point for the ISO file corresponding to the version of the base operating system.
 +
 [options="nowrap"]
 ----

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
@@ -16,7 +16,7 @@ Use this procedure to configure offline repositories for the {RHEL} 8 and {Proje
 +
 [options="nowrap" subs="+quotes"]
 ----
-# mount -o loop _rhel8-DVD_.iso /media/rhel8-
+# mount -o loop _rhel8-DVD_.iso /media/rhel8
 ----
 +
 . To copy the ISO file's repository data file and change permissions, enter:
@@ -24,7 +24,7 @@ Use this procedure to configure offline repositories for the {RHEL} 8 and {Proje
 [options="nowrap"]
 ----
 # cp /media/rhel8/media.repo /etc/yum.repos.d/rhel8.repo
-# chmod u+w /etc/yum.repos.d/rhel8-server.repo
+# chmod u+w /etc/yum.repos.d/rhel8.repo
 ----
 
 . Edit the repository data file and add the `baseurl` directive.

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc
@@ -9,7 +9,7 @@ Use this procedure to configure offline repositories for the {RHEL} 8 and {Proje
 +
 [options="nowrap"]
 ----
-# mkdir /media/rhel8-server
+# mkdir /media/rhel8
 ----
 
 . Mount the ISO image for {RHEL} to the mount point.
@@ -32,7 +32,7 @@ Use this procedure to configure offline repositories for the {RHEL} 8 and {Proje
 [options="nowrap"]
 ----
 [RHEL8-BaseOS]
-name=Red Hat Enterprise Linux BaseOS 8.6.0
+name=Red Hat Enterprise Linux BaseOS
 mediaid=None
 metadata_expire=-1
 gpgcheck=0
@@ -40,7 +40,7 @@ cost=500
 baseurl=file:///media/rhel8-server/BaseOS/
 
 [RHEL8-AppStream]
-name=Red Hat Enterprise Linux Appstream 8.6.0
+name=Red Hat Enterprise Linux Appstream
 mediaid=None
 metadata_expire=-1
 gpgcheck=0


### PR DESCRIPTION
Added a module that describes how to install forman on RHEL 8.6
Existing module updated and used for RHEL 7 instructions:
proc_configuring-the-base-operating-system-with-offline-
repositories.adoc
New module added for RHEL 8 instructions:
proc_configuring-the-base-operating-system-with-offline-
repositories-in-rhel-8.adoc

Content was verified by the QA before creating this PR.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
