### PR TITLE
Add process for Disconnected Server via Leapp

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -14,13 +14,14 @@ ifdef::satellite[]
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 
 .Prerequisites for Disconnected Environments
-* If you run {Project} in a disconnected environment, ensure it meets the following prerequisites:
-** You must obtain and deploy Leapp metadata manually.
- For more information, see https://access.redhat.com/articles/3664871[Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades].
-** You require access to {RHEL} and {Project} packages.
-** Obtain the ISO files for {RHEL} 8 and {Project}.
+If you run {Project} in a disconnected environment, ensure it meets the following prerequisites:
+
+* You must obtain and deploy Leapp metadata manually.
+For more information, see https://access.redhat.com/articles/3664871[Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades].
+* You require access to {RHEL} and {Project} packages.
+* Obtain the ISO files for {RHEL} 8 and {Project}.
 For more information, see xref:upgrading_a_disconnected_satellite[].
-** For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+* For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
 endif::[]
 ifndef::satellite[]
 * Access to available repositories or a local mirror of repositories.
@@ -210,7 +211,7 @@ endif::[]
 
 +
 The first run is expected to fail but report issues and inhibit the upgrade.
-Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`) and manually resolve the other reported problems.
+Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
 +
 The following commands show the most common steps required:
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -12,9 +12,24 @@ endif::[]
 ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+
+.Prerequisites for Disconnected Environments
+* If you run {Project} in a disconnected environment, ensure it meets the following prerequisites:
+** You must obtain and deploy Leapp metadata manually.
+ For more information, see https://access.redhat.com/articles/3664871[Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades].
+** You require access to {RHEL} and {Project} packages.
+** Obtain the ISO files for {RHEL} 8 and {Project}.
+For more information, see xref:upgrading_a_disconnected_satellite[].
+** For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
 endif::[]
+ifndef::satellite[]
 * Access to available repositories or a local mirror of repositories.
+<<<<<<< HEAD:guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
 * If you previously upgraded {Project} or {SmartProxy} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
+=======
+endif::[]
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
+>>>>>>> 4a148403a (Add process for Disconnected Server via Leapp):guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
 * During the upgrade, the PostgreSQL data is moved from `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` to `/var/lib/pgsql/data/`.
 If these two paths reside on the same partition, no further action is required.
 If they reside on different partitions, ensure that there is enough space for the data to be copied over.
@@ -50,6 +65,39 @@ On {RHEL}, enable the `rhel-7-server-extras-rpms` repository:
 ----
 # {package-install-project} leapp leapp-repository
 ----
+ifdef::satellite[]
+. For Leapp to perform the upgrade in a disconnected environment, download the metadata and manually extract, as described in https://access.redhat.com/articles/3664871[Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades].
+
+. Set up the following repositories to perform the upgrade in a disconnected environment:
+.. `/etc/yum.repos.d/rhel8.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[BaseOS]
+name={RepoRHEL8BaseOS}
+baseurl=http://_server.example.com_/rhel8/BaseOS/
+[AppStream]
+name={RepoRHEL8AppStream}
+baseurl=http://_server.example.com_/rhel8/AppStream/
+----
++
+.. `/etc/yum.repos.d/{project-context}.repo:`
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={RepoRHEL8ServerSatelliteServerProductVersion}
+baseurl=http://_server.example.com_/sat6/Satellite/
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+baseurl=http://_server.example.com_/sat6/Maintenance/
+----
++
+[NOTE]
+====
+Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+====
+endif::[]
 
 ifdef::foreman-el,katello[]
 . Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
@@ -144,9 +192,26 @@ endif::[]
 ----
 # leapp preupgrade
 ----
-The first run is expected to fail but report issues and inhibit the upgrade.
+ifdef::satellite[]
 +
+If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp preupgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
++
+When running `leapp preupgrade` and `leapp upgrade`, you must pass `--enablerepo <id>` for each manually defined repository from the previous step.
+endif::[]
+
++
+The first run is expected to fail but report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`) and manually resolve the other reported problems.
++
 The following commands show the most common steps required:
 +
 ----
@@ -154,6 +219,7 @@ The following commands show the most common steps required:
 # echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
 # leapp answer --section remove_pam_pkcs11_module_check.confirm=True
 ----
+
 ifdef::foreman-el,katello[]
 +
 `leapp preupgrade` might fail with a dependency resolution error such as:
@@ -171,9 +237,14 @@ If this happens, do the following to clean up packages that cannot automatically
 # yum remove rubygem-thor rubygem-railties
 ----
 endif::[]
+
 +
+<<<<<<< HEAD:guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
 If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} or {SmartProxy} to use the new interface names:
 
+=======
+If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} to use the new interface names:
+>>>>>>> 4a148403a (Add process for Disconnected Server via Leapp):guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -181,8 +252,8 @@ If `leapp preupgrade` inhibits the upgrade with *Unsupported network configurati
     --foreman-proxy-dhcp-interface  DHCP listen interface (current: "eth0")
     --foreman-proxy-dns-interface  DNS interface (current: "eth0")
 ----
++
 If `eth0` was renamed to `em0`, call the installer to use the new interface name with:
-
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -22,6 +22,8 @@ For more information, see https://access.redhat.com/articles/3664871[Leapp utili
 * Obtain the ISO files for {RHEL} 8 and {Project}.
 For more information, see xref:upgrading_a_disconnected_satellite[].
 * For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+* Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+* For more information, see https://access.redhat.com/solutions/5492401[How to in-place upgrade an offline / disconnected RHEL 7 machine to RHEL 8 with Leapp?]
 endif::[]
 ifndef::satellite[]
 * Access to available repositories or a local mirror of repositories.
@@ -77,6 +79,7 @@ ifdef::satellite[]
 [BaseOS]
 name={RepoRHEL8BaseOS}
 baseurl=http://_server.example.com_/rhel8/BaseOS/
+
 [AppStream]
 name={RepoRHEL8AppStream}
 baseurl=http://_server.example.com_/rhel8/AppStream/
@@ -89,15 +92,11 @@ baseurl=http://_server.example.com_/rhel8/AppStream/
 [{RepoRHEL8ServerSatelliteServerProductVersion}]
 name={RepoRHEL8ServerSatelliteServerProductVersion}
 baseurl=http://_server.example.com_/sat6/Satellite/
+
 [{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
 name={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 baseurl=http://_server.example.com_/sat6/Maintenance/
 ----
-+
-[NOTE]
-====
-Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
-====
 endif::[]
 
 ifdef::foreman-el,katello[]
@@ -203,10 +202,9 @@ If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--e
 --no-rhsm \
 --enablerepo BaseOS \
 --enablerepo AppStream \
+--enablerepo {RepoRHEL8ServerSatelliteServerProductVersion} \
 --enablerepo {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
-+
-When running `leapp preupgrade` and `leapp upgrade`, you must pass `--enablerepo <id>` for each manually defined repository from the previous step.
 endif::[]
 
 +
@@ -267,6 +265,20 @@ If `eth0` was renamed to `em0`, call the installer to use the new interface name
 +
 ----
 # leapp upgrade
+----
+
+ifdef::satellite[]
++
+. If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp upgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL8ServerSatelliteServerProductVersion} \
+--enablerepo {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 
 . Reboot the system.


### PR DESCRIPTION
Process for upgrading Disconnected Satellite Server via Leapp added.
Change was required because we did not have the process in the initial
creation of the new Upgrading Satellite to Red Hat Enterprise Linux 8
In-Place Using Leapp section.
@evgeni you will probably want to add more content to this. I wanted
to get an initial PR submitted with the information you gave me. I can
always squash my commits once this is complete to your liking.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
