### PR TITLE
Remove steps required for EL 7 from the upgrade steps for branch 3.3

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -150,7 +150,8 @@ baseurl=file:///media/sat6/Satellite
 baseurl=file:///media/sat6/Maintenance/
 ----
 
-. Configure the Ansible repository from the ISO file.
+ifndef::satellite[]
+. If the {Project} is running on a {RHEL} 7 system, configure the Ansible repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Ansible packages:
 +
@@ -180,7 +181,7 @@ baseurl=file:///media/sat6/Maintenance/
 baseurl=file:///media/sat6/ansible/
 ----
 
-. Configure the Red Hat Software Collections repository from the ISO file.
+. If the {Project} is running on a {RHEL} 7 system, configure the Red Hat Software Collections repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Red Hat Software Collections packages:
 +
@@ -209,6 +210,7 @@ baseurl=file:///media/sat6/ansible/
 ----
 baseurl=file:///media/sat6/RHSCL/
 ----
+endif::[]
 
 . Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.


### PR DESCRIPTION
Satellite 6.12 is only supported on EL 8. Removing the steps to configure Ansible and Software Collections repositories from the steps to upgrade disconnected systems. These steps are only required for EL 7 systems.

Since, the other projects corresponding to v3.3 are supported with EL7, adding an ifndef condition. Also, adding a rejoinder that these steps are only needed for EL7 systems.

Same change as https://github.com/theforeman/foreman-documentation/pull/1994.

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
