### PR TITLE
Remove EL 7 references (Ansible and Puppet)

### DIFF
--- a/guides/common/modules/proc_assigning-an-ansible-role-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-an-ansible-role-to-a-host-group.adoc
@@ -1,7 +1,7 @@
 [id="assigning-an-ansible-role-to-a-host-group_{context}"]
 = Assigning an Ansible Role to a Host Group
 
-You can use Ansible roles for remote management of {EL} versions 8, 7, and 6.9 or later.
+You can use Ansible roles for remote management of {EL} version 8 or later.
 
 .Prerequisite
 

--- a/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
+++ b/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
@@ -1,7 +1,7 @@
 [id="adding-ansible-roles-to-an-existing-host_{context}"]
 = Assigning Ansible Roles to an Existing Host
 
-You can use Ansible roles for remote management of {EL} versions 8, 7, and 6.9 or later.
+You can use Ansible roles for remote management of {EL} version 8 or later.
 
 .Prerequisites
 

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -40,7 +40,7 @@ You can also define a one-time future job, or set up a recurring job.
 For recurring tasks, you can define start and end dates, number and frequency of runs.
 You can also use cron syntax to define repetition.
 ifndef::orcharhino[]
-For more information about cron, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-automating_system_tasks[Automating System Tasks] section of the {RHEL} 7 _System Administrator's Guide_.
+For more information about cron, see https://www.redhat.com/sysadmin/automate-linux-tasks-cron[Automate your Linux system tasks with cron] in _Red Hat Enable Sysadmin_.
 endif::[]
 
 . Click *Submit*.

--- a/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
@@ -53,18 +53,6 @@ environment = _My_Puppet_Environment_
 server = _{foreman-example-com}_
 ----
 . Configure the Puppet agent to start at boot:
-* On {EL} 6:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# chkconfig puppet on
-----
-ifdef::satellite[]
-* On {EL} 7 and 8:
-endif::[]
-ifndef::satellite[]
-* On other operating systems:
-endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
Removing EL 7 references among pre-3.4 preps
Guides: Configuring Ansible + Managing with Puppet

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

