### PR TITLE
Add networking interface rename command

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -144,8 +144,25 @@ endif::[]
 ----
 # leapp preupgrade
 ----
-The first run is expected to fail but report issues.
-Continue to the next step for remediation.
+The first run is expected to fail but report issues and inhibit the upgrade.
++
+
+If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} to use the new interface names:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --help |grep 'interface.*eth'
+    --foreman-proxy-dhcp-interface  DHCP listen interface (current: "eth0")
+    --foreman-proxy-dns-interface  DNS interface (current: "eth0")
+----
+If `eth0` was renamed to `em0`, call the installer to use the new interface name with:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --foreman-proxy-dhcp-interface=em0 --foreman-proxy-dns-interface=em0
+----
++
+Continue to the next step for remediation if the first run fails.
 
 . Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`) and manually resolve the other reported problems.
 The following commands show the most common steps required:


### PR DESCRIPTION
A step is created to show how network interfaces are renamed and
running the installer once more with the new interface names. The
change was required because upgrading using Leapp is inhibited by an
unsupported network configuration.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
