### PR TITLE
Use systemctl enable --now

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -62,6 +62,8 @@
 :Keycloak: Keycloak
 :KubeVirt: KubeVirt
 :LoraxCompose: Lorax Composer
+:nfs-client-package: nfs-utils
+:nfs-server-package: nfs-utils
 :OpenStack: OpenStack
 :ovirt-example-com: ovirt.example.com
 :oVirt: oVirt

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -1,6 +1,8 @@
 // Attributes only for foreman-deb build
 
 // Overrides for foreman-deb build
+:nfs-client-package: nfs-common
+:nfs-server-package: nfs-kernel-server
 :package-clean: apt-get clean
 :package-install-project: apt-get install
 :package-install: apt-get install

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -18,7 +18,7 @@ You must update each virtual machine configuration so that they receive updates 
 ** For {EL} 7:
 +
 ----
-# systemctl enable chronyd; systemctl start chronyd
+# systemctl enable --now chronyd
 ----
 * Ensure that the daemon `rhsmcertd` is enabled and running on the hosts.
 ** For {EL} 6:
@@ -29,7 +29,7 @@ You must update each virtual machine configuration so that they receive updates 
 ** For {EL} 7:
 +
 ----
-# systemctl start rhsmcertd
+# systemctl enable --now rhsmcertd
 ----
 
 .To Configure a Host for Registration:

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -119,20 +119,11 @@ _990_
 . Export the DHCP configuration and lease files using NFS:
 +
 [options="nowrap" subs="+quotes,attributes"]
-ifndef::foreman-deb[]
 ----
-# {package-install} nfs-utils
-# systemctl enable rpcbind nfs-server
-# systemctl start rpcbind nfs-server nfs-lock nfs-idmapd
+# {package-install} {nfs-server-package}
+# systemctl enable nfs-server
+# systemctl start nfs-server
 ----
-endif::[]
-ifdef::foreman-deb[]
-----
-# {package-install} nfs-kernel-server nfs-common
-# systemctl enable rpcbind nfs-server
-# systemctl start rpcbind nfs-server nfs-idmapd
-----
-endif::[]
 
 . Create directories for the DHCP configuration and lease files that you want to export using NFS:
 +

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -121,8 +121,7 @@ _990_
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install} {nfs-server-package}
-# systemctl enable nfs-server
-# systemctl start nfs-server
+# systemctl enable --now nfs-server
 ----
 
 . Create directories for the DHCP configuration and lease files that you want to export using NFS:

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -109,11 +109,11 @@ _990_
 # chattr +i /etc/dhcp/ /etc/dhcp/dhcpd.conf
 ----
 
-. Start the DHCP service:
+. Enable and start the DHCP service:
 +
 [options="nowrap"]
 ----
-# systemctl start dhcpd
+# systemctl enable --now dhcpd
 ----
 
 . Export the DHCP configuration and lease files using NFS:

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -70,7 +70,7 @@ euid = __ID_of_Apache_User__
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # systemctl restart gssproxy.service
-# systemctl enable gssproxy.service
+# systemctl enable --now gssproxy.service
 ----
 . To configure the Apache server to use the `gssproxy` service, create a `systemd` drop-in file and add the following content to it:
 +

--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -8,19 +8,12 @@ You can configure {ProductName} with an external DHCP server.
 For more information, see xref:configuring-an-external-dhcp-server_{context}[].
 
 .Procedure
-. Install the `nfs-utils` utility:
+. Install the `{nfs-client-package}` package:
 +
 [options="nowrap" subs="+quotes,attributes"]
-ifndef::foreman-deb[]
 ----
-# {package-install} nfs-utils
+# {package-install} {nfs-client-package}
 ----
-endif::[]
-ifdef::foreman-deb[]
-----
-# {package-install} nfs-kernel-server nfs-common
-----
-endif::[]
 . Create the DHCP directories for NFS:
 +
 [options="nowrap"]

--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -4,13 +4,13 @@
 In the {Project} CLI, enroll {ProjectServer} with the Active Directory server.
 
 .Prerequisite
-* GSS-proxy and nfs-utils are installed.
+* GSS-proxy and {nfs-client-package} are installed.
 +
-Installing GSS-proxy and nfs-utils:
+Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} gssproxy nfs-utils
+# {package-install-project} gssproxy {nfs-client-package}
 ----
 
 .Procedure

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -66,8 +66,7 @@ listen_addresses = '*'
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# systemctl start postgresql
-# systemctl enable postgresql
+# systemctl enable --now postgresql
 ----
 
 . Open the *postgresql* port on the external PostgreSQL server:

--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -20,6 +20,5 @@ For more information about the `chrony` suite, see https://access.redhat.com/doc
 +
 [options="nowrap"]
 ----
-# systemctl start chronyd
-# systemctl enable chronyd
+# systemctl enable --now chronyd
 ----

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -19,11 +19,11 @@ Ensure this share provides the appropriate permissions to {ProjectServer} and it
 ----
 # {foreman-maintain} service stop
 ----
-. Ensure {ProjectServer} has the `nfs-utils` package installed:
+. Ensure {ProjectServer} has the `{nfs-server-package}` package installed:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} nfs-utils
+# {package-install-project} {nfs-server-package}
 ----
 . You need to copy the existing contents of `/var/lib/pulp` to the NFS share.
 First, mount the NFS share to a temporary location:

--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -47,6 +47,5 @@ This is required because communication from clients to {SmartProxyServer}s depen
 . Start and enable the HAProxy service:
 +
 ----
-# systemctl start haproxy
-# systemctl enable haproxy
+# systemctl enable --now haproxy
 ----


### PR DESCRIPTION
Using systemctl enable --now is equivalent to enable and start. It is already used in some places in the documentation, but this makes it consistent. The benefit for users is that they have to copy fewer commands.

It's still a draft since there are some oddities which I'll highlight.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.