### PR TITLE
Update the Executing a remote job procedure

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -42,6 +42,8 @@ include::modules/proc_setting-up-job-templates.adoc[leveloffset=+1]
 
 include::modules/proc_executing-a-remote-job.adoc[leveloffset=+1]
 
+include::modules/ref_advanced-settings-in-the-job-wizard.adoc[leveloffset=+1]
+
 include::modules/proc_scheduling-a-recurring-ansible-job-for-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_scheduling-a-recurring-ansible-job-for-a-hostgroup.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -6,45 +6,54 @@ You can execute a job that is based on a job template against one or more hosts.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-executing-a-remote-job_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the target hosts on which you want to execute a remote job.
-You can use the search field to filter the host list.
-. From the *Select Action* list, select *Schedule a Job*.
-. On the *Job invocation* page, define the main job settings:
-. Select the *Job category* and the *Job template* you want to use.
-. Optional: Select a stored search string in the *Bookmark* list to specify the target hosts.
-. Optional: Further limit the targeted hosts by entering a *Search query*.
-The *Resolves to* line displays the number of hosts affected by your query.
-Use the refresh button to recalculate the number after changing the query.
-The preview icon lists the targeted hosts.
-. The remaining settings depend on the selected job template.
-See {ManagingHostsDocURL}creating-a-job-template_managing-hosts[Creating a Job Template] for information on adding custom parameters to a template.
-. Optional: To configure advanced settings for the job, click *Display advanced fields*.
-Some of the advanced settings depend on the job template, the following settings are general:
-
-* *Effective user* defines the user for executing the job, by default it is the SSH user.
-
-* *Concurrency level* defines the maximum number of jobs executed at once, which can prevent overload of systems' resources in a case of executing the job on a large number of hosts.
-
-* *Timeout to kill* defines time interval in seconds after which the job should be killed, if it is not finished already.
-A task which could not be started during the defined interval, for example, if the previous task took too long to finish, is canceled.
-
-* *Type of query* defines when the search query is evaluated.
-This helps to keep the query up to date for scheduled tasks.
-
-* *Execution ordering* determines the order in which the job is executed on hosts: alphabetical or randomized.
+. In the {ProjectWebUI}, navigate to *Monitor* > *Jobs* and click *Run job*.
 +
-*Concurrency level* and *Timeout to kill* settings enable you to tailor job execution to fit your infrastructure hardware and needs.
-
-. To run the job immediately, ensure that *Schedule* is set to *Execute now*.
-You can also define a one-time future job, or set up a recurring job.
-For recurring tasks, you can define start and end dates, number and frequency of runs.
-You can also use cron syntax to define repetition.
-ifndef::orcharhino[]
-For more information about cron, see https://www.redhat.com/sysadmin/automate-linux-tasks-cron[Automate your Linux system tasks with cron].
+[NOTE]
+====
+{Project} {ProjectVersion} features a new job wizard.
+If you want to use job wizard from earlier {Project} versions, click *Use legacy form* in the top right corner of the job wizard.
+Note that this guide only applies to the new job wizard.
+====
+. Select the *Job category* and the *Job template* you want to use, then click *Next*.
+. Select hosts on which you want to run the job.
+ifdef::satellite,orcharhino,katello[]
+You can filter hosts by host names, host collections, host groups, and a search query.
 endif::[]
+ifndef::satellite,orcharhino,katello[]
+You can filter hosts by host names, host groups, and a search query.
+endif::[]
+If you do not select any hosts, the job will run on all hosts you can see in the current context.
+. If required, provide inputs for the job template.
+Different templates have different inputs and some templates do not have any inputs.
+After entering all the required inputs, click *Next*.
+. Optional: To configure advanced settings for the job, fill in the *Advanced fields*.
+To learn more about advanced settings, see xref:advanced-settings-in-the-job-wizard_{context}[].
+When you are done entering the advanced settings or you do not need to enter any advanced settings, click *Next*.
+. Schedule time for the job.
+* To execute the job immediately, keep the pre-selected *Immediate execution*.
+* To execute the job in future time, select *Future execution*.
+* To execute the job on regular basis, select *Recurring execution*.
+. Optional: If you selected future or recurring execution, select the *Query type*, otherwise click *Next*.
+* *Static query* means that job executes on the exact list of hosts that you provided.
+* *Dynamic query* means that the list of hosts is evaluated just before the job is executed.
+If you entered the list of hosts based on some filter, the results can be different from when you first used that filter.
 
-. Click *Submit*.
-You can view status of the jobs in the *Recent Jobs* section on the same page.
++
+Click *Next* after you have selected the query type.
+. Optional: If you selected future or recurring execution, provide additional details:
+* For *Future execution*, enter the *Starts at* date and time.
+You also have the option to select the *Starts before* date and time.
+If the job cannot start before that time, it will be canceled.
+* For *Recurring execution*, select the start date and time, frequency, and the condition for ending the recurring job.
+You can choose the recurrence to never end, end at a certain time, or end after a given number of repetitions.
+You can also add *Purpose* - a special label for tracking the job.
+There can only be one active job with a given purpose at a time.
+
++
+Click *Next* after you have entered the required information.
+. Review job details.
+You have the option to return to any part of the job wizard and edit the information.
+. Click *Run* to schedule the job for execution.
 
 [id="cli-executing-a-remote-job_{context}"]
 .CLI procedure

--- a/guides/common/modules/ref_advanced-settings-in-the-job-wizard.adoc
+++ b/guides/common/modules/ref_advanced-settings-in-the-job-wizard.adoc
@@ -1,0 +1,47 @@
+[id="advanced-settings-in-the-job-wizard_{context}"]
+= Advanced Settings in the Job Wizard
+
+Some job templates require you to enter advanced settings.
+Some of the advanced settings are only visible to certain job templates.
+Below is the list of general advanced settings.
+
+// in order of appearance in the job wizard
+SSH user::
+A user to be used for connecting to the host through SSH.
+
+Effective user::
+A user to be used for executing the job.
+By default it is the SSH user.
+If it differs from the SSH user, su or sudo, depending on your settings, is used to switch the accounts.
+
+Description::
+A description template for the job.
+
+Timeout to kill::
+Time in seconds from the start of the job after which the job should be killed if it is not finished already.
+
+Time to pickup::
+Time in seconds after which the job is canceled if it is not picked up by a client.
+This setting only applies to hosts using `pull-mqtt` transport.
+
+Password::
+Is used if SSH authentication method is a password instead of the SSH key.
+
+Private key passphrase::
+Is used if SSH keys are protected by a passphrase.
+
+Effective user password::
+Is used if effective user is different from the ssh user.
+
+Concurrency level::
+Defines the maximum number of jobs executed at once.
+This can prevent overload of system resources in a case of executing the job on a large number of hosts.
+
+Time span::
+Distributes the remote execution over the selected number of seconds.
+Jobs start one at a time in regular intervals to fit the given time window.
+Similarly to concurrency level, this can also prevent overload of system resources.
+
+Execution ordering::
+Determines the order in which the job is executed on hosts.
+It can be alphabetical or randomized.


### PR DESCRIPTION
The new job wizard requires updating the procedure.

I also separated the despription of advanced settings to another module as I believe it makes the procedure more readable. Users can click on the provided link to learn more about the advanced settings.

CC @adamruzicka

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
