### PR TITLE
Introduce attributes for PostgreSQL paths & update storage tables

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -75,6 +75,10 @@
 :package-remove: dnf remove
 :package-update-project: dnf update
 :package-update: dnf update
+:postgresql-lib-dir: /var/lib/pgsql
+:postgresql-data-dir: {postgresql-lib-dir}/data
+:postgresql-conf-dir: {postgresql-data-dir}
+:postgresql-log-dir: {postgresql-data-dir}/log
 :PIV: PIV
 :Project_Link: Red_Hat_Satellite
 :project-client-name: https://yum.theforeman.org/client/{ProjectVersion}/

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -10,3 +10,7 @@
 :package-remove: apt-get remove
 :package-update-project: apt-get upgrade
 :package-update: apt-get upgrade
+:postgresql-conf-dir: /etc/postgresql/13/main
+:postgresql-lib-dir: /var/lib/postgresql
+:postgresql-data-dir: {postgresql-lib-dir}/13/main
+:postgresql-log-dir: /var/log/postgresql

--- a/guides/common/modules/proc_benchmarking-raw-db-performance.adoc
+++ b/guides/common/modules/proc_benchmarking-raw-db-performance.adoc
@@ -5,7 +5,7 @@ ifndef::orcharhino[]
 To get a list of the top table sizes in disk space for both Candlepin, Foreman, and Pulp check https://github.com/RedHatSatellite/satellite-support/blob/master/postgres-size-report[postgres-size-report] script in https://github.com/RedHatSatellite/satellite-support[satellite-support] git repository.
 endif::[]
 
-PGbench utility (note you may need to resize PostgreSQL data directory `/var/opt/rh/rh-postgresql12/lib/pgsql/` directory to 100 GiB or what does benchmark take to run) might be used to measure PostgreSQL performance on your system.
+PGbench utility (note you may need to resize PostgreSQL data directory `{postgresql-lib-dir}` directory to 100 GiB or what does benchmark take to run) might be used to measure PostgreSQL performance on your system.
 Use `{package-install} postgresql-contrib` to install it.
 ifndef::orcharhino[]
 For more information, see https://github.com/RedHatSatellite/satellite-support[github.com/RedHatSatellite/satellite-support].

--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -17,9 +17,10 @@ A full backup requires space to store the following data:
 .Procedure
 . Enter the `du` command to estimate the size of uncompressed directories containing {Project} database and configuration files:
 +
+[options="nowrap", subs="+quotes,attributes"]
 ----
-# du -sh /var/lib/pgsql/data /var/lib/pulp
-100G    /var/lib/pgsql/data
+# du -sh {postgresql-data-dir} /var/lib/pulp
+100G    {postgresql-data-dir}
 100G	/var/lib/pulp
 
 # du -csh /var/lib/qpidd /var/lib/tftpboot /etc /root/ssl-build \
@@ -42,7 +43,7 @@ The following table describes the compression ratio of all data items included i
 |Data type |Directory |Ratio |Example results
 
 |PostgreSQL database files
-|`/var/lib/pgsql/data`
+|`{postgresql-data-dir}`
 |80{range}85%
 |100 GB -> 20 GB
 

--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -25,6 +25,8 @@ ifndef::foreman-deb[]
 # {foreman-maintain} service restart
 ----
 
+// These paths mirror hardcoded paths in hammer-cli-foreman-admin which is a bug in itself
+// Do not attempt to "fix" this here without fixing the project itself
 .Listing all components and changed configuration files
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -214,8 +216,8 @@ Ensure to restart the Redis service afterwards:
 
 == Increasing the Logging Level For Postgres
 
-You can find the log for Postgres in `/var/opt/rh/rh-postgresql12/lib/pgsql/data/log/`.
-Uncomment the `log_statement` in `/var/opt/rh/rh-postgresql12/lib/pgsql/data/postgresql.conf`:
+You can find the log for Postgres in `{postgresql-log-dir}`.
+Uncomment the `log_statement` in `{postgresql-conf-dir}/postgresql.conf`:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -26,11 +26,11 @@ endif::[]
 # postgresql-setup initdb
 ----
 +
-. Edit the `/var/lib/pgsql/data/postgresql.conf` file:
+. Edit the `{postgresql-conf-dir}/postgresql.conf` file:
 +
-[options="nowrap" subs="verbatim,quotes"]
+[options="nowrap" subs="verbatim,quotes,attributes"]
 ----
-# vi /var/lib/pgsql/data/postgresql.conf
+# vi {postgresql-conf-dir}/postgresql.conf
 ----
 +
 Note that the default configuration of external PostgreSQL needs to be adjusted to work with {Project}.
