### PR TITLE
Correct content on Managing_Content for foreman-{el,deb}

### DIFF
--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -8,7 +8,13 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-// Render only for relevant and finished contexts
+ifndef::katello,satellite,orcharhino[]
+Mangaging content requires the Katello plugin.
+Migrating from Foreman without Katello to Foreman with Katello is unsupported.
+// TODO: This needs to link to index-katello.html, not index-foreman-el.html.
+// can we somehow get the attributes from katello without breaking the rest of the document?
+Please have a look at {InstallingServerDocURL}[{InstallingServerDocTitle}] and migrate your hosts.
+endif::[]
 ifdef::katello,satellite,orcharhino[]
 
 include::common/modules/con_introduction-to-content-management.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -58,7 +58,6 @@ endif::[]
 [appendix]
 include::common/modules/proc_importing-content-isos-into-a-connected-foreman.adoc[leveloffset=+1]
 
-endif::[]
 ifndef::satellite[]
 [appendix]
 == Configuring {ISS} (ISS) in {Project}
@@ -68,4 +67,5 @@ include::common/modules/con_how-to-configure-inter-server-sync.adoc[leveloffset=
 include::common/modules/proc_configuring-server-to-sync-content-using-exports.adoc[leveloffset=+2]
 
 include::common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc[leveloffset=+2]
+endif::[]
 endif::[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -15,7 +15,7 @@ include::common/modules/con_introduction-to-content-management.adoc[leveloffset=
 
 include::common/modules/con_content-types-overview.adoc[leveloffset=+1]
 
-ifdef::foreman-el,katello[]
+ifdef::katello[]
 include::common/assembly_basic-content-management-workflow.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
The goal of this is to at least show some text making it actionable for users. I'm not sure what a good text is, but this is a pattern I'd like to apply more.

Fow now we don't display the Managing_Content guide at all for stable releases, so no cherry picks are needed though they should be safe.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.