### PR TITLE
Removed Obsolet option --upgrade from UpgradeGuide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -236,7 +236,7 @@ Include /etc/httpd/conf.modules.d/*.conf
 +
 [options="nowrap" subs="attributes"]
 ----
-# {installer-scenario} --upgrade --verbose --noop
+# {installer-scenario} --verbose --noop
 ----
 Review the `{installer-log-file}` to preview the changes that are applied during the upgrade.
 Locate the `\+++` and `---` symbols that indicate the changes to the configurations files.


### PR DESCRIPTION
Removed an Obsolete "--upgrade" option from the upgrade guide,
section Upgrading a Disconnected Project Server.
Passing the --upgrade option results in errors, hence cannot be used.

https://bugzilla.redhat.com/show_bug.cgi?id=2119099


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
