### PR TITLE
Modify the prerequisites to install Proxy

### DIFF
--- a/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
@@ -16,7 +16,8 @@ For more information on manifests and repositories, see {ContentManagementDocURL
 
 .Proxy and Network Prerequisites
 * The {ProjectServer} base operating system must be able to resolve the host name of the {SmartProxy} base operating system and vice versa.
-* The base operating system on which you want to install {SmartProxyServer} must not be configured to use a proxy to connect to the Red Hat CDN.
+* Ensure HTTPS connection using client certificate authentication is possible between {SmartProxyServer} and {ProjectServer}.
+HTTP proxies between {SmartProxyServer} and {ProjectServer} are not supported.
 * You must configure the host and network-based firewalls accordingly.
 For more information, see {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements].
 include::snip_host-registration-steps.adoc[]


### PR DESCRIPTION
The mentioning of the base operating system was not required as it does not
play any role in reaching out to Red Hat CDN. So, the second prerequisite
was corrected with accurate information about proxy server, and project 
correlation.

Should 'Red Hat CDN' be 'the Satellite'

https://bugzilla.redhat.com/show_bug.cgi?id=2104596


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
