### PR TITLE
Updated DNF module enablement command

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -127,16 +127,17 @@ ifdef::satellite[]
 ----
 # dnf module enable satellite:el8
 ----
++
+[NOTE]
+====
+Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8. The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module. These warnings do not cause installation process failure, hence can be ignored safely.
+
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle.
+====
 endif::[]
 endif::[]
 
 +
-[NOTE]
-====
-With the enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8. The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module. These warnings do not cause installation process failure, hence can be ignored safely.
-
-For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle.
-====
 
 ifdef::foreman-el,katello,satellite[]
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -131,17 +131,14 @@ ifdef::satellite[]
 [NOTE]
 ====
 Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
-
 The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module.
-
 These warnings do not cause installation process failure, hence can be ignored safely.
-
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle.
 ====
 endif::[]
 endif::[]
 
-+
+
 
 ifdef::foreman-el,katello,satellite[]
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -130,7 +130,11 @@ ifdef::satellite[]
 +
 [NOTE]
 ====
-Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8. The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module. These warnings do not cause installation process failure, hence can be ignored safely.
+Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
+
+The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module.
+
+These warnings do not cause installation process failure, hence can be ignored safely.
 
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle.
 ====

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -125,7 +125,7 @@ ifdef::katello[]
 endif::[]
 ifdef::satellite[]
 ----
-# dnf module enable satellite:el8
+# dnf module enable satellite:el8 postgresql:12 ruby:2.7
 ----
 endif::[]
 endif::[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -133,12 +133,10 @@ ifdef::satellite[]
 Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
 The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module.
 These warnings do not cause installation process failure, hence can be ignored safely.
-For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle.
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 endif::[]
 endif::[]
-
-
 
 ifdef::foreman-el,katello,satellite[]
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -125,11 +125,18 @@ ifdef::katello[]
 endif::[]
 ifdef::satellite[]
 ----
-# dnf module enable satellite:el8 postgresql:12 ruby:2.7
+# dnf module enable satellite:el8
 ----
 endif::[]
 endif::[]
+
 +
+[NOTE]
+====
+With the enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8. The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module. These warnings do not cause installation process failure, hence can be ignored safely.
+
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle.
+====
 
 ifdef::foreman-el,katello,satellite[]
 


### PR DESCRIPTION
Enabling only satellite:el8 module, system warns enablement conflicts.
To workaround this issue and avoid warnings while configuring,
It is advised to Enable both postgresql:12, ruby:2.7, and satellite:el8
in the same command.
To do so, command to enable satellite:el8 module has been updated to
dnf module enable satellite:el8 postgresql:12 ruby:2.7 to enable
3 modules (satellite:el8, postgresql:12, and ruby:2.7) in one command.

https://bugzilla.redhat.com/show_bug.cgi?id=2104560


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
