### PR TITLE
Increase linkchecker-tryer retries to 5

### DIFF
--- a/guides/scripts/linkchecker-tryer
+++ b/guides/scripts/linkchecker-tryer
@@ -7,7 +7,7 @@ import time
 from subprocess import DEVNULL, STDOUT, call
 
 
-RETRIES = 3
+RETRIES = 5
 SLEEP_TIME = 30
 
 


### PR DESCRIPTION
In 95a8a2f7d74882613237ad033a9b14f7dbc14d7d the linkchecker-retryer implementation was rewritten. While it certainly helps compared to no retryer, it doesn't fix all issues. This increases the number of times it retries, which hopefully makes it work better.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.