### PR TITLE
Add proc export syncable imports via web server

### DIFF
--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -18,6 +18,8 @@ include::modules/proc_exporting-a-content-view-version.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc[leveloffset=+1]
 
+include::modules/proc_exporting-syncable-imports-via-a-web-server.adoc[leveloffset=+1]
+
 include::modules/proc_exporting-a-content-view-version-incrementally.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-a-repository.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_exporting-syncable-imports-via-a-web-server.adoc
+++ b/guides/common/modules/proc_exporting-syncable-imports-via-a-web-server.adoc
@@ -1,0 +1,10 @@
+[id="Exporting_Syncable_Imports_via-a_Web-Server_{context}"]
+= Exporting Syncable Imports via a Web Server
+
+.Procedure
+* You can pass a HTTP URL to the path command :
++
+[options="nowrap" subs="+quotes"]
+----
+# CDN connected Sat |   | => [webserver] <copy URL here> -> 
+----


### PR DESCRIPTION
A procedure needed to be created to show how to export a syncable
export via a web server instead of requiring it to be locally on the
disk.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
