### PR TITLE
Add the missing SSL protocol for external database

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -30,6 +30,7 @@ Use the `{foreman-installer}` command to configure {Project} to connect to an ex
 
 To enable the Secure Sockets Layer (SSL) protocol for these external databases, add the following options:
 +
+ifndef::satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 --foreman-db-sslmode verify-full
@@ -39,5 +40,19 @@ To enable the Secure Sockets Layer (SSL) protocol for these external databases, 
 --foreman-proxy-content-pulpcore-postgresql-ssl true
 --foreman-proxy-content-pulpcore-postgresql-ssl-root-ca <path_to_CA>
 ----
+endif::[]
+
+ifdef::satellite[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+--foreman-db-sslmode verify-full
+--foreman-db-root-cert <path_to_CA>
+--katello-candlepin-db-ssl true
+--katello-candlepin-db-ssl-verify true
+--katello-candlepin-db-ssl-ca <path_to_CA>
+--foreman-proxy-content-pulpcore-postgresql-ssl true
+--foreman-proxy-content-pulpcore-postgresql-ssl-root-ca <path_to_CA>
+----
+endif::[]
 
 


### PR DESCRIPTION
The protocol is a part of latest version but it is required to consider
the same for earlier versions too. It is applicable to even earlier
versions while writing this commit.

Add more information on External database configuration with SSL in
Documentation  for both ends.

https://bugzilla.redhat.com/show_bug.cgi?id=2079973


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
