### PR TITLE
Add note about steps required gor EL 7 in the disconnected upgrade pr…

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -153,7 +153,7 @@ baseurl=file:///media/sat6/Satellite
 baseurl=file:///media/sat6/Maintenance/
 ----
 
-. Configure the Ansible repository from the ISO file.
+. If the {Project} is running on a {RHEL} 7 system, configure the Ansible repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Ansible packages:
 +
@@ -183,7 +183,7 @@ baseurl=file:///media/sat6/Maintenance/
 baseurl=file:///media/sat6/ansible/
 ----
 
-. Configure the Red Hat Software Collections repository from the ISO file.
+. If the {Project} is running on a {RHEL} 7 system, configure the Red Hat Software Collections repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Red Hat Software Collections packages:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -153,7 +153,7 @@ baseurl=file:///media/sat6/Satellite
 baseurl=file:///media/sat6/Maintenance/
 ----
 
-. If your {Project} runs on a {RHEL} 7 system, configure the Ansible repository from the ISO file.
+. If your {Project} runs on {RHEL} 7, configure the Ansible repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Ansible packages:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -153,7 +153,7 @@ baseurl=file:///media/sat6/Satellite
 baseurl=file:///media/sat6/Maintenance/
 ----
 
-. If the {Project} is running on a {RHEL} 7 system, configure the Ansible repository from the ISO file.
+. If your {Project} runs on a {RHEL} 7 system, configure the Ansible repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Ansible packages:
 +
@@ -183,7 +183,7 @@ baseurl=file:///media/sat6/Maintenance/
 baseurl=file:///media/sat6/ansible/
 ----
 
-. If the {Project} is running on a {RHEL} 7 system, configure the Red Hat Software Collections repository from the ISO file.
+. If your {Project} runs on a {RHEL} 7 system, configure the Red Hat Software Collections repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Red Hat Software Collections packages:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -183,7 +183,7 @@ baseurl=file:///media/sat6/Maintenance/
 baseurl=file:///media/sat6/ansible/
 ----
 
-. If your {Project} runs on a {RHEL} 7 system, configure the Red Hat Software Collections repository from the ISO file.
+. If your {Project} runs on {RHEL} 7, configure the Red Hat Software Collections repository from the ISO file.
 
 .. Copy the ISO file's repository data file for Red Hat Software Collections packages:
 +


### PR DESCRIPTION
…ocedure for 3.2

The steps to configure Ansible and Software Collections repositories from the procedure to upgrade disconnected systems are only required for EL 7 systems. Since v 3.1 and 3.2 are supported with EL7 as well as EL8, adding a rejoinder that these steps are only needed for EL7 systems.

Same change as https://github.com/theforeman/foreman-documentation/pull/1996.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
