### PR TITLE
Add missing step to enable satellite-utils module

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -18,6 +18,12 @@ ifdef::satellite[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
 ----
+. Enable the satellite-utils module.
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# dnf module enable satellite-utils
+----
 endif::[]
 . Install the Pulp Manifest package:
 +

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -18,7 +18,7 @@ ifdef::satellite[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
 ----
-. Enable the satellite-utils module.
+. Enable the satellite-utils module:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -43,6 +43,12 @@ ifdef::satellite[]
 --enable={RepoRHEL7ServerSatelliteUtils} \
 --enable={RepoRHEL7Server}
 ----
+. Enable the satellite-utils module.
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# dnf module enable satellite-utils
+----
 endif::[]
 . Install the Pulp Manifest package:
 ** On {EL} 8:

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -43,7 +43,7 @@ ifdef::satellite[]
 --enable={RepoRHEL7ServerSatelliteUtils} \
 --enable={RepoRHEL7Server}
 ----
-. Enable the satellite-utils module.
+. Enable the satellite-utils module:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
Enabling Satellite Utils module was missing in 2 modules: 
Creating a Local Source for a Custom File Type Repository and 
Creating a Remote Source for a Custom File Type Repository

This has been reported in BZ2116585.
For confirmation see: https://bugzilla.redhat.com/show_bug.cgi?id=2116585#c12

https://bugzilla.redhat.com/show_bug.cgi?id=2116585


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
