### PR TITLE
New modules for Filtering and Removing Facts

### DIFF
--- a/guides/common/assembly_configuring-networking.adoc
+++ b/guides/common/assembly_configuring-networking.adoc
@@ -1,5 +1,9 @@
 include::modules/con_configuring-networking.adoc[]
 
+include::modules/con_facts-and-nic-filtering.adoc[leveloffset=+1]
+
+include::modules/proc_optimizing-performance-by-removing-nics-from-database.adoc[leveloffset=+1]
+
 include::modules/con_network-resources.adoc[leveloffset=+1]
 
 include::modules/con_dhcp-options.adoc[leveloffset=+1]

--- a/guides/common/modules/con_facts-and-nic-filtering.adoc
+++ b/guides/common/modules/con_facts-and-nic-filtering.adoc
@@ -1,7 +1,7 @@
 [id="facts-and-nic-filtering_{context}"]
 = Facts and NIC filtering
 
-Facts are host parameters such as total memory, operating system version, or architecture.
+Facts describe aspects such as total memory, operating system version, or architecture as reported by the host.
 You can find facts in *Monitor* > *Facts* and search hosts through facts or use facts in templates.
 
 {Project} collects facts from multiple sources:

--- a/guides/common/modules/con_facts-and-nic-filtering.adoc
+++ b/guides/common/modules/con_facts-and-nic-filtering.adoc
@@ -1,0 +1,17 @@
+[id="facts-and-nic-filtering_{context}"]
+= Facts and NIC filtering
+
+Facts are host parameters such as total memory, operating system version, or architecture.
+You can find facts in *Monitor* > *Facts* and search hosts through facts or use facts in templates.
+
+{Project} collects facts from multiple sources:
+
+* `subscription manager`
+* `ansible`
+* `puppet`
+
+{Project} is an inventory system for hosts and network interfaces.
+For hypervisors or container hosts, adding thousands of interfaces per host and updating the inventory every few minutes is inadequate.
+For each individual NIC reported, {Project} creates a NIC entry and those entries are never removed from the database.
+Parsing all the facts and comparing all records in the database makes {Project} extremely slow and unusable.
+To optimize the performance of various actions, most importantly fact import, you can use the options available on the *Facts* tab under *Administer* > *Settings*.

--- a/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
+++ b/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
@@ -1,0 +1,33 @@
+[id="optimizing-performance-by-removing-nics-from-database_{context}"]
+= Optimizing performance by removing NICs from database
+
+Filter and exclude the connections using the `Exclude pattern for facts stored in {Project}` and `Ignore interfaces with matching identifier` option.
+By default, these options are set to most common hypervisors.
+If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings* and select the *Facts* tab.
+. To filter out all interfaces starting with specific names, for example, `blu`, add `blu*` to the `Ignore interfaces with matching identifier` option.
+. To prevent databases from storing facts related to interfaces starting with specific names, for example, `blu`, add `blu*` to the `Exclude pattern for facts stored in {Project}` option.
++
+By default, it contains the same list as the `Ignore interfaces with matching identifier` option.
+You can override it based on the your requirements.
+This filters out facts completely without storing them.
+
+. To remove facts from the database, enter the following command:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foreman-rake facts:clean
+----
++
+This command removes all facts matching with the filter added in *Administer* > *Settings* > *Facts* > the `Exclude pattern for facts stored in {Project}` option.
+
+. To remove interfaces from the database, enter the following command:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foreman-rake interfaces:clean
+----
++
+This command removes all interfaces matching with the filter added in *Administer* > *Settings* > *Facts* > the `Ignore interfaces with matching identifier` option.


### PR DESCRIPTION
Added new modules (Facts and NIC filtering and
Optimizing performance by removing NICs from database).
These modules explain how to filter facts and NICs in order to
optimize the performance and remove unwanted facts and NICs
from the database and system.

These modules are added under Provisioning Hosts > Network Resources.

This PR also contains the reviews and suggestions provided in PR#1351.

Add chapters about facts, filtering and cleaning

https://bugzilla.redhat.com/show_bug.cgi?id=2009649


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
