### PR TITLE
Change link for manifests for Subscription

### DIFF
--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -14,7 +14,7 @@ Note that legacy subscription management, including the need to attach subscript
 endif::[]
 
 ifndef::orcharhino[]
-To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/red_hat_subscription_management/2022/html/using_red_hat_subscription_management/using_manifests_con[Using Manifests] in _Using Red Hat Subscription Management_.
+To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 
 Use this chapter to import a Red{nbsp}Hat Subscription Manifest and manage the manifest within the {ProjectWebUI}.

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -13,7 +13,7 @@ Note that legacy subscription management, including the need to attach subscript
 {Team} recommends that you use https://access.redhat.com/articles/simple-content-access[Simple Content Access] as a substitute.
 endif::[]
 
-ifndef::orcharhino[]
+ifdef::satellite[]
 To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 


### PR DESCRIPTION
Manifests have migrated to the Hybrid Cloud Console. New documentation
is available at Subscription Central
(https://access.redhat.com/documentation/
en-us/subscription_central/2021).
The link has been updated to reflect this change.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
