### PR TITLE
Adding +attributes to make sure '{foreman-installer}' gets expanded

### DIFF
--- a/guides/common/modules/proc_configuring-puma-workers.adoc
+++ b/guides/common/modules/proc_configuring-puma-workers.adoc
@@ -22,6 +22,7 @@ In our measurements, setups with 2 workers were able to handle up to 480 concurr
 .Manual tuning
 You can set the number of workers to two and the number of threads to five:
 
+[options="nowrap", subs="+attributes"]
 ----
 # {foreman-installer} \
 --foreman-foreman-service-puma-threads-max=5


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
