### PR TITLE
Add new procedure for errata card

### DIFF
--- a/guides/common/assembly_configuring-host-collections.adoc
+++ b/guides/common/assembly_configuring-host-collections.adoc
@@ -28,6 +28,8 @@ include::modules/proc_applying-installable-errata.adoc[leveloffset=+2]
 
 include::modules/proc_filter-errata-by-type-severity.adoc[leveloffset=+2]
 
+include::modules/proc_viewing-errata-by-applicable-and-installable.adoc[leveloffset=+2]
+
 include::modules/proc_removing-content-from-a-host-collection.adoc[leveloffset=+2]
 
 include::modules/proc_changing-the-lifecycle-environment-or-content-view-of-a-host-collection.adoc[leveloffset=+2]

--- a/guides/common/modules/proc_viewing-errata-by-applicable-and-installable.adoc
+++ b/guides/common/modules/proc_viewing-errata-by-applicable-and-installable.adoc
@@ -1,7 +1,7 @@
 [id="Viewing_Errata_by_Applicable_and_Installable_{context}"]
 = Viewing Errata by Applicable and Installable
 
-Use the following procedure to view errata by Applicable or Installable.
+Use the following procedure to view errata by applicable or installable.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/proc_viewing-errata-by-applicable-and-installable.adoc
+++ b/guides/common/modules/proc_viewing-errata-by-applicable-and-installable.adoc
@@ -1,0 +1,13 @@
+[id="Viewing_Errata_by_Applicable_and_Installable_{context}"]
+= Viewing Errata by Applicable and Installable
+
+Use the following procedure to view errata by Applicable or Installable.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select the host name.
+. Click the *Overview* tab. Under the Errata card, there are two types of Errata.
+. Click *Applicable* to view the type of Errata that applies to a package installed on your host.
+. Click *Installable* to view errata that are applicable errata available in the host’s content view and lifecycle environment.
+. Click the available number link under each type to see the list of all available errata.
+. Click the other links for each type to filter *security advisories*, *bug fixes*, and *enhancements*.

--- a/guides/common/modules/proc_viewing-errata-by-applicable-and-installable.adoc
+++ b/guides/common/modules/proc_viewing-errata-by-applicable-and-installable.adoc
@@ -6,8 +6,9 @@ Use the following procedure to view errata by Applicable or Installable.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the host name.
-. Click the *Overview* tab. Under the Errata card, there are two types of Errata.
-. Click *Applicable* to view the type of Errata that applies to a package installed on your host.
-. Click *Installable* to view errata that are applicable errata available in the host’s content view and lifecycle environment.
-. Click the available number link under each type to see the list of all available errata.
-. Click the other links for each type to filter *security advisories*, *bug fixes*, and *enhancements*.
+. Click the *Overview* tab.
+Under the Errata card, there are two types of Errata.
+. Click *Applicable* to view errata that apply to a package installed on your host.
+. Click *Installable* to view applicable errata that are available in the host content view and lifecycle environment.
+. Click the link with number of errata under each type to see the list of all available errata of that type.
+. Click *security advisories*, *bug fixes*, or *enhancements* under each type to view only the respective type of errata.


### PR DESCRIPTION
The Errata card under the Overview tab under a host can toggle between
Applicable and Installable. This procedure describes how to do it and
what they mean.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
