### PR TITLE
Hide a load-balancing step out of LB context 3.4-3.1

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -5,6 +5,7 @@ You can register hosts with {Project} using the host registration feature, the {
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Log in to the host you want register and run the previously generated command.
+ifeval::["{context}" == "load-balancing"]
 . Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -13,6 +14,7 @@ You can register hosts with {Project} using the host registration feature, the {
 --rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
 --server.hostname=loadbalancer.example.com
 ----
+endif::[]
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 
 .CLI procedure
@@ -32,6 +34,7 @@ ifdef::katello,satellite,orcharhino[]
 ----
 endif::[]
 . Log in to the host you want register and run the previously generated command.
+ifeval::["{context}" == "load-balancing"]
 . Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -40,6 +43,7 @@ endif::[]
 --rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
 --server.hostname=loadbalancer.example.com
 ----
+endif::[]
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 
 .API procedure
@@ -71,6 +75,7 @@ Keep in mind this can save the password in the shell history.
 +
 For more information about registration see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering a Host to {ProjectName}] in _{ManagingHostsDocTitle}_.
 . Log in to the host you want register and run the previously generated command.
+ifeval::["{context}" == "load-balancing"]
 . Update subscription manager configuration for `rhsm.baseurl` and `server.hostname`:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -79,4 +84,5 @@ For more information about registration see {ManagingHostsDocURL}Registering_Hos
 --rhsm.baseurl=https://loadbalancer.example.com/pulp/content \
 --server.hostname=loadbalancer.example.com
 ----
+endif::[]
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.


### PR DESCRIPTION
The step was meant for _Configuring Load Balancer_ therefore it must not be rendered for other contexts.
The step was removed in 3.5+, therefore this change applies only to 3.4-3.1.

https://bugzilla.redhat.com/show_bug.cgi?id=2173714

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
