### PR TITLE
don't suggest to enable upstream repositories for satellite

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -53,6 +53,8 @@ On the main {Project} server:
 ----
 +
 . Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
+endif::[]
+ifdef::katello[]
 . Update repositories for EL7
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
in b5602838a194cbc2415a0f2a9999debd3d1d84dd a condition to generate
certificates was adjusted, but it was overseen that this also added
unneded repository operations to the satellite version of the guide.

Fixes: b5602838a194cbc2415a0f2a9999debd3d1d84dd


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
