### PR TITLE
Add a comment where releases should be added

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -12,6 +12,8 @@ include::topics/foreman.adoc[leveloffset=+1]
 include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
+// Start inserting specific x.y.z releases here
+
 [appendix]
 [id="foreman-contributors"]
 = Foreman Contributors


### PR DESCRIPTION
Looking at the past releases it appears nobody understands the README I wrote so here's an explicit marker where it should be added.

I don't think cherry picks are needed since all releases have versions so there it's clear.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.