### PR TITLE
Reconsider partition size for EL8

### DIFF
--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -21,22 +21,24 @@ ifdef::foreman-el,katello,satellite[]
 |====
 |Directory |Installation Size |Runtime Size
 
-|/var/log/ |10 MB |10 GB
+|/var/log |10 MB |10 GB
 
-|/var/lib/pgsql |100 MB |20 GB
+|/var/lib/pgsql |100 MB |20 GB
 
-|/usr | 3 GB | Not Applicable
+|/usr | 5 GB | Not Applicable
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 
 ifdef::katello,satellite,orcharhino[]
-|/var/lib/pulp/ |1 MB |300 GB
+|/var/lib/pulp |1 MB |300 GB
 
-|/var/lib/qpidd/ |25 MB | Not Applicable
+|/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
 
 For external database servers: `/var/lib/pgsql` with installation size of 100 MB and runtime size of 20 GB.
+
+For detailed information on partitioning and size, refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[{RHEL} 8 partitioning guide].
 
 == [[storage-el-7]]{EL} 7
 
@@ -45,9 +47,9 @@ For external database servers: `/var/lib/pgsql` with installation size of 100 MB
 |====
 |Directory |Installation Size |Runtime Size
 
-|/var/log/ |10 MB |10 GB
+|/var/log |10 MB |10 GB
 
-|/var/opt/rh/rh-postgresql12 |100 MB |20 GB
+|/var/opt/rh/rh-postgresql12 |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
 
@@ -56,9 +58,9 @@ For external database servers: `/var/lib/pgsql` with installation size of 100 MB
 |/opt/puppetlabs | 500 MB | Not Applicable
 
 ifdef::katello,satellite,orcharhino[]
-|/var/lib/pulp/ |1 MB |300 GB
+|/var/lib/pulp |1 MB |300 GB
 
-|/var/lib/qpidd/ |25 MB | Not Applicable
+|/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
 endif::[]
@@ -71,9 +73,9 @@ ifdef::foreman-deb[]
 |====
 |Directory |Installation Size |Runtime Size
 
-|/var/log/ |10 MB |10 GB
+|/var/log |10 MB |10 GB
 
-|/var/lib/postgresql |100 MB |20 GB
+|/var/lib/postgresql |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
 


### PR DESCRIPTION
The partition size of /usr for RHEL 8 is 3GB at present which is not accurate as it is more than that. It is now increased to 5GB for EL8. Also, there is already a detailed guide on the same which helps user to set correct size of partitions that includes /usr and /var/lib/qpidd as well. So, we have added a link to redirect users to the detailed guide.

https://bugzilla.redhat.com/show_bug.cgi?id=2108615


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
