### PR TITLE
Correct the command for default SSL certificate

### DIFF
--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -21,13 +21,13 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 # mkdir /root/_{smart-proxy-context}_cert_
 ----
 
-. On {ProjectServer}, generate the `_/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_` certificate archive for your {SmartProxyServer}:
+. On {ProjectServer}, generate the `/root/{smart-proxy-context}_cert/_{smartproxy-example-com}_-certs.tar` certificate archive for your {SmartProxyServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {certs-generate} \
 --foreman-proxy-fqdn _{smartproxy-example-com}_ \
---certs-tar _/root/{smart-proxy-context}_cert/{smart-proxy-context}_certs.tar_
+--certs-tar /root/{smart-proxy-context}_cert/_{smartproxy-example-com}_-certs.tar
 ----
 +
 Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
@@ -37,7 +37,7 @@ Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` c
 ----
 _output omitted_
 {installer-scenario-smartproxy} \
---certs-tar-file "_/root/{smart-proxy-context}_certs.tar_" \
+--certs-tar-file "/root/_{smartproxy-example-com}_-certs.tar" \
 --foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -99,7 +99,7 @@ endif::[]
 ----
 _output omitted_
 {installer-scenario-smartproxy} \
---certs-tar-file "_/root/{smart-proxy-context}_certs.tar_" \
+--certs-tar-file "/root/_{smartproxy-example-com}_-certs.tar" \
 --foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \


### PR DESCRIPTION
In configuring the Proxy's default SSL certificate, the command for copying the archive file to the Proxy Server is incorrect as it has a typo. We are making corrections to that command because it generated the tar file in the previous step. The present command that is incorrect is throwing an error stating the tar file generated by the server is not present.

https://bugzilla.redhat.com/show_bug.cgi?id=2167827

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
