### PR TITLE
Update Pulpcore version to 3.21

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -6,7 +6,6 @@
 :ProjectVersion: nightly
 :ProjectVersionPrevious: 3.4
 :KatelloVersion: nightly
-:PulpcoreVersion: 3.18
 :TargetVersion: {ProjectVersion}
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9


### PR DESCRIPTION
In Katello Nightly (to be 4.7) the version has been updated to 3.21.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.