### PR TITLE
Introduce attributes for "managing containers"

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -35,6 +35,10 @@
 :certs-proxy-context: foreman-proxy
 :Cockpit: Cockpit
 :CockpitTitle: Cockpit
+:container-image-name: rhel7
+:container-product-name: Red Hat Container Catalog
+:container-repository-name: RHEL7
+:container-url: http://registry.access.redhat.com/
 :customcontent: content
 :customdeb: DEB
 :customdebtitle: DEB

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -55,12 +55,12 @@ From the list, you can also remove any manifests that you do not require.
 [options="nowrap" subs="+quotes"]
 ----
 # hammer repository create \
---name "RHEL7" \
 --content-type "docker" \
---url "http://registry.access.redhat.com/" \
 --docker-upstream-name "rhel7" \
+--name "RHEL7" \
+--organization "_My_Organization_" \
 --product "Red Hat Container Catalog" \
---organization "_My_Organization_"
+--url "http://registry.access.redhat.com/"
 ----
 . Synchronize the repository:
 +
@@ -68,6 +68,6 @@ From the list, you can also remove any manifests that you do not require.
 ----
 # hammer repository synchronize \
 --name "RHEL7" \
---product "Red Hat Container Catalog" \
---organization "_My_Organization_"
+--organization "_My_Organization_" \
+--product "Red Hat Container Catalog"
 ----

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -40,13 +40,13 @@ From the list, you can also remove any manifests that you do not require.
 
 [id="cli-importing-container-images"]
 .CLI procedure
-. Create the custom `Red Hat Container Catalog` product:
+. Create the custom `{container-product-name}` product:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer product create \
---description "Red Hat Container Catalog content" \
---name "Red Hat Container Catalog" \
+--description "_My_Description_" \
+--name "{container-product-name}" \
 --organization "_My_Organization_" \
 --sync-plan "_My_Sync_Plan_"
 ----
@@ -56,18 +56,18 @@ From the list, you can also remove any manifests that you do not require.
 ----
 # hammer repository create \
 --content-type "docker" \
---docker-upstream-name "rhel7" \
---name "RHEL7" \
+--docker-upstream-name "{container-image-name}" \
+--name "{container-repository-name}" \
 --organization "_My_Organization_" \
---product "Red Hat Container Catalog" \
---url "http://registry.access.redhat.com/"
+--product "{container-product-name}" \
+--url "{container-url}"
 ----
 . Synchronize the repository:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer repository synchronize \
---name "RHEL7" \
+--name "{container-repository-name}" \
 --organization "_My_Organization_" \
---product "Red Hat Container Catalog"
+--product "{container-product-name}"
 ----


### PR DESCRIPTION
In order to use the "managing container" section for multiple OS (e.g. importing a container image for Ubuntu), I want to introduce attributes to handle all OS-specific parameters.

Do you think the attributes should be part of the assembly or moved to the "attributes-base" file?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
