### PR TITLE
Replace "via" with "on" in RN header

### DIFF
--- a/guides/doc-Release_Notes/redmine_release_notes
+++ b/guides/doc-Release_Notes/redmine_release_notes
@@ -86,7 +86,7 @@ redmine_link = build_uri('/issues', [['set_filter', '1'], ['sort', 'id:desc'], [
 
 puts "= #{project.capitalize} #{release_name}"
 puts
-puts "A full list of changes is available via #{redmine_link}[Redmine]"
+puts "A full list of changes is available on #{redmine_link}[Redmine]"
 
 projects = Hash.new { |hash, key| hash[key] = {issues: [], categories: Hash.new { |c, k| c[k] = [] }} }
 


### PR DESCRIPTION
The header now says:
"A full list of issues is available on Redmine."
Instead of:
"A full list of issues is available via Redmine."

I feel like this preposition fits the header better. Any thoughts?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
