### PR TITLE
Add a link to the RHEL 7 to RHEL 8 post upgrade steps section

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -313,7 +313,9 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
-. Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+. Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+
+. Verify the post-upgrade state of the system as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
 endif::[]
 . For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -313,9 +313,7 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
-. Complete the post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
-
-. Verify the post-upgrade state of the system as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+. Verify the post-upgrade state of the system as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide and complete any remaining post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
 endif::[]
 . For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -313,7 +313,7 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
-. Verify the post-upgrade state of the system as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide and complete any remaining post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+. Verify the post-upgrade state of the system as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system] in the _Upgrading from RHEL 7 to RHEL 8_ guide and complete any remaining post-upgrade steps described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks] in the same guide.
 endif::[]
 . For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
 +


### PR DESCRIPTION
The link to the post upgrade steps is missing in the upgrading RHEL 7 to RHEL 8 using LEAPP section. This results in some issues post upgrade (e.g. leapp setting the release version to 8.6). https://bugzilla.redhat.com/show_bug.cgi?id=2164027


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
