### PR TITLE
Register hosts through a load balancer

### DIFF
--- a/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
+++ b/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
@@ -1,0 +1,32 @@
+[id="setting-the-load-balancer-for-host-registration_{context}"]
+= Setting the Load Balancer for Host Registration
+
+You can configure {Project} to register clients through a load balancer when using the host registration feature.
+
+You will be able to register hosts to the load balancer instead of {SmartProxy}.
+The load balancer will decide through which {SmartProxy} to register the host at the time of request.
+Upon registration, the subscription manager on the host will be configured to manage content through the load balancer.
+
+.Prerequisites
+* You configured SSL certificates on all {SmartProxyServer}s.
+For more information, see xref:configuring-capsule-servers-for-load-balancing[].
+* You enabled Registration and Templates plug-ins on all {SmartProxyServer}s:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {installer-scenario-smartproxy} \
+--foreman-proxy-registration true \
+--foreman-proxy-templates true
+----
+
+.Procedure
+. On all {SmartProxyServer}s, set the registration and template URLs using `{foreman-installer}`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {installer-scenario-smartproxy} \
+--foreman-proxy-registration-url "https://_loadbalancer.example.com_:{smartproxy_port}" \
+--foreman-proxy-template-url "https://_loadbalancer.example.com_:8000"
+----
+. In the {ProjectWebUI}, navigate to *Infrastracture* > *{SmartProxies}*.
+. For each {SmartProxy}, click the dropdown menu in the *Actions* column and select *Refresh*.

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -1,18 +1,15 @@
-You can register hosts with {Project} using the host registration feature, the {Project} API, or Hammer CLI.
+You can register hosts with {Project} using the host registration feature in the {ProjectWebUI}, Hammer CLI, or the {Project} API.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts > Register Host*.
+ifeval::["{context}" == "load-balancing"]
+. From the *{SmartProxy}* dropdown list, select the load balancer.
+. Select *Force* to register a host that has been previously registered to a {SmartProxyServer}.
+endif::[]
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
-. Log in to the host you want register and run the previously generated command.
-. Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager config \
---rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
---server.hostname=loadbalancer.example.com
-----
+. Connect to your host using SSH and run the registration command.
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 
 .CLI procedure
@@ -31,15 +28,15 @@ ifdef::katello,satellite,orcharhino[]
 --activation-keys "_My_Activation_Key_"
 ----
 endif::[]
-. Log in to the host you want register and run the previously generated command.
-. Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
+ifeval::["{context}" == "load-balancing"]
 +
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager config \
---rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
---server.hostname=loadbalancer.example.com
-----
+Include the `--smart-proxy-id __{SmartProxy}_ID__` option.
+You can use the ID of any {SmartProxyServer} that you configured for host registration load balancing.
+{Project} will apply the load balancer to the registration command automatically.
++
+Include the `--force` option to register a host that has been previously registered to a {SmartProxyServer}.
+endif::[]
+. Connect to your host using SSH and run the registration command.
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 
 .API procedure
@@ -65,18 +62,18 @@ ifdef::katello,satellite,orcharhino[]
 Use an activation key to simplify specifying the environments.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
+ifeval::["{context}" == "load-balancing"]
 +
-To enter a password as command line argument, use `username:password` syntax.
+Include `{ "smart_proxy_id": __{SmartProxy}_ID__ }`.
+You can use the ID of any {SmartProxyServer} that you configured for host registration load balancing.
+{Project} will apply the load balancer to the registration command automatically.
++
+Include `{ "force": true }` to register a host that has been previously registered to a {SmartProxyServer}.
+endif::[]
++
+To enter a password as a command line argument, use `username:password` syntax.
 Keep in mind this can save the password in the shell history.
-+
-For more information about registration see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host to {ProjectName}] in _{ManagingHostsDocTitle}_.
-. Log in to the host you want register and run the previously generated command.
-. Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager config \
---rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
---server.hostname=loadbalancer.example.com
-----
+Alternatively, you can use a temporary personal access token instead of a password.
+To generate a token in the {ProjectWebUI}, navigate to *My Account* > *Personal Access Tokens*.
+. Connect to your host using SSH and run the registration command.
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -32,6 +32,8 @@ include::topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with
 // Configuring Capsule Server with Custom SSL Certificates and with Puppet for Load Balancing
 include::topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc[leveloffset=+2]
 
