### PR TITLE
Add supported URLs for Custom repositories

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -110,7 +110,7 @@ You can select either a repository for RPM files (`yum`), Docker images (`docker
 . Optional: From the *Restrict to OS Version* list, select the OS version. Ensure that *No restriction*, which is the default value, is selected to make the repository available to all hosts regardless of the OS version.
 . In the *URL* field, enter the URL of the external repository to use as a source.
 {Project} supports three protocols: `http://`, `https://`, and `file://`.
-If you are using a `file://` repositories, you have to place it under `/var/lib/pulp/sync_imports/` directory.
+If you are using a `file://` repository, you have to place it under `/var/lib/pulp/sync_imports/` directory.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs. See xref:Importing_Content-Configuring_Download_Policies[]
 . Ensure that the *Mirror on Sync* check box is selected.
 This ensures that the content that is no longer part of the upstream repository is removed during synchronization.

--- a/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Importing_Content.adoc
@@ -109,6 +109,8 @@ You can select either a repository for RPM files (`yum`), Docker images (`docker
 . Optional: From the *Restrict to Architecture* list, select the architecture. Ensure that *No restriction*, which is the default value, is selected to make the repository available to all hosts regardless of the architecture.
 . Optional: From the *Restrict to OS Version* list, select the OS version. Ensure that *No restriction*, which is the default value, is selected to make the repository available to all hosts regardless of the OS version.
 . In the *URL* field, enter the URL of the external repository to use as a source.
+{Project} supports three protocols: `http://`, `https://`, and `file://`.
+If you are using a `file://` repositories, you have to place it under `/var/lib/pulp/sync_imports/` directory.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs. See xref:Importing_Content-Configuring_Download_Policies[]
 . Ensure that the *Mirror on Sync* check box is selected.
 This ensures that the content that is no longer part of the upstream repository is removed during synchronization.


### PR DESCRIPTION
The list of the supported URLs for adding custom repositories
was needed to make users aware. In addition to this, there is a
condition to using file:// protocol where the file permissions and SELinux
are setup to only allow file:// syncs within the
/var/lib/pulp/sync_imports/ directory.

What are the supported URL (http, https,file,nfs,git etc)
for custom repositories?

https://bugzilla.redhat.com/show_bug.cgi?id=2078031


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
