### PR TITLE
Steps update for Creating a local file repository

### DIFF
--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -65,11 +65,11 @@ endif::[]
 # ls __my_file_repo__
 PULP_MANIFEST test.txt
 ----
-. Configure additional import paths to sync a file repository that exists on the {Project}. For example, if a file repository is at `/root/myrepo`, enter:
+. Configure additional import paths to sync a file repository that exists on the {Project}. For example, if a file repository is at `__/path/to/myrepo__`, enter:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --foreman-proxt-content-pulpcore-additional-import-paths __/root/myrepo__
+# {foreman-installer} --foreman-proxy-content-pulpcore-additional-import-paths __/path/to/myrepo__
 ----
 
 .Importing Files from a File Type Repository
@@ -83,7 +83,7 @@ To import files from a file type repository in a local directory, complete the f
 . In the *Name* field, enter a name for the repository.
 {Project} automatically completes this field based on what you enter for *Name*.
 . From the *Type* list, select the content type of the repository.
-. In the *Upstream URL* field, enter the local directory with the repository to use as the source, in the form `\http://sat_fqdn/pub/__new_repo__`.
+. In the *Upstream URL* field, enter the local directory with the repository to use as the source, in the form `\file:///__my_file_repo__`.
 . Select the *Verify SSL* checkbox to check the SSL certificate for the repository or clear the *Verify SSL* checkbox.
 . Optional: In the *Upstream Username* field, enter the upstream user name that you require.
 . Optional: In the *Upstream Password* field, enter the corresponding password for your upstream user name.

--- a/guides/common/modules/proc_creating-a-local-file-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-file-repository.adoc
@@ -40,11 +40,11 @@ Alternatively, to prevent downtime caused by stopping the service, you can use t
 # {foreman-maintain} packages lock
 ----
 endif::[]
-. Create a directory that you want to use as the file type repository in the HTTP server's public folder:
+. Create a directory that you want to use as the file type repository in the HTTP server's public folder, for example, `/var/lib/pulp/sync_imports/__new_repo__`
 +
 [options="nowrap" subs="+quotes"]
 ----
-# mkdir __my_file_repo__
+# mkdir `/var/lib/pulp/sync_imports/__new_repo__`
 ----
 . Add files to the directory or create a test file:
 +
@@ -65,6 +65,12 @@ endif::[]
 # ls __my_file_repo__
 PULP_MANIFEST test.txt
 ----
+. Configure additional import paths to sync a file repository that exists on the {Project}. For example, if a file repository is at `/root/myrepo`, enter:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-proxt-content-pulpcore-additional-import-paths __/root/myrepo__
+----
 
 .Importing Files from a File Type Repository
 
@@ -77,7 +83,7 @@ To import files from a file type repository in a local directory, complete the f
 . In the *Name* field, enter a name for the repository.
 {Project} automatically completes this field based on what you enter for *Name*.
 . From the *Type* list, select the content type of the repository.
-. In the *Upstream URL* field, enter the local directory with the repository to use as the source, in the form `\file:///__my_file_repo__`.
+. In the *Upstream URL* field, enter the local directory with the repository to use as the source, in the form `\http://sat_fqdn/pub/__new_repo__`.
 . Select the *Verify SSL* checkbox to check the SSL certificate for the repository or clear the *Verify SSL* checkbox.
 . Optional: In the *Upstream Username* field, enter the upstream user name that you require.
 . Optional: In the *Upstream Password* field, enter the corresponding password for your upstream user name.


### PR DESCRIPTION
The upstream URL format mentioned in the documentation was throwing a sync error. 
It is not corrected.
A new step is added to describe how to sync a file repository that exists on the Project.

https://bugzilla.redhat.com/show_bug.cgi?id=2131854

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
