### PR TITLE
Use Python 3 in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-ccutil:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/ivanhorvath/ccutil:amazing
     steps:
@@ -42,7 +42,7 @@ jobs:
           done
 
   check-html:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -91,7 +91,7 @@ jobs:
           make linkchecker
 
   build-html:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -132,7 +132,7 @@ jobs:
           path: guides/build/
 
   pr-metadata:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     steps:
       - name: Get branch name (pull request)
@@ -157,7 +157,7 @@ jobs:
           path: ./pr/
 
   build-html-base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     defaults:
       run:
@@ -191,7 +191,7 @@ jobs:
           path: guides/build/
 
   build-pdf:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
@@ -242,7 +242,7 @@ jobs:
           path: guides/build/*.pdf
 
   build-web:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -277,7 +277,7 @@ jobs:
       - build-html
       - build-web
       - build-ccutil
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ on:
       - "[0-9]+.[0-9]+"
 env:
   RUBY_VERSION: 3.1
-  PYTHON_VERSION: 2.x
   BUNDLE_WITHOUT: "nanoc"
   MAKE_J: 3
 
@@ -67,13 +66,8 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
       - name: Install linkchecker
-        run: pip install linkchecker
+        run: sudo apt update && sudo apt install linkchecker -y
 
       - name: Clean the environment
         run: make clean

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,8 +72,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install linkchecker and tryer
-        run: pip install linkchecker linkchecker-tryer
+      - name: Install linkchecker
+        run: pip install linkchecker
 
       - name: Clean the environment
         run: make clean
@@ -88,7 +88,7 @@ jobs:
 
       - name: Check HTML links of all builds
         run: |
-          make linkchecker-tryer
+          make linkchecker
 
   build-html:
     runs-on: ubuntu-latest

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 SUBDIRS = $(shell ls -d doc-*)
 
-.PHONY: all clean html pdf linkchecker linkchecker-tryer serve subdirs $(SUBDIRS)
+.PHONY: all clean html pdf linkchecker serve subdirs $(SUBDIRS)
 
 all: html
 
@@ -21,6 +21,3 @@ clean:
 
 linkchecker:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
-
-linkchecker-tryer:
-	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | linkchecker-tryer


### PR DESCRIPTION
Python 2 is EOL and this allows moving forward.

It looks like it's only used for linkchecker so cherry picking to all releases looks safe.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.