### PR TITLE
Add the package for EL8

### DIFF
--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -57,9 +57,17 @@ To prepare iPXE environment, you must perform this procedure on all {SmartProxie
 ifdef::foreman-el,katello,satellite,orcharhino[]
 . Install the `ipxe-bootimgs` package:
 +
+* For {EL} 7:
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install} ipxe-bootimgs
+----
+* For {EL} 8:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} ipxe-bootimgs-x86
 ----
 . Correct the SELinux file contexts:
 +


### PR DESCRIPTION
For v3.1, the package applicable to EL8 is added in the Provisioning
guide.

The package name for EL7 is correct and but need to update it for EL8.

https://bugzilla.redhat.com/show_bug.cgi?id=2121433


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
