### PR TITLE
Add warning while creating keytab entry

### DIFF
--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -53,6 +53,8 @@ euid = __ID_of_Apache_User__
 ----
 . Create a keytab entry:
 +
+WARNING: The host must not be enrolled to a domain before creating a keytab entry.
++
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # KRB5_KTNAME=FILE:/etc/httpd/conf/http.keytab net ads keytab add HTTP -U administrator -d3 -s /etc/net-keytab.conf


### PR DESCRIPTION
In creating keytab entry during the configuration of direct AD integration with GSS-Proxy, we can warn the end-user about connectivity between hosts and domain. This will save time for end-users.

https://bugzilla.redhat.com/show_bug.cgi?id=2159686

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
