### PR TITLE
Replace bootstrap with the curl command on 3.2 and 3.1

### DIFF
--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -47,24 +47,8 @@ For more information, see {InstallingServerDocURL}configuring-satellite-custom-s
 ----
 . Optional: If you have created a custom SSL certificate for the new {ProjectServer} host name, run the {Project} installation script to install the certificate.
 For more information about installing a custom SSL certificate, see {InstallingServerDocURL}Deploying_a_Custom_SSL_Certificate_to_Server_{project-context}[Deploying a Custom SSL Certificate to {ProjectServer}] in _Installing {ProjectServer} from a Connected Network_.
-. On all {Project} clients, enter the following commands to reinstall the bootstrap RPM, reregister clients, and refresh their subscriptions.
-+
-You can use remote execution feature to perform this step.
-For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting up Remote Jobs] in _Managing Hosts_.
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# yum remove -y katello-ca-consumer*
-
-# rpm -Uvh http://_new-{foreman-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
-
-# subscription-manager register \
---org="_My_Organization_" \
---environment="_Library_" \
---force
-
-# subscription-manager refresh
-----
+. Reregister all {Project} hosts.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 . On all {SmartProxyServer}s, run the {Project} installation script to update references to the new host name:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
The bootstrap procedure to register hosts is deprecated, users should use the curl command instead.

Resolves merge conflicts in #1927. The content is verified by SME.

(cherry picked from commit 46a85444cda166a4253b29a8eef05f5dc37e52b0)


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
