### PR TITLE
Clarify remediations in host Leapp upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -36,9 +36,17 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 . Click *Submit* to start the pre-upgrade check.
 . When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on your hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
-Some issues might have documentation linked that describes how to fix them.
-. Optional: If you have issues that have commands associated with them, you can fix them using remote execution.
-To do that, select these issues, click the *Fix Selected* button, and submit the job.
-. After the issues are fixed, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the hosts you are upgrading do not have any issues and are ready to be upgraded.
+Issues that have the *Has Remediation* flag contain remediation that can help you fix the issue.
+.. Click an issue that is flagged as *Has Remediation* to expand it.
+
+* If the issue contains a remediation *Command*, you can fix it directly from {Project} using remote execution.
+Select the issue.
+* If the issue contains only a remediation *Hint*, use the hint to fix the issue on the host manually.
+
++
++
+Repeat this step for other issues.
+.. After you selected any issues with remediation commands, click *Fix Selected* and submit the job.
+.. After the issues are fixed, click the *Rerun* button, and then click *Submit* to run the pre-upgrade check again to verify that the hosts you are upgrading do not have any issues and are ready to be upgraded.
 . If the pre-upgrade check verifies that the hosts do not have any issues, click the *Run Upgrade* button and click *Submit* to start the upgrade.
 . Optional: You can also upgrade by selecting the *Schedule a Job* dropdown in the host details page.


### PR DESCRIPTION
Previously, it wasn't clear, how to handle remediation hints vs. commands and which issues can be selected to be fixed directly from the WebUI.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* TBD a separate PR for 2.5

