### PR TITLE
dnf needs-rebooting -r instead of 2 steps

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/snip_needs_reboot.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/snip_needs_reboot.adoc
@@ -8,19 +8,12 @@ $ ls /run/reboot-required
 . Optional: If the `/run/reboot-required` file exists, reboot the system:
 endif::[]
 ifndef::foreman-deb[]
-.. Check the version of newest installed kernel:
 +
 [options="nowrap"]
 ----
-# rpm --query --last kernel | head -n 1
+# dnf needs-restarting --reboothint
 ----
-.. Compare this to the version of currently running kernel:
-+
-[options="nowrap"]
-----
-# uname --kernel-release
-----
-. Optional: If the newest kernel differs from the currently running kernel, reboot the system:
+. Optional: If the previous command told you to reboot, then reboot the system:
 endif::[]
 +
 [options="nowrap"]


### PR DESCRIPTION
Resolves: #1858


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.

Since `dnf needs -restarting` is available on el8, I tried to select the version that for running on RHEL/CentOS Stream require 8.

The plugin used is part of `dnf-plugins-core` which is installed on a system with `@Base` (and if I read comps.xml correctly actually comes with @core).

plugin presence has been successfully verified on both RHEL8 and CentOS Stream 8 @Base installs