### PR TITLE
Add details about Autocompletion option for templates

### DIFF
--- a/guides/common/assembly_template-writing-reference.adoc
+++ b/guides/common/assembly_template-writing-reference.adoc
@@ -2,6 +2,8 @@ include::modules/con_template-writing-reference.adoc[]
 
 include::modules/proc_accessing-the-template-writing-reference.adoc[leveloffset=+1]
 
+include::modules/proc_using-autocompletion-in-templates.adoc[leveloffset=+1]
+
 include::modules/proc_writing-erb-templates.adoc[leveloffset=+1]
 
 include::modules/proc_troubleshooting-erb-templates.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -1,7 +1,7 @@
 [id="Using_Autocompletion_in_Templates_{context}"]
 = Using Autocompletion in Templates
 
-Using the autocompletion option, you can access a list of all available macros and information about using it, in the template editor itself.
+You can access a list of available macros and usage information in the template editor with the autocompletion option.
 This works for all {ProjectName} templates.
 
 .Procedure

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -5,6 +5,7 @@ Using the autocompletion option, you can access a list of all available macros a
 This works for all {ProjectName} templates.
 
 .Procedure
+. Navigate to *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.
 . Click the *settings* icon at the top right corner of the template editor and select *Autocompletion*.
 . Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
 . You can narrow down the list of macros by typing in more information about what you are looking for.

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -13,5 +13,5 @@ For example, if you are looking for a method to list the ID of the content sourc
 . A window next to the dropdown provides a description of the macro, its usage, and the value it will return.
 . When you find the method you are looking for, hit `Enter` to input the method.
 
-You can also enable *Live Autocompletion* in the *settings* menu, this will provide a list of macros that match the pattern whenever you type something.
+You can also enable *Live Autocompletion* in the *settings* menu to view a list of macros that match the pattern whenever you type something.
 However, this might input macros in unintended places, like package names in a provisioning template.

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -1,4 +1,4 @@
-[id="Using_Autocompletion_in_Templates{context}"]
+[id="Using_Autocompletion_in_Templates_{context}"]
 = Using Autocompletion in Templates
 
 Using the autocompletion option, you can access a list of all available macros and information about using it, in the template editor itself.
@@ -9,7 +9,7 @@ This works for all {ProjectName} templates.
 . Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
 . You can narrow down the list of macros by typing in more information about what you are looking for.
 . For example, if you are looking for a method to list the ID of the content source for a host, you can type `host` and check the list of available macros for content source.
-. A window next to the dropdown provides a description of the macro, its usagei, and the value it will return.
+. A window next to the dropdown provides a description of the macro, its usage, and the value it will return.
 . When you find the method you are looking for, hit `Enter` to input the method.
 
 You can also enable *Live Autocompletion* in the *settings* menu, this will provide a list of macros that match the pattern whenever you type something.

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -2,7 +2,7 @@
 = Using Autocompletion in Templates
 
 You can access a list of available macros and usage information in the template editor with the autocompletion option.
-This works for all {ProjectName} templates.
+This works for all templates within {Project}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to either *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -8,8 +8,8 @@ This works for all templates within {Project}.
 . In the {ProjectWebUI}, navigate to either *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.
 . Click the *settings* icon at the top right corner of the template editor and select *Autocompletion*.
 . Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
-. You can narrow down the list of macros by typing in more information about what you are looking for.
-. For example, if you are looking for a method to list the ID of the content source for a host, you can type `host` and check the list of available macros for content source.
+You can narrow down the list of macros by typing in more information about what you are looking for.
+For example, if you are looking for a method to list the ID of the content source for a host, you can type `host` and check the list of available macros for content source.
 . A window next to the dropdown provides a description of the macro, its usage, and the value it will return.
 . When you find the method you are looking for, hit `Enter` to input the method.
 

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -1,0 +1,16 @@
+[id="Using_Autocompletion_in_Templates{context}"]
+= Using Autocompletion in Templates
+
+Using the autocompletion option, you can access a list of all available macros and information about using it, in the template editor itself.
+This works for all {ProjectName} templates.
+
+.Procedure
+. Click the *settings* icon at the top right corner of the template editor and select *Autocompletion*.
+. Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
+. You can narrow down the list of macros by typing in more information about what you are looking for.
+. For example, if you are looking for a method to list the ID of the content source for a host, you can type `host` and check the list of available macros for content source.
+. A window next to the dropdown provides a description of the macro, its usagei, and the value it will return.
+. When you find the method you are looking for, hit `Enter` to input the method.
+
+You can also enable *Live Autocompletion* in the *settings* menu, this will provide a list of macros that match the pattern whenever you type something.
+However, this might input macros in unintended places, like package names in a provisioning template.

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -5,7 +5,7 @@ Using the autocompletion option, you can access a list of all available macros a
 This works for all {ProjectName} templates.
 
 .Procedure
-. Navigate to *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.
+. Navigate to either *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.
 . Click the *settings* icon at the top right corner of the template editor and select *Autocompletion*.
 . Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
 . You can narrow down the list of macros by typing in more information about what you are looking for.

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -5,7 +5,7 @@ Using the autocompletion option, you can access a list of all available macros a
 This works for all {ProjectName} templates.
 
 .Procedure
-. Navigate to either *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.
+. In the {ProjectWebUI}, navigate to either *Hosts* > *Partition tables*, *Hosts* > *Provisioning templates*, or *Hosts* > *Job templates*.
 . Click the *settings* icon at the top right corner of the template editor and select *Autocompletion*.
 . Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
 . You can narrow down the list of macros by typing in more information about what you are looking for.


### PR DESCRIPTION
Adding a module describing the Autocopmpletion option for template writing in the Managing Hosts doc.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
