### PR TITLE
Correct the command for enabling & syncing repos

### DIFF
--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -31,7 +31,7 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 ----
 # hammer repository-set enable \
 --basearch='x86_64' \
---name 'Red Hat {project-client-name} (for RHEL 8) (RPMs)' \
+--name 'Red Hat {project-client-name} for RHEL 8 x86_64 (RPMs)' \
 --organization _"My_Organization"_ \
---product 'Red Hat Enterprise Linux Server'
+--product '{RHEL} for x86_64'
 ----

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -20,8 +20,7 @@ A list of product repositories available for synchronization is displayed.
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository synchronize \
---async \
---name 'Red Hat {project-client-name} for RHEL 8 RPMs x86_64' \
+--name 'Red Hat {project-client-name} for RHEL 8 x86_64 RPMs' \
 --organization _"My_Organization"_ \
---product 'Red Hat Enterprise Linux Server'
+--product '{RHEL} for x86_64'
 ----


### PR DESCRIPTION
The current command in enabling and synchronizing the Project Client Repositories is not working. Now, the correct command has been added to both sections.

https://bugzilla.redhat.com/show_bug.cgi?id=2148091

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
