### PR TITLE
Remove 'For Red Hat systems only' note

### DIFF
--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -3,10 +3,6 @@ ifdef::context[:parent-context: {context}]
 [id="using-external-databases_{context}"]
 = Using External Databases with {Project}
 
-ifdef::foreman-el,katello[]
-For Red Hat systems only.
-endif::[]
-
 As part of the installation process for {ProjectName}, the *{foreman-installer}* command installs PostgreSQL databases on the same server as {Project}.
 In certain {Project} deployments, using external databases instead of the default local databases can help with the server load.
 

--- a/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
@@ -1,10 +1,6 @@
 [id="Migrating_from_Internal_Databases_to_External_Databases_{context}"]
 = Migrating from Internal {Project} Databases to External Databases
 
-ifdef::foreman-el,katello[]
-For Red Hat systems only.
-endif::[]
-
 When you install {ProjectName}, the *{foreman-installer}* command installs PostgreSQL databases on the same server as {Project}.
 If you are using the default internal databases but want to start using external databases to help with the server load, you can migrate your internal databases to external databases.
 

--- a/guides/common/modules/proc_installing-the-sos-package.adoc
+++ b/guides/common/modules/proc_installing-the-sos-package.adoc
@@ -1,10 +1,6 @@
 [id="installing-the-sos-package_{context}"]
 = Installing the SOS Package on the Base Operating System
 
-ifdef::foreman-el,katello[]
-For Red Hat systems only.
-endif::[]
-
 Install the *sos* package on the base operating system so that you can collect configuration and diagnostic information from a {RHEL} system.
 You can also use it to provide the initial system analysis, which is required when opening a service request with Red Hat Technical Support.
 For more information on using `sos`, see the Knowledgebase solution https://access.redhat.com/solutions/3592[What is a sosreport and how to create one in {RHEL} 4.6 and later?] on the Red{nbsp}Hat Customer Portal.


### PR DESCRIPTION
These notes should never be added. Instead, ifdef should be used to generate the appropriate manual.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.