### PR TITLE
Correct puppet-agent log level instructions

### DIFF
--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -277,18 +277,12 @@ endif::[]
 You can increase the logging level for Puppet agent on your {ProjectServer}.
 
 .Procedure
-. Add the following line to the `[main]` block in the `/etc/puppetlabs/puppet/puppet.conf` file:
+. Add the following line to the `[agent]` block in the `/etc/puppetlabs/puppet/puppet.conf` file:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-[main]
+[agent]
     log_level = debug
-----
-. Restart the Puppet server:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service restart --only puppetserver
 ----
 
 You can find the logs in `/var/log/puppetlabs/puppet/`


### PR DESCRIPTION
The main block in puppet.conf is used for both the server and agent.  Modifying it in the agent block only affects the agent.

Restarting the server is also not needed. The puppetserver is technically a completely unrelated daemon. Combined with changing only the agent section in puppet.conf it remains at the old log level. The puppet-agent daemon automatically reloads the config if it changed, as can be seen in the logs:

    Config file /etc/puppetlabs/puppet/puppet.conf changed; triggering re-parse of all config files.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.