### PR TITLE
Drop references to EL 7.1

### DIFF
--- a/guides/common/modules/con_gss-proxy.adoc
+++ b/guides/common/modules/con_gss-proxy.adoc
@@ -6,11 +6,6 @@ GSS-Proxy allows you to implement stricter privilege separation for the Apache s
 When using AD as an external authentication source for {Project}, it is recommended to implement GSS-proxy, because the keys in the keytab file are the same as the host keys.
 
 ifndef::orcharhino[]
-[NOTE]
-====
-The AD integration requires {ProjectServer} to be deployed on {EL} 7.1 or later.
-====
-
 Perform the following procedures on {EL} that acts as a base operating system for your {ProjectServer}.
 For the examples in this section _EXAMPLE.ORG_ is the Kerberos realm for the AD domain.
 By completing the procedures, users that belong to the EXAMPLE.ORG realm can log in to {ProjectServer}.

--- a/guides/common/modules/con_using-freeipa.adoc
+++ b/guides/common/modules/con_using-freeipa.adoc
@@ -10,7 +10,6 @@ For more information, see xref:Using_LDAP_{context}[].
 ====
 
 .Prerequisites
-* {ProjectServer} has to run on {EL} 7.1 or later.
 * The base operating system of {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.


### PR DESCRIPTION
Dropped references to EL 7.1 which is no longer supported.
[Related BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2134737)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
