### PR TITLE
Update remote address for remote proxies

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -190,11 +190,12 @@ You can use the xref:Adding_VMware_Images_to_Server_{context}[] section to add t
 If you deploy {Project} with the {SmartProxy} templates feature, you must configure {Project} to recognize hosts' IP addresses forwarded over the X-Forwarded-For HTTP header to serve correct template payload.
 
 For security reasons, {Project} recognizes this HTTP header only from localhost.
-For each individual {SmartProxy}, you must configure a regular expression to recognize hosts' IP addresses.
-From the {ProjectWebUI}, you can do this by navigating to *Administer* > *Settings* > *Provisioning*, and changing the *Remote address* setting.
-From the CLI, you can do this by entering the following command:
+For each individual {SmartProxy}, you must configure a setting to recognize hosts' IP addresses.
+To add an IP address (e.g. 192.0.2.10) or range (e.g. 192.0.2.0/24), use the following command:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer settings set --name remote_addr --value '(localhost(4|6|4to6)?|192.168.122.(1|2|3))'
+# {foreman-installer} --foreman-trusted-proxies 127.0.0.1/8 --foreman-trusted-proxies ::1 --foreman-trusted-proxies 192.0.2.10
 ----
+
+The localhost entries are required, do not omit them.


### PR DESCRIPTION
In Foreman 2.3.4 the remote address verification was tightened to [only trust certain proxies](https://projects.theforeman.org/issues/30779). Then in Foreman 3.2 the installer added [a flag to configure this](https://projects.theforeman.org/issues/34089).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.