### PR TITLE
Add missing instructions for EL 8

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -18,13 +18,20 @@ For more information, see the Red Hat Knowledgebase solution https://access.redh
 .To Update {ProjectServer}:
 
 . Ensure the {Project} Maintenance repository is enabled:
+** For {EL} 8:
 +
-[options="nowrap" subs="attributes"]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable \
+{RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+** For {EL} 7:
++
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable \
 {RepoRHEL7ServerSatelliteMaintenanceProductVersion}
 ----
-
 . Check the available versions to confirm the next minor version is listed:
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
Instructions were missing to enable {Project} Maintenance repository on EL 8. 
The same has been reported in BZ-2114484 and fixed in this PR.

https://bugzilla.redhat.com/show_bug.cgi?id=2114484

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
