### PR TITLE
Removed redundant part from the Hyperlink text

### DIFF
--- a/guides/common/modules/proc_overriding-ansible-variables.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables.adoc
@@ -10,7 +10,7 @@ For more information, see {ManagingHostsDocURL}[_{ManagingHostsDocTitle}_].
 .Precedence in Overriding Variables
 
 If you use an Ansible role to run a task as a user that is not the `Effective User`, there is a strict order of precedence for overriding Ansible variables.
-To ensure that the variable that you override follows the correct order of precedence, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#ansible-variable-precedence[Variable precedence: Where should I put a variable?] in the _Ansible User Guide_.
+To ensure the variable that you override follows the correct order of precedence, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#ansible-variable-precedence[Variable precedence: Where should I put a variable?]
 
 .Prerequisite
 


### PR DESCRIPTION
This PR removes the part from the URL that is not required in the URL.
Ansible User Guide is redundant and hence being removed.
It does not affect any information part and does not break anything.
For details see comments in BZ#2119611

https://bugzilla.redhat.com/show_bug.cgi?id=2119611


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
