### PR TITLE
Fix a step in Configuring External Authentication

### DIFF
--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -1,6 +1,6 @@
 [id="Enrolling_Server_with_the_AD_Server_{context}"]
-
 = Enrolling {ProjectServer} with the AD Server
+
 In the {Project} CLI, enroll {ProjectServer} with the Active Directory server.
 
 .Prerequisite

--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -1,6 +1,6 @@
 [id="Enrolling_Server_with_the_AD_Server_{context}"]
-= Enrolling {ProjectServer} with the AD Server
 
+= Enrolling {ProjectServer} with the AD Server
 In the {Project} CLI, enroll {ProjectServer} with the Active Directory server.
 
 .Prerequisite
@@ -25,5 +25,5 @@ You may need to have administrator permissions to perform the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# realm join -v _EXAMPLE.ORG_
+# realm join -v _EXAMPLE.ORG_ --membership-software=samba -U Administrator
 ----


### PR DESCRIPTION
The procedure for enrolling server with AD needs to be changed, as it does not work properly.
https://bugzilla.redhat.com/show_bug.cgi?id=2118978


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
