### PR TITLE
Re-introduce linkchecker-tryer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Check HTML links of all builds
         run: |
-          make linkchecker
+          make linkchecker-tryer
 
   build-html:
     runs-on: ubuntu-22.04

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 SUBDIRS = $(shell ls -d doc-*)
 
-.PHONY: all clean html pdf linkchecker serve subdirs $(SUBDIRS)
+.PHONY: all clean html pdf linkchecker linkchecker-tryer serve subdirs $(SUBDIRS)
 
 all: html
 
@@ -21,3 +21,6 @@ clean:
 
 linkchecker:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
+
+linkchecker-tryer:
+	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | ./scripts/linkchecker-tryer

--- a/guides/scripts/linkchecker-tryer
+++ b/guides/scripts/linkchecker-tryer
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import fileinput
+import re
+import sys
+import time
+from subprocess import DEVNULL, STDOUT, call
+
+
+RETRIES = 3
+SLEEP_TIME = 30
+
+
+def parse_linkchecker_output(linkchecker_output):
+    pattern = re.compile(r"^URL\s+\`(?P<url>.+)\'$\n" +
+                         r"(^Name\s+\`(?P<name>.*?)\'$\n)?" +
+                         r"^Parent URL\s+(?P<parent>.*?)$\n"+
+                         r".*?^Result\s+(?P<result>.*?)$"
+                         , flags=re.M + re.S)
+
+    return {x.group("url"): x.group(0) for x in pattern.finditer(linkchecker_output)}
+
+
+def is_good_link(link):
+    return call(["linkchecker", "-r0", link], stdout=DEVNULL, stderr=STDOUT) == 0
+
+
+def find_bad_links(linkchecker_output):
+    bad_links = parse_linkchecker_output(linkchecker_output)
+
+    for _retry in range(RETRIES):
+        if bad_links:
+            time.sleep(SLEEP_TIME)
+
+        for link in list(bad_links.keys()):
+            if is_good_link(link):
+                del bad_links[link]
+
+    return bad_links.values()
+
+
+def main():
+    messages = find_bad_links(''.join(fileinput.input()))
+
+    print("\n")
+    print("-------------------------------------------------")
+    print("----------=========FINAL RESULT========----------")
+    print("-------------------------------------------------")
+    for message in messages:
+        print(message)
+        print()
+    if messages:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The official [linkchecker-tryer project](https://github.com/terryyin/linkchecker-tryer) has been unmaintained for the past 7 years, but clearly it was serving a purpose. Many links sometimes give some network error and aren't really a 404 which was breaking CI needlessly.

This takes the code from the original project and makes it run on Python 3. It removes reduce and filter since they're fairly hard to understand.  The current code should be easier to follow.

I also thought about submitting the script elsewhere so we don't have to maintain it in multiple places, but then we have to deal with installing it.

@evgeni I'd appreciate a look at this.

Fixes #1831

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.