### PR TITLE
Add akamaiedge.net Host name in adding HTTP proxy

### DIFF
--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -4,7 +4,11 @@
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for Products, repositories, and supported compute resources.
 
-If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com or subscription.rhn.redhat.com, and cdn.redhat.com then the proxy must not perform SSL inspection on these communications.
+.Prerequisites
+Your HTTP proxy must allow access to the following hosts:
+include::snip_host-names-for-http-proxy.adoc[]
+
+If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com and cdn.redhat.com then the proxy must not perform SSL inspection on these communications.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-proxy[].
 
@@ -12,21 +16,6 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *HTTP Proxies* and select *New HTTP Proxy*.
 . In the *Name* field, enter a name for the HTTP proxy.
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
-The following host names are available:
-+
-[cols="2,1,1",options="header"]
-|====
-| Host name | Port | Protocol
-| subscription.rhsm.redhat.com | 443 | HTTPS
-| subscription.rhn.redhat.com | 443 | HTTPS
-| cdn.redhat.com | 443 | HTTPS
-| *.akamaiedge.net |  443 | HTTPS
-ifdef::satellite[]
-| api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-| cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-endif::[]
-|====
-+
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
 . Click the *Locations* tab and add a location.

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -20,6 +20,7 @@ The following host names are available:
 | subscription.rhsm.redhat.com | 443 | HTTPS
 | subscription.rhn.redhat.com | 443 | HTTPS
 | cdn.redhat.com | 443 | HTTPS
+| *.akamaiedge.net |  443 | HTTPS
 ifdef::satellite[]
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS

--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -1,29 +1,19 @@
 [id="configuring-http-proxy-to-connect-to-cdn_{context}"]
 = Configuring the HTTP Proxy to Connect to Red Hat CDN
 
-To configure subscription-manager with an HTTP proxy, follow the procedure below.
+.Prerequisites
+Your network gateway and the HTTP proxy must allow access to the following hosts:
+include::snip_host-names-for-http-proxy.adoc[]
 
-.Procedure
-
-. On the network gateway and the HTTP Proxy, enable TCP for the following host names:
-+
-[cols="2,1,1",options="header"]
-|====
-| Host name | Port | Protocol
-| subscription.rhsm.redhat.com | 443 | HTTPS
-| cdn.redhat.com |  443 | HTTPS
-| *.akamaiedge.net |  443 | HTTPS
-| cert.console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-| cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
-| api.access.redhat.com (if using Red{nbsp}Hat Insights) |  443 | HTTPS
-|====
-+
 {ProjectServer} uses SSL to communicate with the Red{nbsp}Hat CDN securely.
 Use of an SSL interception proxy interferes with this communication.
 These hosts must be whitelisted on the proxy.
-+
+
 For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red{nbsp}Hat] on the Red{nbsp}Hat Customer Portal.
-+
+
+To configure the subscription-manager with the HTTP proxy, follow the procedure below.
+
+.Procedure
 . On {ProjectServer}, complete the following details in the `/etc/rhsm/rhsm.conf` file:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/snip_host-names-for-http-proxy.adoc
+++ b/guides/common/modules/snip_host-names-for-http-proxy.adoc
@@ -1,0 +1,14 @@
+[id="host-names-for-http-proxy_{context}"]
+
+[cols="2,1,1",options="header"]
+|====
+| Host name | Port | Protocol
+| subscription.rhsm.redhat.com | 443 | HTTPS
+| cdn.redhat.com | 443 | HTTPS
+| *.akamaiedge.net | 443 | HTTPS
+ifdef::satellite[]
+| cert.console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+| api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+| cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+endif::[]
+|====


### PR DESCRIPTION
The *.akamaiedge.net Host hame should also be part of Adding an HTTP Proxy while Importing Content. The reason is it is a part of Configuring the HTTP Proxy in the Installation Guide.

https://bugzilla.redhat.com/show_bug.cgi?id=2152785


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
