### PR TITLE
Fix RH Hybrid Cloud Console mentions

### DIFF
--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -13,7 +13,7 @@ To configure subscription-manager with an HTTP proxy, follow the procedure below
 | subscription.rhsm.redhat.com | 443 | HTTPS
 | cdn.redhat.com |  443 | HTTPS
 | *.akamaiedge.net |  443 | HTTPS
-| cert.cloud.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+| cert.console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
 |====

--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -1,15 +1,12 @@
-:_module-type: PROCEDURE
-
-[id="proc_synchronizing-ansible-collections_{context}"]
+[id="synchronizing-ansible-collections_{context}"]
 = Synchronizing Ansible Collections
 
-[role="_abstract"]
-On {Project}, you can synchronize your Ansible Collections from Private Automation Hub, `cloud.redhat.com`, and other {Project} instances.
+On {Project}, you can synchronize your Ansible Collections from Private Automation Hub, `console.redhat.com`, and other {Project} instances.
 Ansible Collections will appear on {Project} as a new repository type in the {ProjectWebUI} menu under *Content* after the sync.
 
 NOTE: Ansible Collections live in the Library environment and the lifecycle management is not supported.
 {SmartProxies} with Pulp 3 have collections support and will sync collection repositories if tied to the Library environment.
-You can also use `hammer content-export` functionality.
+You can also use Export functionality for {ISS}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
@@ -23,7 +20,7 @@ The *Label* field is populated automatically based on the name.
 . In the *Upstream URL* field, enter the URL for the upstream collections repository.
 +
 The URL can be any Galaxy endpoint.
-For example, `++https://cloud.redhat.com/api/automation-hub/++`.
+For example, `\https://console.redhat.com/api/automation-hub/`.
 . Optional: In the *Requirements.yml* field, you can specify the list of collections you want to sync from the endpoint, as well as their versions.
 +
 If you do not specify the list of collections, everything from the endpoint will be synced.
@@ -41,7 +38,7 @@ For more information, see link:https://docs.ansible.com/ansible/latest/galaxy/us
 .. To sync {Project} from *Private Automation Hub*, enter your token in the *Auth Token* field.
 +
 For more information, see link:https://console.redhat.com/ansible/automation-hub/token[Connect Private Automation Hub] in the _Connect to Hub_ guide.
-.. To sync {Project} from `cloud.redhat.com`, enter your token in the *Auth Token* field and enter your SSO URL in the the *Auth URL* field.
+.. To sync {Project} from `console.redhat.com`, enter your token in the *Auth Token* field and enter your SSO URL in the the *Auth URL* field.
 +
 For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html-single/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index#proc-create-api-token[Retrieving your Red Hat Certified Collections Sync URL and API token] in the _Managing Red{nbsp}Hat Certified and Ansible Galaxy collections in Automation Hub_ guide.
 .. To sync {Project} from {Project}, leave both authentication fields blank.

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -94,7 +94,7 @@ Remote Execution result upload
 | 443 | TCP | HTTPS | Amazon EC2, Azure, Google GCE | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
-| 443 | TCP | HTTPS | cloud.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
+| 443 | TCP | HTTPS | console.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
 | 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
 | 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |


### PR DESCRIPTION
cloud.redhat.com URL is a redirect to console.redhat.com, which can cause timeout errors (especially with API calls)

https://bugzilla.redhat.com/show_bug.cgi?id=2149457


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
