### PR TITLE
A step added to update subscription manager config

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -5,6 +5,14 @@ You can register hosts with {Project} using the host registration feature, the {
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Log on to the host you want register and run the previously generated command.
+. Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager config \
+--rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
+--server.hostname=loadbalancer.example.com
+----
 . Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
 
 .CLI procedure
@@ -24,6 +32,14 @@ ifdef::katello,satellite,orcharhino[]
 ----
 endif::[]
 . Log on to the host you want register and run the previously generated command.
+. Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager config \
+--rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
+--server.hostname=loadbalancer.example.com
+----
 . Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
 
 .API procedure
@@ -55,4 +71,12 @@ Keep in mind this can save the password in the shell history.
 +
 For more information about registration see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName}].
 . Log on to the host you want register and run the previously generated command.
+. Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager config \
+--rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
+--server.hostname=loadbalancer.example.com
+----
 . Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.


### PR DESCRIPTION
A step to update subscription manager config while project host
registration has been added.
This step is added after having discussion in BZ#2105995
This step is required for proper Registration method in Load-balancing 
capsule setup for a clients.

https://bugzilla.redhat.com/show_bug.cgi?id=2105995  

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
