### PR TITLE
Correct the description of dns_libvirt

### DIFF
--- a/guides/common/modules/con_managing-dns-using-smart-proxy.adoc
+++ b/guides/common/modules/con_managing-dns-using-smart-proxy.adoc
@@ -15,7 +15,7 @@ endif::[]
 * `dns_infoblox` - For more information, see {ProvisioningDocURL}Using_Infoblox_as_DHCP_and_DNS_Providers_provisioning[Using Infoblox as DHCP and DNS Providers] in _{ProvisioningDocTitle}_.
 ifndef::satellite[]
 * `dns_libvirt` - Dnsmasq DNS via libvirt API.
-For more information, see xref:configuring-dynamic-dns-update-with-gss-tsig-authentication_{context}[].
+For more information, see xref:configuring_dns_libvirt_{context}[].
 endif::[]
 * `dns_nsupdate` - Dynamic DNS update using nsupdate.
 For more information, see {ProvisioningDocURL}Using_Infoblox_as_DHCP_and_DNS_Providers_provisioning[Using Infoblox as DHCP and DNS Providers] in _{ProvisioningDocTitle}_.

--- a/guides/common/modules/proc_configuring-dns-libvirt.adoc
+++ b/guides/common/modules/proc_configuring-dns-libvirt.adoc
@@ -1,7 +1,7 @@
-[id="Configuring_dns_libvirt_{context}"]
+[id="configuring_dns_libvirt_{context}"]
 = Configuring dns_libvirt
 
-The _dns_libvirt_ DNS provider manages IP reservations and leases using dnsmasq through the libvirt API.
+The _dns_libvirt_ DNS provider manages DNS records using dnsmasq through the libvirt API.
 It uses `ruby-libvirt` gem to connect to the local or a remote instance of libvirt daemon.
 
 .Procedure


### PR DESCRIPTION
This looks like the dhcp_libvirt description was copied.

Fixes: 29f85aab7520b52425d3917e3148ec2c9434f978

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.