### PR TITLE
Add procedure for listing installed packages

### DIFF
--- a/guides/common/assembly_using-report-templates.adoc
+++ b/guides/common/assembly_using-report-templates.adoc
@@ -12,6 +12,8 @@ include::modules/proc_importing-report-templates.adoc[leveloffset=+1]
 
 include::modules/proc_importing-report-templates-using-the-api.adoc[leveloffset=+1]
 
+include::modules/proc_generating-a-list-of-installed-packages.adoc[leveloffset=+1]
+
 ifdef::satellite[]
 include::modules/proc_creating-a-report-template-to-monitor-entitlements.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -7,7 +7,7 @@ Use this procedure to generate a list of installed packages in *Report Templates
 
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Select the *Host - All Installed Packages* report template.
-Under the *Editor* tab, the report template shows the host’s name with the name of the package.
+Under the *Preview* tab, the report template shows the host’s name with the name of the package.
 There is a host filter, so it does not have to display every host you have available in the report.
 . After you verify the report template, return to the *Report Templates* screen.
 . To the right of *Host - All Installed Packages*, click *Generate*.

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -6,7 +6,6 @@ Use this procedure to generate a list of installed packages in *Report Templates
 .Procedure
 
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
-. Select the *Host - All Installed Packages* report template.
 . To the right of *Host - All Installed Packages*, click *Generate*.
 . Optional: Use the *Hosts filter* search field to search for and apply specific host filters.
 . Click *Generate*.

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -7,11 +7,13 @@ Use this procedure to generate a list of installed packages in *Report Templates
 
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Select the *Host - All Installed Packages* report template.
-Under the *Preview* tab, the report template shows the host’s name with the name of the package.
+Under the *Preview* tab, the report template shows the host name with the name of the package.
 There is a host filter, so it does not have to display every host you have available in the report.
 . After you verify the report template, return to the *Report Templates* screen.
 . To the right of *Host - All Installed Packages*, click *Generate*.
-. Use the *Hosts filter* Search field to search for specific hosts filters.
+. Optional: Use the *Hosts filter* search field to search for and apply specific host filters.
 . Click *Generate*.
-. Click *Download*.
-A spreadsheet will open to display the host and list of installed packages for that host.
+. If the download does not start automatically, click *Download*.
+
+.Verification
+* You have the spreadsheet listing the installed packages for the selected hosts downloaded on your machine.

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -7,8 +7,6 @@ Use this procedure to generate a list of installed packages in *Report Templates
 
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Select the *Host - All Installed Packages* report template.
-There is a host filter, so it does not have to display every host you have available in the report.
-. After you verify the report template, return to the *Report Templates* screen.
 . To the right of *Host - All Installed Packages*, click *Generate*.
 . Optional: Use the *Hosts filter* search field to search for and apply specific host filters.
 . Click *Generate*.

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -1,0 +1,20 @@
+[id="Generating_a_List_of_Installed_Packages_{context}"]
+= Generating a List of Installed Packages
+
+Use this procedure to generate a list of installed packages in *Report Templates*.
+
+.Procedure
+
+. In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
+. Select the *Host - All Installed Packages* report template.
+
+Under the *Editor* tab, the report template shows the host’s name with the name of the package.
+There is a host filter, so it does not have to display every host you have available in the report.
+
+. After you verify the report template, return to the *Report Templates* screen.
+. To the right of *Host - All Installed Packages*, click *Generate*.
+. Use the *Hosts filter* Search field to search for specific hosts filters.
+. Click *Generate*.
+. Click *Download*.
+
+A spreadsheet will open to display the host and list of installed packages for that host.

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -7,14 +7,11 @@ Use this procedure to generate a list of installed packages in *Report Templates
 
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Select the *Host - All Installed Packages* report template.
-
 Under the *Editor* tab, the report template shows the host’s name with the name of the package.
 There is a host filter, so it does not have to display every host you have available in the report.
-
 . After you verify the report template, return to the *Report Templates* screen.
 . To the right of *Host - All Installed Packages*, click *Generate*.
 . Use the *Hosts filter* Search field to search for specific hosts filters.
 . Click *Generate*.
 . Click *Download*.
-
 A spreadsheet will open to display the host and list of installed packages for that host.

--- a/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
+++ b/guides/common/modules/proc_generating-a-list-of-installed-packages.adoc
@@ -7,7 +7,6 @@ Use this procedure to generate a list of installed packages in *Report Templates
 
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Select the *Host - All Installed Packages* report template.
-Under the *Preview* tab, the report template shows the host name with the name of the package.
 There is a host filter, so it does not have to display every host you have available in the report.
 . After you verify the report template, return to the *Report Templates* screen.
 . To the right of *Host - All Installed Packages*, click *Generate*.


### PR DESCRIPTION
A procedure was created for generating a list of
installed packages in
Report Templates.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
