### PR TITLE
Add EL8 in the path of unmounting ISO

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -49,6 +49,14 @@ The script displays its progress and writes logs to `{installer-log-file}`.
 
 ifeval::["{mode}" == "disconnected"]
 . Unmount the ISO images:
+* On {RHEL} 8:
++
+[options="nowrap"]
+----
+# umount /media/sat6
+# umount /media/rhel8
+----
+* On {RHEL} 7:
 +
 [options="nowrap"]
 ----


### PR DESCRIPTION
In addition to the EL7 server, the project also supports EL8 and hence it is required to add the path for unmounting the ISO of EL8 as well.

https://bugzilla.redhat.com/show_bug.cgi?id=2166016

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
