### PR TITLE
Use installer support for scc-manager plugin

### DIFF
--- a/guides/common/modules/proc_installing-the-scc-manager.adoc
+++ b/guides/common/modules/proc_installing-the-scc-manager.adoc
@@ -1,33 +1,14 @@
 [id="Installing_the_SCC_Manager_Plugin_{context}"]
 = Installing the SCC Manager Plug-in
 
-Perform the following steps to install the _SCC Manager_ plug-in on your {Project}.
+Perform the following step to install the _SCC Manager_ plug-in on your {Project}.
 
 .Procedure
-. Connect to your {ProjectServer} using SSH:
+. Install the SCC Manager plug-in on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ssh root@{foreman-example-com}
-----
-. Install the SCC Manager plug-in on your {Project}:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {package-install-project} -y tfm-rubygem-foreman_scc_manager
-----
-. Run database migrations on your {Project}:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# foreman-rake db:migrate
-# foreman-rake db:seed
-----
-. Restart {Project} services:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service restart
+# {foreman-installer} --enable-foreman-plugin-scc-manager
 ----
 
 Continue with xref:Adding_an_SCC_Account_to_Server_{context}[adding your SCC account] to {Project}.


### PR DESCRIPTION
Since Foreman 3.4 there is installer support for scc-manager. This greatly simplifies the steps needed.

This came up in https://github.com/theforeman/foreman-documentation/pull/1773/files#r1018084831.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.