### PR TITLE
Add a case in Remote Execution Workflow

### DIFF
--- a/guides/common/modules/con_remote-execution-workflow.adoc
+++ b/guides/common/modules/con_remote-execution-workflow.adoc
@@ -16,9 +16,16 @@ endif::[]
 . {Project} finds remote execution {SmartProxies} assigned to these subnets.
 . From this set of {SmartProxies}, {Project} selects the {SmartProxy} that has the least number of running jobs.
 By doing this, {Project} ensures that the jobs load is balanced between remote execution {SmartProxies}.
-. If {Project} does not find a remote execution {SmartProxy} at this stage, and if the *Fallback to Any {SmartProxy}* setting is enabled, {Project} adds another set of {SmartProxies} to select the remote execution {SmartProxy} from.
+
+If you have enabled *remote_execution_prefer_registered_through_proxy*, {Project} runs the REX job using the {SmartProxy} the host is registered to.
+
+By default, *remote_execution_prefer_registered_through_proxy* is set to *No*.
+To enable it, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and on the *Content* tab, set `remote_execution_prefer_registered_through_proxy` to *Yes*.
+This ensures that {Project} performs REX jobs on hosts by the {SmartProxy} to which they are registered to.
+
+If {Project} does not find a remote execution {SmartProxy} at this stage, and if the *Fallback to Any {SmartProxy}* setting is enabled, {Project} adds another set of {SmartProxies} to select the remote execution {SmartProxy} from.
 {Project} selects the most lightly loaded {SmartProxy} from the following types of {SmartProxies} that are assigned to the host:
-+
+
 * DHCP, DNS and TFTP {SmartProxies} assigned to the host's subnets
 * DNS {SmartProxy} assigned to the host's domain
 * Realm {SmartProxy} assigned to the host's realm
@@ -26,5 +33,4 @@ By doing this, {Project} ensures that the jobs load is balanced between remote e
 * Puppet CA {SmartProxy}
 * OpenSCAP {SmartProxy}
 
-+
-. If {Project} does not find a remote execution {SmartProxy} at this stage, and if the *Enable Global {SmartProxy}* setting is enabled, {Project} selects the most lightly loaded remote execution {SmartProxy} from the set of all {SmartProxies} in the host's organization and location to execute a remote job.
+If {Project} does not find a remote execution {SmartProxy} at this stage, and if the *Enable Global {SmartProxy}* setting is enabled, {Project} selects the most lightly loaded remote execution {SmartProxy} from the set of all {SmartProxies} in the host's organization and location to execute a remote job.


### PR DESCRIPTION
We mention how project searches for the remote execution proxy of a host and we cover all the points except one i.e. the "Prefer registered through proxy for remote execution" settings. Hence, we are adding a case where project prefers to execute remote workflow that are registered through proxies. From all the other processes that are mentioned in this section, this is the preferable way and it is the reason why we kept it in the starting of section.

Document the function of "Prefer registered through proxy for remote execution" option in "Remote Execution Workflow" section

https://bugzilla.redhat.com/show_bug.cgi?id=2123976


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
