### PR TITLE
missing step to enable Sat Utils in 2 modules

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -18,6 +18,12 @@ ifdef::satellite[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
 ----
+. Enable the satellite-utils module:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# dnf module enable satellite-utils
+----
 endif::[]
 . Install the Pulp Manifest package:
 ifndef::satellite[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -34,6 +34,12 @@ ifdef::satellite[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
 ----
+. Enable the satellite-utils module:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# dnf module enable satellite-utils
+----
 endif::[]
 . Install the Pulp Manifest package:
 ifndef::satellite[]


### PR DESCRIPTION
Creating a Local Source for a Custom File Type Repository and 
Creating a Remote Source for a Custom File Type Repository 
This PR is a clone of PR#1930 for foreman version 3.3 and 3.1

For confirmation see: https://bugzilla.redhat.com/show_bug.cgi?id=2116585#c12
https://bugzilla.redhat.com/show_bug.cgi?id=2116585


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
