### PR TITLE
Hide "Building a Discovery Image" modules

### DIFF
--- a/guides/common/assembly_configuring-the-discovery-service.adoc
+++ b/guides/common/assembly_configuring-the-discovery-service.adoc
@@ -14,7 +14,7 @@ include::modules/proc_creating-discovery-rules.adoc[leveloffset=+1]
 
 include::modules/proc_implementing-pxe-less-discovery.adoc[leveloffset=+1]
 
-include::modules/proc_building-a-discovery-image.adoc[leveloffset=+1]
+//include::modules/proc_building-a-discovery-image.adoc[leveloffset=+1]
 
 include::modules/con_unattended-use-customization-and-image-remastering.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_implementing-pxe-less-discovery.adoc
+++ b/guides/common/modules/proc_implementing-pxe-less-discovery.adoc
@@ -32,7 +32,7 @@ ifndef::satellite,orcharhino[]
 image::common/pxeless-mode.svg[]
 endif::[]
 
-If you have not yet installed the Discovery service or image, see xref:Building_a_Discovery_Image_{context}[].
+//If you have not yet installed the Discovery service or image, see xref:Building_a_Discovery_Image_{context}[].
 
 ifdef::satellite[]
 The ISO for the Discovery service resides at `/usr/share/foreman-discovery-image/` and is installed using the `foreman-discovery-image` package.


### PR DESCRIPTION
We are hiding these instructions to build the discovery image because
we don't have working instructions.
Soon we will plan a task to rewrite the steps to work on RHEL 8.

https://bugzilla.redhat.com/show_bug.cgi?id=2151585


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
