### PR TITLE
Provide examples for Ansible variables

### DIFF
--- a/guides/common/modules/proc_creating-variables-for-convert2rhel-role.adoc
+++ b/guides/common/modules/proc_creating-variables-for-convert2rhel-role.adoc
@@ -3,18 +3,18 @@
 
 Assigning the Ansible role to a host also installs variables.
 You must create the following additional variables:
-[cols="20%,10%,15%",options="header"]
+[cols="20%,10%,20%,15%",options="header"]
 |====
-| Name | Type | Default value and description
-| {project-context}_rhel_wait_for_syncs | boolean | false
-| {project-context}_manifest_path | string | path to manifest
-| {project-context}_organization | string | name of organization
-| {project-context}_password | string | your admin password
-| {project-context}_server_url | string | URL of {project-context} instance
-| {project-context}_username | string | admin
-| {project-context}_validate_certs |boolean | Set to `true` if you wish to enable certificate checks in Ansible (default: true)
-| {project-context}_content_rhel_enable_rhel7 | boolean | Set to `true` if converting to {RHEL} 7
-| {project-context}_content_rhel_enable_rhel8 | boolean | Set to `true` if converting to {RHEL} 8
+| Name | Type | Default value and description | Example
+| {project-context}_rhel_wait_for_syncs | boolean | false | false
+| {project-context}_manifest_path | string | path to manifest | /root/manifest_Sat_20220623T124844Z.zip
+| {project-context}_organization | string | name of organization | Default Organization
+| {project-context}_password | string | your admin password | _My_Admin_Password_
+| {project-context}_server_url | string | {ProjectServer} URL | {foreman-example-com}
+| {project-context}_username | string | admin | admin
+| {project-context}_validate_certs | boolean | Set to `false` if you wish to disable certificate checks in Ansible | true
+| {project-context}_content_rhel_enable_rhel7 | boolean | Set to `true` if converting to {RHEL} 7 | false
+| {project-context}_content_rhel_enable_rhel8 | boolean | Set to `true` if converting to {RHEL} 8 | true
 |====
 
 If you want to use Convert2RHEL on Oracle Linux 7 or 8, create an additional variable depending on the conversion you intend:


### PR DESCRIPTION
In Managing Content guide, section 11.3.: Provided examples for variables that the user has to create. Removed duplicate information from the description of the `{project-context}_validate_certs` variable.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
