### PR TITLE
Correction in the installation logs location

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -59,7 +59,7 @@ For more information on how to apply custom configuration on other services, see
 --foreman-initial-admin-password _admin_password_
 ----
 +
-The script displays its progress and writes logs to `/var/log/foreman-installer/{installer-scenario}.log`.
+The script displays its progress and writes logs to `{installer-log-file}`.
 
 ifeval::["{mode}" == "disconnected"]
 . Unmount the ISO images:


### PR DESCRIPTION
As per the Bugzilla, the installation log location should be
/var/log/foreman-installer/satellite.log and not the
/var/log/foreman-installer/satellite-installer --scenario satellite.log
in Configuring Satellite Installation.
The installation log location is now updated based on the suggestion.

https://bugzilla.redhat.com/show_bug.cgi?id=2104280


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
