### PR TITLE
Updated incorrect Hyperlinks in Migration Chapter

### DIFF
--- a/guides/common/modules/proc_creating-a-backup-of-a-server-on-el7.adoc
+++ b/guides/common/modules/proc_creating-a-backup-of-a-server-on-el7.adoc
@@ -5,7 +5,6 @@ Before you perform a fresh installation of the {ProjectServer} or {SmartProxySer
 
 If you recently created an offline backup, you can perform an incremental backup to update the existing backup.
 
-
 .Procedure
 * Perform a backup on the source server:
 ** To perform a full backup, see {AdministeringDocURL}Backing_Up_Server_and_Proxy_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_creating-a-backup-of-a-server-on-el7.adoc
+++ b/guides/common/modules/proc_creating-a-backup-of-a-server-on-el7.adoc
@@ -5,7 +5,8 @@ Before you perform a fresh installation of the {ProjectServer} or {SmartProxySer
 
 If you recently created an offline backup, you can perform an incremental backup to update the existing backup.
 
+
 .Procedure
 * Perform a backup on the source server:
-** To perform a full backup, see {AdministeringDocURL}Backing_Up_Server_and_Proxy_{project-context}[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
-** To perform an incremental backup, see {AdministeringDocURL}Performing_an_Incremental_Backup_{project-context}[Performing an Incremental Backup] in _{AdministeringDocTitle}_.
+** To perform a full backup, see {AdministeringDocURL}Backing_Up_Server_and_Proxy_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+** To perform an incremental backup, see {AdministeringDocURL}Performing_an_Incremental_Backup_admin[Performing an Incremental Backup] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
+++ b/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
@@ -5,5 +5,5 @@ After you perform a fresh installation of {ProjectServer} or {SmartProxyServer} 
 
 .Procedure
 * Restore a backup on the target server:
-** To restore a full backup, see {AdministeringDocURL}restoring-from-a-full-backup[Restoring From a Full Backup] in _{AdministeringDocTitle}_.
-** To restore an incremental backup, see {AdministeringDocURL}Restoring_from_Incremental_Backups_{project-context}[Restoring From Incremental Backups] in _{AdministeringDocTitle}_.
+** To restore a full backup, see {AdministeringDocURL}Restoring_from_a_Full_Backup_admin[Restoring From a Full Backup] in _{AdministeringDocTitle}_.
+** To restore an incremental backup, see {AdministeringDocURL}Restoring_from_Incremental_Backups_admin[Restoring From Incremental Backups] in _{AdministeringDocTitle}_.


### PR DESCRIPTION
Few hyperlinks were pointing to the beginning of the Administering Project guide.
Updated such hyperlinks to point to the specific section in
the Administering {Project} guide.
Changes are made only in the Migrating Satellite to a New RHEL System
section of the Upgrade guide.  

No more updates required from the docs side.

https://bugzilla.redhat.com/show_bug.cgi?id=2110885


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
