### PR TITLE
Update note to provide Pull Provider feature

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
@@ -6,7 +6,7 @@ The {project-client-name} repository provides `katello-agent` and `katello-host-
 NOTE: The Katello agent is deprecated and will be removed in a future {Project} version.
 Migrate your workloads to use the remote execution feature to update clients remotely.
 For more information, see {ManagingHostsDocURL}Migrating_From_Katello_Agent_to_Remote_Execution_managing-hosts[Migrating from Katello Agent to Remote Execution] in _{ManagingHostsDocTitle}_.
-With the release of {Project} {ProjectVersion}, we are providing support for a pull-based provider, an agent-based tool as a replacement for the Katello agent.
+{Project} now supports a pull-based provider as a replacement for the Katello agent.
 
 For deployments using `katello-agent` and *goferd*, update all clients to the new version of `katello-agent`.
 For deployments not using `katello-agent` and *goferd*, update all clients to the new version of `katello-host-tools`.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_content_hosts.adoc
@@ -6,6 +6,7 @@ The {project-client-name} repository provides `katello-agent` and `katello-host-
 NOTE: The Katello agent is deprecated and will be removed in a future {Project} version.
 Migrate your workloads to use the remote execution feature to update clients remotely.
 For more information, see {ManagingHostsDocURL}Migrating_From_Katello_Agent_to_Remote_Execution_managing-hosts[Migrating from Katello Agent to Remote Execution] in _{ManagingHostsDocTitle}_.
+With the release of {Project} {ProjectVersion}, we are providing support for a pull-based provider, an agent-based tool as a replacement for the Katello agent.
 
 For deployments using `katello-agent` and *goferd*, update all clients to the new version of `katello-agent`.
 For deployments not using `katello-agent` and *goferd*, update all clients to the new version of `katello-host-tools`.


### PR DESCRIPTION
In the Upgrading Content Hosts section,
the note was updated to provide a
reference about the pull-based provider
feature so customers can try it.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
