### PR TITLE
Change location of PostgreSQL data

### DIFF
--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -16,6 +16,7 @@ A full backup requires space to store the following data:
 
 .Procedure
 . Enter the `du` command to estimate the size of uncompressed directories containing {Project} database and configuration files:
+ifndef::satellite[]
 +
 .For {EL} 8:
 ----
@@ -105,6 +106,54 @@ a|`/var/lib/qpidd` +
 |85%
 |942 MB -> 141 MB
 |===
+endif::[]
+ifdef::satellite[]
++
+----
+# du -sh /var/lib/pgsql/data /var/lib/pulp
+100G    /var/lib/pgsql/data
+100G	/var/lib/pulp
+
+# du -csh /var/lib/qpidd /var/lib/tftpboot /etc /root/ssl-build \
+/var/www/html/pub /opt/puppetlabs
+886M  /var/lib/qpidd
+16M   /var/lib/tftpboot
+37M   /etc
+900K  /root/ssl-build
+100K  /var/www/html/pub
+2M    /opt/puppetlabs
+942M  total
+----
+. Calculate how much space is required to store the compressed data.
++
+The following table describes the compression ratio of all data items included in the backup:
++
+.Backup Data Compression Ratio
+[cols="4,6,3,5"]
+|===
+|Data type |Directory |Ratio |Example results
+
+|PostgreSQL database files
+|`/var/lib/pgsql/data`
+|80 - 85%
+|100 GB -> 20 GB
+
+|Pulp RPM files
+|`/var/lib/pulp`
+|(not compressed)
+|100 GB
+
+|Configuration files
+a|`/var/lib/qpidd` +
+`/var/lib/tftpboot` +
+`/etc` +
+`/root/ssl-build` +
+`/var/www/html/pub` +
+`/opt/puppetlabs`
+|85%
+|942 MB -> 141 MB
+|===
+endif::[]
 +
 In this example, the compressed backup data occupies 180 GB in total.
 . To calculate the amount of available space you require to store a backup, calculate the sum of the estimated values of compressed and uncompressed backup data, and add an extra 20% to ensure a reliable backup.

--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -17,6 +17,24 @@ A full backup requires space to store the following data:
 .Procedure
 . Enter the `du` command to estimate the size of uncompressed directories containing {Project} database and configuration files:
 +
+.For {EL} 8:
+----
+# du -sh /var/lib/pgsql/data /var/lib/pulp
+100G    /var/lib/pgsql/data
+100G	/var/lib/pulp
+
+# du -csh /var/lib/qpidd /var/lib/tftpboot /etc /root/ssl-build \
+/var/www/html/pub /opt/puppetlabs
+886M  /var/lib/qpidd
+16M   /var/lib/tftpboot
+37M   /etc
+900K  /root/ssl-build
+100K  /var/www/html/pub
+2M    /opt/puppetlabs
+942M  total
+----
++
+.For {EL} 7:
 ----
 # du -sh /var/opt/rh/rh-postgresql12/lib/pgsql/data /var/lib/pulp
 100G    /var/opt/rh/rh-postgresql12/lib/pgsql/data
@@ -36,7 +54,33 @@ A full backup requires space to store the following data:
 +
 The following table describes the compression ratio of all data items included in the backup:
 +
-.Backup Data Compression Ratio
+.Backup Data Compression Ratio for {EL} 8
+[cols="4,6,3,5"]
+|===
+|Data type |Directory |Ratio |Example results
+
+|PostgreSQL database files
+|`/var/lib/pgsql/data`
+|80 - 85%
+|100 GB -> 20 GB
+
+|Pulp RPM files
+|`/var/lib/pulp`
+|(not compressed)
+|100 GB
+
+|Configuration files
+a|`/var/lib/qpidd` +
+`/var/lib/tftpboot` +
+`/etc` +
+`/root/ssl-build` +
+`/var/www/html/pub` +
+`/opt/puppetlabs`
+|85%
+|942 MB -> 141 MB
+|===
++
+.Backup Data Compression Ratio for {EL} 7
 [cols="4,6,3,5"]
 |===
 |Data type |Directory |Ratio |Example results

