### PR TITLE
Add missing quotes

### DIFF
--- a/guides/common/modules/proc_using-shellhook-arguments.adoc
+++ b/guides/common/modules/proc_using-shellhook-arguments.adoc
@@ -7,8 +7,8 @@ To pass arguments into a shellhook script, create the following HTTP headers:
 [options="nowrap" subs="+quotes,attributes"]
 ----
 {
-  "X-Shellhook-Arg-1": "<%= @object.content_view_version_id %>,
-  "X-Shellhook-Arg-2": "<%= @object.content_view_name %>
+  "X-Shellhook-Arg-1": "<%= @object.content_view_version_id %>",
+  "X-Shellhook-Arg-2": "<%= @object.content_view_name %>"
 }
 ----
 


### PR DESCRIPTION
Added missing quotes in Administering Project guide, section 16.8.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
