### PR TITLE
unify "watch installation" section

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -5,23 +5,12 @@ This initial configuration procedure creates an organization, location, user nam
 After the initial configuration, you can create additional organizations and locations if required.
 The initial configuration also installs PostgreSQL databases on the same server.
 
+The installation process can take tens of minutes to complete.
+If you are connecting remotely to the system, use a utility such as `tmux` or `screen` that allows suspending and reattaching a communication session so that you can check the installation progress in case you become disconnected from the remote system.
 ifdef::satellite[]
-The installation process can take tens of minutes to complete.
-If you are connecting remotely to the system, use a utility such as `screen` or `tmux` that allows suspending and reattaching a communication session so that you can check the installation progress in case you become disconnected from the remote system.
 For more information, see https://access.redhat.com/articles/5247[How to use the screen command] or alternately the `screen` manual page.
+endif::[]
 If you lose connection to the shell where the installation command is running, see the log at `{installer-log-file}` to determine if the process completed successfully.
-endif::[]
-
-ifdef::foreman-el,foreman-deb,katello[]
-The installation process can take tens of minutes to complete.
-If you are connecting remotely to the system, use a utility that allows suspending and reattaching a communication session so that you can check the installation progress in case you become disconnected from the remote system.
-endif::[]
-ifdef::foreman-el,katello[]
-For example, on Red Hat-based operating systems, use a utility such as `tmux` or `screen`.
-endif::[]
-ifdef::foreman-el,foreman-deb,katello[]
-If you lose connection to the shell where the installation command is running, see the log at `{installer-log-file}` to determine if the process completed successfully.
-endif::[]
 
 .Considerations
 


### PR DESCRIPTION
1. prefer tmux over screen (screen is deprecated since EL7.6)
2. only put the Red Hat KCS link behind an ifdef
3. drop all unnecessary ifdefs


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
