### PR TITLE
Add missing attribute lable to a code block

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -2,6 +2,7 @@
 
 = Configuring Repositories
 :dnf-module: satellite-capsule:el8
+:package-manager: dnf
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
 

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -2,6 +2,7 @@
 
 = Configuring Repositories
 :dnf-module: satellite-capsule:el8
+:package-manager: dnf
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
@@ -38,10 +39,10 @@ include::snip_dnf-module-enable-note.adoc[]
 
 NOTE: If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
-+
+
 . Optional: Verify that the required repositories are enabled:
 +
-[options="nowrap"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-manager} repolist enabled
 ----

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -2,7 +2,6 @@
 
 = Configuring Repositories
 :dnf-module: satellite-capsule:el8
-:package-manager: dnf
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
 


### PR DESCRIPTION
"attributes" lable was missing for one of the code-blocks.

It was causing one of the attribute to render incorrectly.

The same has been fixed in this MR.

https://bugzilla.redhat.com/show_bug.cgi?id=2161266


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
