### PR TITLE
Remove link to unincluded module

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -13,7 +13,6 @@ ifdef::satellite[]
 
 You cannot upgrade a self-registered {Project}.
 You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade.
-To migrate a self-registered {Project} to the CDN, see {UpgradingDocURL}Migrating_a_Self_Registered_Server_upgrade-guide[Migrating Self-Registered {Project}s] in _{UpgradingDocTitle}_.
 endif::[]
 
 ifndef::foreman-deb[]


### PR DESCRIPTION
Module migrating_a_self_registered_satellite.adoc is not included in the Upgrading guide and the link to it is invalid, therefore it needs to be removed.

In the long term, the module could be included back in the guide, however; it needs to be updated since it contains references to EL 6 and I don't know whether its contents are still actual. For the short-term solution, this link needs to be removed because it is an invalid link in the released Satelliite 6.11 as well as in the soon to be released Satellite 6.12.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3