### PR TITLE
Add Repository Sets as a new procedure

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -92,6 +92,9 @@ include::modules/proc_adding-custom-deb-repositories.adoc[leveloffset=+1]
 include::modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc[leveloffset=+1]
 
 include::modules/proc_adding-custom-deb-repository-example-for-ubuntu-22-04.adoc[leveloffset=+1]
+
+include::modules/proc_changing-the-repository-sets-status-in-project.adoc[leveloffset=+1]
+
 endif::[]
 
 include::modules/proc_enabling-red-hat-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -91,10 +91,14 @@ include::modules/proc_adding-custom-deb-repositories.adoc[leveloffset=+1]
 
 include::modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc[leveloffset=+1]
 
+<<<<<<< HEAD
 include::modules/proc_adding-custom-deb-repository-example-for-ubuntu-22-04.adoc[leveloffset=+1]
 
 include::modules/proc_changing-the-repository-sets-status-in-project.adoc[leveloffset=+1]
 
+=======
+include::modules/proc_changing-the-repository-sets.adoc[leveloffset=+1]
+>>>>>>> 0a7e7fbbb (Replace modify with change and make line optional)
 endif::[]
 
 include::modules/proc_enabling-red-hat-repositories.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
@@ -1,0 +1,16 @@
+[id="Changing_the_Repository_Sets_Status_in_Project_{context}"]
+= Changing the Repository Sets Status in {Project}
+
+Repository sets show available repositories to each host. If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* to choose from a list of available hosts.
+. Select the *Repository sets* tab.
+On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
+. You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.
+. Navigate to the *Overview* tab to *Content view details* to view the environment for the host.
+[NOTE]
+====
+For hosts not in a default view or a lifecycle environment, the *Repository sets* tab shows only repositories that are relevant to the host.
+====
+. Select *Show all* or *Limit to environment* to view available repositories.

--- a/guides/common/modules/proc_changing-the-repository-sets.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets.adoc
@@ -1,15 +1,15 @@
-[id="Modifying_the_Repository_Sets_Status_in_Project{context}"]
-= Modifying the Repository Sets Status in {Project}
+[id="Changing_the_Repository_Sets_Status_in_Project{context}"]
+= Changing the Repository Sets Status in {Project}
 
 Repository sets show available repositories to each host.
 If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts*, and select the host whose repository sets you want to modify.
-. Select a host and navigate to the *Repository sets* tab.
+. In the {ProjectWebUI}, navigate to *Hosts*, and select the host whose repository sets you want to change.
+. Select a host and select the *Repository sets* tab.
 On the *Repository sets* tab, there is a set of available repositories available to each host with a status of *Enabled* or *Disabled*.
-. Override the default status by selecting *Override to disabled*, *Override to enabled*, or *Reset to default* from the action menus on each table row.
-. Navigate to the *Overview* tab to *Content view details* to view the environment for the host.
+. Select *Override to disabled*, *Override to enabled*, or *Reset to default* from the action menus on each row to overwrite the default status.
+. Optional: Verify the environment for the host in *Content view details* in the *Overview* tab.
 +
 [NOTE]
 ====

--- a/guides/common/modules/proc_modifying-the-repository-sets.adoc
+++ b/guides/common/modules/proc_modifying-the-repository-sets.adoc
@@ -1,0 +1,19 @@
+[id="Modifying_the_Repository_Sets_Status_in_Project{context}"]
+= Modifying the Repository Sets Status in {Project}
+
+Repository sets show available repositories to each host.
+If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts*, and select the host whose repository sets you want to modify.
+. Select a host and navigate to the *Repository sets* tab.
+On the *Repository sets* tab, there is a set of available repositories available to each host with a status of *Enabled* or *Disabled*.
+. Override the default status by selecting *Override to disabled*, *Override to enabled*, or *Reset to default* from the action menus on each table row.
+. Navigate to the *Overview* tab to *Content view details* to view the environment for the host.
++
+[NOTE]
+====
+For hosts not in a default view or a lifecycle environment, the repository tab looks different.
+It defaults to showing only the repositories that are relevant to the host.
+====
+. Select *Show all* or *Limit to environment* to view available repositories.


### PR DESCRIPTION
New feature for Modifying Repository Sets added as a procedure module
in the Managing Content Guide in Section 5 Importing Content.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
