### PR TITLE
Fix rendering of italics in code block

### DIFF
--- a/guides/common/modules/proc_creating-a-personal-access-token.adoc
+++ b/guides/common/modules/proc_creating-a-personal-access-token.adoc
@@ -21,11 +21,10 @@ You can click *Copy to clipboard* to copy your {PAT}.
 
 .Verification
 . Make an API request to your {ProjectServer} and authenticate with your {PAT}:
-// tags in combination with `none` substitution have to be used here to render colon between USERNAME and PAT as normal.
 +
-[options="nowrap", subs="none,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# curl https://<em>{foreman-example-com}</em>/api/status --user <em>USERNAME</em>:<em>PERSONAL_ACCESS_TOKEN</em>
+# curl https://_{foreman-example-com}_/api/status --user __My_Username__:__My_Personal_Access_Token__
 ----
 . You should receive a response with status `200`, for example:
 +

--- a/guides/common/modules/proc_revoking-a-personal-access-token.adoc
+++ b/guides/common/modules/proc_revoking-a-personal-access-token.adoc
@@ -11,17 +11,16 @@ Use this procedure to revoke a {PAT} before its expiration date.
 
 .Verification
 . Make an API request to your {ProjectServer} and try to authenticate with the revoked {PAT}:
-// tags in combination with `none` substitution have to be used here to render colon between USERNAME and PAT as normal.
 +
-[options="nowrap", subs="none,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# curl https://<em>{foreman-example-com}</em>/api/status --user <em>USERNAME</em>:<em>PERSONAL_ACCESS_TOKEN</em>
+# curl https://_{foreman-example-com}_/api/status --user __My_Username__:__My_Personal_Access_Token__
 ----
 . You receive the following error message:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 {
-  "error": {"message":"Unable to authenticate user _USERNAME_"}
+  "error": {"message":"Unable to authenticate user __My_Username__"}
 }
 ----


### PR DESCRIPTION
Apparently, publishing tool we use for Satellite documentation does not render the code block correctly when using italic marks <em> and </em>. The reason I used them in the first place was that the code refused to render correctly when using underscores. However, I only today discovered that doubling underscores solves this issue. Apologies to @maximiliankolb for not interpreting his [comment](https://github.com/theforeman/foreman-documentation/pull/2050#pullrequestreview-1339543486), in which he notified me about this option, correctly the first time.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
