### PR TITLE
Add information about RHEL 8 to RHEL 9 upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -1,4 +1,4 @@
-[id="Upgrading_Hosts_to_Next_Major RHEL_release_{context}"]
+[id="Upgrading_Hosts_to_Next_Major_RHEL_Release_{context}"]
 = Upgrading Hosts to Next Major {RHEL} Release
 
 You can use a job template to upgrade your {RHEL} hosts to the next major release.

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -4,27 +4,18 @@
 You can use a job template to upgrade your {RHEL} hosts to the next major version.
 Below upgrade paths are possible:
 
-* Red Hat Enterprise Linux 7 to Red Hat Enterprise Linux 8
-* Red Hat Enterprise Linux 8 to Red Hat Enterprise Linux 9
-
+* {RHEL} 7 to {RHEL} 8
+* {RHEL} 8 to {RHEL} 9
 .Prerequisites
-* For upgrading {RHEL} 7 hosts to {RHEL} 8
-** Ensure that your {RHEL} 7 hosts meet the requirements for the upgrade to {RHEL} 8.
+* Ensure that your {RHEL} hosts meet the requirements for the upgrade.
 ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/planning-an-upgrade_upgrading-from-rhel-7-to-rhel-8[Planning an upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+** For {RHEL} 7 to {RHEL} 8 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/planning-an-upgrade_upgrading-from-rhel-7-to-rhel-8[Planning an upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+** For {RHEL} 8 to {RHEL} 9 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/planning-an-upgrade_upgrading-from-rhel-8-to-rhel-9[Planning an upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
 endif::[]
-** Prepare your hosts for the upgrade.
+* Prepare your {RHEL} hosts for the upgrade.
 ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index#preparing-a-rhel-7-system-for-the-upgrade_upgrading-from-rhel-7-to-rhel-8[Preparing a RHEL 7 system for the upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
-endif::[]
-* For upgrading {RHEL} 8 hosts to {RHEL} 9
-** Ensure that your {RHEL} 8 hosts meet the requirements for the upgrade to {RHEL} 9.
-ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/planning-an-upgrade_upgrading-from-rhel-8-to-rhel-9[Planning an upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
-endif::[]
-** Prepare your hosts for the upgrade.
-ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/assembly_preparing-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9#preparing-a-rhel-8-system-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9[Preparing a RHEL 8 system for the upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
+** For {RHEL} 7 to {RHEL} 8 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index#preparing-a-rhel-7-system-for-the-upgrade_upgrading-from-rhel-7-to-rhel-8[Preparing a RHEL 7 system for the upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+** For {RHEL} 8 to {RHEL} 9 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/assembly_preparing-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9#preparing-a-rhel-8-system-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9[Preparing a RHEL 8 system for the upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
 endif::[]
 * Enable remote execution feature on {Project}.
 For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[].
@@ -42,10 +33,10 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 . Select the hosts that you want to upgrade to the next major {RHEL} version.
 . In the upper right of the Hosts window, from the *Select Action* list, select *Preupgrade check with Leapp*.
 . Click *Submit* to start the pre-upgrade check.
-. When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on the hosts.
+. When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on your hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
 Some issues might have documentation linked that describe how to fix them.
 . Optional: If you have issues that have commands associated with them, you can fix them with a remote job.
 To do that, select these issues, click the *Fix Selected* button, and submit the job.
-. After you fixed the issues, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the {RHEL} hosts you are upgrading do not have any issues and are ready to be upgraded.
+. Once the issues are fixed, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the {RHEL} hosts you are upgrading do not have any issues and are ready to be upgraded.
 . When your systems are ready for the upgrade, click the *Run Upgrade* button and click *Submit* to start the upgrade.

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -6,16 +6,17 @@ Below upgrade paths are possible:
 
 * {RHEL} 7 to {RHEL} 8
 * {RHEL} 8 to {RHEL} 9
+
 .Prerequisites
 * Ensure that your {RHEL} hosts meet the requirements for the upgrade.
 ifndef::orcharhino[]
-** For {RHEL} 7 to {RHEL} 8 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/planning-an-upgrade_upgrading-from-rhel-7-to-rhel-8[Planning an upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
-** For {RHEL} 8 to {RHEL} 9 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/planning-an-upgrade_upgrading-from-rhel-8-to-rhel-9[Planning an upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
+** For {RHEL} 7 to {RHEL} 8 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/planning-an-upgrade_upgrading-from-rhel-7-to-rhel-8[Planning an upgrade] in _Upgrading from RHEL 7 to RHEL 8_.
+** For {RHEL} 8 to {RHEL} 9 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/planning-an-upgrade_upgrading-from-rhel-8-to-rhel-9[Planning an upgrade] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
 * Prepare your {RHEL} hosts for the upgrade.
 ifndef::orcharhino[]
-** For {RHEL} 7 to {RHEL} 8 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index#preparing-a-rhel-7-system-for-the-upgrade_upgrading-from-rhel-7-to-rhel-8[Preparing a RHEL 7 system for the upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
-** For {RHEL} 8 to {RHEL} 9 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/assembly_preparing-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9#preparing-a-rhel-8-system-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9[Preparing a RHEL 8 system for the upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
+** For {RHEL} 7 to {RHEL} 8 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index#preparing-a-rhel-7-system-for-the-upgrade_upgrading-from-rhel-7-to-rhel-8[Preparing a RHEL 7 system for the upgrade] in _Upgrading from RHEL 7 to RHEL 8_.
+** For {RHEL} 8 to {RHEL} 9 upgrade, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/assembly_preparing-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9#preparing-a-rhel-8-system-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9[Preparing a RHEL 8 system for the upgrade] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
 * Enable remote execution feature on {Project}.
 For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[].
@@ -35,8 +36,8 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 . Click *Submit* to start the pre-upgrade check.
 . When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on your hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
-Some issues might have documentation linked that describe how to fix them.
-. Optional: If you have issues that have commands associated with them, you can fix them with a remote job.
+Some issues might have documentation linked that describes how to fix them.
+. Optional: If you have issues that have commands associated with them, you can fix them using remote execution.
 To do that, select these issues, click the *Fix Selected* button, and submit the job.
-. Once the issues are fixed, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the {RHEL} hosts you are upgrading do not have any issues and are ready to be upgraded.
-. When your systems are ready for the upgrade, click the *Run Upgrade* button and click *Submit* to start the upgrade.
+. After the issues are fixed, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the hosts you are upgrading do not have any issues and are ready to be upgraded.
+. If the pre-upgrade check verifies that the hosts do not have any issues, click the *Run Upgrade* button and click *Submit* to start the upgrade.

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -1,16 +1,30 @@
-[id="Upgrading_Hosts_From_RHEL7_to_RHEL8_{context}"]
-= Upgrading Hosts From RHEL 7 to RHEL 8
+[id="Upgrading_Hosts_to_Next_Major RHEL_release_{context}"]
+= Upgrading Hosts to Next Major {RHEL} Release
 
-You can use a job template to upgrade your {RHEL} 7 hosts to {RHEL} 8.
+You can use a job template to upgrade your {RHEL} hosts to the next major version.
+Below upgrade paths are possible:
+
+* Red Hat Enterprise Linux 7 to Red Hat Enterprise Linux 8
+* Red Hat Enterprise Linux 8 to Red Hat Enterprise Linux 9
 
 .Prerequisites
-* Ensure that your {RHEL} 7 hosts meet the requirements for the upgrade to {RHEL} 8.
+* For upgrading {RHEL} 7 hosts to {RHEL} 8
+** Ensure that your {RHEL} 7 hosts meet the requirements for the upgrade to {RHEL} 8.
 ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/planning-an-upgrade_upgrading-from-rhel-7-to-rhel-8[Planning an upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
 endif::[]
-* Prepare your hosts for the upgrade.
+** Prepare your hosts for the upgrade.
 ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index#preparing-a-rhel-7-system-for-the-upgrade_upgrading-from-rhel-7-to-rhel-8[Preparing a RHEL 7 system for the upgrade] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+endif::[]
+* For upgrading {RHEL} 8 hosts to {RHEL} 9
+** Ensure that your {RHEL} 8 hosts meet the requirements for the upgrade to {RHEL} 9.
+ifndef::orcharhino[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/planning-an-upgrade_upgrading-from-rhel-8-to-rhel-9[Planning an upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
+endif::[]
+** Prepare your hosts for the upgrade.
+ifndef::orcharhino[]
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/assembly_preparing-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9#preparing-a-rhel-8-system-for-the-upgrade_upgrading-from-rhel-8-to-rhel-9[Preparing a RHEL 8 system for the upgrade] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
 endif::[]
 * Enable remote execution feature on {Project}.
 For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[].
@@ -25,13 +39,13 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 # {foreman-installer} --enable-foreman-plugin-leapp
 ----
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
-. Select the hosts that you want to upgrade to {RHEL} 8.
+. Select the hosts that you want to upgrade to the next major {RHEL} version.
 . In the upper right of the Hosts window, from the *Select Action* list, select *Preupgrade check with Leapp*.
 . Click *Submit* to start the pre-upgrade check.
-. When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on {RHEL} 7 hosts.
+. When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on the hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
 Some issues might have documentation linked that describe how to fix them.
 . Optional: If you have issues that have commands associated with them, you can fix them with a remote job.
 To do that, select these issues, click the *Fix Selected* button, and submit the job.
-. After you fixed the issues, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that your {RHEL} 7 hosts do not have any issues and are ready to be upgraded.
+. After you fixed the issues, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the {RHEL} hosts you are upgrading do not have any issues and are ready to be upgraded.
 . When your systems are ready for the upgrade, click the *Run Upgrade* button and click *Submit* to start the upgrade.

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -1,7 +1,7 @@
 [id="Upgrading_Hosts_to_Next_Major RHEL_release_{context}"]
 = Upgrading Hosts to Next Major {RHEL} Release
 
-You can use a job template to upgrade your {RHEL} hosts to the next major version.
+You can use a job template to upgrade your {RHEL} hosts to the next major release.
 Below upgrade paths are possible:
 
 * {RHEL} 7 to {RHEL} 8

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -20,7 +20,7 @@ include::common/assembly_registering-hosts.adoc[leveloffset=+1]
 
 include::common/assembly_managing-network-interfaces.adoc[leveloffset=+1]
 
-include::common/modules/proc_upgrading-rhel7-hosts-to-rhel8.adoc[leveloffset=+1]
+include::common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc[leveloffset=+1]
 
 include::common/assembly_converting-a-host-to-rhel.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Currently, the Managing Hosts guide only has information about RHEL 7 to RHEL 8 upgrade. The same procedure can be used for upgrading RHEL 8 hosts to RHEL 9. Tweaking the contents of the `Upgrading Hosts From RHEL 7 to RHEL 8` section so that it applies to upgrades between any major RHEL release.

- Renamed proc_upgrading-rhel7-hosts-to-rhel8.adoc to proc_upgrading-hosts-to-next-major-rhel-release.adoc.
- Edited the contents to make it more generic.
- Renamed the section to "= Upgrading Hosts to Next Major Red Hat Enterprise Linux Release.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
