### PR TITLE
Fix the leapp plugin name

### DIFF
--- a/guides/common/modules/proc_upgrading-rhel7-hosts-to-rhel8.adoc
+++ b/guides/common/modules/proc_upgrading-rhel7-hosts-to-rhel8.adoc
@@ -18,7 +18,7 @@ For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[
 For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{context}[].
 
 .Procedure
-. On {Project}, enable the `foreman_plugin_leapp` puppet module:
+. On {Project}, enable the Leapp plugin:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
The RHEL7 to RHEL8 upgrade guide mentions that installer uses Puppet under the hood. Changing the plugin name as this information is not relevant to the user.
https://bugzilla.redhat.com/show_bug.cgi?id=2117556


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
