### PR TITLE
Link to the correct Administering guide

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -45,7 +45,7 @@ const navVersions = [
           },
           {
             title: "Administering Foreman",
-            path: "Administering_Red_Hat_Satellite"
+            path: "Administering_Project"
           },
           {
             title: "Application Centric Deployment",
@@ -87,7 +87,7 @@ const navVersions = [
           },
           {
             title: "Administering Foreman",
-            path: "Administering_Red_Hat_Satellite"
+            path: "Administering_Project"
           }
         ]
       },
@@ -157,7 +157,7 @@ const navVersions = [
           },
           {
             title: "Administering Foreman",
-            path: "Administering_Red_Hat_Satellite"
+            path: "Administering_Project"
           },
           {
             title: "Application Centric Deployment",
@@ -237,7 +237,7 @@ const navVersions = [
           },
           {
             title: "Administering Foreman",
-            path: "Administering_Red_Hat_Satellite"
+            path: "Administering_Project"
           },
           {
             title: "Application Centric Deployment",
@@ -317,7 +317,7 @@ const navVersions = [
           },
           {
             title: "Administering Foreman",
-            path: "Administering_Red_Hat_Satellite"
+            path: "Administering_Project"
           },
           {
             title: "Application Centric Deployment",
@@ -397,7 +397,7 @@ const navVersions = [
           },
           {
             title: "Administering Foreman",
-            path: "Administering_Red_Hat_Satellite"
+            path: "Administering_Project"
           },
           {
             title: "Application Centric Deployment",


### PR DESCRIPTION
In f2edd6ab45cddb26f57e892f613666b15979721b this guide was renamed (and picked to 3.1), but the navigation wasn't updated. This meant an old stale guide was being linked.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

I don't think navigation needs to be cherry picked.

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.