--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -16,98 +16,6 @@ A full backup requires space to store the following data:
 
 .Procedure
 . Enter the `du` command to estimate the size of uncompressed directories containing {Project} database and configuration files:
-ifndef::satellite[]
-+
-.For {EL} 8:
-----
-# du -sh /var/lib/pgsql/data /var/lib/pulp
-100G    /var/lib/pgsql/data
-100G	/var/lib/pulp
-
-# du -csh /var/lib/qpidd /var/lib/tftpboot /etc /root/ssl-build \
-/var/www/html/pub /opt/puppetlabs
-886M  /var/lib/qpidd
-16M   /var/lib/tftpboot
-37M   /etc
-900K  /root/ssl-build
-100K  /var/www/html/pub
-2M    /opt/puppetlabs
-942M  total
-----
-+
-.For {EL} 7:
-----
-# du -sh /var/opt/rh/rh-postgresql12/lib/pgsql/data /var/lib/pulp
-100G    /var/opt/rh/rh-postgresql12/lib/pgsql/data
-100G	/var/lib/pulp
-
-# du -csh /var/lib/qpidd /var/lib/tftpboot /etc /root/ssl-build \
-/var/www/html/pub /opt/puppetlabs
-886M  /var/lib/qpidd
-16M   /var/lib/tftpboot
-37M   /etc
-900K  /root/ssl-build
-100K  /var/www/html/pub
-2M    /opt/puppetlabs
-942M  total
-----
-. Calculate how much space is required to store the compressed data.
-+
-The following table describes the compression ratio of all data items included in the backup:
-+
-.Backup Data Compression Ratio for {EL} 8
-[cols="4,6,3,5"]
-|===
-|Data type |Directory |Ratio |Example results
-
-|PostgreSQL database files
-|`/var/lib/pgsql/data`
-|80 - 85%
-|100 GB -> 20 GB
-
-|Pulp RPM files
-|`/var/lib/pulp`
-|(not compressed)
-|100 GB
-
-|Configuration files
-a|`/var/lib/qpidd` +
-`/var/lib/tftpboot` +
-`/etc` +
-`/root/ssl-build` +
-`/var/www/html/pub` +
-`/opt/puppetlabs`
-|85%
-|942 MB -> 141 MB
-|===
-+
-.Backup Data Compression Ratio for {EL} 7
-[cols="4,6,3,5"]
-|===
-|Data type |Directory |Ratio |Example results
-
-|PostgreSQL database files
-|`/var/opt/rh/rh-postgresql12/lib/pgsql/data`
-|80 - 85%
-|100 GB -> 20 GB
-
-|Pulp RPM files
-|`/var/lib/pulp`
-|(not compressed)
-|100 GB
-
-|Configuration files
-a|`/var/lib/qpidd` +
-`/var/lib/tftpboot` +
-`/etc` +
-`/root/ssl-build` +
-`/var/www/html/pub` +
-`/opt/puppetlabs`
-|85%
-|942 MB -> 141 MB
-|===
-endif::[]
-ifdef::satellite[]
 +
 ----
 # du -sh /var/lib/pgsql/data /var/lib/pulp
@@ -153,7 +61,6 @@ a|`/var/lib/qpidd` +
 |85%
 |942 MB -> 141 MB
 |===
-endif::[]
 +
 In this example, the compressed backup data occupies 180 GB in total.
 . To calculate the amount of available space you require to store a backup, calculate the sum of the estimated values of compressed and uncompressed backup data, and add an extra 20% to ensure a reliable backup.


### PR DESCRIPTION
The procedure in Administering Foreman, section 9.1 assumes
RHEL 7 disk layout. Added correct location of PostgreSQL data
for RHEL 8 and 9 while maintaining the original location for
RHEL 7.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick 6e231a30c7525d7920c578289dc238626db9c335 into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3

Please cherry-pick fb40004da94195977b87a15f35cc76a840de108f into:

* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3