### PR TITLE
Update in Chainbooting virtual machines Steps

### DIFF
--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -154,10 +154,10 @@ If you want to change the default values in the template, clone the template and
 . Click the *Templates* tab.
 . From the *iPXE Template* list, select the template you want to use.
 . Click *Submit* to save the changes.
-. Navigate to *Hosts* > *All Hosts*.
-. In the *Hosts* page, select the host that you want to use.
-. Select the *Templates* tab.
-. From the *iPXE template* list, select *Review* to verify that the *Kickstart default iPXE* template is the correct template.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*, and select the host group you want to configure.
+. Select the *Operating System* tab.
+. Select the *Architecture* and *Operating system*.
+. Set *PXE Loader* to *PXELinux BIOS* to chainboot iPXE via PXELinux, or to *iPXE Chain BIOS* to load `undionly-ipxe.0` directly.
 . To use the iPXE bootstrapping feature for {Project}, configure the `dhcpd.conf` file as follows:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
+++ b/guides/doc-Provisioning_Guide/topics/proc_configuring_iPXE_to_reduce_provisioning_times.adoc
@@ -158,6 +158,7 @@ If you want to change the default values in the template, clone the template and
 . Select the *Operating System* tab.
 . Select the *Architecture* and *Operating system*.
 . Set *PXE Loader* to *PXELinux BIOS* to chainboot iPXE via PXELinux, or to *iPXE Chain BIOS* to load `undionly-ipxe.0` directly.
+. Click *Submit*.
 . To use the iPXE bootstrapping feature for {Project}, configure the `dhcpd.conf` file as follows:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
Removed incorrect steps for setting *iPXE Template* through the Hosts page (Hosts > All Hosts). 
Added missing steps setting *PXE Loader*.

https://bugzilla.redhat.com/show_bug.cgi?id=2134961


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
