### PR TITLE
Step update in Chainbooting virtual machines

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -150,7 +150,7 @@ If you want to change the default values in the template, clone the template and
 . Click the *Locations* tab, and add the location where the host resides.
 . Click the *Organizations* tab, and add the organization that the host belongs to.
 . Click *Submit* to save the changes.
-. Navigate to *Hosts* > *Operating systems* and select the operating system of your host.
+. Navigate to *Configure* > *Host Groups* and select the host group you want to configure.
 . Click the *Templates* tab.
 . From the *iPXE Template* list, select the template you want to use.
 . Click *Submit* to save the changes.


### PR DESCRIPTION
A step in the procedure Chainbooting virtual machines was incorrect. 
The same has been reported in this BZ-2134961.
This PR contains fix for reported issue for foreman 2.5.

https://bugzilla.redhat.com/show_bug.cgi?id=2134961

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
