### PR TITLE
add more realistic CPU/memory recommendations

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -7,7 +7,7 @@ The following requirements apply to the networked base operating system:
 ifdef::satellite[]
 * The latest version of {RHEL} 8
 endif::[]
-* 4-core 2.0 GHz CPU at a minimum
+* 4-core 2.0 GHz CPU at a minimum (8-core recommended)
 
 ifdef::foreman-el,foreman-deb[]
 ifeval::["{context}" == "{project-context}"]
@@ -18,7 +18,7 @@ endif::[]
 
 ifdef::katello,satellite[]
 ifeval::["{context}" == "{project-context}"]
-* A minimum of 20 GB RAM is required for {ProjectServer} to function.
+* A minimum of 20 GB RAM is required for {ProjectServer} to function (32 GB recommended).
 In addition, a minimum of 4 GB RAM of swap space is also recommended.
 {Project} running with less RAM than the minimum value might not operate correctly.
 endif::[]


### PR DESCRIPTION
Hi Foreman community,
during installations I often stumble upon that the minimum system requirements aren't realistic for production scenarios. When running Foreman/Katello with 4 CPUs and 20 GB memory you'll most likely slow down synchronization (and other Pulp tasks) when syncing your first repositories.

Orcharhino extended the system requirements to [include production recommendations](https://docs.orcharhino.com/or/docs/sources/installation_and_maintenance/installing_orcharhino_server.html#System_Requirements).

I think this might also be useful for Foreman/Katello and Red Hat Satellite. Beginners might appreciate it.

What do you think?

Keep up the good work, highly appreciated!

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
