### PR TITLE
Updated Repo list in Synchronizing New Repositories

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -15,7 +15,7 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 +
 *{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 7 Server) (RPMs)*
 +
-*{ProjectName} Maintenance 6 (for RHEL 7 Server) (RPMs)*
+*{ProjectName} Maintenance {ProjectVersion} (for RHEL 7 Server) (RPMs)*
 +
 *Red{nbsp}Hat Ansible Engine {SatelliteAnsibleVersion} RPMs for {RHEL} 7 Server*
 +


### PR DESCRIPTION
The module Synchronizing the New Repositories contains list of repos.
As per the comment in Bugzilla, the list needed an update.

List has been updated to reflect the requested information in bugzilla.

https://bugzilla.redhat.com/show_bug.cgi?id=2104310


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
