### PR TITLE
Remove duplicate content from Pre-Migration Checks

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -21,14 +21,12 @@ The sequence should always be if you have any Composite Content Views, take acti
 * Ensure that all enabled repositories complete the synchronization process.
 * If any repositories are synced with a *Warning* or *Error* state, fix the underlying problem and resync the repository.
 * Ensure that no paused tasks in the system are related to any repositories or Content Views.
-* If you no longer require specific Content Views or Composite Content View Versions, you can perform a cleanup action.
-* For more information about how to perform the cleanup, see https://access.redhat.com/solutions/2760531[How to remove old content view versions in Red Hat Satellite 6 using CLI/hammer?] .
 * If some Content View or Composite Content View versions are not required anymore, please consider performing a cleanup of them.
 * For more information about how to perform the cleanup of older Content View or Composite Content View versions using `hammer_cli`, see https://access.redhat.com/solutions/2760531[How to remove old content view versions in Red Hat Satellite 6 using CLI/hammer?].
 * If you no longer require or use certain repositories, disable those specific repositories.
 * When the cleanup process finishes, ensure that you clean up the orphan data by following the steps in https://access.redhat.com/solutions/2639291[How to delete orphaned content in /var/lib/pulp on Capsule?].
 * Ensure that you can enter the following command on {Project} without error:
-
++
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # foreman-rake katello:correct_repositories COMMIT=true --trace


### PR DESCRIPTION
2 items from in the Pre-Migration Checks were duplicate. 
They are removed in this PR for foreman version 2.5. 

https://bugzilla.redhat.com/show_bug.cgi?id=2164509

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
