### PR TITLE
Add procedure to select columns in the host table

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -42,6 +42,8 @@ include::modules/proc_assigning-a-host-to-a-specific-location.adoc[leveloffset=+
 
 include::modules/con_switching-between-hosts.adoc[leveloffset=+1]
 
+include::modules/proc_selecting-host-columns.adoc[leveloffset=+1]
+
 include::modules/proc_removing-a-host-from-server.adoc[leveloffset=+1]
 
 include::modules/proc_disassociating-a-virtual-machine-without-removing-it-from-a-hypervisor.adoc[leveloffset=+2]

--- a/guides/common/modules/proc_selecting-host-columns.adoc
+++ b/guides/common/modules/proc_selecting-host-columns.adoc
@@ -1,0 +1,27 @@
+[id="selecting-host-columns_{context}"]
+= Selecting Host Columns
+
+You can select what columns you want to see in the host table on the *Hosts* > *All Hosts* page.
+For a complete list of host columns, see xref:overview-of-the-host-columns_{context}[].
+
+[NOTE]
+====
+It is not possible to deselect the *Name* column.
+The *Name* column serves as a primary identification method of the host.
+====
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Click *Manage columns*.
+. Select columns that you want to display.
+You can select individual columns or column categories.
+Selecting or deselecting a category selects or deselects all columns in that category.
++
+[NOTE]
+====
+Some columns are included in more than one category, but you can display a column of a specific type only once.
+By selecting or deselecting a specific column, you select or deselect all instances of that column.
+====
+
+.Verification
+* You can now see the selected columns in the host table.

--- a/guides/common/modules/ref_overview-of-the-host-columns.adoc
+++ b/guides/common/modules/ref_overview-of-the-host-columns.adoc
@@ -1,0 +1,48 @@
+[id="overview-of-the-host-columns_{context}"]
+= Overview of the Host Columns
+
+Below is the complete overview of columns that can be displayed in the host table divided into content categories.
+For more information on how to customize columns in the host table, see xref:selecting-host-columns_{context}[].
+
+// Columns are ordered as in the Web UI
+General::
+* Power - Whether the host is turned on or off, if available
+* Name - name of the host
+* Operating system - operating system of the host
+* Owner - user or group owning the host
+* Host group - host group of the host
+* Boot time - last boot time of the host
+* Last report - time of the last host report
+* Comment - comment given to host
+
+ifdef::katello,satellite,orcharhino[]
+Content::
+* Name - name of the host
+* Operating system - operating system of the host
+* Subscription status - does the host have a valid subscription attached
+* Installable updates - numbers of installable updates divided into four categories: security, bugfix, enhancement, total
+* Lifecycle Environment - lifecycle environment of the host
+* Content view - content view of the host
+* Registered - time when the host was registered to {Project}
+* Last checkin - last time of the communication between the host and the {ProjectServer}
+endif::[]
+
+Network::
+* IPv4 - IPv4 address of the host
+* IPv6 - IPv6 address of the host
+* MAC - MAC address of the host
+
+Reported data::
+* Model - host hardware model (or compute resource in case of virtual hosts)
+* Sockets - number of host sockets
+* Cores - number of host processor cores
+* RAM - amount of memory
+* Virtual - whether or not the host is recognized as a virtual machine
+* Disks total space - total host storage space
+* Kernel Version - Kernel version of the host operating system
+* BIOS vendor - vendor of the host BIOS
+* BIOS release date - release date of the host BIOS
+* BIOS version - version of the host BIOS
+
+Puppet (only if the Puppet plug-in is installed)::
+* Environment name - name of the Puppet environment of the host

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -56,4 +56,7 @@ include::common/assembly_template-writing-reference.adoc[leveloffset=+1]
 [appendix]
 include::common/assembly_job-template-examples-and-extensions.adoc[leveloffset=+1]
 
+[appendix]
+include::common/modules/ref_overview-of-the-host-columns.adoc[leveloffset=+1]
+
 endif::[]


### PR DESCRIPTION
Also added descriptions of the host columns in an appendix.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6
* [ ] Foreman 3.3/Katello 4.5 (Satellite 6.12)
* [ ] Foreman 3.2/Katello 4.4
* [ ] Foreman 3.1/Katello 4.3 (Satellite 6.11, orcharhino 6.1+)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
