### PR TITLE
Add workaround in Prerequisites

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -12,6 +12,23 @@ endif::[]
 ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+* Leapp utility does not properly enable the {Project} module for {ProjectServer}.
+Run the following command to work around the issue on {ProjectServer}:
++
+[options="nowrap", subs="attributes"]
+----
+# subscription-manager repo-override \
+--{RepoRHEL8ServerSatelliteServerProductVersion} \
+--add=module_hotfixes:1
+----
+Run the following command to work around the issue on {SmartProxyServer}:
++
+[options="nowrap", subs="attributes"]
+----
+# subscription-manager repo-override \
+--{RepoRHEL8ServerSatelliteCapsuleProductVersion} \
+--add=module_hotfixes:1
+----
 endif::[]
 * Access to available repositories or a local mirror of repositories.
 * If you previously upgraded {Project} or {SmartProxy} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.


### PR DESCRIPTION
A workaround was required for Leapp upgrade involving steps to properly
enable a Satellite module since Leapp utility does not properly support
it. Two commands for both Satellite Server and Capsule Server were
added as prerequisite.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

@adamlazik1 Sorry I had to create a new PR because I accidentally created a branch on 3.3 instead for #1698. You can go ahead and approve this one.

@ekohl Can you merge this?

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
