### PR TITLE
Remove redunant proxy instructions

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -79,13 +79,4 @@ bash-4.2$ exit
 --enable-foreman-proxy-plugin-dhcp-remote-isc \
 --foreman-proxy-dhcp-server=_DHCP_Server_FQDN_
 ----
-. Restart the `foreman-proxy` service:
-+
-[options="nowrap"]
-----
-# systemctl restart foreman-proxy
-----
-[cols="40%,60%",options="header"]
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
-. Locate the {ProductName} and select *Refresh* from the list in the *Actions* column.
 . Associate the DHCP service with the appropriate subnets and domain.


### PR DESCRIPTION
The installer restarts and refreshes the Foreman Proxy if needed. The user doesn't have to perform these.

I only picked the upstream supported version, but it probably applies to all versions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.