### PR TITLE
Add a step to regenerate custom certificates on branch 3.1

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -22,6 +22,7 @@
 :SmartProxyServer: orcharhino Proxy
 :TargetVersion: 6.0
 :Team: ATIX AG
+:certs-proxy-context: orcharhino-proxy
 :customcontent: custom content
 :customcontenttitle: Custom Content
 :customfiletype: custom file type
@@ -40,5 +41,5 @@
 :installer-log-file: /var/log/foreman-installer/katello.log
 :project-client-name: orcharhino client
 :project-context: orcharhino
-:smart-proxy-context: orcharhino Proxy
+:smart-proxy-context: orcharhino-proxy
 :smartproxy-example-com: orcharhino-proxy.example.com

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -40,21 +40,32 @@ For information on backups, see {AdministeringDocURL}Backing_Up_Server_and_Proxy
 
 ifdef::katello,satellite[]
 +
-. Regenerate certificates.
-On the main {Project} server:
+. Regenerate certificates on your {ProjectServer}:
+.. Regenerate certificates for {SmartProxies} that use default certificates:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {certs-generate} --foreman-proxy-fqdn "myproxy.example.com" \
-                       --certs-update-all \
-                       --certs-tar "~/myproxy.example.com-certs.tar"
+# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+--certs-update-all \
+--certs-tar "~/{smartproxy-example-com}-certs.tar"
 ----
+.. Regenerate certificates for {SmartProxies} that use custom certificates:
 +
+[options="nowrap" subs="attributes"]
+----
+# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+--certs-tar "~/{smartproxy-example-com}-certs.tar" \
+--server-cert "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert.pem" \
+--server-key "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert_key.pem" \
+--server-ca-cert "/root/{certs-proxy-context}_cert/ca_cert_bundle.pem" \
+--certs-update-server
+----
 For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 +
 endif::[]
 ifdef::katello[]
-. Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/myproxy.example.com-certs.tar`
+. Copy the resulting tarball to your {SmartProxy}.
+For this example, we will use `/root/{smartproxy-example-com}-certs.tar`.
 . Update repositories for EL7
 +
 [options="nowrap" subs="attributes"]
@@ -83,8 +94,9 @@ ifdef::katello[]
 +
 . Run the installer:
 +
+[options="nowrap" subs="attributes"]
 ----
-# foreman-installer --certs-tar-file /root/myproxy.example.com-certs.tar \
+# foreman-installer --certs-tar-file /root/{smartproxy-example-com}-certs.tar \
                     --certs-update-all --certs-regenerate true --certs-deploy true
 ----
 endif::[]


### PR DESCRIPTION
Same changes as in #1669. This PR exists because of a merge conflict when cherry-picking the original PR to 3.1 branch. While resolving the conflict, I also made a little adjustment to the conflicting section.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
