### PR TITLE
Reconsider /usr partition size for RHEL 8

### DIFF
--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -3,8 +3,6 @@
 
 ifdef::foreman-el,katello,satellite[]
 * xref:#storage-el-8[{EL} 8]
-endif::[]
-ifdef::satellite[]
 * xref:#storage-el-7[{EL} 7]
 endif::[]
 
@@ -22,27 +20,46 @@ ifdef::foreman-el,katello,satellite[]
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
-ifdef::katello,satellite,orcharhino[]
-|/var/lib/pulp |1 MB |300 GB
-endif::[]
-|/var/lib/pgsql |100 MB |10 GB
-|/usr |3 GB |Not Applicable
-|/opt/puppetlabs |500 MB |Not Applicable
-|====
-endif::[]
 
-ifdef::satellite[]
+|/var/log/ |10 MB |10 GB
+
+|/var/lib/pgsql |100 MB |20 GB
+
+|/usr | 5 GB | Not Applicable
+
+|/opt/puppetlabs | 500 MB | Not Applicable
+
+ifdef::katello,satellite,orcharhino[]
+|/var/lib/pulp/ |1 MB |300 GB
+
+|/var/lib/qpidd/ |25 MB | Not Applicable
+endif::[]
+|====
+
+For detailed information on partitioning and size, refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[{RHEL} 8 partitioning guide].
+
 == [[storage-el-7]]{EL} 7
 
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
-|/var/lib/pulp |1 MB |300 GB
-|/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |10 GB
-|/usr |3 GB | Not Applicable
-|/opt |3 GB | Not Applicable
-|/opt/puppetlabs |500 MB | Not Applicable
+
+|/var/log/ |10 MB |10 GB
+
+|/var/opt/rh/rh-postgresql12 |100 MB |20 GB
+
+|/usr | 3 GB | Not Applicable
+
+|/opt | 3 GB | Not Applicable
+
+|/opt/puppetlabs | 500 MB | Not Applicable
+
+ifdef::katello,satellite,orcharhino[]
+|/var/lib/pulp/ |1 MB |300 GB
+
+|/var/lib/qpidd/ |25 MB | Not Applicable
+endif::[]
 |====
 endif::[]
 

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -32,7 +32,7 @@ ifdef::foreman-el,katello,satellite[]
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
 
-|/var/lib/qpidd |25 MB | Not Applicable
+|/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
 
@@ -58,7 +58,7 @@ For detailed information on partitioning and size, refer to the https://access.r
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
 
-|/var/lib/qpidd |25 MB | Not Applicable
+|/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
 endif::[]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -21,7 +21,7 @@ ifdef::foreman-el,katello,satellite[]
 |====
 |Directory |Installation Size |Runtime Size
 
-|/var/log/ |10 MB |10 GB
+|/var/log |10 MB |10 GB
 
 |/var/lib/pgsql |100 MB |20 GB
 
@@ -30,9 +30,9 @@ ifdef::foreman-el,katello,satellite[]
 |/opt/puppetlabs | 500 MB | Not Applicable
 
 ifdef::katello,satellite,orcharhino[]
-|/var/lib/pulp/ |1 MB |300 GB
+|/var/lib/pulp |1 MB |300 GB
 
-|/var/lib/qpidd/ |25 MB | Not Applicable
+|/var/lib/qpidd |25 MB | Not Applicable
 endif::[]
 |====
 
@@ -45,7 +45,7 @@ For detailed information on partitioning and size, refer to the https://access.r
 |====
 |Directory |Installation Size |Runtime Size
 
-|/var/log/ |10 MB |10 GB
+|/var/log |10 MB |10 GB
 
 |/var/opt/rh/rh-postgresql12 |100 MB |20 GB
 
@@ -56,9 +56,9 @@ For detailed information on partitioning and size, refer to the https://access.r
 |/opt/puppetlabs | 500 MB | Not Applicable
 
 ifdef::katello,satellite,orcharhino[]
-|/var/lib/pulp/ |1 MB |300 GB
+|/var/lib/pulp |1 MB |300 GB
 
-|/var/lib/qpidd/ |25 MB | Not Applicable
+|/var/lib/qpidd |25 MB | Not Applicable
 endif::[]
 |====
 endif::[]
@@ -69,7 +69,7 @@ ifdef::foreman-deb[]
 |====
 |Directory |Installation Size |Runtime Size
 
-|/var/log/ |10 MB |10 GB
+|/var/log |10 MB |10 GB
 
 |/var/lib/postgresql |100 MB |20 GB
 


### PR DESCRIPTION
The partition size of /usr for RHEL 8 is 3GB at present which is not
accurate as it is more than that. It is now increased to 5GB for EL8.
Also, there is already a detailed guide on the same which helps user
to set correct size of partitions that includes /usr as well.
So, we have added a link to redirect users to the detailed guide.

Recommended /usr partition size for RHEL 8 is incorrect.

https://bugzilla.redhat.com/show_bug.cgi?id=2108615


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
