### PR TITLE
streamline Leapp prerequisite difinition

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -14,22 +14,19 @@ ifdef::satellite[]
 Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL} 8.
 endif::[]
 
-ifdef::foreman-el,katello[]
 .Prerequisites
+ifdef::foreman-el,katello[]
 * {Project} {ProjectVersion} running on Enterprise Linux 7.
-* Access to available repositories or a local mirror of repositories.
 * {Project} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
 * {Project} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
 endif::[]
-
 ifdef::satellite[]
-.Prerequisites
 * {Project} {ProjectVersion} running on {RHEL} 7.
-* Access to available repositories or a local mirror of repositories.
-* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
+* Access to available repositories or a local mirror of repositories.
+* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 * During the upgrade, the PostgreSQL data is moved from `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` to `/var/lib/pgsql/data/`.
 If these two paths reside on the same partition, no further action is required.
 If they reside on different partitions, ensure that there is enough space for the data to be copied over.


### PR DESCRIPTION
only a fraction is different between Satellite and non-Satellite builds.
move these to an ifdef section, and everything else outside of it


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
