### PR TITLE
Add the reference to activation key

### DIFF
--- a/guides/common/modules/proc_creating-hosts-on-vmware.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-vmware.adoc
@@ -52,7 +52,9 @@ endif::[]
 Modify these settings to suit your requirements.
 ifdef::satellite,orcharhino[]
 . Click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+If a parameter does not exist, click *+ Add Parameter*.
+In the field *Name*, enter *kt_activation_keys*.
+In the field *Value*, enter the name of the activation key used to register the Content Hosts.
 endif::[]
 ifdef::foreman-el,katello[]
 . If you use the Katello plugin, click the *Parameters* tab and ensure that a parameter exists that provides an activation key.


### PR DESCRIPTION
The end-user needs to add the activation key via parameters but there were not any proper steps documented for the same to add the kt_activation_keys. Therefore, we added the required steps in the topic Creating Hosts on VMware. In addition to this, we are guiding an end-user to enter the correct values in the field of Name and Value.

https://bugzilla.redhat.com/show_bug.cgi?id=2122797

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6
* [X] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [X] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
