### PR TITLE
Render Backup/Restore documentation for Debian too

### DIFF
--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -15,13 +15,15 @@ For more information, see the xref:Example_of_a_Weekly_Full_Backup_Followed_by_D
 During offline or snapshot backups, the services are inactive and {Project} is in a maintenance mode.
 All the traffic from outside on port 443 is rejected by a firewall to ensure there are no modifications triggered.
 
+ifndef::foreman-el,foreman-deb[]
 A backup contains sensitive information from the `/root/ssl-build` directory.
 For example, it can contain hostnames, ssh keys, request files and SSL certificates.
+endif::[]
 You must encrypt or move the backup to a secure location to minimize the risk of damage or unauthorized access to the hosts.
 
 .Conventional Backup Methods
 You can also use conventional backup methods.
-ifndef::orcharhino[]
+ifndef::orcharhino,foreman-deb[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#assembly_recovering-and-restoring-a-system_configuring-basic-system-settings[Recovering and restoring a system] in _{RHEL}{nbsp}8 Configuring basic system settings_.
 endif::[]
 

--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -27,6 +27,7 @@ To check for free space, enter the following command:
 +
 Add the ``--total`` option to get a total of the results from more than one directory.
 
+ifndef::foreman-deb[]
 * Ensure that all SELinux contexts are correct.
 Enter the following command to restore the correct SELinux contexts:
 +
@@ -34,6 +35,7 @@ Enter the following command to restore the correct SELinux contexts:
 ----
 # restorecon -Rv /
 ----
+endif::[]
 
 .Procedure
 . Choose the appropriate method to install {Project} or {SmartProxy}:

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -10,9 +10,7 @@ endif::[]
 
 include::common/assembly_accessing-server.adoc[leveloffset=+1]
 
-ifndef::foreman-deb[]
 include::common/modules/proc_starting-and-stopping-server.adoc[leveloffset=+1]
-endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
@@ -36,11 +34,9 @@ include::common/assembly_managing-security-compliance.adoc[leveloffset=+1]
 include::common/assembly_running-openscap-scans.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::foreman-deb[]
 include::common/assembly_backing-up-server-and-proxy.adoc[leveloffset=+1]
 
 include::common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc[leveloffset=+1]
-endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renaming-server-or-smart-proxy.adoc[leveloffset=+1]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -40,9 +40,7 @@ endif::[]
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 +
-ifndef::foreman-deb[]
 For information on backups, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
-endif::[]
 
 ifdef::foreman-el,katello[]
 . Update repositories

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -34,9 +34,7 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 * Back up your {ProjectServer} and all {SmartProxyServer}s.
-ifndef::foreman-deb[]
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
-endif::[]
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 
 ifdef::satellite[]


### PR DESCRIPTION
Foreman 3.4+ supports that


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
