### PR TITLE
Remove duplicate entry for port 443 in LB guide

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -38,7 +38,6 @@ For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg`
 | HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServer}s
 //| Anaconda | 8000 | TCP | roundrobin | port 8000 on all {SmartProxies}
 | HTTPS | 443 | TCP | source | port 443 on all {SmartProxyServer}s
-| RHSM | 443 | TCP | roundrobin | port 443 on all {SmartProxyServer}s
 | AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServer}s
 | Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServer}s
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates

--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -37,7 +37,7 @@ For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg`
 | Service | Port | Mode | Balance Mode | Destination
 | HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServer}s
 //| Anaconda | 8000 | TCP | roundrobin | port 8000 on all {SmartProxies}
-| HTTPS | 443 | TCP | source | port 443 on all {SmartProxyServer}s
+| HTTPS and RHSM | 443 | TCP | source | port 443 on all {SmartProxyServer}s
 | AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServer}s
 | Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServer}s
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates


### PR DESCRIPTION
Port 443 has been mentioned twice in the Ports configuration table for LB. The second instance is not required, as HTTPS 443 source is defined at the beginning of the config and will be used by haproxy to control the traffic from RHSM\YUM or any other https-based requests.

https://bugzilla.redhat.com/show_bug.cgi?id=2119979


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
