### PR TITLE
Add EL8 to External Database guide alongside EL7

### DIFF
--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -14,6 +14,10 @@ endif::[]
 
 To create and use external databases for {Project}, you must complete the following procedures:
 
+ifdef::orcharhino[]
+. xref:preparing-a-host-for-external-databases_{context}[].
+Prepare a {EL} 7 server to host the external databases.
+endif::[]
 ifndef::orcharhino[]
 . xref:preparing-a-host-for-external-databases_{context}[].
 Prepare a {EL} 8 or {EL} 7 server to host the external databases.

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -14,8 +14,10 @@ endif::[]
 
 To create and use external databases for {Project}, you must complete the following procedures:
 
+ifndef::orcharhino[]
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare a {RHEL} 7 server to host the external databases.
+Prepare a {EL} 8 or {EL} 7 server to host the external databases.
+endif::[]
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:Configuring_Server_to_Use_External_Databases_{context}[].

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -14,12 +14,11 @@ endif::[]
 
 To create and use external databases for {Project}, you must complete the following procedures:
 
-ifdef::orcharhino[]
 . xref:preparing-a-host-for-external-databases_{context}[].
+ifdef::orcharhino[]
 Prepare a {EL} 7 server to host the external databases.
 endif::[]
 ifndef::orcharhino[]
-. xref:preparing-a-host-for-external-databases_{context}[].
 Prepare a {EL} 8 or {EL} 7 server to host the external databases.
 endif::[]
 . xref:installing-postgresql_{context}[].

--- a/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
@@ -20,8 +20,14 @@ endif::[]
 
 To migrate from the default internal databases to external databases, you must complete the following procedures:
 
+ifndef::orcharhino[]
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare a {RHEL} 7 server to host the external databases.
+Prepare a {EL} 8 or {EL} 7 server to host the external databases.
+endif::[]
+ifdef::orcharhino[]
+. xref:preparing-a-host-for-external-databases_{context}[].
+Prepare a {EL} 7 server to host the external databases.
+endif::[]
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Pulp and Candlepin with dedicated users owning them.
 . xref:migrating-to-external-databases_{context}[].

--- a/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
@@ -20,12 +20,11 @@ endif::[]
 
 To migrate from the default internal databases to external databases, you must complete the following procedures:
 
-ifndef::orcharhino[]
 . xref:preparing-a-host-for-external-databases_{context}[].
+ifndef::orcharhino[]
 Prepare a {EL} 8 or {EL} 7 server to host the external databases.
 endif::[]
 ifdef::orcharhino[]
-. xref:preparing-a-host-for-external-databases_{context}[].
 Prepare a {EL} 7 server to host the external databases.
 endif::[]
 . xref:installing-postgresql_{context}[].

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -5,7 +5,7 @@ ifndef::orcharhino[]
 Install a freshly provisioned system with the latest {EL} 7 server to host the external databases.
 endif::[]
 ifdef::orcharhino[]
-Install a freshly provisioned system with the latest CentOS 7, Oracle Linux 7, or {RHEL} 7 to host the external databases.
+Install a freshly provisioned system with the latest CentOS 7, Oracle Linux 7, or {EL} 7 to host the external databases.
 endif::[]
 
 ifdef::satellite[]
@@ -20,6 +20,7 @@ endif::[]
 ifndef::orcharhino[]
 . Use the instructions in {InstallingServerDocURL}attaching-infrastructure-subscription_{project-context}[Attaching the {Project} Infrastructure Subscription] to attach a {Project} subscription to your server.
 . Disable all repositories and enable only the following repositories:
+* For {EL} 7:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -31,6 +32,20 @@ endif::[]
 ifdef::foreman-el,katello[]
 # subscription-manager repos --enable={RepoRHEL7ServerSoftwareCollections} \
 --enable={RepoRHEL7Server}
+endif::[]
+----
+endif::[]
+
+ifdef::satellite,katello[]
+* For {EL} 8:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+ifdef::satellite[]
+# dnf module enable satellite:el8
+endif::[]
+ifdef::katello[]
+# dnf module enable katello:el8
 endif::[]
 ----
 endif::[]


### PR DESCRIPTION
Adding the reference of EL8 alongside EL7 for the upstream v3.1. It is required to keep the reference of both as they are supported by Foreman 3.1/Katello 4.3

Need to update guide to have instructions to use EL8 based external DB

https://bugzilla.redhat.com/show_bug.cgi?id=2097380


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
