### PR TITLE
Update name of REX setting

### DIFF
--- a/guides/common/modules/con_remote-execution-workflow.adoc
+++ b/guides/common/modules/con_remote-execution-workflow.adoc
@@ -17,10 +17,10 @@ endif::[]
 . From this set of {SmartProxies}, {Project} selects the {SmartProxy} that has the least number of running jobs.
 By doing this, {Project} ensures that the jobs load is balanced between remote execution {SmartProxies}.
 
-If you have enabled *remote_execution_prefer_registered_through_proxy*, {Project} runs the REX job using the {SmartProxy} the host is registered to.
+If you have enabled *Prefer registered through {SmartProxy} for remote execution*, {Project} runs the REX job using the {SmartProxy} the host is registered to.
 
-By default, *remote_execution_prefer_registered_through_proxy* is set to *No*.
-To enable it, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and on the *Content* tab, set `remote_execution_prefer_registered_through_proxy` to *Yes*.
+By default, *Prefer registered through {SmartProxy} for remote execution* is set to *No*.
+To enable it, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and on the *Content* tab, set `Prefer registered through {SmartProxy} for remote execution` to *Yes*.
 This ensures that {Project} performs REX jobs on hosts by the {SmartProxy} to which they are registered to.
 
 If {Project} does not find a remote execution {SmartProxy} at this stage, and if the *Fallback to Any {SmartProxy}* setting is enabled, {Project} adds another set of {SmartProxies} to select the remote execution {SmartProxy} from.


### PR DESCRIPTION
The `remote_execution_prefer_registered_through_proxy` cannot  be found in Administer > Settings, this setting is in fact `Prefer registered through {SmartProxy} for remote execution`. 

[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=2167486)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.1 on EL7, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
