### PR TITLE
Customize Ansible cfg persistently

### DIFF
--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -15,5 +15,7 @@ include::modules/proc_adding-rhel-system-roles.adoc[leveloffset=+1]
 endif::[]
 include::modules/proc_synchronizing-ansible-collections.adoc[leveloffset=+1]
 
+include::modules/ref_customizing-ansible-configuration.adoc[leveloffset=+1]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
+++ b/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
@@ -21,22 +21,25 @@ endif::[]
 [id="Ansible-paths_{context}"]
 .Ansible paths
 
-{Project} imports Ansible roles and variables from paths based on configuration in `/etc/ansible/ansible.cfg`.
-{Project} then runs imported roles from paths based on configuration in `/etc/foreman-proxy/ansible.cfg`.
-In both cases, {Project} reads the paths from `roles_path` and `collections_paths` directives.
-Keep these two cfg files in sync, otherwise you might import roles that cannot be run or you will not see roles you can run.
-
-If none of the paths are specified in the configuration files, the following default paths are used:
+{Project} imports and runs Ansible roles from the following paths:
 
 * `/etc/ansible/roles`
 * `/usr/share/ansible/roles`
 * `/etc/ansible/collections`
 * `/usr/share/ansible/collections`
 
-.Procedure
+Roles and collections from installed packages are placed under `/usr/share/ansible`.
+If you want to add custom roles or collections, place them under `/etc/ansible`.
 
-. Configure your xref:Ansible-paths_{context}[] on the {ProjectServer} and all {SmartProxyServer}s where you want to use the roles.
-. Add the roles to a directory in an xref:Ansible-paths_{context}[Ansible path] on the {ProjectServer} and all {SmartProxyServer}s from where you want to use the roles.
+ifdef::satellite[]
+Note that Red{nbsp}Hat provides support only for Ansible roles and collections obtained from Red{nbsp}Hat.
+endif::[]
+
+The paths are configured by {Project}.
+For more information, see xref:customizing-ansible-configuration_{context}[].
+
+.Procedure
+. Add the roles to a directory in an xref:Ansible-paths_{context}[Ansible path] on {ProjectServer} and all {SmartProxyServer}s from where you want to use the roles.
 If you want to use custom or third party Ansible roles, ensure to configure an external version control system to synchronize roles between {ProjectServer} and {SmartProxyServer}s.
 
 . On all {SmartProxyServer}s that you want to use to run Ansible roles on hosts, enable the Ansible plug-in:

--- a/guides/common/modules/ref_customizing-ansible-configuration.adoc
+++ b/guides/common/modules/ref_customizing-ansible-configuration.adoc
@@ -1,0 +1,31 @@
+[id="customizing-ansible-configuration_{context}"]
+= Customizing Ansible Configuration
+
+{Project} manages essential Ansible configuration that is required for Ansible integration with {Project}.
+However, you can customize other Ansible configuration options as usual.
+
+{Project} stores the essential Ansible configuration as environment variables in `/etc/foreman-proxy/ansible.env`.
+This file is managed by the {foreman-installer}.
+
+Ansible reads configuration from `/etc/ansible/ansible.cfg` and the environment provided by {SmartProxy}.
+If you need to customize Ansible configuration, you can do so in the `/etc/ansible/ansible.cfg` file.
+
+Note that environment variables take precedence over values in `ansible.cfg`, which ensures that the essential configuration required by {Project} is retained.
+
+The following table lists the essential Ansible configuration options managed by {Project}.
+
+.Essential Ansible Configuration
+[options="header",cols="1,1,2"]
+|====
+| Environment Variable | Config Key | Description
+| ANSIBLE_CALLBACK_WHITELIST | callback_whitelist | Enables callback to {Project}; equivalent to `callbacks_enabled` for cross-version compatibility
+| ANSIBLE_CALLBACKS_ENABLED | callbacks_enabled | Enables callback to {Project}; equivalent to `callback_whitelist` for cross-version compatibility
+| ANSIBLE_COLLECTIONS_PATHS | collections_paths | List of paths to Ansible collections
+| ANSIBLE_LOCAL_TEMP | local_tmp | Temporary directory on {SmartProxy}
+| ANSIBLE_HOST_KEY_CHECKING | host_key_checking | Disables checking of host keys during SSH connection
+| ANSIBLE_ROLES_PATH | roles_path | List of paths to Ansible roles
+| ANSIBLE_SSH_ARGS | ssh_args | Arguments passed to SSH connection
+|====
+
+.Additional resources
+* https://docs.ansible.com/ansible/latest/reference_appendices/config.html[Ansible Configuration Settings]


### PR DESCRIPTION
Foreman used to store essential Ansible settings in a config file that was managed by Foreman (and overwritten on each foreman-installer run). Now, Foreman stores these values as `.env`. This allows the user to customize Ansible configuration in a persistent manner.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
