### PR TITLE
Unregister host when assigning to a new org

### DIFF
--- a/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
+++ b/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
@@ -9,6 +9,13 @@ ifndef::satellite[]
 For general information about organizations and how to configure them, see {ManagingOrganizationsLocationsDocURL}Managing_Organizations_managing-organizations-locations[Managing Organizations] in _{ManagingOrganizationsLocationsDocTitle}_.
 endif::[]
 
+[NOTE]
+====
+If your host is already registered with a different organization, you must first unregister the host before assigning it to a new organization.
+To unregister the host, run `subscription-manager unregister` on the host.
+After you assign the host to a new organization, you can re-register the host.
+====
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All hosts*.
 . Select the checkbox of the host you want to change.


### PR DESCRIPTION
Trying to assign registered hosts to organization results in:
 "Error: Unregister host before assigning an organization".

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2170837

CC @jeremylenz 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
