### PR TITLE
Generalize the ipxe installation instructions

### DIFF
--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -54,31 +54,25 @@ To prepare iPXE environment, you must perform this procedure on all {SmartProxie
 ----
 # {foreman-installer} --foreman-proxy-httpboot true --foreman-proxy-tftp true
 ----
-. Install the `ipxe-bootimgs` RPM package:
+ifdef::foreman-el,katello,satellite,orcharhino[]
+. Install the `ipxe-bootimgs` package:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install} ipxe-bootimgs
 ----
-ifdef::foreman-el,katello[]
-. On Debian/Ubuntu, install the `ipxe` .deb package:
-+
-----
-# {package-install} ipxe
-----
-endif::[]
-ifdef::foreman-el,katello[]
-. On systems with SELinux, correct the file contexts:
-+
-----
-# restorecon -RvF /var/lib/tftpboot/
-----
-endif::[]
-ifdef::satellite,orcharhino[]
 . Correct the SELinux file contexts:
 +
 ----
 # restorecon -RvF /var/lib/tftpboot/
+----
+endif::[]
+ifdef::foreman-deb[]
+. Install the `ipxe` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} ipxe
 ----
 endif::[]
 


### PR DESCRIPTION
This treats all EL-based installs the same and only shows the appropriate instructions. We have macros to determine if it's deb based or RPM based so those are used to simplify the end user instructions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.