### PR TITLE
PR with EL7 instructions - replica of PR#1650

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -111,8 +111,8 @@
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
 :RepoRHEL9ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-9-<arch>-rpms
-:RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-6.11-rpms
-:RepoRHEL8ServerSatelliteUtils: satellite-utils-6.11-for-rhel-8-x86_64-rpms
+:RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
+:RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -111,6 +111,8 @@
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
 :RepoRHEL9ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-9-<arch>-rpms
+:RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-6.11-rpms
+:RepoRHEL8ServerSatelliteUtils: satellite-utils-6.11-for-rhel-8-x86_64-rpms
 
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}

--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -12,13 +12,14 @@ To create a file type repository in a directory on a remote server, see xref:Cre
 
 To create a file type repository in a local directory, complete the following procedure:
 
-. Ensure the Server and {project-client-name} repositories are enabled.
 ifdef::satellite[]
+. Ensure the Utils repository is enabled.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable={project-client-RHEL7-url}
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteUtils}
 ----
 endif::[]
 . Install the Pulp Manifest package:
@@ -27,6 +28,18 @@ endif::[]
 ----
 # {package-install-project} python3-pulp_manifest
 ----
+ifdef::satellite[]
++
+Note that this command stops the {Project} service and re-runs {foreman-installer}.
+Alternatively, to prevent downtime caused by stopping the service, you can use the following:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages unlock
+# {package-install} python3-pulp_manifest
+# {foreman-maintain} packages lock
+----
+endif::[]
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -48,13 +48,13 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} python3-pulp_manifest
+# dnf install python3-pulp_manifest
 ----
 ** For {EL} 7:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} tfm-pulpcore-python3-pulp_manifest
+# yum tfm-pulpcore-python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -25,20 +25,36 @@ endif::[]
 
 To create a file type repository in a remote directory, complete the following procedure:
 
-. On your remote server, ensure that the Server and {project-client-name} repositories are enabled.
 ifdef::satellite[]
+. On your machine, ensure that the right repositories are enabled.
+** For {EL} 8:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteUtils}
+----
+** For {EL} 7:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable={project-client-RHEL7-url}
+--enable={RepoRHEL7ServerSatelliteUtils}
 ----
 endif::[]
 . Install the Pulp Manifest package:
+** For {EL} 8:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum install python3-pulp_manifest
+# {package-install-project} python3-pulp_manifest
+----
+** For {EL} 7:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} tfm-pulpcore-python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +


### PR DESCRIPTION
This PR is specifically created for Foreman 3.1 and 3.3. This PR is a replica of PR #1650 created to keep EL7 instructions. Steps updated for creating a local/remote file repository. The tool will be provided by utils repo (not client). Hence steps are now splited for RHEL 8 and 7.
Added 2 new variables for downstream docs in attribute-satellite. Also, Pulp Manifest package name is different for RHEL 7 and 8.

https://bugzilla.redhat.com/show_bug.cgi?id=2123940


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
