### PR TITLE
Drop version number for RHEL hosts

### DIFF
--- a/guides/common/modules/proc_applying-errata-to-multiple-hosts.adoc
+++ b/guides/common/modules/proc_applying-errata-to-multiple-hosts.adoc
@@ -1,7 +1,7 @@
 [id="Applying_Errata_to_Multiple_Hosts_{context}"]
 = Applying Errata to Multiple Hosts
 
-Use these procedures to review and apply errata to multiple RHEL 7 hosts.
+Use these procedures to review and apply errata to multiple RHEL hosts.
 
 .Prerequisites
 * Synchronize {ProjectName} repositories with the latest errata available from Red{nbsp}Hat.


### PR DESCRIPTION
Removed RHEL 7 specific references and updated to reflect RHEL 8 based
installation and upgrade scenarios. The change was required because
support for installation on RHEL 7 is being dropped and only RHEL 8
installations will be supported.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
