### PR TITLE
Add filter for a single user

### DIFF
--- a/guides/common/modules/ref_examples-ldap-filters.adoc
+++ b/guides/common/modules/ref_examples-ldap-filters.adoc
@@ -7,6 +7,7 @@ As an administrator, you can create LDAP filters to restrict the access of speci
 [cols="3,9" options="header"]
 |====
 | User | Filter
+| User1 |(distinguishedName=cn=User1,cn=Users,dc=domain,dc=example)
 | User1, User3 |(memberOf=cn=Group1,cn=Users,dc=domain,dc=example)
 | User2, User3 |(memberOf=cn=Group2,cn=Users,dc=domain,dc=example)
 | User1, User2, User3 | (\|(memberOf=cn=Group1,cn=Users,dc=domain,dc=example)(memberOf=cn=Group2,cn=Users,dc=domain,dc=example))


### PR DESCRIPTION
While giving the example of LDAP filters while configuring External Authentication, a use case of a single user was missing. We added it with applicable filter data.

https://bugzilla.redhat.com/show_bug.cgi?id=2170700

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
