### PR TITLE
Add EL 8 instructions to Disconnected section

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -32,7 +32,7 @@ For more information, see the Red Hat Knowledgebase solution https://access.redh
 # {foreman-maintain} upgrade list-versions
 ----
 
-. Use the health check option to determine if the system is ready for upgrade.
+. Use the health check option to determine if the system is ready to upgrade.
 On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -45,7 +45,7 @@ Review the results and address any highlighted error conditions before performin
 . Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process was completed successfully.
 
 . Perform the upgrade:
 +
@@ -73,6 +73,175 @@ ifdef::satellite[]
 = Updating Disconnected {ProjectServer}
 
 This section describes the steps needed to update in an Air-gapped Disconnected setup where the connected {ProjectServer} (which synchronizes content from CDN) is air gapped from a disconnected {ProjectServer}.
+
+== Updating Disconnected {ProjectServer} on {EL} 8
+
+Complete the following steps on the connected {ProjectServer} for {EL} 8.
+
+. Ensure that you have synchronized the following repositories in your connected {ProjectServer}.
++
+[options="nowrap" subs="attributes"]
+----
+{RepoRHEL8BaseOS}
+{RepoRHEL8AppStream}
+{RepoRHEL8ServerSatelliteServerProductVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
++
+. Download the debug certificate of the organization and store it locally at, for example, `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
+. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
++
+[options="nowrap" subs="attributes"]
+----
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/baseos/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
+
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/appstream/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
+
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={ProjectName} {ProjectVersion} for RHEL 8 RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/satellite/{ProjectVersion}/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={ProjectName} Maintenance {ProjectVersion} for RHEL 8 RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/sat-maintenance/{ProjectVersion}/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
+----
++
+. In the configuration file, replace `/etc/pki/katello/certs/org-debug-cert.pem` in `sslclientcert` and `sslclientkey` with the location of the downloaded organization debug certificate.
+. Update `{foreman-example-com}` with the correct FQDN for your deployment.
+. Replace `My_Organization` with the correct organization label in the `baseurl`.
+To obtain the organization label, enter the command:
++
+----
+# hammer organization list
+----
+
+. Enter the `reposync` command:
++
+[options="nowrap" subs="attributes"]
+----
+# reposync --delete --download-metadata -p ~/{Project}-repos -n \
+ -r {RepoRHEL8BaseOS} \
+ -r {RepoRHEL8AppStream} \
+ -r {RepoRHEL8ServerSatelliteServerProductVersion} \
+ -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
++
+This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
++
+. Verify that the RPMs have been downloaded and the repository data directory is generated in each of the sub-directories of `~/{Project}-repos`.
+. Archive the contents of the directory
++
+[options="nowrap" subs="attributes"]
+----
+# cd ~
+# tar czf {Project}-repos.tgz {Project}-repos
+----
+. Use the generated `{Project}-repos.tgz` file to upgrade in the disconnected {ProjectServer}.
+
+Perform the following steps on the disconnected {ProjectServer}:
+
+. Copy the generated `{Project}-repos.tgz` file to your disconnected {ProjectServer}
+. Extract the archive to anywhere accessible by the `root` user.
+In the following example `/root` is the extraction location.
++
+[options="nowrap" subs="attributes"]
+----
+# cd /root
+# tar zxf {Project}-repos.tgz
+----
+. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
++
+[options="nowrap" subs="attributes"]
+----
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+baseurl=file:///root/{Project}-repos/{RepoRHEL8BaseOS}
+enabled=1
+
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl=file:///root/{Project}-repos/{RepoRHEL8AppStream}
+enabled=1
+
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={ProjectNameX} for RHEL 8 Server RPMs x86_64
+baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteServerProductVersion}
+enabled=1
+
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
+baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+enabled=1
+----
++
+. In the configuration file, replace the `/root/{Project}-repos` with the extracted location.
+. Check the available versions to confirm the next minor version is listed:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-maintain} upgrade list-versions
+----
++
+. Use the health check option to determine if the system is ready to upgrade.
+On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} upgrade check --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
+----
++
+. Review the results and address any highlighted error conditions before performing the upgrade.
+
+. Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
++
+If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process was completed successfully.
+
+. Perform the upgrade:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
+----
++
+. Check when the kernel packages were last updated:
++
+----
+# rpm -qa --last | grep kernel
+----
++
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} service stop
+# reboot
+----
+
+== Updating Disconnected {ProjectServer} on {EL} 7
 
 Complete the following steps on the connected {ProjectServer} for {EL} 7.
 
@@ -273,171 +442,6 @@ If you lose connection to the command shell where the upgrade command is running
 . Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
 +
 [options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} service stop
-# reboot
-----
-
-Complete the following steps on the connected {ProjectServer} for {EL} 8.
-
-. Ensure that you have synchronized the following repositories in your connected {ProjectServer}.
-+
-[options="nowrap" subs="attributes"]
-----
-{RepoRHEL8BaseOS}
-{RepoRHEL8AppStream}
-{RepoRHEL8ServerSatelliteServerProductVersion}
-{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
-----
-+
-. Download the debug certificate of the organization and store it locally at, for example, `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
-. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
-+
-[options="nowrap" subs="attributes"]
-----
-[{RepoRHEL8BaseOS}]
-name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/baseos/os
-enabled=1
-sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
-sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
-sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
-sslverify = 1
-
-[{RepoRHEL8AppStream}]
-name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/appstream/os
-enabled=1
-sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
-sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
-sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
-sslverify = 1
-
-[{RepoRHEL8ServerSatelliteServerProductVersion}]
-name={ProjectName} {ProjectVersion} for RHEL 8 RPMs x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/satellite/{ProjectVersion}/os
-enabled=1
-sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
-sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
-sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
-
-[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
-name={ProjectName} Maintenance {ProjectVersion} for RHEL 8 RPMs x86_64
-baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/sat-maintenance/{ProjectVersion}/os
-enabled=1
-sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
-sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
-sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
-sslverify = 1
-----
-+
-. In the configuration file, replace `/etc/pki/katello/certs/org-debug-cert.pem` in `sslclientcert` and `sslclientkey` with the location of the downloaded organization debug certificate.
-. Update `{foreman-example-com}` with correct FQDN for your deployment.
-. Replace `My_Organization` with the correct organization label in the `baseurl`.
-To obtain the organization label, enter the command:
-+
-----
-# hammer organization list
-----
-
-. Enter the `reposync` command:
-+
-[options="nowrap" subs="attributes"]
-----
-# reposync --delete --download-metadata -p ~/{Project}-repos -n \
- -r {RepoRHEL8BaseOS} \
- -r {RepoRHEL8AppStream} \
- -r {RepoRHEL8ServerSatelliteServerProductVersion} \
- -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
-----
-+
-This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
-+
-. Verify that the RPMs have been downloaded and the repository data directory is generated in each of the sub-directories of `~/{Project}-repos`.
-. Archive the contents of the directory
-+
-[options="nowrap" subs="attributes"]
-----
-# cd ~
-# tar czf {Project}-repos.tgz {Project}-repos
-----
-. Use the generated `{Project}-repos.tgz` file to upgrade in the disconnected {ProjectServer}.
-
-Perform the following steps on the disconnected {ProjectServer}:
-
-. Copy the generated `{Project}-repos.tgz` file to your disconnected {ProjectServer}
-. Extract the archive to anywhere accessible by the `root` user.
-In the following example `/root` is the extraction location.
-+
-[options="nowrap" subs="attributes"]
-----
-# cd /root
-# tar zxf {Project}-repos.tgz
-----
-. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
-+
-[options="nowrap" subs="attributes"]
-----
-[{RepoRHEL8BaseOS}]
-name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
-baseurl=file:///root/{Project}-repos/{RepoRHEL8BaseOS}
-enabled=1
-
-[{RepoRHEL8AppStream}]
-name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
-baseurl=file:///root/{Project}-repos/{RepoRHEL8AppStream}
-enabled=1
-
-[{RepoRHEL8ServerSatelliteServerProductVersion}]
-name={ProjectNameX} for RHEL 8 Server RPMs x86_64
-baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteServerProductVersion}
-enabled=1
-
-[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
-name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
-baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
-enabled=1
-----
-+
-. In the configuration file, replace the `/root/{Project}-repos` with the extracted location.
-. Check the available versions to confirm the next minor version is listed:
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} upgrade list-versions
-----
-+
-. Use the health check option to determine if the system is ready for upgrade.
-On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} upgrade check --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
-----
-+
-. Review the results and address any highlighted error conditions before performing the upgrade.
-
-. Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
-You can then check the upgrade progress without staying connected to the command shell continuously.
-+
-If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
-
-. Perform the upgrade:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
-----
-+
-. Check when the kernel packages were last updated:
-+
-----
-# rpm -qa --last | grep kernel
-----
-+
-. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
-+
-[options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service stop
 # reboot

--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -74,7 +74,7 @@ ifdef::satellite[]
 
 This section describes the steps needed to update in an Air-gapped Disconnected setup where the connected {ProjectServer} (which synchronizes content from CDN) is air gapped from a disconnected {ProjectServer}.
 
-Complete the following steps on the connected {ProjectServer}.
+Complete the following steps on the connected {ProjectServer} for {EL} 7.
 
 . Ensure that you have synchronized the following repositories in your connected {ProjectServer}.
 +
@@ -277,4 +277,170 @@ If you lose connection to the command shell where the upgrade command is running
 # {foreman-maintain} service stop
 # reboot
 ----
+
+Complete the following steps on the connected {ProjectServer} for {EL} 8.
+
+. Ensure that you have synchronized the following repositories in your connected {ProjectServer}.
++
+[options="nowrap" subs="attributes"]
+----
+{RepoRHEL8BaseOS}
+{RepoRHEL8AppStream}
+{RepoRHEL8ServerSatelliteServerProductVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
++
+. Download the debug certificate of the organization and store it locally at, for example, `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
+. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
++
+[options="nowrap" subs="attributes"]
+----
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/baseos/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
+
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/rhel8/8/x86_64/appstream/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
+
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={ProjectName} {ProjectVersion} for RHEL 8 RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/satellite/{ProjectVersion}/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={ProjectName} Maintenance {ProjectVersion} for RHEL 8 RPMs x86_64
+baseurl=https://{foreman-example-com}/pulp/content/My_Organization/Library/content/dist/layered/rhel8/x86_64/sat-maintenance/{ProjectVersion}/os
+enabled=1
+sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
+sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
+sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
+----
++
+. In the configuration file, replace `/etc/pki/katello/certs/org-debug-cert.pem` in `sslclientcert` and `sslclientkey` with the location of the downloaded organization debug certificate.
+. Update `{foreman-example-com}` with correct FQDN for your deployment.
+. Replace `My_Organization` with the correct organization label in the `baseurl`.
+To obtain the organization label, enter the command:
++
+----
+# hammer organization list
+----
+
+. Enter the `reposync` command:
++
+[options="nowrap" subs="attributes"]
+----
+# reposync --delete --download-metadata -p ~/{Project}-repos -n \
+ -r {RepoRHEL8BaseOS} \
+ -r {RepoRHEL8AppStream} \
+ -r {RepoRHEL8ServerSatelliteServerProductVersion} \
+ -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
++
+This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
++
+. Verify that the RPMs have been downloaded and the repository data directory is generated in each of the sub-directories of `~/{Project}-repos`.
+. Archive the contents of the directory
++
+[options="nowrap" subs="attributes"]
+----
+# cd ~
+# tar czf {Project}-repos.tgz {Project}-repos
+----
+. Use the generated `{Project}-repos.tgz` file to upgrade in the disconnected {ProjectServer}.
+
+Perform the following steps on the disconnected {ProjectServer}:
+
+. Copy the generated `{Project}-repos.tgz` file to your disconnected {ProjectServer}
+. Extract the archive to anywhere accessible by the `root` user.
+In the following example `/root` is the extraction location.
++
+[options="nowrap" subs="attributes"]
+----
+# cd /root
+# tar zxf {Project}-repos.tgz
+----
+. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
++
+[options="nowrap" subs="attributes"]
+----
+[{RepoRHEL8BaseOS}]
+name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+baseurl=file:///root/{Project}-repos/{RepoRHEL8BaseOS}
+enabled=1
+
+[{RepoRHEL8AppStream}]
+name=Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+baseurl=file:///root/{Project}-repos/{RepoRHEL8AppStream}
+enabled=1
+
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={ProjectNameX} for RHEL 8 Server RPMs x86_64
+baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteServerProductVersion}
+enabled=1
+
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
+baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+enabled=1
+----
++
+. In the configuration file, replace the `/root/{Project}-repos` with the extracted location.
+. Check the available versions to confirm the next minor version is listed:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-maintain} upgrade list-versions
+----
++
+. Use the health check option to determine if the system is ready for upgrade.
+On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} upgrade check --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
+----
++
+. Review the results and address any highlighted error conditions before performing the upgrade.
+
+. Because of the lengthy update time, use a utility such as `tmux` to suspend and reattach a communication session.
+You can then check the upgrade progress without staying connected to the command shell continuously.
++
+If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-log-file}` file to check if the process completed successfully.
+
+. Perform the upgrade:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
+----
++
+. Check when the kernel packages were last updated:
++
+----
+# rpm -qa --last | grep kernel
+----
++
+. Optional: If a kernel update occurred since the last reboot, stop {Project} services and reboot the system:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} service stop
+# reboot
+----
++
 endif::[]


### PR DESCRIPTION
Added RHEL 8 instructions for the Disconnected
Satellite Server section
of the guide. This change was needed because there were no instructions
on the Minor update procedure for
connected/disconnected Red Hat
Satellite 6 on RHEL 8.

@evgeni This is the first PR I am submitting for SATDOC-1019 
specifically for the Disconnected section.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
