### PR TITLE
Pass build-pdf test for satellite build

### DIFF
--- a/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
+++ b/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
@@ -5,7 +5,6 @@
 
 We appreciate your input on our documentation. Please let us know how we could make it better.
 
-[l10n-exclude-start]
 * For simple comments on specific passages:
 +
 . Ensure you are viewing the documentation in the _Multi-page HTML_ format.
@@ -15,7 +14,6 @@ In addition, ensure you see the *Feedback* button in the upper right corner of t
 . Click the *Add Feedback* pop-up that appears below the highlighted text.
 . Follow the displayed instructions.
 
-[l10n-exclude-end]
 * For submitting feedback via Bugzilla, create a new ticket:
 +
 . Go to the link:https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Satellite[Bugzilla] website.


### PR DESCRIPTION
PR https://github.com/theforeman/foreman-documentation/pull/2022 Fixed rendering feedback module on Satellite documentation but also caused the build-pdf test to fail. This issue did not emerge before merging the PR. Removing special unordered list styles fixes this issue. I do not believe the extra styles have to be included and would prefer build-pdf tests to pass instead (while keeping the source documentation as simple as possible).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

CC @Lennonka 

Please cherry-pick my commits into:

* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.3 or older.
