### PR TITLE
Correct the non-Katello instructions for cloud-init

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -113,16 +113,17 @@ EOM
 ----
 # update-ca-trust enable
 ----
+ifdef::katello,satellite,orcharhino[]
 . Download the `katello-server-ca.crt` file from {ProjectServer}:
-ifdef::foreman-el,katello[]
-You must have the Katello plugin installed to complete this step.
-For {ProjectServer} deployments, copy the CA certificate from the Apache configuration.
-endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # wget -O /etc/pki/ca-trust/source/anchors/cloud-init-ca.crt http://_{foreman-example-com}_/pub/katello-server-ca.crt
 ----
+endif::[]
+ifndef::katello,satellite,orcharhino[]
+. Copy the CA certificate from the Apache configuration to `/etc/pki/ca-trust/source/anchors/cloud-init-ca.crt`.
+endif::[]
 . To update the record of certificates, enter the following command:
 +
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.