### PR TITLE
Make cloning optional in upgrade workflow

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -62,10 +62,10 @@ endif::[]
 
 === High-Level Upgrade Steps
 
-The high-level steps in upgrading {Project} to {ProjectVersion} are as follows.
+The high-level steps in upgrading {Project} to {ProjectVersion} are as follows:
 
 ifdef::satellite[]
-. Clone your existing {ProjectServer}s. For more information, see xref:cloning_satellite_server[].
+. Optional: Clone your existing {ProjectServer}s. For more information, see xref:cloning_satellite_server[].
 endif::[]
 . Upgrade {ProjectServer} to {ProjectVersion}.
 For more information, see xref:Upgrading_Server_{context}[].


### PR DESCRIPTION
In step 1 of High-Level Upgrade Steps, the first step for cloning is
optional. The word Optional is added to clarify that before clicking
the link to the guide for Cloning Satellite Server.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
