### PR TITLE
Move Personal Access Tokens to correct assembly

### DIFF
--- a/guides/common/assembly_configuring-external-authentication.adoc
+++ b/guides/common/assembly_configuring-external-authentication.adoc
@@ -32,12 +32,6 @@ include::modules/con_active-directory-with-cross-forest-trust.adoc[leveloffset=+
 
 include::modules/proc_configuring-the-freeipa-server-to-use-cross-forest-trust.adoc[leveloffset=+2]
 
-include::modules/con_using-personal-access-tokens.adoc[leveloffset=+1]
-
-include::modules/proc_creating-a-personal-access-token.adoc[leveloffset=+2]
-
-include::modules/proc_revoking-a-personal-access-token.adoc[leveloffset=+2]
-
 include::modules/proc_configuring-external-user-groups.adoc[leveloffset=+1]
 
 include::modules/proc_refreshing-external-user-groups-for-ldap.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-users-and-roles.adoc
+++ b/guides/common/assembly_managing-users-and-roles.adoc
@@ -14,6 +14,12 @@ include::modules/con_managing-ssh-keys.adoc[leveloffset=+1]
 
 include::modules/proc_managing-ssh-keys-for-a-user.adoc[leveloffset=+2]
 
+include::modules/con_managing-personal-access-tokens.adoc[leveloffset=+1]
+
+include::modules/proc_creating-a-personal-access-token.adoc[leveloffset=+2]
+
+include::modules/proc_revoking-a-personal-access-token.adoc[leveloffset=+2]
+
 include::modules/con_creating-and-managing-user-groups.adoc[leveloffset=+1]
 
 include::modules/con_user-groups.adoc[leveloffset=+2]

--- a/guides/common/modules/con_managing-personal-access-tokens.adoc
+++ b/guides/common/modules/con_managing-personal-access-tokens.adoc
@@ -1,5 +1,5 @@
-[id="using-personal-access-tokens_{context}"]
-= Using {PAT}s
+[id="managing-personal-access-tokens_{context}"]
+= Managing {PAT}s
 
 {PAT}s allow you to authenticate API requests without using your password.
 You can set an expiration date for your {PAT} and you can revoke it if you decide it should expire before the expiration date.


### PR DESCRIPTION
In #2050, I put section on Personal Access Tokens to Configuring External Authentication, but this was a mistake since PAT is not an external but internal authentication method. Instead, I am putting it in Managing Users and Roles, right after Managing SSH Keys section as this suits the content much better. I am also renaming the con file to preserve paralellism.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
