### PR TITLE
Remove link to unincluded module on 3.2

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_parent.adoc
@@ -13,7 +13,6 @@ ifdef::satellite[]
 
 You cannot upgrade a self-registered {Project}.
 You must migrate a self-registered {Project} to the Red Hat Content Delivery Network (CDN) and then perform the upgrade.
-To migrate a self-registered {Project} to the CDN, see {UpgradingDocURL}Migrating_a_Self_Registered_Server_upgrade-guide[Migrating Self-Registered {Project}s] in the _Upgrading and Updating {ProjectName}_ guide.
 endif::[]
 
 ifndef::foreman-deb[]


### PR DESCRIPTION
Change from #1794 applied to 3.2 branch.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
