### PR TITLE
Reflect that Foreman 3.6 has branched

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,11 @@
 
 Please cherry-pick my commits into:
 
+* [ ] Foreman 3.6/Katello 4.8
 * [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
 * [ ] Foreman 3.4/Katello 4.6 (EL8 only)
 * [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
 * [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
 * [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
 * For Foreman 3.0 or older, please create a separate PR.
-* We do not accept PRs for Foreman 2.3 or older.
+* We do not accept PRs for Foreman 2.4 or older.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 DEST := result
 PORT := 5000
-VERSION_LINKS := 3.5 3.4 3.3 3.2 3.1 3.0 2.5 2.4
+VERSION_LINKS := 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.5 2.4
 
 .PHONY: all clean html web compile serve prep
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When a commit is pushed into `X.Y`:
   * Add the new release versions to the site's index page and navigation bar by editing [/web/content/index.adoc](https://github.com/theforeman/foreman-documentation/blob/master/web/content/index.adoc) and [/web/content/js/nav.js](https://github.com/theforeman/foreman-documentation/blob/master/web/content/js/nav.js).
   * Test the changes by following the instructions in [/web/README.md](https://github.com/theforeman/foreman-documentation/tree/master/web/README.md) to deploy the website locally.
   * Add the new Foreman version to [/.github/PULL_REQUEST_TEMPLATE.md](https://github.com/theforeman/foreman-documentation/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
-  * Update `SYMLINK_VERSIONS` in the root `Makefile`.
+  * Update `VERSION_LINKS` in the root `Makefile`.
   * Push the changes into `master`.
 * Check the site if links and landing page appeared correctly. HTML guides should be deployed into `/X.Y`
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -4,7 +4,7 @@
 
 // Version numbers
 :ProjectVersion: nightly
-:ProjectVersionPrevious: 3.5
+:ProjectVersionPrevious: 3.6
 :KatelloVersion: nightly
 
 //

--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -11,6 +11,10 @@ The following releases are supported, meaning they receive (security) updates. V
 
 === Unsupported releases
 
+There is a release candidate available for testing.
+
+* link:/release/3.6/[Foreman 3.6 & Katello 4.8]
+
 The future version is built in nightly.
 
 * link:/release/nightly/[Nightly]

--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -168,6 +168,174 @@ const navVersions = [
     ]
   },
   {
+    "title": "Foreman 3.6 - Katello 4.8 (release candidate)",
+    "path": "3.6",
+    "builds": [
+      {
+        "title": "Foreman on EL",
+        "filename": "index-foreman-el.html",
+        "guides": [
+          {
+            "title": "Release Notes",
+            "path": "Release_Notes"
+          },
+          {
+            "title": "Quickstart Guide",
+            "path": "Quickstart"
+          },
+          {
+            "title": "Installing Foreman Server",
+            "path": "Installing_Server"
+          },
+          {
+            "title": "Installing Smart Proxy",
+            "path": "Installing_Proxy"
+          },
+          {
+            "title": "Deploying Foreman on AWS",
+            "path": "Deploying_Project_on_AWS"
+          },
+          {
+            "title": "Provisioning Hosts",
+            "path": "Provisioning_Hosts"
+          },
+          {
+            "title": "Managing Hosts",
+            "path": "Managing_Hosts"
+          },
+          {
+            "title": "Configuring Hosts Using Ansible",
+            "path": "Managing_Configurations_Ansible"
+          },
+          {
+            "title": "Configuring Hosts Using Puppet",
+            "path": "Managing_Configurations_Puppet"
+          },
+          {
+            "title": "Administering Foreman",
+            "path": "Administering_Project"
+          },
+          {
+            "title": "Application Centric Deployment",
+            "path": "Deploying_Hosts_AppCentric"
+          }
+        ]
+      },
+      {
+        "title": "Foreman on Debian",
+        "filename": "index-foreman-deb.html",
+        "guides": [
+          {
+            "title": "Release Notes",
+            "path": "Release_Notes"
+          },
+          {
+            "title": "Quickstart Guide",
+            "path": "Quickstart"
+          },
+          {
+            "title": "Installing Foreman Server",
+            "path": "Installing_Server"
+          },
+          {
+            "title": "Deploying Foreman on AWS",
+            "path": "Deploying_Project_on_AWS"
+          },
+          {
+            "title": "Provisioning Hosts",
+            "path": "Provisioning_Hosts"
+          },
+          {
+            "title": "Configuring Hosts Using Ansible",
+            "path": "Managing_Configurations_Ansible"
+          },
+          {
+            "title": "Configuring Hosts Using Puppet",
+            "path": "Managing_Configurations_Puppet"
+          },
+          {
+            "title": "Administering Foreman",
+            "path": "Administering_Project"
+          }
+        ]
+      },
+      {
+        "title": "Katello on EL",
+        "filename": "index-katello.html",
+        "guides": [
+          {
+            "title": "Release Notes",
+            "path": "Release_Notes"
+          },
+          {
+            "title": "Planning Guide",
+            "path": "Planning_for_Project"
+          },
+          {
+            "title": "Quickstart Guide",
+            "path": "Quickstart"
+          },
+          {
+            "title": "Installing Katello Server",
+            "path": "Installing_Server"
+          },
+          {
+            "title": "Installing Smart Proxy with Content",
+            "path": "Installing_Proxy"
+          },
+          {
+            "title": "Upgrading and Updating",
+            "path": "Upgrading_and_Updating"
+          },
+          {
+            "title": "Tuning Performance",
+            "path": "Tuning_Performance"
+          },
+          {
+            "title": "Configuring Smart Proxies with a Load Balancer",
+            "path": "Configuring_Load_Balancer"
+          },
+          {
+            "title": "Managing Organizations and Locations in Foreman",
+            "path": "Managing_Organizations_and_Locations"
+          },
+          {
+            "title": "Managing Content",
+            "path": "Managing_Content"
+          },
+          {
+            "title": "Deploying Foreman on AWS",
+            "path": "Deploying_Project_on_AWS"
+          },
+          {
+            "title": "Provisioning Hosts",
+            "path": "Provisioning_Hosts"
+          },
+          {
+            "title": "Managing Hosts",
+            "path": "Managing_Hosts"
+          },
+          {
+            "title": "Configuring Hosts Using Ansible",
+            "path": "Managing_Configurations_Ansible"
+          },
+          {
+            "title": "Configuring Hosts Using Puppet",
+            "path": "Managing_Configurations_Puppet"
+          },
+          {
+            "title": "Administering Foreman",
+            "path": "Administering_Project"
+          },
+          {
+            "title": "Application Centric Deployment",
+            "path": "Deploying_Hosts_AppCentric"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "title": "Foreman 3.5 - Katello 4.7 (supported)",
     "path": "3.5",
     "builds": [

--- a/web/content/release-3.6.adoc
+++ b/web/content/release-3.6.adoc
@@ -1,0 +1,23 @@
+---
+title: 3.6
+---
+:FOREMAN_VER: 3.6
+:KATELLO_VER: 4.8
+
+== Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+
+Use the top menu bar for navigation for all guides.
+
+=== Quickstart
+
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+
+=== Installation
+
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+
+=== Upgrading
+
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]


### PR DESCRIPTION
This adds links to the 3.6 branch as well as bumping the previous version number to 3.6.

<del>Currently I'm still working on the 3.6 branch, so this is still a draft</del>

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.