### PR TITLE
Introduce EL macro

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -87,6 +87,7 @@
 :ProductVersion: {ProjectVersion}
 :ProductVersionPrevious: {ProjectVersionPrevious}
 :provision-script: OS installer recipe
+:EL: Enterprise Linux
 :RHEL: Red{nbsp}Hat Enterprise Linux
 :RHELServer: Red{nbsp}Hat Enterprise Linux Server
 :smart-proxy-context: smart-proxy

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -42,6 +42,7 @@
 :customssl: custom SSL
 :customssltitle: Custom SSL
 :DocState: satellite
+:EL: {RHEL}
 :foreman-example-com: satellite.example.com
 :foreman-installer-package: satellite-installer
 :foreman-installer: satellite-installer

--- a/guides/common/modules/con_migrating-project-to-a-new-el-system.adoc
+++ b/guides/common/modules/con_migrating-project-to-a-new-el-system.adoc
@@ -1,10 +1,5 @@
 [id="migrating-project-to-a-new-el-system_{context}"]
-ifdef::satellite[]
-= Migrating {Project} to a New {RHEL} System
-endif::[]
-ifndef::satellite[]
-= Migrating {Project} to a New Enterprise Linux System
-endif::[]
+= Migrating {Project} to a New {EL} System
 
 When you migrate your {Project}, you create a backup of your {ProjectServer} and your {SmartProxy}, install a fresh instance, and restore your backup on the new instance.
 After your migration is complete, you can then decommission the earlier instance of {ProjectServer} and {SmartProxy}.
@@ -21,12 +16,7 @@ To migrate your {Project} to new hardware, follow these high-level steps:
 
 . Create a backup of the {ProjectServer} or {SmartProxyServer} on the source server.
 . Perform a fresh installation of the {ProjectServer} or {SmartProxyServer} on a target server.
-ifdef::satellite[]
-* Install a minimal {RHEL} 8 instance with the capacity to store backup files.
-endif::[]
-ifndef::satellite[]
-* Install a minimal Enterprise Linux 8 (CentOS Stream, {RHEL} or a {RHEL} rebuild) instance with the capacity to store backup files.
-endif::[]
+* Install a minimal {EL} 8 instance with the capacity to store backup files.
 * Do not install any operating system software groups or third-party applications.
 ifdef::satellite[]
 +

--- a/guides/common/modules/proc_creating-a-backup-of-a-server-on-el7.adoc
+++ b/guides/common/modules/proc_creating-a-backup-of-a-server-on-el7.adoc
@@ -1,14 +1,7 @@
 [id="Creating_a_Backup_of_a_Server_on_el7_{context}"]
-ifdef::satellite[]
-= Creating a Backup of a Server on {RHEL} 7
+= Creating a Backup of a Server on {EL} 7
 
-Before you perform a fresh installation of the {ProjectServer} or {SmartProxyServer} on the {RHEL} 8 system, back up your {ProjectServer} or {SmartProxyServer} data on the {RHEL} 7 system by creating an offline backup.
-endif::[]
-ifndef::satellite[]
-= Creating a Backup of a Server on Enterprise Linux 7
-
-Before you perform a fresh installation of the {ProjectServer} or {SmartProxyServer} on the Enterprise Linux 8 system, back up your {ProjectServer} or {SmartProxyServer} data on the Enterprise Linux 7 system by creating an offline backup.
-endif::[]
+Before you perform a fresh installation of the {ProjectServer} or {SmartProxyServer} on the {EL} 8 system, back up your {ProjectServer} or {SmartProxyServer} data on the {EL} 7 system by creating an offline backup.
 
 If you recently created an offline backup, you can perform an incremental backup to update the existing backup.
 

--- a/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
@@ -24,21 +24,13 @@ endif::[]
 .Procedure
 . Log in to the host as the `root` user.
 . Install the Puppet agent package.
-ifdef::satellite[]
-* On hosts running {RHEL}:
+* On hosts running {EL}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # yum install puppet-agent
 ----
-endif::[]
 ifndef::satellite[]
-* On hosts running Enterprise Linux:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# yum install puppet-agent
-----
 * On hosts running Debian:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
+++ b/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
@@ -1,10 +1,5 @@
 [id="Restoring_a_Backup_of_a_Server_on_el8_{context}"]
-ifdef::satellite[]
-= Restoring a Backup of a Server on {RHEL} 8
-endif::[]
-ifndef::satellite[]
-= Restoring a Backup of a Server on Enterprise Linux 8
-endif::[]
+= Restoring a Backup of a Server on {EL} 8
 
 After you perform a fresh installation of {ProjectServer} or {SmartProxyServer} on the target server, you can restore the backup you previously created.
 

--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -1,27 +1,15 @@
 [id="upgrading-project-in-place-using-leapp_{context}"]
-ifdef::foreman-el,katello[]
-= Upgrading {Project} to Enterprise Linux 8 In-Place Using Leapp
-endif::[]
-ifdef::satellite[]
-= Upgrading {Project} to {RHEL} 8 In-Place Using Leapp
-endif::[]
+= Upgrading {Project} to {EL} 8 In-Place Using Leapp
 
