### PR TITLE
Add short procedures on how to add custom RPM repositories for EL9

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -10,6 +10,8 @@ include::modules/proc_adding-custom-rpm-repositories.adoc[leveloffset=+1]
 
 ifndef::satellite[]
 include::modules/proc_adding-custom-rpm-repositories-for-alma-linux-9.adoc[leveloffset=+1]
+
+include::modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::satellite[]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -14,6 +14,8 @@ include::modules/proc_adding-custom-rpm-repositories-for-alma-linux-9.adoc[level
 include::modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc[leveloffset=+1]
 
 include::modules/proc_adding-custom-rpm-repositories-for-oracle-linux-9.adoc[leveloffset=+1]
+
+include::modules/proc_adding-custom-rpm-repositories-for-rocky-linux-9.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::satellite[]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -12,6 +12,8 @@ ifndef::satellite[]
 include::modules/proc_adding-custom-rpm-repositories-for-alma-linux-9.adoc[leveloffset=+1]
 
 include::modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc[leveloffset=+1]
+
+include::modules/proc_adding-custom-rpm-repositories-for-oracle-linux-9.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::satellite[]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -9,6 +9,10 @@ include::modules/proc_creating-a-custom-product.adoc[leveloffset=+1]
 include::modules/proc_adding-custom-rpm-repositories.adoc[leveloffset=+1]
 
 ifndef::satellite[]
+include::modules/proc_adding-custom-rpm-repositories-for-alma-linux-9.adoc[leveloffset=+1]
+endif::[]
+
+ifndef::satellite[]
 include::modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc[leveloffset=+1]
 
 include::modules/proc_adding-custom-deb-repositories.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
@@ -14,17 +14,17 @@ For more information, see xref:Creating_a_Custom_Product_{context}[].
 . On the *Repositories* tab, click *New Repository* to create three repositories of type `deb` as follows:
 +
 * *Debian 11 main*
-** *URL*: `\http://ftp.debian.org/debian/`
+** *Upstream URL*: `\http://ftp.debian.org/debian/`
 ** *Releases/Distributions*: `bullseye`
 ** *Component*: `main`
 ** *Architecture*: `amd64`
 * *Debian 11 updates*
-** *URL*: `\http://ftp.debian.org/debian/`
+** *Upstream URL*: `\http://ftp.debian.org/debian/`
 ** *Releases/Distributions*: `bullseye-updates`
 ** *Component*: `main`
 ** *Architecture*: `amd64`
 * *Debian 11 security*
-** *URL*: `\http://deb.debian.org/debian-security/`
+** *Upstream URL*: `\http://deb.debian.org/debian-security/`
 ** *Releases/Distributions*: `bullseye-security`
 ** *Component*: `main`
 ** *Architecture*: `amd64`
@@ -34,10 +34,10 @@ For more information, see xref:Creating_a_Custom_Product_{context}[].
 +
 * **Debian 11 client**
 ifndef::orcharhino[]
-** *URL*: `\https://apt.atix.de/Debian11/`
+** *Upstream URL*: `\https://apt.atix.de/Debian11/`
 endif::[]
 ifdef::orcharhino[]
-** *URL*: see https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal]
+** *Upstream URL*: see https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal]
 endif::[]
 ** *Releases/Distributions*: `stable`
 ** *Component*: `main`

--- a/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc
@@ -14,12 +14,12 @@ For more information, see xref:Creating_a_Custom_Product_{context}[].
 . On the *Repositories* tab, click *New Repository* to create three repositories of type `deb` as follows:
 +
 * *Debian 11 main*
-** *Upstream URL*: `\http://ftp.debian.org/debian/`
+** *Upstream URL*: `\http://deb.debian.org/debian/`
 ** *Releases/Distributions*: `bullseye`
 ** *Component*: `main`
 ** *Architecture*: `amd64`
 * *Debian 11 updates*
