### PR TITLE
tuning: Hide Katello-only sections in non-Katello setups

### DIFF
--- a/guides/common/modules/con_top-performance-considerations.adoc
+++ b/guides/common/modules/con_top-performance-considerations.adoc
@@ -5,16 +5,24 @@ You can improve the performance and scalability of {ProjectName}:
 
 . Configure httpd
 . Configure Puma to increase concurrency
+ifdef::satellite,orcharhino,katello[]
 . Configure Candlepin
 . Configure Pulp
+endif::[]
 . Configure Foreman's performance and scalability
 . Configure Dynflow
+ifdef::satellite,orcharhino,katello[]
 . Deploy external {SmartProxies} instead of relying on internal {SmartProxies}
 . Configure katello-agent for scalability
+endif::[]
 . Configure Hammer to reduce API timeouts
+ifdef::satellite,orcharhino,katello[]
 . Configure qpid and qdrouterd
+endif::[]
 . Improve PostgreSQL to handle more concurrent loads
 . Configure the storage for DB workloads
+ifdef::satellite,orcharhino,katello[]
 . Ensure the storage requirements for Content Views are met
+endif::[]
 . Ensure the system requirements are met
 . Improve the environment for remote execution

--- a/guides/doc-Performance_Tuning_Guide/master.adoc
+++ b/guides/doc-Performance_Tuning_Guide/master.adoc
@@ -42,6 +42,7 @@ include::common/modules/proc_configuring-how-many-processes-can-be-launched-by-a
 
 include::common/modules/proc_configuring-the-open-files-limit-for-apache-httpd.adoc[leveloffset=+3]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/modules/con_qdrouterd-and-qpid-tuning.adoc[leveloffset=+1]
 
 include::common/modules/proc_calculating-the-maximum-open-files-limit-for-qdrouterd.adoc[leveloffset=+2]
@@ -53,6 +54,7 @@ include::common/modules/proc_configuring-the-maximum-asynchronous-input-output-r
 include::common/modules/ref_storage-considerations.adoc[leveloffset=+2]
 
 include::common/modules/proc_configuring-the-qpid-mgmt-pub-interval-parameter.adoc[leveloffset=+2]
+endif::[]
 
 include::common/modules/con_dynflow-tuning.adoc[leveloffset=+1]
 
@@ -60,6 +62,8 @@ include::common/modules/con_postgresql-tuning.adoc[leveloffset=+1]
 
 include::common/modules/proc_benchmarking-raw-db-performance.adoc[leveloffset=+1]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/modules/con_smart-proxy-configuration-tuning.adoc[leveloffset=+1]
 
 include::common/modules/con_smartproxy_performance_tests.adoc[leveloffset=+1]
+endif::[]


### PR DESCRIPTION
qpid and content serving are Katello-only features.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

This probably affects older versions as well, but for now the guide isn't linked anyway and it doesn't affect downstreams so no picks are needed.

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.