### PR TITLE
Mention supported Ansible versions

### DIFF
--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -6,6 +6,7 @@ ifdef::context[:parent-context: {context}]
 
 Use this guide to configure {Project} to use Ansible, and then information about how to use Ansible for remote execution.
 
+include::modules/con_supported-ansible-versions.adoc[leveloffset=+1]
 include::modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc[leveloffset=+1]
 include::modules/proc_importing-ansible-roles.adoc[leveloffset=+1]
 include::modules/proc_overriding-ansible-variables.adoc[leveloffset=+1]

--- a/guides/common/modules/con_supported-ansible-versions.adoc
+++ b/guides/common/modules/con_supported-ansible-versions.adoc
@@ -1,0 +1,5 @@
+[id="supported-ansible-versions_{context}"]
+= Supported Ansible Versions
+
+{Project} uses Ansible as provided by the base operating system of {ProjectServer} or any {SmartProxies} for remote execution.
+Therefore, the supported version of Ansible depends on your base OS configuration.


### PR DESCRIPTION
We wanted to mention supported Ansible versions, however, they actually depend on the user's configuration of the base OS. Perhaps it's still worth mentioning.

https://bugzilla.redhat.com/show_bug.cgi?id=2139700

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)

