### PR TITLE
Make DNF module enablement consistent

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -110,7 +110,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="attributes"]
 ----
-# dnf module enable -y foreman katello pulpcore
+# dnf module enable -y katello:el8 pulpcore:el8
 ----
 . Clean the yum cache and update the required packages:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -76,7 +76,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="attributes"]
 ----
-# dnf module enable -y foreman katello pulpcore
+# dnf module enable -y katello:el8 pulpcore:el8
 ----
 . Clean the yum cache and update the required packages:
 +


### PR DESCRIPTION
This aligns configuring repositories instructions. The katello module should depend on foreman which makes foreman redundant. We also explicitly state the stream rather than depending on there being only one stream.

Fixes: 801d7c8676a6e330c94ac4f0199a64fbe24b6fe1

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.