### PR TITLE
Verify All Satellite doc links for 3.3

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -4,7 +4,7 @@
 :ConfiguringLoadBalancerDocURL: {BaseURL}Configuring_Load_Balancer/{BaseFilenameURL}#
 :ContentManagementDocURL: {BaseURL}Managing_Content/{BaseFilenameURL}#
 :InstallingServerDocURL: {BaseURL}Installing_Server/{BaseFilenameURL}#
-:InstallingDisconnectedDocURL: {BaseURL}Installing_Server_Disconnected/{BaseFilenameURL}#
+:InstallingServerDisconnectedDocURL: {BaseURL}Installing_Server_Disconnected/{BaseFilenameURL}#
 :InstallingSmartProxyDocURL: {BaseURL}Installing_Proxy/{BaseFilenameURL}#
 :ManagingHostsDocURL: {BaseURL}Managing_Hosts/{BaseFilenameURL}#
 :ManagingConfigurationsAnsibleDocURL: {BaseURL}Managing_Configurations_Ansible/{BaseFilenameURL}#

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,4 +1,6 @@
 // Overrides for orcharhino build
+:BaseURL: https://docs.orcharhino.com/
+
 :KatelloVersion: Katello 4.3
 :ProductVersion: 6.1
 :ProductVersionPrevious: 6.0

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -26,6 +26,10 @@
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
 :ReleaseNotesURL: {MultiBaseURL}/release_notes/index#
 
+// Not upstreamed
+:APIDocURL: {MultiBaseURL}api_guide/index#
+:HammerDocURL: {MultiBaseURL}hammer_cli_guide/index#
+
 // Overrides for satellite build
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/redhat/satellite/docs

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -1,3 +1,10 @@
+// Attributes only for satellite build
+:ProductVersion: 6.12
+:ProductVersionPrevious: 6.11
+:TargetVersion: {ProductVersion}
+// Add -beta for Beta releases
+:ProductVersionRepoTitle: {ProductVersion}
+
 // URLs (published on Red Hat Portal)
 :AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
 :ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#
@@ -13,13 +20,6 @@
 :TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
 :ReleaseNotesURL: {MultiBaseURL}/release_notes/index#
-
-// Attributes only for satellite build
-:ProductVersion: 6.12
-:ProductVersionPrevious: 6.11
-:TargetVersion: {ProductVersion}
-// Add -beta for Beta releases
-:ProductVersionRepoTitle: {ProductVersion}
 
 // Overrides for satellite build
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -29,6 +29,7 @@
 // Not upstreamed
 :APIDocURL: {MultiBaseURL}api_guide/index#
 :HammerDocURL: {MultiBaseURL}hammer_cli_guide/index#
