### PR TITLE
Add redis in the list of users to avoid conflicts

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -60,12 +60,11 @@ endif::[]
 * puppetserver
 ifdef::katello,satellite[]
 * qdrouterd
-endif::[]
-ifdef::katello,satellite[]
 ifeval::["{context}" == "{project-context}"]
 * qpidd
 endif::[]
 endif::[]
+* redis
 ifdef::katello,satellite[]
 ifeval::["{context}" == "{project-context}"]
 * tomcat


### PR DESCRIPTION
We list some user accounts that are created by satellite that should not already exist or fetched from external entities. So here, the Redis was missing. It's applicable to even Proxy Installtion part. The same can be verified by the Redis Database server: /var/lib/redis:/sbin/nologin

https://bugzilla.redhat.com/show_bug.cgi?id=2165956

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
