### PR TITLE
Add Foreman Host Parameter Hierarchy

### DIFF
--- a/guides/common/modules/ref_host-parameter-hierarchy.adoc
+++ b/guides/common/modules/ref_host-parameter-hierarchy.adoc
@@ -1,0 +1,18 @@
+[id="Host_Parameter_Hierarchy_{context}"]
+= Host Parameter Hierarchy
+
+You can access host parameters when provisioning hosts.
+Hosts inherit their parameters from the following locations, in order of increasing precedence:
+
+[cols="50%,50%",options="header"]
+|====
+| Parameter Level | Set in {ProjectWebUI}
+| Globally defined parameters | *Configure* > *Global parameters*
+| Organization-level parameters | *Administer* > *Organizations*
+| Location-level parameters | *Administer* > *Locations*
+| Domain-level parameters | *Infrastructure* > *Domains*
+| Subnet-level parameters | *Infrastructure* > *Subnets*
+| Operating system-level parameters | *Hosts* > *Operating Systems*
+| Host group-level parameters | *Configure* > *Host Groups*
+| Host parameters | *Hosts* > *All Hosts*
+|====

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -50,3 +50,6 @@ ifdef::satellite[]
 [appendix]
 include::common/assembly_building_cloud-images.adoc[leveloffset=+1]
 endif::[]
+
+[appendix]
+include::common/modules/ref_host-parameter-hierarchy.adoc[leveloffset=+1]


### PR DESCRIPTION
This is based on https://theforeman.org/manuals/3.4/index.html#4.2.3Parameters

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3