### PR TITLE
Add EL8 reference for downloading images

### DIFF
--- a/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
+++ b/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
@@ -13,11 +13,13 @@ Use this procedure to download the ISO images for {RHEL} and {ProjectName}.
 
 . Ensure that you have the correct product and version for your environment.
 +
-* *Product Variant* is set to *{RHELServer}*.
+* *Product Variant* is set to *{RHEL} for x86_64* for {EL} 8, or *{RHELServer}* for {EL} 7.
 * *Version*  is set to the latest minor version of the product you plan to use as the base operating system.
 * *Architecture* is set to the 64 bit version.
 
-. On the *Product Software* tab, download the Binary DVD image for the latest {RHELServer} version.
+. On the *Product Software* tab, download the applicable Binary DVD image.
+For {EL} 8, it must be the latest *{RHEL} for x86_64* version.
+For {EL} 7, it must be the latest *{RHELServer}* version.
 
 . Click *DOWNLOADS* and select *{ProjectName}*.
 


### PR DESCRIPTION
Add the reference of EL8 alongside EL7 in the section of Downloading
the Binary DVD Images. Also, mention the name of the relevant option
visible.

[DDF] This is only true for EL7, add the EL8 variant

https://bugzilla.redhat.com/show_bug.cgi?id=2119293


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
