### PR TITLE
[3.3] Use EL8-based instructions in upstream

### DIFF
--- a/guides/common/modules/proc_building-a-discovery-image.adoc
+++ b/guides/common/modules/proc_building-a-discovery-image.adoc
@@ -7,13 +7,10 @@ Discovered hosts keep running the Discovery image until they are rebooted into A
 ifdef::satellite[]
 The operating system image is based on {RHEL} 7.
 endif::[]
-ifdef::orcharhino[]
-Run the following procedure on Rocky Linux 8.
+ifndef::satellite[]
+Run the following procedure on {EL} 8.
 
-The Discovery image is based on Cent OS Stream 8.
-endif::[]
-ifndef::satellite,orcharhino[]
-The operating system image is based on CentOS Stream 8.
+The Discovery image is based on CentOS Stream 8.
 endif::[]
 
 ifdef::satellite[]
@@ -26,14 +23,14 @@ Use this procedure to build a {Project} discovery image or rebuild an image if y
 Do not use this procedure on your production {Project} or {SmartProxy}.
 Use either a dedicated environment or copy the synchronized repositories and a kickstart file to a separate server.
 
-ifdef::orcharhino[]
+ifndef::satellite[]
 .Prerequisites
 * Ensure that hardware virtualization is available on your host.
 * Install the following packages:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# dnf install lorax anaconda pykickstart wget qemu-kvm
+# dnf install git-core lorax anaconda pykickstart wget qemu-kvm
 ----
 * Clone the `foreman-discovery-image` repository:
 +
@@ -44,6 +41,18 @@ $ cd foreman-discovery-image
 ----
 
 .Procedure
+. Replace the contents of the `00-repos-centos8.ks` file with the following:
++
+[options="nowrap" subs="quotes,attributes"]
+----
+url --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=baseos
+repo --name="AppStream" --mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=appstream
+repo --name="foreman-el8" --baseurl=http://yum.theforeman.org/releases/{ProductVersion}/el8/$basearch/
+repo --name="foreman-plugins-el8" --baseurl=http://yum.theforeman.org/plugins/{ProductVersion}/el8/$basearch/
+module --name=ruby --stream=2.7
+module --name=postgresql --stream=12
+module --name=foreman --stream=el8
+----
 . Prepare the kickstart file:
 +
 [options="nowrap" subs="+quotes"]
@@ -78,23 +87,15 @@ proxy.type=foreman fdi.pxmac=52:54:00:be:8e:8c fdi.pxauto=1"
 For more information about configuration options, see xref:Unattended_Use_Customization_and_Image_Remastering_{context}[].
 
 endif::[]
-ifndef::orcharhino[]
+ifdef::satellite[]
 .Prerequisites
 * Install the `livecd-tools` package:
 +
-ifdef::foreman-el,katello,orcharhino[]
-----
-# yum install livecd-tools
-----
-endif::[]
-ifdef::satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install-project} livecd-tools
 ----
-endif::[]
 
-ifdef::satellite[]
 * For the following {RHEL} 7 repositories required to build the Discovery image, change the download policy to *Immediate*.
 This is required because {Project} downloads all packages only during synchronization of repositories with the immediate download policy.
 +
@@ -112,8 +113,7 @@ For example, *{RHEL} 7 Server Kickstart x86_64 7.7*.
 ** *Red Hat Satellite Capsule {ProductVersion} for RHEL 7 Server RPMs x86_64*.
 
 +
-For more information about synchronizing repositories, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Syncing Repositories] in the _Content Management Guide_.
-endif::[]
+For more information about synchronizing repositories, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Syncing Repositories] in _{ContentManagementDocTitle}_.
 
 .Procedure
 . Open the `/usr/share/foreman-discovery-image/foreman-discovery-image.ks` file for editing:
@@ -126,18 +126,8 @@ endif::[]
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
-ifdef::satellite[]
 repo --name=rhel --baseurl=file:///var/lib/pulp/published/yum/https/repos/My_Organization/Library/content/dist/rhel/server/7/7.7/x86_64
 repo --name=sat --baseurl=file:///var/lib/pulp/published/yum/https/repos/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/{ProductVersion}/os
-endif::[]
-ifdef::foreman-el,katello,orcharhino[]
-repo --name=centos --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os
-repo --name=centos-updates --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates
-repo --name=epel7 --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-repo --name=centos-sclo-rh --mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=sclo-rh
-repo --name=foreman-el7 --baseurl=http://yum.theforeman.org/releases/{ProjectVersion}/el7/$basearch/
-repo --name=foreman-plugins-el7 --baseurl=http://yum.theforeman.org/plugins/{ProjectVersion}/el7/$basearch/
-endif::[]
 ----
 . Run the `livecd-creator` tool:
 +
@@ -171,7 +161,7 @@ Complete one of the following procedures.
 If you want to boot the `.iso` file over a network, complete the following steps:
 
 .Procedure
-ifndef::orcharhino[]
+ifdef::satellite[]
 . To extract the initial ramdisk and kernel files from the `.iso` file over a network, enter the following command:
 +
 [options="nowrap" subs="+quotes"]
@@ -185,10 +175,10 @@ endif::[]
 ----
 # mkdir /var/lib/tftpboot/boot/_myimage_
 ----
-ifdef::orcharhino[]
+ifndef::satellite[]
 . Copy the `./tftpboot/initrd0.img` and `./tftpboot/vmlinuz0` files to your new directory.
 endif::[]
-ifndef::orcharhino[]
+ifdef::satellite[]
 . Copy the `initrd0.img` and `vmlinuz0` files to your new directory.
 endif::[]
 . Edit the `KERNEL` and `APPEND` entries in the `/var/lib/tftpboot/pxelinux.cfg` file to add the information about your own initial ramdisk and kernel files.


### PR DESCRIPTION
The previous instructions were for EL7, even though they described it as EL8. The Orcharhino instructions are correct for EL8. This change moves everything to EL8 for non-Satellite and keeps EL7 for Satellite.

The only modification is that the repository file is now modified for production use. This mostly means using mirror lists and pointing to the exact release for which the documentation is generated.

(cherry picked from commit 9feb8b384c05d79305b59b77eeaff80cb826ce64)

Submitting as a separate PR since there was a conflict in cherry picking.