### PR TITLE
Only show RH KB solution on Satellite

### DIFF
--- a/guides/common/modules/snip_using_installer_noop.adoc
+++ b/guides/common/modules/snip_using_installer_noop.adoc
@@ -1,4 +1,6 @@
 [WARNING]
 If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when the installation script runs during upgrading or updating.
 You can use the `--noop` option with the {foreman-installer} script to test for changes.
+ifdef::satellite[]
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
+endif::[]

--- a/guides/common/modules/snip_using_installer_noop.adoc
+++ b/guides/common/modules/snip_using_installer_noop.adoc
@@ -1,0 +1,4 @@
+[WARNING]
+If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when the installation script runs during upgrading or updating.
+You can use the `--noop` option with the {foreman-installer} script to test for changes.
+For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -8,10 +8,7 @@
 * Ensure that you have synchronized {ProjectServer} repositories for {Project}, {SmartProxy}, and {project-client-name}.
 * Ensure each external {SmartProxy} and Content Host can be updated by promoting the updated repositories to all relevant Content Views.
 
-[WARNING]
-If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating.
-You can use the `--noop` option with the {foreman-installer} script to test for changes.
-For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
+include::../common/modules/snip_using_installer_noop.adoc[]
 
 *Updating {ProjectServer} to the Next Minor Version*
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -3,10 +3,7 @@
 
 Use this procedure for a {ProjectServer} with access to the public internet
 
-[WARNING]
-If you customize configuration files, manually or using a tool such as Hiera, these changes are overwritten when the installation script runs during upgrading or updating.
-You can use the `--noop` option with the {foreman-installer} script to test for changes.
-For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
+include::../common/modules/snip_using_installer_noop.adoc[]
 
 .Upgrade {ProjectServer}
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -5,6 +5,7 @@ Use this procedure if your {ProjectServer} is not connected to the Red{nbsp}Hat 
 
 [WARNING]
 ====
+// Keep this in sync with common/modules/snip_using_installer_noop.adoc
 * If you customized configuration files, either manually or using a tool such as Hiera, these changes are overwritten when you enter the `{foreman-maintain}` command during upgrading or updating.
 You can use the `--noop` option with the `{foreman-installer}` command to review the changes that are applied during upgrading or updating.
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -8,7 +8,9 @@ Use this procedure if your {ProjectServer} is not connected to the Red{nbsp}Hat 
 // Keep this in sync with common/modules/snip_using_installer_noop.adoc
 * If you customized configuration files, either manually or using a tool such as Hiera, these changes are overwritten when you enter the `{foreman-maintain}` command during upgrading or updating.
 You can use the `--noop` option with the `{foreman-installer}` command to review the changes that are applied during upgrading or updating.
+ifdef::satellite[]
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade].
+endif::[]
 ifdef::katello,orcharhino,satellite[]
 * The hammer import and export commands have been replaced with `hammer content-import` and `hammer content-export` tooling.
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -43,10 +43,7 @@ ifdef::satellite[]
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]
 
-[WARNING]
-If you customize configuration files, manually or use a tool such as Hiera, these customizations are overwritten when the installation script runs during upgrading or updating.
-You can use the `--noop` option with the {foreman-installer} script to test for changes.
-For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/3351311[How to use the noop option to check for changes in {Project} config files during an upgrade.]
+include::../common/modules/snip_using_installer_noop.adoc[]
 
 [[upgrade_paths]]
 == Upgrade Paths


### PR DESCRIPTION
Only Red Hat customers can access the knowledge base. Ideally this would actually be part of the manual itself, but until then we should hide the link.

It also extracts the text to a snippet to avoid repetition. In one instance it's part of a list so it can't be extracted.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.