### PR TITLE
Fix "REX pull mode" step placement (Registering Hosts)

### DIFF
--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -91,21 +91,6 @@ If set to `Yes`, public SSH keys will be installed on the registered host.
 The inherited value is based on the `host_registration_remote_execution` parameter.
 It can be inherited, for example from a host group, an operating system, or an organization.
 When overridden, the selected value will be stored on host parameter level.
-. From the *REX pull mode* list, select whether you want to deploy {Project} remote execution pull client.
-+
-If set to `Yes`, the remote execution pull client is installed on the registered host.
-The inherited value is based on the `host_registration_remote_execution_pull` parameter.
-It can be inherited, for example from a host group, an operating system, or an organization.
-When overridden, the selected value is stored on the host parameter level.
-+
-The registered host must have access to the {Team} {project-client-name} repository.
-+
-ifdef::managing-hosts[]
-For more information about the pull mode, see xref:transport-modes-for-remote-execution_{context}[].
-endif::[]
-ifndef::managing-hosts[]
-For more information about the pull mode, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.
-endif::[]
 . From the *Setup Insights* list, select whether you want to install `insights-client` and register the hosts to Insights.
 +
 The Insights tool is available for {RHEL} only.
@@ -141,7 +126,21 @@ Therefore, do not delete, block, or change permissions of the user during the to
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
 . Optional: In the *Remote Execution Interface* field, enter the identifier of a network interface that hosts must use for the SSH connection.
 If you keep this field blank, {Project} uses the default network interface.
-
+. From the *REX pull mode* list, select whether you want to deploy {Project} remote execution pull client.
++
+If set to `Yes`, the remote execution pull client is installed on the registered host.
+The inherited value is based on the `host_registration_remote_execution_pull` parameter.
+It can be inherited, for example from a host group, an operating system, or an organization.
+When overridden, the selected value is stored on the host parameter level.
++
+The registered host must have access to the {Team} {project-client-name} repository.
++
+ifdef::managing-hosts[]
+For more information about the pull mode, see xref:transport-modes-for-remote-execution_{context}[].
+endif::[]
+ifndef::managing-hosts[]
+For more information about the pull mode, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.
+endif::[]
 ifdef::satellite,orcharhino[]
 . In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
 . Optional: Select the *Lifecycle environment*.


### PR DESCRIPTION
I noticed too late that the step is misplaced :)) Should it be optional as well?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (already fixed)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