+:ConfiguringVMSubscriptionsDocURL: {MultiBaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index#
 
 // Overrides for satellite build
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -6,7 +6,7 @@
 :ManagingConfigurationsAnsibleDocURL: {BaseURL}managing_configurations_using_ansible_integration_in_red_hat_satellite/index#
 :ManagingConfigurationsPuppetDocURL: {BaseURL}managing_configurations_using_puppet_integration_in_red_hat_satellite/index#
 :InstallingServerDocURL: {BaseURL}installing_satellite_server_in_a_connected_network_environment/index#
-:InstallingDisconnectedDocURL: {BaseURL}installing_satellite_server_in_a_disconnected_network_environment/index#
+:InstallingServerDisconnectedDocURL: {BaseURL}installing_satellite_server_in_a_disconnected_network_environment/index#
 :InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
 :PlanningDocURL: {BaseURL}satellite_overview_concepts_and_deployment_considerations/index#
 :ProvisioningDocURL: {BaseURL}provisioning_hosts/index#

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -5,6 +5,11 @@
 // Add -beta for Beta releases
 :ProductVersionRepoTitle: {ProductVersion}
 
+// Red Hat sometimes prefers the multi page (as opposed to html-single)
+// The URL structure is different and there's no upstream equivalent.
+:MultiBaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/
+:BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/
+
 // URLs (published on Red Hat Portal)
 :AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
 :ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -26,6 +26,10 @@
 :TuningDocTitle: Tuning Performance of {ProjectName}
 :UpgradingDocTitle: Upgrading and Updating {ProjectName}
 
+// Not upstreamed
+:APIDocTitle: API Guide
+:HammerDocTitle: Hammer CLI Guide
+
 // Overrides for titles per product
 
 ifdef::foreman-el[]

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -29,6 +29,7 @@
 // Not upstreamed
 :APIDocTitle: API Guide
 :HammerDocTitle: Hammer CLI Guide
+:ConfiguringVMSubscriptionsDocTitle: Configuring Virtual Machine Subscriptions in {ProjectName}
 
 // Overrides for titles per product
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -69,7 +69,6 @@ include::attributes-satellite.adoc[]
 endif::[]
 
 ifdef::orcharhino[]
-:BaseURL: https://docs.orcharhino.com/
 include::attributes-orcharhino.adoc[]
 endif::[]
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -51,26 +51,8 @@ endif::[]
 include::attributes-base.adoc[]
 include::attributes-typography.adoc[]
 
-// Load overrides for specific scenarios
-ifdef::foreman-el[]
-include::attributes-foreman-el.adoc[]
-endif::[]
-
-ifdef::foreman-deb[]
-include::attributes-foreman-deb.adoc[]
-endif::[]
-
-ifdef::katello[]
-include::attributes-katello.adoc[]
-endif::[]
-
-ifdef::satellite[]
-include::attributes-satellite.adoc[]
-endif::[]
-
-ifdef::orcharhino[]
-include::attributes-orcharhino.adoc[]
-endif::[]
+// Load overrides for the build
+include::attributes-{build}.adoc[]
 
 // Must be loaded after product-specific definitions
 include::attributes-titles.adoc[]

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -11,9 +11,6 @@
 // The above attribute should point to the GA version number (x.y) for all releases including Beta
 :SatelliteAnsibleVersion: 2.9
 
-// Use current RH Satellite release version for links to access.redhat.com
-:AccessRedHatComVersion: 6.12
-
 //
 // WHERE ARE MY ATTRIBUTES?
 //
@@ -51,9 +48,6 @@ endif::[]
 // Load base attributes
 :SiteURL: https://docs.theforeman.org
 :BaseURL:  {SiteURL}/{ProjectVersion}/
-// Red Hat sometimes prefers the multi page (as opposed to html-single)
-// The URL structure is different and there's no upstream equivalent.
-:MultiBaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html/
 include::attributes-base.adoc[]
 include::attributes-typography.adoc[]
 
@@ -71,7 +65,6 @@ include::attributes-katello.adoc[]
 endif::[]
 
 ifdef::satellite[]
-:BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{AccessRedHatComVersion}/html-single/
 include::attributes-satellite.adoc[]
 endif::[]
 

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,5 +18,5 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
-  # This isn't published downstream yet
+  # 6.12 docs are not yet published
   access.redhat.com/documentation/en-us/red_hat_satellite/6.12

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -39,5 +39,5 @@ ifndef::satellite[]
 * {InstallingServerDocURL}configuring-{project-context}-server-to-consume-content-from-a-custom-cdn_{project-context}[Configuring {ProjectServerTitle} to Consume Content from a Custom CDN] in _{InstallingServerDocTitle}_
 endif::[]
 ifdef::satellite[]
-* {InstallingDisconnectedDocURL}configuring-{project-context}-server-to-consume-content-from-a-custom-cdn_{project-context}[Configuring {ProjectServerTitle} to Consume Content from a Custom CDN] in _{InstallingServerDisconnectedDocTitle}_
+* {InstallingServerDisconnectedDocURL}configuring-{project-context}-server-to-consume-content-from-a-custom-cdn_{project-context}[Configuring {ProjectServerTitle} to Consume Content from a Custom CDN] in _{InstallingServerDisconnectedDocTitle}_
 endif::[]

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -25,5 +25,5 @@ endif::[]
 ifdef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure.
 Configure your {Project} for ISS as appropriate for your use case scenario.
-For more information, see {InstallingDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure {ISS}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}how-to-configure-inter-server-sync_{context}[How to Configure {ISS}] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]

