### PR TITLE
Update and drop links to puppet guide

### DIFF
--- a/guides/common/modules/con_template-writing-reference.adoc
+++ b/guides/common/modules/con_template-writing-reference.adoc
@@ -18,7 +18,7 @@ For more information, see {ProvisioningDocURL}creating-partition-tables_provisio
 
 ifndef::orcharhino[]
 Smart Class Parameters::
-For more information, see {ManagingConfigurationsPuppetDocURL}using-puppet-smart-parameters_managing-configurations-puppet[Configuring Smart Class Parameters] in _{ManagingConfigurationsPuppetDocTitle}_.
+For more information, see {ManagingConfigurationsPuppetDocURL}Configuring_Puppet_Smart_Class_Parameters_managing-configurations-puppet[Configuring Puppet Smart Class Parameters] in _{ManagingConfigurationsPuppetDocTitle}_.
 endif::[]
 
 This section provides an overview of {Project}-specific macros and variables that can be used in ERB templates along with some usage examples.

--- a/guides/doc-Planning_for_Project/topics/Glossary.adoc
+++ b/guides/doc-Planning_for_Project/topics/Glossary.adoc
@@ -311,9 +311,6 @@ Provisioning templates can be associated with host groups, life cycle environmen
 [[varl-Glossary_of_Terms-Puppet_Manifest]]
 *Puppet Manifest*:: Refers to Puppet scripts, which are files with the *.pp* extension.
 The files contain code to define a set of necessary resources, such as packages, services, files, users and groups, and so on, using a set of key-value pairs for their attributes.
-ifdef::satellite[]
-For more information and examples of usage, see {MultiBaseURL}puppet_guide/chap-red_hat_satellite-puppet_guide-building_puppet_modules_from_scratch#sect-{Project_Link}-Puppet_Guide-Building_Puppet_Modules_from_Scratch-Examining_the_Anatomy_of_a_Puppet_Module[Examining the Anatomy of a Puppet Module] in the _Puppet Guide_.
-endif::[]
 +
 Do not confuse with xref:varl-Glossary_of_Terms-Manifest[Manifest (Red{nbsp}Hat Subscription Manifest)].
 


### PR DESCRIPTION
Updating of puppet guide made some links invalid.
Updated links to chapters which I found in the new puppet guide.
Dropped links to chapters which I did not find.

I am 99% positive there are more invalid links but these I found for now in the process of fixing invalid puppet links on 3.1. 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3