### PR TITLE
Drop umask system requirement

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -38,7 +38,6 @@ ifdef::satellite[]
 * A current {ProjectName} subscription
 endif::[]
 * Administrative user (root) access
-* A system umask of 0022
 * Full forward and reverse DNS resolution using a fully-qualified domain name
 
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.


### PR DESCRIPTION
Since https://projects.theforeman.org/issues/35138 this is no longer a requirement. This is only for nightly.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.