### PR TITLE
Fix broken links in Updating and Upgrading guide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -22,7 +22,7 @@ endif::[]
 .Before You Begin
 
 * Review and update your firewall configuration before upgrading your {ProjectServer}.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html-single/installing_satellite_server_from_a_disconnected_network/index#satellite-ports-and-firewalls-requirements_satellite[Ports and Firewalls Requirements] in _Installing {ProjectServer} from a Disconnected Network_.
+For more information, see {InstallingDisconnectedDocURL}Ports_and_Firewalls_Requirements_satellite[Ports and Firewalls Requirements] in _{InstallingServerDisconnectedDocTitle}_.
 * Ensure that you do not delete the manifest from the Customer Portal or in the {ProjectWebUI} because this removes all the entitlements of your content hosts.
 * Back up and remove all Foreman hooks before upgrading.
 Reinstate hooks only after {Project} is known to be working after the upgrade is complete.
@@ -82,9 +82,9 @@ Reboot these hosts after the upgrade has completed.
 # {foreman-maintain} service stop
 ----
 
-. Obtain the latest ISO files by following the https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in the _Installing {ProjectServer} from a Disconnected Network_ guide.
+. Obtain the latest ISO files by following the {InstallingDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.
 
-. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` repository by following the https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#configuring-the-base-operating-system-with-offline-repositories_satellite[Configuring the Base System with Offline Repositories] procedure in the _Installing {ProjectServer} from a Disconnected Network_ guide.
+. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` repository by following the {InstallingDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-7_satellite[Configuring the Base System with Offline Repositories] procedure in _{InstallingServerDisconnectedDocTitle}_.
 Do not install or update any packages at this stage.
 
 . Configure the {Project} {ProjectVersion} repository from the ISO file.
@@ -281,7 +281,7 @@ Review the results and address any highlighted error conditions before performin
 ----
 +
 If the script fails due to missing or outdated packages, you must download and install these separately.
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html-single/installing_satellite_server_from_a_disconnected_network/installing-satellite-server-disconnected#resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] section in the _Installing {ProjectServer} from a Disconnected Network_ guide.
+For more information, see {InstallingDisconnectedDocURL}resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] in _{InstallingServerDisconnectedDocTitle}_.
 
 . If using a BASH shell, after a successful or failed upgrade, enter:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -84,7 +84,14 @@ Reboot these hosts after the upgrade has completed.
 
 . Obtain the latest ISO files by following the {InstallingDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.
 
-. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` repository by following the {InstallingDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-7_satellite[Configuring the Base System with Offline Repositories] procedure in _{InstallingServerDisconnectedDocTitle}_.
+. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` or the `rhel8` repository:
++
+.For {EL} 8
+Follow the {InstallingDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-8_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 8] procedure in _{InstallingServerDisconnectedDocTitle}_.
++
+.For {EL} 7
+Follow the {InstallingDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-7_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 7] procedure in _{InstallingServerDisconnectedDocTitle}_.
++
 Do not install or update any packages at this stage.
 
 . Configure the {Project} {ProjectVersion} repository from the ISO file.


### PR DESCRIPTION
Fixed two broken links in Updating and Upgrading guide in section 3.1.2,
procedure steps 9 and 10. Split step 10 into sections for EL 7 and EL 8
and added corresponding link in the EL 8 section.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3