### PR TITLE
drop warning for running the installer in a dir with config subdir

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -286,16 +286,6 @@ Review the results and address any highlighted error conditions before performin
 --whitelist="repositories-validate,repositories-setup"
 ----
 +
-[WARNING]
-====
-If you run the command from a directory containing a *_config_* subdirectory, you will encounter the following error:
-[options="nowrap"]
-----
-ERROR: Scenario (config/satellite.yaml) was not found, can not continue.
-----
-In such a case, change directory, for example to the *_root_* user's home directory, and run the command again.
-====
-+
 If the script fails due to missing or outdated packages, you must download and install these separately.
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] section in the _Installing {ProjectServer} from a Disconnected Network_ guide.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -137,16 +137,6 @@ Review the results and address any highlighted error conditions before performin
 # {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade}
 ----
 +
-[WARNING]
-====
-If you run the command from a directory containing a *_config_* subdirectory, you will encounter the following error:
-[options="nowrap"]
-----
-ERROR: Scenario (config/capsule.yaml) was not found, can not continue.
-----
-In such a case, change directory, for example to the *_root_* user's home directory, and run the command again.
-====
-+
 endif::[]
 . Check when the kernel packages were last updated:
 +


### PR DESCRIPTION
the detection of the correct config dir was fixed in the installer some
time ago in
https://github.com/theforeman/foreman-installer/commit/6fef25e5d3a41f46bff9794946b2c6faed6c84f5
and this warning is not necessary anymore


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
