### PR TITLE
Upgrading guide - finishing touches

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -7,8 +7,8 @@ After your upgrade is complete, you can then decommission the earlier version of
 
 Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
 
-The {Project} clone tool does not support migrating a {SmartProxyServer} to {EL} 7.
-Instead you must backup the existing {SmartProxyServer}, restore it on {EL} 7, then reconfigure {SmartProxyServer}.
+The {Project} clone tool does not support migrating a {SmartProxyServer} to {EL} 8.
+Instead, you must backup the existing {SmartProxyServer}, restore it on {EL} 8, and then reconfigure {SmartProxyServer}.
 
 .Terminology
 Ensure that you understand the following terms:
@@ -34,9 +34,10 @@ Ensure that you understand the following terms:
 
 To clone {ProjectServer}, ensure that you have the following resources available:
 
-* A minimal install of {EL} 7 to become the target server.
-Do not install {EL} 7 software groups, or third-party applications.
-Ensure that your server complies with all the specifications of {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _Installing {ProjectServer}_.
+* A minimal install of {EL} 8 to become the target server.
+Do not install {EL} 8 software groups or third-party applications.
+Ensure that your server complies with all the required specifications.
+For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_.
 * A backup from {Project} {ProjectVersionPrevious} that you make using the `{foreman-maintain} backup` script.
 You can use a backup with or without Pulp data.
 * A {Project} subscription for the target server.
@@ -164,17 +165,14 @@ You can either mount the shared storage or copy the backup files to the `/backup
 . Power off the source server.
 . Enter the following commands to register to the Customer Portal, attach subscriptions, and enable only the required subscriptions:
 +
-[options="nowrap" subs="quotes, attributes"]
+[options="nowrap" subs="quotes,attributes"]
 ----
 # subscription-manager register _your_customer_portal_credentials_
 # subscription-manager attach --pool=__pool_ID__
 # subscription-manager repos --disable=*
-# subscription-manager repos \
---enable=rhel-7-server-rpms \
---enable=rhel-server-rhscl-7-rpms \
---enable=rhel-7-server-satellite-maintenance-6-rpms \
---enable={RepoRHEL7ServerAnsible} \
---enable=rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
+# subscription-manager repos --enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8ServerSatelliteServerProductVersion} \
+--enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 +
 ifdef::satellite[]


### PR DESCRIPTION
Removed reference to EL 7 and edited Release notes URL based on checking all the URLs in the upgrading guide for the upcoming release of Satellite 6.12.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
