### PR TITLE
Remove the redundant RHEL 7 repo

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -81,7 +81,6 @@ ifdef::satellite[]
 # subscription-manager repos --enable={RepoRHEL7Server} \
 --enable={RepoRHEL7ServerSatelliteCapsuleProductVersion} \
 --enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion} \
---enable={project-client-RHEL7-url} \
 --enable={RepoRHEL7ServerSoftwareCollections} \
 --enable={RepoRHEL7ServerAnsible}
 ----


### PR DESCRIPTION
Omitted a repository that was not required while installing the proxy
on RHEL 7.

Incorrect repository for Capsule installation on RHEL 7

https://bugzilla.redhat.com/show_bug.cgi?id=2104573


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.