### PR TITLE
Added reference to Installing SmartProxy Server Guide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -52,6 +52,8 @@ On the main {Project} server:
                        --certs-tar "~/myproxy.example.com-certs.tar"
 ----
 +
+For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
++
 . Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
 endif::[]
 ifdef::katello[]


### PR DESCRIPTION
As mentioned in the description of BZ#2104699, added a reference to
Deploying a Custom SSL Certificate to {SmartProxy} Server section.
This section is currently available in Installing {SmartProxy} server guide.

Reference added in the procedure - Upgrading {SmartProxy} Servers

https://bugzilla.redhat.com/show_bug.cgi?id=2104699


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
