### PR TITLE
Drop installation of centos-release-ansible-29

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -23,16 +23,6 @@ ifdef::katello[]
 ----
 # {package-manager} localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
-
-ifeval::["{distribution-major-version}" == "8"]
-+
-. Install the `centos-release-ansible-29` package to enable repositories for dependencies of the Ansible collection support:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} install centos-release-ansible-29
-----
-endif::[]
 endif::[]
 ifdef::foreman-el,katello[]
 +


### PR DESCRIPTION
CentOS Stream has ansible-core which means Ansible 2.9 can no longer be installed. Setting up the repositories is redundant.

<del>Submitting as a draft since I'm still verifying it in https://github.com/theforeman/forklift/pull/1544.</del>

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.