### PR TITLE
Specify Red Hat Satellite Client repo version

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -31,6 +31,8 @@ In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*, click *Manage Ma
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 . Click the arrow next to the product to view the available repositories.
 . Select the repositories for {ProjectVersion}.
+Note that *Red{nbsp}Hat {project-client-name}* does not have a {ProjectVersion} version.
+Choose *Red{nbsp}Hat {project-client-name}* instead.
 . Click *Synchronize Now*.
 +
 [IMPORTANT]


### PR DESCRIPTION
Specified Red Hat Satellite Client repo version in the *Synchronizing the New Repositories* procedure in *Upgrading and Updating* guide.
See [BZ#2119134](https://bugzilla.redhat.com/show_bug.cgi?id=2119134) for reference.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3