### PR TITLE
Add a step to reindex databases after migration to RHEL8

### DIFF
--- a/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
+++ b/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
@@ -7,3 +7,9 @@ After you perform a fresh installation of {ProjectServer} or {SmartProxyServer} 
 * Restore a backup on the target server:
 ** To restore a full backup, see {AdministeringDocURL}Restoring_from_a_Full_Backup_admin[Restoring From a Full Backup] in _{AdministeringDocTitle}_.
 ** To restore an incremental backup, see {AdministeringDocURL}Restoring_from_Incremental_Backups_admin[Restoring From Incremental Backups] in _{AdministeringDocTitle}_.
+* Reindex the databases:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# runuser -u postgres -- reindexdb -a
+----

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -285,6 +285,13 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 # journalctl -u leapp_resume -f
 ----
 
+. Reindex the databases:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# runuser -u postgres -- reindexdb -a
+----
+
 ifdef::foreman-el[]
 . Enable the Foreman module:
 +


### PR DESCRIPTION
Repo sync fails on Project servers installed on RHEL8. This happens for systems that have been upgraded from RHEL 7 to RHEL 8, or migrated to RHEL 8. A workaround for this is to reindex the databases after upgrading or migrating to RHEL 8. Adding this workaround to the two procedures that are impacted by this bug.

Bug link: https://bugzilla.redhat.com/show_bug.cgi?id=2161413


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
