### PR TITLE
removes 2 procedure steps from proc_promoting-a-content-view.adoc

### DIFF
--- a/guides/common/modules/proc_promoting-a-content-view.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view.adoc
@@ -24,10 +24,6 @@ You must assign both permissions to a user to allow them to promote Content View
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views* and select the Content View that you want to promote.
 . Select the version that you want to promote, click the vertical ellipsis icon, and click *Promote*.
 . Select the environment where you want to promote the Content View and click *Promote*.
-. Click the *Promote* button again.
-This time select the *Testing* environment and click *Promote Version*.
-. Finally click on the *Promote* button again.
-Select the *Production* environment and click *Promote Version*.
 
 Now the repository for the Content View appears in all environments.
 


### PR DESCRIPTION
Remove 2 steps from Promoting a Content View proc


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
