### PR TITLE
Use the installer to change log levels

### DIFF
--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -56,24 +56,12 @@ Edit `/etc/hammer/cli_config.yml` and set the `:log_level:`:
 == Increasing the Logging Level On {SmartProxy}
 
 You can find the log for {SmartProxy} in `/var/log/foreman-proxy/proxy.log`.
-Uncomment the `DEBUG` line in `/etc/foreman-proxy/settings.yml`:
+Change the log level to `DEBUG`:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-:log_level: DEBUG
+{foreman-installer} --foreman-proxy-log-level DEBUG
 ----
-
-Ensure to restart the `foreman-proxy` service afterwards:
-
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# systemctl restart foreman-proxy
-----
-
-[CAUTION]
-====
-Running the installer will revert this change back.
-====
 
 ifdef::katello,orcharhino,satellite[]
 == Increasing the Logging Level For Candlepin
@@ -116,61 +104,28 @@ You can find the log for {Project} in `/var/log/foreman/production.log`.
 * `/var/log/httpd/foreman_ssl_access.log`
 
 .Procedure
-. Set the logging level in `/etc/foreman/settings.yaml`:
+. Set the logging level:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-:logging:
-  :production:
-    :type: file
-    :layout: pattern
-    :level: debug
-----
-. Enable selected loggers in `/etc/foreman/settings.yaml`:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-:loggers:
-  :ldap:
-    :enabled: true
-  :permissions:
-    :enabled: true
-  :sql:
-    :enabled: true
-----
-+
-Note that to see logging from some area, debug logging has to be set.
-. Restart {Project} services:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service restart
+{foreman-installer} --foreman-logging-level debug \
+--foreman-loggers ldap:true \
+--foreman-loggers permissions:true \
+--foreman-loggers sql:true
 ----
 
-You can find the complete list of loggers with their default values in `/usr/share/foreman/config/application.rb` in the `Foreman::Logging.add_loggers` command.
+TODO: this is a combination of proc_enabling-individual-loggers.adoc and guides/common/modules/proc_enabling-debug-logging.adoc
 
 ifdef::katello,orcharhino,satellite[]
 == Increasing the Logging Level For Qpid Dispatch Router
 
 Qpid logs to syslog and can be viewed in `/var/log/messages` or with `journalctl`.
-Enable debug logging in `/etc/qpid-dispatch/qdrouterd.conf`:
+Enable debug logging:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-enable: debug+
+{foreman-installer} --foreman-proxy-content-qpid-router-logging-level debug+
 ----
-
-Ensure to restart the Qpid Dispatch Router afterwards:
-
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# systemctl restart qdrouterd
-----
-
-[CAUTION]
-====
-Running the installer will revert this change back.
-====
 
 == Increasing the Logging Level For Qpid Broker
 


### PR DESCRIPTION
In various places users are told to manually edit files, but that is considered unsupported. This uses the installer to modify files and restart services where needed.

Sadly some things are not exposed as parameters so they're kept in.

There is also some duplication going on and I'd like some writer's opinion on how to address that. See the inline TODO.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.