### PR TITLE
Update instructions for Importing a repository

### DIFF
--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -26,10 +26,6 @@ total 68M
 -rw-r--r--. 1 pulp pulp 333 Mar  2 04:29 export-1e25417c-6d09-49d4-b9a5-23df4db3d52a-20210302_0335-toc.json
 -rw-r--r--. 1 pulp pulp 443 Mar  2 04:29 metadata.json
 ----
-. On {ProjectServer} where you want to import, create/enable a repository with the same name and label as the exported content.
-. In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click the *Yum content* tab.
-. Add the same `Yum` content that the exported Content View version includes.
 . Identify the Organization that you wish to import into.
 . To import the Library content to {ProjectServer}, enter the following command:
 +


### PR DESCRIPTION
Removed few obsolete steps from the module - Importing a repository.

https://bugzilla.redhat.com/show_bug.cgi?id=2134228

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
