### PR TITLE
Step update to configure Host-Chainbooting iPXE

### DIFF
--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -44,13 +44,10 @@ If you want to change the default values in the template, clone the template and
 . From the *PXELinux template* list, select the template you want to use.
 . From the *iPXE template* list, select the template you want to use.
 . Click *Submit* to save the changes.
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*, and select the host you want to use.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*, and select the host group you want to configure.
 . Select the *Operating System* tab.
+. Select the *Architecture* and *Operating system*.
 . Set *PXE Loader* to *PXELinux BIOS* to chainboot iPXE via PXELinux, or to *iPXE Chain BIOS* to load `undionly-ipxe.0` directly.
-. Select the *Templates* tab, and from the *PXELinux template* list, select *Review* to verify the template is the correct template.
-. From the *iPXE template* list, select *Review* to verify the template is the correct template.
-If there is no PXELinux entry, or you cannot find the new template, navigate to *Hosts* > *All Hosts*, and on your host, click *Edit*.
-Click the *Operating system* tab and click the Provisioning Template *Resolve* button to refresh the list of templates.
 . On {ProjectServer}, run:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
This branch is the clone of "BZ-2134961-Chainbooting-iPXE-Steps-Foreman-3.1-3.3" A step in Chainbooting iPXE from PXELinux section needed update. Existing procedure consists incorrect step as reported in this BZ. The same has been fixed in this PR.

https://bugzilla.redhat.com/show_bug.cgi?id=2134961


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
