### PR TITLE
Revert "Step update in Chainbooting virtual machines" on 2.5

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -150,7 +150,7 @@ If you want to change the default values in the template, clone the template and
 . Click the *Locations* tab, and add the location where the host resides.
 . Click the *Organizations* tab, and add the organization that the host belongs to.
 . Click *Submit* to save the changes.
-. Navigate to *Configure* > *Host Groups* and select the host group you want to configure.
+. Navigate to *Hosts* > *Operating systems* and select the operating system of your host.
 . Click the *Templates* tab.
 . From the *iPXE Template* list, select the template you want to use.
 . Click *Submit* to save the changes.


### PR DESCRIPTION
Reverts theforeman/foreman-documentation#1799

@dubewarsagar I'm truly sorry, Sagar, my mistake. The original procedure in 2.5 looks actually correct. Hosts > [Provisioning Setup] Operating Systems is a GUI path that does exist. A host group does not have a "Templates" tab that is mentioned in the next step.