### PR TITLE
Remove tfm as package prefix for EL8

### DIFF
--- a/guides/common/assembly_configuring-the-discovery-service.adoc
+++ b/guides/common/assembly_configuring-the-discovery-service.adoc
@@ -1,4 +1,4 @@
-include::modules/con_configuring-the-discovery-service.adoc[]
+include::modules/proc_configuring-the-discovery-service.adoc[]
 
 include::modules/proc_installing-the-discovery-service.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/con_configuring-the-discovery-service.adoc
@@ -39,13 +39,13 @@ endif::[]
 
 To use {ProjectServer} to provide the Discovery image, install the following RPM packages:
 
-* `tfm-rubygem-foreman_discovery`
+* `rubygem-foreman_discovery`
 ifdef::satellite[]
 * `foreman-discovery-image`
 endif::[]
-* `tfm-rubygem-smart_proxy_discovery`
+* `rubygem-smart_proxy_discovery`
 
-The `tfm-rubygem-foreman_discovery` package contains the {Project} plug-in to handle discovered nodes, connections, and necessary database structures, and API.
+The `rubygem-foreman_discovery` package contains the {Project} plug-in to handle discovered nodes, connections, and necessary database structures, and API.
 
 ifdef::satellite[]
 The `foreman-discovery-image` package installs the Discovery ISO to the `/usr/share/foreman-discovery-image/` directory.
@@ -54,7 +54,7 @@ The tool saves this PXE boot image in the `/var/lib/tftpboot/boot` directory.
 For more information, see xref:Building_a_Discovery_Image_{context}[].
 endif::[]
 
-The `tfm-rubygem-smart_proxy_discovery` package configures {SmartProxyServer}, such as the integrated {SmartProxy} of {ProjectServer}, to act as a proxy for the Discovery service.
+The `rubygem-smart_proxy_discovery` package configures {SmartProxyServer}, such as the integrated {SmartProxy} of {ProjectServer}, to act as a proxy for the Discovery service.
 
 ifndef::satellite[]
 You can use the `{foreman-installer}` tool to install the packages and the Discovery image.

--- a/guides/common/modules/proc_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/proc_configuring-the-discovery-service.adoc
@@ -27,7 +27,7 @@ endif::[]
 
 Ensure that the DHCP range of all subnets that you plan to use for discovery do not intersect with the DHCP lease pool configured for the managed DHCP service.
 The DHCP range is set in the {ProjectWebUI}, while the lease pool range is set using the `{foreman-installer}` command.
-For example, in a 10.1.0.0/16 network range 10.1.0.0 to 10.1.127.255 could be allocated for leases and 10.1.128.0 to 10.1.255.254 could be allocate for reservations.
+For example, in a 10.1.0.0/16 network range 10.1.0.0 to 10.1.127.255 could be allocated for leases and 10.1.128.0 to 10.1.255.254 could be allocated for reservations.
 
 ifndef::orcharhino[]
 Since network interface names are not expected to always be the same https://access.redhat.com/solutions/5984311[between major versions] of {RHEL},
@@ -37,27 +37,38 @@ endif::[]
 hosts or virtual machines can be created with incorrect network configurations. On Dell servers, the new naming scheme can be disabled via `biosdevname=1` kernel command line option, for other hardware or virtual machines, the new naming scheme can be completely turned off via `net.ifnames=1`.
 endif::[]
 
-To use {ProjectServer} to provide the Discovery image, install the following RPM packages:
-
-* `rubygem-foreman_discovery`
-ifdef::satellite[]
-* `foreman-discovery-image`
-endif::[]
-* `rubygem-smart_proxy_discovery`
-
-The `rubygem-foreman_discovery` package contains the {Project} plug-in to handle discovered nodes, connections, and necessary database structures, and API.
-
-ifdef::satellite[]
+.Procedure
+. Install Discovery on {ProjectServer}:
+ifdef::satellite,orcharhino[]
++
 The `foreman-discovery-image` package installs the Discovery ISO to the `/usr/share/foreman-discovery-image/` directory.
 You can build a PXE boot image from this ISO using the `livecd-iso-to-pxeboot` tool.
 The tool saves this PXE boot image in the `/var/lib/tftpboot/boot` directory.
 For more information, see xref:Building_a_Discovery_Image_{context}[].
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-plugin-discovery \
+--enable-foreman-proxy-plugin-discovery
+----
++
+. Install `foreman-discovery-image`:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+{package-install-project} foreman-discovery-image
+----
 endif::[]
 
