### PR TITLE
don't render "upgrade os" steps for Satellite builds

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 Migrating::
 The process of moving an existing {Project} installation to a new instance.
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 For more information, see xref:migrating-{project-context}-to-a-new-el-system_{context}[].
 endif::[]
 
@@ -106,13 +106,13 @@ ifdef::katello,orcharhino,satellite[]
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+3]
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 // Upgrading Project or SmartProxy from Enterprise Linux 7 to Enterprise Linux 8 using Leapp
 include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]
 
 // == Migrating Project
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 // Migrating Project to EL 8
 include::common/modules/con_migrating-project-to-a-new-el-system.adoc[leveloffset=+1]
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -84,10 +84,10 @@ ifdef::katello,orcharhino[]
 . Upgrade to {project-client-name} on all content hosts.
 For more information, see xref:upgrading_content_hosts[].
 endif::[]
-ifndef::foreman-deb,orcharhino[]
+ifndef::foreman-deb,orcharhino,satellite[]
 . Optional: After you upgrade your {Project}, you can also upgrade the operating system on your {ProjectServer}s and {SmartProxies} to {EL} 8.
 endif::[]
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 There are two ways of upgrading your OS:
 
 * xref:upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}[]


### PR DESCRIPTION
Satellite 6.12 is based on Foreman 3.3 and does not support EL7→EL8 upgrades anymore, while Foreman still does (there the removal happens in 3.4).


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
