### PR TITLE
Fix URL in Configuring Load Balancer module

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Before_You_Begin.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Before_You_Begin.adoc
@@ -26,6 +26,6 @@ The following additional steps are required for load balancing:
 .Upgrading {SmartProxyServer}s in a Load Balancing Configuration
 
 ifdef::satellite[]
-To upgrade {SmartProxyServer}s from {ProductVersionPrevious} to {ProductVersion}, complete the {MultiBaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite#upgrading_capsule_server[Upgrading {SmartProxyServer}s] procedure in _Upgrading and Updating {ProjectName}_.
+To upgrade {SmartProxyServer}s from {ProductVersionPrevious} to {ProductVersion}, complete the {UpgradingDocURL}upgrading_capsule_server[Upgrading {SmartProxyServer}s] procedure in _{UpgradingDocTitle}_.
 endif::[]
 There are no additional steps required for {SmartProxyServer}s in a load balancing configuration.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
