### PR TITLE
Remove links to orcharhino documentation

### DIFF
--- a/guides/common/modules/con_provisioning-cloud-instances-in-amazon-ec2.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-in-amazon-ec2.adoc
@@ -4,7 +4,3 @@
 Amazon Elastic Compute Cloud (Amazon EC2) is a web service that provides public cloud compute resources.
 Using {Project}, you can interact with Amazon EC2's public API to create cloud instances and control their power management states.
 Use the procedures in this chapter to add a connection to an Amazon EC2 account and provision a cloud instance.
-
-ifdef::orcharhino[]
-For more information, see xref:sources/compute_resources/ec2.adoc[Amazon EC2].
-endif::[]

--- a/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
@@ -8,10 +8,6 @@
 {ProjectName} can interact with Google Compute Engine (GCE), including creating new virtual machines and controlling their power management states.
 Only image-based provisioning is supported for creating GCE hosts.
 
-ifdef::orcharhino[]
-For more information, see xref:sources/compute_resources/gce.adoc[Google GCE].
-endif::[]
-
 .Prerequisites
 include::snip_common-compute-resource-prereqs.adoc[]
 * In your GCE project, configure a service account with the necessary IAM Compute role.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3