### PR TITLE
Add RHEL 9 architectures to provisioning support

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Host_Provisioning_Support.adoc
+++ b/guides/doc-Planning_for_Project/topics/Host_Provisioning_Support.adoc
@@ -6,6 +6,7 @@ Supported combinations of major versions of {RHEL} and hardware architectures fo
 [options="header"]
 |====
 |Platform |Architectures
+|{RHEL} 9 |x86_64
 |{RHEL} 8 |x86_64
 |{RHEL} 7 |x86_64
 |{RHEL} 6 |x86_64, i386


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
