### PR TITLE
Move the HTTP Configuration section to installation

### DIFF
--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -7,10 +7,6 @@ Use the following procedures to configure {Project} with an HTTP proxy.
 
 include::modules/proc_adding-a-default-http-proxy.adoc[leveloffset=+1]
 
-ifdef::satellite,katello,orcharhino[]
-include::modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc[leveloffset=+1]
-endif::[]
-
 ifndef::foreman-deb[]
 include::modules/proc_configuring-selinux-to-ensure-access-on-custom-ports.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -43,6 +43,10 @@ You can restore the previous file as follows:
 restore /etc/dhcp/dhcpd.conf 622d9820b8e764ab124367c68f5fa3a1
 ----
 
+ifdef::satellite,katello,orcharhino[]
+include::modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc[leveloffset=+1]
+endif::[]
+
 ifdef::satellite[]
 include::modules/proc_registering-to-red-hat-subscription-management.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -1,7 +1,7 @@
 [id="configuring-http-proxy-to-connect-to-cdn_{context}"]
 = Configuring the HTTP Proxy to Connect to Red Hat CDN
 
-Verify that {Project} can connect to the Red{nbsp}Hat CDN and can synchronize its repositories.
+To configure subscription-manager with an HTTP proxy, follow the procedure below.
 
 .Procedure
 


### PR DESCRIPTION
The configuration in HTTP Proxy to connect to the Content Delivery
Network is required at the time of registering the project server to
CDN. At present, it is a part of configuring the project server with an
HTTP Proxy which is not correct. So, we moved the section here to the
installation process where the registration process takes place.

Instructions "Configuring the HTTP Proxy to Connect to CDN"
should be before "Registering to Subscription Management"
in project Documentation.

https://bugzilla.redhat.com/show_bug.cgi?id=2117691

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
