### PR TITLE
Replaced .include directives with drop-in files

### DIFF
--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -77,7 +77,7 @@ euid = __ID_of_Apache_User__
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # mkdir -p /etc/systemd/system/httpd.service.d/
-# vi  /etc/systemd/system/httpd.service.d/gssproxy.conf
+# vi /etc/systemd/system/httpd.service.d/gssproxy.conf
 [Service]
 Environment=GSS_USE_PROXY=1
 ----

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -72,7 +72,7 @@ euid = __ID_of_Apache_User__
 # systemctl restart gssproxy.service
 # systemctl enable gssproxy.service
 ----
-. To configure the Apache server to use the gssproxy service, create a `systemd` drop-in file and add following content in it:
+. To configure the Apache server to use the `gssproxy` service, create a `systemd` drop-in file and add following content in it:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -72,7 +72,7 @@ euid = __ID_of_Apache_User__
 # systemctl restart gssproxy.service
 # systemctl enable gssproxy.service
 ----
-. To configure the Apache server to use the `gssproxy` service, create a `systemd` drop-in file and add following content in it:
+. To configure the Apache server to use the `gssproxy` service, create a `systemd` drop-in file and add the following content to it:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -72,16 +72,16 @@ euid = __ID_of_Apache_User__
 # systemctl restart gssproxy.service
 # systemctl enable gssproxy.service
 ----
-. Configure the Apache server to use the gssproxy service:
-.. Create the `/etc/systemd/system/httpd.service` file with the following content:
+. To configure the Apache server to use the gssproxy service, create a `systemd` drop-in file and add following content in it:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-.include /lib/systemd/system/httpd.service
+# mkdir -p /etc/systemd/system/httpd.service.d/
+# vi  /etc/systemd/system/httpd.service.d/gssproxy.conf
 [Service]
 Environment=GSS_USE_PROXY=1
 ----
-.. Apply changes to the service:
+. Apply changes to the service:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
Replaced a .include directives command as this one is deprecated. 
Support for the same will be removed in the future versions of systemd. 
New command is added to replace .include derivatives as per suggestion. 
New command includes drop-in files.

https://bugzilla.redhat.com/show_bug.cgi?id=2122559

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
