### PR TITLE
Correct escaping in Redmine release notes script

### DIFF
--- a/guides/doc-Release_Notes/redmine_release_notes
+++ b/guides/doc-Release_Notes/redmine_release_notes
@@ -61,7 +61,7 @@ def category_from_issue(issue)
 end
 
 def format_issue(issue)
-  subject = issue['subject'].gsub('`','\\\`').gsub('<','&lt;').gsub('>','&gt;').gsub('*','\\\*').gsub("'", "\\\'")
+  subject = issue['subject'].gsub('`','\\\`').gsub('<','&lt;').gsub('>','&gt;').gsub('*','\\\*').gsub("'", "\\\\'")
   link = build_uri("/issues/#{issue['id']}")
   "* #{subject} - #{link}[##{issue['id']}]"
 end


### PR DESCRIPTION
[Quoting StackOverflow](https://stackoverflow.com/questions/2180322/ruby-gsub-doesnt-escape-single-quotes):

> \' means $' which is everything after the match. Escape the \ again and it works

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.