### PR TITLE
Correctly render foreman-installer attribute

### DIFF
--- a/guides/common/modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc
+++ b/guides/common/modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc
@@ -47,6 +47,7 @@ endif::[]
 ifeval::["{context}" == "ansible"]
 
 . Configure the system:
++
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} --foreman-proxy-plugin-ansible-working-dir _/remote_working_dir_

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -26,7 +26,7 @@ Use this procedure to enable the repositories that are required to install {Prod
 
 . Enable the module:
 +
-[options="nowrap"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # dnf module enable {dnf-module}
 ----


### PR DESCRIPTION
For some weird reason, the missing `+` caused the attribute not to expand. Adding it fixed a formatting issue at the same time. Screenshots from before and after adding `+` below.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2169868

Before:
![image](https://user-images.githubusercontent.com/108661422/219076508-4d1593bc-efcb-4525-a41f-3a3fb40cd801.png)

After:
![image](https://user-images.githubusercontent.com/108661422/219076291-2ae0cd1b-ebf0-4305-a0b8-7c9dc8aa47fc.png)


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
