### PR TITLE
Add EL8 support in preparing host for external DB

### DIFF
--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -2,7 +2,7 @@
 = Preparing a Host for External Databases
 
 ifndef::orcharhino[]
-Install a freshly provisioned system with the latest {EL} 7 server to host the external databases.
+Install a freshly provisioned system with the latest {EL} 8 or {EL} 7 server to host the external databases.
 endif::[]
 ifdef::orcharhino[]
 Install a freshly provisioned system with the latest CentOS 7, Oracle Linux 7, or {EL} 7 to host the external databases.


### PR DESCRIPTION
The EL8 is missing in the content for the process of preparing the host for the external database. Hence, it needs to be added as upstream projects support it except Orcharhino.

https://bugzilla.redhat.com/show_bug.cgi?id=2119884


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
