### PR TITLE
Add information about different types of ACS

### DIFF
--- a/guides/common/assembly_managing-alternate-content-sources.adoc
+++ b/guides/common/assembly_managing-alternate-content-sources.adoc
@@ -1,3 +1,7 @@
 include::modules/con_managing-alternate-content-sources.adoc[]
 
-include::modules/proc_configuring-alternate-content-sources.adoc[leveloffset=+1]
+include::modules/proc_configuring-custom-alternate-content-sources.adoc[leveloffset=+1]
+
+include::modules/proc_configuring-simplified-alternate-content-sources.adoc[leveloffset=+1]
+
+include::modules/proc_configuring-rhui-alternate-content-sources.adoc[leveloffset=+1]

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -26,3 +26,19 @@ RHUI alternate content source downloads content from the Red Hat Update Infrastr
 ifdef::satellite[]
 {Team} only supports RHUI type alternate content source with default RHUI installations of version RHUI 4 or above.
 endif::[]
+
+.Permission Requirements for Alternate Content Sources
+
+Non-administrator users must have the below permissions to manage alternate content sources:
+
+. `view_smart_proxies`
+. `view_content_credentials`
+. `view_organizations`
+. `view_products`
+
+In addition to the above permissions, assign permissions specific to alternate content sources, depending on the actions the users can perform:
+
+. `view_alternate_content_sources`
+. `create_alternate_content_sources`
+. `edit_alternate_content_sources`
+. `destroy_alternate_content_sources`

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -24,7 +24,8 @@ endif::[]
 RHUI::
 RHUI alternate content sources download content from a Red Hat Update Infrastructure server.
 ifdef::satellite[]
