### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.adoc]
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
.editorconfig is a quality of life improvement that helps maintain the same formatting throughout the files. If you get an extension to your code editor (I use [EditorConfig of VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)), it automatically checks and corrects styling in files upon saving. Some editors even have native support, for more info see [editorconfig.org](https://editorconfig.org).

I find this most useful for automatically inserting final newline in the files as well as for trimming the trailing whitespaces; however; you can also set indent style (tab vs spaces), indent size, tab width, enconding, and end of line style (windows vs unix).

Also, I realize all of these can be set in your editor; however; this way the formatting will be the same for anyone whose editor has support for editorconfig.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
