### PR TITLE
Update link to system purpose

### DIFF
--- a/guides/common/modules/proc_creating-a-host.adoc
+++ b/guides/common/modules/proc_creating-a-host.adoc
@@ -55,7 +55,7 @@ When you create a {RHEL} 8 host, you can set system purpose attributes.
 System purpose attributes define what subscriptions to attach automatically on host creation.
 In the *Host Parameters* area, enter the following parameter names with the corresponding values.
 ifndef::orcharhino[]
-For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in _Performing a standard RHEL installation_.
+For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#system_purposes-adoc_connect-to-red-hat[Introduction to System Purpose] in _Performing a standard RHEL 8 installation_.
 endif::[]
 +
 * `syspurpose_role`

--- a/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
+++ b/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
@@ -4,7 +4,7 @@
 You can edit the system purpose attributes for a {RHEL} host.
 System purpose allows you to set the intended use of a system on your network and improves reporting accuracy in the Subscriptions service of the Red Hat Hybrid Cloud Console.
 ifndef::orcharhino[]
-For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in _Performing a standard RHEL installation_.
+For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#system_purposes-adoc_connect-to-red-hat[Introduction to System Purpose] in _Performing a standard RHEL 8 installation_.
 endif::[]
 
 .Prerequisites
@@ -22,7 +22,7 @@ endif::[]
 . Log in to the host and edit the required system purpose attributes.
 For example, set the usage type to `Production`, the role to `{RHELServer}`, and add the `addon` add on.
 ifndef::orcharhino[]
-For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+For the list of values, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#system_purposes-adoc_connect-to-red-hat[Introduction to System Purpose] in  _Performing a standard RHEL 8 installation_.
 endif::[]
 +
 [subs="+quotes"]

--- a/guides/common/modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc
+++ b/guides/common/modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc
@@ -4,7 +4,7 @@
 You can edit the system purpose attributes of {RHEL} hosts.
 System purpose attributes define which subscriptions to attach automatically to hosts.
 ifndef::orcharhino[]
-For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation#configuring-system-purpose-standard_configuring-system-settings[Configuring system purpose] in the _Performing a standard RHEL installation_ guide.
+For more information about system purpose, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_8_installation/graphical-installation_graphical-installation?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#system_purposes-adoc_connect-to-red-hat[Introduction to System Purpose] in _Performing a standard RHEL 8 installation_.
 endif::[]
 
 .Prerequisites


### PR DESCRIPTION
RHEL installation guide appears to have changed structure and link to section about system purpose needs to be updated.

[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=2167488)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