-** *Upstream URL*: `\http://ftp.debian.org/debian/`
+** *Upstream URL*: `\http://deb.debian.org/debian/`
 ** *Releases/Distributions*: `bullseye-updates`
 ** *Component*: `main`
 ** *Architecture*: `amd64`

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-for-alma-linux-9.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-for-alma-linux-9.adoc
@@ -1,0 +1,35 @@
+[id="Adding_Custom_RPM_Repositories_for_Alma_Linux_9_{context}"]
+= Adding {customrpmtitle} Repositories for Alma Linux 9
+
+This example creates a product and repositories for Alma Linux 9.
+
+.Prerequisite
+* Download and import the http://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux-9[GPG public key] for yum repositories for Alma Linux 9 into {Project}.
+For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > Products*.
+. Click *Create Product* to create a product named `Alma Linux 9`.
+For more information, see xref:Creating_a_Custom_Product_{context}[].
+. On the *Repositories* tab, click *New Repository* to create three repositories of type `yum` as follows:
++
+* *Alma Linux 9 BaseOS*
+** *Upstream URL*: `http://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/`
+* *Alma Linux 9 AppStream*
+** *Upstream URL*: `http://repo.almalinux.org/almalinux/9/AppStream/x86_64/os/`
+* *Alma Linux 9 extras*
+** *Upstream URL*: `http://repo.almalinux.org/almalinux/9/extras/x86_64/os/`
+
++
+For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
+. Click *Create Product* to create a product named `Alma Linux 9 client`.
+. On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
++
+ifndef::orcharhino[]
+* **{Project} EL9 Client**
+** *Upstream URL*: `{project-client-name}el9/`
+endif::[]
+ifdef::orcharhino[]
+* **Alma Linux 9 client**
+** *Upstream URL*: see https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal]
+endif::[]

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc
@@ -1,0 +1,33 @@
+[id="Adding_Custom_RPM_Repositories_for_CentOS_Stream_9_{context}"]
+= Adding {customrpmtitle} Repositories for CentOS Stream 9
+
+This example creates a product and repositories for CentOS Stream 9.
+
+.Prerequisite
+* Download and import the https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official[GPG public key] for yum repositories for CentOS Stream 9 into {Project}.
+For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > Products*.
+. Click *Create Product* to create a product named `CentOS Stream 9`.
+For more information, see xref:Creating_a_Custom_Product_{context}[].
+. On the *Repositories* tab, click *New Repository* to create three repositories of type `yum` as follows:
++
+* *CentOS Stream 9 BaseOS*
+** *Upstream URL*: `http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/`
+* *CentOS Stream 9 AppStream*
+** *Upstream URL*: `http://mirror.stream.centos.org/9-stream/AppStream/x86_64/`
+
++
+For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
+. Click *Create Product* to create a product named `CentOS Stream 9 client`.
+. On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
++
+ifndef::orcharhino[]
+* **{Project} EL9 Client**
+** *Upstream URL*: `{project-client-name}el9/`
+endif::[]
+ifdef::orcharhino[]
+* **CentOS Stream 9 client**
+** *Upstream URL*: see https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal]
+endif::[]

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-for-oracle-linux-9.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-for-oracle-linux-9.adoc
@@ -1,0 +1,35 @@
+[id="Adding_Custom_RPM_Repositories_for_Oracle_Linux_9_{context}"]
+= Adding {customrpmtitle} Repositories for Oracle Linux 9
+
+This example creates a product and repositories for Oracle Linux 9.
+
+.Prerequisite
+* Download and import the https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9[GPG public key] for yum repositories for Oracle Linux 9 into {Project}.
+For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > Products*.
+. Click *Create Product* to create a product named `Oracle Linux 9`.
+For more information, see xref:Creating_a_Custom_Product_{context}[].
+. On the *Repositories* tab, click *New Repository* to create three repositories of type `yum` as follows:
++
+* *Oracle Linux 9 BaseOS*
+** *Upstream URL*: `http://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/`
+* *Oracle Linux 9 AppStream*
+** *Upstream URL*: `http://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/`
+* *Oracle Linux 9 Addons*
+** *Upstream URL*: `http://yum.oracle.com/repo/OracleLinux/OL9/addons/x86_64/`
+
++
+For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
+. Click *Create Product* to create a product named `Oracle Linux 9 client`.
+. On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
++
+ifndef::orcharhino[]
+* **{Project} EL9 Client**
+** *Upstream URL*: `{project-client-name}el9/`
+endif::[]
+ifdef::orcharhino[]
+* **Oracle Linux 9 client**
+** *Upstream URL*: see https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal]
+endif::[]

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-for-rocky-linux-9.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-for-rocky-linux-9.adoc
@@ -1,0 +1,35 @@
+[id="Adding_Custom_RPM_Repositories_for_Rocky_Linux_9_{context}"]
+= Adding {customrpmtitle} Repositories for Rocky Linux 9
+
+This example creates a product and repositories for Rocky Linux 9.
+
+.Prerequisite
+* Download and import the https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-rockyofficial[GPG public key] for yum repositories for Rocky Linux 9 into {Project}.
+For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content > Products*.
+. Click *Create Product* to create a product named `Rocky Linux 9`.
+For more information, see xref:Creating_a_Custom_Product_{context}[].
+. On the *Repositories* tab, click *New Repository* to create three repositories of type `yum` as follows:
++
+* *Rocky Linux 9 BaseOS*
+** *Upstream URL*: `http://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/`
+* *Rocky Linux 9 AppStream*
+** *Upstream URL*: `http://dl.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/`
+* *Rocky Linux 9 extras*
+** *Upstream URL*: `http://dl.rockylinux.org/pub/rocky/9/extras/x86_64/os/`
+
++
+For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
+. Click *Create Product* to create a product named `Rocky Linux 9 client`.
+. On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
++
+ifndef::orcharhino[]
+* **{Project} EL9 Client**
+** *Upstream URL*: `{project-client-name}el9/`
+endif::[]
+ifdef::orcharhino[]
+* **Rocky Linux 9 client**
+** *Upstream URL*: see https://atixservice.zendesk.com/hc/de/articles/360013840079[ATIX Service Portal]
+endif::[]

