### PR TITLE
Use package-{install,remove} macros where appropriate

### DIFF
--- a/guides/common/modules/proc_benchmarking-raw-db-performance.adoc
+++ b/guides/common/modules/proc_benchmarking-raw-db-performance.adoc
@@ -6,7 +6,7 @@ To get a list of the top table sizes in disk space for both Candlepin, Foreman, 
 endif::[]
 
 PGbench utility (note you may need to resize PostgreSQL data directory `/var/opt/rh/rh-postgresql12/lib/pgsql/` directory to 100 GiB or what does benchmark take to run) might be used to measure PostgreSQL performance on your system.
-Use `yum install postgresql-contrib` to install it.
+Use `{package-install} postgresql-contrib` to install it.
 ifndef::orcharhino[]
 For more information, see https://github.com/RedHatSatellite/satellite-support[github.com/RedHatSatellite/satellite-support].
 endif::[]

--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -12,7 +12,7 @@ ifdef::foreman-el,katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
+# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
 ----
 endif::[]
 ifdef::katello[]
@@ -21,7 +21,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
+# {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
 ifdef::foreman-el,katello[]
@@ -30,6 +30,6 @@ ifdef::foreman-el,katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} localinstall https://yum.puppet.com/puppet7-release-el-{distribution-major-version}.noarch.rpm
+# {package-install} https://yum.puppet.com/puppet7-release-el-{distribution-major-version}.noarch.rpm
 ----
 endif::[]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -10,6 +10,5 @@ After you configure {ProductName} to use a custom SSL certificate, you must also
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# yum localinstall \
-http://_{context}.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
+# {package-install} http://_{context}.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
 ----

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -32,8 +32,8 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf localinstall https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
-# dnf localinstall https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
+# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
+https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
 +

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -54,9 +54,9 @@ For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y katello-ca-consumer*
+# {package-remove} katello-ca-consumer*
 
-# rpm -Uvh http://_new-{foreman-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
+# {package-install} http://_new-{foreman-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
 
 # subscription-manager register \
 --org="_My_Organization_" \

--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -61,9 +61,9 @@ For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y katello-ca-consumer*
+# {package-remove} katello-ca-consumer*
 
-# rpm -Uvh http://_new-{smartproxy-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
+# {package-install} http://_new-{smartproxy-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
 
 # subscription-manager register --org="_My_Organization_" \
 --environment="_Library_" \

--- a/guides/common/modules/proc_resolving-package-dependancy-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependancy-errors.adoc
@@ -27,9 +27,9 @@ If you have successfully installed the {Project} packages, skip this procedure.
 
 . Install the package locally:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum localinstall _package_name_
+# {package-install} _package_name_
 ----
 
 . Change to the directory where the {Project} ISO is mounted:

--- a/guides/common/modules/proc_uninstalling-amazon-ec2-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-amazon-ec2-plugin.adoc
@@ -8,7 +8,7 @@ If you have previously installed the Amazon EC2 plugin but do not use it anymore
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y foreman-ec2
+# {package-remove-project} foreman-ec2
 # {foreman-installer} --no-enable-foreman-compute-ec2
 ----
 . Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the *Available Providers* tab to verify the removal of the Amazon EC2 plugin.

--- a/guides/common/modules/proc_uninstalling-google-gce-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-google-gce-plugin.adoc
@@ -8,7 +8,7 @@ If you have previously installed the Google GCE plugin but don't use it anymore 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove -y foreman-gce
+# {package-remove-project} foreman-gce
 # {foreman-installer} --no-enable-foreman-compute-gce
 ----
 . Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the *Available Providers* tab to verify the removal of the Google GCE plugin.

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -57,9 +57,9 @@ endif::[]
 .Procedure
 . On the virtual machine that you use to create the image, install `cloud-init`, `open-vm-tools`, and `perl`:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# yum -y install cloud-init open-vm-tools perl
+# {package-install} cloud-init open-vm-tools perl
 ----
 . Disable network configuration by `cloud-init`:
 +

--- a/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
@@ -74,13 +74,13 @@ To register clients manually, complete the following procedure on each client th
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# yum remove 'katello-ca-consumer*'
+# {package-remove} 'katello-ca-consumer*'
 ----
 . Install the `katello-ca-consumer` package from the load balancer:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# rpm -Uvh http://_loadbalancer.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
+# {package-install} http://_loadbalancer.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
 ----
 . Register the client and include the `--serverurl` and `--baseurl` options:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -175,22 +175,12 @@ You can either mount the shared storage or copy the backup files to the `/backup
 --enable={RepoRHEL8ServerSatelliteMaintenanceProductVersionPrevious}
 ----
 +
-ifdef::satellite[]
 . Install the `satellite-clone` package:
 +
 [options="nowrap" subs="attributes"]
 ----
-# yum install satellite-clone
+# {package-install} satellite-clone
 ----
-endif::[]
-ifndef::satellite[]
-. Install the `satellite-clone` package:
-+
-[options="nowrap" subs="attributes"]
-----
-# {package-install-project} satellite-clone
-----
-endif::[]
 +
 After you install the `satellite-clone` tool, you can adjust any configuration to suit your own deployment in the `/etc/satellite-clone/satellite-clone-vars.yml` file.
 +

--- a/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/migrating_a_self_registered_satellite.adoc
@@ -20,19 +20,19 @@ To migrate a self-registered {Project} to the Red Hat Content Delivery Network, 
 +
 . Remove the *katello-ca-consumer* package or any other version of the package:
 +
-[options="nowrap"]
+[options="nowrap", subs="+quotes,attributes"]
 ----
-# yum remove 'katello-ca-consumer*'
+# {package-remove} 'katello-ca-consumer*'
 ----
 +
 . The katello agent is used only for clients of {Project} and must be removed.
 To remove the `katello-agent`, stop and disable the `goferd` service, then enter the remove command:
 +
-[options="nowrap"]
+[options="nowrap", subs="+quotes,attributes"]
 ----
 # systemctl stop goferd
 # systemctl disable goferd
-# yum remove katello-agent
+# {package-remove} katello-agent
 ----
 +
 . Point the base system to Red Hat for registration by restoring the backup configuration with the following commands:


### PR DESCRIPTION
This replaces a lot of manual definitions. It should be noted that
yum/dnf localinstall is deprecated (on EL7+) and an alias for install so
they can also be replaced.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.