### PR TITLE
Modify note while attaching subscription

### DIFF
--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -4,7 +4,12 @@
 [NOTE]
 ====
 Skip this step if you have SCA enabled on {Project}.
+ifeval::["{context}" == "{smart-proxy-context}"]
+There is no requirement of attaching the {SatelliteSub} to the {SmartProxyServer} using subscription-manager.
+endif::[]
+ifeval::["{context}" == "{project-context}"]
 There is no requirement of attaching the {SatelliteSub} to the {ProjectServer} using subscription-manager.
+endif::[]
 ====
 
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.


### PR DESCRIPTION
In the previous PR, we modified the note while considering the SCA enabled in Customer Portal. But, the case is different for Proxy. If the SCA is enabled on the Server, you don't need to attach a subscription for the Proxy. Hence, we added the note in both contexts to avoid even a little confusion.

https://bugzilla.redhat.com/show_bug.cgi?id=2166372

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
