### PR TITLE
Modify the value of acronym ISS

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -52,6 +52,7 @@
 :foreman-maintain: foreman-maintain
 :FreeIPA: FreeIPA
 :installer-log-file: /var/log/foreman-installer/foreman.log
+:ISS: Inter-Server Synchronization
 :Keycloak-short: Keycloak
 :Keycloak: Keycloak
 :KubeVirt: KubeVirt

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -44,6 +44,7 @@
 :installer-log-file: /var/log/foreman-installer/satellite.log
 :installer-scenario-smartproxy: satellite-installer --scenario capsule
 :installer-scenario: satellite-installer --scenario satellite
+:ISS: Inter-Satellite Synchronization
 :Keycloak-short: RHSSO
 :Keycloak: Red{nbsp}Hat Single Sign-On
 :KubeVirt: Container-native Virtualization

--- a/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Using_ISS.adoc
@@ -1,7 +1,7 @@
 [[Using_ISS]]
 == Synchronizing Content Between {ProjectServer}s
 
-{ProjectName} uses {Project}'s Inter-Server Synchronization (ISS) to synchronize content between two {ProjectServer}s including those that are air-gapped.
+{ProjectName} uses {ISS} (ISS) to synchronize content between two {ProjectServer}s including those that are air-gapped.
 
 {Project} {ProjectVersion} and {ProjectVersionPrevious} (and below) are incompatible for export and import due to different Pulp versions.
 You must be running the same version of {Project} on both servers to use this feature.

--- a/guides/doc-Planning_Guide/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_Guide/topics/Deployment_Scenarios.adoc
@@ -46,9 +46,9 @@ To see the products in your subscription for which content ISO images are availa
 For instructions on how to import content ISOs to a disconnected {Project}, see {ContentManagementDocURL}configuring-satellite-to-synchronize-content-with-a-local-cdn-server_content-management[Configuring {Project} to Synchronize Content with a Local CDN Server] in the _Content Management Guide_.
 Note that Content ISOs previously hosted at redhat.com for import into {ProjectServer} have been deprecated and will be removed in the next {Project} version.
 
-* *Disconnected {Project} with {Project}'s Inter-Server Synchronization* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
+* *Disconnected {Project} with {ISS}* – in this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using some storage device.
 This allows for exporting both Red{nbsp}Hat provided and custom content at the frequency you choose, but requires deploying an additional server with a separate subscription.
-For instructions on how to configure Inter-Server synchronization, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in the _Content Management Guide_.
+For instructions on how to configure {ISS}, see {ContentManagementDocURL}Using_ISS[Synchronizing Content Between {ProjectServer}s] in the _Content Management Guide_.
 
 The above methods for importing content to a disconnected {ProjectServer} can also be used to speed up the initial population of a connected {Project}.
 endif::[]


### PR DESCRIPTION
The full-form of ISS was written incorrectly as Inter-Server Synchronization. This is now renamed correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=2129148


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
