### PR TITLE
Add note to remove tfm as package prefix for EL8

### DIFF
--- a/guides/common/assembly_configuring-the-discovery-service.adoc
+++ b/guides/common/assembly_configuring-the-discovery-service.adoc
@@ -1,4 +1,4 @@
-include::modules/con_configuring-the-discovery-service.adoc[]
+include::modules/proc_configuring-the-discovery-service.adoc[]
 
 include::modules/proc_installing-the-discovery-service.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/proc_configuring-the-discovery-service.adoc
@@ -41,12 +41,6 @@ endif::[]
 hosts or virtual machines can be created with incorrect network configurations. On Dell servers, the new naming scheme can be disabled via `biosdevname=1` kernel command line option, for other hardware or virtual machines, the new naming scheme can be completely turned off via `net.ifnames=1`.
 endif::[]
 
-Configure the Discovery Service on the applicable {EL} versions below.
-
-* xref:#configuring-discovery-el-8[{EL} 8]
-* xref:#configuring-discovery-el-7[{EL} 7]
-
-.[[configuring-discovery-el-8]]{EL} 8
 . Install Discovery on {ProjectServer}:
 ifdef::satellite,orcharhino[]
 +
@@ -77,24 +71,6 @@ ifndef::satellite,orcharhino[]
 --enable-foreman-proxy-plugin-discovery \
 --foreman-proxy-plugin-discovery-install-images=true
 ----
-endif::[]
-
-.[[configuring-discovery-el-7]]{EL} 7
-
-To use {ProjectServer} to provide the Discovery image, install the following RPM packages:
-
-* `tfm-rubygem-foreman_discovery`
-ifdef::satellite[]
-* `foreman-discovery-image`
-endif::[]
-* `tfm-rubygem-smart_proxy_discovery`
-
-The `tfm-rubygem-foreman_discovery` package contains the {Project} plug-in to handle discovered nodes, connections, and necessary database structures, and API.
-
-The `tfm-rubygem-smart_proxy_discovery` package configures {SmartProxyServer}, such as the integrated {SmartProxy} of {ProjectServer}, to act as a proxy for the Discovery service.
-
-ifndef::satellite[]
-You can use the `{foreman-installer}` tool to install the packages and the Discovery image.
 endif::[]
 
 When the installation completes, you can view the new menu option by navigating to *Hosts* > *Discovered Hosts*.

--- a/guides/common/modules/proc_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/proc_configuring-the-discovery-service.adoc
@@ -31,7 +31,7 @@ endif::[]
 
 Ensure that the DHCP range of all subnets that you plan to use for discovery do not intersect with the DHCP lease pool configured for the managed DHCP service.
 The DHCP range is set in the {ProjectWebUI}, while the lease pool range is set using the `{foreman-installer}` command.
-For example, in a 10.1.0.0/16 network range 10.1.0.0 to 10.1.127.255 could be allocated for leases and 10.1.128.0 to 10.1.255.254 could be allocate for reservations.
+For example, in a 10.1.0.0/16 network range 10.1.0.0 to 10.1.127.255 could be allocated for leases and 10.1.128.0 to 10.1.255.254 could be allocated for reservations.
 
 ifndef::orcharhino[]
 Since network interface names are not expected to always be the same https://access.redhat.com/solutions/5984311[between major versions] of {RHEL},
@@ -40,6 +40,46 @@ or any other operating system being provisioned,
 endif::[]
 hosts or virtual machines can be created with incorrect network configurations. On Dell servers, the new naming scheme can be disabled via `biosdevname=1` kernel command line option, for other hardware or virtual machines, the new naming scheme can be completely turned off via `net.ifnames=1`.
 endif::[]
