### PR TITLE
Add note about support for LEAPP upgrade of FIPS systems

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -39,9 +39,9 @@ endif::[]
 ifdef::satellite[]
 [NOTE]
 ====
-- {Project} supports DEFAULT and FIPS crypto-policies.
+* {Project} supports DEFAULT and FIPS crypto-policies.
 The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
-- In-place upgrade of {EL} systems in FIPS mode is not supported by {Team}.
+* In-place upgrade of {EL} systems in FIPS mode is not supported by {Team}.
 Turning FIPS off, upgrading from {EL} 7 to {EL} 8, and then turning FIPS on is not supported either.
 Instead, install {Project} {ProductVersion} on a freshly installed {EL} 8 system with FIPS mode enabled.
 ====

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -39,8 +39,11 @@ endif::[]
 ifdef::satellite[]
 [NOTE]
 ====
-{Project} supports DEFAULT and FIPS crypto-policies.
+- {Project} supports DEFAULT and FIPS crypto-policies.
 The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
+- In-place upgrade of {EL} systems in FIPS mode is not supported by {Team}.
+Turning FIPS off, upgrading from {EL} 7 to {EL} 8, and then turning FIPS on is not supported either.
+Instead, install {Project} {ProductVersion} on a freshly installed {EL} 8 system with FIPS mode enabled.
 ====
 endif::[]
 

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -43,7 +43,8 @@ ifdef::satellite[]
 The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
 * In-place upgrade of {EL} systems in FIPS mode is not supported by {Team}.
 Turning FIPS off, upgrading from {EL} 7 to {EL} 8, and then turning FIPS on is not supported either.
-Instead, install {Project} {ProductVersion} on a freshly installed {EL} 8 system with FIPS mode enabled.
+Instead, migrate the {Project} {ProductVersion} to a freshly installed {EL} 8 system with FIPS mode enabled.
+For more information, see xref:migrating-{project-context}-to-a-new-el-system_{context}[].
 ====
 endif::[]
 

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -43,7 +43,7 @@ ifdef::satellite[]
 The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
 * In-place upgrade of {EL} systems in FIPS mode is not supported by {Team}.
 Turning FIPS off, upgrading from {EL} 7 to {EL} 8, and then turning FIPS on is not supported either.
-Instead, migrate the {Project} {ProductVersion} to a freshly installed {EL} 8 system with FIPS mode enabled.
+Instead, migrate your {Project} {ProductVersion} to a freshly installed {EL} 8 system with FIPS mode enabled.
 For more information, see xref:migrating-{project-context}-to-a-new-el-system_{context}[].
 ====
 endif::[]


### PR DESCRIPTION
Red Hat does not support LEAPP upgrades from RHEL 7 to RHEL 8 for systems that have FIPS enabled. As a workaround some users turn off FIPS to perform LEAPP upgrade and then turn it back on, however, this is not supported either and causes further issues. It is advisable to go with a fresh installation on a RHEL 8 system instead. Adding a note about supportability for LEAPP upgrade of FIPS enabled systems for clarification.

Bug link: https://bugzilla.redhat.com/show_bug.cgi?id=2159785


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