-ifdef::foreman-el,katello[]
-Use this procedure to upgrade your {Project} installation from Enterprise Linux 7 to Enterprise Linux 8.
-endif::[]
-
-ifdef::satellite[]
-Use this procedure to upgrade your {Project} installation from {RHEL} 7 to {RHEL} 8.
-endif::[]
+Use this procedure to upgrade your {Project} installation from {EL} 7 to {EL} 8.
 
 .Prerequisites
+* {Project} {ProjectVersion} running on {EL} 7.
 ifdef::foreman-el,katello[]
-* {Project} {ProjectVersion} running on Enterprise Linux 7.
 * {Project} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
 * {Project} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
 endif::[]
 ifdef::satellite[]
-* {Project} {ProjectVersion} running on {RHEL} 7.
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
@@ -131,7 +119,7 @@ gpgcheck=1
 
 * You need a Puppet repository for the Puppet agent that the installer is using.
 
-. We do not support Enterprise Linux 8 installations with EPEL 8 enabled, so remove `epel-release`:
+. We do not support {EL} 8 installations with EPEL 8 enabled, so remove `epel-release`:
 +
 ----
 # yum remove epel-release
@@ -188,13 +176,7 @@ endif::[]
 
 . Reboot the system.
 +
-ifdef::foreman-el,katello[]
-After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final Enterprise Linux 8 system.
-endif::[]
-
-ifdef::satellite[]
-After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {RHEL} 8 system.
-endif::[]
+After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 8 system.
 
 . Leapp finishes the upgrade, watch it with:
 +

--- a/guides/common/modules/ref_performing-a-fresh-installation-of-a-server-on-el8.adoc
+++ b/guides/common/modules/ref_performing-a-fresh-installation-of-a-server-on-el8.adoc
@@ -1,10 +1,5 @@
 [id="Performing_a_Fresh_Installation_of_a_Server_on_el8_{context}"]
-ifdef::satellite[]
-= Performing a Fresh Installation of a Server on {RHEL} 8
-endif::[]
-ifndef::satellite[]
-= Performing a Fresh Installation of a Server on Enterprise Linux 8
-endif::[]
+= Performing a Fresh Installation of a Server on {EL} 8
 
 After you have created a backup of the {ProjectServer} or {SmartProxyServer} on the source server, you can install {ProjectServer} or {SmartProxyServer} on the target server.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -92,7 +92,7 @@ ifdef::katello[]
 ----
 . Update repositories
 +
-.For Centos 7 or {RHEL} 7 Users:
+.For {EL} 7 Users:
 [options="nowrap" subs="attributes"]
 ----
 # yum update -y https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm \
@@ -100,13 +100,13 @@ ifdef::katello[]
 # yum install -y centos-release-scl-rh
 ----
 +
-.For Enterprise Linux 8 or {RHEL} 8 Users:
+.For {EL} 8 Users:
 [options="nowrap" subs="attributes"]
 ----
 # dnf update -y https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
                 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
 ----
-. Ensure the module streams are enabled for Enterprise Linux 8 and {RHEL} 8:
+. Ensure the module streams are enabled for {EL} 8:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -59,20 +59,20 @@ endif::[]
 ifdef::katello[]
 . Update repositories
 +
-.For Centos 7 or {RHEL} 7 Users:
+.For {EL} 7 Users:
 [options="nowrap" subs="attributes"]
 ----
 # yum update -y https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm \
                 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
 ----
 +
-.For Enterprise Linux 8 or {RHEL} 8 Users:
+.For {EL} 8 Users:
 [options="nowrap" subs="attributes"]
 ----
 # dnf update -y https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
                 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
 ----
-. Ensure the module streams are enabled for Enterprise Linux 8 and {RHEL} 8:
+. Ensure the module streams are enabled for {EL} 8:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -75,11 +75,8 @@ ifdef::katello,orcharhino,satellite[]
 . Upgrade to {project-client-name} on all content hosts.
 For more information, see xref:upgrading_content_hosts[].
 endif::[]
-ifdef::satellite[]
-. Optional: After you upgrade your {Project}, you can also upgrade the operating system on your {ProjectServer}s and {SmartProxies} to {RHEL} 8.
-endif::[]
-ifndef::satellite,foreman-deb,orcharhino[]
-. Optional: After you upgrade your {Project}, you can also upgrade the operating system on your {ProjectServer}s and {SmartProxies} to Enterprise Linux 8.
+ifndef::foreman-deb,orcharhino[]
+. Optional: After you upgrade your {Project}, you can also upgrade the operating system on your {ProjectServer}s and {SmartProxies} to {EL} 8.
 endif::[]
 ifdef::foreman-el,katello,satellite[]
 There are two ways of upgrading your OS:


### PR DESCRIPTION
In upstream it's common to use Enterprise Linux to mean any RHEL-like OS (RHEL, its clones and CentOS Stream (which is technically more of an upstream). In satellite only RHEL is used.

The guidance on using this is that where it doesn't matter, {EL} should be used (such as disk space requirements). In cases where it does make a difference (like setting up repositories) the actual names should be used. It may also result in multiple sections.

This takes a more conservative approach than https://github.com/theforeman/foreman-documentation/pull/982 in that it doesn't replace as many sections. I wonder if this should or shouldn't be cherry picked. It's fairly safe and picking it makes future cherry picks easier due to fewer conflicts.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.