### PR TITLE
Fix link to registering hosts

### DIFF
--- a/guides/common/modules/con_converting-a-host-to-rhel-with-convert2rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel-with-convert2rhel.adoc
@@ -24,7 +24,7 @@ endif::[]
 The amount of time taken to do this can vary depending on how many packages need to be replaced, network speed, storage speed, and similar variables.
 
 Use the global registration template to register and subscribe your system before the conversion.
-For more information, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
 
 Parts of the process can be achieved using the {ansible-namespace}.convert2rhel role assigned to the host or host groups.
 The Ansible role prepares data, that is, repositories, certificates, activation keys and host groups required for the host conversion.

--- a/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
@@ -16,4 +16,4 @@ Use the following procedure to create an activation key that you can use to subs
 . Click *Add Selected* to save.
 
 Use your activation key to register a host to the Content View.
-For more information on registering a host, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host] in the _Managing Hosts_ guide.
+For more information on registering a host, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host] in the _Managing Hosts_ guide.

--- a/guides/common/modules/proc_distributing-keys-for-remote-execution.adoc
+++ b/guides/common/modules/proc_distributing-keys-for-remote-execution.adoc
@@ -11,7 +11,7 @@ Use one of the following methods to distribute the public SSH key from {SmartPro
 . xref:using-the-api-to-obtain-ssh-keys-for-remote-execution_{context}[].
 . xref:configuring-a-kickstart-template-to-distribute-ssh-keys-during-provisioning_{context}[].
 . For new {Project} hosts, you can deploy SSH keys to {Project} hosts during registration using the global registration template.
-For more information, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template].
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template].
 
 {Project} distributes SSH keys for the remote execution feature to the hosts provisioned from {Project} by default.
 

--- a/guides/common/modules/proc_using-red-hat-insights.adoc
+++ b/guides/common/modules/proc_using-red-hat-insights.adoc
@@ -8,7 +8,7 @@ You can sort by category, view details of the impact and resolution, and then de
 To use Red{nbsp}Hat Insights to monitor hosts that you manage with {Project}, you must first install Red{nbsp}Hat Insights on your hosts and register your hosts with Red{nbsp}Hat Insights.
 
 For new {Project} hosts, you can install and configure {Project} hosts with Insights during registration using the global registration template.
-For more information, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host to {ProjectName} Using the Global Registration Template] in the _Managing Hosts_ guide.
 
 To install and register your host using Puppet, or manually, see https://access.redhat.com/products/red-hat-insights/#getstarted[Red{nbsp}Hat Insights Getting Started].
 

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -69,7 +69,7 @@ endif::[]
 To enter a password as command line argument, use `username:password` syntax.
 Keep in mind this can save the password in the shell history.
 +
-For more information about registration see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a Host to {ProjectName}].
+For more information about registration see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host to {ProjectName}].
 . Log on to the host you want register and run the previously generated command.
 . Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
 +


### PR DESCRIPTION
try `git grep "registering-a-host_"` vs. `git grep "registering_hosts_"`.

I ran `find . -type f -iname "*.adoc" | xargs sed -i "" "s/registering-a-host_/Registering_Hosts_/g"`.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3