### PR TITLE
Remove mentions of component Content View

### DIFF
--- a/guides/common/modules/proc_creating-a-composite-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-composite-content-view.adoc
@@ -41,9 +41,9 @@ When the `--auto-publish` option is set to `yes`, the Composite Content View is 
 --description "Example Composite Content View" \
 --organization "_My_Organization_"
 ----
-. Add a component Content View to the Composite Content View.
+. Add a Content View to the Composite Content View.
 You must include the Content View Version ID and use the `--latest` option.
-To include multiple component Content Views to the Composite Content View, repeat this step for every Content View you want to include:
+To add multiple Content Views to the Composite Content View, repeat this step for every Content View you want to include:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/ref_content-settings.adoc
+++ b/guides/common/modules/ref_content-settings.adoc
@@ -21,7 +21,7 @@
 | *Finish action timeout* | 3600 | Time in seconds to wait for a host to finish a remote action.
 | *Subscription connection enabled* | Yes | Can communicate with the {Team} Portal for subscriptions.
 | *Installable errata from Content View* | No | Calculate errata host status based only on errata in a host's Content View and Lifecycle Environment.
-| *Restrict Composite Content View promotion* | No | If this is enabled, a composite content view cannot be published or promoted, unless the component content view versions that it includes exist in the target environment.
+| *Restrict Composite Content View promotion* | No | If this is enabled, a composite content view cannot be published or promoted, unless the content view versions that it includes exist in the target environment.
 | *Check services before actions* | Yes | Check the status of backend services such as pulp and candlepin before performing actions?
 | *Batch size to sync repositories in* | 100 | How many repositories should be synced concurrently on a {SmartProxy}.
 A smaller number may lead to longer sync times.


### PR DESCRIPTION
The term 'component Content View' was introduced to denote the Content Views included in a composite Content View. However, since this caused confusion among the users, the change has been reverted and any mentions of component Content View are removed from the UI. This term will soon be dropped from the hammer CLI as well as API too. Removing it from the docs as well.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