-The `rubygem-smart_proxy_discovery` package configures {SmartProxyServer}, such as the integrated {SmartProxy} of {ProjectServer}, to act as a proxy for the Discovery service.
-
-ifndef::satellite[]
-You can use the `{foreman-installer}` tool to install the packages and the Discovery image.
+ifndef::satellite,orcharhino[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-plugin-discovery \
+--enable-foreman-proxy-plugin-discovery \
+--foreman-proxy-plugin-discovery-install-images=true
+----
 endif::[]
 
 When the installation completes, you can view the new menu option by navigating to *Hosts* > *Discovered Hosts*.

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -9,33 +9,29 @@ Complete the following procedure to enable the Discovery service on {SmartProxyS
 ifdef::satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} foreman-discovery-image rubygem-smart_proxy_discovery
+# {foreman-installer} \
+--enable-foreman-proxy-plugin-discovery
 ----
 endif::[]
-ifdef::foreman-el,katello[]
+ifndef::satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} \
 --enable-foreman-proxy-plugin-discovery \
---foreman-proxy-plugin-discovery-install-images=true \
---foreman-proxy-plugin-discovery-source-url=http://downloads.theforeman.org/discovery/releases/3.5/
+--foreman-proxy-plugin-discovery-install-images=true
 ----
 endif::[]
-. Restart {Project} services:
+ifdef::satellite,orcharhino[]
+. Install `foreman-discovery-image`:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} service restart
+{package-install-project} foreman-discovery-image
 ----
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxy}*.
-. Click {SmartProxyServer} and select *Refresh* from the *Actions* list.
-Locate *Discovery* in the list of features to confirm the Discovery service is now running.
+endif::[]
 
 .Subnets
 All subnets with discoverable hosts require an appropriate {SmartProxyServer} selected to provide the Discovery service.
-
-To check this, navigate to *Infrastructure* > *{SmartProxies}* and verify if {SmartProxyServer} that you want to use lists the Discovery feature.
-If not, click *Refresh features*.
 
 In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*, select a subnet, click the {SmartProxies} tab, and select the *Discovery Proxy* that you want to use.
 Perform this for each subnet that you want to use.

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -9,7 +9,7 @@ Complete the following procedure to enable the Discovery service on {SmartProxyS
 ifdef::satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} foreman-discovery-image tfm-rubygem-smart_proxy_discovery
+# {package-install-project} foreman-discovery-image rubygem-smart_proxy_discovery
 ----
 endif::[]
 ifdef::foreman-el,katello[]

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -15,5 +15,5 @@ After installing webhooks, you can configure {ProjectServer} to send webhook req
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum install rubygem-hammer_cli_foreman_webhooks
+# {foreman-installer} --enable-foreman-cli-plugin-webhooks
 ----

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -15,5 +15,5 @@ After installing webhooks, you can configure {ProjectServer} to send webhook req
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum install tfm-rubygem-hammer_cli_foreman_webhooks
+# yum install rubygem-hammer_cli_foreman_webhooks
 ----

--- a/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
@@ -8,7 +8,7 @@ If you have previously installed the Microsoft Azure plugin but don't use it any
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y rubygem-foreman_azure_rm rubygem-ms_rest_azure
+# {package-remove-project} rubygem-foreman_azure_rm rubygem-ms_rest_azure
 # {foreman-installer} --no-enable-foreman-plugin-azure
 ----
 . Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the *Available Providers* tab to verify the removal of the Microsoft Azure plugin.

--- a/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
@@ -8,7 +8,7 @@ If you have previously installed the Microsoft Azure plugin but don't use it any
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y tfm-rubygem-foreman_azure_rm tfm-rubygem-ms_rest_azure
+# yum remove -y rubygem-foreman_azure_rm rubygem-ms_rest_azure
 # {foreman-installer} --no-enable-foreman-plugin-azure
 ----
 . Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the *Available Providers* tab to verify the removal of the Microsoft Azure plugin.


### PR DESCRIPTION
We need to remove the `tfm` as a package prefix as it no longer supports EL8 in Project version 3.4 and later.

https://bugzilla.redhat.com/show_bug.cgi?id=2138391


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
