### PR TITLE
Update steps in upgrading Proxy

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -110,7 +110,7 @@ Use `grep tar_file /etc/foreman-installer/scenarios.d/capsule-answers.yaml` on y
 # yum clean metadata
 ----
 +
-. The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
+. Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVersion}` and update {foreman-maintain}.
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -134,7 +134,7 @@ Use `grep tar_file /etc/foreman-installer/scenarios.d/capsule-answers.yaml` on y
 . Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 
 . Use the health check option to determine if the system is ready for upgrade:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -112,11 +112,10 @@ Use `grep tar_file /etc/foreman-installer/scenarios.d/capsule-answers.yaml` on y
 +
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
-Ensure {SmartProxy} has access to `{RepoRHEL7ServerSatelliteMaintenanceProductVersion}` and execute:
-+
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} self-upgrade
+# subscription-manager repos --enable {RepoRHEL7ServerSatelliteMaintenanceProductVersion}
+# yum --disableplugin=foreman-protector update rubygem-foreman_maintain {foreman-maintain}
 ----
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:


### PR DESCRIPTION
The present upgrade command where maintain package was not able to process the value correctly. As a result, the version of project upgraded is incorrect. The new maintain package and enablement of maintenance repos will be able to resolve it. Also, the rubygem maintain package installed from older repo didn't had the bug fixed. Therefore, the new commands will help end-users to upgrade to correct project version.

https://bugzilla.redhat.com/show_bug.cgi?id=2148435


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [X] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
