### PR TITLE
Move managing organizations and locations (Satellite)

### DIFF
--- a/guides/common/modules/con_provisioning-contexts.adoc
+++ b/guides/common/modules/con_provisioning-contexts.adoc
@@ -8,7 +8,7 @@ Organizations divide {ProjectName} components into logical groups based on owner
 You can create and manage multiple organizations through {ProjectName} and assign components to each individual organization.
 This ensures {ProjectServer} provisions hosts within a certain organization and only uses components that are assigned to that organization.
 ifdef::satellite[]
-For more information about organizations, see {ContentManagementDocURL}Managing_Organizations_content-management[Managing Organizations] in _{ContentManagementDocTitle}_.
+For more information about organizations, see {AdministeringDocURL}Managing_Organizations_admin[Managing Organizations] in _{AdministeringDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information about organizations, see {ManagingOrganizationsLocationsDocURL}Managing_Organizations_managing-organizations-locations[Managing Organizations] in _{ManagingOrganizationsLocationsDocTitle}_.
@@ -18,7 +18,7 @@ Locations function similar to organizations.
 The difference is that locations are based on physical or geographical setting.
 Users can nest locations in a hierarchy.
 ifdef::satellite[]
-For more information about locations, see {ContentManagementDocURL}Managing_Locations_content-management[Managing Locations] in _{ContentManagementDocTitle}_.
+For more information about locations, see {AdministeringDocURL}Managing_Locations_admin[Managing Locations] in _{AdministeringDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information about locations, see {ManagingOrganizationsLocationsDocURL}Managing_Locations_managing-organizations-locations[Managing Locations] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/con_provisioning-templates.adoc
+++ b/guides/common/modules/con_provisioning-templates.adoc
@@ -24,7 +24,7 @@ For more information, see {ManagingHostsDocURL}Template_Writing_Reference_managi
 You can download provisioning templates.
 Before you can download the template, you must create a debug certificate.
 ifdef::satellite[]
-For more information, see {ContentManagementDocURL}Creating_an_Organization_Debug_Certificate_content-management[Creating an Organization Debug Certificate] in _{ContentManagementDocTitle}_.
+For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
+++ b/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to assign a host to a specific organization.
 ifdef::satellite[]
-For general information about organizations and how to configure them, see {ContentManagementDocURL}Managing_Organizations[Managing Organizations] in _{ContentManagementDocTitle}_.
+For general information about organizations and how to configure them, see {AdministeringDocURL}Managing_Organizations_admin[Managing Organizations] in _{AdministeringDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For general information about organizations and how to configure them, see {ManagingOrganizationsLocationsDocURL}Managing_Organizations_managing-organizations-locations[Managing Organizations] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
+++ b/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
@@ -8,7 +8,8 @@ ifndef::satellite[]
 . Create and download an organization certificate as described in {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate].
 endif::[]
 ifdef::satellite[]
-. Create and download an organization certificate as described in xref:Creating_an_Organization_Debug_Certificate_{context}[].
+. Create and download an organization certificate.
+For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle}_.
 endif::[]
 . Open the X.509 certificate, for example, for the default organization:
 +

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
@@ -16,7 +16,7 @@ ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.
 endif::[]
 ifdef::satellite[]
-For more information, see xref:Creating_an_Organization_Debug_Certificate_{context}[].
+For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle}_.
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -14,7 +14,7 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 * For existing virtual machines, ensure that the *Display type* in the *Compute Resource* settings is *VNC*.
 * You must import the Katello root CA certificate into your {ProjectServer}.
 Adding a security exception in the browser is not enough for using noVNC.
-For more information, see the {AdministeringDocURL}Installing_the_Katello_Root_CA_Certificate_admin[Installing the Katello Root CA Certificate] section in the _Administering {ProjectName}_ guide.
+For more information, see {AdministeringDocURL}Installing_the_Katello_Root_CA_Certificate_admin[Installing the Katello Root CA Certificate] in _{AdministeringDocTitle}_.
 
 .Procedure
 . On the VM host system, configure the firewall to allow VNC service on ports 5900 to 5930:

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -20,6 +20,12 @@ endif::[]
 
 include::common/assembly_managing-project-with-ansible-collections.adoc[leveloffset=+1]
 
+ifdef::satellite[]
+include::common/assembly_managing-organizations.adoc[leveloffset=+1]
+
+include::common/assembly_managing-locations.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_managing-users-and-roles.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-email-notifications.adoc[leveloffset=+1]

--- a/guides/doc-Deploying_Project_on_AWS/topics/AWS_Use_Case_Considerations.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/topics/AWS_Use_Case_Considerations.adoc
@@ -30,7 +30,7 @@ Not all Red Hat subscriptions are eligible to run in public cloud environments.
 For more information about subscription eligibility, see the https://www.redhat.com/en/technologies/cloud-computing/cloud-access#program-details[Red Hat Cloud Access Page].
 You can create additional organizations and then import additional manifests to the organizations.
 ifdef::satellite[]
-For more information, see {ContentManagementDocURL}Managing_Organizations-Creating_an_Organization[Creating an Organization] in _{ContentManagementDocTitle}_.
+For more information, see {AdministeringDocURL}Creating_an_Organization_admin[Creating an Organization] in _{AdministeringDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Managing_Organizations_managing-organizations-locations[Managing Organizations] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -19,12 +19,6 @@ ifdef::foreman-el,katello[]
 include::common/assembly_basic-content-management-workflow.adoc[leveloffset=+1]
 endif::[]
 
-ifdef::satellite[]
-include::common/assembly_managing-organizations.adoc[leveloffset=+1]
-
-include::common/assembly_managing-locations.adoc[leveloffset=+1]
-endif::[]
-
 include::common/assembly_managing-red-hat-subscriptions.adoc[leveloffset=+1]
 
 include::common/assembly_importing-content.adoc[leveloffset=+1]


### PR DESCRIPTION
We're moving these chapters to _Administering_ guide for Sat 6.12:

- Managing organizations
- Managing locations

-------

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3

