### PR TITLE
Update link to a KCS article (Satellite)

### DIFF
--- a/guides/common/modules/con_registering_hosts.adoc
+++ b/guides/common/modules/con_registering_hosts.adoc
@@ -41,7 +41,7 @@ Hosts must use one of the following {RHEL} versions:
 * 6.1 or later*
 
 NOTE: Red{nbsp}Hat Enterprise{nbsp}Linux versions 6.1, 6.2, and 6.3 require `subscription-manager` and related packages to be updated manually.
-For more information, see https://access.redhat.com/solutions/1256763[].
+For more information, see https://access.redhat.com/solutions/4480641[].
 
 Note that the subscription model is deprecated and will be removed in a future release.
 {Team} recommends that you use https://access.redhat.com/articles/simple-content-access[Simple Content Access] as a substitute.


### PR DESCRIPTION
The original link was pointing to a retired article.

https://bugzilla.redhat.com/show_bug.cgi?id=2167472

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
