### PR TITLE
Drop redundant Apache restart

### DIFF
--- a/guides/common/modules/proc_configuring-logging-to-journal.adoc
+++ b/guides/common/modules/proc_configuring-logging-to-journal.adoc
@@ -23,9 +23,3 @@ endif::[]
 --foreman-logging-type journald \
 --foreman-proxy-log JOURNAL
 ----
-. Restart the Apache daemon:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service restart --only httpd
-----


### PR DESCRIPTION
The installer should restart any services which are needed. Since we dropped Passenger support this doesn't even work to restart Foreman.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.