@@ -48,11 +48,11 @@ The base recommended external database configuration adjustments are as follows:
 listen_addresses = '*'
 ----
 +
-. Edit the `/var/lib/pgsql/data/pg_hba.conf` file:
+. Edit the `{postgresql-conf-dir}/pg_hba.conf` file:
 +
-[options="nowrap" subs="verbatim,quotes"]
+[options="nowrap" subs="verbatim,quotes,attributes"]
 -----
-# vi /var/lib/pgsql/data/pg_hba.conf
+# vi {postgresql-conf-dir}/pg_hba.conf
 -----
 +
 . Add the following line to the file:

--- a/guides/common/modules/proc_performing-a-snapshot-backup.adoc
+++ b/guides/common/modules/proc_performing-a-snapshot-backup.adoc
@@ -19,7 +19,7 @@ Ensure no other tasks are scheduled for the same time as the backup.
 ====
 
 .Prerequisites
-* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/`, and `/var/opt/rh/rh-postgresql12/lib/pgsql`.
+* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/`, and `{postgresql-lib-dir}`.
 * The free disk space in the relevant volume group (VG) is three times the size of the snapshot.
 More precisely, the VG must have enough space unreserved by the member logical volumes (LVs) to accommodate new snapshots.
 In addition, one of the LVs must have enough free space for the backup directory.

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -15,8 +15,8 @@ endif::[]
 |Directory |Installation Size |Runtime Size
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
-endif::[]
 |{postgresql-lib-dir} |100 MB |10 GB
+endif::[]
 |/usr |3 GB |Not Applicable
 |/opt/puppetlabs |500 MB |Not Applicable
 |====

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -16,7 +16,7 @@ endif::[]
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
 endif::[]
-|/var/lib/pgsql |100 MB |10 GB
+|{postgresql-lib-dir} |100 MB |10 GB
 |/usr |3 GB |Not Applicable
 |/opt/puppetlabs |500 MB |Not Applicable
 |====

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -16,7 +16,7 @@ ifdef::foreman-el,katello,satellite[]
 
 |/var/log |10 MB |10 GB
 
-|/var/lib/pgsql |100 MB |20 GB
+|{postgresql-lib-dir} |100 MB |20 GB
 
 |/usr | 5 GB | Not Applicable
 
@@ -29,7 +29,7 @@ ifdef::katello,satellite,orcharhino[]
 endif::[]
 |====
 
-For external database servers: `/var/lib/pgsql` with installation size of 100 MB and runtime size of 20 GB.
+For external database servers: `{postgresql-lib-dir}` with installation size of 100 MB and runtime size of 20 GB.
 
 For detailed information on partitioning and size, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[Partitioning reference] in the _{RHEL} 8 System Design Guide_.
 endif::[]
@@ -42,7 +42,7 @@ ifdef::foreman-deb[]
 
 |/var/log |10 MB |10 GB
 
-|/var/lib/postgresql |100 MB |20 GB
+|{postgresql-lib-dir} |100 MB |20 GB
 
 |/usr | 3 GB | Not Applicable
 

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -8,7 +8,6 @@ ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
 .Storage Requirements for a {ProjectServer} Installation
 [cols="1,1,1",options="header"]
 |====
@@ -29,23 +28,8 @@ ifdef::katello,satellite,orcharhino[]
 endif::[]
 |====
 
+ifdef::foreman-el,katello,satellite[]
 For external database servers: `{postgresql-lib-dir}` with installation size of 100 MB and runtime size of 20 GB.
 
 For detailed information on partitioning and size, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[Partitioning reference] in the _{RHEL} 8 System Design Guide_.
-endif::[]
-
-ifdef::foreman-deb[]
-.Storage Requirements for a {ProjectServer} Installation
-[cols="1,1,1",options="header"]
-|====
-|Directory |Installation Size |Runtime Size
-
-|/var/log |10 MB |10 GB
-
-|{postgresql-lib-dir} |100 MB |20 GB
-
-|/usr | 3 GB | Not Applicable
-
-|/opt/puppetlabs | 500 MB | Not Applicable
-|====
 endif::[]

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -31,7 +31,7 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |qdrouterd |N/A |qdrouterd |N/A |yes |N/A |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin
 |unbound |N/A |unbound |N/A |yes |/etc/unbound |/sbin/nologin
-|postgres |26 |postgres |26 |no |/var/lib/pgsql |/bin/bash
+|postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
 |apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
 |tomcat |53 |tomcat |53 |no |/usr/share/tomcat |/bin/nologin
 |saslauth |N/A |saslauth |76 |no |N/A |/sbin/nologin


### PR DESCRIPTION
See individual commits for details. This should be picked back to 3.3.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.