### PR TITLE
Added Admonition about supported Crypto Policies

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -19,6 +19,13 @@ endif::[]
 If these two paths reside on the same partition, no further action is required.
 If they reside on different partitions, ensure that there is enough space for the data to be copied over.
 You can move the PostgreSQL data on your own and the upgrade will skip this step if `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` does not exist.
+ifdef::satellite[]
+[NOTE]
+====
+{Project} supports DEFAULT and FIPS crypto-policies.
+The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
+====
+endif::[]
 
 .Procedure
 . Configure the repositories to obtain Leapp.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -109,3 +109,11 @@ endif::[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in the _{RHEL} Security Hardening Guide_.
 For more information about FIPS on {RHEL} 7 systems, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
 endif::[]
+
+ifdef::satellite[]
+[NOTE]
+====
+{Project} supports DEFAULT and FIPS crypto-policies.
+The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
+====
+endif::[]


### PR DESCRIPTION
Added an admonition to clarify that:
Only DEFAULT and FIPS crypto-policies are supported in Project.
Note is project-specific & in sections requested in BZ#2115256.
Added note in `ifdef` statement keeping impact minimal on other guides.

https://bugzilla.redhat.com/show_bug.cgi?id=2115256


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
