### PR TITLE
Correct the note for Project Subscription

### DIFF
--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -3,13 +3,15 @@
 
 [NOTE]
 ====
-Skip this step if you have SCA enabled on {Project}.
 ifeval::["{context}" == "{smart-proxy-context}"]
+Skip this step if you have SCA enabled on {Project}.
 There is no requirement of attaching the {SatelliteSub} to the {SmartProxyServer} using subscription-manager.
 endif::[]
 ifeval::["{context}" == "{project-context}"]
+Skip this step if you have SCA enabled on {Team} Customer Portal.
 There is no requirement of attaching the {SatelliteSub} to the {ProjectServer} using subscription-manager.
 endif::[]
+For more information about SCA, see https://access.redhat.com/articles/simple-content-access[Simple Content Access].
 ====
 
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.


### PR DESCRIPTION
In the earlier PR, we added the note about Project Subscription and its relation to the server. However, when it comes to Project Server, the SCA should be enabled to end-user portal and Project itself. Therefore, the note has been correct according to the relevant contexts of the server.

https://bugzilla.redhat.com/show_bug.cgi?id=2169872

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
