### PR TITLE
Label double xref manually 3.3

### DIFF
--- a/guides/common/modules/con_transport-modes-for-remote-execution.adoc
+++ b/guides/common/modules/con_transport-modes-for-remote-execution.adoc
@@ -22,7 +22,7 @@ ifdef::katello,orcharhino,satellite[]
 endif::[]
 ifdef::managing-hosts[]
 * To migrate a host from Katello Agent, see xref:Migrating_From_Katello_Agent_to_Remote_Execution_{context}[].
-* To enable pull mode on a new host, continue either with xref:Creating_a_Host_{context}[] or xref:Registering_Hosts_{context}[].
+* To enable pull mode on a new host, continue either with xref:Creating_a_Host_{context}[Creating a Host] or xref:Registering_Hosts_{context}[Registering Hosts].
 endif::[]
 ifndef::managing-hosts[]
 * To migrate a host from Katello Agent, see {ManagingHostsDocURL}Migrating_From_Katello_Agent_to_Remote_Execution_managing-hosts[Migrating from Katello Agent to Remote Execution].

--- a/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
+++ b/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
@@ -4,7 +4,7 @@
 In the {ProjectWebUI}, configure {Project} to use LDAP.
 
 Note that if you need single sign-on functionality with Kerberos on {ProjectWebUI}, you should use {FreeIPA} and AD external authentication instead.
-For more information, see xref:Using_FreeIPA_{context}[] or xref:Using_Active_Directory_{context}[].
+For more information, see xref:Using_FreeIPA_{context}[Using Red Hat Identity Management] or xref:Using_Active_Directory_{context}[Using Active Directory].
 
 .Procedure
 . Set the Network Information System (NIS) service boolean to true to prevent SELinux from stopping outgoing LDAP connections:

--- a/guides/common/modules/proc_creating-an-api-only-user.adoc
+++ b/guides/common/modules/proc_creating-an-api-only-user.adoc
@@ -6,7 +6,7 @@ You can create users that can interact only with the {Project} API.
 .Prerequisite
 * You have created a user and assigned roles to them.
 Note that this user must be authorized internally.
-For more information, see xref:Creating_a_User_{context}[] and xref:Assigning_Roles_to_a_User_{context}[].
+For more information, see xref:Creating_a_User_{context}[Creating a User] and xref:Assigning_Roles_to_a_User_{context}[Assigning Roles to a User].
 
 .Procedure
 . Log in to your {Project} as admin.


### PR DESCRIPTION
Due to a bug in our internal build system, I'm adding this workaround for two xrefs on a single line.
The bug causes wrong automatic selection of link labels -- the resulting links are rendered as a single link, which results in bad UX with the docs.
I'm not adding this to _master_, because we expect this bug to be fixed before the next release.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Cherry-pick to 3.1 and 2.5.
