### PR TITLE
Change include path to guide common symlink

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -97,7 +97,7 @@ image::satellite_6.4_upgrade_paths.png[Overview of {ProjectServer} Upgrade Paths
 endif::[]
 ////
 
-include::../../common/modules/ref_post-upgrade.adoc[leveloffset=+2]
+include::../common/modules/ref_post-upgrade.adoc[leveloffset=+2]
 
 [[following_the_progress_of_the_upgrade]]
 == Following the Progress of the Upgrade


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
