### PR TITLE
Managing file repositories 3.3

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -52,8 +52,8 @@ By default, the repository is published through HTTP.
 | *Option* | *Description*
 
 | `--gpg-key-id` _gpg_key_id_         | GPG key numeric identifier
-| `--sync-plan` _sync_plan_name_      | Sync plan name to search by
 | `--sync-plan-id` _sync_plan_id_     | Sync plan numeric identifier
+| `--sync-plan` _sync_plan_name_      | Sync plan name to search by
 |====
 
 . Create a `file` type repository:
@@ -74,12 +74,12 @@ By default, the repository is published through HTTP.
 
 | `--checksum-type` _sha_version_                 | Repository checksum, currently 'sha1' & 'sha256' are supported
 | `--download-policy` _policy_name_       | Download policy for yum repos (either 'immediate' or 'on_demand').
-| `--gpg-key` _gpg_key_name_                  | Key name to search by
 | `--gpg-key-id` _gpg_key_id_                 | GPG key numeric identifier
+| `--gpg-key` _gpg_key_name_                  | Key name to search by
 | `--mirror-on-sync` _boolean_         | Must this repo be mirrored from the source, and stale RPMs removed, when synced? Set to `true` or `false`, `yes` or `no`, `1` or `0`.
 | `--publish-via-http` _boolean_               | Must this also be published using HTTP? Set to `true` or `false`, `yes` or `no`, `1` or `0`.
-| `--upstream-username` _repository_username_   | Upstream repository user, if required for authentication
 | `--upstream-password` _repository_password_   | Password for the upstream repository user
+| `--upstream-username` _repository_username_   | Upstream repository user, if required for authentication
 | `--url` _source_repo_url_                                 | URL of the Source repository
 | `--verify-ssl-on-sync` _boolean_   | Must Katello verify that the upstream URL's SSL certificates are signed by a trusted CA? Set to `true` or `false`, `yes` or `no`, `1` or `0`.
 |====

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -13,8 +13,9 @@ ifdef::satellite[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+# subscription-manager repos \
 --enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -11,7 +11,7 @@ To create a file type repository in a directory on a remote server, see xref:Cre
 ifdef::satellite[]
 . Ensure the Utils repository is enabled:
 +
-[options="nowrap" subs="+quotes,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # subscription-manager repos \
 --enable={RepoRHEL8AppStream} \
@@ -24,7 +24,7 @@ ifndef::satellite[]
 ** On {EL} 8:
 endif::[]
 +
-[options="nowrap" subs="+quotes,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {package-install-project} python39-pulp_manifest
 ----
@@ -33,7 +33,7 @@ ifdef::satellite[]
 Note that this command stops the {Project} service and re-runs `{foreman-installer}`.
 Alternatively, to prevent downtime caused by stopping the service, you can use the following:
 +
-[options="nowrap" subs="+quotes,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} packages unlock
 # {package-install} python39-pulp_manifest
@@ -50,31 +50,31 @@ ifndef::satellite[]
 endif::[]
 . Create a directory that you want to use as the file type repository, such as:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # mkdir -p /var/lib/pulp/__local_repos__/__my_file_repo__
 ----
 . Add the parent folder into allowed import paths:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} --foreman-proxy-content-pulpcore-additional-import-paths /var/lib/pulp/__local_repos__
 ----
 . Add files to the directory or create a test file:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # touch /var/lib/pulp/__local_repos__/__my_file_repo__/_test.txt_
 ----
 . Run the Pulp Manifest command to create the manifest:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # pulp-manifest /var/lib/pulp/__local_repos__/__my_file_repo__
 ----
 . Verify the manifest was created:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # ls /var/lib/pulp/__local_repos__/__my_file_repo__
 PULP_MANIFEST test.txt

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -26,8 +26,9 @@ ifdef::satellite[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+# subscription-manager repos \
 --enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -8,12 +8,15 @@ Use this procedure to configure a repository in a directory on a remote server.
 To create a file type repository in a directory on the base system where {ProjectServer} is installed, see xref:Creating_a_Local_Source_for_a_Custom_File_Type_Repository_{context}[].
 
 .Prerequisites
-ifndef::satellite[]
+ifdef::katello[]
 * You have a server running {EL} 7 or 8 registered to your {Project}.
 endif::[]
 ifdef::satellite[]
 * You have a server running {EL} 8 registered to your {Project} or the Red{nbsp}Hat CDN.
 * Your server has an entitlement to the {RHELServer} and {ProjectName} Utils repositories.
+endif::[]
+ifdef::orcharhino[]
+* You have a server running {EL} registered to your {Project}.
 endif::[]
 * You have installed an HTTP server.
 ifdef::satellite[]


### PR DESCRIPTION
Follow-up to https://github.com/theforeman/foreman-documentation/pull/1906

Merge conflict was only in `guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc` which I've checked out from 3.3 and sorted the list of repos on RHEL 8 manually & amended to the first commit. cc @adamlazik1 