### PR TITLE
Declare Foreman 3.5 as supported & 3.3 as unsupported

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -164,7 +164,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.5 - Katello 4.7 (release candidate)",
+    "title": "Foreman 3.5 - Katello 4.7 (supported)",
     "path": "3.5",
     "builds": [
       {
@@ -316,7 +316,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.3 - Katello 4.5 (supported)",
+    "title": "Foreman 3.3 - Katello 4.5 (unsupported)",
     "path": "3.3",
     "builds": [
       {


### PR DESCRIPTION
Foreman 3.5.1 is the GA version and that makes Foreman 3.3 unsupported.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.