### PR TITLE
Refs #35531 - Use installer option to install Puppet module

### DIFF
--- a/guides/common/modules/proc_installing-openscap-plugin.adoc
+++ b/guides/common/modules/proc_installing-openscap-plugin.adoc
@@ -9,7 +9,7 @@ The OpenSCAP plug-in consists of the main OpenSCAP plug-in itself, the OpenSCAP 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --enable-foreman-plugin-openscap --enable-foreman-proxy-plugin-openscap
+# {foreman-installer} --enable-foreman-plugin-openscap --enable-foreman-proxy-plugin-openscap --foreman-proxy-plugin-openscap-puppet-module true
 ----
 ifndef::satellite[]
 . Optional: Install the OpenSCAP Hammer CLI plug-in on your {ProjectServer}:
@@ -24,13 +24,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --enable-foreman-proxy-plugin-openscap
-----
-. Install the OpenSCAP plug-in Puppet module:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} puppet-foreman_scap_client
+# {foreman-installer} --enable-foreman-proxy-plugin-openscap --foreman-proxy-plugin-openscap-puppet-module true
 ----
 . In the {ProjectWebUI}, navigate to *Configure > Puppet Classes*.
 . Click *Import environments from {foreman-example-com}*.


### PR DESCRIPTION
This new option (introduced in Foreman 3.5) removes the need to run an additional command.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.