### PR TITLE
Update steps for creating a local/remote file repository

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -109,6 +109,8 @@
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
 :RepoRHEL9ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-9-<arch>-rpms
+:RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
+:RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 :project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}

--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -12,13 +12,14 @@ To create a file type repository in a directory on a remote server, see xref:Cre
 
 To create a file type repository in a local directory, complete the following procedure:
 
-. Ensure the Server and {project-client-name} repositories are enabled.
 ifdef::satellite[]
+. Ensure the Utils repository is enabled.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable={project-client-RHEL7-url}
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteUtils}
 ----
 endif::[]
 . Install the Pulp Manifest package:
@@ -27,23 +28,18 @@ endif::[]
 ----
 # {package-install-project} python3-pulp_manifest
 ----
+ifdef::satellite[]
 +
 Note that this command stops the {Project} service and re-runs {foreman-installer}.
 Alternatively, to prevent downtime caused by stopping the service, you can use the following:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-ifdef::satellite[]
-# subscription-manager repos --enable {RepoRHEL7ServerSatelliteToolsProductVersion}
-endif::[]
 # {foreman-maintain} packages unlock
-# yum install install python-pulp-manifest -y
+# {package-install} python3-pulp_manifest
 # {foreman-maintain} packages lock
-ifdef::satellite[]
-# subscription-manager repos --disable {RepoRHEL7ServerSatelliteToolsProductVersion}
-endif::[]
 ----
-This installs the package without downtime.
+endif::[]
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -25,24 +25,25 @@ endif::[]
 
 To create a file type repository in a remote directory, complete the following procedure:
 
-. On your remote server, ensure that the Server and {project-client-name} repositories are enabled.
 ifdef::satellite[]
+. On your machine, ensure that the right repositories are enabled.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable={project-client-RHEL7-url}
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteUtils}
 ----
 endif::[]
 . Install the Pulp Manifest package:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum install python3-pulp_manifest
+# {package-install} python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
-+
 [options="nowrap" subs="+quotes"]
++
 ----
 # mkdir /var/www/html/pub/__my_file_repo__
 ----

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -42,8 +42,8 @@ endif::[]
 # {package-install} python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
-[options="nowrap" subs="+quotes"]
 +
+[options="nowrap" subs="+quotes"]
 ----
 # mkdir /var/www/html/pub/__my_file_repo__
 ----


### PR DESCRIPTION
Added missing steps required for creating a local/remote file type repo. 
This is a copy of PR#1650. 
It was hard to rebase the original PR. 
So created this PR with steps for EL 8 only.
This PR should be merged in foreman-3.4 only.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
