### PR TITLE
Make the use of SCA optional

### DIFF
--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -3,7 +3,7 @@
 
 = Attaching the {Project} Infrastructure Subscription
 
-NOTE: Skip this section if the Simple Content Access (SCA) is already in use.
+NOTE: Skip this section if you enabled the Simple Content Access (SCA) in the {Team} Customer Portal.
 
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName}, Red{nbsp}Hat Enterprise Linux, and Red{nbsp}Hat Software Collections (RHSCL) content.

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -3,6 +3,8 @@
 
 = Attaching the {Project} Infrastructure Subscription
 
+NOTE: Skip this section if the Simple Content Access (SCA) is already in use.
+
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName}, Red{nbsp}Hat Enterprise Linux, and Red{nbsp}Hat Software Collections (RHSCL) content.
 This is the only subscription required.


### PR DESCRIPTION
If Simple Content Access is used while registering the proxy server, the mentioned section becomes optional for end-users to consume. Earlier, due to this section, end-users could not install the project server because they used SCA which was not mandatory.

Now, it is noted to the end-users at the starting of the section to skip this section if they are already using SCA as it will automatically enable proxy to consume project subscriptions.

https://bugzilla.redhat.com/show_bug.cgi?id=2108541


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
