### PR TITLE
Add SmartProxy upgrade using Leapp

### DIFF
--- a/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-in-place-using-leapp.adoc
@@ -1,10 +1,10 @@
 [id="upgrading-{project-context}-in-place-using-leapp_{context}"]
-= Upgrading {Project} to {EL} 8 In-Place Using Leapp
+= Upgrading {Project} or {SmartProxy} to {EL} 8 In-Place Using Leapp
 
-Use this procedure to upgrade your {Project} installation from {EL} 7 to {EL} 8.
+Use this procedure to upgrade your {Project} installation or {SmartProxy} from {EL} 7 to {EL} 8.
 
 .Prerequisites
-* {Project} {ProjectVersion} running on {EL} 7.
+* {Project} {ProjectVersion} or {SmartProxy} running on {EL} 7.
 ifdef::foreman-el,katello[]
 * {Project} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
 * {Project} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
@@ -14,7 +14,7 @@ ifdef::satellite[]
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
 * Access to available repositories or a local mirror of repositories.
-* If you previously upgraded {Project} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
+* If you previously upgraded {Project} or {SmartProxy} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
 * During the upgrade, the PostgreSQL data is moved from `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` to `/var/lib/pgsql/data/`.
 If these two paths reside on the same partition, no further action is required.
 If they reside on different partitions, ensure that there is enough space for the data to be copied over.
@@ -31,7 +31,7 @@ endif::[]
 . Configure the repositories to obtain Leapp.
 ifdef::foreman-el,katello[]
 +
-On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer Leapp packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} upgrades:
+On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer Leapp packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} or {SmartProxy} upgrades:
 +
 ----
 # curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
@@ -172,7 +172,7 @@ If this happens, do the following to clean up packages that cannot automatically
 ----
 endif::[]
 +
-If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} to use the new interface names:
+If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} or {SmartProxy} to use the new interface names:
 
 +
 [options="nowrap" subs="attributes"]
@@ -226,7 +226,7 @@ endif::[]
 ifdef::satellite[]
 . Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
 endif::[]
-. If you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
+. For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,13 +1,13 @@
-[id="upgrading-{project-context}-in-place-using-leapp_{context}"]
+[id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL} 8 In-Place Using Leapp
 
-Use this procedure to upgrade your {Project} installation or {SmartProxy} from {EL} 7 to {EL} 8.
+Use this procedure to upgrade your {Project} or {SmartProxy} installation from {EL} 7 to {EL} 8.
 
 .Prerequisites
-* {Project} {ProjectVersion} or {SmartProxy} running on {EL} 7.
+* {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 7.
 ifdef::foreman-el,katello[]
-* {Project} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
-* {Project} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
+* {Project} or {SmartProxy} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
+* {Project} or {SmartProxy} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
 endif::[]
 ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
@@ -226,7 +226,7 @@ endif::[]
 ifdef::satellite[]
 . Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
 endif::[]
-. For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
+. For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode::
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -102,8 +102,8 @@ include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+3
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
-// Upgrading Project from Enterprise Linux 7 to Enterprise Linux 8 using Leapp
-include::common/modules/proc_upgrading-project-in-place-using-leapp.adoc[leveloffset=+1]
+// Upgrading Project or SmartProxy from Enterprise Linux 7 to Enterprise Linux 8 using Leapp
+include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]
 
 // == Migrating Project

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -85,7 +85,7 @@ endif::[]
 ifdef::foreman-el,katello,satellite[]
 There are two ways of upgrading your OS:
 
-* xref:upgrading-{project-context}-in-place-using-leapp_{context}[]
+* xref:upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}[]
 * xref:migrating-{project-context}-to-a-new-el-system_{context}[]
 endif::[]
 


### PR DESCRIPTION
Structured the Upgrading using Leapp section to include "or {SmartProxy} in addition to {Project}. All the steps were the same except for the step requiring SELinux to be in enforcing mode and running the proper command. This step says it's specifically for {Project}. This change was required because there was no mention of upgrading {SmartProxy} using Leapp.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

@evgeni take a look and see if this makes sense now that we've added "or {SmartProxy}".

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
