### PR TITLE
Rename Satellite Client repo

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -130,7 +130,7 @@
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
 
-:project-client-name: Satellite Client 6
+:project-client-name: {ProjectName} Client{nbsp}6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProductVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProductVersion}
 :dnf-module: satellite:el8


### PR DESCRIPTION
I suggest adding "Red Hat" to "Satellite Client 6" to make it clearer that it's a Red Hat repository.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
