### PR TITLE
Add EL6 to EL9 client repos for enabling & syncing

### DIFF
--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -2,8 +2,15 @@
 = Enabling the {project-client-name} Repository
 
 The {project-client-name} repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
+You must enable the repository for each {RHEL} version that you need to manage hosts.
+Continue with a procedure below according to the operating system version for which you want to enable the {project-client-name} repository.
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_{context}[].
+* xref:#enabling-repos-rhel9-rhel8[{RHEL} 9 & {RHEL} 8]
+* xref:#enabling-repos-rhel7-rhel6[{RHEL} 7 & {RHEL} 6]
+
+== [[enabling-repos-rhel9-rhel8]]{RHEL} 9 & {RHEL} 8
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_rhel_9_{context}[] or xref:CLI_Enabling_the_Client_Repository_rhel_8_{context}[].
 
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
@@ -11,27 +18,92 @@ ifeval::["{mode}" == "disconnected"]
 endif::[]
 
 .Procedure
-. Use the Search field to enter the following repository name: *{project-client-name} (for RHEL 8) (RPMs)*.
-. In the Available Repositories pane, click on *{project-client-name} (for RHEL 8) (RPMs)* to expand the repository set.
+. In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
+. In the Available Repositories pane, enable the *Recommended Repositories* to get the list of repositories.
+. Click *{Team} {project-client-name} for RHEL 9 x86_64 (RPMs)* or *{Team} {project-client-name} for RHEL 8 x86_64 (RPMs)* to expand the repository set.
+. For the *x86_64* architecture, click the *+* icon to enable the repository.
 +
 If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
 To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
 For more information, see {ContentManagementDocURL}Managing_Red_Hat_Subscriptions_content-management[Managing Red Hat Subscriptions] in _{ContentManagementDocTitle}_.
-
-. For the `x86_64` entry, click the *Enable* icon to enable the repository.
-
++
 Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
 After enabling a Red Hat repository, a Product for this repository is automatically created.
 
-[id="CLI_Enabling_the_Client_Repository_{context}"]
-.CLI procedure
+[id="CLI_Enabling_the_Client_Repository_rhel_9_{context}"]
+.CLI procedure for {RHEL} 9
 * Enable the {project-client-name} repository using the `hammer repository-set enable` command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository-set enable \
---basearch='x86_64' \
---name 'Red Hat {project-client-name} for RHEL 8 x86_64 (RPMs)' \
+--basearch="x86_64" \
+--name "{Team} {project-client-name} for RHEL 9 x86_64 (RPMs)" \
 --organization _"My_Organization"_ \
---product '{RHEL} for x86_64'
+--product "{RHEL} for x86_64"
+----
+
+[id="CLI_Enabling_the_Client_Repository_rhel_8_{context}"]
+.CLI procedure for {RHEL} 8
+* Enable the {project-client-name} repository using the `hammer repository-set enable` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository-set enable \
+--basearch="x86_64" \
+--name "{Team} {project-client-name} for RHEL 8 x86_64 (RPMs)" \
+--organization _"My_Organization"_ \
+--product "{RHEL} for x86_64"
+----
+
+== [[enabling-repos-rhel7-rhel6]]{RHEL} 7 & {RHEL} 6
+
+[NOTE]
+====
+You require *{RHEL} Extended Life Cycle Support (ELS) Add-on* subscription to enable the repositories of {RHEL} 6.
+For more information, see https://www.redhat.com/en/resources/els-datasheet[{RHEL} Extended Life Cycle Support (ELS) Add-on] guide.
+====
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Enabling_the_Client_Repository_rhel_7_{context}[] or xref:CLI_Enabling_the_Client_Repository_rhel_6_{context}[].
+
+ifeval::["{mode}" == "disconnected"]
+.Prerequisites
+* Ensure that you import all content ISO images that you require into {ProjectServer}.
+endif::[]
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
+. In the *Available Repositories* pane, enable the *Recommended Repositories* to get the list of repositories.
+. In the *Available Repositories* pane, click on *{project-client-name} (for RHEL 7 Server) (RPMs)* or *{project-client-name} (for RHEL 6 Server - ELS) (RPMs)* to expand the repository set.
++
+If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat Subscription Manifest obtained from the Customer Portal.
+To correct that, log in to the Customer Portal, add these repositories, download the Red{nbsp}Hat Subscription Manifest and import it into {Project}.
+For more information, see {ContentManagementDocURL}Managing_Red_Hat_Subscriptions_content-management[Managing Red Hat Subscriptions] in _{ContentManagementDocTitle}_.
+. For the *x86_64* architecture, click the *+* icon to enable the repository.
+Enable the {project-client-name} repository for every supported major version of {RHEL} running on your hosts.
+After enabling a Red Hat repository, a Product for this repository is automatically created.
+
+[id="CLI_Enabling_the_Client_Repository_rhel_7_{context}"]
+.CLI procedure for {RHEL} 7
+* Enable the {project-client-name} repository using the `hammer repository-set enable` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository-set enable \
+--basearch="x86_64" \
+--name "{Team} {project-client-name} (for RHEL 7 Server) (RPMs)" \
+--organization _"My_Organization"_ \
+--product "{RHEL} Server"
+----
+
+[id="CLI_Enabling_the_Client_Repository_rhel_6_{context}"]
+.CLI procedure for {RHEL} 6
+* Enable the {project-client-name} repository using the `hammer repository-set enable` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository-set enable \
+--basearch="x86_64" \
+--name "{Team} {project-client-name} (for RHEL 6 Server - ELS) (RPMs)" \
+--organization _"My_Organization"_ \
+--product "{RHEL} Server - Extended Life Cycle Support"
 ----

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -3,22 +3,84 @@
 
 Use this section to synchronize the {project-client-name} repository from the Red Hat Content Delivery Network (CDN) to your {Project}.
 This repository provides the `katello-agent`, `katello-host-tools`, and `puppet` packages for clients registered to {ProjectServer}.
