### PR TITLE
Correct the foreman-discovery-image command for EL8

### DIFF
--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -23,6 +23,13 @@ ifndef::satellite,orcharhino[]
 endif::[]
 ifdef::satellite,orcharhino[]
 . Install `foreman-discovery-image`:
+** For {RHEL} 8:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install-project} foreman-discovery-image rubygem-smart_proxy_discovery
+----
+** For {RHEL} 7:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
The present command does not include the rubygem smart proxy discovery image as it is applicable to EL8. Therefore, we need to add it for EL8. For EL7, we are keeping it unchanged as of now.

https://bugzilla.redhat.com/show_bug.cgi?id=2141440


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