--- a/guides/common/modules/proc_deleting-multiple-compliance-reports.adoc
+++ b/guides/common/modules/proc_deleting-multiple-compliance-reports.adoc
@@ -3,7 +3,7 @@
 
 You can delete multiple compliance policies simultaneously.
 However, in the {ProjectWebUI}, compliance policies are paginated, so you must delete one page of reports at a time.
-ifndef::orcharhino[]
+ifdef::satellite[]
 If you want to delete all OpenSCAP reports, use the script in the {MultiBaseURL}api_guide/chap-red_hat_satellite-api_guide-using_the_red_hat_satellite_api#sect-API_Guide-Deleting-OpenSCAP-Reports[Deleting OpenSCAP Reports] section of the _{ProjectName} API Guide_.
 endif::[]
 

--- a/guides/common/modules/proc_deleting-multiple-compliance-reports.adoc
+++ b/guides/common/modules/proc_deleting-multiple-compliance-reports.adoc
@@ -4,7 +4,7 @@
 You can delete multiple compliance policies simultaneously.
 However, in the {ProjectWebUI}, compliance policies are paginated, so you must delete one page of reports at a time.
 ifdef::satellite[]
-If you want to delete all OpenSCAP reports, use the script in the {MultiBaseURL}api_guide/chap-red_hat_satellite-api_guide-using_the_red_hat_satellite_api#sect-API_Guide-Deleting-OpenSCAP-Reports[Deleting OpenSCAP Reports] section of the _{ProjectName} API Guide_.
+If you want to delete all OpenSCAP reports, use the script in the {APIDocURL}chap-red_hat_satellite-api_guide-using_the_red_hat_satellite_api#sect-API_Guide-Deleting-OpenSCAP-Reports[Deleting OpenSCAP Reports] section of _{APIDocTitle}_.
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_enabling-auto-attach.adoc
+++ b/guides/common/modules/proc_enabling-auto-attach.adoc
@@ -5,7 +5,7 @@ When auto-attach is enabled on an activation key and there are subscriptions ass
 
 You can enable auto-attach and have no subscriptions associated with the key.
 This type of key is commonly used to register virtual machines when you do not want the virtual machine to consume a physical subscription, but to inherit a host-based subscription from the hypervisor.
