### PR TITLE
Drop explicit noop step in disconnected upgrade

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -207,49 +207,6 @@ baseurl=file:///media/sat6/ansible/
 baseurl=file:///media/sat6/RHSCL/
 ----
 
-. Optional: If you have applied custom Apache server configurations, note that the custom configurations are reverted to the installation defaults when you perform the upgrade.
-+
-To preview the changes that are applied during the upgrade, enter the `{foreman-installer}` command with the `--noop` (no operation) option.
-These changes are applied when you enter the `{foreman-maintain} upgrade` command in a following step.
-
-.. Add the following line to the `/etc/httpd/conf/httpd.conf` configuration file.
-+
-[options="nowrap"]
-----
-Include /etc/httpd/conf.modules.d/*.conf
-----
-
-.. Restart the `httpd` service.
-+
-[options="nowrap"]
-----
-# systemctl restart httpd
-----
-
-.. Start the `postgresql` database services.
-+
-[options="nowrap"]
-----
-# systemctl start postgresql
-----
-
-.. Enter the `{foreman-installer}` command with the `--noop` option:
-+
-[options="nowrap" subs="attributes"]
-----
-# {installer-scenario} --verbose --noop
-----
-Review the `{installer-log-file}` to preview the changes that are applied during the upgrade.
-Locate the `\+++` and `---` symbols that indicate the changes to the configurations files.
-Although entering the `{foreman-installer}` command with the `--noop` option does not apply any changes to your {Project}, some Puppet resources in the module expect changes to be applied and might display failure messages.
-
-.. Stop {Project} services:
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} service stop
-----
-
 . Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +


### PR DESCRIPTION
There is already a warning ahead of time that it can be done. Generally speaking we don't want to force users to review all changes and the installer should just work.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.