### PR TITLE
Add command in Proxy certificate renewal

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -35,45 +35,41 @@ If you set a wildcard value `*` for the certificate's Common Name `CN =` in the 
 If the command is successful, it returns two `{certs-generate}` commands, one of which you must use to generate the certificate archive file for your {SmartProxyServer}.
 ifdef::satellite[]
 +
-.Example output of `katello-certs-check`
+.To use the certificates inside a _new-{smartproxy-example-com}_, run this command:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-Validation succeeded.
-
-To use them inside a NEW $CAPSULE, run this command:
-
 capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
     --certs-tar  "~/$CAPSULE-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
-
-To use them inside an EXISTING $CAPSULE, run this command INSTEAD:
-
+----
++
+.To use the certificates inside an _existing-{smartproxy-example-com}_, run this command instead:
+----
   capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
     --certs-tar "~/$CAPSULE-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
-    --certs-update-server
+    --certs-update-all
 ----
 endif::[]
 
 ifndef::satellite[]
 +
-.Example output of `katello-certs-check`
+.To use the certificates inside a new $FOREMAN_PROXY, run this command:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-Validation succeeded.
-
-To use them inside a NEW $FOREMAN_PROXY, run this command:
   foreman-proxy-certs-generate --foreman-proxy-fqdn "$FOREMAN_PROXY" \
-    --certs-tar  "~$FOREMAN_PROXY-certs.tar" \
+    --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
-
-To use them inside an EXISTING $FOREMAN_PROXY, run this command INSTEAD:
+----
++
+.To use the certificates inside an existing $FOREMAN_PROXY, run this command instead:
+----
   foreman-proxy-certs-generate --foreman-proxy-fqdn "\$FOREMAN_PROXY" \
     --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
@@ -83,7 +79,10 @@ To use them inside an EXISTING $FOREMAN_PROXY, run this command INSTEAD:
 ----
 endif::[]
 
-. On {ProjectServer}, from the output of the `katello-certs-check` command, depending on your requirements, enter the `{certs-generate}` command that generates a certificate for a new or existing {SmartProxy}.
+. Depending on your requirements, enter the `{certs-generate}` command on the {ProjectServer} that generates a certificate for a new or existing {SmartProxy}.
+The output of the `katello-certs-check` command may not be accurate in some cases.
+// https://bugzilla.redhat.com/show_bug.cgi?id=2093128
+Therefore, you must follow the steps mentioned above instead of the command outputs.
 +
 ifdef::satellite[]
 In this command, change `$CAPSULE` to the FQDN of your {SmartProxyServer}.

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -25,43 +25,38 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 If the command is successful, it returns two `{foreman-installer}` commands, one of which you must use to deploy a certificate to {ProjectServer}.
 ifdef::satellite[]
 +
-.Example output of `katello-certs-check`
+.To install the {Team} {ProjectServer} with the custom certificates, run:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-Validation succeeded.
-
-To install the Red Hat Satellite Server with the custom certificates, run:
-
   {foreman-installer} --scenario satellite \
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
-
-To update the certificates on a currently running Red Hat Satellite installation, run:
-
+----
++
+.To update the certificates on a currently running {Project} installation, run:
+----
   {foreman-installer} --scenario satellite \
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
-    --certs-update-server --certs-update-server-ca
+    --certs-update-all
 ----
 endif::[]
 ifndef::satellite[]
 +
-.Example output of `katello-certs-check`
+.To install the Katello main server with the custom certificates, run:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-Validation succeeded.
-
-To install the Katello main server with the custom certificates, run:
-
   foreman-installer --scenario katello \\
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
     --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+----
 
-To update the certificates on a currently running Katello installation, run:
-
+.To update the certificates on a currently running Katello installation, run:
+[options="nowrap"]
+----
   foreman-installer --scenario katello \\
     --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
     --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
@@ -70,7 +65,9 @@ To update the certificates on a currently running Katello installation, run:
 ----
 endif::[]
 
-. From the output of the `katello-certs-check` command, depending on your requirements, enter the `{foreman-installer}` command that installs a new {Project} with custom SSL certificates or updates certificates on a currently running {Project}.
+. Depending on your requirements, enter the `{foreman-installer}` command that installs a new {ProjectServer} with custom SSL certificates or updates certificates on a currently running {ProjectServer}.
+The output of the `katello-certs-check` command may not be accurate in some cases.
+Therefore, you must follow the steps mentioned above instead of the command outputs.
 +
 If you are unsure which command to run, you can verify that {Project} is installed by checking if the file `/etc/foreman-installer/scenarios.d/.installed` exists.
 If the file exists, run the second `{foreman-installer}` command that updates certificates.


### PR DESCRIPTION
The current commands are not enough to renew the Proxy certificate which can be improved further. So, we added the --certs-update-server-ca option while deploying the custom SSL certificate to the Proxy server. In addition to this, we also added --certs-update-all to Project and Proxy both for the same section in the documentation. In the case where suggested commands do not work, --certs-update-all will help to update the internal Proxy certificates. However, it may not be needed for just the renewal process but in some cases, it is required to update all the certificates.

https://bugzilla.redhat.com/show_bug.cgi?id=2093128


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
