### PR TITLE
Remove outdated Software Collections reference

### DIFF
--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -69,16 +69,12 @@ Software collections are installed in the `/opt/rh/` and `/opt/theforeman/` dire
 Write and execute permissions by the root user are required for installation to the `/opt` directory.
 endif::[]
 
-ifdef::katello,satellite[]
 .Symbolic links
 
 You cannot use symbolic links for `/var/lib/pulp/`.
-endif::[]
 
-ifdef::katello,satellite[]
 ifeval::["{mode}" == "connected"]
 .Synchronized RHEL ISO
 If you plan to synchronize RHEL content ISOs to {Project}, note that all minor versions of {RHEL} also synchronize.
 You must plan to have adequate storage on your {Project} to manage this.
-endif::[]
 endif::[]

--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -61,14 +61,6 @@ The bulk of storage resides in the `/var/lib/pulp/` directory.
 These end points are not manually configurable.
 Ensure that storage is available on the `/var` file system to prevent storage problems.
 
-ifdef::satellite[]
-.Software Collections
-
-Software collections are installed in the `/opt/rh/` and `/opt/theforeman/` directories.
-
-Write and execute permissions by the root user are required for installation to the `/opt` directory.
-endif::[]
-
 .Symbolic links
 
 You cannot use symbolic links for `/var/lib/pulp/`.


### PR DESCRIPTION
With EL8 there are no software collections so these directories no longer exist.

Also removes redundant ifdef statements which are all nested within the same ifdef and can be removed.

Since it's scoped to Satellite and Satellite has dropped EL7, this should be picked to 3.3.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.