### PR TITLE
Add EL9, EL8 & EL7 client repos for enabling and syncing

### DIFF
--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -6,8 +6,83 @@ You require the Katello plug-in to complete this procedure.
 endif::[]
 
 The {project-client-name} repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
+Select the applicable operating system and version to enable the client repository.
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_{context}[].
+* xref:#enabling-repos-rhel-9[{RHEL} 9]
+* xref:#enabling-repos-rhel-8[{RHEL} 8]
+* xref:#enabling-repos-rhel-7[{RHEL} 7]
+
+== [[enabling-repos-rhel-9]]{RHEL} 9
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_rhel_9{context}[].
+
+ifeval::["{mode}" == "disconnected"]
+.Prerequisites
+* Ensure that you import all content ISO images that you require into {ProjectServer}.
+endif::[]
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
+. In the Available Repositories pane, enable the *Recommended Repositories* to get the list of repositories.
+. Click *{Team} {project-client-name} for RHEL 9 x86_64 (RPMs)* to expand the repository set.
+. For the *x86_64*, click the *+* icon to enable the repository.
++
+If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
+To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
+
+Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
+After enabling a Red Hat repository, a Product for this repository is automatically created.
+
+[id="CLI_Enabling_the_Client_Repository_rhel_9{context}"]
+.CLI procedure
+* Enable the {project-client-name} repository using the `hammer repository-set enable` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository-set enable \
+--basearch='x86_64' \
+--name '{Team} {project-client-name} for RHEL 9 x86_64 (RPMs)' \
+--organization _"My_Organization"_ \
+--product '{RHEL} for x86_64'
+----
+
+== [[enabling-repos-rhel-8]]{RHEL} 8
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_rhel_8{context}[].
+
+ifeval::["{mode}" == "disconnected"]
+.Prerequisites
+* Ensure that you import all content ISO images that you require into {ProjectServer}.
+endif::[]
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
+. In the Available Repositories pane, enable the *Recommended Repositories* to get the list of repositories.
+. Click *{Team} {project-client-name} for RHEL 8 x86_64 (RPMs)* to expand the repository set.
+. For the *x86_64*, click the *+* icon to enable the repository.
++
+If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
+To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
+
+Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
+After enabling a Red Hat repository, a Product for this repository is automatically created.
+
+[id="CLI_Enabling_the_Client_Repository_rhel_8{context}"]
+.CLI procedure
+* Enable the {project-client-name} repository using the `hammer repository-set enable` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository-set enable \
+--basearch='x86_64' \
+--name '{Team} {project-client-name} for RHEL 8 x86_64 (RPMs)' \
+--organization _"My_Organization"_ \
+--product '{RHEL} for x86_64'
+----
+
+== [[enabling-repos-rhel-7]]{RHEL} 7
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_rhel_7{context}[].
 
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
@@ -27,7 +102,7 @@ To correct that, log in to the Customer Portal, add these repositories, download
 Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
 After enabling a Red Hat repository, a Product for this repository is automatically created.
 
-[id="CLI_Enabling_the_Client_Repository_{context}"]
+[id="CLI_Enabling_the_Client_Repository_rhel_7{context}"]
 .CLI procedure
 * Enable the {project-client-name} repository using the `hammer repository-set enable` command:
 +
@@ -35,7 +110,7 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 ----
 # hammer repository-set enable \
 --basearch='x86_64' \
---name 'Red Hat {project-client-name} (for RHEL 7 Server) (RPMs)' \
+--name '{Team} {project-client-name} (for RHEL 7 Server) (RPMs)' \
 --organization _"My_Organization"_ \
---product 'Red Hat Enterprise Linux Server'
+--product '{RHEL} Server'
 ----

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -1,10 +1,65 @@
 [id="Synchronizing_the_Client_Repository_{context}"]
 = Synchronizing the {project-client-name} Repository
 
-ifdef::satellite[]
 Use this section to synchronize the {project-client-name} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
-endif::[]
+Select the applicable operating system and version to synchronize the client repository.
+
+* xref:#synchronizing-repos-rhel-9[{RHEL} 9]
+* xref:#synchronizing-repos-rhel-8[{RHEL} 8]
+* xref:#synchronizing-repos-rhel-7[{RHEL} 7]
+
+== [[synchronizing-repos-rhel-9]]{RHEL} 9
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Synchronizing_the_Client_Repository_rhel_9{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
++
+A list of product repositories available for synchronization is displayed.
+. Click the arrow next to the *{RHEL} for x86_64* product to view available content.
+. Select *{Team} {project-client-name} for RHEL 9 x86_64 RPMs*.
+. Click *Synchronize Now*.
+
+[id="CLI_Synchronizing_the_Client_Repository_rhel_9{context}"]
+.CLI procedure
+* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository synchronize \
+--name '{Team} {project-client-name} for RHEL 9 x86_64 RPMs' \
+--organization _"My_Organization"_ \
+--product '{RHEL} for x86_64'
+----
+
+== [[synchronizing-repos-rhel-8]]{RHEL} 8
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Synchronizing_the_Client_Repository_rhel_8{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
++
+A list of product repositories available for synchronization is displayed.
+. Click the arrow next to the *{RHEL} for x86_64* product to view available content.
+. Select *{Team} {project-client-name} for RHEL 8 x86_64 RPMs*.
+. Click *Synchronize Now*.
+
+[id="CLI_Synchronizing_the_Client_Repository_rhel_8{context}"]
+.CLI procedure
+* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository synchronize \
+--name '{Team} {project-client-name} for RHEL 8 x86_64 RPMs' \
+--organization _"My_Organization"_ \
+--product '{RHEL} for x86_64'
+----
+
+== [[synchronizing-repos-rhel-7]]{RHEL} 7
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Synchronizing_the_Client_Repository_rhel_7{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
@@ -14,6 +69,7 @@ A list of product repositories available for synchronization is displayed.
 . Select *{project-client-name} (for RHEL 7 Server) RPMs x86_64*.
 . Click *Synchronize Now*.
 
+[id="CLI_Synchronizing_the_Client_Repository_rhel_7{context}"]
 .CLI procedure
 * Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
 +


### PR DESCRIPTION
The client repositories for enabling and synchronizing the project client for EL9 and EL8 were not added. Now it is added for both of them along with the updated Web UI procedure.

https://bugzilla.redhat.com/show_bug.cgi?id=2150297


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
