### PR TITLE
Fix `make prep` in top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,7 @@ all: html
 
 prep:
 	bundle install --path vendor
-	cd web
-	bundle install --path ../vendor
-	cd ..
+	cd web && bundle install --path ../vendor
 	mkdir -p $(DEST)/nightly
 
 clean:


### PR DESCRIPTION
The `make` utility runs each line in the Makefile in a different
shell from the current working directory. Therefore lines
containing `cd web` and `cd ..` have no effect on the rest
of the commands. Bundle then installs dependencies in the `vendor`
directory which is created outside  of the `foreman-documentation`
repository. You can try this out yourself by running `make prep` in 
the `foreman-documentation` directory. Putting two commands on 
the same line results in them being executed by the same shell 
and dependencies are installed within the repository.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
