### PR TITLE
Missing "attributes" lable for one of code-blocks

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -2,6 +2,7 @@
 
 = Configuring Repositories
 :dnf-module: satellite-capsule:el8
+:package-manager: dnf
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
 
@@ -48,7 +49,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 +
 . Optional: Verify that the required repositories are enabled:
 +
-[options="nowrap"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-manager} repolist enabled
 ----


### PR DESCRIPTION
It was causing one of the attribute to render incorrectly. 
Original PR is #1938. 
This PR is for version 3.4 only. 

https://bugzilla.redhat.com/show_bug.cgi?id=2161266


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
