### PR TITLE
Add a step for manually enabling el8 modules during upgrade

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -47,6 +47,14 @@ Enable the {Project} Maintenance repository and the {Project} {ProjectVersion} r
 --enable {RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
 --enable {RepoRHEL8ServerSatelliteServerProductVersion}
 ----
+ifdef::satellite[]
+If the {Project}-{ProductVersionPrevious} system is upgraded from RHEL7 to RHEL8 using using LEAPP, manually enable the Satellite module:
++
+[options="nowrap" subs="attributes"]
+----
+# dnf module enable satellite:el8
+----
+endif::[]
 
 . Check the available versions to confirm the version you want is listed:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -99,6 +99,14 @@ Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVe
 
 # {foreman-maintain} self-upgrade
 ----
+ifdef::satellite[]
+If the {Project}-{ProductVersionPrevious} system is upgraded from RHEL7 to RHEL8 using using LEAPP, manually enable the Satellite module:
++
+[options="nowrap" subs="attributes"]
+----
+# dnf module enable satellite:el8
+----
+endif::[]
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:
 +


### PR DESCRIPTION
Add a step for manually enabling el8 modules during upgrade

- A bug in older versions of leapp would cause the upgrade to fail on systems that had been upgraded from el7 to el8.
- To enable the Satellite/Capsule modules for such systems, the workaround is setting `module_hotfixes=1`.
- This workaround gets erased when we disable the Satellite 6.11 repos and enable the 6.12 repo.
- Hence, the module has to be manually enabled for systems that have been updated with leapp.

_Bug link:_
https://bugzilla.redhat.com/show_bug.cgi?id=2149092

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
