### PR TITLE
comment on PRs if the preview could not be generated

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,13 @@ jobs:
           name: foreman-docs-html-${{ env.BRANCH_NAME }}
           path: guides/build/
 
+  pr-metadata:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Get branch name (pull request)
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+
       - name: Set target name (master)
         if: github.base_ref == 'master'
         run: echo "TARGET_NAME=nightly" >> $GITHUB_ENV
@@ -140,16 +147,14 @@ jobs:
         run: echo "TARGET_NAME=$(echo ${GITHUB_BASE_REF} | tr / -)" >> $GITHUB_ENV
 
       - name: Save PR metadata
-        if: github.event_name == 'pull_request'
         run: |
           mkdir -p ./pr
           echo '{"pr_number": ${{ github.event.number }}, "branch_name": "${{ env.BRANCH_NAME }}", "target_name": "${{ env.TARGET_NAME }}", "head_sha": "${{ github.event.pull_request.head.sha }}"}' > ./pr/pr.json
 
       - uses: actions/upload-artifact@v3
-        if: github.event_name == 'pull_request'
         with:
           name: pr
-          path: guides/pr/
+          path: ./pr/
 
   build-html-base:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,32 @@ on:
       - completed
 
 jobs:
+  preview-failed:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download metadata artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/download_workflow_run_artifact.js');
+            let fs = require('fs');
+            await script({github, context, core, fs, artifact_name: 'pr'});
+
+      - name: Unzip artifact
+        run: unzip pr.zip
+
+      - name: Read PR data
+        run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ fromJSON(env.PR_DATA).pr_number }}
+          message: "The PR preview for ${{ fromJSON(env.PR_DATA).head_sha }} could not be generated"
+
   preview:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest


### PR DESCRIPTION
this is especially useful if there was a successful preview build in the
past, but the latest revision didn't succeed and thus the preview link
would not reflect the changes in the PR


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
