### PR TITLE
Update ProjectVersion when Cloning to Target Server

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -162,7 +162,7 @@ To clone your server, complete the following steps on your target server:
 --enable=rhel-7-server-rpms \
 --enable=rhel-server-rhscl-7-rpms \
 --enable=rhel-7-server-satellite-maintenance-6-rpms \
---enable=rhel-7-server-satellite-{ProjectVersion}-rpms\
+--enable=rhel-7-server-satellite-{ProjectVersion}-rpms \
 --enable={RepoRHEL7ServerAnsible}
 ----
 +

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -162,7 +162,8 @@ To clone your server, complete the following steps on your target server:
 --enable=rhel-7-server-rpms \
 --enable=rhel-server-rhscl-7-rpms \
 --enable=rhel-7-server-satellite-maintenance-6-rpms \
---enable=rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
+--enable=rhel-7-server-satellite-{ProjectVersion}-rpms\
+--enable={RepoRHEL7ServerAnsible}
 ----
 +
 ifdef::satellite[]


### PR DESCRIPTION
The project version in Cloning to the Target Server module 
in the upgrade guide was incorrect.
One more repo `--enable=rhel-7-server-ansible-2.9-rpms` was missing.
Both issues have been fixed in this PR.

https://bugzilla.redhat.com/show_bug.cgi?id=2135967


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