+
+Configure the Discovery Service on the applicable {EL} versions below.
+
+* xref:#configuring-discovery-el-8[{EL} 8]
+* xref:#configuring-discovery-el-7[{EL} 7]
+
+.[[configuring-discovery-el-8]]{EL} 8
+. Install Discovery on {ProjectServer}:
+ifdef::satellite,orcharhino[]
++
+The `foreman-discovery-image` package installs the Discovery ISO to the `/usr/share/foreman-discovery-image/` directory.
+You can build a PXE boot image from this ISO using the `livecd-iso-to-pxeboot` tool.
+The tool saves this PXE boot image in the `/var/lib/tftpboot/boot` directory.
+For more information, see xref:Building_a_Discovery_Image_{context}[].
+[options="nowrap" subs="+quotes,attributes"]
++
+----
+# {foreman-installer} \
+--enable-foreman-plugin-discovery \
+--enable-foreman-proxy-plugin-discovery
+----
++
+. Install `foreman-discovery-image`:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+{package-install-project} foreman-discovery-image
+----
+endif::[]
+ifndef::satellite,orcharhino[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-plugin-discovery \
+--enable-foreman-proxy-plugin-discovery \
+--foreman-proxy-plugin-discovery-install-images=true
+----
+endif::[]
+
+.[[configuring-discovery-el-7]]{EL} 7
 
 To use {ProjectServer} to provide the Discovery image, install the following RPM packages:
 
@@ -50,13 +90,6 @@ endif::[]
 * `tfm-rubygem-smart_proxy_discovery`
 
 The `tfm-rubygem-foreman_discovery` package contains the {Project} plug-in to handle discovered nodes, connections, and necessary database structures, and API.
-
-ifdef::satellite[]
-The `foreman-discovery-image` package installs the Discovery ISO to the `/usr/share/foreman-discovery-image/` directory.
-You can build a PXE boot image from this ISO using the `livecd-iso-to-pxeboot` tool.
-The tool saves this PXE boot image in the `/var/lib/tftpboot/boot` directory.
-For more information, see xref:Building_a_Discovery_Image_{context}[].
-endif::[]
 
 The `tfm-rubygem-smart_proxy_discovery` package configures {SmartProxyServer}, such as the integrated {SmartProxy} of {ProjectServer}, to act as a proxy for the Discovery service.
 

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -1,18 +1,14 @@
 [id="Installing_the_Discovery_Service_{context}"]
 = Installing the Discovery Service
 
-On the applicable operating system, complete the following procedure to enable the Discovery service on {SmartProxyServer}.
+Complete the following procedure to enable the Discovery service on {SmartProxyServer}.
 
-* xref:#installing-discovery-el-8[{EL} 8]
-* xref:#installing-discovery-el-7[{EL} 7]
-
-.[[installing-discovery-el-8]]{EL} 8
 . Enter the following commands on {SmartProxyServer}:
 +
 ifdef::satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# # {foreman-installer} \
+# {foreman-installer} \
 --enable-foreman-proxy-plugin-discovery
 ----
 
@@ -34,40 +30,8 @@ ifdef::satellite,orcharhino[]
 ----
 endif::[]
 
-.[[installing-discovery-el-7]]{EL} 7
-. Enter the following commands on {SmartProxyServer}:
-+
-ifdef::satellite,orcharhino[]
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install-project} foreman-discovery-image tfm-rubygem-smart_proxy_discovery
-----
-
-endif::[]
-ifndef::satellite,orcharhino[]
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} \
---enable-foreman-proxy-plugin-discovery \
---foreman-proxy-plugin-discovery-install-images=true \
---foreman-proxy-plugin-discovery-source-url=http://downloads.theforeman.org/discovery/releases/3.5/
-----
-endif::[]
-. Restart {Project} services:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} service restart
-----
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxy}*.
-. Click {SmartProxyServer} and select *Refresh* from the *Actions* list.
-Locate *Discovery* in the list of features to confirm the Discovery service is now running.
-
 .Subnets
 All subnets with discoverable hosts require an appropriate {SmartProxyServer} selected to provide the Discovery service.
-
-To check this, navigate to *Infrastructure* > *{SmartProxies}* and verify if {SmartProxyServer} that you want to use lists the Discovery feature.
-If not, click *Refresh features* (applicable to {EL} 7 only).
 
 In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*, select a subnet, click the {SmartProxies} tab, and select the *Discovery Proxy* that you want to use.
 Perform this for each subnet that you want to use.

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -1,9 +1,40 @@
 [id="Installing_the_Discovery_Service_{context}"]
 = Installing the Discovery Service
 
-Complete the following procedure to enable the Discovery service on {SmartProxyServer}.
+On the applicable operating system, complete the following procedure to enable the Discovery service on {SmartProxyServer}.
 
