### PR TITLE
Added admonition for Enabling satellite:el8 module

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -127,6 +127,14 @@ ifdef::satellite[]
 ----
 # dnf module enable satellite:el8
 ----
++
+[NOTE]
+====
+Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
+The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module.
+These warnings do not cause installation process failure, hence can be ignored safely.
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
+====
 endif::[]
 endif::[]
 +


### PR DESCRIPTION
Enabling only satellite:el8 module, system warns enablement conflicts.
To inform users about this warnings and its impact,
an admonition is added to the module - configuring repositories.
This admonition is added only to the satellite version of docs.
In the original PR#1432, Some checks were failed due to git conflict.
Hence creating this PR.
It contains the latest version of admonition.

https://bugzilla.redhat.com/show_bug.cgi?id=2104560


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
