### PR TITLE
Simplify the firewall command for ports

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -47,6 +47,8 @@
 :customrpmtitle: RPM
 :customssl: SSL
 :customssltitle: SSL
+:firewalld-profile: RH-Satellite-6
+:firewalld-profile-proxy: foreman-proxy
 :foreman-example-com: foreman.example.com
 :foreman-installer: foreman-installer
 :foreman-installer-package: foreman-installer

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -6,3 +6,4 @@
 :smartproxy_port: 9090
 :dnf-module: katello:el8
 :dnf-modules: {dnf-module} pulpcore:el8
+:firewalld-profile-proxy: RH-Satellite-6-capsule

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -36,6 +36,8 @@
 :customssl: custom SSL
 :customssltitle: Custom SSL
 :foreman-example-com: orcharhino.example.com
+:firewalld-profile: orcharhino
+:firewalld-profile-proxy: orcharhino-proxy
 :installer-scenario-smartproxy: orcharhino-installer --no-enable-foreman
 :installer-scenario: foreman-installer --scenario katello
 :installer-log-file: /var/log/foreman-installer/katello.log

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -54,6 +54,7 @@
 :customssltitle: Custom SSL
 :DocState: satellite
 :EL: {RHEL}
+:firewalld-profile-proxy: RH-Satellite-6-capsule
 :foreman-example-com: satellite.example.com
 :foreman-installer-package: satellite-installer
 :foreman-installer: satellite-installer

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -11,21 +11,9 @@ include::snip_firewalld.adoc[]
 .Procedure
 . To open the ports for client to {Project} communication, enter the following command on the base operating system that you want to install {Project} on:
 +
-[options="nowrap"]
+[options="nowrap", subs="+quotes,attributes"]
 ----
-# firewall-cmd \
---add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" \
---add-port="69/udp" \
---add-port="80/tcp" --add-port="443/tcp" \
-ifdef::katello,satellite,orcharhino[]
---add-port="5647/tcp" \
---add-port="8000/tcp" --add-port="9090/tcp" \
-endif::[]
-ifndef::katello,satellite,orcharhino[]
---add-port="8443/tcp" \
-endif::[]
---add-port="8140/tcp"
+# firewall-cmd --add-service={firewalld-profile}
 ----
 . Make the changes persistent:
 +

--- a/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
@@ -8,16 +8,3 @@ On {ProjectServer}, you must enable the incoming connection from {SmartProxyServ
 For more information, see {InstallingServerDocURL}Enabling_Connections_from_a_Client_to_Server_{project-context}[Enabling Connections from a Client to {ProjectServer}] in _{InstallingServerDocTitle}_.
 
 include::snip_firewalld.adoc[]
-
-.Procedure
-. On {ProjectServer}, enter the following command to open the port for {SmartProxy} to {Project} communication:
-+
-[options="nowrap"]
-----
-# firewall-cmd --add-port="5646/tcp"
-----
-. Make the changes persistent:
-+
-----
-# firewall-cmd --runtime-to-permanent
-----

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -10,23 +10,10 @@ include::snip_firewalld.adoc[]
 
 . On the base operating system on which you want to install {SmartProxy}, enter the following command to open the ports for {ProjectServer} and clients communication to {SmartProxyServer}:
 +
-[options="nowrap"]
+[options="nowrap", subs="+quotes,attributes"]
 ----
-# firewall-cmd \
---add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" \
---add-port="69/udp" \
-ifdef::katello,satellite,orcharhino[]
---add-port="80/tcp" --add-port="443/tcp" \
---add-port="5647/tcp" \
-endif::[]
---add-port="8140/tcp" \
---add-port="8443/tcp" \
-ifdef::katello,satellite,orcharhino[]
---add-port="8000/tcp" --add-port="9090/tcp"
-endif::[]
+# firewall-cmd --add-service={firewalld-profile-proxy}
 ----
-
 . Make the changes persistent:
 +
 ----


### PR DESCRIPTION
While enabling connections from a Client to Project Server, we open the ports by mentioning all the required ports in the command. However, it can be further simplified by adding just a single command that includes all those ports and practically does the same task as an older one. Therefore, we replaced it with a simple command. Although, we can keep both or either.

https://bugzilla.redhat.com/show_bug.cgi?id=2161296

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
