### PR TITLE
New feature: Host Switcher

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -32,6 +32,8 @@ include::modules/proc_assigning-a-host-to-a-specific-organization.adoc[leveloffs
 
 include::modules/proc_assigning-a-host-to-a-specific-location.adoc[leveloffset=+1]
 
+include::modules/con_switching-between-hosts.adoc[leveloffset=+1]
+
 include::modules/proc_removing-a-host-from-server.adoc[leveloffset=+1]
 
 include::modules/proc_disassociating-a-virtual-machine-without-removing-it-from-a-hypervisor.adoc[leveloffset=+2]

--- a/guides/common/modules/con_switching-between-hosts.adoc
+++ b/guides/common/modules/con_switching-between-hosts.adoc
@@ -1,7 +1,7 @@
-[id="con_switching-between-hosts_{context}"]
+[id="switching-between-hosts_{context}"]
 = Switching between Hosts
 
 When you are on a particular host in the {ProjectWebUI}, you can navigate between hosts without leaving the page by using the host switcher.
-Click the *⇄* next to the hostname.
+Click *⇄* next to the hostname.
 
 A list of hosts is displayed in alphabetical order with a pagination arrow and a search bar to find the host you are looking for.

--- a/guides/common/modules/con_switching-between-hosts.adoc
+++ b/guides/common/modules/con_switching-between-hosts.adoc
@@ -3,5 +3,4 @@
 
 When you are on a particular host in the {ProjectWebUI}, you can navigate between hosts without leaving the page by using the host switcher.
 Click *⇄* next to the hostname.
-
-A list of hosts is displayed in alphabetical order with a pagination arrow and a search bar to find the host you are looking for.
+This displays a list of hosts in alphabetical order with a pagination arrow and a search bar to find the host you are looking for.

--- a/guides/common/modules/con_switching-between-hosts.adoc
+++ b/guides/common/modules/con_switching-between-hosts.adoc
@@ -1,0 +1,7 @@
+[id="con_switching-between-hosts_{context}"]
+= Switching between Hosts
+
+When you are on a particular host in the {ProjectWebUI}, you can navigate between hosts without leaving the page by using the host switcher.
+Click the *⇄* next to the hostname.
+
+A list of hosts is displayed in alphabetical order with a pagination arrow and a search bar to find the host you are looking for.

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -8,7 +8,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-executing-a-remot
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the target hosts on which you want to execute a remote job.
 You can use the search field to filter the host list.
-. From the *Select Action* list, select *Schedule Remote Job*.
+. From the *Select Action* list, select *Schedule a Job*.
 . On the *Job invocation* page, define the main job settings:
 . Select the *Job category* and the *Job template* you want to use.
 . Optional: Select a stored search string in the *Bookmark* list to specify the target hosts.
@@ -40,11 +40,11 @@ You can also define a one-time future job, or set up a recurring job.
 For recurring tasks, you can define start and end dates, number and frequency of runs.
 You can also use cron syntax to define repetition.
 ifndef::orcharhino[]
-For more information about cron, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-automating_system_tasks[Automating System Tasks] section of the {RHEL} 7 _System Administrator's Guide_.
+For more information about cron, see the https://www.redhat.com/sysadmin/automate-linux-tasks-cron[Automate your Linux system tasks with cron].
 endif::[]
 
 . Click *Submit*.
-This displays the *Job Overview* page, and when the job completes, also displays the status of the job.
+You can view status of the jobs in the *Recent Jobs* section on the same page.
 
 [id="cli-executing-a-remote-job_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -40,7 +40,7 @@ You can also define a one-time future job, or set up a recurring job.
 For recurring tasks, you can define start and end dates, number and frequency of runs.
 You can also use cron syntax to define repetition.
 ifndef::orcharhino[]
-For more information about cron, see the https://www.redhat.com/sysadmin/automate-linux-tasks-cron[Automate your Linux system tasks with cron].
+For more information about cron, see https://www.redhat.com/sysadmin/automate-linux-tasks-cron[Automate your Linux system tasks with cron].
 endif::[]
 
 . Click *Submit*.


### PR DESCRIPTION
Added the description of a new feature where users can easily switch
between hosts without leaving the page. Also, added the description
of scheduling remote execution jobs that is on the same page. The status
of the recent jobs can be viewed from the same page as well.

[Foreman demo] New features in host page

https://issues.redhat.com/browse/SATDOC-746

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
