### PR TITLE
Highlight difference in shellhook dir vs URL

### DIFF
--- a/guides/common/modules/con_shellhooks-plugin.adoc
+++ b/guides/common/modules/con_shellhooks-plugin.adoc
@@ -13,6 +13,11 @@ The HTTPS payload is passed using standard input, optional command line argument
 The HTTP method must be POST.
 An example URL would be: `\https://{smartproxy-example-com}:{smartproxy_port}/shellhook/my_script`.
 
+[NOTE]
+====
+Unlike the `shellhooks` directory, the URL must contain `/shellhook/` in singular to be valid.
+====
+
 You must enable *Proxy Authorization* for each webhook that is connected to a shellhook, to enable it to authorize a call.
 
 Standard output and error are redirected to the {SmartProxy} log as messages with debug or warning levels respectively.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2173600

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
