### PR TITLE
Rename the Product Variant for RHEL 8 and above

### DIFF
--- a/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
+++ b/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
@@ -13,11 +13,11 @@ Use this procedure to download the ISO images for {RHEL} and {ProjectName}.
 
 . Ensure that you have the correct product and version for your environment.
 +
-* *Product Variant* is set to *{RHELServer}*.
+* *Product Variant* is set to *{RHEL} for x86_64*.
 * *Version*  is set to the latest minor version of the product you plan to use as the base operating system.
 * *Architecture* is set to the 64 bit version.
 
-. On the *Product Software* tab, download the Binary DVD image for the latest {RHELServer} version.
+. On the *Product Software* tab, download the Binary DVD image for the latest *{RHEL} for x86_64* version.
 
 . Click *DOWNLOADS* and select *{ProjectName}*.
 


### PR DESCRIPTION
Until RHEL 7, there was Red Hat Enterprise Linux Server version as a
name in the Product variant. After the release of RHEL 8, it is changed to
Red Hat Enterprise Linux for x86_64. It is also applicable to RHEL 9
as well. Hence, renamed the Product Variant.

[DDF] This is only true for RHEL7, for RHEL8 the variant is
"Red Hat Enterprise Linux for x86_64"

https://bugzilla.redhat.com/show_bug.cgi?id=2119293


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