+Continue with a procedure below according to the operating system version for which you want to synchronize the {project-client-name} repository.
+
+* xref:#synchronizing-repos-rhel9-rhel8[{RHEL} 9 & {RHEL} 8]
+* xref:#synchronizing-repos-rhel7-rhel6[{RHEL} 7 & {RHEL} 6]
+
+== [[synchronizing-repos-rhel9-rhel8]]{RHEL} 9 & {RHEL} 8
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Synchronizing_the_Client_Repository_rhel_9_{context}[] or xref:CLI_Synchronizing_the_Client_Repository_rhel_8_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
-+
-A list of product repositories available for synchronization is displayed.
-. Click the arrow next to the *{RHEL} Server* product to view available content.
-. Select *{project-client-name} (for RHEL 8) RPMs x86_64*.
+. Click the arrow next to the *{RHEL} for x86_64* product to view available content.
+. Select *{Team} {project-client-name} for RHEL 9 x86_64 RPMs* or *{Team} {project-client-name} for RHEL 8 x86_64 RPMs* whichever is applicable.
 . Click *Synchronize Now*.
 
-.CLI procedure
+[id="CLI_Synchronizing_the_Client_Repository_rhel_9_{context}"]
+.CLI procedure for {RHEL} 9
 * Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository synchronize \
---name 'Red Hat {project-client-name} for RHEL 8 x86_64 RPMs' \
+--name "{Team} {project-client-name} for RHEL 9 x86_64 RPMs" \
 --organization _"My_Organization"_ \
---product '{RHEL} for x86_64'
+--product "{RHEL} for x86_64"
+----
+
+[id="CLI_Synchronizing_the_Client_Repository_rhel_8_{context}"]
+.CLI procedure for {RHEL} 8
+* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository synchronize \
+--name "{Team} {project-client-name} for RHEL 8 x86_64 RPMs" \
+--organization _"My_Organization"_ \
+--product "{RHEL} for x86_64"
+----
+
+== [[synchronizing-repos-rhel7-rhel6]]{RHEL} 7 & {RHEL} 6
+
+[NOTE]
+====
+You require *{RHEL} Extended Life Cycle Support (ELS) Add-on* subscription to synchronize the repositories of {RHEL} 6.
+For more information,
+see https://www.redhat.com/en/resources/els-datasheet[{RHEL} Extended Life Cycle Support (ELS) Add-on] guide.
+====
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:CLI_Synchronizing_the_Client_Repository_rhel_7_{context}[] or xref:CLI_Synchronizing_the_Client_Repository_rhel_6_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
+. Click the arrow next to the *{RHEL} Server* or *{RHEL} Server - Extended Life Cycle Support* whichever product is applicable to view available content.
+. Select *{Team} {project-client-name} (for RHEL 7 Server) RPMs x86_64* or *{Team} {project-client-name} for RHEL 6 Server - ELS RPMs x86_64* based on your operating system version.
+. Click *Synchronize Now*.
+
+[id="CLI_Synchronizing_the_Client_Repository_rhel_7_{context}"]
+.CLI procedure for {RHEL} 7
+* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository synchronize \
+--async \
+--name "{Team} {project-client-name} for RHEL 7 Server RPMs x86_64" \
+--organization _"My_Organization"_ \
+--product "{RHEL} Server"
+----
+
+[id="CLI_Synchronizing_the_Client_Repository_rhel_6_{context}"]
+.CLI procedure for {RHEL} 6
+* Synchronize your {project-client-name} repository using the `hammer repository synchronize` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer repository synchronize \
+--async \
+--name "{Team} {project-client-name} for RHEL 6 Server - ELS RPMs x86_64" \
+--organization _"My_Organization"_ \
+--product "{RHEL} Server - Extended Life Cycle Support"
 ----


### PR DESCRIPTION
The client repositories for enabling and synchronizing the project client for EL9 and EL8 were not added. Now it is added for both of them along with the updated Web UI procedure.

https://bugzilla.redhat.com/show_bug.cgi?id=2150297

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
