### PR TITLE
Declare it Foreman 3.4 as stable

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: unsupported
+:DocState: stable
 
 // Version numbers
 :ProjectVersion: 3.4


### PR DESCRIPTION
Foreman 3.4 is currently the latest supported release so it should be listed as stable.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.