### PR TITLE
Corrected the log file name in the upgrade guides

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -50,6 +50,7 @@
 :installer-log-file: /var/log/foreman-installer/satellite.log
 :installer-scenario-smartproxy: satellite-installer --scenario capsule
 :installer-scenario: satellite-installer --scenario satellite
+:installer-smartproxy-log-file: /var/log/foreman-installer/capsule.log
 :Keycloak-short: RHSSO
 :Keycloak: Red{nbsp}Hat Single Sign-On
 :KubeVirt: Container-native Virtualization

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -32,7 +32,7 @@ Review the results and address any highlighted error conditions before performin
 . Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{SmartProxy}.log` file to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 
 . Perform the upgrade:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -32,7 +32,7 @@ Review the results and address any highlighted error conditions before performin
 . Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{SmartProxy}.log` file to check if the process completed successfully.
 
 . Perform the upgrade:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -123,7 +123,7 @@ Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVe
 . Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{SmartProxy}.log` file to check if the process completed successfully.
 
 . Use the health check option to determine if the system is ready for upgrade:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -123,7 +123,7 @@ Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVe
 . Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{SmartProxy}.log` file to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 
 . Use the health check option to determine if the system is ready for upgrade:
 +


### PR DESCRIPTION
Log file name was incorrect in the Upgrading {SmartProxyServer}s guide.
The name has been corrected from satellite.log to capsule.log.
This issue was reported in BZ#2104682

https://bugzilla.redhat.com/show_bug.cgi?id=2104682


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
