### PR TITLE
Correct availability of server packages

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -217,7 +217,7 @@ ifndef::satellite[]
 [[Foreman_Server_Operating_System]]
 ==== {ProjectServer} Operating System
 
-{Project} has packages for CentOS 7 & 8 and clones, and Debian and clones.
+{Project} has packages for CentOS 8 and clones, and Debian 11 and Ubuntu 20.04.
 Katello plug-in packages, which provide content management capabilities, are only available for CentOS.
 
 The only architecture {Project} has packages for is x86_64.


### PR DESCRIPTION
Nightly has dropped EL 7 and Debian 10, but stable branches still have that support so it shouldn't be cherry picked.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.