### PR TITLE
Fix the attributes for Satellite 6.12

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -10,8 +10,9 @@
 :InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
 :PlanningDocURL: {BaseURL}satellite_overview_concepts_and_deployment_considerations/index#
 :ProvisioningDocURL: {BaseURL}provisioning_hosts/index#
+:TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
-:ReleaseNotesURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/release_notes/index#
+:ReleaseNotesURL: {MultiBaseURL}/release_notes/index#
 
 // Attributes only for satellite build
 :ProductVersion: 6.12
@@ -68,7 +69,6 @@
 :PIV: CAC
 :project-context: satellite
 :project-change-hostname: satellite-change-hostname
-:project-client-name: Satellite Client 6
 :Project: Satellite
 :ProjectName: Red{nbsp}Hat Satellite
 :ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
@@ -114,5 +114,6 @@
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
+:project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -10,9 +10,8 @@
 :InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
 :PlanningDocURL: {BaseURL}satellite_overview_concepts_and_deployment_considerations/index#
 :ProvisioningDocURL: {BaseURL}provisioning_hosts/index#
-:TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
-:ReleaseNotesURL: {MultiBaseURL}/release_notes/index#
+:ReleaseNotesURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/release_notes/index#
 
 // Attributes only for satellite build
 :ProductVersion: 6.12
@@ -69,6 +68,7 @@
 :PIV: CAC
 :project-context: satellite
 :project-change-hostname: satellite-change-hostname
+:project-client-name: Satellite Client 6
 :Project: Satellite
 :ProjectName: Red{nbsp}Hat Satellite
 :ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
@@ -114,6 +114,5 @@
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
-:project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -12,7 +12,7 @@
 :SatelliteAnsibleVersion: 2.9
 
 // Use current RH Satellite release version for links to access.redhat.com
-:AccessRedHatComVersion: 6.11
+:AccessRedHatComVersion: 6.12
 
 //
 // WHERE ARE MY ATTRIBUTES?

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -21,3 +21,4 @@ ignore=example.com
   # This isn't published downstream yet
   access.redhat.com/documentation/en-us/red_hat_satellite/6.10/html-single/managing_configurations_using_puppet_integration/index
   access.redhat.com/documentation/en-us/red_hat_satellite/6.11
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.12

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -19,6 +19,4 @@ ignore=example.com
   sources/
   atixservice.zendesk.com
   # This isn't published downstream yet
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.10/html-single/managing_configurations_using_puppet_integration/index
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.11
   access.redhat.com/documentation/en-us/red_hat_satellite/6.12


### PR DESCRIPTION
- The `project-client-name` attribute is currently set to `Satellite Client {ProductVersionRepoTitle}` rendering the incorrect value `Satellite Client 6.12` for repos.
- The `AccessRedHatComVersion` is set to `6.11`, causing doc links to redirect to 6.11 docs instead of 6.12. Correcting these values for the 3.3 branch, which translates to 6.12.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
