### PR TITLE
Update in the module - Upgrading satellite Server

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -2,8 +2,14 @@
 = Upgrading {ProjectServer}
 
 This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.
-You can upgrade from any minor version of {ProjectName} Server {ProjectVersionPrevious}.
+
 ifdef::satellite[]
+Update your {ProjectServer} {ProjectVersionPrevious} to the latest {ProjectVersionPrevious}.z release before proceeding.
+You can use the following command to update to the latest z-stream.
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# satellite-maintain upgrade run --target-version {ProjectVersionPrevious}.z
+----
 Ensure that you have updated to the latest z-stream before upgrading to {ProjectVersion}. For more information about updating {ProjectServer}, see xref:updating_satellite_server_to_next_minor_version[].
 
 Although the process of upgrading from {ProjectVersionPrevious} to {ProjectVersion} also migrates Pulp content, this can take some considerable time.


### PR DESCRIPTION
The update in the upgrade guide about updating to the latest 6.9.z.
First need to update to the latest 6.9.z before upgrading to 6.10.
The same was requested in BZ#2049350

Changes only applicable for Satellite version 6.10.

https://bugzilla.redhat.com/show_bug.cgi?id=2049350


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
