### PR TITLE
Clarify procedure for content view comparison

### DIFF
--- a/guides/common/modules/proc_comparing-content-view-versions.adoc
+++ b/guides/common/modules/proc_comparing-content-view-versions.adoc
@@ -5,7 +5,6 @@ Use this procedure to compare Content View Version functionality for {Project}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views*.
-. Select the Content View versions you want to compare.
 . On the Versions tab, select the checkbox next to any two versions you want to compare.
 . Click *Compare*.
 +

--- a/guides/common/modules/proc_comparing-content-view-versions.adoc
+++ b/guides/common/modules/proc_comparing-content-view-versions.adoc
@@ -4,7 +4,9 @@
 Use this procedure to compare Content View Version functionality for {Project}.
 
 .Procedure
-* In the {ProjectWebUI}, navigate to *Content* > *Content Views*, then select two Content View versions and click *Compare*.
+. In the {ProjectWebUI}, navigate to *Content* > *Content Views*.
+. Select the content view version you want to compare.
+. On the Versions tab, select the checkbox next to any two versions you want to compare.
 +
 The *Compare* screen has the pre-selected versions in the version dropdown menus and tabs for all content types found in either version.
 You can filter the results to show only the same, different, or all content types.

--- a/guides/common/modules/proc_comparing-content-view-versions.adoc
+++ b/guides/common/modules/proc_comparing-content-view-versions.adoc
@@ -7,6 +7,7 @@ Use this procedure to compare Content View Version functionality for {Project}.
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views*.
 . Select the Content View versions you want to compare.
 . On the Versions tab, select the checkbox next to any two versions you want to compare.
+. Click *Compare*.
 +
 The *Compare* screen has the pre-selected versions in the version dropdown menus and tabs for all content types found in either version.
 You can filter the results to show only the same, different, or all content types.

--- a/guides/common/modules/proc_comparing-content-view-versions.adoc
+++ b/guides/common/modules/proc_comparing-content-view-versions.adoc
@@ -5,7 +5,7 @@ Use this procedure to compare Content View Version functionality for {Project}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views*.
-. Select the content view version you want to compare.
+. Select the Content View versions you want to compare.
 . On the Versions tab, select the checkbox next to any two versions you want to compare.
 +
 The *Compare* screen has the pre-selected versions in the version dropdown menus and tabs for all content types found in either version.

--- a/guides/common/modules/proc_comparing-content-view-versions.adoc
+++ b/guides/common/modules/proc_comparing-content-view-versions.adoc
@@ -5,7 +5,8 @@ Use this procedure to compare Content View Version functionality for {Project}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Views*.
-. On the Versions tab, select the checkbox next to any two versions you want to compare.
+. Select a Content View whose versions you want to compare.
+. On the *Versions* tab, select the checkbox next to any two versions you want to compare.
 . Click *Compare*.
 +
 The *Compare* screen has the pre-selected versions in the version dropdown menus and tabs for all content types found in either version.


### PR DESCRIPTION
Improved the procedure for comparing content view
versions to make more
sense to the user.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
