### PR TITLE
Update section with correct repositories

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -13,13 +13,13 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 +
 * If you have {SmartProxyServer}s, to upgrade them, enable the following repositories too:
 +
-*{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 7 Server) (RPMs)*
+*{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 8 x86_64) (RPMS)*
 +
-*{ProjectName} Maintenance {ProjectVersion} (for RHEL 7 Server) (RPMs)*
+*{ProjectName} Maintenance {ProjectVersion} (for RHEL 8 x86_64) (RPMs)*
 +
-*Red{nbsp}Hat Ansible Engine {SatelliteAnsibleVersion} RPMs for {RHEL} 7 Server*
+*{EL} 8 (for x86_64 - BaseOS) (RPMs)*
 +
-*Red{nbsp}Hat Software Collections RPMs for {RHEL} 7 Server*
+*{EL} 8 (for x86_64 - AppStream) (RPMs)*
 
 +
 [NOTE]

--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -13,13 +13,13 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 +
 * If you have {SmartProxyServer}s, to upgrade them, enable the following repositories too:
 +
-*{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 8 x86_64) (RPMS)*
+*{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 8 x86_64) (RPMs)*
 +
 *{ProjectName} Maintenance {ProjectVersion} (for RHEL 8 x86_64) (RPMs)*
 +
-*{EL} 8 (for x86_64 - BaseOS) (RPMs)*
+*{EL} 8 (for x86_64 {endash} BaseOS) (RPMs)*
 +
-*{EL} 8 (for x86_64 - AppStream) (RPMs)*
+*{EL} 8 (for x86_64 {endash} AppStream) (RPMs)*
 
 +
 [NOTE]


### PR DESCRIPTION
Repository names were changed. This
change was required because the Red Hat
Satellite Client repo is version
independent such as "Red Hat Satellite
Client 6 for RHEL 8 x86_64 RPMs". The
repository names were updated to
reflect that.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
