### PR TITLE
Remove old workaround for hostname-change.rb

### DIFF
--- a/guides/common/modules/proc_configuring-the-qpid-mgmt-pub-interval-parameter.adoc
+++ b/guides/common/modules/proc_configuring-the-qpid-mgmt-pub-interval-parameter.adoc
@@ -24,5 +24,5 @@ qpid::mgmt_pub_interval: 5
 For more information, see xref:Applying_configurations_{context}[].
 ifndef::orcharhino[]
 +
-For more information, see https://bugzilla.redhat.com/show_bug.cgi?id=1335694[BZ 1335694] comment 7.
+For more information, see https://bugzilla.redhat.com/show_bug.cgi?id=1335694#c7[BZ 1335694].
 endif::[]

--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -19,22 +19,6 @@ If the renaming process is not successful, you must restore it from a backup.
 Perform a backup before changing a host name.
 For more information, see xref:Backing_Up_Server_and_Proxy_{context}[].
 
-ifndef::orcharhino[]
-[WARNING]
-====
-Until https://bugzilla.redhat.com/show_bug.cgi?id=1829115[BZ#1829115] is resolved, you must edit the `usr/share/katello/hostname-change.rb` file on {SmartProxyServer} and comment out the following lines before attempting to rename {SmartProxyServer}:
-
-[options='nowrap', subs="+quotes,verbatim,attributes"]
-----
-STDOUT.puts "updating hostname in hammer configuration"
-self.run_cmd("sed -i.bak -e 's/\#_{@old_hostname}_ \
-/_#{@new_hostname}_/g' _\#\{hammer_root_config_path}_/\*.yml")
-self.run_cmd("sed -i.bak -e 's/#_{@old_hostname}_ \
-/#_{@new_hostname>_/g' #_\{hammer_config_path}_/*.yml")
-----
-====
-endif::[]
-
 .Procedure
 . On {ProjectServer}, generate a new certificates archive file for {SmartProxyServer}.
 +


### PR DESCRIPTION
This was [#32125](https://projects.theforeman.org/issues/32125) but that's been resolved in Foreman 2.5.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.