### PR TITLE
fix rendering of the "edit postgresql.conf" section

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -27,8 +27,11 @@ rh-postgresql12-postgresql-evr
 . Edit the `/var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes"]
-
-Note that the default configuration of external PostgreSQL needs to be adjusted to work with {Project}. 
+----
+# vi /var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf
+----
++
+Note that the default configuration of external PostgreSQL needs to be adjusted to work with {Project}.
 The base recommended external database configuration adjustments are as follows:
 
 * checkpoint_completion_target: 0.9
@@ -36,10 +39,6 @@ The base recommended external database configuration adjustments are as follows:
 * shared_buffers: 512MB
 * work_mem: 4MB
 
-----
-# vi /var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf
-----
-+
 . Remove the `#` and edit to listen to inbound connections:
 +
 [options="nowrap" subs="verbatim,quotes"]


### PR DESCRIPTION
the notes and the code block got in their ways


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (the issue is not present in 3.1 branch, as the original PR was not picked there)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
