### PR TITLE
Drop SatelliteAnsibleVersion attribute

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -24,7 +24,6 @@
 :RepoRHEL8AppStream: rhel-8-for-x86_64-appstream-rpms
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
 :RepoRHEL7ServerOptional: rhel-7-server-optional-rpms
-:RepoRHEL7ServerAnsible: rhel-7-server-ansible-2.9-rpms
 
 // Base attributes
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -18,7 +18,6 @@
 :Project_Link: orcharhino
 :RHEL: Red Hat Enterprise Linux
 :RHELServer: Red Hat Enterprise Linux Server
-:SatelliteAnsibleVersion: 2.9
 :SmartProxies: orcharhino Proxies
 :SmartProxy: orcharhino Proxy
 :SmartProxyServer: orcharhino Proxy

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -7,8 +7,6 @@
 :ProjectVersionPrevious: 3.5
 :KatelloVersion: nightly
 :TargetVersion: {ProjectVersion}
-// The above attribute should point to the GA version number (x.y) for all releases including Beta
-:SatelliteAnsibleVersion: 2.9
 
 //
 // WHERE ARE MY ATTRIBUTES?

--- a/guides/common/modules/proc_installing-the-project-ansible-modules-from-rpm.adoc
+++ b/guides/common/modules/proc_installing-the-project-ansible-modules-from-rpm.adoc
@@ -3,17 +3,6 @@
 
 Use this procedure to install the {Project} Ansible modules.
 
-ifdef::satellite[]
-.Prerequisite
-* Ensure that the Ansible 2.9 or later repository is enabled and the ansible package is updated:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager repos --enable rhel-7-server-ansible-2.9-rpms
-# {foreman-maintain} packages update ansible
-----
-endif::[]
-
 .Procedure
 ifdef::satellite[]
 * Install the RPM using the following command:


### PR DESCRIPTION
This also removes a section where the attribute was not used, but should have. Since it's EL7 specific and doesn't apply to EL8, it should be removed.

Fixes: eb0b825d2a29c3bf0d195f8a854da375037073be

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.