### PR TITLE
Corrected a typo reported in BZ-2173641

### DIFF
--- a/guides/common/modules/con_managing-errata.adoc
+++ b/guides/common/modules/con_managing-errata.adoc
@@ -3,7 +3,7 @@
 
 ifdef::satellite[]
 As a part of Red Hat's quality control and release process, we provide customers with updates for each release of official Red Hat RPMs.
-Red Hat compiles groups of related package into an *erratum* along with an advisory that provides a description of the update.
+Red Hat compiles groups of related packages into an *erratum* along with an advisory that provides a description of the update.
 endif::[]
 ifndef::satellite[]
 {RHEL} users receive errata for each release of official Red Hat RPMs.


### PR DESCRIPTION
Corrected a typo that is reported in BZ-2173641.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
