### PR TITLE
Remove reference for bug closed as WONTFIX

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
@@ -41,10 +41,6 @@ ifdef::satellite[]
 +
 * If your deployment uses `katello-agent` and *goferd*, enter `katello-agent`.
 * If your deployment does not use `katello-agent` and *goferd*, enter `katello-host-tools`.
-+
-. Select *via remote execution* from the *Update* list.
-This is required because if you update the package using the Katello agent, the package update disrupts the communication between the client and {Project} or {SmartProxyServer}, which causes the update to fail.
-For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 [[cli-upgrading_content_hosts]]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
@@ -43,6 +43,9 @@ ifdef::satellite[]
 * If your deployment does not use `katello-agent` and *goferd*, enter `katello-host-tools`.
 +
 . https://bugzilla.redhat.com/show_bug.cgi?id=1649764[BZ#1649764] is closed as WONTFIX.
+To workaround the problem, from the *Update* list, you must select *via remote execution*.
+This is required because if you update the package using the Katello agent, the package update disrupts the communication between the client and {Project} or {SmartProxyServer}, which causes the update to fail.
+For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 [[cli-upgrading_content_hosts]]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
@@ -42,9 +42,7 @@ ifdef::satellite[]
 * If your deployment uses `katello-agent` and *goferd*, enter `katello-agent`.
 * If your deployment does not use `katello-agent` and *goferd*, enter `katello-host-tools`.
 +
-. Until https://bugzilla.redhat.com/show_bug.cgi?id=1649764[BZ#1649764] is resolved, from the *Update* list, you must select *via remote execution*.
-This is required because if you update the package using the Katello agent, the package update disrupts the communication between the client and {Project} or {SmartProxyServer}, which causes the update to fail.
-For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in _{ManagingHostsDocTitle}_.
+. https://bugzilla.redhat.com/show_bug.cgi?id=1649764[BZ#1649764] is closed as WONTFIX.
 endif::[]
 
 [[cli-upgrading_content_hosts]]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
@@ -42,8 +42,7 @@ ifdef::satellite[]
 * If your deployment uses `katello-agent` and *goferd*, enter `katello-agent`.
 * If your deployment does not use `katello-agent` and *goferd*, enter `katello-host-tools`.
 +
-. https://bugzilla.redhat.com/show_bug.cgi?id=1649764[BZ#1649764] is closed as WONTFIX.
-To workaround the problem, from the *Update* list, you must select *via remote execution*.
+. Select *via remote execution* from the *Update* list.
 This is required because if you update the package using the Katello agent, the package update disrupts the communication between the client and {Project} or {SmartProxyServer}, which causes the update to fail.
 For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in _{ManagingHostsDocTitle}_.
 endif::[]


### PR DESCRIPTION
Bug #1649764 is closed as WONTFIX so the step referencing the bug
needing to be resolved has been updated to reflect that. The change is
required because the bug has been closed as WONTFIX.
Related to Jira ticket:
https://issues.redhat.com/browse/SATDOC-1216


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
