### PR TITLE
Add a Host name to proxy whitelist

### DIFF
--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -11,8 +11,9 @@ Verify that {Project} can connect to the Red{nbsp}Hat CDN and can synchronize it
 |====
 | Host name | Port | Protocol
 | subscription.rhsm.redhat.com | 443 | HTTPS
-| cdn.redhat.com |  443 | HTTPS
+| cdn.redhat.com | 443 | HTTPS
 | *.akamaiedge.net |  443 | HTTPS
+| cert.cloud.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
 |====


### PR DESCRIPTION
When Project forwards information to insights, the added hostname also becomes part of the process. Hence, it became necessary to add this Host name along with its Port and Protocol to the proxy whitelist table. It is part of configuring the HTTP Proxy to connect to the CDN.

https://bugzilla.redhat.com/show_bug.cgi?id=1804313


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