-ifndef::orcharhino[]
+ifdef::satellite[]
 For more information, see {MultiBaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index[_Configuring Virtual Machine Subscriptions in {ProjectName}_].
 endif::[]
 

--- a/guides/common/modules/proc_enabling-auto-attach.adoc
+++ b/guides/common/modules/proc_enabling-auto-attach.adoc
@@ -6,7 +6,7 @@ When auto-attach is enabled on an activation key and there are subscriptions ass
 You can enable auto-attach and have no subscriptions associated with the key.
 This type of key is commonly used to register virtual machines when you do not want the virtual machine to consume a physical subscription, but to inherit a host-based subscription from the hypervisor.
 ifdef::satellite[]
-For more information, see {MultiBaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index[_Configuring Virtual Machine Subscriptions in {ProjectName}_].
+For more information, see {ConfiguringVMSubscriptionsDocURL}[_{ConfiguringVMSubscriptionsDocTitle}_].
 endif::[]
 
 Auto-attach is enabled by default.

--- a/guides/common/modules/proc_exporting-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_exporting-report-templates-using-the-api.adoc
@@ -3,7 +3,7 @@
 
 You can use the {Project} `report_templates` API to export report templates from {Project}.
 ifdef::satellite[]
-For more information about using the {Project} API, see the {MultiBaseURL}api_guide/index[API Guide].
+For more information about using the {Project} API, see {APIDocURL}[{APIDocTitle}].
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_exporting-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_exporting-report-templates-using-the-api.adoc
@@ -2,7 +2,7 @@
 = Exporting Report Templates Using the {Project} API
 
 You can use the {Project} `report_templates` API to export report templates from {Project}.
-ifndef::orcharhino[]
+ifdef::satellite[]
 For more information about using the {Project} API, see the {MultiBaseURL}api_guide/index[API Guide].
 endif::[]
 

--- a/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
@@ -3,7 +3,7 @@
 
 You can use the {Project} API to import report templates into {Project}.
 Importing report templates using the {Project} API automatically parses the report template metadata and assigns organizations and locations.
-ifndef::orcharhino[]
+ifdef::satellite[]
 For more information about using the {Project} API, see the {MultiBaseURL}api_guide/index[API Guide].
 endif::[]
 

--- a/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
@@ -4,7 +4,7 @@
 You can use the {Project} API to import report templates into {Project}.
 Importing report templates using the {Project} API automatically parses the report template metadata and assigns organizations and locations.
 ifdef::satellite[]
-For more information about using the {Project} API, see the {MultiBaseURL}api_guide/index[API Guide].
+For more information about using the {Project} API, see the {APIDocURL}[{APIDocTitle}].
 endif::[]
 
 .Prerequisites

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -10,7 +10,7 @@ For more information about configuring external authentication, see xref:Configu
 
 If you use virt-who, you must update the virt-who configuration files with the new host name after you run the `{project-change-hostname}` script.
 ifdef::satellite[]
-For more information, see {MultiBaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _Configuring Virtual Machine Subscriptions in {ProjectName}_.
+For more information, see {ConfiguringVMSubscriptionsDocURL}troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _{ConfiguringVMSubscriptionsDocTitle}_.
 endif::[]
 
 .Prerequisites

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -9,7 +9,7 @@ The `{project-change-hostname}` script breaks external authentication for {Proje
 For more information about configuring external authentication, see xref:Configuring_External_Authentication_{context}[].
 
 If you use virt-who, you must update the virt-who configuration files with the new host name after you run the `{project-change-hostname}` script.
-ifndef::orcharhino[]
+ifdef::satellite[]
 For more information, see {MultiBaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _Configuring Virtual Machine Subscriptions in {ProjectName}_.
 endif::[]
 

--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -37,11 +37,11 @@ Enter the following command to restore the correct SELinux contexts:
 
 .Procedure
 . Choose the appropriate method to install {Project} or {SmartProxy}:
-** To install {ProjectServer} from a connected network, follow the procedures in {InstallingServerDocURL}[Installing {ProjectServer} from a Connected Network].
+** To install {ProjectServer} from a connected network, follow the procedures in {InstallingServerDocURL}[{InstallingServerDocTitle}].
 ifdef::satellite[]
-** To install {ProjectServer} from a disconnected network, follow the procedures in {MultiBaseURL}installing_satellite_server_from_a_disconnected_network/[Installing {ProjectServer} from a Disconnected Network].
+** To install {ProjectServer} from a disconnected network, follow the procedures in {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
 endif::[]
-** To install a {SmartProxyServer}, follow the procedures in the {InstallingSmartProxyDocURL}[Installing {SmartProxyServer}].
+** To install a {SmartProxyServer}, follow the procedures in {InstallingSmartProxyDocURL}[{InstallingSmartProxyDocTitle}].
 . Copy the backup data to {ProjectServer}’s local file system.
 Use `/var/` or `/var/tmp/`.
 . Run the restoration script.

--- a/guides/common/modules/ref_performing-a-fresh-installation-of-a-server-on-el8.adoc
+++ b/guides/common/modules/ref_performing-a-fresh-installation-of-a-server-on-el8.adoc
@@ -5,6 +5,6 @@ After you have created a backup of the {ProjectServer} or {SmartProxyServer} on 
 
 * To install connected {ProjectServer}, see {InstallingServerDocURL}[_{InstallingServerDocTitle}_].
 ifdef::satellite[]
-* To install disconnected {ProjectServer}, see {InstallingDisconnectedDocURL}[_{InstallingServerDisconnectedDocTitle}_].
+* To install disconnected {ProjectServer}, see {InstallingServerDisconnectedDocURL}[_{InstallingServerDisconnectedDocTitle}_].
 endif::[]
 * To install {SmartProxyServer}, see {InstallingSmartProxyDocURL}[_{InstallingSmartProxyDocTitle}_].

--- a/guides/doc-Planning_for_Project/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_for_Project/topics/Capsule_Server_Overview.adoc
@@ -102,6 +102,6 @@ You can find complete instructions for configuring the host-based firewall to op
 
 * {InstallingServerDocURL}Ports_and_Firewalls_Requirements_{project-context}[Ports and Firewalls Requirements] in _{InstallingServerDocTitle}_
 ifdef::satellite[]
-* {InstallingDisconnectedDocURL}Ports_and_Firewalls_Requirements_{project-context}[Ports and Firewalls Requirements] in _{InstallingServerDisconnectedDocTitle}_
+* {InstallingServerDisconnectedDocURL}Ports_and_Firewalls_Requirements_{project-context}[Ports and Firewalls Requirements] in _{InstallingServerDisconnectedDocTitle}_
 endif::[]
 * {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements] in _{InstallingSmartProxyDocTitle}_

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -280,5 +280,5 @@ endif::[]
 * *Scripting with Hammer and API* – {Project} provides a command line tool called Hammer that provides a CLI equivalent to the majority of web UI procedures.
 In addition, you can use the access to the {Project} API to write automation scripts in a selected programming language.
 ifdef::satellite[]
-For more information see the {MultiBaseURL}hammer_cli_guide/[_Hammer CLI Guide_] and {MultiBaseURL}api_guide/[_API Guide_].
+For more information, see {HammerDocURL}[{HammerDocTitle}] and {APIDocURL}[{APIDocTitle}].
 endif::[]

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -17,10 +17,10 @@ The first step to a working {Project} infrastructure is installing an instance o
 On large {Project} deployments, you can improve performance by configuring your {Project} with predefined tuning profiles.
 For more information, see {InstallingServerDocURL}tuning-with-predefined-profiles_{project-context}[Tuning {ProjectServer} with Predefined Profiles] in _{InstallingServerDocTitle}_.
 
-* For more information about installing {ProjectServer} in a disconnected network, see {InstallingDisconnectedDocURL}[_{InstallingServerDisconnectedDocTitle}_].
+* For more information about installing {ProjectServer} in a disconnected network, see {InstallingServerDisconnectedDocURL}[_{InstallingServerDisconnectedDocTitle}_].
 +
 On large {Project} deployments, you can improve performance by configuring your {Project} with predefined tuning profiles.
-For more information, see {InstallingDisconnectedDocURL}tuning-with-predefined-profiles_{project-context}[Tuning {ProjectServer} with Predefined Profiles] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}tuning-with-predefined-profiles_{project-context}[Tuning {ProjectServer} with Predefined Profiles] in _{InstallingServerDisconnectedDocTitle}_.
 
 .Adding Red{nbsp}Hat Subscription Manifests to {ProjectServer}
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -279,6 +279,6 @@ endif::[]
 
 * *Scripting with Hammer and API* – {Project} provides a command line tool called Hammer that provides a CLI equivalent to the majority of web UI procedures.
 In addition, you can use the access to the {Project} API to write automation scripts in a selected programming language.
-ifndef::orcharhino[]
+ifdef::satellite[]
 For more information see the {MultiBaseURL}hammer_cli_guide/[_Hammer CLI Guide_] and {MultiBaseURL}api_guide/[_API Guide_].
 endif::[]

--- a/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
@@ -34,8 +34,8 @@ ifdef::satellite[]
 
 In high security environments where hosts are required to function in a closed network disconnected from the Internet, {ProjectName} can provision systems with the latest security updates, errata, packages and other content.
 In such case, {ProjectServer} does not have direct access to the Internet, but the layout of other infrastructure components is not affected.
-For information about installing {ProjectServer} from a disconnected network, see {MultiBaseURL}installing_satellite_server_from_a_disconnected_network/[Installing {ProjectServer} from a Disconnected Network].
-For information about upgrading a disconnected {Project}, see {MultiBaseURL}upgrading_and_updating_red_hat_satellite/upgrading_red_hat_satellite#upgrading_a_disconnected_{project-context}[Upgrading a Disconnected {ProjectServer}] in _Upgrading and Updating {ProjectName}_.
+For information about installing {ProjectServer} from a disconnected network, see {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
+For information about upgrading a disconnected {Project}, see {UpgradingDocURL}upgrading_a_disconnected_{project-context}[Upgrading a Disconnected {ProjectServer}] in _{UpgradingDocTitle}_.
 
 There are two options for importing content to a disconnected {ProjectServer}:
 

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -229,5 +229,5 @@ If you want to change the host name to something different, you can use the `sat
 For more information, see {AdministeringDocURL}Renaming_Server_admin[Renaming a {Project} or {SmartProxyServer}] in _{AdministeringDocTitle}_.
 . If the source server uses the `virt-who` daemon, install and configure it on the target server.
 Copy all the `virt-who` configuration files in the `/etc/virt-who.d/` directory from the source server to the same directory on the target server.
-For more information, see {BaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index[_Configuring Virtual Machine Subscriptions in {ProjectName}_].
+For more information, see {ConfiguringVMSubscriptionsDocURL}[_{ConfiguringVMSubscriptionsDocTitle}_].
 After you perform an upgrade using the following chapters, you can safely decommission the source server.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -22,7 +22,7 @@ endif::[]
 .Before You Begin
 
 * Review and update your firewall configuration before upgrading your {ProjectServer}.
-For more information, see {InstallingDisconnectedDocURL}Ports_and_Firewalls_Requirements_satellite[Ports and Firewalls Requirements] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}Ports_and_Firewalls_Requirements_satellite[Ports and Firewalls Requirements] in _{InstallingServerDisconnectedDocTitle}_.
 * Ensure that you do not delete the manifest from the Customer Portal or in the {ProjectWebUI} because this removes all the entitlements of your content hosts.
 * Back up and remove all Foreman hooks before upgrading.
 Reinstate hooks only after {Project} is known to be working after the upgrade is complete.
@@ -82,15 +82,15 @@ Reboot these hosts after the upgrade has completed.
 # {foreman-maintain} service stop
 ----
 
-. Obtain the latest ISO files by following the {InstallingDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.
+. Obtain the latest ISO files by following the {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.
 
 . Create directories to serve as a mount point, mount the ISO images, and configure the `rhel7-server` or the `rhel8` repository:
 +
 .For {EL} 8
-Follow the {InstallingDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-8_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 8] procedure in _{InstallingServerDisconnectedDocTitle}_.
+Follow the {InstallingServerDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-8_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 8] procedure in _{InstallingServerDisconnectedDocTitle}_.
 +
 .For {EL} 7
-Follow the {InstallingDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-7_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 7] procedure in _{InstallingServerDisconnectedDocTitle}_.
+Follow the {InstallingServerDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-7_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 7] procedure in _{InstallingServerDisconnectedDocTitle}_.
 +
 Do not install or update any packages at this stage.
 
@@ -288,7 +288,7 @@ Review the results and address any highlighted error conditions before performin
 ----
 +
 If the script fails due to missing or outdated packages, you must download and install these separately.
-For more information, see {InstallingDisconnectedDocURL}resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}resolving-package-dependency-errors_satellite[Resolving Package Dependency Errors] in _{InstallingServerDisconnectedDocTitle}_.
 
 . If using a BASH shell, after a successful or failed upgrade, enter:
 +


### PR DESCRIPTION
Same changes as in #1775 for 3.3 branch. There were merge conflicts in linkchecker.ini and attributes-satellite.adoc.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
