### PR TITLE
Hide OSTree content for Satellite on 3.3

### DIFF
--- a/guides/common/modules/con_content-management-types-overview.adoc
+++ b/guides/common/modules/con_content-management-types-overview.adoc
@@ -43,7 +43,9 @@ ISO and KVM Images::
 Download and manage media for installation and provisioning.
 For example, {Project} downloads, stores, and manages ISO images and guest images for specific {RHEL} and non-Red Hat operating systems.
 
+ifndef::satellite[]
 OSTree::
 You can import OSTree branches and publish this content to an HTTP location for consumption by OSTree clients.
+endif::[]
 
 You can use the procedure to add {customcontent} for any type of content you require, for example, SSL certificates and OVAL files.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -39,7 +39,9 @@ include::common/assembly_managing-errata.adoc[leveloffset=+1]
 
 include::common/modules/proc_installing-packages-on-a-host.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::common/assembly_managing-ostree-content.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]
 


### PR DESCRIPTION
OSTree content management is not available in Satellite 6.12

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

No cherry-picks.
