### PR TITLE
Update step with outdated Web Console button

### DIFF
--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -19,8 +19,6 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpit}.
 . In the upper right of the *Overview* tab, click the vertical ellipsis and select *Console*.
-. Optional: In the upper right of the *Overview* tab, click the vertical ellipsis and select *Legacy UI*.
-Select *Enable Web Console* from the *Schedule Remote Job* dropdown in the host details page.
 
 You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through the {Cockpit}.
 

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -18,7 +18,7 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpit}.
-. In the upper right of the host window, click the vertical ellipsis and select *Console*.
+. In the upper right of the host window, click the vertical ellipsis and select *Web Console*.
 
 You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through the {Cockpit}.
 

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -18,7 +18,9 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpit}.
-. In the upper right of the host window, click *Web Console*.
+. In the upper right of the *Overview* tab, click the vertical ellipsis and select *Console*.
+. Optional: In the upper right of the *Overview* tab, click the vertical ellipsis and select *Legacy UI*.
+Select *Enable Web Console* from the *Schedule Remote Job* dropdown in the host details page.
 
 You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through the {Cockpit}.
 

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -18,7 +18,7 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpit}.
-. In the upper right of the *Overview* tab, click the vertical ellipsis and select *Console*.
+. In the upper right of the host window, click the vertical ellipsis and select *Console*.
 
 You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through the {Cockpit}.
 


### PR DESCRIPTION
A step in the Procedure mentions an outdated Web
Console button. A
change was required to reflect the new UI where the user must select a
vertical ellipsis. It is also optional for the user to select the
Legacy UI to choose the old Enable Web Console button if they wish.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
