### PR TITLE
Manage EL7 and EL8 references at upstream & downstream

### DIFF
--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -17,7 +17,9 @@ NOTE: You cannot register {ProjectServer} to itself.
 
 include::modules/proc_downloading-the-binary-dvd-images.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-7.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -17,12 +17,9 @@ You can use KVM provisioning to create hosts over a network connection or from a
 include::snip_common-compute-resource-prereqs.adoc[]
 * A {SmartProxyServer} managing a network on the KVM server.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
-ifndef::satellite[]
-* A {RHEL} server running KVM virtualization tools (libvirt daemon).
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/virtualization_getting_started_guide/[{EL} 7 Virtualization Getting Started Guide].
-endif::[]
+For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in the _Provisioning_ guide.
 ifdef::satellite[]
+* A {RHEL} server running KVM virtualization tools (libvirt daemon).
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/index[_{RHEL} 8 Configuring and managing virtualization_].
 endif::[]
 ifndef::satellite[]
@@ -46,7 +43,7 @@ useradd -a -G libvirt _non_root_user_
 ** *Edit hosts*
 ** *View hosts*
 +
-For more information, see {AdministeringDocURL}Assigning_Roles_to_a_User_admin[Assigning Roles to a User] in _{AdministeringDocTitle}_.
+For more information, see {AdministeringDocURL}Assigning_Roles_to_a_User_admin[Assigning Roles to a User] in the _Administering {ProjectName}_ guide.
 * A custom role in {Project} with the following permissions:
 ** *view_compute_resources*
 ** *destroy_compute_resources_vms*
