### PR TITLE
Add note in Prerequisites to upgrade EL version

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -39,8 +39,8 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 endif::[]
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 
-ifdef::foreman-el,katello,satellite[]
-NOTE: {Project} {ProjectVersion} is planned to be released only on {EL} 8. You must upgrade {Project} {ProjectVersionPrevious} from {EL} 7 to {EL} 8.
+ifdef::satellite[]
+NOTE: {Project} {ProjectVersion} is released only on {EL} 8. You must upgrade {Project} {ProjectVersionPrevious} from {EL} 7 to {EL} 8.
 For more information on upgrading from {EL} 7 to {EL} 8, see xref:upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}[].
 endif::[]
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -39,8 +39,10 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 endif::[]
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 
+ifdef::foreman-el,katello,satellite[]
 NOTE: {Project} {ProjectVersion} is planned to be released only on {EL} 8. You must upgrade {Project} {ProjectVersionPrevious} from {EL} 7 to {EL} 8.
 For more information on upgrading from {EL} 7 to {EL} 8, see xref:upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}[].
+endif::[]
 
 ifdef::satellite[]
 Ensure that all {ProjectServer}s are on the same version.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -39,6 +39,9 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 endif::[]
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 
+NOTE: {Project} {ProjectVersion} is planned to be released only on {EL} 8. You must upgrade {Project} {ProjectVersionPrevious} from {EL} 7 to {EL} 8.
+For more information on upgrading from {EL} 7 to {EL} 8, see xref:upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}[].
+
 ifdef::satellite[]
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]


### PR DESCRIPTION
A note was needed for the Prerequisites section of Upgrading Overview
to inform customers the need to upgrade from {EL} 7 to {EL} 8 for
Satellite 6.12. A link to Upgrading from {EL} 7 to {EL} 8 via Leapp was
provided for more information. This change was required to inform
customers that 6.12 does not run with RHEL 7.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
