### PR TITLE
Update steps for creating a local/remote file repository

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -116,6 +116,8 @@
 // Satellite-Tools becomes Satellite-Client in Satellite 7
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
+:RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
+:RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 :project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}

--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -26,7 +26,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} python3-pulp_manifest
+# {package-install-project} python38-pulp_manifest
 ----
 ifdef::satellite[]
 +
@@ -36,7 +36,7 @@ Alternatively, to prevent downtime caused by stopping the service, you can use t
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} packages unlock
-# {package-install} python3-pulp_manifest
+# {package-install} python38-pulp_manifest
 # {foreman-maintain} packages lock
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -12,13 +12,14 @@ To create a file type repository in a directory on a remote server, see xref:Cre
 
 To create a file type repository in a local directory, complete the following procedure:
 
-. Ensure the Server and {project-client-name} repositories are enabled.
 ifdef::satellite[]
+. Ensure the Utils repository is enabled.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable={project-client-RHEL7-url}
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteUtils}
 ----
 endif::[]
 . Install the Pulp Manifest package:
@@ -27,6 +28,18 @@ endif::[]
 ----
 # {package-install-project} python3-pulp_manifest
 ----
+ifdef::satellite[]
++
+Note that this command stops the {Project} service and re-runs {foreman-installer}.
+Alternatively, to prevent downtime caused by stopping the service, you can use the following:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages unlock
+# {package-install} python3-pulp_manifest
+# {foreman-maintain} packages lock
+----
+endif::[]
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -48,7 +48,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} python3-pulp_manifest
+# {package-install} python38-pulp_manifest
 ----
 ** For {EL} 7:
 +

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -57,8 +57,8 @@ endif::[]
 # yum install tfm-pulpcore-python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
-[options="nowrap" subs="+quotes"]
 +
+[options="nowrap" subs="+quotes"]
 ----
 # mkdir /var/www/html/pub/__my_file_repo__
 ----

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -25,24 +25,40 @@ endif::[]
 
 To create a file type repository in a remote directory, complete the following procedure:
 
-. On your remote server, ensure that the Server and {project-client-name} repositories are enabled.
 ifdef::satellite[]
+. On your machine, ensure that the right repositories are enabled.
+** For {EL} 8:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+--enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteUtils}
+----
+** For {EL} 7:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable={RepoRHEL7Server} \
---enable={project-client-RHEL7-url}
+--enable={RepoRHEL7ServerSatelliteUtils}
 ----
 endif::[]
 . Install the Pulp Manifest package:
+** For {EL} 8:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum install python3-pulp_manifest
+# {package-install} python3-pulp_manifest
+----
+** For {EL} 7:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# yum tfm-pulpcore-python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
-+
 [options="nowrap" subs="+quotes"]
++
 ----
 # mkdir /var/www/html/pub/__my_file_repo__
 ----

--- a/guides/common/modules/proc_creating-a-remote-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-file-repository.adoc
@@ -26,7 +26,7 @@ endif::[]
 To create a file type repository in a remote directory, complete the following procedure:
 
 ifdef::satellite[]
-. On your machine, ensure that the right repositories are enabled.
+. On your machine, ensure that the correct repositories are enabled.
 ** For {EL} 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -54,7 +54,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum tfm-pulpcore-python3-pulp_manifest
+# yum install tfm-pulpcore-python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
Added missing steps required for creating a local/remote file type repo. 
This is a copy of PR #1650.
This PR contains steps for EL 7 and EL 8.
This PR should be merged in foreman-3.1 only.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
