### PR TITLE
enable the foreman/katello modules after leapp upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -184,6 +184,22 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 # journalctl -u leapp_resume -f
 ----
 
+ifdef::foreman-el[]
+. Enable the Foreman module:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module enable foreman:el8
+----
+endif::[]
+ifdef::katello[]
+. Enable the Katello and Pulpcore modules:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module enable katello:el8 pulpcore:el8
+----
+endif::[]
 ifdef::satellite[]
 . Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
 endif::[]


### PR DESCRIPTION
For Satellite, Leapp will enable the right module, but not for
Foreman/Katello. However, without the module enabled, users won't get
updates past the original version they've upgraded to.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
