### PR TITLE
Make Upgrading virt-who Katello-only

### DIFF
--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -5,7 +5,7 @@ Some of the procedures in this section are optional.
 You can choose to perform only those procedures that are relevant to your installation.
 
 * xref:upgrading_discovery_parent[]
-ifndef::foreman-deb[]
+ifdef::katello,satellite,orcharhino[]
 * xref:upgrading_virt_who[]
 endif::[]
 ifdef::satellite[]

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -81,7 +81,7 @@ include::topics/upgrading_discovery_satellite.adoc[leveloffset=+4]
 // Configuring Subnets with a Template Capsule
 include::topics/upgrading_discovery_subnet_with_a_template_capsule.adoc[leveloffset=+4]
 
-ifndef::foreman-deb[]
+ifdef::katello,satellite,orcharhino[]
 // Upgrading virt-who
 include::topics/upgrading_virt_who.adoc[leveloffset=+3]
 endif::[]


### PR DESCRIPTION
Without Katello there is no content management so this part is not needed.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.