### PR TITLE
Modify the value of acronym ISS

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -53,6 +53,7 @@
 :foreman-maintain: foreman-maintain
 :FreeIPA: FreeIPA
 :installer-log-file: /var/log/foreman-installer/foreman.log
+:ISS: Inter-Server Synchronization
 :Keycloak-short: Keycloak
 :Keycloak: Keycloak
 :KubeVirt: KubeVirt

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -52,6 +52,7 @@
 :installer-scenario-smartproxy: satellite-installer --scenario capsule
 :installer-scenario: satellite-installer --scenario satellite
 :installer-smartproxy-log-file: /var/log/foreman-installer/capsule.log
+:ISS: Inter-Satellite Synchronization
 :Keycloak-short: RHSSO
 :Keycloak: Red{nbsp}Hat Single Sign-On
 :KubeVirt: Container-native Virtualization

--- a/guides/common/modules/con_how-to-configure-inter-server-sync.adoc
+++ b/guides/common/modules/con_how-to-configure-inter-server-sync.adoc
@@ -1,7 +1,7 @@
 [id="how-to-configure-inter-server-sync_{context}"]
-= How to Configure Inter-Satellite Synchronization
+= How to Configure {ISS} of {Project}
 
-{ProjectName} uses Inter-Satellite Synchronization (ISS) to synchronize content between two {ProjectServer}s in a multi-server {Project} setup.
+{ProjectName} uses {Project}'s {ISS} (ISS) to synchronize content between two {ProjectServer}s including those that are air-gapped.
 
 You can use ISS in cases such as:
 

--- a/guides/common/modules/con_how-to-configure-inter-server-sync.adoc
+++ b/guides/common/modules/con_how-to-configure-inter-server-sync.adoc
@@ -1,7 +1,7 @@
 [id="how-to-configure-inter-server-sync_{context}"]
-= How to Configure Inter-Server Synchronization
+= How to Configure Inter-Satellite Synchronization
 
-{ProjectName} uses Inter-Server Synchronization (ISS) to synchronize content between two {ProjectServer}s in a multi-server {Project} setup.
+{ProjectName} uses Inter-Satellite Synchronization (ISS) to synchronize content between two {ProjectServer}s in a multi-server {Project} setup.
 
 You can use ISS in cases such as:
 

--- a/guides/common/modules/con_how-to-configure-inter-server-sync.adoc
+++ b/guides/common/modules/con_how-to-configure-inter-server-sync.adoc
@@ -1,7 +1,7 @@
 [id="how-to-configure-inter-server-sync_{context}"]
-= How to Configure {ISS} of {Project}
+= How to Configure {ISS}
 
-{ProjectName} uses {Project}'s {ISS} (ISS) to synchronize content between two {ProjectServer}s including those that are air-gapped.
+{ProjectName} uses {ISS} (ISS) to synchronize content between two {ProjectServer}s including those that are air-gapped.
 
 You can use ISS in cases such as:
 

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -1,7 +1,7 @@
 [id="Synchronizing_Content_Between_Servers_{context}"]
 = Synchronizing Content Between {ProjectServerTitle}s
 
-In a {Project} setup with multiple {ProjectServer}s, you can use Inter-Server Synchronization (ISS) to synchronize content from one upstream server to one or more downstream servers.
+In a {Project} setup with multiple {ProjectServer}s, you can use Inter-Satellite Synchronization (ISS) to synchronize content from one upstream server to one or more downstream servers.
 
 ifndef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure:
@@ -25,5 +25,5 @@ endif::[]
 ifdef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure.
 Configure your {Project} for ISS as appropriate for your use case scenario.
-For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure Inter-Server Synchronization] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure Inter-Satellite Synchronization] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -1,7 +1,7 @@
 [id="Synchronizing_Content_Between_Servers_{context}"]
 = Synchronizing Content Between {ProjectServerTitle}s
 
-In a {Project} setup with multiple {ProjectServer}s, you can use {Project}'s {ISS} (ISS) to synchronize content from one upstream server to one or more downstream servers.
+In a {Project} setup with multiple {ProjectServer}s, you can use {ISS} (ISS) to synchronize content from one upstream server to one or more downstream servers.
 
 ifndef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure:
@@ -25,5 +25,5 @@ endif::[]
 ifdef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure.
 Configure your {Project} for ISS as appropriate for your use case scenario.
-For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure {Project}'s {ISS}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure {ISS}] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -1,7 +1,7 @@
 [id="Synchronizing_Content_Between_Servers_{context}"]
 = Synchronizing Content Between {ProjectServerTitle}s
 
-In a {Project} setup with multiple {ProjectServer}s, you can use Inter-Satellite Synchronization (ISS) to synchronize content from one upstream server to one or more downstream servers.
+In a {Project} setup with multiple {ProjectServer}s, you can use {Project}'s {ISS} (ISS) to synchronize content from one upstream server to one or more downstream servers.
 
 ifndef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure:
@@ -25,5 +25,5 @@ endif::[]
 ifdef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure.
 Configure your {Project} for ISS as appropriate for your use case scenario.
