### PR TITLE
Add a missing setting in the example settings for AD table

### DIFF
--- a/guides/common/modules/ref_example-settings-for-ldap-connections.adoc
+++ b/guides/common/modules/ref_example-settings-for-ldap-connections.adoc
@@ -22,6 +22,7 @@ dc=example,dc=com
 | First name attribute | givenName | givenName | givenName
 | Last name attribute | sn | sn | sn
 | Email address attribute | mail | mail | mail
+| Photo attribute | thumbnailPhoto | - | - 
 |====
 
 [NOTE]


### PR DESCRIPTION
Adding the missing "Photo attribute" to the example settings for active directory table. Currently, we see jpegPhoto as a hint on the LDAP auth page, but this does not work, as the attribute should be thumbnailPhoto.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
