### PR TITLE
Mention a condition for gold images for GCE hosts

### DIFF
--- a/guides/common/assembly_provisioning-cloud-instances-gce.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-gce.adoc
@@ -8,7 +8,9 @@ ifdef::context[:parent-context: {context}]
 :CRname: Google Compute Engine
 
 {ProjectName} can interact with Google Compute Engine (GCE), including creating new virtual machines and controlling their power management states.
-Only image-based provisioning is supported for creating GCE hosts.
+ifdef::satellite[]
+You can only use golden images supported by {Team} with {Project} for creating GCE hosts.
+endif::[]
 
 ifdef::orcharhino[]
 Refer to the xref:sources/compute_resources/gce.adoc[Google GCE] guide for more information.


### PR DESCRIPTION
While troubleshooting a project case on provisioning to the Google Cloud, we've discovered that the only Google Cloud images that are visible to the project are Team-supported gold images. Neither customer-created nor other third-party Google Cloud images are accessible from Project. So, we have asked end-users to consider only images with Project through the Google Cloud that are supported by team.

https://bugzilla.redhat.com/show_bug.cgi?id=2106854


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
