### PR TITLE
Use FirewallD services where possible

### DIFF
--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc
@@ -23,11 +23,11 @@ If you wish to avoid this scenario, configure all {SmartProxies} to use the same
  # {installer-scenario-smartproxy} \
 --foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
 ----
-. Configure the firewall to allow MQTT service on port 1883:
+. Configure the firewall to allow MQTT service:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# firewall-cmd --add-port="1883/tcp"
+# firewall-cmd --add-service=mqtt
 # firewall-cmd --runtime-to-permanent
 ----
 . In `pull-mqtt` mode, hosts subscribe for job notifications to the {SmartProxy} through which they are registered.

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -14,18 +14,20 @@ include::snip_firewalld.adoc[]
 [options="nowrap"]
 ----
 # firewall-cmd \
---add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" \
---add-port="69/udp" \
---add-port="80/tcp" --add-port="443/tcp" \
+--add-service=dns \
+--add-service=dhcp \
+--add-service=tftp \
+--add-service=http \
+--add-service=https \
 ifdef::katello,satellite,orcharhino[]
 --add-port="5647/tcp" \
---add-port="8000/tcp" --add-port="9090/tcp" \
+--add-port="8000/tcp" \
+--add-port="9090/tcp" \
 endif::[]
 ifndef::katello,satellite,orcharhino[]
---add-port="8443/tcp" \
+--add-service=foreman-proxy \
 endif::[]
---add-port="8140/tcp"
+--add-service=puppetmaster
 ----
 . Make the changes persistent:
 +

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -13,17 +13,21 @@ include::snip_firewalld.adoc[]
 [options="nowrap"]
 ----
 # firewall-cmd \
---add-port="53/udp" --add-port="53/tcp" \
---add-port="67/udp" \
---add-port="69/udp" \
+--add-service=dns \
+--add-service=dhcp \
+--add-service=tftp \
 ifdef::katello,satellite,orcharhino[]
---add-port="80/tcp" --add-port="443/tcp" \
+--add-service=http \
+--add-service=https \
 --add-port="5647/tcp" \
 endif::[]
---add-port="8140/tcp" \
---add-port="8443/tcp" \
+--add-service=puppetmaster \
+ifndef::katello,satellite,orcharhino[]
+--add-service=foreman-proxy
+endif::[]
 ifdef::katello,satellite,orcharhino[]
---add-port="8000/tcp" --add-port="9090/tcp"
+--add-port="8000/tcp" \
+--add-port="9090/tcp"
 endif::[]
 ----
 


### PR DESCRIPTION
Using services is easier to read for users and a smaller chance of typos in port numbers. It also can enable helpers if needed.

It doesn't use the foreman-proxy for content proxies, since it runs on a non-standard port.

Currently untested, but here to start the discussion if this is something we want. From there on I also want to investigate what we open by default. For example, opening the DNS/DHCP/TFTP ports if we don't enable those services by default is redundant. Should we open them only if we tell users to enable the service, like we do with MQTT?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.