### PR TITLE
Change outdated screen tool to tmux

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -6,10 +6,7 @@ After the initial configuration, you can create additional organizations and loc
 The initial configuration also installs PostgreSQL databases on the same server.
 
 The installation process can take tens of minutes to complete.
-If you are connecting remotely to the system, use a utility such as `tmux` or `screen` that allows suspending and reattaching a communication session so that you can check the installation progress in case you become disconnected from the remote system.
-ifdef::satellite[]
-For more information, see https://access.redhat.com/articles/5247[How to use the screen command] or alternately the `screen` manual page.
-endif::[]
+If you are connecting remotely to the system, use a utility such as `tmux` that allows suspending and reattaching a communication session so that you can check the installation progress in case you become disconnected from the remote system.
 If you lose connection to the shell where the installation command is running, see the log at `{installer-log-file}` to determine if the process completed successfully.
 
 .Considerations

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -29,9 +29,8 @@ Use this procedure to update {SmartProxyServer}s to the next minor version.
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session.
+. Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -42,9 +42,8 @@ On first use of this command, `{foreman-maintain}` prompts you to enter the hamm
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session.
+. Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 
@@ -252,9 +251,8 @@ On first use of this command, `{foreman-maintain}` prompts you to enter the hamm
 +
 . Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy update time, use a utility such as `screen` to suspend and reattach a communication session.
+. Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -65,9 +65,8 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+. Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -249,9 +249,8 @@ Although entering the `{foreman-installer}` command with the `--noop` option doe
 # {foreman-maintain} service stop
 ----
 
-. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+. Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running you can see the logs in `{installer-log-file}` to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -125,9 +125,8 @@ Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVe
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+. Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
 +
 If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -103,9 +103,8 @@ endif::[]
 [[following_the_progress_of_the_upgrade]]
 == Following the Progress of the Upgrade
 
-Because of the lengthy upgrade time, use a utility such as `screen` to suspend and reattach a communication session.
+Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
-For more information about using the screen command, see link:https://access.redhat.com/articles/5247[How do I use the screen command?] article in the _Red{nbsp}Hat Knowledge{nbsp}Base_.
-For more information, see the `screen` manual page.
+For more information, see the `tmux` manual page.
 
 If you lose connection to the command shell where the upgrade command is running you can see the logs in `{installer-log-file}` to check if the process completed successfully.


### PR DESCRIPTION
The `screen` utility has been updated to `tmux`. This change was
required because Red Hat has deprecated the 'screen' utility and
removed it from RHEL 8.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
