### PR TITLE
Do not use yaml syntax highlighting

### DIFF
--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -313,7 +313,7 @@ ifdef::foreman-el,orcharhino[]
 
 You can increase the log level for Salt Master (`/etc/salt/master`) and Salt Minion (`/etc/salt/minion`) by changing the following option:
 
-[yaml, options="nowrap", subs="+quotes,verbatim,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 log_level: debug
 ----


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
