### PR TITLE
Update in the paths for the repositories URL

### DIFF
--- a/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
@@ -162,9 +162,10 @@ To use the organization debug certificate with CURL, enter the following command
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ curl -k --cert cert.pem --key key.pem \
-http://_{foreman-example-com}_/pulp/repos/Default_Organization/Library/content/dist/rhel/server/7/7Server/x86_64/sat-tools/{ProductVersion}/os/
+http://_{foreman-example-com}_/pulp/content/_My_Organization_Label_/Library/content/dist/rhel/server/7/7Server/x86_64/sat-tools/{ProductVersion}/os/
 ----
 Ensure that the paths to `cert.pem` and `key.pem` are the correct absolute paths otherwise the command fails silently.
+Pulp uses the organization label, therefore, you must enter the organization label into the URL.
 
 [[Managing_Organizations-Deleting_an_Organization]]
 === Deleting an Organization

--- a/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
+++ b/guides/doc-Content_Management_Guide/topics/Managing_Organizations.adoc
@@ -153,10 +153,8 @@ $ openssl pkcs12 -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -export -in cert.p
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-http://_{foreman-example-com}_/pulp/repos/_organization_label_
+http://_{foreman-example-com}_/pulp/content
 ----
-+
-Pulp uses the organization label, therefore, you must enter the organization label into the URL.
 
 .For CURL Users
 


### PR DESCRIPTION
The URL to add in the address bar to browse the accessible paths for 
all the repositories was incorrect for foreman 2.5. 
The same has been reported in BZ-2135217 and fixed in this PR.

https://bugzilla.redhat.com/show_bug.cgi?id=2135217


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
