### PR TITLE
Correct hammer command showcasing location option

### DIFF
--- a/guides/common/modules/proc_setting-the-location-context.adoc
+++ b/guides/common/modules/proc_setting-the-location-context.adoc
@@ -14,10 +14,9 @@ Click *Any location* and select the location to use.
 While using the CLI, include either `--location "_My_Location_"` or `--location-id "_My_Location_ID_"` as an option.
 For example:
 
-[subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer subscription list \
---location "_My_Location_"
+# hammer host list --location "_My_Location_"
 ----
 
-This command outputs subscriptions allocated for the _My_Location_.
+This command lists hosts associated with the _My_Location_ location.


### PR DESCRIPTION
`hammer subscription list --location` is not a valid command. Replaced example with valid command and added new command description.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2172613

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
