### PR TITLE
Introduce "client-content-X" attributes

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -117,3 +117,4 @@
 :SmartProxyServersTitle: {SmartProxyServerTitle}s
 :Team: {Project} developers
 :sectanchors:
+:client-content-dnf:

--- a/guides/common/modules/con_content-filter-overview.adoc
+++ b/guides/common/modules/con_content-filter-overview.adoc
@@ -43,7 +43,9 @@ The list of package groups is based on the repositories added to the Content Vie
 | *Erratum (by ID)* | Select which specific errata to add to the filter.
 The list of Errata is based on the repositories added to the Content View.
 | *Erratum (by Date and Type)* | Select a issued or updated date range and errata type (Bugfix, Enhancement, or Security) to add to the filter.
+ifdef::client-content-dnf[]
 | *Module Streams* | Select whether to include or exclude specific module streams.
 The *Module Streams* option filters modular RPMs and errata, but does not filter non-modular content that is associated with the selected module stream.
+endif::[]
 | *Container Image Tag* | Select whether to include or exclude specific container image tags.
 |===

--- a/guides/common/modules/con_managing-content-views.adoc
+++ b/guides/common/modules/con_managing-content-views.adoc
@@ -43,7 +43,12 @@ For more information, see xref:Resolving_Package_Dependencies_{context}[].
 For more information, see xref:Promoting_a_Content_View_{context}[].
 . Attach the content host to the Content View.
 
+ifdef::client-content-dnf[]
 If a repository is not associated with the Content View, the file `/etc/yum.repos.d/redhat.repo` remains empty and systems registered to it cannot receive updates.
+endif::[]
+ifdef::client-content-apt[]
+If a repository is not associated with the Content View, the file `/etc/apt/sources.list.d/rhsm.sources` remains empty and systems registered to it cannot receive updates.
+endif::[]
 
 Hosts can only be associated with a single Content View.
 To associate a host with multiple Content Views, create a composite Content View.

--- a/guides/common/modules/proc_importing-a-custom-gpg-key.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key.adoc
@@ -10,6 +10,7 @@ endif::[]
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-a-gpg-key[].
 
+ifdef::client-content-dnf[]
 .Prerequisites
 Ensure that you have a copy of the GPG key used to sign the RPM content that you want to use and manage in {Project}.
 Most RPM distribution providers provide their GPG Key on their website.
@@ -29,6 +30,7 @@ $ rpm2cpio _example-9.5-2.noarch.rpm_ | cpio -idmv
 ----
 
 The GPG key is located relative to the extraction at `etc/pki/rpm-gpg/RPM-GPG-KEY-_EXAMPLE-95_`.
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Credentials* and in the upper-right of the window, click *Create Content Credential*.

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -10,7 +10,12 @@ endif::[]
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Connect to your host using SSH and run the registration command.
+ifdef::client-content-dnf[]
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+endif::[]
+ifdef::client-content-apt[]
+. Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+endif::[]
 
 .CLI procedure
 . Generate the host registration command using the Hammer CLI:
@@ -37,7 +42,12 @@ You can use the ID of any {SmartProxyServer} that you configured for host regist
 Include the `--force` option to register a host that has been previously registered to a {SmartProxyServer}.
 endif::[]
 . Connect to your host using SSH and run the registration command.
+ifdef::client-content-dnf[]
 . Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+endif::[]
+ifdef::client-content-apt[]
+. Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+endif::[]
 
 .API procedure
 . Generate the host registration command using the {Project} API:


### PR DESCRIPTION
Please review commit by commit.

This is the start to allow content specifically aimed at users managing Debian or SLES hosts. My PR does not change the output yet, because for all build targets, `:dnf:` is set and `:apt:` remains unset.
In downstream, I build all three big guides (managing content, provisioning hosts, configuring hosts) for multiple OS which set or unset specific attributes.

For the future, I could see a way of adding specific procedures in upstream docs twice: once for rpm and once for deb.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)