### PR TITLE
Remove link to deprecated KCS

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -36,7 +36,6 @@ For more information, see {InstallingServerDocURL}Preparing_your_Environment_for
 * Back up your {ProjectServer} and all {SmartProxyServer}s.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
-For more information about changes in the API, see the Red Hat Knowledgebase article https://access.redhat.com/articles/4396911[API Changes Between {Project} Versions] on the Red{nbsp}Hat Customer Portal.
 
 ifdef::satellite[]
 Ensure that all {ProjectServer}s are on the same version.


### PR DESCRIPTION
Removed link to deprecated KCS article about API changes inbetween Satellite versions 6.3 and 6.6.
[Related BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2135236)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
