### PR TITLE
Update repo label attribute in various sections

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -10,7 +10,7 @@ Use this procedure to update {SmartProxyServer}s to the next minor version.
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
-{RepoRHEL7ServerSatelliteMaintenanceProductVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 
 . Check the available versions to confirm the next minor version is listed:

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -67,11 +67,10 @@ Complete the following steps on the connected {ProjectServer}.
 +
 [options="nowrap" subs="attributes"]
 ----
-{RepoRHEL7ServerAnsible}
 {RepoRHEL8BaseOS}
+{RepoRHEL8AppStream}
 {RepoRHEL8ServerSatelliteServerProductVersion}
 {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
-{RepoRHEL8AppStream}
 ----
 +
 . Download the debug certificate of the organization and store it locally at, for example, `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
@@ -79,18 +78,18 @@ Complete the following steps on the connected {ProjectServer}.
 +
 [options="nowrap" subs="attributes"]
 ----
-[{RepoRHEL7ServerAnsible}]
-name=Ansible {SatelliteAnsibleVersion} RPMs for Red Hat Enterprise Linux 7 Server x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/$releasever/$basearch/ansible/{SatelliteAnsibleVersion}/os/
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/baseos/os
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 sslverify = 1
 
-[{RepoRHEL8BaseOS}]
-name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/baseos/os
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/appstream/os
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
@@ -113,15 +112,6 @@ sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 sslverify = 1
-
-[{RepoRHEL8AppStream}]
-name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/appstream/os
-enabled=1
-sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
-sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
-sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
-sslverify = 1
 ----
 +
 . In the configuration file, replace `/etc/pki/katello/certs/org-debug-cert.pem` in `sslclientcert` and `sslclientkey` with the location of the downloaded organization debug certificate.
@@ -139,9 +129,9 @@ To obtain the organization label, enter the command:
 ----
 # reposync --delete --download-metadata -p ~/{Project}-repos -n \
  -r {RepoRHEL8BaseOS} \
+ -r {RepoRHEL8AppStream} \
  -r {RepoRHEL8ServerSatelliteServerProductVersion} \
- -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
- -r {RepoRHEL8AppStream}
+ -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 +
 This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
@@ -156,7 +146,7 @@ This downloads the contents of the repositories from the connected {ProjectServe
 ----
 . Use the generated `{Project}-repos.tgz` file to upgrade in the disconnected {ProjectServer}.
 
-Perform the following steps on the disconnected {ProjectServer}
+Perform the following steps on the disconnected {ProjectServer}:
 
 . Copy the generated `{Project}-repos.tgz` file to your disconnected {ProjectServer}
 . Extract the archive to anywhere accessible by the `root` user.
@@ -176,6 +166,11 @@ name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
 baseurl=file:///root/{Project}-repos/{RepoRHEL8BaseOS}
 enabled=1
 
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl=file:///root/{Project}-repos/{RepoRHEL8AppStream}
+enabled=1
+
 [{RepoRHEL8ServerSatelliteServerProductVersion}]
 name={ProjectNameX} for RHEL 8 Server RPMs x86_64
 baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteServerProductVersion}
@@ -184,11 +179,6 @@ enabled=1
 [{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
 name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
 baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
-enabled=1
-
-[{RepoRHEL8AppStream}]
-name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-baseurl=file:///root/{Project}-repos/{RepoRHEL8AppStream}
 enabled=1
 ----
 +
@@ -222,18 +212,5 @@ If you lose connection to the command shell where the upgrade command is running
 # {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
 ----
 
-. Check when the kernel packages were last updated:
-+
-[options="nowrap"]
-----
-# rpm -qa --last | grep kernel
-----
-+
-. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} service stop
-# reboot
-----
+include::snip_needs_reboot.adoc[]
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -22,7 +22,7 @@ For more information, see the Red Hat Knowledgebase solution https://access.redh
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
-{RepoRHEL7ServerSatelliteMaintenanceProductVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 
 . Check the available versions to confirm the next minor version is listed:
@@ -69,8 +69,8 @@ Complete the following steps on the connected {ProjectServer}.
 ----
 {RepoRHEL7ServerAnsible}
 {RepoRHEL7Server}
-{RepoRHEL7ServerSatelliteServerProductVersion}
-{RepoRHEL7ServerSatelliteMaintenanceProductVersion}
+{RepoRHEL8ServerSatelliteServerProductVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 {RepoRHEL7ServerSoftwareCollections}
 ----
 +
@@ -97,17 +97,17 @@ sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 sslverify = 1
 
-[{RepoRHEL7ServerSatelliteServerProductVersion}]
-name={ProjectNameX} for RHEL 7 Server RPMs x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/satellite/{ProjectVersion}/os/
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={ProjectNameX} for RHEL 8 Server RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/8/8Server/x86_64/satellite/{ProjectVersion}/os/
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 
-[{RepoRHEL7ServerSatelliteMaintenanceProductVersion}]
-name={ProjectName} Maintenance 6 for RHEL 7 Server RPMs x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/sat-maintenance/6/os/
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/8/8Server/x86_64/sat-maintenance/6/os/
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
@@ -140,8 +140,8 @@ To obtain the organization label, enter the command:
 # reposync --delete --download-metadata -p ~/{Project}-repos -n \
  -r {RepoRHEL7ServerAnsible} \
  -r {RepoRHEL7Server} \
- -r {RepoRHEL7ServerSatelliteServerProductVersion} \
- -r {RepoRHEL7ServerSatelliteMaintenanceProductVersion} \
+ -r {RepoRHEL8ServerSatelliteServerProductVersion} \
+ -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
  -r {RepoRHEL7ServerSoftwareCollections}
 ----
 +
@@ -204,14 +204,14 @@ name=Red Hat Enterprise Linux 7 Server RPMs x86_64
 baseurl=file:///root/{Project}-repos/{RepoRHEL7Server}
 enabled=1
 
-[{RepoRHEL7ServerSatelliteServerProductVersion}]
-name={ProjectNameX} for RHEL 7 Server RPMs x86_64
-baseurl=file:///root/{Project}-repos/{RepoRHEL7ServerSatelliteServerProductVersion}
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={ProjectNameX} for RHEL 8 Server RPMs x86_64
+baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteServerProductVersion}
 enabled=1
 
-[{RepoRHEL7ServerSatelliteMaintenanceProductVersion}]
-name={ProjectName} Maintenance 6 for RHEL 7 Server RPMs x86_64
-baseurl=file:///root/{Project}-repos/{RepoRHEL7ServerSatelliteMaintenanceProductVersion}
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
+baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 enabled=1
 
 [{RepoRHEL7ServerSoftwareCollections}]
@@ -247,8 +247,21 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__ 
+# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
 ----
 
-include::snip_needs_reboot.adoc[]
+. Check when the kernel packages were last updated:
++
+[options="nowrap"]
+----
+# rpm -qa --last | grep kernel
+----
++
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-maintain} service stop
+# reboot
+----
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -68,10 +68,10 @@ Complete the following steps on the connected {ProjectServer}.
 [options="nowrap" subs="attributes"]
 ----
 {RepoRHEL7ServerAnsible}
-{RepoRHEL7Server}
+{RepoRHEL8BaseOS}
 {RepoRHEL8ServerSatelliteServerProductVersion}
 {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
-{RepoRHEL7ServerSoftwareCollections}
+{RepoRHEL8AppStream}
 ----
 +
 . Download the debug certificate of the organization and store it locally at, for example, `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
@@ -88,8 +88,8 @@ sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 sslverify = 1
 
-[{RepoRHEL7Server}]
-name=Red Hat Enterprise Linux 7 Server RPMs x86_64
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
 baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/os/
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
@@ -114,8 +114,8 @@ sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 sslverify = 1
 
-[{RepoRHEL7ServerSoftwareCollections}]
-name=Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server x86_64
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
 baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os/
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
@@ -139,10 +139,10 @@ To obtain the organization label, enter the command:
 ----
 # reposync --delete --download-metadata -p ~/{Project}-repos -n \
  -r {RepoRHEL7ServerAnsible} \
- -r {RepoRHEL7Server} \
+ -r {RepoRHEL8BaseOS} \
  -r {RepoRHEL8ServerSatelliteServerProductVersion} \
  -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
- -r {RepoRHEL7ServerSoftwareCollections}
+ -r {RepoRHEL8AppStream}
 ----
 +
 This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
@@ -199,8 +199,8 @@ name=Ansible {SatelliteAnsibleVersion} RPMs for Red Hat Enterprise Linux 7 Serve
 baseurl=file:///root/{Project}-repos/{RepoRHEL7ServerAnsible}
 enabled=1
 
-[{RepoRHEL7Server}]
-name=Red Hat Enterprise Linux 7 Server RPMs x86_64
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
 baseurl=file:///root/{Project}-repos/{RepoRHEL7Server}
 enabled=1
 
@@ -214,8 +214,8 @@ name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
 baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 enabled=1
 
-[{RepoRHEL7ServerSoftwareCollections}]
-name=Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server x86_64
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
 baseurl=file:///root/{Project}-repos/{RepoRHEL7ServerSoftwareCollections}
 enabled=1
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -90,7 +90,7 @@ sslverify = 1
 
 [{RepoRHEL8BaseOS}]
 name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/os/
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/baseos/os
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
@@ -98,16 +98,16 @@ sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 sslverify = 1
 
 [{RepoRHEL8ServerSatelliteServerProductVersion}]
-name={ProjectNameX} for RHEL 8 Server RPMs x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/8/8Server/x86_64/satellite/{ProjectVersion}/os/
+name={ProjectName} {ProjectVersion} for RHEL 8 RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/satellite/{ProjectVersion}/os
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
 
 [{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
-name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/8/8Server/x86_64/sat-maintenance/6/os/
+name={ProjectName} Maintenance {ProjectVersion} for RHEL 8 RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/sat-maintenance/{ProjectVersion}/os
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
@@ -116,7 +116,7 @@ sslverify = 1
 
 [{RepoRHEL8AppStream}]
 name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os/
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/appstream/os
 enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
@@ -138,7 +138,6 @@ To obtain the organization label, enter the command:
 [options="nowrap" subs="attributes"]
 ----
 # reposync --delete --download-metadata -p ~/{Project}-repos -n \
- -r {RepoRHEL7ServerAnsible} \
  -r {RepoRHEL8BaseOS} \
  -r {RepoRHEL8ServerSatelliteServerProductVersion} \
  -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
@@ -146,28 +145,6 @@ To obtain the organization label, enter the command:
 ----
 +
 This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
-The `reposync` command in {RHEL} 7 downloads the RPMs but not the Yum metadata.
-+
-Because of this, you must manually run `createrepo` in each sub-directory of `{Project}-repos`. Make sure you have the `createrepo` rpm installed. If not use the following command to install it.
-+
-[options="nowrap" subs="attributes"]
-----
-# {package-install-project} createrepo
-----
-+
-Run the following command to create repodata in each sub-directory of `~/{Project}-repos`. :
-+
-[options="nowrap" subs="attributes"]
-----
-# cd ~/{Project}-repos
-# for directory in */
-do
-  echo "Processing $directory"
-  cd $directory
-  createrepo .
-  cd ..
-done
-----
 +
 . Verify that the RPMs have been downloaded and the repository data directory is generated in each of the sub-directories of `~/{Project}-repos`.
 . Archive the contents of the directory
@@ -194,14 +171,9 @@ In the following example `/root` is the extraction location.
 +
 [options="nowrap" subs="attributes"]
 ----
-[{RepoRHEL7ServerAnsible}]
-name=Ansible {SatelliteAnsibleVersion} RPMs for Red Hat Enterprise Linux 7 Server x86_64
-baseurl=file:///root/{Project}-repos/{RepoRHEL7ServerAnsible}
-enabled=1
-
 [{RepoRHEL8BaseOS}]
 name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
-baseurl=file:///root/{Project}-repos/{RepoRHEL7Server}
+baseurl=file:///root/{Project}-repos/{RepoRHEL8BaseOS}
 enabled=1
 
 [{RepoRHEL8ServerSatelliteServerProductVersion}]
@@ -216,7 +188,7 @@ enabled=1
 
 [{RepoRHEL8AppStream}]
 name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-baseurl=file:///root/{Project}-repos/{RepoRHEL7ServerSoftwareCollections}
+baseurl=file:///root/{Project}-repos/{RepoRHEL8AppStream}
 enabled=1
 ----
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -44,7 +44,7 @@ ifdef::satellite[]
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
-{RepoRHEL7ServerSatelliteMaintenanceProductVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 
 . Check the available versions to confirm the version you want is listed:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -86,7 +86,7 @@ ifdef::satellite[]
 +
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
-Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVersion}` and execute:
+Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVersion}` and execute:
 +
 [options="nowrap" subs="attributes"]
 ----


### PR DESCRIPTION
In several sections, the attribute for
`rhel-7-server-satellite-maintenance-6.12-rpms` was incorrect and needed to be updated with the attribute for
`rhel-8-server-satellite-maintenance-6.12-rpms`. This change was required because Satellite 6.12 is only a RHEL 8 based release. We do not have a RHEL 7 based repo for Satellite 6.12.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
