### PR TITLE
Fix typo in Ansible cfg directive

### DIFF
--- a/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
+++ b/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 {Project} imports Ansible roles and variables from paths based on configuration in `/etc/ansible/ansible.cfg`.
 {Project} then runs imported roles from paths based on configuration in `/etc/foreman-proxy/ansible.cfg`.
-In both cases, {Project} reads the paths from `roles_path` and `collections_path` directives.
+In both cases, {Project} reads the paths from `roles_path` and `collections_paths` directives.
 Keep these two cfg files in sync, otherwise you might import roles that cannot be run or you will not see roles you can run.
 
 If none of the paths are specified in the configuration files, the following default paths are used:


### PR DESCRIPTION
The collections directive should be "collections_paths" (according to [ansible.cfg example](https://github.com/ansible/ansible/blob/stable-2.10/examples/ansible.cfg#L64))

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)

