### PR TITLE
Add note on subscription attachment

### DIFF
--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -1,6 +1,12 @@
 [id="attaching-infrastructure-subscription_{context}"]
 = Attaching the {Project} Infrastructure Subscription
 
+[NOTE]
+====
+This step is *optional* if you have SCA enabled in the Red Hat Customer Portal.
+There is no requirement of attaching the {SatelliteSub} to the {ProjectServer} using subscription-manager.
+====
+
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName} and {RHEL} content.
 For {RHEL} 7, it also provides access to Red{nbsp}Hat Software Collections (RHSCL).


### PR DESCRIPTION
If the SCA is enabled by the customer in the portal, there is no need of
attaching the subscription after registering the Project server. A user
can start the configuration part directly.

No mention of no need to attach a subscription with
Simple Content Access mode

https://bugzilla.redhat.com/show_bug.cgi?id=2104602

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.