-.Procedure
+* xref:#installing-discovery-el-8[{EL} 8]
+* xref:#installing-discovery-el-7[{EL} 7]
+
+.[[installing-discovery-el-8]]{EL} 8
+. Enter the following commands on {SmartProxyServer}:
++
+ifdef::satellite,orcharhino[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# # {foreman-installer} \
+--enable-foreman-proxy-plugin-discovery
+----
+
+endif::[]
+ifndef::satellite,orcharhino[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-proxy-plugin-discovery \
+--foreman-proxy-plugin-discovery-install-images=true
+----
+endif::[]
+ifdef::satellite,orcharhino[]
+. Install `foreman-discovery-image`:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} foreman-discovery-image
+----
+endif::[]
+
+.[[installing-discovery-el-7]]{EL} 7
 . Enter the following commands on {SmartProxyServer}:
 +
 ifdef::satellite,orcharhino[]
@@ -11,8 +42,9 @@ ifdef::satellite,orcharhino[]
 ----
 # {package-install-project} foreman-discovery-image tfm-rubygem-smart_proxy_discovery
 ----
+
 endif::[]
-ifdef::foreman-el,katello[]
+ifndef::satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} \
@@ -35,7 +67,7 @@ Locate *Discovery* in the list of features to confirm the Discovery service is n
 All subnets with discoverable hosts require an appropriate {SmartProxyServer} selected to provide the Discovery service.
 
 To check this, navigate to *Infrastructure* > *{SmartProxies}* and verify if {SmartProxyServer} that you want to use lists the Discovery feature.
-If not, click *Refresh features*.
+If not, click *Refresh features* (applicable to {EL} 7 only).
 
 In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*, select a subnet, click the {SmartProxies} tab, and select the *Discovery Proxy* that you want to use.
 Perform this for each subnet that you want to use.

--- a/guides/common/modules/proc_installing-the-scc-manager.adoc
+++ b/guides/common/modules/proc_installing-the-scc-manager.adoc
@@ -16,6 +16,9 @@ Perform the following steps to install the _SCC Manager_ plug-in on your {Projec
 ----
 # {package-install-project} -y tfm-rubygem-foreman_scc_manager
 ----
+
+NOTE: For {EL} 8, remove `tfm-` from the prefix of packages.
+
 . Run database migrations on your {Project}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -12,8 +12,17 @@ After installing webhooks, you can configure {ProjectServer} to send webhook req
 # {foreman-installer} --enable-foreman-plugin-webhooks
 ----
 * Optionally, you can install the CLI plugin using the following command:
+
+** For {EL} 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum install tfm-rubygem-hammer_cli_foreman_webhooks
+# {foreman-installer} --enable-foreman-cli-plugin-webhooks
+----
++
+** For {EL} 7:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} tfm-rubygem-hammer_cli_foreman_webhooks
 ----

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -12,17 +12,8 @@ After installing webhooks, you can configure {ProjectServer} to send webhook req
 # {foreman-installer} --enable-foreman-plugin-webhooks
 ----
 * Optionally, you can install the CLI plugin using the following command:
-
-** For {EL} 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --enable-foreman-cli-plugin-webhooks
-----
-+
-** For {EL} 7:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install-project} tfm-rubygem-hammer_cli_foreman_webhooks
 ----

--- a/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
@@ -5,10 +5,21 @@ If you have previously installed the Microsoft Azure plugin but don't use it any
 
 .Procedure
 . Uninstall the Azure compute resource provider from your {ProjectServer}:
+
+** For {EL} 8:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y tfm-rubygem-foreman_azure_rm tfm-rubygem-ms_rest_azure
+# {package-remove-project} rubygem-foreman_azure_rm rubygem-ms_rest_azure
 # {foreman-installer} --no-enable-foreman-plugin-azure
 ----
++
+** For {EL} 7:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {package-remove-project} -y tfm-rubygem-foreman_azure_rm tfm-rubygem-ms_rest_azure
+# {foreman-installer} --no-enable-foreman-plugin-azure
+----
+
 . Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the *Available Providers* tab to verify the removal of the Microsoft Azure plugin.


### PR DESCRIPTION
The EL8 does not support tfm as a prefix for packages but the EL7 does. Therefore, we added a note to alert users to remove the prefix if they are carrying out the process for EL8. The tfm prefix remains unchanged for EL7. This is applicable to Project versions 3.2 and 3.1.

https://bugzilla.redhat.com/show_bug.cgi?id=2138391


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
