### PR TITLE
Updated postgres option to make it more inclusive

### DIFF
--- a/guides/common/modules/proc_reclaiming-postgresql-space.adoc
+++ b/guides/common/modules/proc_reclaiming-postgresql-space.adoc
@@ -17,7 +17,7 @@ Use this procedure to reclaim some of this disk space on {Project}.
 +
 [options="nowrap"]
 ----
-# su - postgres -c 'vacuumdb --full --dbname=foreman'
+# su - postgres -c 'vacuumdb --full --all'
 ----
 
 . Start the other services when the vacuum completes:


### PR DESCRIPTION
A suggestion was received to replace PostGre Switch command to cover
the candlepin & pulpcore database replacing option ``--dbname` to `all`.
It has been updated after receiving confirmation from SME in BZ#2122618.
Updates are made in the module - Reclaiming PostgreSQL Space

https://bugzilla.redhat.com/show_bug.cgi?id=2122618


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
