### PR TITLE
Correct the path to unmount ISO

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -54,7 +54,7 @@ ifeval::["{mode}" == "disconnected"]
 [options="nowrap"]
 ----
 # umount /media/sat6
-# umount /media/rhel7-server
+# umount /media/rhel8
 ----
 endif::[]
 endif::[]


### PR DESCRIPTION
The path to unmounting ISO while installing the project is applicable to only EL7. While in the latest project version, it has to be relevant to EL8. Therefore, it was required to update it with the correct path considering the supported operating systems.

https://bugzilla.redhat.com/show_bug.cgi?id=2166016

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
