### PR TITLE
Remove Container Images from snip

### DIFF
--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -23,7 +23,6 @@ You can export the following content in a syncable format from {ProjectServer}:
 * Yum repositories
 * Kickstart repositories
 * File repositories
-* Container Images
 
 You cannot export Ansible and DEB content.
 

--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -24,6 +24,6 @@ You can export the following content in a syncable format from {ProjectServer}:
 * Kickstart repositories
 * File repositories
 
-You cannot export Ansible and DEB content.
+You cannot export Ansible, DEB, and Docker content.
 
 The export contains directories with the packages, *listing* files, and metadata of the repository in Yum format that can be used to synchronize in the importing {ProjectServer}.


### PR DESCRIPTION
Removed "Container Images" from snip_generating-
content.adoc located in
modules/proc_exporting-the-library-environment-in-a- syncable-format.adoc.
This change was required because we do not support container images for
syncable formats.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
