### PR TITLE
Change PgSQL database to PostgreSQL database

### DIFF
--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -43,7 +43,7 @@ If you want to set a custom directory name, add the `--preserve-directory` optio
 The backup is then stored in the directory you provide in the command line.
 If you use the `--preserve-directory` option, no data is removed if the backup fails.
 
-Note that if you use a local PgSQL database, the `postgres` user requires write access to the backup directory.
+Note that if you use a local PostgresSQL database, the `postgres` user requires write access to the backup directory.
 
 .Remote databases
 You can use the `{foreman-maintain} backup` command to back up remote databases.

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -43,7 +43,7 @@ If you want to set a custom directory name, add the `--preserve-directory` optio
 The backup is then stored in the directory you provide in the command line.
 If you use the `--preserve-directory` option, no data is removed if the backup fails.
 
-Note that if you use a local PostgresSQL database, the `postgres` user requires write access to the backup directory.
+Note that if you use a local PostgreSQL database, the `postgres` user requires write access to the backup directory.
 
 .Remote databases
 You can use the `{foreman-maintain} backup` command to back up remote databases.


### PR DESCRIPTION
In Administering Foreman, section 9.2.: Changed "PgSQL database"
to "PostgreSQL database" as that is the correct wording.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
