### PR TITLE
Revert "Add workaround to prerequisites of Leapp (#1703)"

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -12,23 +12,6 @@ endif::[]
 ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
-* Leapp utility does not properly enable the {Project} module for {ProjectServer}.
-Run the following command to work around the issue on {ProjectServer}:
-+
-[options="nowrap", subs="attributes"]
-----
-# subscription-manager repo-override \
---{RepoRHEL8ServerSatelliteServerProductVersion} \
---add=module_hotfixes:1
-----
-Run the following command to work around the issue on {SmartProxyServer}:
-+
-[options="nowrap", subs="attributes"]
-----
-# subscription-manager repo-override \
---{RepoRHEL8ServerSatelliteCapsuleProductVersion} \
---add=module_hotfixes:1
-----
 endif::[]
 * Access to available repositories or a local mirror of repositories.
 * If you previously upgraded {Project} or {SmartProxy} from an earlier version, and the `/var/lib/pgsql` contained the PostgreSQL database content before the migration from PostgreSQL 9 to PostgreSQL 12 from the SCL, empty `/var/lib/pgsql` before proceeding.


### PR DESCRIPTION
This reverts commit 1705488d82dc6c7e4550c740fb0c46a908f4a17f.

Those changes are not needed since `leapp-repository-0.16.0-8.el7_9` which is present in current RHEL7.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
