### PR TITLE
Use MultiBaseURL instead of copying it

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -12,7 +12,7 @@
 :ProvisioningDocURL: {BaseURL}provisioning_hosts/index#
 :TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
-:ReleaseNotesURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/release_notes/index#
+:ReleaseNotesURL: {MultiBaseURL}/release_notes/index#
 
 // Attributes only for satellite build
 :ProductVersion: 6.12


### PR DESCRIPTION
I'm not sure why the release notes use the Multi page view, but in 3d7230b7c24146e152488c64a80d8aa033164705 I just moved the existing link to a macro.

On a related note: I'd really like it if we could align Satellite links on a single style.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.