### PR TITLE
Add line for moving the PostgreSQL data directory

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -30,6 +30,10 @@ ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
+* During the upgrade, the PostgreSQL data is moved from `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` to `/var/lib/pgsql/data/`.
+If these two paths reside on the same partition, no further action is required.
+If they reside on different partitions, ensure that there is enough space for the data to be copied over.
+You can move the PostgreSQL data on your own and the upgrade will skip this step if `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` does not exist.
 
 .Procedure
 . Configure the repositories to obtain Leapp.


### PR DESCRIPTION
New paragraph added to the Upgrade Paths section. It states that moving
the PostgreSQL data directory will require space if the /var/lib/pgsql/
paths are on different partitions.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
