### PR TITLE
Correct estimated backup size in example

### DIFF
--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -62,8 +62,8 @@ a|`/var/lib/qpidd` +
 |942 MB -> 141 MB
 |===
 +
-In this example, the compressed backup data occupies 180 GB in total.
+In this example, the compressed backup data occupies 120 GB in total.
 . To calculate the amount of available space you require to store a backup, calculate the sum of the estimated values of compressed and uncompressed backup data, and add an extra 20% to ensure a reliable backup.
 +
-This example requires 681 GB plus 180 GB for the uncompressed and compressed backup data, 861 GB in total.
-With 172 GB of extra space, 1033 GB must be allocated for the backup location.
+This example requires 201 GB plus 120 GB for the uncompressed and compressed backup data, 321 GB in total.
+With 64 GB of extra space, 385 GB must be allocated for the backup location.


### PR DESCRIPTION
- In the older version docs, the example for full backup took into consideration the sizes of the **/var/lib/mongodb** directory, bringing the total size to 680 GB. 
```
480G	/var/lib/mongodb
100G       /var/lib/pgsql/data
100G	/var/lib/pulp
```

- This brought the total size to 681 GB. Subsequent docs did not include the **/var/lib/mongodb** directory, as the project migrated from **pulp2** to **pulp3**, but the example size of 681 GB was not changed.

- Updating the docs to reflect the correct size for the example backup scenario.

Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2150343

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
