### PR TITLE
Fixes Foreman Support #22332 - document multiple pxdns

### DIFF
--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -69,6 +69,7 @@ For example, `fdi.pxfactvalue1` sets the value for the fact named with `fdi.pxfa
 fdi.pxip, fdi.pxgw, fdi.pxdns::
 Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the DNS (`fdi.pxdns`) for the primary network interface.
 If your omit these parameters, the image uses DHCP to configure the network interface.
+Separate multiple DNS with comma (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
 
 fdi.pxmac::
 The MAC address of the primary interface in the format of `AA:BB:CC:DD:EE:FF`.

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -68,7 +68,7 @@ For example, `fdi.pxfactvalue1` sets the value for the fact named with `fdi.pxfa
 
 fdi.pxip, fdi.pxgw, fdi.pxdns::
 Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the DNS (`fdi.pxdns`) for the primary network interface.
-If your omit these parameters, the image uses DHCP to configure the network interface.
+If you omit these parameters, the image uses DHCP to configure the network interface.
 Separate multiple DNS with comma (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
 
 fdi.pxmac::

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -70,7 +70,7 @@ fdi.pxip, fdi.pxgw, fdi.pxdns::
 Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the DNS (`fdi.pxdns`) for the primary network interface.
 If you omit these parameters, the image uses DHCP to configure the network interface.
 You can add multiple DNS entries in a comma-separated list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`
-footnote:[Please note that using `,` abuses the fact that NetworkManager expects a `;` but currently also accepts a `,`
+footnote:[NetworkManager expects `;` as a list separator but currently also accepts `,`.
 see also `man nm-settings-keyfile` and <https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting>]).
 
 fdi.pxmac::

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -69,9 +69,10 @@ For example, `fdi.pxfactvalue1` sets the value for the fact named with `fdi.pxfa
 fdi.pxip, fdi.pxgw, fdi.pxdns::
 Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the DNS (`fdi.pxdns`) for the primary network interface.
 If you omit these parameters, the image uses DHCP to configure the network interface.
-You can add multiple DNS entries in a comma-separated list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`
+You can add multiple DNS entries in a comma-separated
 footnote:[NetworkManager expects `;` as a list separator but currently also accepts `,`.
-For more information, see `man nm-settings-keyfile` and https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting[Shell-like scripting in GRUB]]).
+For more information, see `man nm-settings-keyfile` and https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting[Shell-like scripting in GRUB]]
+list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
 
 fdi.pxmac::
 The MAC address of the primary interface in the format of `AA:BB:CC:DD:EE:FF`.

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -69,7 +69,7 @@ For example, `fdi.pxfactvalue1` sets the value for the fact named with `fdi.pxfa
 fdi.pxip, fdi.pxgw, fdi.pxdns::
 Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the DNS (`fdi.pxdns`) for the primary network interface.
 If you omit these parameters, the image uses DHCP to configure the network interface.
-Separate multiple DNS with comma (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
+You can add multiple DNS entries in a comma-separated list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
 
 fdi.pxmac::
 The MAC address of the primary interface in the format of `AA:BB:CC:DD:EE:FF`.

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -72,7 +72,7 @@ If you omit these parameters, the image uses DHCP to configure the network inter
 You can add multiple DNS entries in a comma-separated
 footnote:[NetworkManager expects `;` as a list separator but currently also accepts `,`.
 For more information, see `man nm-settings-keyfile` and https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting[Shell-like scripting in GRUB]]
-list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
+list, for example `fdi.pxdns=192.168.1.1,192.168.200.1`.
 
 fdi.pxmac::
 The MAC address of the primary interface in the format of `AA:BB:CC:DD:EE:FF`.

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -71,7 +71,7 @@ Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the D
 If you omit these parameters, the image uses DHCP to configure the network interface.
 You can add multiple DNS entries in a comma-separated list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`
 footnote:[NetworkManager expects `;` as a list separator but currently also accepts `,`.
-see also `man nm-settings-keyfile` and <https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting>]).
+For more information, see `man nm-settings-keyfile` and https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting[Shell-like scripting in GRUB]]).
 
 fdi.pxmac::
 The MAC address of the primary interface in the format of `AA:BB:CC:DD:EE:FF`.

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -69,7 +69,9 @@ For example, `fdi.pxfactvalue1` sets the value for the fact named with `fdi.pxfa
 fdi.pxip, fdi.pxgw, fdi.pxdns::
 Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the DNS (`fdi.pxdns`) for the primary network interface.
 If you omit these parameters, the image uses DHCP to configure the network interface.
-You can add multiple DNS entries in a comma-separated list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`).
+You can add multiple DNS entries in a comma-separated list (for example `fdi.pxdns=192.168.1.1,192.168.200.1`
+footnote:[Please note that using `,` abuses the fact that NetworkManager expects a `;` but currently also accepts a `,`
+see also `man nm-settings-keyfile` and <https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting>]).
 
 fdi.pxmac::
 The MAC address of the primary interface in the format of `AA:BB:CC:DD:EE:FF`.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.

While customizing an FDI for Satellite 6.11, I failed to find in the docs how to feed multiple DNS to the `fdi.pxdns` parameter. This PR attempts to address that.

I came across https://projects.theforeman.org/issues/22332 which has the same ask, but the suggestion of `;` as separator did not work for me. Using `,` as separator does work for me.

### Testresults

These verification were done by using `discovery-remaster` from foreman-discovery-image-3.8.2-1.el7sat.noarch

Because the DHCP server my testhost queries does give me both an IP and a gateway, but not the DNSes I want; I only set `fdi.pxdns` but neither `fdi.pxip` nor `fdi.pxgw` while testing.

#### using ; as separator

```bash
discovery-remaster \
  /usr/share/foreman-discovery-image/foreman-discovery-image-3.8.2-1.iso \
  "proxy.url=https://satellite.example.com:9090 proxy.type=proxy fdi.pxdns=192.168.1.1;192.168.200.1 fdi.pxauto=1" \
  /var/tmp/fdi-builddir/fdi-2023021701.iso
```

did not work for me
-  a host booted with `fdi-2023021701.iso` complains during bootup along the lines of `command not found 192.168.200.1` (in grub). While it proceeds to boot the FDI after a timeout, FDI asks me to set up network.

#### using , as separator

```bash
discovery-remaster \
  /usr/share/foreman-discovery-image/foreman-discovery-image-3.8.2-1.iso \
  "proxy.url=https://satellite.example.com:9090 proxy.type=proxy fdi.pxdns=192.168.1.1,192.168.200.1 fdi.pxauto=1" \
  /var/tmp/fdi-builddir/fdi-2023021702.iso
```

works for me
- a host booted with `fdi-2023021702.iso` shows up in Satellite 6.11 under _Hosts_ / _Discovered Hosts_
- a host booted with `fdi-2023021702.iso` has both DNS in /etc/resolv.conf (before the kexec is triggered, after I enabled SSH so I could log in on a tty and check)
