### PR TITLE
Add missing clarification to file

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -13,7 +13,7 @@ You can register hosts with {Project} using the host registration feature, the {
 --rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
 --server.hostname=loadbalancer.example.com
 ----
-. Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
+. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 
 .CLI procedure
 . Generate the host registration command using the Hammer CLI:
@@ -40,7 +40,7 @@ endif::[]
 --rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
 --server.hostname=loadbalancer.example.com
 ----
-. Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
+. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 
 .API procedure
 . Generate the host registration command using the {Project} API:
@@ -79,4 +79,4 @@ For more information about registration see {ManagingHostsDocURL}Registering_Hos
 --rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
 --server.hostname=loadbalancer.example.com
 ----
-. Check the `/etc/yum.repos.d/redhat.repo` and ensure that the appropriate repositories have been enabled.
+. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.


### PR DESCRIPTION
In Installing Capsule Server, section 2.1; changed three
occurences of "Check the `/etc/yum.repos.d/redhat.repo`" to
"Check the `/etc/yum.repos.d/redhat.repo` file" to clarify
that the object in question is a file.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3