-The RHUI alternate content source must be RHUI version 4 or greater and use the default installation configuration. For example, AWS RHUI is unsupported because it uses an installation scenario with unique authentication requirements.
+The RHUI alternate content source must be RHUI version 4 or greater and use the default installation configuration.
+For example, AWS RHUI is unsupported because it uses an installation scenario with unique authentication requirements.
 endif::[]
 
 .Permission Requirements for Alternate Content Sources

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -12,19 +12,19 @@ You can also refresh the alternate content sources manually using the {ProjectWe
 There are three types of alternate content sources:
 
 Custom::
-Custom alternate content source downloads the content from any upstream repository or the local filesystem.
+Custom alternate content sources download the content from any upstream repository on the network or filesystem.
 
 Simplified::
-Simplified alternate content source copies the upstream repo information from your {ProjectServer}.
-You can use simplified alternate content sources in situations where the connection from your {SmartProxy} to the upstream repo is faster than from your {ProjectServer}.
+Simplified alternate content sources copy the upstream repository information from your {ProjectServer} for the selected products.
+Simplified alternate content sources are ideal for situations where the connection from your {SmartProxy} to the upstream repo is faster than from your {ProjectServer}.
 ifdef::satellite[]
 Selecting the Red Hat products when creating a simplified alternate content source will download the content to the {SmartProxies} from the {Team} CDN.
 endif::[]
 
 RHUI::
-RHUI alternate content source downloads content from the Red Hat Update Infrastructure server in your environment.
+RHUI alternate content sources download content from a Red Hat Update Infrastructure server.
 ifdef::satellite[]
-{Team} only supports RHUI type alternate content source with default RHUI installations of version RHUI 4 or above.
+The RHUI alternate content source must be RHUI version 4 or greater and use the default installation configuration. For example, AWS RHUI is unsupported because it uses an installation scenario with unique authentication requirements.
 endif::[]
 
 .Permission Requirements for Alternate Content Sources

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -23,6 +23,7 @@ endif::[]
 
 RHUI::
 RHUI alternate content sources download content from a Red Hat Update Infrastructure server.
+{ProjectWebUI} provides examples to help you find the network paths and to import authentication credentials.
 ifdef::satellite[]
 The RHUI alternate content source must be RHUI version 4 or greater and use the default installation configuration.
 For example, AWS RHUI is unsupported because it uses an installation scenario with unique authentication requirements.

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -24,6 +24,6 @@ endif::[]
 RHUI::
 RHUI alternate content source downloads content from the Red Hat Update Infrastructure server in your environment.
 ifdef::satellite[]
-Note that {Team} only supports RHUI type alternate content source with RHUI 4 or above.
+{Team} only supports RHUI type alternate content source with RHUI 4 or above.
 {Team} also does not support configuration of RHUI alternate content source with the {Team} provided RHUI instances for AWS.
 endif::[]

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -23,3 +23,7 @@ endif::[]
 
 RHUI::
 RHUI alternate content source downloads content from the Red Hat Update Infrastructure server in your environment.
+ifdef::satellite[]
+Note that Red{nbsp}Hat only supports RHUI type alternate content source with RHUI 4 or above.
+Red{nbsp}Hat also does not support configuration of RHUI alternate content source with the Red{nbsp}Hat provided RHUI instances for AWS.
+endif::[]

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -12,7 +12,7 @@ You can also refresh the alternate content sources manually using the {ProjectWe
 There are three types of alternate content sources:
 
 Custom::
-Custom alternate content source downloads the content from any upstream repository or from the local filesystem.
+Custom alternate content source downloads the content from any upstream repository or the local filesystem.
 
 Simplified::
 Simplified alternate content source copies the upstream repo information from your {ProjectServer}.
@@ -24,6 +24,5 @@ endif::[]
 RHUI::
 RHUI alternate content source downloads content from the Red Hat Update Infrastructure server in your environment.
 ifdef::satellite[]
-{Team} only supports RHUI type alternate content source with RHUI 4 or above.
-{Team} also does not support configuration of RHUI alternate content source with the {Team} provided RHUI instances for AWS.
+{Team} only supports RHUI type alternate content source with default RHUI installations of version RHUI 4 or above.
 endif::[]

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -15,15 +15,15 @@ Custom::
 Custom alternate content source downloads the content from any upstream repository or from the local filesystem.
 
 Simplified::
-Simplified alternate content source copies the upstream repo information from the {ProjectServer}.
-You can use simplified alternate content sources in situations where the connection from the {SmartProxy} to the upstream repo is faster than the {ProjectServer}.
+Simplified alternate content source copies the upstream repo information from your {ProjectServer}.
+You can use simplified alternate content sources in situations where the connection from your {SmartProxy} to the upstream repo is faster than from your {ProjectServer}.
 ifdef::satellite[]
-Selecting the Red Hat products when creating a simplified alternate content source will download the content to the {SmartProxies} from the Red Hat CDN.
+Selecting the Red Hat products when creating a simplified alternate content source will download the content to the {SmartProxies} from the {Team} CDN.
 endif::[]
 
 RHUI::
 RHUI alternate content source downloads content from the Red Hat Update Infrastructure server in your environment.
 ifdef::satellite[]
-Note that Red{nbsp}Hat only supports RHUI type alternate content source with RHUI 4 or above.
-Red{nbsp}Hat also does not support configuration of RHUI alternate content source with the Red{nbsp}Hat provided RHUI instances for AWS.
+Note that {Team} only supports RHUI type alternate content source with RHUI 4 or above.
+{Team} also does not support configuration of RHUI alternate content source with the {Team} provided RHUI instances for AWS.
 endif::[]

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -2,9 +2,24 @@
 = Managing Alternate Content Sources
 
 Alternate content sources define alternate paths to download content during synchronization.
-The content itself is downloaded from the alternate content source and only the metadata is downloaded from the upstream URL.
+The content itself is downloaded from the alternate content source and only the metadata is downloaded from the {ProjectServer}.
 You can use alternate content source to speed up synchronization if the content is located on the local filesystem or on a nearby network.
 You can set up alternate content sources for {ProjectServer} and {SmartProxy}.
 You must refresh the alternate content source after creation or after making any changes.
 A weekly cron job refreshes all alternate content sources.
 You can also refresh the alternate content sources manually using the {ProjectWebUI} or the Hammer CLI.
+
+There are three types of alternate content sources:
+
+Custom::
+Custom alternate content source downloads the content from any upstream repository or from the local filesystem.
+
+Simplified::
+Simplified alternate content source copies the upstream repo information from the {ProjectServer}.
+You can use simplified alternate content sources in situations where connections to the upstream repo is faster than the {ProjectServer}.
+ifdef::satellite[]
+Selecting the Red Hat products when creating a simplified alternate content source will download the content to the {SmartProxies} from the Red Hat CDN.
+endif::[]
+
+RHUI::
+RHUI alternate content source downloads content from the Red Hat Update Infrastructure server in your environment.

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -2,7 +2,7 @@
 = Managing Alternate Content Sources
 
 Alternate content sources define alternate paths to download content during synchronization.
-The content itself is downloaded from the alternate content source and only the metadata is downloaded from the {ProjectServer}.
+The content itself is downloaded from the alternate content source, while the metadata is downloaded from the {ProjectServer} or the upstream URL, depending on the configuration.
 You can use alternate content source to speed up synchronization if the content is located on the local filesystem or on a nearby network.
 You can set up alternate content sources for {ProjectServer} and {SmartProxy}.
 You must refresh the alternate content source after creation or after making any changes.
@@ -16,7 +16,7 @@ Custom alternate content source downloads the content from any upstream reposito
 
 Simplified::
 Simplified alternate content source copies the upstream repo information from the {ProjectServer}.
-You can use simplified alternate content sources in situations where connections to the upstream repo is faster than the {ProjectServer}.
+You can use simplified alternate content sources in situations where the connection from the {SmartProxy} to the upstream repo is faster than the {ProjectServer}.
 ifdef::satellite[]
 Selecting the Red Hat products when creating a simplified alternate content source will download the content to the {SmartProxies} from the Red Hat CDN.
 endif::[]

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -2,7 +2,7 @@
 = Configuring Custom Alternate Content Sources
 
 .Prerequisites
-* If the repository requires SSL authentication, import the SSL certificate and key to the Satellite.
+* If the repository requires SSL authentication, import the SSL certificate and key to the {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_. 
 
 .Procedure

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -1,5 +1,5 @@
-[id="Configuring_Alternate_Content_Sources_{context}"]
-= Configuring Alternate Content Sources
+[id="Configuring_Custom_Alternate_Content_Sources_{context}"]
+= Configuring Custom Alternate Content Sources
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
@@ -15,7 +15,7 @@
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.
 
-[id="cli-configuring-alternate-content-sources_{context}"]
+[id="cli-configuring-custom-alternate-content-sources_{context}"]
 .CLI Procedure
 . On {ProjectServer}, enter the following command:
 +

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -1,6 +1,10 @@
 [id="Configuring_Custom_Alternate_Content_Sources_{context}"]
 = Configuring Custom Alternate Content Sources
 
+.Prerequisites
+* If the repository requires SSL authentication, import the SSL certificate and key to the Satellite.
+For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_. 
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
 . Click *Add Source* and set the *Source type* as *Custom*.

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -4,7 +4,8 @@
 .Prerequisites
 * If the repository requires SSL authentication, import the SSL certificate and key to the {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_. 
-* Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide. For example, if your base URL is `https://server.example.com` and your subpaths are `rhel7/` and `rhel8/`, then both `https://server.example.com/rhel7/` and `https://server.example.com/rhel8/` will be searched.
+* Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide.
+For example, if your base URL is `https://server.example.com` and your subpaths are `rhel7/` and `rhel8/`, then both `https://server.example.com/rhel7/` and `https://server.example.com/rhel8/` will be searched.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -4,6 +4,7 @@
 .Prerequisites
 * If the repository requires SSL authentication, import the SSL certificate and key to the {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_. 
+* Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide. For example, if your base URL is `https://server.example.com` and your subpaths are `rhel7/` and `rhel8/`, then both `https://server.example.com/rhel7/` and `https://server.example.com/rhel8/` will be searched.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -9,6 +9,7 @@ Ensure that you pass the repo labels of the desired repositories.
 . In the *Name* field, enter a name for the alternate content source.
 . Optional: In the the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
+. Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
 . Enter the Base URL of the Red Hat Update Infrastructure server.
 . Enter a comma-separated list of Subpaths.
 . Provide the *Content Credentials*, if these are needed.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -1,0 +1,17 @@
+[id="Configuring_RHUI_Alternate_Content_Sources_{context}"]
+= Configuring RHUI Alternate Content Sources
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
+. Click *Add Source* and set the *Source type* as *RHUI*.
+. Generate RHUI certificates using the command provided in the {ProjectWebUI}.
+Ensure that you pass the repo labels of the desired repositories.
+. In the *Name* field, enter a name for the alternate content source.
+. Optional: In the the *Description* field, provide a description for the ACS.
+. Select {SmartProxies} to which the alternate content source is to be synced.
+. Enter the Base URL of the Red Hat Update Infrastructure server.
+. Enter a comma-separated list of Subpaths.
+. Provide the *Content Credentials*, if these are needed.
+. If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
+. Review details and click *Add*.
+. Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -19,10 +19,10 @@ Execute the following command on the RHUA server:
 . Generate RHUI certificates using the command provided in the {ProjectWebUI}.
 Ensure that you pass the repo labels of the desired repositories.
 . In the *Name* field, enter a name for the alternate content source.
-. Optional: In the the *Description* field, provide a description for the ACS.
+. Optional: In the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
 . Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
-. Enter the Base URL of the Red Hat Update Infrastructure server.
+. Enter the Base URL of the Red Hat Update Infrastructure CDS node.
 . Enter a comma-separated list of Subpaths.
 . Provide the *Content Credentials*, if these are needed.
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -42,9 +42,9 @@ Ensure that you pass the repo labels of the desired repositories.
 --alternate-content-source-type rhui \
 --base-url "_https://rhui-cds-node/pulp/content_" \
 --subpaths _path/to/repo/1/,path/to/repo/2/_ \
---ssl-client-cert-id _SSL_Client_Cert_ID_ \
---ssl-client-key-id _SSL_Client_Key_ID_ \
---smart-proxy-ids _{SmartProxy}_ID_ \
+--ssl-client-cert-id _My_SSL_Client_Certificate_ID_ \
+--ssl-client-key-id _My_SSL_Client_Key_ID_ \
+--smart-proxy-ids _My_{SmartProxy}_ID_ \
 --verify-ssl 1
 ----
 . Check if the newly created alternate content source is listed:

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -41,7 +41,7 @@ Ensure that you pass the repo labels of the desired repositories.
 --name "_My_ACS_Name_" \
 --alternate-content-source-type rhui \
 --base-url "_https://rhui-cds-node/pulp/content_" \
---subpaths _path/to/repo/1/, path/to/repo/2/_ \
+--subpaths _path/to/repo/1/,path/to/repo/2/_ \
 --ssl-client-cert-id _SSL_Client_Cert_ID_ \
 --ssl-client-key-id _SSL_Client_Key_ID_ \
 --smart-proxy-ids _{SmartProxy}_ID_ \

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -2,7 +2,7 @@
 = Configuring RHUI Alternate Content Sources
 
 .Prerequisites
-* Generate the client entitlement certificates for the required repos on the RHUA node as described in https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in the _Configuring and Managing Red Hat Update Infrastructure Guide_.
+* Generate the client entitlement certificates for the required repos on the RHUA node as described in https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in _Configuring and Managing Red Hat Update Infrastructure_.
 * Import the client entitlement certificates into your {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
 * Obtain a list of the subpaths for the required repositories.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -6,7 +6,7 @@
 * Import the client entitlement certificates into your {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
 * Obtain a list of the subpaths for the required repositories.
-Execute the following command on the RHUA server:
+Execute the following command on your RHUA server:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -3,7 +3,7 @@
 
 .Prerequisites
 * Generate the client entitlement certificates for the required repos on the RHUA node as described in https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in the _Configuring and Managing Red Hat Update Infrastructure Guide_.
-Import the client entitlement certificates to the {Project}.
+* Import the client entitlement certificates into your {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
 * Obtain a list of the subpaths for the required repositories.
 Execute the following command on the RHUA server:

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -1,6 +1,18 @@
 [id="Configuring_RHUI_Alternate_Content_Sources_{context}"]
 = Configuring RHUI Alternate Content Sources
 
+.Prerequisites
+* Generate the client entitlement certificates for the required repos on the RHUA node as described in https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in the _Configuring and Managing Red Hat Update Infrastructure Guide_.
+Import the client entitlement certificates to the {Project}.
+For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
+* Obtain a list of the subpaths for the required repositories.
+Execute the following command on the RHUA server:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# rhui-manager repo info --repo_id _My_Repo_ID_
+----
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
 . Click *Add Source* and set the *Source type* as *RHUI*.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -12,6 +12,7 @@ Execute the following command on the RHUA server:
 ----
 # rhui-manager repo info --repo_id _My_Repo_ID_
 ----
+* Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide. For example, if your base URL is `https://server.example.com` and your subpaths are `rhel7/` and `rhel8/`, then both `https://server.example.com/rhel7/` and `https://server.example.com/rhel8/` will be searched. 
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -23,7 +23,7 @@ Ensure that you pass the repo labels of the desired repositories.
 . In the *Name* field, enter a name for the alternate content source.
 . Optional: In the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
-. Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
+. Optional: Select *Use HTTP proxies* if you want the ACS to use the {SmartProxy}'s HTTP proxy.
 . Enter the Base URL of the Red Hat Update Infrastructure CDS node.
 . Enter a comma-separated list of Subpaths.
 . Provide the *Content Credentials*, if these are needed.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -40,7 +40,10 @@ Ensure that you pass the repo labels of the desired repositories.
 # hammer alternate-content-source create \
 --name "_My_ACS_Name_" \
 --alternate-content-source-type rhui \
---base-url "_https://local-repo.example.com:port_" \
+--base-url "_https://rhui-cds-node/pulp/content_" \
+--subpaths _path/to/repo/1/, path/to/repo/2/_ \
+--ssl-client-cert-id _SSL_Client_Cert_ID_ \
+--ssl-client-key-id _SSL_Client_Key_ID_ \
 --smart-proxy-ids _{SmartProxy}_ID_
 ----
 . Check if the newly created alternate content source is listed:

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -16,3 +16,42 @@ Ensure that you pass the repo labels of the desired repositories.
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.
+
+[id="cli-configuring-rhui-alternate-content-sources_{context}"]
+.CLI Procedure
+. On {ProjectServer}, enter the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer alternate-content-source create \
+--name "_My_ACS_Name_" \
+--alternate-content-source-type rhui \
+--base-url "_https://local-repo.example.com:port_" \
+--smart-proxy-ids _{SmartProxy}_ID_
+----
+. Check if the newly created alternate content source is listed:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer alternate-content-source list
+----
+. Refresh the alternate content source:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
+----
+. Add the {SmartProxies} to which the alternate content source is to be synced:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer alternate-content-source update \
+--id _My_Alternate_Content_Source_ID_ \
+--smart-proxy-ids _{SmartProxy}_ID_
+----
+. Refresh the alternate content sources:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
+----

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -12,7 +12,8 @@ Execute the following command on the RHUA server:
 ----
 # rhui-manager repo info --repo_id _My_Repo_ID_
 ----
-* Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide. For example, if your base URL is `https://server.example.com` and your subpaths are `rhel7/` and `rhel8/`, then both `https://server.example.com/rhel7/` and `https://server.example.com/rhel8/` will be searched. 
+* Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide.
+For example, if your base URL is `https://server.example.com` and your subpaths are `rhel7/` and `rhel8/`, then both `https://server.example.com/rhel7/` and `https://server.example.com/rhel8/` will be searched. 
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -44,7 +44,8 @@ Ensure that you pass the repo labels of the desired repositories.
 --subpaths _path/to/repo/1/, path/to/repo/2/_ \
 --ssl-client-cert-id _SSL_Client_Cert_ID_ \
 --ssl-client-key-id _SSL_Client_Key_ID_ \
---smart-proxy-ids _{SmartProxy}_ID_
+--smart-proxy-ids _{SmartProxy}_ID_ \
+--verify-ssl 1
 ----
 . Check if the newly created alternate content source is listed:
 +

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -29,7 +29,7 @@ Ensure that you pass the repo labels of the desired repositories.
 . Provide the *Content Credentials*, if these are needed.
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Review details and click *Add*.
-. Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.
+. Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.
 
 [id="cli-configuring-rhui-alternate-content-sources_{context}"]
 .CLI Procedure

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -11,7 +11,7 @@
 . Optional: Select *Use HTTP proxies* if you want the ACS to use the {SmartProxyServer}'s HTTP proxy.
 . Select the products that should use the alternate content source.
 . Review details and click *Add*.
-. Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.
+. Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.
 
 [id="cli-configuring-simplified-alternate-content-sources_{context}"]
 .CLI Procedure

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -22,7 +22,7 @@
 # hammer alternate-content-source create \
 --name _My_ACS_Name_ \
 --alternate-content-source-type simplified \
---smart-proxy-ids _{SmartProxy}_ID_ \
+--smart-proxy-ids _My_{SmartProxy}_ID_ \
 --product-ids _Product_ID_
 ----
 . Check if the newly created ACS is listed:

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -9,7 +9,7 @@
 . Optional: In the the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
 . Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
-. Select the products whose repositories you want to sync.
+. Select the products that should use the alternate content source.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.
 

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -23,7 +23,7 @@
 --name _My_ACS_Name_ \
 --alternate-content-source-type simplified \
 --smart-proxy-ids _My_{SmartProxy}_ID_ \
---product-ids _Product_ID_
+--product-ids _My_Product_ID_
 ----
 . Check if the newly created ACS is listed:
 +

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -28,12 +28,14 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 . Check if the newly created ACS is listed:
++
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer alternate-content-source list
 ----
+. Refresh the ACS:
 +
 [options="nowrap" subs="+quotes,attributes"]
-. Refresh the ACS:
 ----
 # hammer alternate-content-source refresh --id  _My_ACS_ID_ 
 ----

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -1,0 +1,39 @@
+[id="Configuring_Simplified_Alternate_Content_Sources_{context}"]
+= Configuring Simplified Alternate Content Sources
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
+. Click *Add Source* and set the *Source type* as *Simplified*.
+. Select the *Content type*.
+. In the *Name* field, enter a name for the alternate content source.
+. Optional: In the the *Description* field, provide a description for the ACS.
+. Select {SmartProxies} to which the alternate content source is to be synced.
+. Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
+. Select the products whose repositories you want to sync.
+. Review details and click *Add*.
+. Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.
+
+[id="cli-configuring-simplified-alternate-content-sources_{context}"]
+.CLI Procedure
+. Create the simplified ACS:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# hammer alternate-content-source create \
+--name _My_ACS_Name_ \
+--alternate-content-source-type simplified \
+--smart-proxy-ids _{SmartProxy}_ID_ \
+--product-ids _Product_ID_
+----
++
+[options="nowrap" subs="+quotes,attributes"]
+. Check if the newly created ACS is listed:
+----
+# hammer alternate-content-sources list
+----
++
+[options="nowrap" subs="+quotes,attributes"]
+. Refresh the ACS:
+----
+# hammer alternate-content-sources refresh --id  _My_ACS_ID_ 
+----

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -6,7 +6,7 @@
 . Click *Add Source* and set the *Source type* as *Simplified*.
 . Select the *Content type*.
 . In the *Name* field, enter a name for the alternate content source.
-. Optional: In the the *Description* field, provide a description for the ACS.
+. Optional: In the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
 . Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
 . Select the products that should use the alternate content source.

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -8,7 +8,7 @@
 . In the *Name* field, enter a name for the alternate content source.
 . Optional: In the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
-. Optional: Select `Use HTTP proxies` if you want the ACS to use the {SmartProxy}'s HTTP proxy.
+. Optional: Select *Use HTTP proxies* if you want the ACS to use the {SmartProxyServer}'s HTTP proxy.
 . Select the products that should use the alternate content source.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources* > click the vertical ellipsis next to the newly created alternate content source > Select *Refresh*.

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -25,8 +25,6 @@
 --smart-proxy-ids _{SmartProxy}_ID_ \
 --product-ids _Product_ID_
 ----
-+
-[options="nowrap" subs="+quotes,attributes"]
 . Check if the newly created ACS is listed:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -29,11 +29,11 @@
 [options="nowrap" subs="+quotes,attributes"]
 . Check if the newly created ACS is listed:
 ----
-# hammer alternate-content-sources list
+# hammer alternate-content-source list
 ----
 +
 [options="nowrap" subs="+quotes,attributes"]
 . Refresh the ACS:
 ----
-# hammer alternate-content-sources refresh --id  _My_ACS_ID_ 
+# hammer alternate-content-source refresh --id  _My_ACS_ID_ 
 ----

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -15,7 +15,7 @@
 
 [id="cli-configuring-simplified-alternate-content-sources_{context}"]
 .CLI Procedure
-. Create the simplified ACS:
+. Create a simplified ACS:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
Since there are three types of ACS, creating separate sections for each of the three. 
- Tweaked the existing concept module for ACS to include a generic introduction and to provide an overview of the three types. 
- Renamed the existing proc module so that it correctly mentions that it only talks about custom type ACS. 
- Added two separate proc modules to talk about RHUI and simplified ACSs.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
