### PR TITLE
Installing Puppet agent during Registration

### DIFF
--- a/guides/common/assembly_building_cloud-images.adoc
+++ b/guides/common/assembly_building_cloud-images.adoc
@@ -8,7 +8,7 @@ include::modules/proc_registering-hosts.adoc[leveloffset=+1]
 
 include::modules/proc_installing-the-katello-agent.adoc[leveloffset=+1]
 
-include::modules/proc_installing-and-configuring-the-puppet-agent.adoc[leveloffset=+1]
+include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]
 
 include::modules/proc_completing-the-rhel7-image.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -43,7 +43,7 @@ include::modules/proc_installing-the-katello-agent.adoc[leveloffset=+1]
 
 include::modules/proc_installing-tracer.adoc[leveloffset=+1]
 
-include::modules/proc_installing-and-configuring-the-puppet-agent.adoc[leveloffset=+1]
+include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]
 
 include::modules/proc_migrating-from-katello-agent-to-remote-execution.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -13,6 +13,8 @@ include::modules/proc_registering-hosts.adoc[leveloffset=+1]
 
 include::modules/ref_customizing-the-registration-templates.adoc[leveloffset=+1]
 
+include::modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc[leveloffset=+1]
+
 include::modules/proc_registering-an-atomic-host.adoc[leveloffset=+1]
 
 include::modules/proc_registering-a-host-using-the-bootstrap-script.adoc[leveloffset=+1]

--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -47,7 +47,7 @@ by syncing repositories in custom products
 endif::[]
 and by using {ContentManagementDocURL}Managing_Activation_Keys_content-management[Activation Keys] and {ContentManagementDocURL}Managing_Content_Views_content-management[Content Views].
 endif::[]
-. Install Puppet agent on hosts during xref:Installing_Puppet_Agent_during_Host_Provisioning_{context}[provisioning], registration, xref:Installing_and_Configuring_the_Puppet_Agent_on_a_Host_Manually_{context}[manually], or by remote job execution.
+. Install Puppet agent on hosts during xref:Installing_Puppet_Agent_during_Host_Provisioning_{context}[provisioning], registration, xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[manually], or by remote job execution.
 
 .Additional resources
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -47,7 +47,7 @@ by syncing repositories in custom products
 endif::[]
 and by using {ContentManagementDocURL}Managing_Activation_Keys_content-management[Activation Keys] and {ContentManagementDocURL}Managing_Content_Views_content-management[Content Views].
 endif::[]
-. Install Puppet agent on hosts during xref:Installing_Puppet_Agent_during_Host_Provisioning_{context}[provisioning], registration, xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[manually], or by remote job execution.
+. Install Puppet agent on hosts during xref:Installing_Puppet_Agent_during_Host_Provisioning_{context}[provisioning], xref:installing-and-configuring-puppet-agent-during-host-registration_{context}[registration], xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[manually], or by remote job execution.
 
 .Additional resources
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/con_registering_hosts.adoc
+++ b/guides/common/modules/con_registering_hosts.adoc
@@ -28,7 +28,7 @@ Use the following procedures to install and configure host tools:
 
 * xref:Installing_the_Katello_Agent_{context}[]
 * xref:Installing_Tracer_{context}[]
