### PR TITLE
Add EL 9 to supported host OS list

### DIFF
--- a/guides/common/modules/con_registering_hosts.adoc
+++ b/guides/common/modules/con_registering_hosts.adoc
@@ -35,9 +35,10 @@ ifdef::satellite[]
 
 Hosts must use one of the following {RHEL} versions:
 
-* 6.1 or later*
-* 7.0 or later
+* 9.0 or later
 * 8.0 or later
+* 7.0 or later
+* 6.1 or later*
 
 NOTE: Red{nbsp}Hat Enterprise{nbsp}Linux versions 6.1, 6.2, and 6.3 require `subscription-manager` and related packages to be updated manually.
 For more information, see https://access.redhat.com/solutions/1256763[].


### PR DESCRIPTION
Also inverted the order so the newest EL is on top.

[Related BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2144382)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
