### PR TITLE
add Satellite 6.11 and 6.12 to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,10 @@
 
 Please cherry-pick my commits into:
 
-* [ ] Foreman 3.5/Katello 4.7
+* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
 * [ ] Foreman 3.4/Katello 4.6
-* [ ] Foreman 3.3/Katello 4.5
+* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
 * [ ] Foreman 3.2/Katello 4.4
-* [ ] Foreman 3.1/Katello 4.3
+* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11)
 * For Foreman 3.0 or older, please create a separate PR.
 * We do not accept PRs for Foreman 2.3 or older.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
