### PR TITLE
Add condition for Satellite specific step

### DIFF
--- a/guides/common/modules/proc_installing-openscap-plugin.adoc
+++ b/guides/common/modules/proc_installing-openscap-plugin.adoc
@@ -20,7 +20,7 @@ ifndef::satellite[]
 ----
 endif::[]
 
-. Install the OpenSCAP plug-in on any {SmartProxies}:
+. Install the OpenSCAP plug-in on any {SmartProxyServer}s:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-openscap-plugin.adoc
+++ b/guides/common/modules/proc_installing-openscap-plugin.adoc
@@ -9,21 +9,22 @@ The OpenSCAP plug-in consists of the main OpenSCAP plug-in itself, the OpenSCAP 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --enable-foreman-plugin-openscap
+# {foreman-installer} --enable-foreman-plugin-openscap --enable-foreman-proxy-plugin-openscap
 ----
-. Install the OpenSCAP plug-in on your {SmartProxies}:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --enable-foreman-proxy-plugin-openscap
-----
-+
-Perform this command on both your {ProjectServer} and any attached {SmartProxies}.
-. Optional: Install the OpenSCAP Hammer CLI plug-in:
+ifndef::satellite[]
+. Optional: Install the OpenSCAP Hammer CLI plug-in on your {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --enable-foreman-cli-openscap
+----
+endif::[]
+
+. Install the OpenSCAP plug-in on any {SmartProxies}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --enable-foreman-proxy-plugin-openscap
 ----
 . Install the OpenSCAP plug-in Puppet module:
 +


### PR DESCRIPTION
Hammer cli plugin is always available & enabled by default downstream. Steps are not required to enable it.
Added a condition for such one step in proc_installing-openscap-plugin.

https://bugzilla.redhat.com/show_bug.cgi?id=2125360


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
