### PR TITLE
Add protocol for : foreman-example-com

### DIFF
--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -34,5 +34,5 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 --puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
 --puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
 --puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key \
---puppet-server-foreman-url "{foreman-example-com}"
+--puppet-server-foreman-url "https://_{foreman-example-com}_"
 ----

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -72,7 +72,7 @@ For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote
 # {foreman-installer} \
 --foreman-proxy-foreman-base-url https://_new-{foreman-example-com}_ \
 --foreman-proxy-trusted-hosts _new-{foreman-example-com}_ \
---puppet-server-foreman-url _new-{foreman-example-com}_
+--puppet-server-foreman-url https://_new-{foreman-example-com}_
 ----
 . On {ProjectServer}, list all {SmartProxyServer}s:
 +


### PR DESCRIPTION
Currently, protocol "https://" is missing for foreman-example-com 
in the module Enabling Puppet Integration with {Project}

This has been reported as one of the DDF.
https://bugzilla.redhat.com/show_bug.cgi?id=2157880


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