@@ -56,5 +53,5 @@ For more information, see {AdministeringDocURL}Assigning_Roles_to_a_User_admin[A
 ** *view_locations*
 ** *view_subnets*
 +
-For more information about creating roles, see {AdministeringDocURL}Creating_a_Role_admin[Creating a Role] in _{AdministeringDocTitle}_.
-For more information about adding permissions to a role, see {AdministeringDocURL}Adding_Permissions_to_a_Role_admin[Adding Permissions to a Role] in _{AdministeringDocTitle}_.
+For more information about creating roles, see {AdministeringDocURL}Creating_a_Role_admin[Creating a Role] in the _Administering {ProjectName}_ guide.
+For more information about adding permissions to a role, see {AdministeringDocURL}Adding_Permissions_to_a_Role_admin[Adding Permissions to a Role] in the _Administering {ProjectName}_ guide.

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -17,7 +17,7 @@ You can use KVM provisioning to create hosts over a network connection or from a
 include::snip_common-compute-resource-prereqs.adoc[]
 * A {SmartProxyServer} managing a network on the KVM server.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in the _Provisioning_ guide.
+For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
 ifdef::satellite[]
 * A {RHEL} server running KVM virtualization tools (libvirt daemon).
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/index[_{RHEL} 8 Configuring and managing virtualization_].
@@ -43,7 +43,7 @@ useradd -a -G libvirt _non_root_user_
 ** *Edit hosts*
 ** *View hosts*
 +
-For more information, see {AdministeringDocURL}Assigning_Roles_to_a_User_admin[Assigning Roles to a User] in the _Administering {ProjectName}_ guide.
+For more information, see {AdministeringDocURL}Assigning_Roles_to_a_User_admin[Assigning Roles to a User] in _{AdministeringDocTitle}_.
 * A custom role in {Project} with the following permissions:
 ** *view_compute_resources*
 ** *destroy_compute_resources_vms*
@@ -53,5 +53,5 @@ For more information, see {AdministeringDocURL}Assigning_Roles_to_a_User_admin[A
 ** *view_locations*
 ** *view_subnets*
 +
-For more information about creating roles, see {AdministeringDocURL}Creating_a_Role_admin[Creating a Role] in the _Administering {ProjectName}_ guide.
-For more information about adding permissions to a role, see {AdministeringDocURL}Adding_Permissions_to_a_Role_admin[Adding Permissions to a Role] in the _Administering {ProjectName}_ guide.
+For more information about creating roles, see {AdministeringDocURL}Creating_a_Role_admin[Creating a Role] in _{AdministeringDocTitle}_.
+For more information about adding permissions to a role, see {AdministeringDocURL}Adding_Permissions_to_a_Role_admin[Adding Permissions to a Role] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -18,9 +18,12 @@ include::snip_common-compute-resource-prereqs.adoc[]
 * A {SmartProxyServer} managing a network on the KVM server.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
-ifdef::satellite[]
+ifndef::satellite[]
 * A {RHEL} server running KVM virtualization tools (libvirt daemon).
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/virtualization_getting_started_guide/[{RHEL} 7 Virtualization Getting Started Guide].
+For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/virtualization_getting_started_guide/[{EL} 7 Virtualization Getting Started Guide].
+endif::[]
+ifdef::satellite[]
+For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/index[_{RHEL} 8 Configuring and managing virtualization_].
 endif::[]
 ifndef::satellite[]
 * A server running KVM virtualization tools (libvirt daemon).

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,10 +3,6 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-ifdef::satellite[]
-* If you plan to provision hosts from {Project} or {SmartProxies}, you must install {Project} and {SmartProxies} on {RHEL} version 7.9 or higher because these versions include the latest version of the `grub2` package.
-endif::[]
-
 ifndef::satellite[]
 * If you plan to provision hosts from {Project} or {SmartProxy}, you must install {Project} and {SmartProxies} on a system with `grub2` version 2.05 or higher or system with fixes for HTTP Boot, for example CentOS version 7.9 or 8.3 or higher.
 For other operating systems, copy the newest GRUB build to `/var/lib/tftpboot/grub2/grubx64.efi`.

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -33,31 +33,35 @@ The command displays output similar to the following:
 ----
 Subscription Name:   {SatelliteSub}
 Provides:            Red Hat Satellite
-                      Red Hat Software Collections (for RHEL Server)
-                      Red Hat CodeReady Linux Builder for x86_64
-                      Red Hat Ansible Engine
-                      Red Hat Enterprise Linux Load Balancer (for RHEL Server)
-                      Red Hat
-                      Red Hat Software Collections (for RHEL Server)
-                      Red Hat Enterprise Linux Server
-                      Red Hat Satellite Capsule
-                      Red Hat Enterprise Linux for x86_64
-                      Red Hat Enterprise Linux High Availability for x86_64
-                      Red Hat Satellite
-                      Red Hat Satellite 5 Managed DB
-                      Red Hat Satellite 6
-                      Red Hat Discovery
-SKU:                 MCT3719
-Contract:            11878983
-Pool ID:             8a85f99968b92c3701694ee998cf03b8
-Provides Management: No
-Available:           1
+                     Red Hat Software Collections (for RHEL Server)
+                     Red Hat CodeReady Linux Builder for x86_64
+                     Red Hat Satellite Capsule
+                     Red Hat Ansible Engine
+                     Red Hat Satellite with Embedded Oracle
+                     Red Hat Satellite 5 Managed DB
+                     Red Hat Enterprise Linux Load Balancer (for RHEL Server)
+                     Red Hat Beta
+                     Red Hat Software Collections Beta (for RHEL Server)
+                     Red Hat Enterprise Linux Server
+                     Red Hat Enterprise Linux for x86_64
+                     Red Hat Satellite Proxy
+                     Red Hat Enterprise Linux High Availability for x86_64
+                     Red Hat Discovery
+SKU:                 MCT3718
+Contract:
+Pool ID:             8aca43dd771bf31101771c0231f906a5
+Provides Management: Yes
+Available:           10
 Suggested:           1
-Service Level:       Premium
 Service Type:        L1-L3
+Roles:
+Service Level:       Premium
+Usage:
+Add-ons:
 Subscription Type:   Standard
-Ends:                03/04/2020
-System Type:         Physical
+Starts:              11/11/2020
+Ends:                11/11/2023
+Entitlement Type:    Physical
 ----
 
 . Make a note of the subscription Pool ID.

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -3,14 +3,6 @@
 = Configuring Repositories
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
-ifndef::satellite[]
-Select the option that corresponds with operating system and version you want to install on:
-
-* xref:#repositories-rhel-8[{RHEL} 8]
-* xref:#repositories-rhel-7[{RHEL} 7]
-
-== [[repositories-rhel-8]]{RHEL} 8
-endif::[]
 
 . Disable all repositories:
 +
@@ -44,28 +36,6 @@ The module `satellite-capsule:el8` has a dependency for the modules `postgresql:
 These warnings do not cause installation process failure, hence can be ignored safely.
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
-
-ifndef::satellite[]
-== [[repositories-rhel-7]]{RHEL} 7
-
-. Disable all repositories:
-+
-[options="nowrap"]
-----
-# subscription-manager repos --disable "*"
-----
-+
-. Enable the following repositories:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable={RepoRHEL7ServerSatelliteCapsuleProductVersion} \
---enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion} \
---enable={RepoRHEL7ServerSoftwareCollections} \
---enable={RepoRHEL7ServerAnsible}
-----
-endif::[]
 +
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -3,12 +3,14 @@
 = Configuring Repositories
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
+ifndef::satellite[]
 Select the option that corresponds with operating system and version you want to install on:
 
 * xref:#repositories-rhel-8[{RHEL} 8]
 * xref:#repositories-rhel-7[{RHEL} 7]
 
 == [[repositories-rhel-8]]{RHEL} 8
+endif::[]
 
 . Disable all repositories:
 +
@@ -43,6 +45,7 @@ These warnings do not cause installation process failure, hence can be ignored s
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 
+ifndef::satellite[]
 == [[repositories-rhel-7]]{RHEL} 7
 
 . Disable all repositories:
@@ -62,10 +65,10 @@ For more information about modules and lifecycle streams on {RHEL} 8, see https:
 --enable={RepoRHEL7ServerSoftwareCollections} \
 --enable={RepoRHEL7ServerAnsible}
 ----
+endif::[]
 +
-
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
 +
 . Clear any metadata:
 +
@@ -78,5 +81,5 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 +
 [options="nowrap"]
 ----
-# yum repolist enabled
+# {package-manager} repolist enabled
 ----

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,6 +5,7 @@
 Use this procedure to enable the repositories that are required to install {ProductName}.
 ifndef::satellite[]
 Choose from the available list which operating system and version you are installing on:
+
 endif::[]
 ifdef::foreman-el,katello[]
 * xref:#repositories-centos-8[CentOS 8]
@@ -12,8 +13,6 @@ ifdef::foreman-el,katello[]
 endif::[]
 ifdef::foreman-el,katello[]
 * xref:#repositories-rhel-8[{RHEL} 8]
-endif::[]
-ifdef::foreman-el,katello[]
 * xref:#repositories-rhel-7[{RHEL} 7]
 endif::[]
 ifdef::foreman-deb[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -76,6 +76,7 @@ include::proc_configuring-repositories-el.adoc[]
 ----
 endif::[]
 
+ifdef::foreman-el,katello,satellite[]
 ifdef::foreman-el,katello[]
 == [[repositories-rhel-8]]{RHEL} 8
 endif::[]
@@ -140,6 +141,7 @@ The module `satellite:el8` has a dependency for the modules `postgresql:12` and 
 These warnings do not cause installation process failure, hence can be ignored safely.
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
+endif::[]
 endif::[]
 +
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -186,7 +186,7 @@ endif::[]
 [NOTE]
 ====
 If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
 ====
 endif::[]
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -2,14 +2,18 @@
 
 = Configuring Repositories
 
-Use this procedure to enable the repositories that are required to install {ProductName}. Choose from the available list which operating system and version you are installing on:
-
+Use this procedure to enable the repositories that are required to install {ProductName}.
+ifndef::satellite[]
+Choose from the available list which operating system and version you are installing on:
+endif::[]
 ifdef::foreman-el,katello[]
 * xref:#repositories-centos-8[CentOS 8]
 * xref:#repositories-centos-7[CentOS 7]
 endif::[]
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 * xref:#repositories-rhel-8[{RHEL} 8]
+endif::[]
+ifdef::foreman-el,katello[]
 * xref:#repositories-rhel-7[{RHEL} 7]
 endif::[]
 ifdef::foreman-deb[]
@@ -73,8 +77,9 @@ include::proc_configuring-repositories-el.adoc[]
 ----
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 == [[repositories-rhel-8]]{RHEL} 8
+endif::[]
 
 :distribution: rhel
 :distribution-major-version: 8
@@ -137,10 +142,9 @@ These warnings do not cause installation process failure, hence can be ignored s
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 endif::[]
-endif::[]
 +
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 
 == [[repositories-rhel-7]]{RHEL} 7
 
@@ -172,26 +176,17 @@ ifdef::foreman-el,katello[]
 # {package-manager} localinstall https://dl.fedoraproject.org/pub/epel/epel-release-latest-{distribution-major-version}.noarch.rpm
 ----
 endif::[]
-
-ifdef::satellite[]
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager repos --enable={RepoRHEL7Server} \
---enable={RepoRHEL7ServerSoftwareCollections} \
---enable={RepoRHEL7ServerAnsible} \
---enable={RepoRHEL7ServerSatelliteServerProductVersion} \
---enable={RepoRHEL7ServerSatelliteMaintenanceProductVersion}
-----
-endif::[]
 +
 
 ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
-NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
+[NOTE]
+====
+If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
+====
 endif::[]
 
 ifdef::foreman-deb[]

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -1,10 +1,6 @@
 [id="Enabling_the_Client_Repository_{context}"]
 = Enabling the {project-client-name} Repository
 
-ifdef::foreman-el,katello[]
-You require the Katello plug-in to complete this procedure.
-endif::[]
-
 The {project-client-name} repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_{context}[].
@@ -15,15 +11,8 @@ ifeval::["{mode}" == "disconnected"]
 endif::[]
 
 .Procedure
-ifndef::satellite[]
-. In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
-. Use the Search field to enter the following repository name: *{project-client-name} (for RHEL 8 and RHEL 7 Server) (RPMs)*.
-. In the Available Repositories pane, click on *{project-client-name} (for RHEL 8 and RHEL 7 Server) (RPMs)* to expand the repository set.
-endif::[]
-ifdef::satellite[]
 . Use the Search field to enter the following repository name: *{project-client-name} (for RHEL 8) (RPMs)*.
 . In the Available Repositories pane, click on *{project-client-name} (for RHEL 8) (RPMs)* to expand the repository set.
-endif::[]
 +
 If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
 To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
@@ -37,17 +26,6 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 .CLI procedure
 * Enable the {project-client-name} repository using the `hammer repository-set enable` command:
 +
-ifndef::satellite[]
-[options="nowrap" subs="+quotes,attributes"]
-----
-# hammer repository-set enable \
---basearch='x86_64' \
---name 'Red Hat {project-client-name} (for RHEL 8 or RHEL 7 Server) (RPMs)' \
---organization _"My_Organization"_ \
---product 'Red Hat Enterprise Linux Server'
-----
-endif::[]
-ifdef::satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository-set enable \
@@ -56,4 +34,3 @@ ifdef::satellite[]
 --organization _"My_Organization"_ \
 --product 'Red Hat Enterprise Linux Server'
 ----
-endif::[]

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -15,9 +15,15 @@ ifeval::["{mode}" == "disconnected"]
 endif::[]
 
 .Procedure
+ifndef::satellite[]
 . In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
-. Use the Search field to enter the following repository name: *{project-client-name} (for RHEL 7 Server) (RPMs)*.
-. In the Available Repositories pane, click on *{project-client-name} (for RHEL 7 Server) (RPMs)* to expand the repository set.
+. Use the Search field to enter the following repository name: *{project-client-name} (for RHEL 8 and RHEL 7 Server) (RPMs)*.
+. In the Available Repositories pane, click on *{project-client-name} (for RHEL 8 and RHEL 7 Server) (RPMs)* to expand the repository set.
+endif::[]
+ifdef::satellite[]
+. Use the Search field to enter the following repository name: *{project-client-name} (for RHEL 8) (RPMs)*.
+. In the Available Repositories pane, click on *{project-client-name} (for RHEL 8) (RPMs)* to expand the repository set.
+endif::[]
 +
 If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
 To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
@@ -31,11 +37,23 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 .CLI procedure
 * Enable the {project-client-name} repository using the `hammer repository-set enable` command:
 +
+ifndef::satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository-set enable \
 --basearch='x86_64' \
---name 'Red Hat {project-client-name} (for RHEL 7 Server) (RPMs)' \
+--name 'Red Hat {project-client-name} (for RHEL 8 or RHEL 7 Server) (RPMs)' \
 --organization _"My_Organization"_ \
 --product 'Red Hat Enterprise Linux Server'
 ----
+endif::[]
+ifdef::satellite[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository-set enable \
+--basearch='x86_64' \
+--name 'Red Hat {project-client-name} (for RHEL 8) (RPMs)' \
+--organization _"My_Organization"_ \
+--product 'Red Hat Enterprise Linux Server'
+----
+endif::[]

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -3,7 +3,7 @@
 
 Before installing {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 * xref:el-7-package[{EL} 7]
 * xref:el-8-package[{EL} 8]
 endif::[]
@@ -16,7 +16,7 @@ ifdef::foreman-deb[]
 include::proc_installing-proxy-packages.adoc[]
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 == [[el-7-package]]{EL} 7
 
 :package-manager: yum
@@ -24,6 +24,11 @@ include::proc_installing-proxy-packages.adoc[]
 
 == [[el-8-package]]{EL} 8
 
+:package-manager: dnf
+include::proc_installing-proxy-packages.adoc[]
+endif::[]
+
+ifdef::satellite[]
 :package-manager: dnf
 include::proc_installing-proxy-packages.adoc[]
 endif::[]

--- a/guides/common/modules/proc_installing-the-infoblox-ca-certificate-on-smartproxy.adoc
+++ b/guides/common/modules/proc_installing-the-infoblox-ca-certificate-on-smartproxy.adoc
@@ -33,7 +33,3 @@ Example positive response:
     }
 ]
 ----
-
-ifdef::satellite[]
-Use the following Red{nbsp}Hat Knowledgebase article to install the certificate: https://access.redhat.com/solutions/1519813[How to install a CA certificate on {RHEL} 6 / 7].
-endif::[]

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -3,19 +3,24 @@ ifdef::context[:parent-context: {context}]
 [id="Installing_Server_Packages_{context}"]
 = Installing {ProjectServer} Packages
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 * xref:#el-8[{EL} 8]
 * xref:#el-7[{EL} 7]
 endif::[]
 
 .Procedure
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 == [[el-8]]{EL} 8
+endif::[]
+
+ifdef::foreman-el,katello,satellite[]
 :context: el8
 :package-manager: dnf
 include::proc_installing-server-packages-el.adoc[]
+endif::[]
 
+ifdef::foreman-el,katello[]
 == [[el-7]]{EL} 7
 :context: el7
 :package-manager: yum

--- a/guides/common/modules/proc_registering-to-red-hat-subscription-management.adoc
+++ b/guides/common/modules/proc_registering-to-red-hat-subscription-management.adoc
@@ -7,7 +7,6 @@ endif::[]
 
 Registering the host to Red Hat Subscription Management enables the host to subscribe to and consume content for any subscriptions available to the user.
 This includes content such as {RHEL} and {ProjectName}.
-For {RHEL} 7, it also provides access to Red{nbsp}Hat Software Collections (RHSCL).
 
 .Procedure
 

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -1,22 +1,9 @@
 [id="Synchronizing_the_Client_Repository_{context}"]
 = Synchronizing the {project-client-name} Repository
 
-ifdef::satellite[]
 Use this section to synchronize the {project-client-name} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
-endif::[]
 
-ifndef::satellite[]
-.Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
-+
-A list of product repositories available for synchronization is displayed.
-. Click the arrow next to the *{RHEL} Server* product to view available content.
-. Select *{project-client-name} (for RHEL 8 or RHEL 7 Server) RPMs x86_64*.
-. Click *Synchronize Now*.
-endif::[]
-
-ifdef::satellite[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 +
@@ -24,23 +11,7 @@ A list of product repositories available for synchronization is displayed.
 . Click the arrow next to the *{RHEL} Server* product to view available content.
 . Select *{project-client-name} (for RHEL 8) RPMs x86_64*.
 . Click *Synchronize Now*.
-endif::[]
 
-ifndef::satellite[]
-.CLI procedure
-* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# hammer repository synchronize \
---async \
---name 'Red Hat {project-client-name} for RHEL 8 or RHEL 7 Server RPMs x86_64' \
---organization _"My_Organization"_ \
---product 'Red Hat Enterprise Linux Server'
-----
-endif::[]
-
-ifdef::satellite[]
 .CLI procedure
 * Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
 +
@@ -52,4 +23,3 @@ ifdef::satellite[]
 --organization _"My_Organization"_ \
 --product 'Red Hat Enterprise Linux Server'
 ----
-endif::[]

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -6,14 +6,27 @@ Use this section to synchronize the {project-client-name} repository from the Re
 This repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
 endif::[]
 
+ifndef::satellite[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 +
 A list of product repositories available for synchronization is displayed.
 . Click the arrow next to the *{RHEL} Server* product to view available content.
-. Select *{project-client-name} (for RHEL 7 Server) RPMs x86_64*.
+. Select *{project-client-name} (for RHEL 8 or RHEL 7 Server) RPMs x86_64*.
 . Click *Synchronize Now*.
+endif::[]
 
+ifdef::satellite[]
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
++
+A list of product repositories available for synchronization is displayed.
+. Click the arrow next to the *{RHEL} Server* product to view available content.
+. Select *{project-client-name} (for RHEL 8) RPMs x86_64*.
+. Click *Synchronize Now*.
+endif::[]
+
+ifndef::satellite[]
 .CLI procedure
 * Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
 +
@@ -21,7 +34,22 @@ A list of product repositories available for synchronization is displayed.
 ----
 # hammer repository synchronize \
 --async \
---name 'Red Hat {project-client-name} for RHEL 7 Server RPMs x86_64' \
+--name 'Red Hat {project-client-name} for RHEL 8 or RHEL 7 Server RPMs x86_64' \
 --organization _"My_Organization"_ \
 --product 'Red Hat Enterprise Linux Server'
 ----
+endif::[]
+
+ifdef::satellite[]
+.CLI procedure
+* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository synchronize \
+--async \
+--name 'Red Hat {project-client-name} for RHEL 8 RPMs x86_64' \
+--organization _"My_Organization"_ \
+--product 'Red Hat Enterprise Linux Server'
+----
+endif::[]

--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -5,7 +5,13 @@
 To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProductName} with Network Time Protocol (NTP) servers.
 If the base operating system clock is configured incorrectly, certificate verification might fail.
 
+ifndef::satellite[]
 For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in the _{RHEL} 8 System Administrator's Guide_, and https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite[Configuring NTP Using the chrony Suite] in the _{RHEL} 7 System Administrator's Guide_.
+endif::[]
+
+ifdef::satellite[]
+For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in _{RHEL} 8 Configuring basic system settings_.
+endif::[]
 
 .Procedure
 

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -19,9 +19,6 @@ For more information, see {AdministeringDocURL}Importing_the_Katello_Root_CA_Cer
 .Procedure
 . On the VM host system, configure the firewall to allow VNC service on ports 5900 to 5930:
 +
-ifdef::satellite[]
-* On {RHEL} 6:
-endif::[]
 ifndef::satellite[]
 * On operating systems with the `iptables` command:
 endif::[]
@@ -32,9 +29,6 @@ endif::[]
 # service iptables save
 ----
 +
-ifdef::satellite[]
-* On {RHEL} 7:
-endif::[]
 ifndef::satellite[]
 * On operating systems with the `firewalld` service:
 endif::[]

--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -42,7 +42,13 @@ rtt min/avg/max/mdev = 0.019/0.019/0.019/0.000 ms
 # hostnamectl set-hostname _name_
 ----
 
+ifndef::satellite[]
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/networking_guide/index#sec_Configuring_Host_Names_Using_hostnamectl[Configuring Host Names Using hostnamectl] in the _{RHEL} 7 Networking Guide_.
+endif::[]
+
+ifdef::satellite[]
+For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/assembly_changing-a-hostname_configuring-and-managing-networking#proc_changing-a-hostname-using-hostnamectl_assembly_changing-a-hostname[Changing a hostname using hostnamectl] in the _{RHEL} 8 Configuring and managing networking_.
+endif::[]
 
 ifndef::foreman-deb[]
 [WARNING]

--- a/guides/common/modules/proc_verifying-firewall-settings.adoc
+++ b/guides/common/modules/proc_verifying-firewall-settings.adoc
@@ -15,6 +15,10 @@ include::snip_firewalld.adoc[]
 # firewall-cmd --list-all
 ----
 
-ifndef::foreman-deb[]
+ifndef::foreman-deb,satellite[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and Configuring firewalld] in the _{RHEL} 8 Security Guide_, and https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using_firewalls#sec-Getting_started_with_firewalld[Getting Started with firewalld] in the _{RHEL} 7 Security Guide_.
+endif::[]
+
+ifdef::satellite[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and Configuring firewalld] in _{RHEL} 8 Securing networks_.
 endif::[]

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -5,10 +5,7 @@
 
 The maximum number of {SmartProxyServer}s that {ProjectServer} can support has no fixed limit.
 ifndef::satellite[]
-The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {EL} 8 or {EL} 7.
-endif::[]
-ifndef::satellite[]
-The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {EL} 8.
+The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {EL} 7.
 endif::[]
 However, scalability is highly variable, especially when managing Puppet clients.
 

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -4,7 +4,12 @@
 = {SmartProxyServer} Scalability Considerations
 
 The maximum number of {SmartProxyServer}s that {ProjectServer} can support has no fixed limit.
-The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {RHEL} 7.
+ifndef::satellite[]
+The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {EL} 8 or {EL} 7.
+endif::[]
+ifndef::satellite[]
+The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {EL} 8.
+endif::[]
 However, scalability is highly variable, especially when managing Puppet clients.
 
 {SmartProxyServer} scalability when managing Puppet clients depends on the number of CPUs, the run-interval distribution, and the number of Puppet managed resources.

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -5,7 +5,7 @@
 
 The maximum number of {SmartProxyServer}s that {ProjectServer} can support has no fixed limit.
 ifndef::satellite[]
-The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer} with {EL} 7.
+The tested limit is 17 {SmartProxyServer}s with 2 vCPUs on a {ProjectServer}.
 endif::[]
 However, scalability is highly variable, especially when managing Puppet clients.
 

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -9,7 +9,9 @@ ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
+ifndef::satellite[]
 == [[storage-el-8]]{EL} 8
+endif::[]
 
 .Storage Requirements for {SmartProxyServer} Installation
 [cols="1,1,1",options="header"]
@@ -23,6 +25,7 @@ endif::[]
 |/opt/puppetlabs |500 MB |Not Applicable
 |====
 
+ifndef::satellite[]
 == [[storage-el-7]]{EL} 7
 
 .Storage Requirements for {SmartProxyServer} Installation
@@ -37,3 +40,4 @@ endif::[]
 |/opt |3 GB | Not Applicable
 |/opt/puppetlabs |500 MB | Not Applicable
 |====
+endif::[]

--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -31,8 +31,12 @@ endif::[]
 
 Log files are written to `/var/log/messages/,` `/var/log/httpd/`, and `/var/lib/foreman-proxy/openscap/content/`.
 You can manage the size of these files using *logrotate*.
-ifdef::foreman-el,katello,satellite[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-viewing_and_managing_log_files#s2-log_rotation[Log Rotation] in the _{RHEL} 7 System Administrator’s Guide_.
+ifdef::foreman-el,katello[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-viewing_and_managing_log_files#s2-log_rotation[Log Rotation] in _{RHEL} 7 System Administrator’s Guide_.
+endif::[]
+
+ifdef::satellite[]
+For more information, see https://access.redhat.com/solutions/1294[How to use logrotate utility to rotate log files].
 endif::[]
 
 The exact amount of storage you require for log messages depends on your installation and setup.

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -1,7 +1,7 @@
 [id="storage-requirements_{context}"]
 = Storage Requirements
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 * xref:#storage-el-8[{EL} 8]
 * xref:#storage-el-7[{EL} 7]
 endif::[]
@@ -13,9 +13,11 @@ ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 == [[storage-el-8]]{EL} 8
+endif::[]
 
+ifdef::,foreman-el,katello,satellite[]
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
 |====
@@ -35,11 +37,13 @@ ifdef::katello,satellite,orcharhino[]
 |/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
+endif::[]
 
 For external database servers: `/var/lib/pgsql` with installation size of 100 MB and runtime size of 20 GB.
 
-For detailed information on partitioning and size, refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[{RHEL} 8 partitioning guide].
+For detailed information on partitioning and size, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[Partitioning reference] in the _{RHEL} 8 System Design Guide_.
 
+ifndef::satellite[]
 == [[storage-el-7]]{EL} 7
 
 .Storage Requirements for a {ProjectServer} Installation
@@ -57,7 +61,7 @@ For detailed information on partitioning and size, refer to the https://access.r
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 
-ifdef::katello,satellite,orcharhino[]
+ifdef::katello,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
 
 |/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -10,7 +10,7 @@ The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
 ifdef::katello,satellite[]
-The runtime size was measured with {RHEL} 6, 7, and 8 Client repositories synchronized.
+The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
 ifdef::foreman-el,katello[]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -17,7 +17,7 @@ ifdef::foreman-el,katello[]
 == [[storage-el-8]]{EL} 8
 endif::[]
 
-ifdef::,foreman-el,katello,satellite[]
+ifdef::foreman-el,katello,satellite[]
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
 |====

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -1,7 +1,7 @@
 [id="storage-requirements_{context}"]
 = Storage Requirements
 
-ifdef::foreman-el,katello[]
+ifdef::foreman-el,katello,orcharhino[]
 * xref:#storage-el-8[{EL} 8]
 * xref:#storage-el-7[{EL} 7]
 endif::[]
@@ -10,19 +10,18 @@ The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
 ifdef::katello,satellite[]
-The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
+The runtime size was measured with {RHEL} 6, 7, and 8 Client repositories synchronized.
 endif::[]
 
 ifdef::foreman-el,katello[]
 == [[storage-el-8]]{EL} 8
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello,orcharhino,satellite[]
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size
-
 |/var/log |10 MB |10 GB
 
 |/var/lib/pgsql |100 MB |20 GB
@@ -37,13 +36,13 @@ ifdef::katello,satellite,orcharhino[]
 |/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
-endif::[]
 
 For external database servers: `/var/lib/pgsql` with installation size of 100 MB and runtime size of 20 GB.
 
 For detailed information on partitioning and size, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[Partitioning reference] in the _{RHEL} 8 System Design Guide_.
+endif::[]
 
-ifndef::satellite[]
+ifndef::foreman-deb,satellite[]
 == [[storage-el-7]]{EL} 7
 
 .Storage Requirements for a {ProjectServer} Installation
@@ -67,9 +66,9 @@ ifdef::katello,orcharhino[]
 |/var/lib/qpidd |25 MB | xref:storage-guidelines_{context}[Refer Storage Guidelines]
 endif::[]
 |====
-endif::[]
 
 For external database servers: `/var/lib/pgsql` with installation size of 100 MB and runtime size of 20 GB.
+endif::[]
 
 ifdef::foreman-deb[]
 .Storage Requirements for a {ProjectServer} Installation

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -1,19 +1,20 @@
 [id="supported-operating-systems_{context}"]
 = Supported Operating Systems
 
-ifdef::satellite[]
-You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
-endif::[]
-ifndef::satellite[]
+ifndef::foreman-deb,satellite[]
 {ProductName} is supported on the latest versions of {EL} 8 and {EL} 7 Server that are available at the time when {ProductName} is installed.
+Previous versions of {EL} including EUS or z-stream are not supported.
 endif::[]
 ifdef::satellite[]
 {ProductName} is supported on the latest versions of {RHEL} 8 that are available at the time when {ProductName} is installed.
-endif::[]
 Previous versions of {EL} including EUS or z-stream are not supported.
+endif::[]
 
 ifdef::foreman-el,foreman-deb,katello[]
 You can install the operating system from a disc, local ISO image, or kickstart.
+endif::[]
+ifdef::satellite[]
+You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
 endif::[]
 
 The following operating systems are supported by the installer, have packages, and are tested for deploying {Project}:
@@ -38,7 +39,7 @@ endif::[]
 Before you install {Project}, apply all operating system updates if possible.
 
 ifdef::satellite[]
-Red{nbsp}Hat {ProductName} requires a {RHEL} installation with the `@Base` package group with no other package-set modifications, and without third-party configurations or software not directly necessary for the direct operation of the server.
+{ProductName} requires a {RHEL} installation with the `@Base` package group with no other package-set modifications, and without third-party configurations or software not directly necessary for the direct operation of the server.
 This restriction includes hardening and other non-Red{nbsp}Hat security software.
 If you require such software in your infrastructure, install and verify a complete working {ProductName} first, then create a backup of the system before adding any non-Red{nbsp}Hat software.
 endif::[]

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -3,9 +3,14 @@
 
 ifdef::satellite[]
 You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
-Red{nbsp}Hat {ProductName} is supported on the latest versions of {RHEL} 8, and {RHEL} 7 Server that are available at the time when {ProductName} is installed.
-Previous versions of {RHEL} including EUS or z-stream are not supported.
 endif::[]
+ifndef::satellite[]
+{ProductName} is supported on the latest versions of {EL} 8, and {EL} 7 Server that are available at the time when {ProductName} is installed.
+endif::[]
+ifdef::satellite[]
+Red{nbsp}Hat {ProductName} is supported on the latest versions of {RHEL} 8 that are available at the time when {ProductName} is installed.
+endif::[]
+Previous versions of {EL} including EUS or z-stream are not supported.
 
 ifdef::foreman-el,foreman-deb,katello[]
 You can install the operating system from a disc, local ISO image, or kickstart.
@@ -22,7 +27,6 @@ ifdef::foreman-el,katello,orcharhino[]
 endif::[]
 ifdef::satellite[]
 | {RHEL} 8 | x86_64 only |
-| {RHEL} 7 | x86_64 only |
 endif::[]
 ifdef::foreman-deb[]
 | Debian 10 (Buster) | amd64 |

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 Previous versions of {EL} including EUS or z-stream are not supported.
 endif::[]
 
-ifdef::foreman-el,foreman-deb,katello[]
+ifndef::satellite[]
 You can install the operating system from a disc, local ISO image, or kickstart.
 endif::[]
 ifdef::satellite[]

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -8,7 +8,7 @@ ifndef::satellite[]
 {ProductName} is supported on the latest versions of {EL} 8, and {EL} 7 Server that are available at the time when {ProductName} is installed.
 endif::[]
 ifdef::satellite[]
-Red{nbsp}Hat {ProductName} is supported on the latest versions of {RHEL} 8 that are available at the time when {ProductName} is installed.
+{ProductName} is supported on the latest versions of {RHEL} 8 that are available at the time when {ProductName} is installed.
 endif::[]
 Previous versions of {EL} including EUS or z-stream are not supported.
 

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -5,7 +5,7 @@ ifdef::satellite[]
 You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
 endif::[]
 ifndef::satellite[]
-{ProductName} is supported on the latest versions of {EL} 8, and {EL} 7 Server that are available at the time when {ProductName} is installed.
+{ProductName} is supported on the latest versions of {EL} 8 and {EL} 7 Server that are available at the time when {ProductName} is installed.
 endif::[]
 ifdef::satellite[]
 {ProductName} is supported on the latest versions of {RHEL} 8 that are available at the time when {ProductName} is installed.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -43,7 +43,7 @@ endif::[]
 {Project} only supports `UTF-8` encoding.
 If your territory is USA and your language is English, set `en_US.utf-8` as the system-wide locale settings.
 ifdef::foreman-el,katello,satellite[]
-For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring the system locale] in _{RHEL} 8 {Configuring basic system settings}_.
+For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring the system locale] in _{RHEL} 8 Configuring basic system settings_.
 endif::[]
 
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -50,7 +50,9 @@ endif::[]
 
 {Project} only supports `UTF-8` encoding.
 If your territory is USA and your language is English, set `en_US.utf-8` as the system-wide locale settings.
+ifdef::foreman-el,katello,satellite[]
 For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring the system locale] in _{RHEL} 8 {Configuring basic system settings}_.
+endif::[]
 
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.
 When using custom certificates, the Common Name (CN) of the custom certificate must be a fully qualified domain name (FQDN) instead of a shortname.
@@ -118,7 +120,9 @@ You can install {ProductName} on a {EL} system that is operating in FIPS mode.
 ifndef::satellite[]
 {RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {EL}.
 endif::[]
+ifdef::satellite[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in _{RHEL} Security hardening_.
+endif::[]
 ifdef::foreman-el,katello[]
 For more information about FIPS on {RHEL} 7 systems, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
 endif::[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -4,8 +4,11 @@
 The following requirements apply to the networked base operating system:
 
 * x86_64 architecture
-ifdef::satellite[]
+ifndef::satellite[]
 * The latest version of {RHEL} 8 or {RHEL} 7 Server
+endif::[]
+ifdef::satellite[]
+* The latest version of {RHEL} 8
 endif::[]
 * 4-core 2.0 GHz CPU at a minimum
 
@@ -112,7 +115,9 @@ ifndef::satellite[]
 {RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {RHEL}.
 endif::[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in the _{RHEL} Security Hardening Guide_.
+ifdef::foreman-el,katello[]
 For more information about FIPS on {RHEL} 7 systems, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
+endif::[]
 endif::[]
 
 ifdef::satellite[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -51,7 +51,7 @@ When using custom certificates, the Common Name (CN) of the custom certificate m
 This does not apply to the clients of a {Project}.
 
 ifdef::satellite[]
-* If you use multiple {ProjectServer}s, they must be on the same {Project} version for the {ISS} Export/Import to work.
+* All {ProjectServer}s must be on the same version.
 endif::[]
 
 Before you install {ProductName}, ensure that your environment meets the requirements for installation.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -27,15 +27,7 @@ In addition, a minimum of 4 GB RAM of swap space is also recommended.
 endif::[]
 endif::[]
 
-ifdef::foreman-deb[]
-* The latest version of a supported operating system
-endif::[]
-ifndef::foreman-deb,satellite[]
-* The latest version of {EL} 8 or {EL} 7 Server
-endif::[]
-ifdef::satellite[]
-* The latest version of {EL} 8
-endif::[]
+* A supported operating system installed with all available updates applied
 
 ifdef::katello,satellite[]
 * A unique host name, which can contain lower-case letters, numbers, dots (.) and hyphens (-)
@@ -59,7 +51,7 @@ When using custom certificates, the Common Name (CN) of the custom certificate m
 This does not apply to the clients of a {Project}.
 
 ifdef::satellite[]
-* If you deploy multiple {ProjectServer}s, they must be on the same OS version.
+* If you use multiple {ProjectServer}s, they must be on the same {Project} version for the {ISS} Export/Import to work.
 endif::[]
 
 Before you install {ProductName}, ensure that your environment meets the requirements for installation.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -116,9 +116,9 @@ SELinux must be enabled, either in enforcing or permissive mode.
 Installation with disabled SELinux is not supported.
 
 .FIPS Mode
-You can install {ProductName} on a {EL} system that is operating in FIPS mode.
+You can install {ProductName} on a {RHEL} system that is operating in FIPS mode.
 ifndef::satellite[]
-{RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {EL}.
+{RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {RHEL}.
 endif::[]
 ifdef::satellite[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in _{RHEL} Security hardening_.

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -4,12 +4,6 @@
 The following requirements apply to the networked base operating system:
 
 * x86_64 architecture
-ifndef::satellite[]
-* The latest version of {RHEL} 8 or {RHEL} 7 Server
-endif::[]
-ifdef::satellite[]
-* The latest version of {RHEL} 8
-endif::[]
 * 4-core 2.0 GHz CPU at a minimum
 
 ifdef::foreman-el,foreman-deb[]
@@ -33,6 +27,16 @@ In addition, a minimum of 4 GB RAM of swap space is also recommended.
 endif::[]
 endif::[]
 
+ifdef::foreman-deb[]
+* The latest version of a supported operating system
+endif::[]
+ifndef::foreman-deb,satellite[]
+* The latest version of {EL} 8 or {EL} 7 Server
+endif::[]
+ifdef::satellite[]
+* The latest version of {EL} 8
+endif::[]
+
 ifdef::katello,satellite[]
 * A unique host name, which can contain lower-case letters, numbers, dots (.) and hyphens (-)
 endif::[]
@@ -46,14 +50,14 @@ endif::[]
 
 {Project} only supports `UTF-8` encoding.
 If your territory is USA and your language is English, set `en_US.utf-8` as the system-wide locale settings.
-For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring System Locale guide].
+For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring the system locale] in _{RHEL} 8 {Configuring basic system settings}_.
 
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.
 When using custom certificates, the Common Name (CN) of the custom certificate must be a fully qualified domain name (FQDN) instead of a shortname.
 This does not apply to the clients of a {Project}.
 
 ifdef::satellite[]
-* All {ProjectServer}s must be on the same version.
+* If you deploy multiple {ProjectServer}s, they must be on the same OS version.
 endif::[]
 
 Before you install {ProductName}, ensure that your environment meets the requirements for installation.
@@ -110,11 +114,11 @@ SELinux must be enabled, either in enforcing or permissive mode.
 Installation with disabled SELinux is not supported.
 
 .FIPS Mode
-You can install {ProductName} on a {RHEL} system that is operating in FIPS mode.
+You can install {ProductName} on a {EL} system that is operating in FIPS mode.
 ifndef::satellite[]
-{RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {RHEL}.
+{RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {EL}.
 endif::[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in the _{RHEL} Security Hardening Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in _{RHEL} Security hardening_.
 ifdef::foreman-el,katello[]
 For more information about FIPS on {RHEL} 7 systems, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the _{RHEL} Security Guide_.
 endif::[]


### PR DESCRIPTION
Removed the references of EL7 from the 2 most recent project versions of downstream as it is no longer supported. However, the EL7 is still supported at upstream and hence it is unchanged.

[doc] - Remove EL7-specific references from all installation guides and from the Provisioning guide

https://issues.redhat.com/browse/SAT-9867

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
