### PR TITLE
Update Simple Content Access wording

### DIFF
--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -9,7 +9,7 @@ All subscription information is available in your Red Hat Customer Portal accoun
 Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat Subscription Manifest in the Customer Portal.
 
 ifdef::satellite[]
-Note that the subscription model is deprecated and will be removed in a future release.
+Note that legacy subscription management, including the need to attach subscriptions to hosts and activation keys, is deprecated and will be removed in a future release.
 {Team} recommends that you use https://access.redhat.com/articles/simple-content-access[Simple Content Access] as a substitute.
 endif::[]
 

--- a/guides/common/modules/proc_disabling-subscription-connection.adoc
+++ b/guides/common/modules/proc_disabling-subscription-connection.adoc
@@ -2,7 +2,7 @@
 = Disabling Subscription Connection
 
 Disable subscription connection on disconnected {ProjectServer} to avoid connecting to the Red{nbsp}Hat Portal.
-This will also prevent you from refreshing the manifest, updating upstream entitlements, and changing the status of Simple Content Access.
+This will also prevent you from refreshing the manifest and updating upstream entitlements.
 
 .Procedure
 


### PR DESCRIPTION
As of Katello 4.6, Simple Content Access status is no longer tied to the upstream manifest, so we need to update some wording to ensure it continues to be accurate.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