+include::common/modules/proc_setting-the-load-balancer-for-host-registration.adoc[leveloffset=+1]
+
 //Installing the Load Balancer
 include::topics/Installing_the_Load_Balancer.adoc[leveloffset=+1]
 

--- a/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Installing_the_Load_Balancer.adoc
@@ -29,16 +29,16 @@ For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg`
 +
 [id='ports-configuration-for-the-load-balancer']
 .Ports Configuration for the Load Balancer
-[cols="18%,16%,16%,20%,30%",options="header"]
+[cols="3,1,1,2,3",options="header"]
 |====
 | Service | Port | Mode | Balance Mode | Destination
 | HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServer}s
-//| Anaconda | 8000 | TCP | roundrobin | port 8000 on all {SmartProxies}
 | HTTPS and RHSM | 443 | TCP | source | port 443 on all {SmartProxyServer}s
 | AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServer}s
+| Anaconda for template retrieval | 8000 | TCP | roundrobin | port 8000 on all {SmartProxyServer}s
 | Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServer}s
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates
-| SmartProxy (_Optional for OpenScap_)| 9090 | TCP | roundrobin | port 9090 on all {SmartProxyServer}s
+| {SmartProxy} HTTPS for Host Registration and optionally OpenSCAP| {smartproxy_port} | TCP | roundrobin | port {smartproxy_port} on all {SmartProxyServer}s
 |====
 
 . Configure the load balancer to disable SSL offloading and allow client-side SSL certificates to pass through to back end servers.

--- a/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Registering_Clients.adoc
@@ -1,9 +1,9 @@
 [id='registering-clients']
-= Registering Clients
+= Registering Clients to the Load Balancer
 
-You can register a client running a {EL} 6, 7, or 8 operating system to {SmartProxyServer}s that you configure for load balancing.
-For more information about registering clients and configuring them to use Puppet, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+To balance the load of network traffic from clients, you must register the clients to the load balancer.
 
+ifdef::orcharhino,satellite[]
 To register clients, proceed to one of the following procedures:
 
 * xref:registering-clients-using-the-host-registration[]
@@ -11,10 +11,12 @@ To register clients, proceed to one of the following procedures:
 * xref:registering-clients-manually[]
 
 [id='registering-clients-using-the-host-registration']
-== {ProjectName} host registration
+== Registering Clients Using Host Registration
+endif::[]
 
 include::../common/modules/snip_host-registration-steps.adoc[]
 
+ifdef::orcharhino,satellite[]
 [id='registering-clients-using-the-bootstrap-script']
 == **(Deprecated)** Registering Clients Using the Bootstrap Script
 
@@ -22,10 +24,10 @@ To register clients, enter the following command on the client.
 You must complete the registration procedure for each client.
 
 .Prerequisite
-
-Ensure that you install the bootstrap script on the client and change the script's file permissions to executable.
+* Ensure that you install the bootstrap script on the client and change file permissions of the script to executable.
 For more information, see {ManagingHostsDocURL}Registering_a_Host_Using_the_Bootstrap_Script_managing-hosts[Registering Hosts to {ProjectName} Using The Bootstrap Script] in _{ManagingHostsDocTitle}_.
 
+.Procedure
 * On {EL} 8, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -44,8 +46,7 @@ For more information, see {ManagingHostsDocURL}Registering_a_Host_Using_the_Boot
 <1> Include the `--puppet-ca-port 8141` option if you use Puppet.
 <2> Include the `--force` option to register the client that has been previously registered to a standalone {SmartProxy}.
 
-
-* On {EL} 7, 6, or 5, enter the following command:
+* On {EL} 7 or 6, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -92,3 +93,4 @@ To register clients manually, complete the following procedure on each client th
 --org=_Your_Organization_ \
 --serverurl=https://_loadbalancer.example.com_/rhsm
 ----
+endif::[]


### PR DESCRIPTION
In a deployment with load balancing, the user can configure SmartProxies to provide a load balancer as an option for the global registration feature. Then the user can register hosts in Foreman to the load balancer directly, which eliminates the need to manually reconfigure subscription manager on the hosts after registration.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
