### PR TITLE
Refs #35985 - Update Puppet enablement options

### DIFF
--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -15,12 +15,8 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 --enable-foreman-cli-puppet \
 --foreman-proxy-puppet true \
 --foreman-proxy-puppetca true \
---foreman-proxy-content-puppet true \
 --enable-puppet \
---puppet-server true \
---puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
---puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
---puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+--puppet-server true
 ----
 . If you want to use Puppet integration on {SmartProxies}, enable Puppet integration and install Puppet server on {SmartProxies}:
 +
@@ -28,11 +24,7 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 ----
 # {foreman-installer} --foreman-proxy-puppet true \
 --foreman-proxy-puppetca true \
---foreman-proxy-content-puppet true \
 --enable-puppet \
---puppet-server true \
---puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
---puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
---puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key \
+--puppet-server true
 --puppet-server-foreman-url "https://_{foreman-example-com}_"
 ----

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Custom_SSL_Certificates_and_with_Puppet_for_Load_Balancing.adoc
@@ -174,12 +174,8 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --foreman-proxy-puppetca "true" \
 --puppet-server-ca "true" \
 --enable-foreman-proxy-plugin-remote-execution-script \
---foreman-proxy-content-puppet true \
 --enable-puppet \
---puppet-server true \
---puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
---puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
---puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+--puppet-server true
 ----
 
 . On {SmartProxyServer}, generate Puppet certificates for all other {SmartProxies} that you configure for load balancing, except this first system where you configure Puppet certificates signing:

--- a/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
+++ b/guides/doc-Configuring_Load_Balancer/topics/Configuring_Capsule_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet.adoc
@@ -66,12 +66,8 @@ root@_{smart-proxy-context}-ca.example.com_:__{smart-proxy-context}-ca.example.c
 --foreman-proxy-puppetca "true" \
 --puppet-server-ca "true" \
 --enable-foreman-proxy-plugin-remote-execution-script \
---foreman-proxy-content-puppet true \
 --enable-puppet \
---puppet-server true \
---puppet-server-foreman-ssl-ca /etc/pki/katello/puppet/puppet_client_ca.crt \
---puppet-server-foreman-ssl-cert /etc/pki/katello/puppet/puppet_client.crt \
---puppet-server-foreman-ssl-key /etc/pki/katello/puppet/puppet_client.key
+--puppet-server true
 ----
 
 . On {SmartProxyServer}, stop the Puppet server:


### PR DESCRIPTION
As part of a larger feature, this simplifies the options users need to pass to enable Puppet.

Right now this still depends on https://github.com/theforeman/foreman-installer/pull/828 and its dependencies to be merged. It's just to demonstrate the new way for end users.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.