### PR TITLE
Add post-upgrade steps to Upgrading using Leapp

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -211,7 +211,7 @@ endif::[]
 ifdef::foreman-el[]
 # dnf reinstall foreman-selinux --disableplugin=foreman-protector
 endif::[]
-ifndef::foreman-el[]
+ifdef::katello,satellite,orcharhino[]
 # dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector
 endif::[]
 ----

--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -209,7 +209,7 @@ endif::[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::foreman-el[]
-# dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector
+# dnf reinstall foreman-selinux --disableplugin=foreman-protector
 endif::[]
 ifndef::foreman-el[]
 # dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector

--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -201,6 +201,24 @@ endif::[]
 # journalctl -u leapp_resume -f
 ----
 
+ifdef::satellite[]
+. Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
+. If you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+ifdef::foreman-el[]
+# dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector
+endif::[]
+ifndef::foreman-el[]
+# dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector
+endif::[]
+----
+ifdef::satellite[]
+ . Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/applying-security-policies_upgrading-from-rhel-7-to-rhel-8#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
+
 [NOTE]
 ====
 If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.


### PR DESCRIPTION
Added post-upgrade steps after final step in **Upgrading Satellite to Red
Hat Enterprise Linux 8 In-Place Using Leapp.** This change was required
because they were missing in the latest release.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
