### PR TITLE
Additional Steps-Certificate Tar file when Upgrade

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -41,20 +41,41 @@ endif::[]
 For information on backups, see {AdministeringDocURL}Backing_Up_Server_and_Proxy_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
 
 ifdef::katello,satellite[]
-+
 . Regenerate certificates.
 On the main {Project} server:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {certs-generate} --foreman-proxy-fqdn "myproxy.example.com" \
+# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
                        --certs-update-all \
-                       --certs-tar "~/myproxy.example.com-certs.tar"
+                       --certs-tar "~/{smartproxy-example-com}-certs.tar"
 ----
 +
-For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
+
+. If you use custom SSL certificates on your {smart-proxy-context} server, use the following command to regenerate the certificate tar file on the {ProjectServer}:
 +
-. Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
+[options="nowrap" subs="attributes"]
+----
+# {certs-generate} \
+--foreman-proxy-fqdn "{smartproxy-example-com}" \
+--certs-tar "~/{smartproxy-example-com}-certs.tar" \
+--server-cert "/path/to/{smart-proxy-context}_cert.pem" \
+--server-key "/path/to/{smart-proxy-context}_key.pem" \
+--server-ca-cert "/path/to/{smart-proxy-context}_ca.pem" \
+--certs-update-server
+----
++
+For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {smart-proxy-context}] in _{InstallingSmartProxyDocTitle}_.
+
+. Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/{smartproxy-example-com}-certs.tar`
+
+. Run the installer:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --certs-tar-file /root/{smartproxy-example-com}-certs.tar \
+--certs-update-all --certs-regenerate true --certs-deploy true
+----
 endif::[]
 ifdef::katello[]
 . Update repositories
@@ -89,7 +110,7 @@ ifdef::katello[]
 . Run the installer:
 +
 ----
-# foreman-installer --certs-tar-file /root/myproxy.example.com-certs.tar \
+# foreman-installer --certs-tar-file /root/{smartproxy-example-com}-certs.tar \
                     --certs-update-all --certs-regenerate true --certs-deploy true
 ----
 endif::[]


### PR DESCRIPTION
Added 2 additional steps while upgrading {smart-proxy-context} server
Step-2:Confirm cert tar file on existing {smart-proxy-context} server
Step-4:If you use custom SSL certificates on....

A reference to Installing {smart-proxy-context} Server guide is
moved from step 3 to 4.

https://bugzilla.redhat.com/show_bug.cgi?id=2104948


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
