### PR TITLE
Fixes for the occurrences of {Project}

### DIFF
--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -28,6 +28,7 @@ Ensure this share provides the appropriate permissions to {ProjectServer} and it
 . You need to copy the existing contents of `/var/lib/pulp` to the NFS share.
 First, mount the NFS share to a temporary location:
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # mkdir /mnt/temp
 # mount -o rw nfs.example.com:/{Project}/pulp /mnt/temp
@@ -51,6 +52,7 @@ Copy the existing contents of `/var/lib/pulp` to the temporary location:
 ----
 . Edit the `/etc/fstab` file and add the following line:
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
 nfs.example.com:/{Project}/pulp    /var/lib/pulp   nfs    rw,hard,intr,context="system_u:object_r:pulpcore_var_lib_t:s0"
 ----
@@ -64,6 +66,7 @@ Ensure to include the SELinux context.
 ----
 . Confirm the NFS share mounts to `var/lib/pulp`:
 +
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # df
 Filesystem                         1K-blocks     Used Available Use% Mounted on


### PR DESCRIPTION
In Using an NFS Share for Content Storage of Managing Content 
Variable {Project} was not rendering correctly when used in codeblock. 
It was due to missing "attributes" label above the code block. 
Fixed by adding "attributes" label above the code block.

Module - proc_using-an-nfs-share-for-content-storage.adoc

https://bugzilla.redhat.com/show_bug.cgi?id=2123939


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
