### PR TITLE
Remove EL7 reference

### DIFF
--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -9,8 +9,6 @@ There is no requirement of attaching the {SatelliteSub} to the {ProjectServer} u
 
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName} and {RHEL} content.
-For {RHEL} 7, it also provides access to Red{nbsp}Hat Software Collections (RHSCL).
-This is the only subscription required.
 
 {ProjectName} Infrastructure is included with all subscriptions that include Smart Management.
 For more information, see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/3382781[{Project} Infrastructure Subscriptions MCT3718 MCT3719].


### PR DESCRIPTION
There can be some more EL7 references that should be removed.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
