### PR TITLE
Move host-related modules to Managing Hosts

### DIFF
--- a/guides/common/assembly_managing-activation-keys.adoc
+++ b/guides/common/assembly_managing-activation-keys.adoc
@@ -9,5 +9,3 @@ include::modules/proc_using-activation-keys-for-host-registration.adoc[leveloffs
 include::modules/proc_enabling-auto-attach.adoc[leveloffset=+1]
 
 include::modules/proc_setting-the-service-level.adoc[leveloffset=+1]
-
-include::modules/proc_enabling-and-disabling-repositories-on-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -1,0 +1,12 @@
+[id="managing-packages_{context}"]
+= Managing Packages
+
+You can use {Project} to install, upgrade, and remove packages on hosts, as well as to enable or disable repositories on hosts.
+
+include::modules/proc_enabling-and-disabling-repositories-on-hosts.adoc[leveloffset=+1]
+
+include::modules/proc_installing-packages-on-a-host.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-packages-on-a-host-in-bulk.adoc[leveloffset=+1]
+
+include::modules/proc_removing-packages-from-a-host.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -7,6 +7,6 @@ include::modules/proc_enabling-and-disabling-repositories-on-hosts.adoc[leveloff
 
 include::modules/proc_installing-packages-on-a-host.adoc[leveloffset=+1]
 
-include::modules/proc_upgrading-packages-on-a-host-in-bulk.adoc[leveloffset=+1]
+include::modules/proc_upgrading-packages-on-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_removing-packages-from-a-host.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_upgrading-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_upgrading-packages-on-a-host.adoc
@@ -1,5 +1,5 @@
-[id="upgrading-packages-on-a-host-in-bulk_{context}"]
-= Upgrading Packages on a Host in Bulk
+[id="upgrading-packages-on-a-host_{context}"]
+= Upgrading Packages on a Host
 
 You can upgrade packages on a host in bulk in the {ProjectWebUI}.
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -39,12 +39,6 @@ endif::[]
 
 include::common/assembly_managing-errata.adoc[leveloffset=+1]
 
-include::common/modules/proc_installing-packages-on-a-host.adoc[leveloffset=+1]
-
-include::common/modules/proc_upgrading-packages-on-a-host-in-bulk.adoc[leveloffset=+1]
-
-include::common/modules/proc_removing-packages-from-a-host.adoc[leveloffset=+1]
-
 include::common/assembly_managing-ostree-content.adoc[leveloffset=+1]
 
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -48,6 +48,8 @@ include::common/assembly_host-status.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-template-repositories.adoc[leveloffset=+1]
 
+include::common/assembly_managing-packages.adoc[leveloffset=+1]
+
 :numbered!:
 
 [appendix]


### PR DESCRIPTION
Inspect individual commits for easier review.
Disclaimer: There are no links associated with the moved modules so moving them is safe.

cc @jeremylenz 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
