### PR TITLE
Mention a condition for gold images for GCE hosts

### DIFF
--- a/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
@@ -6,7 +6,9 @@
 :CRname: Google Compute Engine
 
 {ProjectName} can interact with Google Compute Engine (GCE), including creating new virtual machines and controlling their power management states.
-Only image-based provisioning is supported for creating GCE hosts.
+ifdef::satellite[]
+You can only use golden images supported by {Team} with {Project} for creating GCE hosts.
+endif::[]
 
 .Prerequisites
 include::snip_common-compute-resource-prereqs.adoc[]


### PR DESCRIPTION
While troubleshooting a project case on provisioning to the Google Cloud, we've discovered that the only Google Cloud images that are visible to the project are Team-supported gold images. Neither customer-created nor other third-party Google Cloud images are accessible from Project. So, we have asked end-users to consider only images with Project through the Google Cloud that are supported by team.

https://bugzilla.redhat.com/show_bug.cgi?id=2106854


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
