### PR TITLE
Add missing endif

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -116,3 +116,4 @@ For more information about FIPS on {RHEL} 7 systems, see https://access.redhat.c
 The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
 ====
 endif::[]
+endif::[]


### PR DESCRIPTION
Without this the whole Installing an External Smart Proxy Server on Debian/Ubuntu fails to render.

Fixes: b9437c01aa8bd93ebe56ab8321abbc87f8bb1cbf

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.