### PR TITLE
correct module-enable-note for capsules and non-satellite builds

### DIFF
--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -1,2 +1,3 @@
 // Overrides for foreman-el build
-:dnf-modules: foreman:el8
+:dnf-module: foreman:el8
+:dnf-modules: {dnf-module}

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -4,4 +4,5 @@
 :installer-scenario: foreman-installer --scenario katello
 :installer-log-file: /var/log/foreman-installer/katello.log
 :smartproxy_port: 9090
-:dnf-modules: katello:el8 pulpcore:el8
+:dnf-module: katello:el8
+:dnf-modules: {dnf-module} pulpcore:el8

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -130,4 +130,5 @@
 :project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}
-:dnf-modules: satellite:el8
+:dnf-module: satellite:el8
+:dnf-modules: {dnf-module}

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -1,6 +1,7 @@
 [id="configuring-repositories-proxy_{context}"]
 
 = Configuring Repositories
+:dnf-module: satellite-capsule:el8
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
@@ -26,12 +27,12 @@ Use this procedure to enable the repositories that are required to install {Prod
 +
 [options="nowrap"]
 ----
-# dnf module enable satellite-capsule:el8
+# dnf module enable {dnf-module}
 ----
 +
 [NOTE]
 ====
-include::snip_satellite-el8-enable-note.adoc[]
+include::snip_dnf-module-enable-note.adoc[]
 ====
 +
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -91,8 +91,6 @@ ifdef::foreman-el,katello,satellite[]
 ----
 # dnf module enable {dnf-modules}
 ----
-endif::[]
-ifdef::satellite[]
 +
 [NOTE]
 ====

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -96,7 +96,7 @@ ifdef::satellite[]
 +
 [NOTE]
 ====
-include::snip_satellite-el8-enable-note.adoc[]
+include::snip_dnf-module-enable-note.adoc[]
 ====
 endif::[]
 

--- a/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
+++ b/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
@@ -43,8 +43,8 @@ ifdef::satellite[]
 +
 [NOTE]
 ====
-The script contains a command that enables the `satellite:el8` module.
-include::snip_satellite-el8-enable-note.adoc[]
+The script contains a command that enables the `{dnf-module}` module.
+include::snip_dnf-module-enable-note.adoc[]
 ====
 endif::[]
 +

--- a/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
+++ b/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
@@ -39,13 +39,11 @@ Use this procedure to install the {Project} packages from the offline repositori
 ----
 # ./install_packages
 ----
-ifdef::satellite[]
 +
 [NOTE]
 ====
 The script contains a command that enables the `{dnf-module}` module.
 include::snip_dnf-module-enable-note.adoc[]
 ====
-endif::[]
 +
 If you have successfully installed the {Project} packages, the following message is displayed: `Install is complete. Please run {installer-scenario}`.

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -47,7 +47,7 @@ ifdef::satellite[]
 +
 [NOTE]
 ====
-include::snip_satellite-el8-enable-note.adoc[]
+include::snip_dnf-module-enable-note.adoc[]
 ====
 endif::[]
 endif::[]

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -43,13 +43,11 @@ endif::[]
 ----
 # dnf module enable {dnf-modules}
 ----
-ifdef::satellite[]
 +
 [NOTE]
 ====
 include::snip_dnf-module-enable-note.adoc[]
 ====
-endif::[]
 endif::[]
 ifdef::orcharhino[]
 . Ensure the prepared host has the same content available as your {ProjectServer}.

--- a/guides/common/modules/proc_resolving-package-dependency-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependency-errors.adoc
@@ -50,8 +50,8 @@ ifdef::satellite[]
 +
 [NOTE]
 ====
-The script contains a command that enables the `satellite:el8` module.
-include::snip_satellite-el8-enable-note.adoc[]
+The script contains a command that enables the `{dnf-module}` module.
+include::snip_dnf-module-enable-note.adoc[]
 ====
 endif::[]
 +

--- a/guides/common/modules/proc_resolving-package-dependency-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependency-errors.adoc
@@ -46,13 +46,11 @@ If there are further package dependency errors, repeat this procedure.
 ----
 # ./install_packages
 ----
-ifdef::satellite[]
 +
 [NOTE]
 ====
 The script contains a command that enables the `{dnf-module}` module.
 include::snip_dnf-module-enable-note.adoc[]
 ====
-endif::[]
 +
 If you have successfully installed the {Project} packages, the following message is displayed: `Install is complete. Please run {installer-scenario}`.

--- a/guides/common/modules/snip_dnf-module-enable-note.adoc
+++ b/guides/common/modules/snip_dnf-module-enable-note.adoc
@@ -1,4 +1,6 @@
-Enablement of the module `{dnf-module}` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
+Enablement of the module `{dnf-module}` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {EL} 8.
 The module `{dnf-module}` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `{dnf-module}` module.
 These warnings do not cause installation process failure, hence can be ignored safely.
+ifdef::satellite[]
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
+endif::[]

--- a/guides/common/modules/snip_dnf-module-enable-note.adoc
+++ b/guides/common/modules/snip_dnf-module-enable-note.adoc
@@ -1,0 +1,4 @@
+Enablement of the module `{dnf-module}` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
+The module `{dnf-module}` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `{dnf-module}` module.
+These warnings do not cause installation process failure, hence can be ignored safely.
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].

--- a/guides/common/modules/snip_satellite-el8-enable-note.adoc
+++ b/guides/common/modules/snip_satellite-el8-enable-note.adoc
@@ -1,4 +1,0 @@
-Enablement of the module `satellite:el8` warns about a conflict with `postgresql:10` and `ruby:2.5` as these modules are set to the default module versions on {RHEL} 8.
-The module `satellite:el8` has a dependency for the modules `postgresql:12` and `ruby:2.7` that will be enabled with the `satellite:el8` module.
-These warnings do not cause installation process failure, hence can be ignored safely.
-For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
