### PR TITLE
Add repositories' list the puppet-agent rpm is available in

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -109,6 +109,7 @@
 // Satellite-Tools becomes Satellite-Client in Satellite 7
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
+:RepoRHEL9ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-9-<arch>-rpms
 
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}

--- a/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
@@ -12,7 +12,11 @@ endif::[]
 .Prerequisites
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-* The {ProjectName} Client Puppet 7.0 repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.
+* The {ProjectName} Client repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.
+The `puppet-agent` rpm is available within the following repositories:
+** {Team} {project-client-name} for RHEL 7 Server RPMs x86_64 - `{RepoRHEL7ServerSatelliteToolsProductVersion}`
+** {Team} {project-client-name} for RHEL 8 Server RPMs <arch> - `{RepoRHEL8ServerSatelliteToolsProductVersion}`
+** {Team} {project-client-name} for RHEL 9 Server RPMs <arch> - `{RepoRHEL9ServerSatelliteToolsProductVersion}`
 endif::[]
 ifdef::orcharhino[]
 * The {Team} {project-client-name} repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.


### PR DESCRIPTION
PR to resolve merge Conflicts.
A list of repositories is added to which has puppet-agent rpm available. 
Added a new attribute in the attribute-satellite.adoc 
Module updated-Installing & Configuring Puppet Agent on a Host Manually.

https://bugzilla.redhat.com/show_bug.cgi?id=2126470 (cherry picked from commit fb4bd022b6110f4121acb6bff313a29f7cf6ce46)


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
