### PR TITLE
Update Debian installation instructions to Puppet 7

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-deb.adoc
@@ -2,11 +2,11 @@
 
 :PuppetReleaseDeb: puppet7-release-{distribution-codename}.deb
 
-. Install the `ca-certificates` package:
+. Install the `wget` and `ca-certificates` packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} ca-certificates
+# {package-install} wget ca-certificates
 ----
 
 . Change directory to `/tmp` and retrieve the `{PuppetReleaseDeb}` package:

--- a/guides/common/modules/proc_configuring-repositories-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-deb.adoc
@@ -1,5 +1,7 @@
 [id="configuring-repositories-deb-{distribution-codename}"]
 
+:PuppetReleaseDeb: puppet7-release-{distribution-codename}.deb
+
 . Install the `ca-certificates` package:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -7,18 +9,18 @@
 # {package-install} ca-certificates
 ----
 
-. Change directory to `/tmp` and install the `puppet6-release-{distribution-codename}.deb` package:
+. Change directory to `/tmp` and retrieve the `{PuppetReleaseDeb}` package:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# cd /tmp && wget https://apt.puppet.com/puppet6-release-{distribution-codename}.deb
+# cd /tmp && wget https://apt.puppet.com/{PuppetReleaseDeb}
 ----
 
-. Install the `puppet6-release-{distribution-codename}.deb` package:
+. Install the `{PuppetReleaseDeb}` package:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} /tmp/puppet6-release-{distribution-codename}.deb
+# {package-install} /tmp/{PuppetReleaseDeb}
 ----
 
 . Enable the Foreman repository:


### PR DESCRIPTION
Puppet 7 is the latest and recommended version.

This also introduces an attribute to avoid repetition.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.