### PR TITLE
Restructure the task cleanup section

### DIFF
--- a/guides/common/modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc
+++ b/guides/common/modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc
@@ -10,7 +10,7 @@ By default, {Project} executes a cron job that cleans tasks every day at 19:45.
 * Tasks that have run successfully and are older than thirty days
 * All tasks that are older than a year
 
-You can configure the cleaning unused tasks feature using the below options:
+You can configure the cleaning unused tasks feature using these options:
 
 * To configure the time at which {Project} runs the cron job, set the `--foreman-plugin-tasks-cron-line` parameter to the time you want in cron format.
 For example, to schedule the cron job to run every day at 15:00, enter the following command:
@@ -20,7 +20,8 @@ For example, to schedule the cron job to run every day at 15:00, enter the follo
 # {foreman-installer} --foreman-plugin-tasks-cron-line "00 15 * * *"
 ----
 * To configure the period after which {Project} deletes the tasks, edit the `:rules:` section in the `/etc/foreman/plugins/foreman-tasks.yaml` file.
-* To disable regular task cleanupon {Project}, enter the following command:
+* To disable regular task cleanup on {Project}, enter the following command:
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --foreman-plugin-tasks-automatic-cleanup false

--- a/guides/common/modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc
+++ b/guides/common/modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc
@@ -10,23 +10,8 @@ By default, {Project} executes a cron job that cleans tasks every day at 19:45.
 * Tasks that have run successfully and are older than thirty days
 * All tasks that are older than a year
 
-Note that automatic task cleanup is enabled by default on freshly installed {Project} servers.
-For {Project} servers upgraded from previous versions, you will have to manually enable the automatic task cleanup.
-
 You can configure the cleaning unused tasks feature using the below options:
 
-* To enable {Project} to perform regular cleaning, enter the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --foreman-plugin-tasks-automatic-cleanup true
-----
-* To disable {Project} to perform regular cleaning, enter the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --foreman-plugin-tasks-automatic-cleanup false
-----
 * To configure the time at which {Project} runs the cron job, set the `--foreman-plugin-tasks-cron-line` parameter to the time you want in cron format.
 For example, to schedule the cron job to run every day at 15:00, enter the following command:
 +
@@ -35,3 +20,14 @@ For example, to schedule the cron job to run every day at 15:00, enter the follo
 # {foreman-installer} --foreman-plugin-tasks-cron-line "00 15 * * *"
 ----
 * To configure the period after which {Project} deletes the tasks, edit the `:rules:` section in the `/etc/foreman/plugins/foreman-tasks.yaml` file.
+* To disable regular task cleanupon {Project}, enter the following command:
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-plugin-tasks-automatic-cleanup false
+----
+* To reenable regular task cleanup on {Project}, enter the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-plugin-tasks-automatic-cleanup true
+----

--- a/guides/common/modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc
+++ b/guides/common/modules/proc_configuring-the-cleaning-unused-tasks-feature.adoc
@@ -10,26 +10,28 @@ By default, {Project} executes a cron job that cleans tasks every day at 19:45.
 * Tasks that have run successfully and are older than thirty days
 * All tasks that are older than a year
 
-.For {Project}s Upgraded from Previous Versions
-ifndef::orcharhino[]
-Until https://bugzilla.redhat.com/show_bug.cgi?id=1788615[BZ#1788615] is resolved, this functionality works only on fresh installations of {ProjectXY} and later.
-endif::[]
-If you upgrade {Project} from previous versions, this functionality is disabled by default.
-To enable {Project} to perform regular cleaning, enter the following command:
+Note that automatic task cleanup is enabled by default on freshly installed {Project} servers.
+For {Project} servers upgraded from previous versions, you will have to manually enable the automatic task cleanup.
 
+You can configure the cleaning unused tasks feature using the below options:
+
+* To enable {Project} to perform regular cleaning, enter the following command:
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --foreman-plugin-tasks-automatic-cleanup true
 ----
-
-Optionally use this procedure to adjust the configuration to serve your needs.
-
-.Procedure
-. Optional: To configure the time at which {Project} runs the cron job, set the `--foreman-plugin-tasks-cron-line` parameter to the time you want in cron format.
+* To disable {Project} to perform regular cleaning, enter the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-plugin-tasks-automatic-cleanup false
+----
+* To configure the time at which {Project} runs the cron job, set the `--foreman-plugin-tasks-cron-line` parameter to the time you want in cron format.
 For example, to schedule the cron job to run every day at 15:00, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --foreman-plugin-tasks-cron-line "00 15 * * *"
 ----
-. Optional: To configure the period after which {Project} deletes the tasks, edit the `:rules:` section in the `/etc/foreman/plugins/foreman-tasks.yaml` file.
+* To configure the period after which {Project} deletes the tasks, edit the `:rules:` section in the `/etc/foreman/plugins/foreman-tasks.yaml` file.


### PR DESCRIPTION
- The bug mentioned in this section has been closed as WONTFIX, as the cleanup feature has been deliberately disabled for upgraded Satellites.
- Restructured the section to make the option to enable and disable the task cleanup feature more prominent.
- Removed the **Procedure** header as this only contained two separate options for configuring the task cleanup.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
