### PR TITLE
Rework procedure to install OpenSCAP plugin (#1632)

### DIFF
--- a/guides/common/modules/proc_installing-openscap-plugin.adoc
+++ b/guides/common/modules/proc_installing-openscap-plugin.adoc
@@ -9,21 +9,22 @@ The OpenSCAP plug-in consists of the main OpenSCAP plug-in itself, the OpenSCAP 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --enable-foreman-plugin-openscap
+# {foreman-installer} --enable-foreman-plugin-openscap --enable-foreman-proxy-plugin-openscap
 ----
-. Install the OpenSCAP plug-in on your {SmartProxies}:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --enable-foreman-proxy-plugin-openscap
-----
-+
-Perform this command on both your {ProjectServer} and any attached {SmartProxies}.
-. Optional: Install the OpenSCAP Hammer CLI plug-in:
+ifndef::satellite[]
+. Optional: Install the OpenSCAP Hammer CLI plug-in on your {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --enable-foreman-cli-openscap
+----
+endif::[]
+
+. Install the OpenSCAP plug-in on any {SmartProxyServer}s:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --enable-foreman-proxy-plugin-openscap
 ----
 . Install the OpenSCAP plug-in Puppet module:
 +


### PR DESCRIPTION
This became necessary to cherry-pick the commit from @dubewarsagar 's PR for the version `3.2` and `3.1`. Because this change is applicable to even mentioned versions according to the reporter.

https://bugzilla.redhat.com/show_bug.cgi?id=2158411

(cherry picked from commit fc47b5b924ec5f28a8962c8fc6d3e8d7083d2698)

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [X] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
