### PR TITLE
Modify note and a step in the SCA enabled case

### DIFF
--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -3,7 +3,7 @@
 
 [NOTE]
 ====
-This step is *optional* if you have SCA enabled on {Project}.
+Skip this step if you have SCA enabled on {Project}.
 There is no requirement of attaching the {SatelliteSub} to the {ProjectServer} using subscription-manager.
 ====
 

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -3,7 +3,7 @@
 
 [NOTE]
 ====
-This step is *optional* if you have SCA enabled in the Red Hat Customer Portal.
+This step is *optional* if you have SCA enabled on {Project}.
 There is no requirement of attaching the {SatelliteSub} to the {ProjectServer} using subscription-manager.
 ====
 
@@ -11,10 +11,10 @@ After you have registered {ProductName}, you must identify your subscription Poo
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName} and {RHEL} content.
 
 {ProjectName} Infrastructure is included with all subscriptions that include Smart Management.
-For more information, see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/3382781[{Project} Infrastructure Subscriptions MCT3718 MCT3719].
+For more information, see https://access.redhat.com/solutions/3382781[{Project} Infrastructure Subscriptions MCT3718 MCT3719] in the _Red{nbsp}Hat Knowledgebase_.
 
 Subscriptions are classified as available if they are not already attached to a system.
-If you are unable to find an available {Project} subscription, see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/2058823[How do I figure out which subscriptions have been consumed by clients registered under Red Hat Subscription Manager?] to run a script to see if your subscription is being consumed by another system.
+If you are unable to find an available {Project} subscription, see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/2058823[How do I figure out which subscriptions have been consumed by clients registered under Red Hat Subscription Manager?] to run a script to see if another system is consuming your subscription.
 
 .Procedure
 
@@ -65,7 +65,8 @@ Entitlement Type:    Physical
 . Make a note of the subscription Pool ID.
 Your subscription Pool ID is different from the example provided.
 
-. Attach the {Project} Infrastructure subscription to the base operating system that your {ProductName} is running on:
+. Attach the {Project} Infrastructure subscription to the base operating system that your {ProductName} is running on.
+If SCA is enabled on {ProjectServer}, you can skip this step:
 +
 [options="nowrap" subs="+quotes"]
 ----


### PR DESCRIPTION
One of the steps of attaching the Pool ID in the Attaching the Satellite Infrastructure Subscription is optional when SCA is already enabled in the Satellite. The reason is the Capsule server is registered with the Satellite server and not with the Customer Portal. So, we also modified the note at the start of the section where we went ahead and documented about Customer Portal.

https://bugzilla.redhat.com/show_bug.cgi?id=2166372

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
