### PR TITLE
Add supported URLs for Custom RPM repositories

### DIFF
--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -26,6 +26,8 @@ If you want to make the repository available to all hosts regardless of the arch
 . Optional: From the *Restrict to OS Version* list, select the OS version.
 If you want to make the repository available to all hosts regardless of the OS version, ensure to select *No restriction*.
 . Optional: In the *Upstream URL* field, enter the URL of the external repository to use as a source.
+{Project} supports three protocols: `http://`, `https://`, and `file://`.
+If you are using a `file://` repository, you have to place it under `/var/lib/pulp/sync_imports/` directory.
 +
 If you do not enter an upstream URL, you can manually upload packages.
 . Optional: Check the *Ignore SRPMs* checkbox to exclude source RPM packages from being synchronized to {Project}.


### PR DESCRIPTION
The list of the supported URLs for adding custom rpm repositories
was needed to make users aware. In addition to this, there is a
condition to use file:// protocol where the file permissions and selinux
are setup to only allow file:// syncs within the
/var/lib/pulp/sync_imports/ directory.

What are the supported URL (http, https,file,nfs,git etc)
for custom repositories?

https://bugzilla.redhat.com/show_bug.cgi?id=2123631


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
