### PR TITLE
Add Foreman 3.2 release notes

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -4,8 +4,36 @@
 [id="foreman-headline-features"]
 == Headline Features
 
+=== Foreman on Debian 11 (Bullseye)
+
+It is now possible to run Foreman on Debian 11. Users are encouraged to upgrade.
+
 [id="foreman-upgrade-warnings"]
 == Upgrade Warnings
 
+=== `require_ssl_smart_proxies` setting dropped
+
+The `require_ssl_smart_proxies` setting has been dropped and Foreman now behaves as if the value was `true` (the default). This means it's no longer possible to use reverse DNS instead of client certificates over HTTPS connections. Upgrading users should ensure a valid Public Key Infrastructure (PKI) exists.
+
+For more information see the https://community.theforeman.org/t/drop-require-ssl-and-require-ssl-smart-proxies-settings/26772[RFC] and https://github.com/theforeman/foreman/pull/9021[PR].
+
 [id="foreman-deprecations"]
 == Deprecations
+
+=== Running Foreman on EL7
+
+Foreman 3.4 will drop EL7 support.
+For fresh installations, it is advisable to install on EL8.
+Existing installations should start thinking about a migration plan.
+
+Note that this support statement refers to running Foreman and Foreman Smart Proxy themselves on EL7.
+Managing EL7 hosts remains supported.
+See https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008[the RFC] for more information.
+
+=== Running Foreman on Debian 10
+
+Now that Debian 11 is supported, Debian 10 support is deprecated and will be dropped with Foreman 3.4
+
+Note that this support statement refers to running Foreman and Foreman Proxy themselves on Debian 10.
+Managing Debian 10 hosts remains supported.
+See https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008[the RFC] for more information.


### PR DESCRIPTION
While individual releases were added, the headline features, upgrade warnings and deprecations weren't. This copies them from theforeman.org.