### PR TITLE
Remove link to deprecated KCS for 2.5

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_process_overview.adoc
@@ -44,7 +44,7 @@ For more information on preparing for Pulp migration and the upgrade process, se
 
 * Back up your {ProjectServer} and all {SmartProxyServer}s. For more information, see {AdministeringDocURL}#backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProductVersionPrevious}_ guide.
 
-* Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}. For more information about changes in the API, see the Knowledgebase article https://access.redhat.com/articles/4396911[API Changes Between {Project} Versions] on the Red{nbsp}Hat Customer Portal.
+* Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 
 [WARNING]
 If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating. You can use the `--noop` option with the {foreman-installer} script to test for changes. For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]


### PR DESCRIPTION
Removed link to deprecated KCS about API changes inbetween Satellite versions 6.3 and 6.6 on branch 2.5
[Related BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2135236)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
