### PR TITLE
Show create OS for both Debian and Ubuntu

### DIFF
--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -7,6 +7,16 @@ include::modules/proc_setting-the-provisioning-context.adoc[leveloffset=+1]
 include::modules/proc_creating-operating-systems.adoc[leveloffset=+1]
 
 ifndef::satellite[]
+:os_codename: bullseye
+:os_major: 11
+:os_minor: 5
+:os_name: Debian
+include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
+
+:os_codename: focal
+:os_major: 20.04
+:os_minor: 5
+:os_name: Ubuntu
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/modules/proc_creating-an-operating-system-for-debian.adoc
+++ b/guides/common/modules/proc_creating-an-operating-system-for-debian.adoc
@@ -1,8 +1,8 @@
-[id="Creating_an_Operating_System_for_Debian_{context}"]
-= Creating an Operating System for Debian
+[id="Creating_an_Operating_System_for_{os_name}_{context}"]
+= Creating an Operating System for {os_name}
 
-Create an operating system in {Project} to provision hosts running Debian or Ubuntu.
-This examples uses Debian 11 "Bullseye".
+Create an operating system in {Project} to provision hosts running {os_name}.
+This example creates an operating system entry for {os_name} {os_major}.{os_minor}.
 
 ifdef::orcharhino[]
 [TIP]
@@ -14,15 +14,27 @@ endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts > Operating Systems*.
-. Click *Create Operating System* to create an operating system entry for Debian.
-. Enter `Debian 11` as *Name* for the operating system.
+. Click *Create Operating System* to create an operating system entry for {os_name}.
+. Enter `{os_name} {os_major}` as *Name* for the operating system.
 Choose a name as reported by Ansible, Puppet, or Salt as fact.
-. Set the *Major Version* to `11` and omit the *Minor Version*.
-. Set the *Release Name* to `bullseye` for Debian 11 or `focal` for Ubuntu 20.04.
+. Set the *Major Version* to `{os_major}`.
+. Set the *Minor Version* to `{os_minor}`.
+ifdef::katello,orcharhino[]
++
+[CAUTION]
+====
+{Project} searches for the boot files in the installation medium depending on the major and minor version of the operating system.
+Ensure to enter both the major and minor version correctly.
+
+For example, for {os_name} {os_major}, set the major field to `{os_major}` and leave the minor field empty.
+For example, for {os_name} {os_major}.{os_minor}, set the major field to `{os_major}` and the minor field to `{os_minor}`.
+====
+endif::[]
+. Set the *Release Name* to `{os_codename}` for {os_name} {os_major}.
 . On the *Partition Table* tab, select the `Preseed` partition table.
 +
 For more information, see xref:creating-partition-tables_{context}[].
 . On the *Templates* tab, select the `Preseed Finish` template as *Finish template*, the `Preseed` template as *Provisioning Template*, and the `Preseed PXELinux` template as *PXELinux template*.
 +
 For more information, see xref:creating-provisioning-templates_{context}[].
-. Click *Submit* to save the operating system entry for Debian.
+. Click *Submit* to save the operating system entry for {os_name}.


### PR DESCRIPTION
This is due to user feedback: we should ensure users don't set the minor version for Ubuntu 22.04 when trying to provision hosts using Ubuntu Autoinstall. cc @bastian-src

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3