### PR TITLE
Correct satellite guide URLs

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -23,12 +23,12 @@
 :ProvisioningDocURL: {BaseURL}provisioning_hosts/index#
 :TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_and_updating_red_hat_satellite/index#
-:ReleaseNotesURL: {MultiBaseURL}release_notes/index#
 
 // Not upstreamed
-:APIDocURL: {MultiBaseURL}api_guide/index#
-:HammerDocURL: {MultiBaseURL}hammer_cli_guide/index#
-:ConfiguringVMSubscriptionsDocURL: {MultiBaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index#
+:ReleaseNotesURL: {BaseURL}release_notes/index#
+:APIDocURL: {BaseURL}api_guide/index#
+:HammerDocURL: {BaseURL}hammer_cli_guide/index#
+:ConfiguringVMSubscriptionsDocURL: {BaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index#
 
 // Overrides for satellite build
 :ansible-collection-package: ansible-collection-redhat-satellite

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -4,9 +4,6 @@
 // Add -beta for Beta releases
 :ProductVersionRepoTitle: {ProductVersion}
 
-// Red Hat sometimes prefers the multi page (as opposed to html-single)
-// The URL structure is different and there's no upstream equivalent.
-:MultiBaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html/
 :BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProductVersion}/html-single/
 
 // URLs (published on Red Hat Portal)


### PR DESCRIPTION
Multi-page html links behave differently than single-page, thus the attributes cannot in current state be used link the proper sections of the guides.

Compare:

https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html-single/hammer_cli_guide/index#hammer-defaults

VS

https://access.redhat.com/documentation/en-us/red_hat_satellite/6.12/html/hammer_cli_guide/index#hammer-defaults

Also moved Satellite Release Notes URL in the correct section of the attributes file under *not upstreamed*.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
