### PR TITLE
Synchronize smartproxy servers through web ui

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -74,6 +74,7 @@
 :ProjectX: Satellite{nbsp}6
 :ProjectXY: Satellite{nbsp}{ProductVersionRepoTitle}
 :ProjectWebUI: {Project} web UI
+:ProjectWebUITitle: {Project} Web UI
 :provision-script: kickstart
 :smart-proxy-context: capsule
 :smart-proxy-installation-guide-title: Installing Capsule Server

--- a/guides/common/modules/proc_synchronizing-smartproxy-servers-through-project-web-ui.adoc
+++ b/guides/common/modules/proc_synchronizing-smartproxy-servers-through-project-web-ui.adoc
@@ -1,0 +1,10 @@
+[id="synchronizing-{smart-proxy-context}-servers-through-{project-context}-web-ui_{context}"]
+= Synchronizing {SmartProxyServer}s Through {ProjectWebUITitle}
+
+Use this procedure if you did not synchronize your repositories before upgrading your {ProjectServer}.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
+. Click on the name of {SmartProxyServer} you wish to synchronize.
+. Click *Synchronize*.
+. Select *Complete Sync*.

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -51,6 +51,9 @@ endif::[]
 // Upgrading Capsule Server
 include::topics/upgrading_capsule_server.adoc[leveloffset=+2]
 
+// Synchronizing SmartProxy Servers Through Project Web UI
+include::common/modules/proc_synchronizing-smartproxy-servers-through-project-web-ui.adoc[leveloffset=+2]
+
 // Upgrading Satellite Clients
 include::topics/upgrading_clients.adoc[leveloffset=+2]
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -171,6 +171,12 @@ This removes Pulp 2 RPMs, content in `/var/lib/pulp/content/`, the mongo databas
 ----
 # hammer capsule content synchronize --name ${{SmartProxy}} --skip-metadata-check true --async
 ----
++
+[NOTE]
+====
+If you did not synchronize your repositories before upgrading your {ProjectServer}, running this command fails to synchronize your content with {SmartProxyServer}s.
+In this case, follow xref:synchronizing-{smart-proxy-context}-servers-through-{project-context}-web-ui_{context}[] to synchronize your {SmartProxyServer}s.
+====
 
 .Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI}
 


### PR DESCRIPTION
If users skip the pre-migration steps and opt to sync their repositories after upgrading their Project server, running this command fails to synchronize their content with their capsule servers:
```
# hammer capsule content synchronize --name ${Capsule} --async
```
Users are able to sync this content with a full capsule sync in the project web UI. This is for Foreman 2.5 (Satellite 6.10) only.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.