### PR TITLE
Replace a deprecated snippet

### DIFF
--- a/guides/common/modules/proc_preparing-a-cloud-init-template.adoc
+++ b/guides/common/modules/proc_preparing-a-cloud-init-template.adoc
@@ -41,7 +41,7 @@ runcmd:
 end %>
 <% if @host.info['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'Red Hat Identity Management' -%>
   <%= indent 4 do
-    snippet 'idm_register'
+    snippet 'freeipa_register'
   end %>
 <% end -%>
 <% unless @host.operatingsystem.atomic? -%>


### PR DESCRIPTION
While preparing for the Cloud-init template, the relevant team has deprecated
the old snippet idm-register. It is now replaced with the new one.

'idm_register' snippet still referenced in provisioning guide

https://bugzilla.redhat.com/show_bug.cgi?id=2106348


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.