### PR TITLE
Change outdated screen tool to tmux

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -99,8 +99,10 @@ include::../common/modules/ref_post-upgrade.adoc[leveloffset=+2]
 [[following_the_progress_of_the_upgrade]]
 == Following the Progress of the Upgrade
 
+ifdef::foreman-el,katello,satellite[]
 Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 For more information, see the `tmux` manual page.
+endif::[]
 
 If you lose connection to the command shell where the upgrade command is running you can see the logs in `{installer-log-file}` to check if the process completed successfully.


### PR DESCRIPTION
The `screen` utility has been updated to `tmux`. This change was
required because Red Hat has deprecated the 'screen' utility and
removed it from RHEL 8.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
