### PR TITLE
Correct user requirements

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -49,24 +49,30 @@ Before you install {ProductName}, ensure that your environment meets the require
 {ProductName} must be installed on a freshly provisioned system that serves no other function except to run {ProductName}.
 The freshly provisioned system must not have the following users provided by external identity providers to avoid conflicts with the local users that {ProductName} creates:
 
+ifdef::foreman-deb[]
+* www-data
+endif::[]
+ifndef::foreman-deb[]
 * apache
+endif::[]
+ifeval::["{context}" == "{project-context}"]
 * foreman
+endif::[]
 * foreman-proxy
 * postgres
-ifdef::katello,satellite[]
+ifdef::katello,satellite,orcharhino[]
 * pulp
 endif::[]
 * puppet
-* puppetserver
-ifdef::katello,satellite[]
+ifdef::katello,satellite,orcharhino[]
 * qdrouterd
 endif::[]
-ifdef::katello,satellite[]
+ifdef::katello,satellite,orcharhino[]
 ifeval::["{context}" == "{project-context}"]
 * qpidd
 endif::[]
 endif::[]
-ifdef::katello,satellite[]
+ifdef::katello,satellite,orcharhino[]
 ifeval::["{context}" == "{project-context}"]
 * tomcat
 endif::[]


### PR DESCRIPTION
The puppetserver user doesn't exist. puppet agent runs as root and puppetserver runs as puppet.

The foreman user only exists when foreman is installed. This isn't the case on content proxies so it isn't a requirement.



* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.