### PR TITLE
Add host details view procedure

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -44,6 +44,8 @@ include::modules/proc_assigning-a-host-to-a-specific-location.adoc[leveloffset=+
 
 include::modules/con_switching-between-hosts.adoc[leveloffset=+1]
 
+include::modules/proc_viewing-host-details-from-a-content-host.adoc[leveloffset=+1]
+
 include::modules/proc_selecting-host-columns.adoc[leveloffset=+1]
 
 include::modules/proc_removing-a-host-from-server.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
+++ b/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
@@ -3,12 +3,7 @@
 
 Use this procedure to view the host details page from a content host.
 
-.Prerequisites
-
-* Before viewing a content host, change your settings by navigating to *Administer* > *Settings*.
-
 .Procedure
-. On the *General* tab, select *New host details UI*, and from the dropdown list, change the settings from *No* to *Yes*.
-. Click *Submit*.
+
 . In the {ProjectWebUI}, navigate to *Hosts* > *Content Hosts* and select the host you want to view.
-. Click the *Content* tab and you will see the new host details page.
+. Click the *Content* tab and you will see the host details page.

--- a/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
+++ b/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
@@ -1,0 +1,12 @@
+[id="Viewing_Host_Details_from_a_Content_Host_{context}"]
+= Viewing Host Details from a Content Host
+
+Use this procedure to view the host details page from a content host.
+
+.Procedure
+
+. Before viewing a content host, change your settings by navigating to *Administer* > *Settings*.
+. On the *General* tab, select *New host details UI*, and from the dropdown list, change the settings from *No* to *Yes*.
+. Click *Submit*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Content Hosts* and select the host you want to view.
+. Click the *Content* tab and you will see the new host details page.

--- a/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
+++ b/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
@@ -10,4 +10,4 @@ Use this procedure to view the host details page from a content host.
 . Select the *Details* tab to see the host details page.
 
 The cards in the *Details* tab show details for the *System properties*, *BIOS*, *Networking interfaces*, *Operating system*, *Provisioning templates*, and *Provisioning*.
-Registered content hosts show additional cards for *Registration details*, *Installed products*, and *HW properties* providing information about *Model*, *Number of CPU(s)*, *Sockets*, *Cores per socket* and *RAM*.
+Registered content hosts show additional cards for *Registration details*, *Installed products*, and *HW properties* providing information about *Model*, *Number of CPU(s)*, *Sockets*, *Cores per socket*, and *RAM*.

--- a/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
+++ b/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
@@ -3,9 +3,11 @@
 
 Use this procedure to view the host details page from a content host.
 
-.Procedure
+.Prerequisites
 
-. Before viewing a content host, change your settings by navigating to *Administer* > *Settings*.
+* Before viewing a content host, change your settings by navigating to *Administer* > *Settings*.
+
+.Procedure
 . On the *General* tab, select *New host details UI*, and from the dropdown list, change the settings from *No* to *Yes*.
 . Click *Submit*.
 . In the {ProjectWebUI}, navigate to *Hosts* > *Content Hosts* and select the host you want to view.

--- a/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
+++ b/guides/common/modules/proc_viewing-host-details-from-a-content-host.adoc
@@ -5,5 +5,9 @@ Use this procedure to view the host details page from a content host.
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Hosts* > *Content Hosts* and select the host you want to view.
-. Click the *Content* tab and you will see the host details page.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Content Hosts*
+. Click the content host you want to view.
+. Select the *Details* tab to see the host details page.
+
+The cards in the *Details* tab show details for the *System properties*, *BIOS*, *Networking interfaces*, *Operating system*, *Provisioning templates*, and *Provisioning*.
+Registered content hosts show additional cards for *Registration details*, *Installed products*, and *HW properties* providing information about *Model*, *Number of CPU(s)*, *Sockets*, *Cores per socket* and *RAM*.


### PR DESCRIPTION
Created a procedure to view the host details page from a content host.
The procedure involves going to the Administer
settings.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
