### PR TITLE
Clean up Foreman 3.4 release notes

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -10,6 +10,10 @@ ifdef::katello[]
 
 include::topics/foreman.adoc[leveloffset=+1]
 include::topics/katello.adoc[leveloffset=+1]
+endif::[]
+
+// Start inserting specific x.y.z releases here
+ifdef::katello[]
 include::topics/katello-4.6.0.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Release_Notes/topics/foreman-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-contributors.adoc
@@ -1,0 +1,5 @@
+We'd like to thank the following people who contributed to the Foreman {ProjectVersion} release:
+
+Adam Ruzicka, Amit Upadhye, Andrew Teixeira, Antoine Beaupré, Bastian Schmidt, Bernhard Suttner, Chris Roberts, Dirk Götz, Eric D. Helms, Evgeni Golov, Ewoud Kohl van Wijngaarden, Garret Rumohr, Gordon Bleux, Jeremy Lenz, John Mitsch, Jonathon Turel, Justin Sherrill, Kenyon Ralph, Leos Stejskal, Lucy Fu, Lukáš Zapletal, Marcel Kühlhorn, Marek Hulán, Maria Agaphontzev, Markus Bucher, Matěj Mudra, Melanie Corr, Nofar Alfassi, Oleh Fedorenko, Ondřej Ezr, Ondřej Pražák, Pat Riehecky, Patrick Creech, Peter Koprda, Rahul Bajaj, Robert Frank, Romuald Conty, Ron Lavi, Shimon Shtein, Shira Maximov, Tilman Kranz, Tim Meusel, Tomer Brisker, William Clark, Yifat Makias, naveen, pandrieux
+
+As well as all users who helped test releases, report bugs and provide feedback on the project.

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -11,13 +11,13 @@
 
 EL7 support is dropped with Foreman 3.4. Users are advised to upgrade to EL8.
 
-Note that this support statement refers to running Foreman and Foreman Smart Proxy themselves on EL7. Managing EL7 hosts remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
+Note that this support statement refers to running Foreman and Foreman Smart Proxy themselves on EL7. Managing EL7 hosts remains supported. See https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008[the RFC] for more information.
 
 === Running Foreman on Debian 10
 
 Debian 10 support is dropped with Foreman 3.4. Users are advised to upgrade to Debian 11.
 
-Note that this support statement refers to running Foreman and Foreman Proxy themselves on Debian 10. Managing Debian 10 hosts remains supported. See [the RFC](https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008) for more information.
+Note that this support statement refers to running Foreman and Foreman Proxy themselves on Debian 10. Managing Debian 10 hosts remains supported. See https://community.theforeman.org/t/deprecation-plans-for-foreman-on-el7-debian-10-and-ubuntu-18-04/25008[the RFC] for more information.
 
 === Running Foreman on Ruby 2.5
 

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -1,9 +1,6 @@
 [id="foreman-release-notes"]
 = Foreman {ProjectVersion} Release Notes
 
-[id="foreman-headline-features"]
-== Headline Features
-
 [id="foreman-upgrade-warnings"]
 == Upgrade Warnings
 
@@ -23,6 +20,3 @@ Note that this support statement refers to running Foreman and Foreman Proxy the
 
 With dropping the support of Debian 10 deployments in Foreman 3.2 (and the removal of support in 3.4), there is no supported platform with Ruby 2.5 anymore.
 Therefore running Foreman on Ruby 2.5 is dropped in Foreman 3.4. Please switch to Ruby 2.7.
-
-[id="foreman-deprecations"]
-== Deprecations

--- a/guides/doc-Release_Notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/katello-contributors.adoc
@@ -1,21 +1,21 @@
- Adam Růžička <adamruzicka@users.noreply.github.com>
- Aliya Tazhibayeva <57777196+tazhibaevaaliya@users.noreply.github.com>
- Bernhard Suttner <sbernhard@users.noreply.github.com>
- Chris Roberts <chrobert@redhat.com>
- Eric D. Helms <ericdhelms@gmail.com>
- Evgeni Golov <evgeni@golov.de>
- Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>
- Ian Ballou <ianballou67@gmail.com>
- Jeremy Lenz <jlenz@redhat.com>
- Joniel Pasqualetto <jpasqualetto@gmail.com>
- Leos Stejskal <github@stejskalleos.cz>
- Lucy Fu <lufu@redhat.com>
- Manisha Singhal <singhal@atix.de>
- Maria <mariaaga@redhat.com>
- Markus Bucher <bucher@atix.de>
- Partha Aji <paji@redhat.com>
- Pavel Moravec <pmoravec@redhat.com>
- Ron Lavi <1ronlavi@gmail.com>
- Samir Jha <sjha4@ncsu.edu>
- William Bradford Clark <wclark@redhat.com>
- hao-yu <hyu@redhat.com>
+ Adam Růžička
+ Aliya Tazhibayeva
+ Bernhard Suttner
+ Chris Roberts
+ Eric D. Helms
+ Evgeni Golov
+ Ewoud Kohl van Wijngaarden
+ Ian Ballou
+ Jeremy Lenz
+ Joniel Pasqualetto
+ Leos Stejskal
+ Lucy Fu
+ Manisha Singhal
+ Maria Agaphontzev
+ Markus Bucher
+ Partha Aji
+ Pavel Moravec
+ Ron Lavi
+ Samir Jha
+ William Bradford Clark
+ hao-yu

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -17,9 +17,3 @@
 - Tracer has been added to 'System properties' card on host details page.
 - 'Hardware properties' card has been added to the host details.
 * Over 30 bug fixes.
-
-[id="katello-upgrade-warnings"]
-== Upgrade Warnings
-
-[id="katello-deprecations"]
-== Deprecations


### PR DESCRIPTION
See individual commits for details.

The styles of authors are still quite different, but I wonder which is best. Perhaps a long list is not too bad given it's an appendix. Should Foreman adopt the same style as Katello?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.