### PR TITLE
Add process for Disconnected Server via Leapp

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,0 +1,322 @@
+[id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
+= Upgrading {Project} or {SmartProxy} to {EL} 8 In-Place Using Leapp
+
+Use this procedure to upgrade your {Project} or {SmartProxy} installation from {EL} 7 to {EL} 8.
+
+.Prerequisites
+* {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 7.
+ifdef::foreman-el,katello[]
+* {Project} or {SmartProxy} installations running on CentOS 7 can be upgraded to CentOS Stream 8 or a {RHEL} rebuild.
+* {Project} or {SmartProxy} installations running on {RHEL} 7 can be upgraded to {RHEL} 8.
+endif::[]
+ifdef::satellite[]
+* Review Known Issues before you begin an upgrade.
+For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+
+.Prerequisites for Disconnected Environment
+If you run {Project} or {SmartProxy} in a disconnected environment, ensure it meets the following requirements:
+
+* You must obtain and deploy Leapp metadata manually.
+For more information, see https://access.redhat.com/articles/3664871[Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades].
+* You have access to {RHEL} and {Project} or {SmartProxy} packages.
+* You must obtain the ISO files for {RHEL} 8 and {Project} or {SmartProxy}.
+For more information, see xref:upgrading_a_disconnected_satellite[].
+* For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+* Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+* For more information, see https://access.redhat.com/solutions/5492401[How to in-place upgrade an offline / disconnected RHEL 7 machine to RHEL 8 with Leapp?]
+endif::[]
+ifndef::satellite[]
+* Access to available repositories or a local mirror of repositories.
+endif::[]
+* If you previously upgraded {Project} or {SmartProxy} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.
+* During the upgrade, the PostgreSQL data is moved from `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` to `/var/lib/pgsql/data/`.
+If these two paths reside on the same partition, no further action is required.
+If they reside on different partitions, ensure that there is enough space for the data to be copied over.
+You can move the PostgreSQL data on your own and the upgrade will skip this step if `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` does not exist.
+ifdef::satellite[]
+[NOTE]
+====
+{Project} supports DEFAULT and FIPS crypto-policies.
+The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
+====
+endif::[]
+
+.Procedure
+. Configure the repositories to obtain Leapp.
+ifdef::foreman-el,katello[]
++
+On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer Leapp packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} or {SmartProxy} upgrades:
++
+----
+# curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
+----
+endif::[]
++
+On {RHEL}, enable the `rhel-7-server-extras-rpms` repository:
++
+----
+# subscription-manager repos --enable=rhel-7-server-extras-rpms
+----
+
+. Install required packages:
+[options="nowrap", subs="+quotes,verbatim,attributes"]
++
+----
+# {package-install-project} leapp leapp-repository
+----
+ifdef::satellite[]
+. For Leapp to perform the upgrade in a disconnected environment, download the metadata and manually extract, as described in https://access.redhat.com/articles/3664871[Leapp utility metadata in-place upgrades of RHEL for disconnected upgrades].
+
+. Set up the following repositories to perform the upgrade in a disconnected environment:
+.. `/etc/yum.repos.d/rhel8.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[BaseOS]
+name={RepoRHEL8BaseOS}
+baseurl=http://_server.example.com_/rhel8/BaseOS/
+
+[AppStream]
+name={RepoRHEL8AppStream}
+baseurl=http://_server.example.com_/rhel8/AppStream/
+----
++
+.. `/etc/yum.repos.d/{project-context}.repo:`
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={RepoRHEL8ServerSatelliteServerProductVersion}
+baseurl=http://_server.example.com_/sat6/Satellite/
+
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+baseurl=http://_server.example.com_/sat6/Maintenance/
+----
+endif::[]
+
+ifdef::foreman-el,katello[]
+. Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
+Note that this is not required for {RHEL} based installations.
++
+----
+# yum install leapp-data-centos
+----
+
++
+. Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[leapp-foreman]
+name=Foreman {ProjectVersion}
+baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/el8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+ifdef::katello[]
+[leapp-katello]
+name=Katello {KatelloVersion}
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-katello-candlepin]
+name=Candlepin: an open source entitlement management system.
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-pulpcore]
+name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
+baseurl=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el8/$basearch/
+gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+endif::[]
+
+[leapp-foreman-plugins]
+name=Foreman plugins {ProjectVersion}
+baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el8/$basearch
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
+
+[leapp-foreman-client]
+name=Foreman client {ProjectVersion}
+baseurl=https://yum.theforeman.org/client/{ProjectVersion}/el8/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
+
+[leapp-puppet7]
+name=Puppet 7 Repository el 8 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1
+----
+
+* If you are using Puppet 6 instead of Puppet 7, replace the `7` with a `6` in the `leapp-puppet7` entry.
+
+* You need a Puppet repository for the Puppet agent that the installer is using.
+
+. We do not support {EL} 8 installations with EPEL 8 enabled, so remove `epel-release`:
++
+----
+# yum remove epel-release
+----
+
+. Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
++
+----
+# yum remove centos-release-scl centos-release-scl-rh
+----
+endif::[]
+
+. Let Leapp analyze your system:
++
+----
+# leapp preupgrade
+----
+ifdef::satellite[]
++
+If you run {Project} or {SmartProxy} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp preupgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL8ServerSatelliteServerProductVersion} \
+--enablerepo {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+endif::[]
+
++
+The first run is expected to fail but report issues and inhibit the upgrade.
+Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
++
+The following commands show the most common steps required:
++
+----
+# rmmod pata_acpi
+# echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
+# leapp answer --section remove_pam_pkcs11_module_check.confirm=True
+----
+
+ifdef::foreman-el,katello[]
++
+`leapp preupgrade` might fail with a dependency resolution error such as:
++
+--
+* "package rubygem-fx-0.5.0-2.el8.noarch requires rubygem(railties) >= 4.0.0, but none of the providers can be installed"
+* "package rubygem-railties-6.0.4.7-1.el8.noarch requires rubygem(thor) < 2.0, but none of the providers can be installed"
+--
+
++
+If this happens, do the following to clean up packages that cannot automatically upgrade (`rubygem(thor)` and `rubygem(railties)` in the example above):
+
++
+----
+# yum remove rubygem-thor rubygem-railties
+----
+endif::[]
+
++
+If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} or {SmartProxy} to use the new interface names:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --help |grep 'interface.*eth'
+    --foreman-proxy-dhcp-interface  DHCP listen interface (current: "eth0")
+    --foreman-proxy-dns-interface  DNS interface (current: "eth0")
+----
++
+If `eth0` was renamed to `em0`, call the installer to use the new interface name with:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --foreman-proxy-dhcp-interface=em0 --foreman-proxy-dns-interface=em0
+----
+
+. Ensure `leapp preupgrade` has no issues.
+
+. Run:
++
+----
+# leapp upgrade
+----
+
+ifdef::satellite[]
++
+. If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp upgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL8ServerSatelliteServerProductVersion} \
+--enablerepo {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+
+. Reboot the system.
++
+After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 8 system.
+
+. Leapp finishes the upgrade, watch it with:
++
+----
+# journalctl -u leapp_resume -f
+----
+
+ifdef::foreman-el[]
+. Enable the Foreman module:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module enable foreman:el8
+----
+endif::[]
+ifdef::katello[]
+. Enable the Katello and Pulpcore modules:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module enable katello:el8 pulpcore:el8
+----
+endif::[]
+ifdef::satellite[]
+. Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
+. If you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+ifdef::foreman-el[]
+# dnf reinstall foreman-selinux --disableplugin=foreman-protector
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+# dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector
+endif::[]
+----
+ifdef::satellite[]
+ . Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/applying-security-policies_upgrading-from-rhel-7-to-rhel-8#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
+
+[NOTE]
+====
+If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
+====


### PR DESCRIPTION
Process for upgrading Disconnected Satellite Server via Leapp added.
Change was required because we did not have the process in the initial
creation of the new Upgrading Satellite to Red Hat Enterprise Linux 8
In-Place Using Leapp section.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

@adamlazik1 My apologies but this is an exact copy of #1697 but I had that on the 3.3 branch. I applied your changes from that PR into this one. I promise no more PRs for this one :-)

@evgeni Can you take a look and see if this is ready to be merged?  It's a copy of both #1427 and #1697.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
