### PR TITLE
Work around an upgrade bug in Satellite repositories

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -39,13 +39,19 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
-. Ensure that the {Project} Maintenance repository is enabled:
+. Ensure that the {Project} Maintenance repository and the {Project} {ProjectVersion} repository are enabled:
 +
 [options="nowrap" subs="attributes"]
 ----
-# subscription-manager repos --enable \
-{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+# subscription-manager repos \
+--enable {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
+--enable {RepoRHEL8ServerSatelliteServerProductVersion}
 ----
+
+[NOTE]
+====
+If you find further issues on upgrading the {ProjectServer}, please refer https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
+====
 
 . Check the available versions to confirm the version you want is listed:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -39,7 +39,10 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
-. Ensure that the {Project} Maintenance repository and the {Project} {ProjectVersion} repositories are enabled:
+. In the current upgrade process, you must enable the {Project} {ProductVersion} (or {SmartProxy}) repository to restrict any updates outside the {Project} Maintenance repository.
+Please read the {MultiBaseURL}release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround before proceeding further.
++
+Enable the {Project} Maintenance repository and the {Project} {ProjectVersion} repositories:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -47,11 +50,6 @@ ifdef::satellite[]
 --enable {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
 --enable {RepoRHEL8ServerSatelliteServerProductVersion}
 ----
-
-[NOTE]
-====
-If you find further issues on upgrading the {ProjectServer}, please refer {MultiBaseURL}release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
-====
 
 . Check the available versions to confirm the version you want is listed:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -39,7 +39,7 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
-. Ensure that the {Project} Maintenance repository and the {Project} {ProjectVersion} repository are enabled:
+. Ensure that the {Project} Maintenance repository and the {Project} {ProjectVersion} repositories are enabled:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -50,7 +50,7 @@ ifdef::satellite[]
 
 [NOTE]
 ====
-If you find further issues on upgrading the {ProjectServer}, please refer https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
+If you find further issues on upgrading the {ProjectServer}, please refer {MultiBaseURL}release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
 ====
 
 . Check the available versions to confirm the version you want is listed:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -91,8 +91,16 @@ Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVe
 +
 [options="nowrap" subs="attributes"]
 ----
+# subscription-manager repos --enable \
+{RepoRHEL8ServerSatelliteCapsuleProductVersion}
+
 # {foreman-maintain} self-upgrade
 ----
+
+[NOTE]
+====
+If you find further issues on upgrading the {ProjectServer}, please refer https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
+====
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -99,7 +99,7 @@ Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVe
 
 [NOTE]
 ====
-If you find further issues on upgrading the {ProjectServer}, please refer https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
+If you find further issues on upgrading the {ProjectServer}, please refer {MultiBaseURL}release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
 ====
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -87,6 +87,9 @@ ifdef::satellite[]
 +
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
+In the current upgrade process, you must enable the {Project} {ProductVersion} (or {SmartProxy}) repository to restrict any updates outside the {Project} Maintenance repository.
+Please read the {MultiBaseURL}release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround before proceeding further.
++
 Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVersion}` and execute:
 +
 [options="nowrap" subs="attributes"]
@@ -96,11 +99,6 @@ Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVe
 
 # {foreman-maintain} self-upgrade
 ----
-
-[NOTE]
-====
-If you find further issues on upgrading the {ProjectServer}, please refer {MultiBaseURL}release_notes/assembly_introducing-red-hat-satellite_sat6-release-notes#ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues] in the Release Notes as a workaround.
-====
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:
 +


### PR DESCRIPTION
The present command is not upgrading the Project to correct version. Therefore, it was required to add the maintenance repository for both, Project and Proxy. The newly added command will ensure the correct version of project to be upgraded.

https://bugzilla.redhat.com/show_bug.cgi?id=2148466


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
