### PR TITLE
Remove container gateway unauthenticated repo warning

### DIFF
--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -30,11 +30,3 @@ Pulling container images:
 ----
 # podman pull {foreman-example-com}/my-image:<optional_tag>
 ----
-
-ifdef::katello[]
-.Limitations
-
-With the Katello 4.0 release, the Container Gateway does not support pulling container images that require authentication.
-Until it does, ensure that *Unauthenticated Pull* is checked for all Lifecycle Environments that have container repositories that are expected to be served by {SmartProxies}.
-See also https://projects.theforeman.org/issues/32085[Foreman Issue #32085]
-endif::[]


### PR DESCRIPTION
Removes the warning about the Container Gateway not supporting authenticated repositories.




* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