-* xref:Installing_and_Configuring_the_Puppet_Agent_on_a_Host_Manually_{context}[]
+* xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[]
 
 ifdef::satellite[]
 .Supported Host Operating Systems

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -1,0 +1,59 @@
+[id="installing-and-configuring-puppet-agent-during-host-registration_{context}"]
+= Installing and Configuring Puppet Agent during Host Registration
+
+Use this procedure to install and configure the Puppet agent on the host during registration.
+
+ifdef::satellite[]
+.Prerequisites
+* You enabled and synchronized the *{project-client-name}* repository to {Project}.
+For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
+* You created an activation key that enables the *{project-client-name}* repository for hosts.
+For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
+endif::[]
+ifdef::katello,orcharhino[]
+.Prerequisites
+* You created a Product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
+For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
+* You created an activation key that enables the Puppet agent repository for hosts.
+For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
+endif::[]
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Configure* > *Global Parameters* to add host parameters globally.
+Alternatively, you can navigate to *Configure* > *Host Groups* and edit or create a host group to add host parameters only to a host group.
+ifdef::katello,orcharhino,satellite[]
+. Enable the Puppet agent using a host parameter in global parameters or a host group.
+Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
+endif::[]
+ifndef::katello,orcharhino,satellite[]
+. Enable the Puppet agent from the official Puppet repository using one of the following host parameters in global parameters or a host group:
+
+* Add a host parameter named `enable-puppetlabs-repo` for the latest stable Puppet release in the unversioned repository.
+* Add a host parameter named `enable-official-puppet7-repo` for the Puppet 7 release repository.
+
++
+Select the *boolean* type and set the value to `true`.
+endif::[]
+. Specify configuration for the Puppet agent using the following host parameters in global parameters or a host group:
+* Add a host parameter named `puppet_server`, select the *string* type, and set the value to the hostname of your Puppet server, such as `puppet.example.com`.
+* Optional: Add a host parameter named `puppet_ca_server`, select the *string* type, and set the value to the hostname of your Puppet CA server, such as `puppet-ca.example.com`.
+If `puppet_ca_server` is not set, the Puppet agent will use the same server as `puppet_server`.
+* Optional: Add a host parameter named `puppet_environment`, select the *string* type, and set the value to the Puppet environment you want the host to use.
+
++
+Until the https://bugzilla.redhat.com/show_bug.cgi?id=2177730[BZ2177730] is resolved, you must use host parameters to specify the Puppet agent configuration even in integrated setups where the Puppet server is a {SmartProxyServer}.
+ifdef::katello,orcharhino,satellite[]
+. Navigate to *Hosts* > *Register Host* and register your host using an appropriate activation key.
+endif::[]
+ifndef::katello,orcharhino,satellite[]
+. Navigate to *Hosts* > *Register Host* and register your host.
+endif::[]
+ifeval::[{context} == "managing-hosts"]
+For more information, see xref:Registering_Hosts_{context}[].
+endif::[]
+ifeval::[{context} != "managing-hosts"]
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+endif::[]
+. Navigate to *Infrastructure* > *{SmartProxies}*.
+. From the list in the *Actions* column for the required {SmartProxyServer}, select *Certificates*.
+. Click *Sign* to the right of the required host to sign the SSL certificate for the Puppet agent.

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -1,7 +1,7 @@
-[id="Installing_and_Configuring_the_Puppet_Agent_on_a_Host_Manually_{context}"]
-= Installing and Configuring Puppet Agent on a Host Manually
+[id="Installing_and_Configuring_Puppet_Agent_Manually_{context}"]
+= Installing and Configuring Puppet Agent Manually
 
-Install and configure the Puppet agent on a host manually.
+Use this procedure to install and configure the Puppet agent on a host manually.
 
 ifndef::managing-configurations-puppet[]
 ifdef::satellite[]

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -21,7 +21,7 @@ endif::[]
 
 include::common/modules/proc_installing-puppet-agent-during-host-provisioning.adoc[leveloffset=+2]
 
-include::common/modules/proc_installing-and-configuring-the-puppet-agent.adoc[leveloffset=+2]
+include::common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+2]
 
 include::common/modules/ref_performing-configuration-management.adoc[leveloffset=+2]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -21,6 +21,8 @@ endif::[]
 
 include::common/modules/proc_installing-puppet-agent-during-host-provisioning.adoc[leveloffset=+2]
 
+include::common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc[leveloffset=+2]
+
 include::common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+2]
 
 include::common/modules/ref_performing-configuration-management.adoc[leveloffset=+2]


### PR DESCRIPTION
Add a section about installing and configuring Puppet agent during host registration.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
