### PR TITLE
Remove steps to regenerate capsule certs

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -40,33 +40,7 @@ endif::[]
 +
 For information on backups, see {AdministeringDocURL}Backing_Up_Server_and_Proxy_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 
-ifdef::katello,satellite[]
-+
-. Regenerate certificates on your {ProjectServer}:
-.. Regenerate certificates for {SmartProxies} that use default certificates:
-+
-[options="nowrap" subs="attributes"]
-----
-# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
---certs-update-all \
---certs-tar "~/{smartproxy-example-com}-certs.tar"
-----
-.. Regenerate certificates for {SmartProxies} that use custom certificates:
-+
-[options="nowrap" subs="attributes"]
-----
-# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
---certs-tar "~/{smartproxy-example-com}-certs.tar" \
---server-cert "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert.pem" \
---server-key "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert_key.pem" \
---server-ca-cert "/root/{certs-proxy-context}_cert/ca_cert_bundle.pem" \
---certs-update-server
-----
-For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
-+
-endif::[]
 ifdef::katello[]
-. Copy the resulting tarball to your {SmartProxy}, for this example we will use `/root/{smartproxy-example-com}-certs.tar`
 . Update repositories
 +
 .For {EL} 7 Users:
@@ -105,9 +79,6 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
-. Copy the resulting tarball to your {SmartProxy}.
-The location must match what the installer expects.
-Use `grep tar_file /etc/foreman-installer/scenarios.d/capsule-answers.yaml` on your {SmartProxy} to determine this.
 . Clean yum cache:
 +
 ----


### PR DESCRIPTION
In the section for Upgrading {SmartProxy} Servers, the steps for
regenerating certificates for {SmartProxy} were removed. This change
was required because there is no need to regenerate {SmartProxy}
certificates or copying the resulting tarball to {SmartProxy} for the
6.11 to 6.12 upgrade.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
