### PR TITLE
Drop migrating internal DB to external from foreman-el

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -12,7 +12,9 @@ include::common/assembly_accessing-server.adoc[leveloffset=+1]
 
 ifndef::foreman-deb[]
 include::common/modules/proc_starting-and-stopping-server.adoc[leveloffset=+1]
+endif::[]
 
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
The instructions are very katello-centric and don't work on Foreman.

I'm unsure about cherry picks. We don't link to the guides for non-nightly so it doesn't matter that much.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.