--- a/guides/common/modules/proc_creating-an-installation-medium-for-debian.adoc
+++ b/guides/common/modules/proc_creating-an-installation-medium-for-debian.adoc
@@ -15,7 +15,7 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts > Installation Media*.
 . Click *Create Medium* to create an installation medium entry.
 . Enter a *Name* for the installation medium.
-. Set the *Path* to the upstream URL `\http://ftp.debian.org/debian/`.
+. Set the *Path* to the upstream URL `\http://deb.debian.org/debian/`.
 +
 Alternatively, you can also use a Debian Mirror.
 Note that synchronized content from {Project} does not work for two reasons: first, the `linux` and `initrd.gz` files are not synchronized; second, the `Release` file is not signed with the official Debian GPG private key.

--- a/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
+++ b/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
@@ -9,8 +9,8 @@ This example verifies the signature for the `Release` file from Debian 11.
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ wget https://ftp.debian.org/debian/dists/bullseye/Release
-$ wget https://ftp.debian.org/debian/dists/bullseye/Release.gpg
+$ wget https://deb.debian.org/debian/dists/bullseye/Release
+$ wget https://deb.debian.org/debian/dists/bullseye/Release.gpg
 ----
 . Verify the signature:
 +


### PR DESCRIPTION
Current example for DEB only: [Adding DEB Repository Example for Debian 11](https://docs.theforeman.org/nightly/Content_Management_Guide/index-katello.html#Adding_Custom_DEB_Repository_Example_for_Debian_11_content-management)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* Do not cherry-pick to 3.2 and below because there are no clients for EL9 available.