### PR TITLE
Remove redundant macros from configuring proxy repos

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -2,23 +2,13 @@
 
 = Configuring Repositories
 
-ifdef::foreman-el,katello[]
-This procedure is only for Katello plug-in and {RHEL}-based operating system users.
-endif::[]
-
 Use this procedure to enable the repositories that are required to install {ProductName}.
 Select the option that corresponds with operating system and version you want to install on:
 
-ifdef::foreman-el,katello,satellite[]
 * xref:#repositories-rhel-8[{RHEL} 8]
 * xref:#repositories-rhel-7[{RHEL} 7]
-endif::[]
 
-ifdef::foreman-el,katello,satellite[]
 == [[repositories-rhel-8]]{RHEL} 8
-
-:distribution-major-version: 8
-:package-manager: dnf
 
 . Disable all repositories:
 +
@@ -27,10 +17,8 @@ ifdef::foreman-el,katello,satellite[]
 # subscription-manager repos --disable "*"
 ----
 +
-endif::[]
 
 . Enable the following repositories:
-ifdef::satellite[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -54,15 +42,8 @@ The module `satellite-capsule:el8` has a dependency for the modules `postgresql:
 These warnings do not cause installation process failure, hence can be ignored safely.
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
-+
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
 
 == [[repositories-rhel-7]]{RHEL} 7
-
-:distribution-major-version: 7
-:package-manager: yum
 
 . Disable all repositories:
 +
@@ -72,17 +53,6 @@ ifdef::foreman-el,katello,satellite[]
 ----
 +
 . Enable the following repositories:
-ifdef::foreman-el,katello[]
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable {RepoRHEL7ServerOptional} \
---enable {RepoRHEL7ServerSoftwareCollections}
-----
-+
-endif::[]
-ifdef::satellite[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -93,7 +63,6 @@ ifdef::satellite[]
 --enable={RepoRHEL7ServerAnsible}
 ----
 +
-endif::[]
 
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
@@ -111,70 +80,3 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 ----
 # yum repolist enabled
 ----
-
-ifdef::foreman-el,katello[]
-+
-. Install the `foreman-release.rpm` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# yum localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
-----
-+
-. Install the `katello-repos-latest.rpm` package
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# yum localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
-----
-+
-. Install the `puppet6-release-el-7.noarch.rpm` package:
-+
-----
-# yum localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
-----
-+
-. Install the `epel-release-latest-7.noarch.rpm` package:
-+
-----
-# yum localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-----
-endif::[]
-
-ifdef::foreman-el,katello[]
-
-.CentOS Users
-If you use a CentOS operating system, complete the following steps:
-
-. Install the `foreman-release.rpm` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# yum localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el7/x86_64/foreman-release.rpm
-----
-+
-. Install the `katello-repos-latest.rpm` package
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# yum localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el7/x86_64/katello-repos-latest.rpm
-----
-+
-. Install the `puppet6-release-el-7.noarch.rpm` package:
-+
-----
-# yum localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
-----
-+
-. Install the `epel-release` package:
-+
-----
-# yum install epel-release
-----
-+
-. Install the `centos-release-scl-rh` package:
-+
-----
-# yum install centos-release-scl-rh
-----
-endif::[]


### PR DESCRIPTION
This document is only used for satellite. That means all non-satellite content can be dropped. It also has set some macros that unused.

The expected diff of this PR is no visual change. Perhaps some empty lines are dropped.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.