### PR TITLE
Sort categories in the release notes

### DIFF
--- a/guides/doc-Release_Notes/redmine_release_notes
+++ b/guides/doc-Release_Notes/redmine_release_notes
@@ -109,7 +109,7 @@ projects.sort.each do |name, project|
     puts format_issue(issue)
   end
 
-  project[:categories].each do |category, issues|
+  project[:categories].sort.each do |category, issues|
     puts
     puts "=== #{category}"
     puts


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.