### PR TITLE
Link to correct build target in navigation

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -333,7 +333,7 @@ const navVersions = [
     builds: [
       {
         title: "Katello on EL",
-        filename: "index-foreman-deb.html",
+        filename: "index-katello.html",
         guides: [
           {
             title: "Release Notes",
@@ -413,7 +413,7 @@ const navVersions = [
     builds: [
       {
         title: "Katello on EL",
-        filename: "index-foreman-deb.html",
+        filename: "index-katello.html",
         guides: [
           {
             title: "Release Notes",
@@ -485,7 +485,7 @@ const navVersions = [
     builds: [
       {
         title: "Katello on EL",
-        filename: "index-foreman-deb.html",
+        filename: "index-katello.html",
         guides: [
           {
             title: "Planning Guide",
@@ -553,7 +553,7 @@ const navVersions = [
     builds: [
       {
         title: "Katello on EL",
-        filename: "index-foreman-deb.html",
+        filename: "index-katello.html",
         guides: [
           {
             title: "Planning Guide",


### PR DESCRIPTION
IMHO does not require cherry-picking because the navigation comes from master only.

WRONG: https://docs.theforeman.org/release/3.1/#
See 
<img width="713" alt="Screenshot 2022-07-13 at 17 07 54" src="https://user-images.githubusercontent.com/12595287/178767749-e9ec9c5d-b413-4a0b-a67b-f4859d9142c5.png">
