### PR TITLE
Add a note about requesting unset email

### DIFF
--- a/guides/common/modules/con_configuring-external-authentication.adoc
+++ b/guides/common/modules/con_configuring-external-authentication.adoc
@@ -3,6 +3,7 @@
 
 By using external authentication you can derive user and user group permissions from user group membership in an external identity provider.
 When you use external authentication, you do not have to create these users and maintain their group membership manually on {ProjectServer}.
+In case the external source does not provide email, it will be requested during the first login through {ProjectWebUI}.
 
 .Important User and Group Account Information
 All user and group accounts must be local accounts.


### PR DESCRIPTION
In Administering {Project}, section 14: when the mail is not set
properly and/or available via an external source, during the first
login, the email will be requested. However, this is not mentioned
in the docs. Added a note to notify the user about this behavior.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3