### PR TITLE
improve technical users table to closer match deployments

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -28,11 +28,11 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |pulp |N/A |pulp |N/A |no |N/A |/sbin/nologin
 |puppet |N/A |puppet |N/A |yes |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
 |puppetserver |N/A |puppet |N/A |no |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
-|qdrouterd |N/A |qdrouterd |N/A |yes |N/A |/sbin/nologin
+|qdrouterd |N/A |qdrouterd |N/A |yes |/var/lib/qdrouterd |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin
 |unbound |N/A |unbound |N/A |yes |/etc/unbound |/sbin/nologin
 |postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
 |apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
 |tomcat |53 |tomcat |53 |no |/usr/share/tomcat |/bin/nologin
-|saslauth |N/A |saslauth |76 |no |N/A |/sbin/nologin
+|saslauth |N/A |saslauth |76 |no |/run/saslauthd |/sbin/nologin
 |====

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -25,7 +25,12 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |User name |UID |Group name |GID |Flexible UID and GID |Home |Shell
 |foreman |N/A |foreman |N/A |yes |/usr/share/foreman |/sbin/nologin
 |foreman-proxy |N/A |foreman-proxy |N/A |yes |/usr/share/foreman-proxy |/sbin/nologin
+ifdef::foreman-deb[]
+|www-data |33 |www-data |33 |no |/var/www |/usr/sbin/nologin
+endif::[]
+ifndef::foreman-deb[]
 |apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
+endif::[]
 |postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
 ifdef::katello,orcharhino,satellite[]
 |pulp |N/A |pulp |N/A |no |N/A |/sbin/nologin

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -25,14 +25,14 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |User name |UID |Group name |GID |Flexible UID and GID |Home |Shell
 |foreman |N/A |foreman |N/A |yes |/usr/share/foreman |/sbin/nologin
 |foreman-proxy |N/A |foreman-proxy |N/A |yes |/usr/share/foreman-proxy |/sbin/nologin
+|apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
+|postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
 |pulp |N/A |pulp |N/A |no |N/A |/sbin/nologin
 |puppet |N/A |puppet |N/A |yes |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
 |puppetserver |N/A |puppet |N/A |no |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
 |qdrouterd |N/A |qdrouterd |N/A |yes |/var/lib/qdrouterd |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin
-|unbound |N/A |unbound |N/A |yes |/etc/unbound |/sbin/nologin
-|postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
-|apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
-|tomcat |53 |tomcat |53 |no |/usr/share/tomcat |/bin/nologin
 |saslauth |N/A |saslauth |76 |no |/run/saslauthd |/sbin/nologin
+|tomcat |53 |tomcat |53 |no |/usr/share/tomcat |/bin/nologin
+|unbound |N/A |unbound |N/A |yes |/etc/unbound |/sbin/nologin
 |====

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -35,7 +35,7 @@ endif::[]
 ifdef::katello,orcharhino,satellite[]
 |pulp |N/A |pulp |N/A |no |N/A |/sbin/nologin
 endif::[]
-|puppet |N/A |puppet |N/A |yes |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
+|puppet |52 |puppet |52 |no |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
 ifdef::katello,orcharhino,satellite[]
 |qdrouterd |N/A |qdrouterd |N/A |yes |/var/lib/qdrouterd |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -27,12 +27,18 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |foreman-proxy |N/A |foreman-proxy |N/A |yes |/usr/share/foreman-proxy |/sbin/nologin
 |apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
 |postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
+ifdef::katello,orcharhino,satellite[]
 |pulp |N/A |pulp |N/A |no |N/A |/sbin/nologin
+endif::[]
 |puppet |N/A |puppet |N/A |yes |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
 |puppetserver |N/A |puppet |N/A |no |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
+ifdef::katello,orcharhino,satellite[]
 |qdrouterd |N/A |qdrouterd |N/A |yes |/var/lib/qdrouterd |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin
 |saslauth |N/A |saslauth |76 |no |/run/saslauthd |/sbin/nologin
 |tomcat |53 |tomcat |53 |no |/usr/share/tomcat |/bin/nologin
+endif::[]
+ifndef::foreman-deb[]
 |unbound |N/A |unbound |N/A |yes |/etc/unbound |/sbin/nologin
+endif::[]
 |====

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -31,7 +31,6 @@ ifdef::katello,orcharhino,satellite[]
 |pulp |N/A |pulp |N/A |no |N/A |/sbin/nologin
 endif::[]
 |puppet |N/A |puppet |N/A |yes |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
-|puppetserver |N/A |puppet |N/A |no |/opt/puppetlabs/server/data/puppetserver |/sbin/nologin
 ifdef::katello,orcharhino,satellite[]
 |qdrouterd |N/A |qdrouterd |N/A |yes |/var/lib/qdrouterd |/sbin/nologin
 |qpidd |N/A |qpidd |N/A |yes |/var/lib/qpidd |/sbin/nologin


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
