### PR TITLE
Remove EL7 references from Managing Hosts and Administering Project g…

### DIFF
--- a/guides/common/modules/con_active-directory-with-cross-forest-trust.adoc
+++ b/guides/common/modules/con_active-directory-with-cross-forest-trust.adoc
@@ -5,7 +5,7 @@ Kerberos can create `cross-forest trust` that defines a relationship between two
 A domain forest is a hierarchical structure of domains; both AD and {FreeIPA} constitute a forest.
 With a trust relationship enabled between AD and {FreeIPA}, users of AD can access Linux hosts and services using a single set of credentials.
 ifndef::orcharhino[]
-For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/windows_integration_guide/active-directory-trust[Creating Cross-forest Trusts with Active Directory and Identity Management] in the _{RHEL} Windows Integration_ guide.
+For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/planning_identity_management/planning-a-cross-forest-trust-between-idm-and-ad_planning-identity-management[Planning a cross-forest trust between IdM and AD] in the _{RHEL} Planning Identity Management_ guide.
 endif::[]
 
 From the {Project} point of view, the configuration process is the same as integration with {FreeIPA} server without cross-forest trust configured.

--- a/guides/common/modules/con_active-directory-with-cross-forest-trust.adoc
+++ b/guides/common/modules/con_active-directory-with-cross-forest-trust.adoc
@@ -4,8 +4,8 @@
 Kerberos can create `cross-forest trust` that defines a relationship between two otherwise separate domain forests.
 A domain forest is a hierarchical structure of domains; both AD and {FreeIPA} constitute a forest.
 With a trust relationship enabled between AD and {FreeIPA}, users of AD can access Linux hosts and services using a single set of credentials.
-ifndef::orcharhino[]
-For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/planning_identity_management/planning-a-cross-forest-trust-between-idm-and-ad_planning-identity-management[Planning a cross-forest trust between IdM and AD] in the _{RHEL} Planning Identity Management_ guide.
+ifdef::satellite[]
+For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/planning_identity_management/planning-a-cross-forest-trust-between-idm-and-ad_planning-identity-management[Planning a cross-forest trust between IdM and AD] in _{RHEL} Planning Identity Management_.
 endif::[]
 
 From the {Project} point of view, the configuration process is the same as integration with {FreeIPA} server without cross-forest trust configured.

--- a/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
+++ b/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
@@ -2,7 +2,7 @@
 = Kerberos Configuration in Web Browsers
 
 ifndef::orcharhino[]
-For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/configuring_applications_for_sso#configuring_firefox_to_use_kerberos_for_sso[Configuring Firefox to Use Kerberos for Single Sign-On] in the _{RHEL} System-Level Authentication_ guide.
+For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_authentication_and_authorization_in_rhel/index#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _{RHEL} Configuring authentication and authorization in RHEL_ guide.
 endif::[]
 
 If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.
@@ -23,6 +23,6 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifndef::orcharhino[]
-For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/windows_integration_guide/sssd-gpo[{RHEL} Windows Integration Guide].
+For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[{RHEL} Integrating RHEL systems directly with Windows Active Directory guide].
 endif::[]
 ====

--- a/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
+++ b/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
@@ -23,6 +23,6 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifdef::satellite[]
-For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[{RHEL} Integrating RHEL systems directly with Windows Active Directory guide].
+For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory_.
 endif::[]
 ====

--- a/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
+++ b/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
@@ -2,7 +2,7 @@
 = Kerberos Configuration in Web Browsers
 
 ifndef::orcharhino[]
-For information on configuring the Firefox browser see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_authentication_and_authorization_in_rhel/index#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _{RHEL} Configuring authentication and authorization in RHEL_ guide.
+For information on configuring Firefox, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_authentication_and_authorization_in_rhel/index#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _{RHEL} Configuring authentication and authorization in RHEL_ guide.
 endif::[]
 
 If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.
@@ -22,7 +22,7 @@ ad_gpo_map_service = +foreman
 ----
 
 Here, _foreman_ is the PAM service name.
-ifndef::orcharhino[]
-For more information on GPOs, please refer to the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[{RHEL} Integrating RHEL systems directly with Windows Active Directory guide].
+ifdef::satellite[]
+For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[{RHEL} Integrating RHEL systems directly with Windows Active Directory guide].
 endif::[]
 ====

--- a/guides/common/modules/proc_adding-a-bonded-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bonded-interface.adoc
@@ -26,7 +26,7 @@ These can be physical interfaces or VLANs.
 
 * *Bond options*: Specify a space-separated list of configuration options, for example *miimon=100*.
 ifdef::satellite[]
-For more information on configuration options for bonded interfaces, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index[{RHEL} 8 Configuring and Managing Networking Guide].
+For more information on configuration options for bonded interfaces, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding] in the _{RHEL} Configuring and Managing Networking_ guide.
 endif::[]
 
 . Click *OK* to save the interface configuration.

--- a/guides/common/modules/proc_adding-a-bonded-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bonded-interface.adoc
@@ -26,7 +26,7 @@ These can be physical interfaces or VLANs.
 
 * *Bond options*: Specify a space-separated list of configuration options, for example *miimon=100*.
 ifndef::orcharhino[]
