### PR TITLE
Warn users about setting other Unicode

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -41,6 +41,9 @@ endif::[]
 * A system umask of 0022
 * Full forward and reverse DNS resolution using a fully-qualified domain name
 
+{Project} only supports `UTF-8` encoding.
+If your territory is USA and your language is English, set `en_US.utf-8` as the system-wide locale settings.
+For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring System Locale guide].
 Before you install {ProductName}, ensure that your environment meets the requirements for installation.
 
 {ProductName} must be installed on a freshly provisioned system that serves no other function except to run {ProductName}.


### PR DESCRIPTION
The project only supports the UTF-8 encoding system. However, there are some users who set another encoding method in their system and as a result, they face issues in the installation process. Hence, we are asking users to set UTF-8 as an encoding method mandatorily before installing Project.

https://bugzilla.redhat.com/show_bug.cgi?id=2127567

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
