### PR TITLE
Update list of selectable columns

### DIFF
--- a/guides/common/modules/ref_overview-of-the-host-columns.adoc
+++ b/guides/common/modules/ref_overview-of-the-host-columns.adoc
@@ -2,6 +2,7 @@
 = Overview of the Host Columns
 
 Below is the complete overview of columns that can be displayed in the host table divided into content categories.
+Some columns fall under more than one category.
 For more information on how to customize columns in the host table, see xref:selecting-host-columns_{context}[].
 
 // Columns are ordered as in the Web UI
@@ -9,9 +10,9 @@ General::
 * Power - Whether the host is turned on or off, if available
 * Name - name of the host
 * Operating system - operating system of the host
+* Model - host hardware model (or compute resource in case of virtual hosts)
 * Owner - user or group owning the host
 * Host group - host group of the host
-* Boot time - last boot time of the host
 * Last report - time of the last host report
 * Comment - comment given to host
 
@@ -33,10 +34,10 @@ Network::
 * MAC - MAC address of the host
 
 Reported data::
-* Model - host hardware model (or compute resource in case of virtual hosts)
 * Sockets - number of host sockets
 * Cores - number of host processor cores
 * RAM - amount of memory
+* Boot time - last boot time of the host
 * Virtual - whether or not the host is recognized as a virtual machine
 * Disks total space - total host storage space
 * Kernel Version - Kernel version of the host operating system
@@ -46,3 +47,8 @@ Reported data::
 
 Puppet (only if the Puppet plug-in is installed)::
 * Environment name - name of the Puppet environment of the host
+
+ifdef::satellite[]
+RH Cloud::
+* Recommendations - number of available recommendations for the host
+endif::[]

--- a/guides/common/modules/ref_overview-of-the-host-columns.adoc
+++ b/guides/common/modules/ref_overview-of-the-host-columns.adoc
@@ -7,48 +7,48 @@ For more information on how to customize columns in the host table, see xref:sel
 
 // Columns are ordered as in the Web UI
 General::
-* Power - Whether the host is turned on or off, if available
-* Name - name of the host
-* Operating system - operating system of the host
-* Model - host hardware model (or compute resource in case of virtual hosts)
-* Owner - user or group owning the host
-* Host group - host group of the host
-* Last report - time of the last host report
-* Comment - comment given to host
+* Power {endash} Whether the host is turned on or off, if available
+* Name {endash} name of the host
+* Operating system {endash} operating system of the host
+* Model {endash} host hardware model (or compute resource in case of virtual hosts)
+* Owner {endash} user or group owning the host
+* Host group {endash} host group of the host
+* Last report {endash} time of the last host report
+* Comment {endash} comment given to host
 
 ifdef::katello,satellite,orcharhino[]
 Content::
-* Name - name of the host
-* Operating system - operating system of the host
-* Subscription status - does the host have a valid subscription attached
-* Installable updates - numbers of installable updates divided into four categories: security, bugfix, enhancement, total
-* Lifecycle Environment - lifecycle environment of the host
-* Content view - content view of the host
-* Registered - time when the host was registered to {Project}
-* Last checkin - last time of the communication between the host and the {ProjectServer}
+* Name {endash} name of the host
+* Operating system {endash} operating system of the host
+* Subscription status {endash} does the host have a valid subscription attached
+* Installable updates {endash} numbers of installable updates divided into four categories: security, bugfix, enhancement, total
+* Lifecycle Environment {endash} lifecycle environment of the host
+* Content view {endash} content view of the host
+* Registered {endash} time when the host was registered to {Project}
+* Last checkin {endash} last time of the communication between the host and the {ProjectServer}
 endif::[]
 
 Network::
-* IPv4 - IPv4 address of the host
-* IPv6 - IPv6 address of the host
-* MAC - MAC address of the host
+* IPv4 {endash} IPv4 address of the host
+* IPv6 {endash} IPv6 address of the host
+* MAC {endash} MAC address of the host
 
 Reported data::
-* Sockets - number of host sockets
-* Cores - number of host processor cores
-* RAM - amount of memory
-* Boot time - last boot time of the host
-* Virtual - whether or not the host is recognized as a virtual machine
-* Disks total space - total host storage space
-* Kernel Version - Kernel version of the host operating system
-* BIOS vendor - vendor of the host BIOS
-* BIOS release date - release date of the host BIOS
-* BIOS version - version of the host BIOS
+* Sockets {endash} number of host sockets
+* Cores {endash} number of host processor cores
+* RAM {endash} amount of memory
+* Boot time {endash} last boot time of the host
+* Virtual {endash} whether or not the host is recognized as a virtual machine
+* Disks total space {endash} total host storage space
+* Kernel Version {endash} Kernel version of the host operating system
+* BIOS vendor {endash} vendor of the host BIOS
+* BIOS release date {endash} release date of the host BIOS
+* BIOS version {endash} version of the host BIOS
 
 Puppet (only if the Puppet plug-in is installed)::
-* Environment name - name of the Puppet environment of the host
+* Environment name {endash} name of the Puppet environment of the host
 
 ifdef::satellite[]
 RH Cloud::
-* Recommendations - number of available recommendations for the host
+* Recommendations {endash} number of available recommendations for the host
 endif::[]


### PR DESCRIPTION
Edited list of selectable columns based on the newest snapshot. Attaching screenshot below.
Note: BIOS columns do not appear in the screenshot but are planned to be included.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.

![image](https://user-images.githubusercontent.com/108661422/215541398-62ec41e6-4c2c-497b-b23c-aeb1a8137f3c.png)
