### PR TITLE
Recommend the correct tar file location in Satellite

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -52,9 +52,9 @@ On the main {Project} server:
 +
 For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 +
-. Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
 endif::[]
 ifdef::katello[]
+. Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
 . Update repositories for EL7
 +
 [options="nowrap" subs="attributes"]
@@ -89,6 +89,9 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
+. Copy the resulting tarball to your {SmartProxy}.
+The location must match what the installer expects.
+Use `grep tar_file /etc/foreman-installer/scenarios.d/capsule-answers.yaml` on your {SmartProxy} to determine this.
 . Clean yum cache:
 +
 ----


### PR DESCRIPTION
In upstream the installer is ran explicitly with the --certs-tar-file location. This means the stored answer is irrelevant and we can safely use any location we want. It just has to be consistent.

For Satellite it's different since satellite-maintain is used without the --certs-tar-file option. This means the file must be transfered to the expected location. The safest way to do so is via the answers file.

(cherry picked from commit 54fedc9f10e8ed300878bb577776e65fc82cd32c)