### PR TITLE
Unpublish OSTree content management for Satellite

### DIFF
--- a/guides/common/modules/con_content-management-types-overview.adoc
+++ b/guides/common/modules/con_content-management-types-overview.adoc
@@ -43,7 +43,9 @@ ISO and KVM Images::
 Download and manage media for installation and provisioning.
 For example, {Project} downloads, stores, and manages ISO images and guest images for specific {RHEL} and non-Red Hat operating systems.
 
+ifndef::satellite[]
 OSTree::
 You can import OSTree branches and publish this content to an HTTP location for consumption by OSTree clients.
+endif::[]
 
 You can use the procedure to add {customcontent} for any type of content you require, for example, SSL certificates and OVAL files.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -43,7 +43,9 @@ endif::[]
 
 include::common/assembly_managing-errata.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::common/assembly_managing-ostree-content.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Our product management moved this feature to a later Satellite version, so we need to unpublish it for Sat 6.11.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

No cherry-picks.