### PR TITLE
Enabling satellite-capsule:el8 module Admonition

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -47,6 +47,14 @@ ifdef::satellite[]
 # dnf module enable satellite-capsule:el8
 ----
 +
+[NOTE]
+====
+Enablement of the module `satellite-capsule:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
+The module `satellite-capsule:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite-capsule:el8` module.
+These warnings do not cause installation process failure, hence can be ignored safely.
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
+====
++
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]


### PR DESCRIPTION
Enabling only satellite-capsule:el8, system warns enablement conflicts.
To inform users about this warnings and its impact,
an admonition is added to the module - Configuring Repositories.
This admonition is added only to the satellite version of docs.

https://bugzilla.redhat.com/show_bug.cgi?id=2104609


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
