### PR TITLE
Refresh smartproxy features when removing puppet

### DIFF
--- a/guides/common/modules/proc_disabling-puppet.adoc
+++ b/guides/common/modules/proc_disabling-puppet.adoc
@@ -13,6 +13,9 @@ To discontinue using Puppet in your {Project}, follow this procedure.
 ----
 # {foreman-maintain} plugin purge-puppet
 ----
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
+. For each {SmartProxy}, select *Refresh* from the *Actions* list.
+. Optional: Verify that *Puppet* and *Puppet CA* are gone from the list of features after clicking on a {SmartProxy} name.
 . Disable Puppet server on {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
Added a step to refresh smartproxy features in the Disabling Puppet Integration with Project procedure.
See [BZ#2132688](https://bugzilla.redhat.com/show_bug.cgi?id=2132688) for reference.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3