### PR TITLE
Changed upgrade command to reflect current version

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -21,7 +21,6 @@
 :SmartProxy: orcharhino Proxy
 :SmartProxyServer: orcharhino Proxy
 :TargetVersion: 6.0
-:TargetVersionMaintainUpgrade: 6.0
 :Team: ATIX AG
 :customcontent: custom content
 :customcontenttitle: Custom Content

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -17,7 +17,6 @@
 :ProductVersion: 6.11
 :ProductVersionPrevious: 6.10
 :TargetVersion: {ProductVersion}
-:TargetVersionMaintainUpgrade: {ProductVersion}
 // Add -beta for Beta releases
 :ProductVersionRepoTitle: {ProductVersion}
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -8,7 +8,6 @@
 :KatelloVersion: nightly
 :PulpcoreVersion: 3.18
 :TargetVersion: {ProjectVersion}
-:TargetVersionMaintainUpgrade: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -60,7 +60,7 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade check --target-version {TargetVersion}
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -75,7 +75,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade run --target-version {TargetVersion}
 ----
 endif::[]
 ifdef::katello[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -272,7 +272,7 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade} \
+# {foreman-maintain} upgrade check --target-version {TargetVersion} \
 --whitelist="repositories-validate,repositories-setup"
 ----
 +
@@ -281,7 +281,7 @@ Review the results and address any highlighted error conditions before performin
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade} \
+# {foreman-maintain} upgrade run --target-version {TargetVersion} \
 --whitelist="repositories-validate,repositories-setup"
 ----
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -127,7 +127,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade check --target-version {TargetVersion}
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -136,7 +136,7 @@ Review the results and address any highlighted error conditions before performin
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade run --target-version {TargetVersion}
 ----
 +
 endif::[]


### PR DESCRIPTION
Step 7 and Step 9 of the Upgrading a connected Satellite section had a command reference that was pointing to the previous target version for 6.10. Updated the command reference and built a preview that shows it properly references 6.11.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
