### PR TITLE
Modified attribute for version specific client repo

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -104,8 +104,8 @@
 :RepoRHEL7ServerSatelliteMaintenanceProductVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL8ServerSatelliteMaintenanceProductVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 // Satellite-Tools becomes Satellite-Client in Satellite 7
-:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-7-rpms
-:RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-7-for-rhel-8-<arch>-rpms
+:RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
+:RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
 
-:project-client-name: Satellite Client {ProductVersionRepoTitle}
+:project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}


### PR DESCRIPTION
Modified the attribute for version-specific client repo
as it resembled a specific one. Made it more generic as per the
release notes.

Incorrect name for Satellite Client repo in Installation guide

https://bugzilla.redhat.com/show_bug.cgi?id=2103698


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
