### PR TITLE
Define templates in context

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -9,7 +9,7 @@ For more information, see {InstallingServerDocURL}Preparing_your_Environment_for
 ifdef::katello,orcharhino,satellite[]
 * Ensure that you do not delete the manifest from the Customer Portal or in the {ProjectWebUI} because this removes all the entitlements of your content hosts.
 endif::[]
-* If you have edited any of the default templates, back up the files either by cloning or exporting them.
+* If you have edited any of the default job or provisioning templates, back up the files either by cloning or exporting them.
 Cloning is the recommended method because that prevents them being overwritten in future updates or upgrades.
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.


### PR DESCRIPTION
In one section, DDF requested to know what templates were being referred to specifically. SME stated it covers job and provisioning templates. This change was required to help clarify the templates being referred to in the section mentioning templates. This is the same change as PR #1645 but for the 3.3 branch.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
