### PR TITLE
Update satellite version to 6.13 in docinfo

### DIFF
--- a/guides/doc-Administering_Project/docinfo.xml
+++ b/guides/doc-Administering_Project/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Administering Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>A guide to administering Red Hat Satellite.</subtitle>
 <abstract>
 

--- a/guides/doc-Administering_with_Ansible/docinfo.xml
+++ b/guides/doc-Administering_with_Ansible/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Administering Satellite using Ansible </title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Managing Satellite with Ansible</subtitle>
 <abstract>
     <para>This guide describes how to set up and configure Red Hat Satellite to use Ansible to perform remote execution and automate repetitive tasks.</para>

--- a/guides/doc-Configuring_Load_Balancer/docinfo.xml
+++ b/guides/doc-Configuring_Load_Balancer/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Configuring Capsules with a Load Balancer</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Distributing load between Capsule Servers</subtitle>
 <abstract>
     <para>This guide describes how to configure Red Hat Satellite to use a load balancer to distribute load between Capsule Servers.</para>

--- a/guides/doc-Deploying_Project_on_AWS/docinfo.xml
+++ b/guides/doc-Deploying_Project_on_AWS/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Deploying Red Hat Satellite on Amazon Web Services</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Reference guide for deploying Red Hat Satellite Server and Capsules on Amazon Web Services</subtitle>
 <abstract>
     <para>Use this guide to deploy Red Hat Satellite Server and Capsules on Amazon Web Services (AWS) Elastic Compute Cloud (Amazon EC2).</para>

--- a/guides/doc-Installing_Proxy/docinfo.xml
+++ b/guides/doc-Installing_Proxy/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing Capsule Server</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Installing Red Hat Satellite Capsule Server</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite Capsule Server, perform initial configuration, and configure external services.</para>

--- a/guides/doc-Installing_Server/docinfo.xml
+++ b/guides/doc-Installing_Server/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing Satellite Server in a Connected Network Environment</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Install Red Hat Satellite Server that is deployed inside a network connected to the Internet</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite from a connected network, perform initial configuration, and configure external services.</para>

--- a/guides/doc-Installing_Server_Disconnected/docinfo.xml
+++ b/guides/doc-Installing_Server_Disconnected/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing Satellite Server in a Disconnected Network Environment</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Install Red Hat Satellite Server that is deployed inside a network without an Internet connection</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite in a disconnected network, perform initial configuration, and configure external services.</para>

--- a/guides/doc-Managing_Configurations_Ansible/docinfo.xml
+++ b/guides/doc-Managing_Configurations_Ansible/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Configurations Using Ansible Integration in Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Use Ansible integration in Satellite to configure host systems</subtitle>
 <abstract>
     <para>This guide describes how to integrate Red Hat Satellite with Ansible and how to perform remote execution and automate repetitive tasks using Ansible roles and playbooks in Satellite.</para>

--- a/guides/doc-Managing_Configurations_Puppet/docinfo.xml
+++ b/guides/doc-Managing_Configurations_Puppet/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Configurations Using Puppet Integration in Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Using Puppet integration to manage configurations of hosts and to report host system status to Satellite</subtitle>
 <abstract><para>This guide describes how to enable Puppet integration with Satellite, configure the Puppet agent on hosts, how to import Puppet modules, and how to use the Puppet modules to enforce configurations on hosts managed in your Red&nbsp;Hat Satellite infrastructure.</para></abstract>
 <authorgroup id="Author_Group">

--- a/guides/doc-Managing_Content/docinfo.xml
+++ b/guides/doc-Managing_Content/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Content Management Guide</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>A guide to managing content from Red Hat and custom sources</subtitle>
 <abstract>
     <para>Use this guide to understand and manage content in Satellite 6. Examples of such content include RPM files, and ISO images. Red Hat Satellite 6 manages this content using a set of Content Views promoted across the application lifecycle. This guide demonstrates how to create an application lifecycle that suits your organization and content views that fulfils host states within lifecycle environments. These content views eventually form the basis for provisioning and updating hosts in your Red Hat Satellite 6 environment.</para>

--- a/guides/doc-Managing_Hosts/docinfo.xml
+++ b/guides/doc-Managing_Hosts/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Hosts</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>A guide to managing hosts in a Red Hat Satellite 6 environment.</subtitle>
 <abstract><para>This guide describes how to configure and work with hosts in a Red&nbsp;Hat Satellite environment. Before continuing with this workflow you must have successfully installed a Red&nbsp;Hat Satellite 6 Server and any required Capsule Servers.</para></abstract>
 <authorgroup id="Author_Group">

--- a/guides/doc-Planning_for_Project/docinfo.xml
+++ b/guides/doc-Planning_for_Project/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Satellite Overview, Concepts, and Deployment Considerations</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Planning Satellite Deployment</subtitle>
 <abstract><para>This document explains architecture concepts of Red&nbsp;Hat Satellite and provides recommendations for your deployment planning.</para></abstract>
 <authorgroup id="Author_Group">

--- a/guides/doc-Provisioning_Hosts/docinfo.xml
+++ b/guides/doc-Provisioning_Hosts/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Provisioning Guide</title>
 <subtitle>A guide to provisioning physical and virtual hosts on Red&nbsp;Hat Satellite Servers.</subtitle>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <abstract>
   <para>
     The Red&nbsp;Hat Satellite Provisioning Guide has instructions on provisioning physical and virtual hosts. This includes setting up the required network topology, configuring the necessary services, and providing all of the other configuration information to provision hosts on your network.

--- a/guides/doc-Tuning_Performance/docinfo.xml
+++ b/guides/doc-Tuning_Performance/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Tuning Performance of Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>A guide to optimize performance for Red Hat Satellite</subtitle>
 <abstract>
 	<para>This guide aims to cover the set of tunings and tips that can be used as a reference to scale up your Red Hat Satellite environment.</para>

--- a/guides/doc-Upgrading_and_Updating/docinfo.xml
+++ b/guides/doc-Upgrading_and_Updating/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Upgrading and Updating Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.12</productnumber>
+<productnumber>6.13</productnumber>
 <subtitle>Upgrading and updating Red Hat Satellite Server and Capsule Server</subtitle>
 <abstract>
     <para>This guide describes upgrading and updating Red Hat Satellite Server, Capsule Server, and hosts.</para>


### PR DESCRIPTION
The Satellite version in docinfo.xml files needs to be updated to able to build Pantheon previews.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
