### PR TITLE
Apply job rate limit only to mqtt based jobs

### DIFF
--- a/guides/common/modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc
+++ b/guides/common/modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc
@@ -4,6 +4,8 @@
 You can limit the maximum number of active jobs on a {SmartProxy} at a time to prevent performance spikes.
 The job is active from the time {SmartProxy} first tries to notify the host about the job until the job is finished on the host.
 
+The job rate limit only applies to mqtt based jobs.
+
 [NOTE]
 ====
 The optimal maximum number of active jobs depends on the computing resources of your {SmartProxyServer}.


### PR DESCRIPTION
CC @adamruzicka 

Note: last line is displaying change because of the added newline.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
