### PR TITLE
Add the missing service principal

### DIFF
--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -37,7 +37,7 @@ endif::[]
 ifeval::["{context}" == "{project-context}"]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# ipa service-add _{foreman-example-com}_
+# ipa service-add _{smart-proxy-context}/{foreman-example-com}_
 ----
 endif::[]
 


### PR DESCRIPTION
There is a requirement to add the service principal i.e. Smart Proxy in the command of Creating a Kerberos Principal on the IdM Server process. There is a high probability of issues being occurred without a service principal in the command.

https://bugzilla.redhat.com/show_bug.cgi?id=2118391

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
