### PR TITLE
correct rhel 7 server repo name

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -17,7 +17,7 @@
 // Repositories and subscriptions (used both upstream and Satellite guides)
 // The rest of repo IDs moved to attributes-satellite.adoc
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
-:RepoRHEL7Server: rhel-7-server-satellite
+:RepoRHEL7Server: rhel-7-server-rpms
 :RepoRHEL8BaseOS: rhel-8-for-x86_64-baseos-rpms
 :RepoRHEL8AppStream: rhel-8-for-x86_64-appstream-rpms
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms


### PR DESCRIPTION
Fixes: bfa9406ec6b2839fe086664957257fb05ac6dd03
(cherry picked from commit 40081f0f77d1ed4719815701618c63a5fe18d920)

Addresses a regression introduced by https://github.com/theforeman/foreman-documentation/pull/1357

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