-See the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/index[{RHEL} 7 Networking Guide] for details of the configuration options you can specify for the bonded interface.
+See the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index[{RHEL} 8 Configuring and managing networking guide] for details of the configuration options you can specify for the bonded interface.
 endif::[]
 
 . Click *OK* to save the interface configuration.

--- a/guides/common/modules/proc_adding-a-bonded-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bonded-interface.adoc
@@ -25,8 +25,8 @@ See xref:Bonding_Modes_Available_{context}[] for a brief description of each bon
 These can be physical interfaces or VLANs.
 
 * *Bond options*: Specify a space-separated list of configuration options, for example *miimon=100*.
-ifndef::orcharhino[]
-See the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index[{RHEL} 8 Configuring and managing networking guide] for details of the configuration options you can specify for the bonded interface.
+ifdef::satellite[]
+For more information on configuration options for bonded interfaces, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index[{RHEL} 8 Configuring and Managing Networking Guide].
 endif::[]
 
 . Click *OK* to save the interface configuration.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -8,7 +8,9 @@ To configure the IdM server to use the GSS-TSIG technology, you must install the
 .Prerequisites
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
+ifdef::satellite[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/installing_identity_management/index#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in the _Installing Identity Management Guide_.
+endif::[]
 * You must contact the IdM server administrator to ensure that you obtain an account on the IdM server with permissions to create zones on the IdM server.
 * You should create a backup of the answer file.
 You can use the backup to restore the answer file to its original state if it becomes corrupted.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -8,7 +8,7 @@ To configure the IdM server to use the GSS-TSIG technology, you must install the
 .Prerequisites
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/installing-ipa#prereq-ports[Port Requirements] in the _Linux Domain Identity, Authentication, and Policy Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/installing_identity_management/index#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in the _Installing Identity Management Guide_.
 * You must contact the IdM server administrator to ensure that you obtain an account on the IdM server with permissions to create zones on the IdM server.
 * You should create a backup of the answer file.
 You can use the backup to restore the answer file to its original state if it becomes corrupted.

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -29,7 +29,7 @@ The generated one-time password must be used on the client to complete {FreeIPA}
 ====
 +
 ifdef::satellite[]
-For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_identity_management/index#con_host-entry-LDAP_managing-hosts-ui[Host entry in IdM] in _{RHEL}{nbsp}8 Linux Domain Identity, Authentication, and Policy_.
+For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_identity_management/index#con_host-entry-LDAP_managing-hosts-ui[Host entry in IdM LDAP] in _Configuring and managing Identity Management_.
 endif::[]
 . Create an HTTP service for {ProjectServer}, for example:
 +

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -29,7 +29,7 @@ The generated one-time password must be used on the client to complete {FreeIPA}
 ====
 +
 ifndef::orcharhino[]
-For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/host-attr[About Host Entry Configuration Properties] in the _{RHEL}{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_identity_management/index#con_host-entry-LDAP_managing-hosts-ui[Host entry in IdM] in the _{RHEL}{nbsp}8 Linux Domain Identity, Authentication, and Policy Guide_.
 endif::[]
 . Create an HTTP service for {ProjectServer}, for example:
 +
@@ -39,7 +39,7 @@ endif::[]
 ----
 +
 ifndef::orcharhino[]
-For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/services[Managing Services] in the _{RHEL}{nbsp}7 Linux Domain Identity, Authentication, and Policy_ guide.
+For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/accessing_identity_management_services/index#viewing-starting-and-stopping-the-ipa-server_accessing-idm-services[Accessing Identity Management services] guide.
 endif::[]
 . On {ProjectServer}, install the IPA client:
 ifdef::satellite[]

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -28,8 +28,8 @@ In the {Project} CLI, configure {FreeIPA} authentication by first creating a hos
 The generated one-time password must be used on the client to complete {FreeIPA}-enrollment.
 ====
 +
-ifndef::orcharhino[]
-For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_identity_management/index#con_host-entry-LDAP_managing-hosts-ui[Host entry in IdM] in the _{RHEL}{nbsp}8 Linux Domain Identity, Authentication, and Policy Guide_.
+ifdef::satellite[]
+For more information on host configuration properties, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_identity_management/index#con_host-entry-LDAP_managing-hosts-ui[Host entry in IdM] in _{RHEL}{nbsp}8 Linux Domain Identity, Authentication, and Policy_.
 endif::[]
 . Create an HTTP service for {ProjectServer}, for example:
 +
@@ -38,8 +38,8 @@ endif::[]
 # ipa service-add HTTP/_hostname_
 ----
 +
-ifndef::orcharhino[]
-For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/accessing_identity_management_services/index#viewing-starting-and-stopping-the-ipa-server_accessing-idm-services[Accessing Identity Management services] guide.
+ifdef::satellite[]
+For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/accessing_identity_management_services/index[{RHEL} 8 Accessing Identity Management Services guide].
 endif::[]
 . On {ProjectServer}, install the IPA client:
 ifdef::satellite[]


### PR DESCRIPTION
…uides

Recent project version does not support RHEL7 as the base OS, hence links that point to RHEL7 guides are obsolete. Replacing links in the Administering Project and Managing Hosts doc that point to the RHEL7 guides, to point to the corresponding RHEL8 guides.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
