### PR TITLE
Capitalize Cockpit attribute in titles

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -34,6 +34,7 @@
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy
 :Cockpit: Cockpit
+:CockpitTitle: Cockpit
 :customcontent: content
 :customdeb: DEB
 :customdebtitle: DEB

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -41,6 +41,7 @@
 :certs-generate: capsule-certs-generate
 :certs-proxy-context: capsule
 :Cockpit: Red{nbsp}Hat web console
+:CockpitTitle: Red{nbsp}Hat Web Console
 :customcontent: custom content
 :customfiletype: custom file type
 :customfiletypetitle: Custom File Type

--- a/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
@@ -1,5 +1,5 @@
 [id="Host_Management_and_Monitoring_Using_Cockpit_{context}"]
-= Host Management and Monitoring Using {Cockpit}
+= Host Management and Monitoring Using {CockpitTitle}
 
 {Cockpit} is an interactive web interface that you can use to perform actions and monitor {EL} hosts.
 You can enable a remote-execution feature to integrate {Project} with {Cockpit}.

--- a/guides/common/modules/proc_enabling-cockpit-on-server.adoc
+++ b/guides/common/modules/proc_enabling-cockpit-on-server.adoc
@@ -1,5 +1,5 @@
 [id="Enabling_Cockpit_on_Server_{context}"]
-= Enabling {Cockpit} on {Project}
+= Enabling {CockpitTitle} on {Project}
 
 By default, {Cockpit} integration is disabled in {Project}.
 If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {Cockpit} integration on {ProjectServer}.

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -1,5 +1,5 @@
 [id="Managing_and_Monitoring_Hosts_Using_Cockpit_{context}"]
-= Managing and Monitoring Hosts Using {Cockpit}
+= Managing and Monitoring Hosts Using {CockpitTitle}
 
 You can access the {Cockpit} web UI through the {ProjectWebUI} and use the functionality to manage and monitor hosts in {Project}.
 


### PR DESCRIPTION
{Cockpit} renders lowercased in Satellite build titles. Added new attribute to fix this issue and to be consistent with Camel Case titles throughout the guides.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
