### PR TITLE
Restructure nightly landing page

### DIFF
--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -4,9 +4,20 @@ title: Home
 
 == Foreman and Katello Documentation
 
-* link:/release/nightly/[Nightly build]
-* link:/release/3.3/[3.3 (supported)]
-* link:/release/3.2/[3.2 (supported)]
-* link:/release/3.1/[3.1 (unsupported)]
-* link:/release/3.0/[3.0 (unsupported)]
-* link:/release/2.5/[2.5 (unsupported)]
+The following releases are supported, meaning they receive (security) updates. Visit the https://community.theforeman.org/c/support/10[support forum] for questions.
+
+* link:/release/3.3/[Foreman 3.3 & Katello 4.5]
+* link:/release/3.2/[Foreman 3.2 & Katello 4.4]
+
+=== Unsupported releases
+
+The future version is built in nightly.
+
+* link:/release/nightly/[Nightly]
+
+These releases are unsupported and no longer receive updates. Users should update to a supported release.
+
+* link:/release/3.1/[Foreman 3.1 & Katello 4.3]
+* link:/release/3.0/[Foreman 3.0 & Katello 4.2]
+* link:/release/2.5/[Foreman 2.5 & Katello 4.1]
+* link:/release/2.4/[Foreman 2.4 & Katello 4.0]

--- a/web/content/release-2.4.adoc
+++ b/web/content/release-2.4.adoc
@@ -1,10 +1,21 @@
+---
+title: 2.4
+---
 :FOREMAN_VER: 2.4
 :KATELLO_VER: 4.0
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
 * link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]

--- a/web/content/release-2.5.adoc
+++ b/web/content/release-2.5.adoc
@@ -1,11 +1,21 @@
+---
+title: 2.5
+---
 :FOREMAN_VER: 2.5
 :KATELLO_VER: 4.1
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
 * link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]

--- a/web/content/release-3.0.adoc
+++ b/web/content/release-3.0.adoc
@@ -1,12 +1,22 @@
+---
+title: 3.0
+---
 :FOREMAN_VER: 3.0
 :KATELLO_VER: 4.2
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
 * link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]

--- a/web/content/release-3.1.adoc
+++ b/web/content/release-3.1.adoc
@@ -1,14 +1,22 @@
+---
+title: 3.1
+---
 :FOREMAN_VER: 3.1
 :KATELLO_VER: 4.3
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-foreman-el.html[Managing Organizations and Locations]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
+* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]

--- a/web/content/release-3.2.adoc
+++ b/web/content/release-3.2.adoc
@@ -1,14 +1,22 @@
+---
+title: 3.2
+---
 :FOREMAN_VER: 3.2
 :KATELLO_VER: 4.4
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-foreman-el.html[Managing Organizations and Locations]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
+* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]

--- a/web/content/release-3.3.adoc
+++ b/web/content/release-3.3.adoc
@@ -1,32 +1,22 @@
+---
+title: 3.3
+---
 :FOREMAN_VER: 3.3
 :KATELLO_VER: 4.5
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Planning_Guide/index-foreman-el.html[Planning for Foreman]
-* link:/{FOREMAN_VER}/Release_notes/index-foreman-el.html[Release notes for Foreman]
-* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-el.html[Foreman Quickstart Guide on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-deb.html[Foreman Quickstart Guide on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-el.html[Upgrading and Updating Foreman]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
-* link:/{FOREMAN_VER}/Deploying_on_AWS/index-foreman-el.html[Deploying Foreman on AWS (reference guide)]
-* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-foreman-el.html[Configuring Smart Proxies with a Load Balancer]
-* link:/{FOREMAN_VER}/Provisioning_Guide/index-foreman-el.html[Provisioning Guide]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
-* link:/{FOREMAN_VER}/Configuring_Ansible/index-foreman-el.html[Configuring Foreman to use Ansible]
-* link:/{FOREMAN_VER}/Managing_Hosts/index-foreman-el.html[Managing Hosts Guide]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-el.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-deb.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-foreman-el.html[Administering Foreman]
-* link:/{FOREMAN_VER}/Application_Centric_Deployment/index-foreman-el.html[Application Centric Deployment]
-* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-foreman-el.html[Managing Organizations and Locations]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
+* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]

--- a/web/content/release-nightly.adoc
+++ b/web/content/release-nightly.adoc
@@ -1,32 +1,36 @@
+---
+title: nightly
+---
 :FOREMAN_VER: nightly
 :KATELLO_VER: nightly
 
-= Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 
-Use the top menu bar for navigation in the following guides:
+Use the top menu bar for navigation for all guides.
 
-* link:/{FOREMAN_VER}/Planning_Guide/index-foreman-el.html[Planning for Foreman]
-* link:/{FOREMAN_VER}/Release_notes/index-foreman-el.html[Release notes for Foreman]
-* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-el.html[Foreman Quickstart Guide on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-deb.html[Foreman Quickstart Guide on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello Quickstart Guide on RHEL/CentOS]
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-el.html[Foreman on RHEL/CentOS Quickstart Guide]
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-foreman-deb.html[Foreman on Debian/Ubuntu Quickstart Guide]
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
 * link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
 * link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
+
+* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-el.html[Upgrading and Updating Foreman]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello]
-* link:/{FOREMAN_VER}/Deploying_on_AWS/index-foreman-el.html[Deploying Foreman on AWS (reference guide)]
-* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-foreman-el.html[Configuring Smart Proxies with a Load Balancer]
-* link:/{FOREMAN_VER}/Provisioning_Guide/index-foreman-el.html[Provisioning Guide]
-* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
-* link:/{FOREMAN_VER}/Configuring_Ansible/index-foreman-el.html[Configuring Foreman to use Ansible]
-* link:/{FOREMAN_VER}/Managing_Hosts/index-foreman-el.html[Managing Hosts Guide]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-el.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-deb.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
-* link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-foreman-el.html[Administering Foreman]
-* link:/{FOREMAN_VER}/Application_Centric_Deployment/index-foreman-el.html[Application Centric Deployment]
-* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-foreman-el.html[Managing Organizations and Locations]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Release_notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Release_notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+
+// Upgrading guides are not ready for non-Katello
+//* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-el.html[Upgrading and Updating Foreman on RHEL/CentOS]
+//* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-deb.html[Upgrading and Updating Foreman on Debian]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]


### PR DESCRIPTION
This only shows a small set of guides to keep it easier for users to navigate. Copying the full navigation will be confusing for new users because the list is overwhelming.

It also removes links to guides which aren't even in the top navigation (and thus are considered not to be ready).

There is still plenty of room for improvement on this, like implementing columns, but this is a start.

If this is considered OK, the same should be applied to all releases.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.