### PR TITLE
Add container image tag filters

### DIFF
--- a/guides/common/modules/con_managing-content-views.adoc
+++ b/guides/common/modules/con_managing-content-views.adoc
@@ -3,7 +3,7 @@
 
 {ProjectName} uses Content Views to create customized repositories from the repositories.
 To do this, you must define which repositories to use and then apply certain filters to the content.
-These filters include both package filters, package group filters, errata filters, and module stream filters.
+These filters include package filters, package group filters, errata filters, module stream filters, and container image tag filters.
 You can use Content Views to define which software versions a particular environment uses.
 For example, a _Production_ environment might use a Content View containing older package versions, while a _Development_ environment might use a Content View containing newer package versions.
 


### PR DESCRIPTION
In Managing Content guide, section 8.: expanded list to include container image tag filters.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3