### PR TITLE
Update the rpm command

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -133,13 +133,20 @@ ifdef::katello[]
 # {foreman-installer}
 ----
 endif::[]
-. Check when the kernel packages were last updated:
+. Determine if the system needs a reboot:
+.. Check the version of newest installed kernel:
 +
 [options="nowrap"]
 ----
-# rpm -qa --last | grep kernel
+# rpm --query --last kernel | head -n 1
 ----
-. Optional: If a kernel update occurred since the last reboot, reboot the system:
+.. Compare this to the version of currently running kernel:
++
+[options="nowrap"]
+----
+# uname --kernel-release
+----
+. Optional: If the newest kernel differs from the currently running kernel, reboot the system:
 +
 ----
 # reboot


### PR DESCRIPTION
In Upgrading and Updating guide, section 3.1.1.: Updated the rpm
command to a simpler and faster variant in step 10 of the procedure.
`rpm -q --last kernel` only shows information relevant to the user
and the shortened output is more readable compared to the output of
`rpm -qa --last | grep kernel`.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
