### PR TITLE
Removed qpid/qdrouterd references from install guides

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -37,7 +37,6 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
-| 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
 endif::[]
 | 5910 - 5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
@@ -106,9 +105,6 @@ endif::[]
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 | 5000 | TCP | HTTPS | OpenStack Compute Resource | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::katello,satellite,orcharhino[]
-| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
-| 5671 |  |  | Qpid |Remote install | Send install command to client
-| 5671 |  |  | Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
 | 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client
 | 5671 | | | {ProjectServer} | Remote install for Katello agent | Forward message to dispatch router on {Project}
 endif::[]

--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -9,9 +9,6 @@ This is a requirement for the `puppetserver` service to work.
 
 * Because most {ProductName} data is stored in the `/var` directory, mounting `/var` on LVM storage can help the system to scale.
 
-* The `/var/lib/qpidd/` directory uses slightly more than 2 MB per Content Host managed by the `goferd` service.
-For example, 10 000 Content Hosts require 20 GB of disk space in `/var/lib/qpidd/`.
-
 * Use high-bandwidth, low-latency storage for the `/var/lib/pulp/` directories.
 As {ProjectName} has many operations that are I/O intensive, using high latency, low-bandwidth storage causes performance degradation.
 Ensure your installation has a speed in the range 60 - 80 Megabytes per second.

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -36,7 +36,6 @@ ifdef::foreman-el,katello[]
 ifdef::katello,satellite[]
 |/var/lib/pulp/ |1 MB |300 GB
 
-|/var/lib/qpidd/ |25 MB | Not Applicable
 endif::[]
 |====
 
@@ -60,7 +59,6 @@ endif::[]
 ifdef::katello,satellite[]
 |/var/lib/pulp/ |1 MB |300 GB
 
-|/var/lib/qpidd/ |25 MB | Not Applicable
 endif::[]
 |====
 endif::[]
@@ -81,7 +79,7 @@ ifdef::foreman-el,katello,satellite[]
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 
-ifdef::katello,satellite[]
+ifdef::katello[]
 |/var/lib/pulp/ |1 MB |300 GB
 
 |/var/lib/qpidd/ |25 MB | Not Applicable
@@ -107,7 +105,7 @@ ifdef::foreman-el,katello,satellite[]
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 
-ifdef::katello,satellite[]
+ifdef::katello[]
 |/var/lib/pulp/ |1 MB |300 GB
 
 |/var/lib/qpidd/ |25 MB | Not Applicable

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -58,10 +58,10 @@ ifdef::katello,satellite[]
 endif::[]
 * puppet
 * puppetserver
-ifdef::katello,satellite[]
+ifdef::katello[]
 * qdrouterd
 endif::[]
-ifdef::katello,satellite[]
+ifdef::katello[]
 ifeval::["{context}" == "{project-context}"]
 * qpidd
 endif::[]


### PR DESCRIPTION
All the references of qpid/qdrouterd are requested to be removed.
All those references are now removed in this PR.
Reason: Qpid is not part of {project} anymore. 

https://bugzilla.redhat.com/show_bug.cgi?id=2103782


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
