### PR TITLE
Add missing command-Configuring Capsule as a Puppet Server

### DIFF
--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -33,6 +33,6 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 --puppet-server true \
 --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
 --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
---puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+--puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key \
 --puppet-server-foreman-url "{foreman-example-com}"
 ----

--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -34,4 +34,5 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
 --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
 --puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+--puppet-server-foreman-url "{foreman-example-com}"
 ----


### PR DESCRIPTION
Add a missing "puppet-server-formen-url" Flag.
It is required when Configuring Capsule as a Puppet Server. 
As of 6.11, the downstream project no longer generates this 
for the "project-installer" command to be run on the Capsule server.

https://bugzilla.redhat.com/show_bug.cgi?id=2133052


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
