### PR TITLE
Replace the name of package for EL8

### DIFF
--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -59,7 +59,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} ipxe-bootimgs
+# {package-install} ipxe-bootimgs-x86
 ----
 . Correct the SELinux file contexts:
 +


### PR DESCRIPTION
The package name applicable to EL8 is not correct. It needs to be
replaced with the correct package name that is applicable to v3.3 and above.
For v3.1, the current package name is correct for EL7 and it will
require adding a package for EL8.

Package name for EL7 is correct and but need to update it for EL8.

https://bugzilla.redhat.com/show_bug.cgi?id=2121433


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
