### PR TITLE
Fix spelling of identical

### DIFF
--- a/guides/common/modules/proc_importing-a-virtual-machine-from-vmware.adoc
+++ b/guides/common/modules/proc_importing-a-virtual-machine-from-vmware.adoc
@@ -7,6 +7,6 @@ You can import existing virtual machines running on VMware into {Project}.
 . In the {ProjectWebUI}, navigate to *Infrastructure > Compute Resources*.
 . Select your VMware compute resource.
 . On the *Virtual Machines* tab, click *Import as managed Host* or *Import as unmanaged Host* from the *Actions* menu.
-The following page looks idential to creating a host with the compute resource being already selected.
+The following page looks identical to creating a host with the compute resource being already selected.
 For more information, see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in {Project}] in _{ManagingHostsDocTitle}_.
 . Click *Submit* to import the virtual machine into {Project}.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
