### PR TITLE
Replace `foreman-maintain` services

### DIFF
--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -27,7 +27,7 @@ endif::[]
 
 [NOTE]
 ====
-If you plan to use the `{foreman-maintain} backup` command to create a backup, do not stop the `{foreman-maintain}` services.
+If you plan to use the `{foreman-maintain} backup` command to create a backup, do not stop {Project} services.
 ====
 
 * When creating a snapshot or conventional backup, you must stop all services as follows:

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -88,7 +88,7 @@ endif::[]
 ----
 # {foreman-installer} --foreman-ipa-authentication=true
 ----
-. Restart the `{foreman-maintain}` services:
+. Restart {Project} services:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -140,7 +140,7 @@ You can find the log for {Project} in `/var/log/foreman/production.log`.
 ----
 +
 Note that to see logging from some area, debug logging has to be set.
-. Restart the {Project} services:
+. Restart {Project} services:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -222,7 +222,7 @@ Uncomment the `log_statement` in `/var/opt/rh/rh-postgresql12/lib/pgsql/data/pos
 log_statement = 'all'
 ----
 
-Ensure to restart the {Project} services afterwards:
+Ensure to restart {Project} services afterwards:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -21,7 +21,7 @@ ifdef::foreman-el,katello[]
 --foreman-proxy-plugin-discovery-source-url=http://downloads.theforeman.org/discovery/releases/3.5/
 ----
 endif::[]
-. Restart the {foreman-maintain} services:
+. Restart {Project} services:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -9,7 +9,7 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 
 .Procedure
 
-. On {ProjectServer}, stop the `{foreman-maintain}` services:
+. On {ProjectServer}, stop {Project} services:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_recovering-from-a-full-disk.adoc
+++ b/guides/common/modules/proc_recovering-from-a-full-disk.adoc
@@ -29,14 +29,14 @@ endif::[]
 If you use an untypical file system (other than for example ext3, ext4, or xfs), you might need to unmount the file system so that it is not in use.
 In that case, complete the following steps:
 
-. Stop the `{foreman-maintain}` services:
+. Stop {Project} services:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service stop
 ----
 . Grow the file system on the LV.
-. Start the `{foreman-maintain}` services:
+. Start {Project} services:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_restarting-services.adoc
+++ b/guides/common/modules/proc_restarting-services.adoc
@@ -2,7 +2,7 @@
 = Restarting Services
 
 {Project} uses a set of back-end services to perform tasks.
-You you experience an issue with your {Project}, check the status of the {Project} services.
+You you experience an issue with your {Project}, check the status of {Project} services.
 
 .Procedure
 * Use `{foreman-maintain}` to restart {Project} services:

--- a/guides/common/modules/proc_salt-activating-salt.adoc
+++ b/guides/common/modules/proc_salt-activating-salt.adoc
@@ -20,7 +20,7 @@
 ----
 # ssh root@{foreman-example-com}
 ----
-. Restart the {Project} services:
+. Restart {Project} services:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/common/modules/proc_starting-and-stopping-server.adoc
+++ b/guides/common/modules/proc_starting-and-stopping-server.adoc
@@ -20,21 +20,21 @@ To see the status of running services, execute:
 # {foreman-maintain} service status
 ----
 
-To stop the `{foreman-maintain}` services, execute:
+To stop {Project} services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} service stop
 ----
 
-To start the `{foreman-maintain}` services, execute:
+To start {Project} services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} service start
 ----
 
-To restart the `{foreman-maintain}` services, execute:
+To restart {Project} services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -13,7 +13,7 @@ Use high-bandwidth, low-latency storage for the `/var/lib/pulp` file system.
 . Create the NFS share.
 This example uses a share at `nfs.example.com:/{Project}/pulp`.
 Ensure this share provides the appropriate permissions to {ProjectServer} and its `apache` user.
-. Stop the `{foreman-maintain}` services on the {Project} host:
+. Stop {Project} services on your {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -77,7 +77,7 @@ Also confirm that the existing content exists at the mount on `var/lib/pulp`:
 ----
 # ls /var/lib/pulp
 ----
-. Start the `{foreman-maintain}` services on the {Project} host:
+. Start {Project} services on your {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Planning_for_Project/topics/Glossary.adoc
+++ b/guides/doc-Planning_for_Project/topics/Glossary.adoc
@@ -150,7 +150,7 @@ Foreman is the main upstream counterpart of Red Hat Satellite.
 endif::[]
 
 [[varl-Glossary_of_Terms-satellite-maintain_Services]]
-*{foreman-maintain} services*:: A set of services that {ProjectServer} and {SmartProxyServer}s use for operation.
+*{Project} services*:: A set of services that {ProjectServer} and {SmartProxyServer}s use for operation.
 You can use the `{foreman-maintain}` tool to manage these services.
 To see the full list of services, enter the `{foreman-maintain} service list` command on the machine where {Project} or {SmartProxyServer} is installed.
 

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -78,7 +78,7 @@ Follow the steps in the procedure in xref:sec_Cloning_Satellite_Server[] and rep
 --assumeyes /var/backup
 ----
 +
-. Stop and disable the `{foreman-maintain}` services
+. Stop and disable {Project} services:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -141,7 +141,7 @@ If you have more than 500 GB of Pulp data, skip the following steps and complete
 # {foreman-maintain} backup offline --assumeyes /var/backup
 ----
 +
-. Stop and disable the `{foreman-maintain}` services:
+. Stop and disable {Project} services:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -48,7 +48,7 @@ If you lose connection to the command shell where the upgrade command is running
 # rpm -qa --last | grep kernel
 ----
 
-. Optional: If a kernel update occurred since the last reboot, stop the `{foreman-maintain}` services and reboot the system:
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -61,7 +61,7 @@ If you lose connection to the command shell where the upgrade command is running
 # rpm -qa --last | grep kernel
 ----
 
-. Optional: If a kernel update occurred since the last reboot, stop the `{foreman-maintain}` services and reboot the system:
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -270,7 +270,7 @@ If you lose connection to the command shell where the upgrade command is running
 # rpm -qa --last | grep kernel
 ----
 +
-. Optional: If a kernel update occurred since the last reboot, stop the `{foreman-maintain}` services and reboot the system:
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -75,7 +75,7 @@ Reboot these hosts after the upgrade has completed.
 # rm /etc/yum.repos.d/*
 ----
 
-. Stop the `{foreman-maintain}` services.
+. Stop {Project} services:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -242,7 +242,7 @@ Review the `{installer-log-file}` to preview the changes that are applied during
 Locate the `\+++` and `---` symbols that indicate the changes to the configurations files.
 Although entering the `{foreman-installer}` command with the `--noop` option does not apply any changes to your {Project}, some Puppet resources in the module expect changes to be applied and might display failure messages.
 
-.. Stop the `{foreman-maintain}` services:
+.. Stop {Project} services:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -297,7 +297,7 @@ For more information, see the https://access.redhat.com/documentation/en-us/red_
 # rpm -qa --last | grep kernel
 ----
 
-. Optional: If a kernel update occurred since the last reboot, stop the `{foreman-maintain}` services and reboot the system:
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -307,7 +307,7 @@ For more information, see the https://access.redhat.com/documentation/en-us/red_
 
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups that you made.
 
-. If you make changes in the previous step, restart the `{foreman-maintain}` services.
+. If you make changes in the previous step, restart {Project} services:
 +
 [options="nowrap" subs="attributes"]
 ----


### PR DESCRIPTION
Replaced multiple occurrences of `{foreman-maintain}` services
with {Project} services.
Command `{foreman-maintain} service <action>` controls the
{Project} services, so whenever the text is descriptive, it
should read "{Project} services", not `{foreman-maintain}` services.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
