### PR TITLE
Add an example of generating report entitlement

### DIFF
--- a/guides/common/modules/proc_generating-host-monitoring-reports.adoc
+++ b/guides/common/modules/proc_generating-host-monitoring-reports.adoc
@@ -31,3 +31,25 @@ If you have selected the *Send report via e-mail* checkbox, the host monitoring 
 +
 This command waits until the report fully generates before completing.
 If you want to generate the report as a background task, you can use the `hammer report-template schedule` command.
++
+[NOTE]
+====
+If you want to generate a subscription entitlement report, you have to use the `Days from Now` option to specify the latest expiration time of entitlement subscriptions.
+You can use the `no limit` value to show all entitlements.
+
+.Show all entitlements
+[options="nowrap", subs="+quotes,attributes,verbatim"]
+----
+# hammer report-template generate \
+--inputs "Days from Now=no limit" \
+--name "Subscription - Entitlement Report"
+----
+
+.Show all entitlements that are going to expire within 60 days
+[options="nowrap", subs="+quotes,attributes,verbatim"]
+----
+# hammer report-template generate \
+--inputs "Days from Now=60" \
+--name "Subscription - Entitlement Report"
+----
+====


### PR DESCRIPTION
Generating report entitlement requires an extra option compared to other reports.
CC @adamruzicka 

[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=2156762)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6
* [x] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [x] Foreman 3.2/Katello 4.4
* [x] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
