### PR TITLE
Show KernelCare plug-in only for Katello

### DIFF
--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -30,7 +30,7 @@ ifdef::satellite[]
 include::common/assembly_monitoring-hosts-using-red-hat-insights.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::satellite[]
+ifdef::katello,orcharhino[]
 include::common/assembly_using-kernelcare.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
