### PR TITLE
Correct the URLs in iPXE DHCP configuration

### DIFF
--- a/guides/common/modules/proc_booting-virtual-machines.adoc
+++ b/guides/common/modules/proc_booting-virtual-machines.adoc
@@ -48,26 +48,14 @@ If you want to change the default values in the template, clone the template and
 . Set *PXE Loader* to *iPXE Embedded*.
 . Select the *Templates* tab.
 . From the *iPXE template* list, select *Review* to verify that the *Kickstart default iPXE* template is the correct template.
-. Configure the `dhcpd.conf` file as follows:
+. On {ProjectServer}, run:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-if exists user-class and option user-class = "iPXE" {
-  filename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1";
-} # elseif existing statements if non-iPXE environment should be preserved
+{foreman-installer} --foreman-proxy-dhcp-ipxefilename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1"
 ----
 +
-If you use an isolated network, use a {SmartProxyServer} URL with TCP port `8000`, instead of the URL of {ProjectServer}.
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-if exists user-class and option user-class = "iPXE" {
-  filename "http://{smartproxy-example-com}:8000/unattended/iPXE?bootstrap=1";
-} # elseif existing statements if non-iPXE environment should be preserved
-----
-
 [NOTE]
 ====
-If you have changed the port using the `--foreman-proxy-http-port installer` option, use your custom port.
-You must update the `/etc/dhcp/dhcpd.conf` file after every upgrade.
+Ensure that `--foreman-trusted-proxies` is configured correctly on the {ProjectServer}.
 ====

--- a/guides/common/modules/proc_booting-virtual-machines.adoc
+++ b/guides/common/modules/proc_booting-virtual-machines.adoc
@@ -53,12 +53,19 @@ If you want to change the default values in the template, clone the template and
 [options="nowrap" subs="+quotes,attributes"]
 ----
 if exists user-class and option user-class = "iPXE" {
-  filename "http://{smartproxy-example-com}:8000/unattended/iPXE?bootstrap=1";
+  filename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1";
 } # elseif existing statements if non-iPXE environment should be preserved
 ----
 +
 If you use an isolated network, use a {SmartProxyServer} URL with TCP port `8000`, instead of the URL of {ProjectServer}.
 +
+[options="nowrap" subs="+quotes,attributes"]
+----
+if exists user-class and option user-class = "iPXE" {
+  filename "http://{smartproxy-example-com}:8000/unattended/iPXE?bootstrap=1";
+} # elseif existing statements if non-iPXE environment should be preserved
+----
+
 [NOTE]
 ====
 If you have changed the port using the `--foreman-proxy-http-port installer` option, use your custom port.

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -51,26 +51,14 @@ If you want to change the default values in the template, clone the template and
 . From the *iPXE template* list, select *Review* to verify the template is the correct template.
 If there is no PXELinux entry, or you cannot find the new template, navigate to *Hosts* > *All Hosts*, and on your host, click *Edit*.
 Click the *Operating system* tab and click the Provisioning Template *Resolve* button to refresh the list of templates.
-. Configure the `dhcpd.conf` file as follows:
+. On {ProjectServer}, run:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-if exists user-class and option user-class = "iPXE" {
-  filename "http://{foreman-example-com}:8000/unattended/iPXE?bootstrap=1";
-} # elseif existing statements if non-iPXE environment should be preserved
+{foreman-installer} --foreman-proxy-dhcp-ipxefilename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1"
 ----
 +
-If you use an isolated network, use a {SmartProxyServer} URL with TCP port `8000`, instead of the URL of {ProjectServer}.
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-if exists user-class and option user-class = "iPXE" {
-  filename "http://{smartproxy-example-com}:8000/unattended/iPXE?bootstrap=1";
-} # elseif existing statements if non-iPXE environment should be preserved
-----
-
 [NOTE]
 ====
-If you have changed the port using the `--foreman-proxy-http-port installer` option, use your custom port.
-You must update the `/etc/dhcp/dhcpd.conf` file after every upgrade.
+Ensure that `--foreman-trusted-proxies` is configured correctly on the {ProjectServer}.
 ====

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -56,10 +56,19 @@ Click the *Operating system* tab and click the Provisioning Template *Resolve* b
 [options="nowrap" subs="+quotes,attributes"]
 ----
 if exists user-class and option user-class = "iPXE" {
-  filename "http://{smartproxy-example-com}:8000/unattended/iPXE?bootstrap=1";
+  filename "http://{foreman-example-com}:8000/unattended/iPXE?bootstrap=1";
 } # elseif existing statements if non-iPXE environment should be preserved
 ----
 +
+If you use an isolated network, use a {SmartProxyServer} URL with TCP port `8000`, instead of the URL of {ProjectServer}.
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+if exists user-class and option user-class = "iPXE" {
+  filename "http://{smartproxy-example-com}:8000/unattended/iPXE?bootstrap=1";
+} # elseif existing statements if non-iPXE environment should be preserved
+----
+
 [NOTE]
 ====
 If you have changed the port using the `--foreman-proxy-http-port installer` option, use your custom port.


### PR DESCRIPTION
In the section of Booting Virtual Machines and Chainbooting iPXE from PXELinux in the Provisioning Guide, the URL for the project was rendering of smartproxy which was incorrect. It needed to be fixed by replacing it with the project URL. Also, we mentioned the separate URL for smartproxy to avoid confusion while configuration.

If we kept this unchanged, the deployment would have failed as port 8000 will not be listening on the project server.

https://bugzilla.redhat.com/show_bug.cgi?id=2123489

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
