### PR TITLE
Standardize wording for common steps in upgrade doc

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -15,7 +15,7 @@ ifdef::satellite[]
 For more information, see xref:synchronizing_the_new_repositories_{context}[].
 endif::[]
 ifdef::katello,orcharhino,satellite[]
-* If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories and publish their updated versions.
+* If you use Content Views to control updates to the base operating system of {SmartProxyServer}, update those Content Views with new repositories, publish, and promote their updated versions.
 For more information, see {ContentManagementDocURL}Managing_Content_Views_content-management[Managing Content Views] in _{ContentManagementDocTitle}_.
 * Ensure the {SmartProxy}'s base system is registered to the newly upgraded {ProjectServer}.
 endif::[]


### PR DESCRIPTION
The `Upgrading Capsule Servers` section has a step to update Content Views, which is similar to the last step in `Synchronising New Repositories` section. However, the `Upgrading Capsule Servers` section needs to reflect that the CV has to be promoted as well. Rewording the step so that it reflects the correct information.

Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2169783


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
