### PR TITLE
Remove API version from curl header option

### DIFF
--- a/guides/common/modules/proc_refreshing-the-compute-resources-cache.adoc
+++ b/guides/common/modules/proc_refreshing-the-compute-resources-cache.adoc
@@ -12,7 +12,7 @@ Refresh the cache of compute resources to update compute resources information.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# curl -H "Accept:application/json,version=2" \
+# curl -H "Accept:application/json" \
 -H "Content-Type:application/json" -X PUT \
 -u _username_:__password__ -k \
 https://_{foreman-example-com}_/api/compute_resources/_compute_resource_id_/refresh_cache

--- a/guides/common/modules/proc_synchronizing-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-using-the-api.adoc
@@ -48,7 +48,7 @@ Do not specify a passphrase.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ curl -H "Accept:application/json,version=2" \
+$ curl -H "Accept:application/json" \
 -H "Content-Type:application/json" \
 -u _login_:__password__ \
 -k https://_{foreman-example-com}/api/v2/templates/export \
@@ -60,7 +60,7 @@ $ curl -H "Accept:application/json,version=2" \
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ curl -H "Accept:application/json,version=2" \
+$ curl -H "Accept:application/json" \
 -H "Content-Type:application/json" \
 -u _login_:__password__ \
 -k https://_{foreman-example-com}/api/v2/templates/import \

--- a/guides/common/modules/proc_synchronizing-templates-with-a-local-directory-using-the-api.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-a-local-directory-using-the-api.adoc
@@ -41,7 +41,7 @@ organizations:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-$ curl -H "Accept:application/json,version=2" \
+$ curl -H "Accept:application/json" \
 -H "Content-Type:application/json" \
 -u _login_:__password__ \
 -k https://_{foreman-example-com}/api/v2/templates/export \
@@ -53,7 +53,7 @@ $ curl -H "Accept:application/json,version=2" \
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-$ curl -H "Accept:application/json,version=2" \
+$ curl -H "Accept:application/json" \
 -H "Content-Type:application/json" \
 -u _login_:__password__ \
 -k https://_{foreman-example-com}/api/v2/templates/import \
@@ -72,7 +72,7 @@ The following example exports templates to the `git.example.com/templates` repos
 
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-$ curl -H "Accept:application/json,version=2" \
+$ curl -H "Accept:application/json" \
 -H "Content-Type:application/json" \
 -u login:password \
 -k https://{foreman-example-com}/api/v2/templates/export \


### PR DESCRIPTION
This was required in Satellite API guide so I thought the same change should be done in the rest of the guides as well.
Related BZ: [https://bugzilla.redhat.com/show_bug.cgi?id=1917726](https://bugzilla.redhat.com/show_bug.cgi?id=1917726)
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3