### PR TITLE
Remove EL7 references for most recent project versions

### DIFF
--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -22,7 +22,7 @@ You must encrypt or move the backup to a secure location to minimize the risk of
 .Conventional Backup Methods
 You can also use conventional backup methods.
 ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/part-system_backup_and_recovery[System Backup and Recovery] in the _{RHEL}{nbsp}7 System Administrator's Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#assembly_recovering-and-restoring-a-system_configuring-basic-system-settings[Recovering and restoring a system] in the _{RHEL}{nbsp}8 Configuring Basic System Settings Guide_.
 endif::[]
 
 [NOTE]

--- a/guides/common/modules/con_scap-content.adoc
+++ b/guides/common/modules/con_scap-content.adoc
@@ -11,7 +11,7 @@ SCAP content consists of both rules and profiles.
 You can either create SCAP content or obtain it from a vendor.
 Supported profiles are provided for {RHEL} in the scap-security-guide package.
 ifndef::orcharhino[]
-The creation of SCAP content is outside the scope of this guide, but see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/security_guide/[{RHEL} 7 Security Guide] for information on how to download, deploy, modify, and create your own content.
+The creation of SCAP content is outside the scope of this guide, but see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/[{RHEL} 8 Security Hardening Guide] for information on how to download, deploy, modify, and create your own content.
 endif::[]
 
 The default SCAP content provided with the OpenSCAP components of {Project} depends on the version of {RHEL}.

--- a/guides/common/modules/con_security-content-automation-protocol.adoc
+++ b/guides/common/modules/con_security-content-automation-protocol.adoc
@@ -5,5 +5,5 @@
 For example, a security policy might specify that for hosts running {RHEL}, login via SSH is not permitted for the `root` account.
 With {Project}, you can schedule compliance auditing and reporting on all managed hosts.
 ifndef::orcharhino[]
-For more information about SCAP, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/security_guide/[{RHEL} 7 Security Guide].
+For more information about SCAP, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/[{RHEL} 8 Security Hardening Guide].
 endif::[]

--- a/guides/common/modules/con_ssh-key-management.adoc
+++ b/guides/common/modules/con_ssh-key-management.adoc
@@ -5,5 +5,5 @@ Adding SSH keys to a user allows deployment of SSH keys during provisioning.
 For information on deploying SSH keys during provisioning, see {ProvisioningDocURL}Deploying_SSH_Keys_During_Provisioning_provisioning[Deploying SSH Keys during Provisioning] in _{ProvisioningDocTitle}_.
 
 ifndef::orcharhino[]
-For information on SSH keys and SSH key creation, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-getting_started#sec-SSH[Using SSH-based Authentication] in the _{RHEL} 7 System Administrator's Guide_.
+For information on SSH keys and SSH key creation, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#setting-an-openssh-server-for-key-based-authentication_assembly_using-secure-communications-between-two-systems-with-openssh[Using SSH-based Authentication] in the _{RHEL} 8 Configuring Basic System Settings Guide_.
 endif::[]

--- a/guides/common/modules/con_using-freeipa.adoc
+++ b/guides/common/modules/con_using-freeipa.adoc
@@ -15,5 +15,5 @@ For more information, see xref:Using_LDAP_{context}[].
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
 ifndef::orcharhino[]
-However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/index#ldi-install[{RHEL} 7 Linux Domain Identity, Authentication, and Policy Guide].
+However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/installing_identity_management/index[{RHEL} 8 Installing Identity Management Guide].
 endif::[]

--- a/guides/common/modules/con_using-ldap.adoc
+++ b/guides/common/modules/con_using-ldap.adoc
@@ -13,5 +13,5 @@ SSSD improves the consistency of the authentication process.
 For more information about the preferred configurations, see xref:Using_Active_Directory_{context}[].
 You can also cache the SSSD credentials and use them for LDAP authentication.
 ifndef::orcharhino[]
-For more information on SSSD, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/sssd[Configuring SSSD] in the _{RHEL} 7 System-Level Authentication Guide_.
+For more information on SSSD, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_authentication_and_authorization_in_rhel/index#configuring-SSSD-to-use-LDAP-and-require-TLS-authentication_configuring-authentication-and-authorization-in-rhel[Configuring SSSD] in the _{RHEL} 8 Configuring Authentication and Authorization in RHEL Guide_.
 endif::[]

--- a/guides/common/modules/proc_configuring-host-based-authentication-control.adoc
+++ b/guides/common/modules/proc_configuring-host-based-authentication-control.adoc
@@ -5,7 +5,7 @@ HBAC rules define which machine within the domain a {FreeIPA} user is allowed to
 You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing {ProjectServer}.
 With this approach, you can prevent {Project} from creating database entries for users that are not allowed to log in.
 ifndef::orcharhino[]
-For more information on HBAC, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/configuring-host-access[Configuring Host-Based Access Control] in the _{RHEL} 7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on HBAC, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/managing_idm_users_groups_hosts_and_access_control_rules/index#host-based-access-control-rules-in-idm_ensuring-the-presence-of[Managing IdM Users, Groups, Hosts, and Access Control Rules Guide].
 endif::[]
 
 On the {FreeIPA} server, configure Host-Based Authentication Control (HBAC).

--- a/guides/common/modules/proc_configuring-logging-to-journal.adoc
+++ b/guides/common/modules/proc_configuring-logging-to-journal.adoc
@@ -6,7 +6,7 @@ Journal then forwards log messages to `rsyslog` and `rsyslog` writes the log mes
 Note that after this change the log messages do not appear in `/var/log/foreman/production.log` or `/var/log/foreman-proxy.log` any more.
 
 ifdef::satellite[]
-For more information about Journal, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-viewing_and_managing_log_files#s1-Using_the_Journal[Using the Journal] in the _{RHEL} 7 System Administrator's guide_.
+For more information about Journal, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#viewing-logs-using-the-command-line_assembly_troubleshooting-problems-using-log-files[Viewing logs using the command line] in the _{RHEL} 8 Configuring Basic System Settings Guide_.
 endif::[]
 ifndef::satellite,orcharhino[]
 For more information about Journal, see https://github.com/lzap/foreman-elasticsearch[].

--- a/guides/common/modules/proc_recovering-from-a-full-disk.adoc
+++ b/guides/common/modules/proc_recovering-from-a-full-disk.adoc
@@ -21,7 +21,7 @@ See the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/
 endif::[]
 .. Grow the file system on the LV with the `/var/lib/pulp` directory on it.
 ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/logical_volume_manager_administration/fsgrow_overview[Growing a File System on a Logical Volume] in the _{RHEL} 7 Logical Volume Manager Administration Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_logical_volumes/index#growing-a-logical-volume-and-file-system_modifying-the-size-of-a-logical-volume[Growing a logical volume and file system] in the _{RHEL} 8 Configuring and Managing Logical Volumes Guide_.
 endif::[]
 +
 [NOTE]


### PR DESCRIPTION
The recent project version does not support RHEL7 as the base OS. Replaced links in the Administering Project doc that point to the RHEL7 guides, to point to the corresponding RHEL8 guides.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
