### PR TITLE
Add Foreman 3.5 & Katello 4.7 to versions.js

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -164,6 +164,82 @@ const navVersions = [
     ]
   },
   {
+    "title": "Foreman 3.5 - Katello 4.7 (release candidate)",
+    "path": "3.5",
+    "builds": [
+      {
+        "title": "Katello on EL",
+        "filename": "index-katello.html",
+        "guides": [
+          {
+            "title": "Release Notes",
+            "path": "Release_Notes"
+          },
+          {
+            "title": "Planning Guide",
+            "path": "Planning_for_Project"
+          },
+          {
+            "title": "Quickstart Guide",
+            "path": "Quickstart"
+          },
+          {
+            "title": "Installing Katello Server",
+            "path": "Installing_Server"
+          },
+          {
+            "title": "Installing Smart Proxy with Content",
+            "path": "Installing_Proxy"
+          },
+          {
+            "title": "Upgrading and Updating",
+            "path": "Upgrading_and_Updating"
+          },
+          {
+            "title": "Configuring Smart Proxies with a Load Balancer",
+            "path": "Configuring_Load_Balancer"
+          },
+          {
+            "title": "Managing Organizations and Locations in Foreman",
+            "path": "Managing_Organizations_and_Locations"
+          },
+          {
+            "title": "Managing Content",
+            "path": "Managing_Content"
+          },
+          {
+            "title": "Deploying Foreman on AWS",
+            "path": "Deploying_Project_on_AWS"
+          },
+          {
+            "title": "Provisioning Hosts",
+            "path": "Provisioning_Hosts"
+          },
+          {
+            "title": "Managing Hosts",
+            "path": "Managing_Hosts"
+          },
+          {
+            "title": "Configuring Hosts Using Ansible",
+            "path": "Managing_Configurations_Ansible"
+          },
+          {
+            "title": "Configuring Hosts Using Puppet",
+            "path": "Managing_Configurations_Puppet"
+          },
+          {
+            "title": "Administering Foreman",
+            "path": "Administering_Project"
+          },
+          {
+            "title": "Application Centric Deployment",
+            "path": "Deploying_Hosts_AppCentric"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "title": "Foreman 3.4 - Katello 4.6 (supported)",
     "path": "3.4",
     "builds": [


### PR DESCRIPTION
Fixes: 0c77d6a50df47ff90ea8378b7501a2b7d1f782c3

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.