### PR TITLE
Set 'dnf' as package manager for Satellite on 3.3

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -64,8 +64,11 @@
 :oVirtEngine: Red{nbsp}Hat Virtualization Manager
 :oVirtShort: RHV
 :package-install-project: satellite-maintain packages install
+:package-install: dnf install
 :package-remove-project: satellite-maintain packages remove
+:package-remove: dnf remove
 :package-update-project: satellite-maintain packages update
+:package-update: dnf update
 :PIV: CAC
 :project-context: satellite
 :project-change-hostname: satellite-change-hostname


### PR DESCRIPTION
Because Sat 6.12 runs on RHEL8 only, we need to use `dnf` to install, update and remove packages.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
