### PR TITLE
don't mention MongoDB during upgrades

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -229,12 +229,11 @@ Include /etc/httpd/conf.modules.d/*.conf
 # systemctl restart httpd
 ----
 
-.. Start the `postgresql` and `rh-mongodb34-mongod` database services.
+.. Start the `postgresql` database services.
 +
 [options="nowrap"]
 ----
 # systemctl start postgresql
-# systemctl start rh-mongodb34-mongod
 ----
 
 .. Enter the `{foreman-installer}` command with the `--noop` option:


### PR DESCRIPTION
there is no more MongoDB after upgrading to 6.10


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
