### PR TITLE
Fix link failing the the html-check test

### DIFF
--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -40,7 +40,7 @@ For more information, see link:https://docs.ansible.com/ansible/latest/galaxy/us
 For more information, see link:https://console.redhat.com/ansible/automation-hub/token[Connect Private Automation Hub] in the _Connect to Hub_ guide.
 .. To sync {Project} from `console.redhat.com`, enter your token in the *Auth Token* field and enter your SSO URL in the the *Auth URL* field.
 +
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html-single/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index#proc-create-api-token[Retrieving your Red Hat Certified Collections Sync URL and API token] in the _Managing Red{nbsp}Hat Certified and Ansible Galaxy collections in Automation Hub_ guide.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2/html-single/managing_red_hat_certified_and_ansible_galaxy_collections_in_automation_hub/index#proc-create-api-token[Retrieving your Red{nbsp}Hat Certified Collections Sync URL and API token] in the _Managing Red{nbsp}Hat Certified and Ansible Galaxy collections in Automation Hub_ guide.
 .. To sync {Project} from {Project}, leave both authentication fields blank.
 . Click *Save*.
 . Navigate to the Ansible Collections repository.


### PR DESCRIPTION
Links to older versions are of this guide are no longer valid.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