-For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure Inter-Satellite Synchronization] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure {Project}'s {ISS}] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -61,7 +61,7 @@ include::common/modules/proc_importing-content-isos-into-a-connected-foreman.ado
 endif::[]
 ifndef::satellite[]
 [appendix]
-== Configuring Inter-Server Synchronization in {Project}
+== Configuring Inter-Satellite Synchronization in {Project}
 
 include::common/modules/con_how-to-configure-inter-server-sync.adoc[leveloffset=+2]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -61,7 +61,7 @@ include::common/modules/proc_importing-content-isos-into-a-connected-foreman.ado
 endif::[]
 ifndef::satellite[]
 [appendix]
-== Configuring Inter-Satellite Synchronization in {Project}
+== Configuring {ISS} (ISS) in {Project}
 
 include::common/modules/con_how-to-configure-inter-server-sync.adoc[leveloffset=+2]
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -109,7 +109,7 @@ In such case, {SmartProxies} have to integrate with those external services (see
 
 ifdef::satellite[]
 * *Is my {ProjectServer} required to be disconnected from the Internet?* – Disconnected {Project} is a common deployment scenario (see xref:sect-Architecture_Guide-Disconnected_Satellite[]).
-If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for Inter-Server synchronization.
+If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for Inter-Satellite synchronization.
 endif::[]
 
 * *What compute resources do I need for my hosts?* – Apart from provisioning bare metal hosts, you can use various compute resources supported by {Project}.

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -109,7 +109,7 @@ In such case, {SmartProxies} have to integrate with those external services (see
 
 ifdef::satellite[]
 * *Is my {ProjectServer} required to be disconnected from the Internet?* – Disconnected {Project} is a common deployment scenario (see xref:sect-Architecture_Guide-Disconnected_Satellite[]).
-If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for Inter-Satellite synchronization.
+If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for {ISS} of {Project}.
 endif::[]
 
 * *What compute resources do I need for my hosts?* – Apart from provisioning bare metal hosts, you can use various compute resources supported by {Project}.

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -109,7 +109,7 @@ In such case, {SmartProxies} have to integrate with those external services (see
 
 ifdef::satellite[]
 * *Is my {ProjectServer} required to be disconnected from the Internet?* – Disconnected {Project} is a common deployment scenario (see xref:sect-Architecture_Guide-Disconnected_Satellite[]).
-If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for {ISS} of {Project}.
+If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for {ISS}.
 endif::[]
 
 * *What compute resources do I need for my hosts?* – Apart from provisioning bare metal hosts, you can use various compute resources supported by {Project}.

--- a/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
@@ -46,9 +46,9 @@ To see the products in your subscription for which content ISO images are availa
 For instructions on how to import content ISOs to a disconnected {Project}, see {ContentManagementDocURL}Configuring_Server_to_Synchronize_Content_with_a_Local_CDN_Server_content-management[Configuring {Project} to Synchronize Content with a Local CDN Server] in _{ContentManagementDocTitle}_.
 Note that Content ISOs previously hosted at redhat.com for import into {ProjectServer} have been deprecated and will be removed in the next {Project} version.
 
-* *Disconnected {Project} with Inter-Server Synchronization* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
+* *Disconnected {Project} with Inter-Satellite Synchronization* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
 This allows for exporting both Red{nbsp}Hat provided and custom content at the frequency you choose, but requires deploying an additional server with a separate subscription.
-For instructions on how to configure Inter-Server synchronization, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in _{ContentManagementDocTitle}_.
+For instructions on how to configure Inter-Satellite synchronization, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in _{ContentManagementDocTitle}_.
 
 The above methods for importing content to a disconnected {ProjectServer} can also be used to speed up the initial population of a connected {Project}.
 endif::[]

--- a/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
@@ -46,9 +46,9 @@ To see the products in your subscription for which content ISO images are availa
 For instructions on how to import content ISOs to a disconnected {Project}, see {ContentManagementDocURL}Configuring_Server_to_Synchronize_Content_with_a_Local_CDN_Server_content-management[Configuring {Project} to Synchronize Content with a Local CDN Server] in _{ContentManagementDocTitle}_.
 Note that Content ISOs previously hosted at redhat.com for import into {ProjectServer} have been deprecated and will be removed in the next {Project} version.
 
-* *Disconnected {Project} with Inter-Satellite Synchronization* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
+* *Disconnected {Project} with {ISS}* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
 This allows for exporting both Red{nbsp}Hat provided and custom content at the frequency you choose, but requires deploying an additional server with a separate subscription.
-For instructions on how to configure Inter-Satellite synchronization, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in _{ContentManagementDocTitle}_.
+For instructions on how to configure {ISS} in {Project}, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in _{ContentManagementDocTitle}_.
 
 The above methods for importing content to a disconnected {ProjectServer} can also be used to speed up the initial population of a connected {Project}.
 endif::[]


### PR DESCRIPTION
The full-form of ISS was written incorrectly as Inter-Server Synchronization. This is now renamed correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=2129148


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
