### PR TITLE
Remove Satellite 6.12 docs from linkchecker ignore list

### DIFF
--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,5 +18,3 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
-  # 6.12 docs are not yet published
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.12

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,3 +18,6 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
+  # 6.13 docs are not yet published
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.13
+


### PR DESCRIPTION
Since Satellite 6.12 docs were not published on the RH website, linkchecker would fail when checking for doc links to these. As 6.12 docs have now been published, linkchecker should be able to reach the doc links.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
