### PR TITLE
Mention required version of ruby, pgsql for EL8

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -10,6 +10,24 @@ Select the option that corresponds with operating system and version you want to
 
 == [[repositories-rhel-8]]{RHEL} 8
 
+For configuring repositories in {EL} 8, you must enable `ruby:2.7` and `postgresql:12`.
+
+. Verify the module versions:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module list --enabled
+----
++
+If the version of modules is incompatible:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module reset ruby
+# dnf module reset postgresql
+----
++
+
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -32,14 +50,11 @@ Select the option that corresponds with operating system and version you want to
 +
 [options="nowrap"]
 ----
-# dnf module enable satellite-capsule:el8
+# dnf module enable satellite-capsule:el8 postgresql:12 ruby:2.7
 ----
 +
 [NOTE]
 ====
-Enablement of the module `satellite-capsule:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
-The module `satellite-capsule:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite-capsule:el8` module.
-These warnings do not cause installation process failure, hence can be ignored safely.
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -92,6 +92,24 @@ ifdef::foreman-el,katello,satellite[]
 :distribution-major-version: 8
 :package-manager: dnf
 
+For configuring repositories in {EL} 8, you must enable `ruby:2.7` and `postgresql:12`.
+
+. Verify the module versions:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module list --enabled
+----
++
+If the version of modules is incompatible:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module reset ruby
+# dnf module reset postgresql
+----
++
+
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -138,14 +156,11 @@ ifdef::katello[]
 endif::[]
 ifdef::satellite[]
 ----
-# dnf module enable satellite:el8
+# dnf module enable satellite:el8 postgresql:12 ruby:2.7
 ----
 +
 [NOTE]
 ====
-Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
-The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module.
-These warnings do not cause installation process failure, hence can be ignored safely.
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 endif::[]


### PR DESCRIPTION
The project needs ruby:2.7 and postgresql:12 modules to work\get installed. If end-users proceed with enabling the present el8 module in installing project and proxy, it will pop-up a huge warning related to conflict with ruby:2.5 and postgresql:10 modules. In the end, the command does enable the ruby:2.7 and postgresql:12 but the list of warnings itself is not a healthy status of the output and this occurence should be prevented. However, in the document, these warnings are mentioned as expected and can be ignored but it should not be the standard practice of user experience. Hence, this warning can be easily avoided by enabling the required dependant modules and the actual module.

https://bugzilla.redhat.com/show_bug.cgi?id=2126884


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
