### PR TITLE
Enhance the procedure to export Subscription Manifest

### DIFF
--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -17,6 +17,7 @@ endif::[]
 +
 If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
 To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
+For more information, see {ContentManagementDocURL}managing_red_hat_subscriptions_content-management[Managing Red Hat Subscriptions] in _{ContentManagementDocTitle}_.
 
 . For the `x86_64` entry, click the *Enable* icon to enable the repository.
 

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -17,7 +17,7 @@ endif::[]
 +
 If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
 To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
-For more information, see {ContentManagementDocURL}managing_red_hat_subscriptions_content-management[Managing Red Hat Subscriptions] in _{ContentManagementDocTitle}_.
+For more information, see {ContentManagementDocURL}Managing_Red_Hat_Subscriptions_content-management[Managing Red Hat Subscriptions] in _{ContentManagementDocTitle}_.
 
 . For the `x86_64` entry, click the *Enable* icon to enable the repository.
 


### PR DESCRIPTION
The current procedure does not give a clear understanding of exporting the Subscription Manifest from the Red Hat Hybrid Cloud Console. We added enhanced navigation to export the manifest and import it into the Satellite.

https://bugzilla.redhat.com/show_bug.cgi?id=2158805

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
-
Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
