### PR TITLE
Update LB docs to include puppet options in installer commands in bra…

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
@@ -173,7 +173,13 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca "true" \
 --puppet-server-ca "true" \
---enable-foreman-proxy-plugin-remote-execution-ssh
+--enable-foreman-proxy-plugin-remote-execution-script \
+--foreman-proxy-content-puppet true \
+--enable-puppet \
+--puppet-server true \
+--puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
+--puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
+--puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
 ----
 
 . On {SmartProxyServer}, generate Puppet certificates for all other {SmartProxies} that you configure for load balancing, except this first system where you configure Puppet certificates signing:

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
@@ -65,7 +65,13 @@ root@_{smart-proxy-context}-ca.example.com_:__{smart-proxy-context}-ca.example.c
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --foreman-proxy-puppetca "true" \
 --puppet-server-ca "true" \
---enable-foreman-proxy-plugin-remote-execution-ssh
+--enable-foreman-proxy-plugin-remote-execution-script \
+--foreman-proxy-content-puppet true \
+--enable-puppet \
+--puppet-server true \
+--puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
+--puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
+--puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
 ----
 
 . On {SmartProxyServer}, stop the Puppet server:


### PR DESCRIPTION
…nch 3.2.

Same change as https://github.com/theforeman/foreman-documentation/pull/1828. Created a separate PR for 3.2 as suggested in the original PR.

As puppetserver and puppet-related features are disabled in later versions, the installer options in the LB docs fail for "with Puppet" scenarios.

The procedures in the below two sections are affected: 1.Configuring {SmartProxyServer} with Default SSL Certificates for Load Balancing with Puppet 2.Configuring {SmartProxyServer} with Custom SSL Certificates for Load Balancing with Puppet

The installer commands in these two sections result in the error:

[ERROR ] [configure] Could not set groups on user[foreman-proxy]: Execution of '/sbin/usermod -G puppet foreman-proxy' returned 6: usermod: group 'puppet' does not exist

This is because the puppetserver package is not installed yet and hence no puppet group is present either.

Updating the installer options to include options to use Puppet integration on Capsules, enable Puppet integration and install Puppet server on Capsules.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
