### PR TITLE
Issue #1471: Output feedback module for HTML deliverables only

### DIFF
--- a/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
+++ b/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
@@ -5,15 +5,17 @@
 
 We appreciate your input on our documentation. Please let us know how we could make it better.
 
+[l10n-exclude-start]
 * For simple comments on specific passages:
 +
-. Ensure you are viewing the documentation in the _Multi-page HTML_ format. 
+. Ensure you are viewing the documentation in the _Multi-page HTML_ format.
 +
 In addition, ensure you see the *Feedback* button in the upper right corner of the document.
 . Use your mouse cursor to highlight the part of text that you want to comment on.
 . Click the *Add Feedback* pop-up that appears below the highlighted text.
 . Follow the displayed instructions.
 
+[l10n-exclude-end]
 * For submitting feedback via Bugzilla, create a new ticket:
 +
 . Go to the link:https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Satellite[Bugzilla] website.

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {AdministeringDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {AdministeringAnsibleDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Configuring_Ansible/master.adoc
+++ b/guides/doc-Configuring_Ansible/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {ConfiguringAnsibleDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {ConfiguringLoadBalancerDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {DeployingAWSDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 = {InstallingSmartProxyDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 = {InstallingServerDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 
 = {InstallingServerDisconnectedDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {ManagingConfigurationsPuppetDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {ContentManagementDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -7,7 +7,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 
 = {ManagingHostsDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Performance_Tuning_Guide/master.adoc
+++ b/guides/doc-Performance_Tuning_Guide/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = Performance Tuning Guide
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {PlanningDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {ProvisioningDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {UpgradingDocTitle}
 
-ifdef::satellite[]
+ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
I modified the condition for output of the feedback module in Satellite.

Expects reversal of removed l10n markers as mentioned in https://github.com/theforeman/foreman-documentation/issues/1471#issuecomment-1189198094

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
