### PR TITLE
Unify ansible module installation

### DIFF
--- a/guides/common/modules/proc_installing-the-project-ansible-modules-from-rpm.adoc
+++ b/guides/common/modules/proc_installing-the-project-ansible-modules-from-rpm.adoc
@@ -1,5 +1,5 @@
 [id="Installing_the_Project_Ansible_Modules_from_RPM_{context}"]
-= Installing the {Project} Ansible Modules from RPM
+= Installing the {Project} Ansible Modules using Packages
 
 Use this procedure to install the {Project} Ansible modules.
 
@@ -14,28 +14,17 @@ ifdef::satellite[]
 ----
 endif::[]
 
-.Procedure
 ifdef::satellite[]
-* Install the RPM using the following command:
+:ansible-collection-package: ansible-collection-redhat-satellite
+endif::[]
+ifndef::satellite[]
+:ansible-collection-package: ansible-collection-theforeman-foreman
+endif::[]
+
+.Procedure
+* Install the package using the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} ansible-collection-redhat-satellite
+# {package-install-project} {ansible-collection-package}
 ----
-endif::[]
-ifdef::foreman-el,foreman-deb,katello[]
-* Install the RPM from the client repository on yum.theforeman.org using the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install-project} ansible-collection-theforeman-foreman
-----
-endif::[]
-ifdef::orcharhino[]
-* Install the RPM using the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install-project} ansible-collection-theforeman-foreman
-----
-endif::[]


### PR DESCRIPTION
This uses Package(s) instead of RPM since Debian doesn't use RPMs, but does use the same package name.

Technically the file and id should also be changed, but I'm submitting this as a draft for discussion. https://github.com/theforeman/foreman-documentation/pull/1817 will introduce some conflicts as well.

Is this a good idea or not?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.