### PR TITLE
Remove TargetVersionMaintainUpgrade attribute

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -21,7 +21,6 @@
 :SmartProxy: orcharhino Proxy
 :SmartProxyServer: orcharhino Proxy
 :TargetVersion: 6.0
-:TargetVersionMaintainUpgrade: 6.0
 :Team: ATIX AG
 :customcontent: custom content
 :customcontenttitle: Custom Content

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -21,7 +21,6 @@
 :ProductVersion: 6.11
 :ProductVersionPrevious: 6.10
 :TargetVersion: {ProductVersion}
-:TargetVersionMaintainUpgrade: {ProductVersion}
 // Add -beta for Beta releases
 :ProductVersionRepoTitle: {ProductVersion}
 // Change to "Red Hat Satellite Infrastructure Subscription (Beta)" for beta releases
@@ -93,7 +92,6 @@
 :SmartProxyServer: Capsule{nbsp}Server
 :Team: Red{nbsp}Hat
 :TargetVersion: {ProductVersion}
-:TargetVersionMaintainUpgrade: {ProductVersionPrevious}
 
 
 // Repositories and subscriptions (used in Satellite guides)

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -8,7 +8,6 @@
 :KatelloVersion: 4.3
 :PulpcoreVersion: 3.16
 :TargetVersion: {ProjectVersion}
-:TargetVersionMaintainUpgrade: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9
 // For Package Manifests etc that will fail the upstream link-checker during the beta see Issue #115 on GitHub

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -60,7 +60,7 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade check --target-version {TargetVersion}
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -75,7 +75,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade run --target-version {TargetVersion}
 ----
 endif::[]
 ifdef::katello[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -270,7 +270,7 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade} \
+# {foreman-maintain} upgrade check --target-version {TargetVersion} \
 --whitelist="repositories-validate,repositories-setup"
 ----
 +
@@ -279,7 +279,7 @@ Review the results and address any highlighted error conditions before performin
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade} \
+# {foreman-maintain} upgrade run --target-version {TargetVersion} \
 --whitelist="repositories-validate,repositories-setup"
 ----
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -125,7 +125,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade check --target-version {TargetVersion}
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -134,7 +134,7 @@ Review the results and address any highlighted error conditions before performin
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {TargetVersionMaintainUpgrade}
+# {foreman-maintain} upgrade run --target-version {TargetVersion}
 ----
 +
 endif::[]


### PR DESCRIPTION
The TargetVersionMaintainUpgrade attribute needed to be removed because
it was determined to be downstream specific and outdated for upstream
documentation. This is related to an already existing PR #1413 which
addresses removing the attribute for other versions.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
