### PR TITLE
Fix Client repo name on 3.3

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -68,7 +68,6 @@
 :PIV: CAC
 :project-context: satellite
 :project-change-hostname: satellite-change-hostname
-:project-client-name: Satellite Client {ProductVersionRepoTitle}
 :Project: Satellite
 :ProjectName: Red{nbsp}Hat Satellite
 :ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
@@ -114,5 +113,6 @@
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
+:project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}


### PR DESCRIPTION
This fix seems to have "got lost" on the 3.3 branch, while it's present on master and 3.4.

Relates to: https://bugzilla.redhat.com/show_bug.cgi?id=2136485

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

No cherry-picks.
