### PR TITLE
Add a note about not running Ansible role

### DIFF
--- a/guides/common/modules/proc_assigning-convert2rhel-role-to-project-server.adoc
+++ b/guides/common/modules/proc_assigning-convert2rhel-role-to-project-server.adoc
@@ -9,3 +9,6 @@ Use this procedure to assign the Ansible Role to {ProjectServer}.
 . Click the *Ansible Roles* tab and from the *Available Ansible Roles* list, search for the `{ansible-namespace}.convert2rhel` role.
 . Click the `+` icon to add it to the *Assigned Ansible Roles* for {ProjectServer}.
 . Click *Submit*.
+
+Continue by creating the required variables.
+For more information, see xref:creating_variables_for_ansible_role_{context}[].


### PR DESCRIPTION
In Managing Content guide, section 11.2.: Added another step in the procedure to inform the user to continue by creating required variables for the role. This is to clarify that the Ansible role is not to be run yet.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
