### PR TITLE
Add attribute for RHSCL repo

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -126,6 +126,8 @@
 :RepoRHEL7ServerSatelliteServerProductVersionPrevious: rhel-7-server-satellite-{ProductVersionPrevious}-rpms
 :RepoRHEL7ServerSatelliteToolsProductVersion: rhel-7-server-satellite-client-6-rpms
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
+// Used in downstream guides
+:RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
 
 :project-client-name: Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}


### PR DESCRIPTION
Downstream documentation (hammer guide) is not rendering correctly because of the missing attribute. Attaching screenshot below.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.

![image](https://user-images.githubusercontent.com/108661422/217555481-80d4d2b1-4c88-4ea1-a454-80d521e5a329.png)

