### PR TITLE
Correct the command in deploying SSL certs

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -52,7 +52,7 @@ capsule-certs-generate --foreman-proxy-fqdn "$CAPSULE" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
-    --certs-update-all
+    --certs-update-server
 ----
 endif::[]
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -29,18 +29,19 @@ ifdef::satellite[]
 [options="nowrap", subs="+quotes,attributes"]
 ----
   {foreman-installer} --scenario satellite \
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+    --certs-server-cert "_/root/satellite_cert/satellite.example.com_cert.pem_" \
+    --certs-server-key "_/root/satellite_cert/satellite.example.com_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/satellite_cert/CA-Chain.pem_"
 ----
 +
 .To update the certificates on a currently running {Project} installation, run:
 ----
   {foreman-installer} --scenario satellite \
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
-    --certs-update-all
+    --certs-server-cert "_/root/satellite_cert/satellite.example.com_cert.pem_" \
+    --certs-server-key "_/root/satellite_cert/satellite.example.com_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/satellite_cert/CA-Chain.pem_" \
+    --certs-update-server \
+    --certs-update-server-ca
 ----
 endif::[]
 ifndef::satellite[]


### PR DESCRIPTION
In the previous PR, we added the --certs-update-all which does the large change. While, these changes will do the changes as per the minimal requirements. Therefore, these changes are recommended over the previous ones by reporters and reviewers.

https://bugzilla.redhat.com/show_bug.cgi?id=2093128

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
