### PR TITLE
Fix supported Puppet versions for orcharhino

### DIFF
--- a/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
+++ b/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
@@ -5,23 +5,16 @@ Before you begin with the Puppet integration, review the supported Puppet versio
 
 Supported Puppet Versions::
 {Project} supports the following Puppet versions:
-ifndef::orcharhino[]
+
 * Puppet 7
-endif::[]
 ifndef::satellite[]
 * Puppet 6
 endif::[]
 
 System Requirements::
 Before you begin integrating Puppet with your {Project}, ensure that you meet the system requirements.
-For details, see
-ifndef::orcharhino[]
-https://puppet.com/docs/puppet/7/system_requirements.html[System Requirements for Puppet 7]
-endif::[]
-ifndef::satellite,orcharhino[]
-or
-endif::[]
+For details, see https://puppet.com/docs/puppet/7/system_requirements.html[System Requirements for Puppet 7]
 ifndef::satellite[]
-https://puppet.com/docs/puppet/6/system_requirements.html[System Requirements for Puppet 6]
+or https://puppet.com/docs/puppet/6/system_requirements.html[System Requirements for Puppet 6]
 endif::[]
 in the _Open Source Puppet_ documentation.


### PR DESCRIPTION
orcharhino supports Puppet 7. (It was a mistake to exclude it.)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
