### PR TITLE
Updated DNF module enablement command in Installing Proxy

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -44,7 +44,7 @@ ifdef::satellite[]
 +
 [options="nowrap"]
 ----
-# dnf module enable satellite-capsule:el8
+# dnf module enable satellite-capsule:el8 postgresql:12 ruby:2.7
 ----
 +
 endif::[]


### PR DESCRIPTION
Enabling only satellite:el8 module, system warns enablement conflicts.
To workaround this issue and avoid warnings while configuring,
It is advised to Enable both postgresql:12, ruby:2.7, and satellite:el8
in the same command.
To do so, command to enable satellite-capsule:el8 module has been
updated to dnf module enable satellite-capsule:el8 postgresql:12 ruby:2.7.
It enables 3 modules-satellite-capsule:el8,postgresql:12,ruby:2.7 in one go.

https://bugzilla.redhat.com/show_bug.cgi?id=2104609


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
