### PR TITLE
Fix name of repo with Puppet agent (Sat only) 3.1

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -122,6 +122,7 @@
 // Satellite-Tools becomes Satellite-Client in Satellite 7
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL8ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-8-<arch>-rpms
+:RepoRHEL9ServerSatelliteToolsProductVersion: satellite-client-6-for-rhel-9-<arch>-rpms
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 

--- a/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-puppet-agent.adoc
@@ -12,7 +12,11 @@ endif::[]
 .Prerequisites
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-* The {ProjectName} Client Puppet 7.0 repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.
+* A {Team} {project-client-name} repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.
+The `puppet-agent` package is available within the following repositories:
+** {Team} {project-client-name} for RHEL 7 Server RPMs x86_64 {endash} `{RepoRHEL7ServerSatelliteToolsProductVersion}`
+** {Team} {project-client-name} for RHEL 8 RPMs <arch> {endash} `{RepoRHEL8ServerSatelliteToolsProductVersion}`
+** {Team} {project-client-name} for RHEL 9 RPMs <arch> {endash} `{RepoRHEL9ServerSatelliteToolsProductVersion}`
 endif::[]
 ifdef::orcharhino[]
 * The {Team} {project-client-name} repository must be enabled and synchronized to {ProjectServer}, and enabled on the host.


### PR DESCRIPTION
Puppet agent is shipped in the "Red Hat Satellite Client 6" repository, not in a special repository.
(This is correct in newer versions.)

https://bugzilla.redhat.com/show_bug.cgi?id=2150287

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* 3.2 for consistency
