### PR TITLE
Render feedback module on Satellite

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {AdministeringDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {AdministeringAnsibleDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {ConfiguringLoadBalancerDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {DeployingAWSDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 = {InstallingSmartProxyDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 = {InstallingServerDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 
 = {InstallingServerDisconnectedDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {ManagingConfigurationsAnsibleDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 
 = {ManagingConfigurationsPuppetDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {ContentManagementDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -8,7 +8,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 
 = {ManagingHostsDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {PlanningDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {ProvisioningDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -4,7 +4,7 @@ include::common/header.adoc[]
 
 = {TuningDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
+ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -5,10 +5,6 @@ include::common/header.adoc[]
 
 = {UpgradingDocTitle}
 
-ifeval::["{build}" == "satellite" && "{backend}" == "html5"]
-include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
-endif::[]
-
 In this guide, the terms upgrade, update, and migrate have the following meanings:
 
 Upgrading::
@@ -23,6 +19,10 @@ endif::[]
 
 Migrating::
 The process of moving an existing {Project} installation to a new instance.
+
+ifdef::satellite[]
+include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
+endif::[]
 
 // Upgrading Satellite Server overview
 include::topics/upgrading_overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Pantheon does not use html5 as backend anymore, the module is currently not being displayed.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
