### PR TITLE
Add line about details in OS card

### DIFF
--- a/guides/common/modules/proc_using-the-host-details-tab.adoc
+++ b/guides/common/modules/proc_using-the-host-details-tab.adoc
@@ -13,7 +13,7 @@ Your browser remembers the card expansion and collapse state.
 The cards in the *Details* tab show details for the *System properties*, *BIOS*, *Networking interfaces*, *Operating system*, *Provisioning templates*, and *Provisioning*.
 Registered content hosts show additional cards for *Registration details*, *Installed products*, and *HW properties* providing information about *Model*, *Number of CPU(s)*, *Sockets*, *Cores per socket* and *RAM*.
 
-In the  *Operating system* card, you can see details for the *Architecture*, *OS*, *Boot time* and *Kernel release*. 
+In the  *Operating system* card, you can see details for the *Architecture*, *OS*, *Boot time*, and *Kernel release*. 
 
 There are interactive features for the following *Details* cards:
 

--- a/guides/common/modules/proc_using-the-host-details-tab.adoc
+++ b/guides/common/modules/proc_using-the-host-details-tab.adoc
@@ -13,6 +13,8 @@ Your browser remembers the card expansion and collapse state.
 The cards in the *Details* tab show details for the *System properties*, *BIOS*, *Networking interfaces*, *Operating system*, *Provisioning templates*, and *Provisioning*.
 Registered content hosts show additional cards for *Registration details*, *Installed products*, and *HW properties* providing information about *Model*, *Number of CPU(s)*, *Sockets*, *Cores per socket* and *RAM*.
 
+In the  *Operating system* card, you can see details for the *Architecture*, *OS*, *Boot time* and *Kernel release*. 
+
 There are interactive features for the following *Details* cards:
 
 .Networking interfaces


### PR DESCRIPTION
There are new available details in the OS card under the Details tab in
a host. Specifically the kernel release. A line had been added to call
out the details available under the OS card.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
