### PR TITLE
Fix yum clean instruction

### DIFF
--- a/guides/common/modules/proc_completing-the-rhel6-image.adoc
+++ b/guides/common/modules/proc_completing-the-rhel6-image.adoc
@@ -5,13 +5,13 @@
 . Update the system:
 +
 -----------
-# {package-update}
+# yum update
 -----------
 . Install the `cloud-init` packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 -----------
-# {package-install} cloud-utils-growpart cloud-init
+# yum install cloud-utils-growpart cloud-init
 -----------
 . Edit the `/etc/cloud/cloud.cfg` configuration file and under `cloud_init_modules` add:
 +
@@ -40,7 +40,7 @@ NOZEROCONF=yes
 ----------
 # subscription-manager repos --disable=*
 # subscription-manager unregister
-# {package-clean} all
+# yum clean all
 ----------
 . Power off the instance:
 +

--- a/guides/common/modules/proc_completing-the-rhel7-image.adoc
+++ b/guides/common/modules/proc_completing-the-rhel7-image.adoc
@@ -5,13 +5,13 @@
 . Update the system:
 +
 -----------
-# {package-update}
+# yum update
 -----------
 . Install the `cloud-init` packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 -----------
-# {package-install} cloud-utils-growpart cloud-init
+# yum install cloud-utils-growpart cloud-init
 -----------
 . Open the `/etc/cloud/cloud.cfg` configuration file:
 +

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -102,7 +102,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-clean} all
+# yum clean all
 ----
 +
 . Optional: Verify that the required repositories are enabled:


### PR DESCRIPTION
In b9437c01aa8bd93ebe56ab8321abbc87f8bb1cbf the macro was changed to `dnf clean` but these instructions are specifically for EL6 or EL7 which have yum.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.