### PR TITLE
3.4: Rework attribute usage for Smart Proxies (#2067)

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -3,9 +3,9 @@ ifdef::context[:parent-context: {context}]
 
 [id="configuring-capsule-custom-server-certificate_{context}"]
 
-= Configuring {SmartProxyServer} with a Custom SSL Certificate
+= Configuring {SmartProxyServerTitle} with a Custom SSL Certificate
 
-If you configure {ProjectServer} to use a custom SSL certificate, you must also configure each of your external {SmartProxyServer}s with a distinct custom SSL certificate.
+If you configure {ProjectServer} to use a custom SSL certificate, you must also configure each of your external {SmartProxyServers} with a distinct custom SSL certificate.
 
 To configure your {SmartProxyServer} with a custom certificate, complete the following procedures on each {SmartProxyServer}:
 

--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="Configuring_Server_with_a_Custom_SSL_Certificate_{context}"]
 = Configuring {ProjectServer} with a Custom SSL Certificate
 
-By default, {ProjectName} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
+By default, {ProjectName} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServers}, and all hosts.
 If you cannot use a {Project} self-signed certificate, you can configure {ProjectServer} to use an SSL certificate signed by an external Certificate Authority.
 
 To configure your {ProjectServer} with a custom certificate, complete the following procedures:
@@ -11,7 +11,7 @@ To configure your {ProjectServer} with a custom certificate, complete the follow
 . xref:creating-a-custom-certificate_{project-context}[]
 . xref:Deploying_a_Custom_SSL_Certificate_to_Server_{project-context}[]
 . xref:deploying-a-custom-ssl-certificate-to-hosts_{project-context}[]
-. If you have external {SmartProxyServer}s registered to {ProjectServer}, you must configure them with custom SSL certificates.
+. If you have external {SmartProxyServers} registered to {ProjectServer}, you must configure them with custom SSL certificates.
 The same Certificate Authority must sign certificates for {ProjectServer} and {SmartProxyServer}.
 For more information, see {InstallingSmartProxyDocURL}configuring-capsule-custom-server-certificate_{smart-proxy-context}[Configuring {SmartProxyServer} with a Custom SSL Certificate] in _{InstallingSmartProxyDocTitle}_.
 

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="installing-capsule-server"]
 
-= Installing {SmartProxyServer}
+= Installing {SmartProxyServerTitle}
 
 Before you install {SmartProxyServer}, you must ensure that your environment meets the requirements for installation.
 For more information, see {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation].
@@ -37,11 +37,11 @@ include::modules/proc_synchronizing-the-system-clock-with-chronyd.adoc[leveloffs
 
 ifdef::katello,satellite[]
 [id="configuring-capsule-server-with-ssl-certificates"]
-== Configuring {SmartProxyServer} with SSL Certificates
+== Configuring {SmartProxyServerTitle} with SSL Certificates
 endif::[]
 
 ifdef::katello,satellite[]
-{ProjectName} uses SSL certificates to enable encrypted communications between {ProjectServer}, external {SmartProxyServer}s, and all hosts.
+{ProjectName} uses SSL certificates to enable encrypted communications between {ProjectServer}, external {SmartProxyServers}, and all hosts.
 Depending on the requirements of your organization, you must configure your {SmartProxyServer} with a default or custom certificate.
 
 * If you use a default SSL certificate, you must also configure each external {SmartProxyServer} with a distinct default SSL certificate.

--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 [id="performing-additional-configuration-on-capsule-server"]
 
-= Performing Additional Configuration on {SmartProxyServer}
+= Performing Additional Configuration on {SmartProxyServerTitle}
 
 Use this chapter to configure additional settings on your {SmartProxyServer}.
 
@@ -18,7 +18,7 @@ include::modules/proc_enabling-openscap.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello,satellite[]
-// Adding Life Cycle Environments to {SmartProxyServer}s
+// Adding Life Cycle Environments to {SmartProxyServers}
 include::modules/proc_adding-life-cycle-environments.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -114,5 +114,7 @@
 :SmartProxy: Smart{nbsp}Proxy
 :SmartProxyServer: Smart{nbsp}Proxy{nbsp}server
 :SmartProxyServerTitle: Smart{nbsp}Proxy{nbsp}Server
+:SmartProxyServers: Smart{nbsp}Proxy{nbsp}servers
+:SmartProxyServersTitle: Smart{nbsp}Proxy{nbsp}Servers
 :Team: Foreman developers
 :sectanchors:

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -23,6 +23,8 @@
 :TargetVersion: 6.1
 :SmartProxyServer: orcharhino{nbsp}Proxy
 :SmartProxyServerTitle: {SmartProxyServer}
+:SmartProxyServers: orcharhino{nbsp}Proxies
+:SmartProxyServersTitle: {SmartProxyServers}
 :Team: ATIX AG
 :certs-proxy-context: orcharhino-proxy
 :customcontent: custom content

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -98,6 +98,8 @@
 :SmartProxy: Capsule
 :SmartProxyServer: Capsule{nbsp}Server
 :SmartProxyServerTitle: {SmartProxyServer}
+:SmartProxyServers: {SmartProxyServer}s
+:SmartProxyServersTitle: {SmartProxyServers}
 :Team: Red{nbsp}Hat
 
 // Repositories and subscriptions (used in Satellite guides)

--- a/guides/common/modules/con_acd-architecture.adoc
+++ b/guides/common/modules/con_acd-architecture.adoc
@@ -5,4 +5,4 @@ ACD uses {SmartProxies} and a remote execution provider called `acd`.
 
 Ansible playbooks are downloaded from {ProjectServer} to {SmartProxyServer} before being executed.
 Submit any Ansible playbooks that you want to use to {ProjectServer}.
-You do not have to manually add Ansible playbooks to {SmartProxyServer}s.
+You do not have to manually add Ansible playbooks to {SmartProxyServers}.

--- a/guides/common/modules/con_adding-network-interfaces.adoc
+++ b/guides/common/modules/con_adding-network-interfaces.adoc
@@ -27,8 +27,8 @@ For more information about configuring BMC interfaces, see xref:Adding_a_Baseboa
 
 [NOTE]
 ====
-Additional interfaces have the *Managed* flag enabled by default, which means the new interface is configured automatically during provisioning by the DNS and DHCP {SmartProxyServer}s associated with the selected subnet.
-This requires a subnet with correctly configured DNS and DHCP {SmartProxyServer}s.
+Additional interfaces have the *Managed* flag enabled by default, which means the new interface is configured automatically during provisioning by the DNS and DHCP {SmartProxyServers} associated with the selected subnet.
+This requires a subnet with correctly configured DNS and DHCP {SmartProxyServers}.
 If you use a Kickstart method for host provisioning, configuration files are automatically created for managed interfaces in the post-installation phase at `/etc/sysconfig/network-scripts/ifcfg-_interface_id_`.
 ====
 

--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -1,5 +1,5 @@
 [id="backing-up-{project-context}-server-and-{smart-proxy-context}_{context}"]
-= Backing Up {ProjectServer} and {SmartProxyServer}
+= Backing Up {ProjectServer} and {SmartProxyServerTitle}
 
 You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.

--- a/guides/common/modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc
+++ b/guides/common/modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc
@@ -1,5 +1,5 @@
 [id="backup-and-restore-{smart-proxy-context}-using-a-virtual-machine-snapshot_{context}"]
-= Backup and Restore {SmartProxyServer} Using a Virtual Machine Snapshot
+= Backup and Restore {SmartProxyServerTitle} Using a Virtual Machine Snapshot
 
 If your {SmartProxyServer} is a virtual machine, you can restore it from a snapshot.
 Creating weekly snapshots to restore from is recommended.

--- a/guides/common/modules/con_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,4 +1,4 @@
 [id="con_Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}"]
 = Configuring {SmartProxyServerTitle} with Custom SSL Certificates for Load Balancing without Puppet
 
-The following section describes how to configure {SmartProxyServer}s that use custom SSL certificates for load balancing without Puppet.
+The following section describes how to configure {SmartProxyServers} that use custom SSL certificates for load balancing without Puppet.

--- a/guides/common/modules/con_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet_{context}"]
 = Configuring {SmartProxyServerTitle} with Default SSL Certificates for Load Balancing with Puppet
 
-The following section describes how to configure {SmartProxyServer}s that use default SSL certificates for load balancing with Puppet.
+The following section describes how to configure {SmartProxyServers} that use default SSL certificates for load balancing with Puppet.
 
 If you use Puppet in your {Project} configuration, you must complete the following procedures:
 

--- a/guides/common/modules/con_configuring-smart-proxy-servers-for-load-balancing.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-servers-for-load-balancing.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_{smart-proxy-context}_Servers_for_Load_Balancing_{context}"]
-= Configuring {SmartProxyServerTitle}s for Load Balancing
+= Configuring {SmartProxyServersTitle} for Load Balancing
 
-This chapter outlines how to configure {SmartProxyServer}s for load balancing.
+This chapter outlines how to configure {SmartProxyServers} for load balancing.
 Proceed to one of the following sections depending on your {ProjectServer} configuration:
 
 * xref:Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}[]

--- a/guides/common/modules/con_dynflow-tuning.adoc
+++ b/guides/common/modules/con_dynflow-tuning.adoc
@@ -10,7 +10,7 @@ For more information about the tunings involved related to Dynflow, see `\https:
 {Project} contains a Dynflow service called `dynflow-sidekiq` that performs tasks scheduled by Dynflow.
 Sidekiq workers can be grouped into various queues to ensure lots of tasks of one type will not block execution of tasks of other type.
 
-{Team} recommends to increase the number of sidekiq workers to scale the Foreman tasking system for bulk concurrent tasks, for example for multiple Content View publications and promotions, content synchronizations, and synchronizations to {SmartProxyServer}s.
+{Team} recommends to increase the number of sidekiq workers to scale the Foreman tasking system for bulk concurrent tasks, for example for multiple Content View publications and promotions, content synchronizations, and synchronizations to {SmartProxyServers}.
 There are two options available:
 
 * You can increase the number of threads used by a worker (worker's concurrency).

--- a/guides/common/modules/con_load-balancing-considerations.adoc
+++ b/guides/common/modules/con_load-balancing-considerations.adoc
@@ -1,7 +1,7 @@
 [id="Load_Balancing_Considerations_{context}"]
 = Load Balancing Considerations
 
-Distributing load between several {SmartProxyServer}s prevents any one {SmartProxy} from becoming a single point of failure.
+Distributing load between several {SmartProxyServers} prevents any one {SmartProxy} from becoming a single point of failure.
 Configuring {SmartProxies} to use a load balancer can provide resilience against planned and unplanned outages.
 This improves availability and responsiveness.
 
@@ -21,8 +21,8 @@ The following additional steps are required for load balancing:
 * You must upgrade each {SmartProxy} in sequence
 * You must backup each {SmartProxy} that you configure regularly
 
-.Upgrading {SmartProxyServer}s in a Load Balancing Configuration
+.Upgrading {SmartProxyServers} in a Load Balancing Configuration
 ifdef::satellite[]
-To upgrade {SmartProxyServer}s from {ProductVersionPrevious} to {ProductVersion}, complete the {UpgradingDocURL}upgrading_capsule_server[Upgrading {SmartProxyServer}s] procedure in _{UpgradingDocTitle}_.
+To upgrade {SmartProxyServers} from {ProductVersionPrevious} to {ProductVersion}, complete the {UpgradingDocURL}upgrading_capsule_server[Upgrading {SmartProxyServers}] procedure in _{UpgradingDocTitle}_.
 endif::[]
-There are no additional steps required for {SmartProxyServer}s in a load balancing configuration.
+There are no additional steps required for {SmartProxyServers} in a load balancing configuration.

--- a/guides/common/modules/con_load-balancing-solution-architecture.adoc
+++ b/guides/common/modules/con_load-balancing-solution-architecture.adoc
@@ -1,15 +1,15 @@
 [id="Load_Balancing_Solution_Architecture_{context}"]
 = Load Balancing Solution Architecture
 
-You can configure {ProjectServer} to use a load balancer to distribute client requests and network load across multiple {SmartProxyServer}s.
-This results in an overall performance improvement on {SmartProxyServer}s.
+You can configure {ProjectServer} to use a load balancer to distribute client requests and network load across multiple {SmartProxyServers}.
+This results in an overall performance improvement on {SmartProxyServers}.
 
 This guide outlines how to prepare {ProjectServer} and {SmartProxyServer} for load balancing, and provides guidelines on how to configure a load balancer and register clients in a load-balanced setup.
 
 A load-balanced setup consists of the following components:
 
 * {ProjectServer}
-* Two or more {SmartProxyServer}s
+* Two or more {SmartProxyServers}
 * A load balancer
 * Multiple clients
 

--- a/guides/common/modules/con_managing-custom-file-type-content.adoc
+++ b/guides/common/modules/con_managing-custom-file-type-content.adoc
@@ -6,7 +6,7 @@ To achieve this, {customproduct}s in {ProjectName} include repositories for {cus
 This provides a generic method to incorporate arbitrary files in a product.
 
 You can upload files to the repository and synchronize files from an upstream {ProjectServer}.
-When you add files to a {customfiletype} repository, you can use the normal {Project} management functions such as adding a specific version to a Content View to provide version control and making the repository of files available on various {SmartProxyServer}s.
+When you add files to a {customfiletype} repository, you can use the normal {Project} management functions such as adding a specific version to a Content View to provide version control and making the repository of files available on various {SmartProxyServers}.
 Clients must download the files over HTTP or HTTPS using `curl -O`.
 
 You can create a file type repository in {ProjectServer} only in a {customproduct}, but there is flexibility in how you create the repository source.

--- a/guides/common/modules/con_monitoring-smart-proxy-server.adoc
+++ b/guides/common/modules/con_monitoring-smart-proxy-server.adoc
@@ -1,4 +1,4 @@
 [id="monitoring-{smart-proxy-context}-server_{context}"]
-= Monitoring {SmartProxyServer}
+= Monitoring {SmartProxyServerTitle}
 
 The following section shows how to use the {ProjectWebUI} to find {SmartProxy} information valuable for maintenance and troubleshooting.

--- a/guides/common/modules/con_prerequisites-for-configuring-smart-proxy-server-for-load-balancing.adoc
+++ b/guides/common/modules/con_prerequisites-for-configuring-smart-proxy-server-for-load-balancing.adoc
@@ -1,12 +1,12 @@
-= Prerequisites for Configuring {SmartProxyServerTitle}s for Load Balancing
+= Prerequisites for Configuring {SmartProxyServersTitle} for Load Balancing
 
 ifdef::orcharhino[]
 You can find a list of requirements for {SmartProxyServer} in xref:sources/installation_and_maintenance/installing_orcharhino_proxy.adoc[_{InstallingSmartProxyDocTitle}_].
 endif::[]
 
 ifndef::orcharhino[]
-To configure {SmartProxyServer}s for load balancing, complete the following procedures described in _{InstallingSmartProxyDocTitle}_.
-{Project} does not support configuring existing {SmartProxyServer}s for load balancing.
+To configure {SmartProxyServers} for load balancing, complete the following procedures described in _{InstallingSmartProxyDocTitle}_.
+{Project} does not support configuring existing {SmartProxyServers} for load balancing.
 
 . {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering {SmartProxyServer} to {ProjectServer}]
 . {InstallingSmartProxyDocURL}attaching-infrastructure-subscription_{smart-proxy-context}[Attaching the {Project} Infrastructure Subscription]

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -32,7 +32,7 @@ For more information, see https://access.redhat.com/documentation/en-us/openshif
 endif::[]
 * A {SmartProxyServer} managing a network on the {KubeVirt} server.
 Ensure that no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
+For more information about network service configuration for {SmartProxyServers}, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
 * A {Project} user account with the following roles:
 ** *Edit hosts*
 ** *View hosts*

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -17,7 +17,7 @@ You can use KVM provisioning to create hosts over a network connection or from a
 include::snip_common-compute-resource-prereqs.adoc[]
 * A {SmartProxyServer} managing a network on the KVM server.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information about network service configuration for {SmartProxyServer}s, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
+For more information about network service configuration for {SmartProxyServers}, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
 ifdef::satellite[]
 * A {RHEL} server running KVM virtualization tools (libvirt daemon).
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_virtualization/index[_{RHEL} 8 Configuring and managing virtualization_].

--- a/guides/common/modules/con_renaming-server-or-smart-proxy.adoc
+++ b/guides/common/modules/con_renaming-server-or-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Renaming_Server_or_Smart_Proxy_{context}"]
-= Renaming {ProjectServer} or {SmartProxyServer}
+= Renaming {ProjectServer} or {SmartProxyServerTitle}
 
 To rename {ProjectServer} or {SmartProxyServer}, you must use the `{project-change-hostname}` script.
 

--- a/guides/common/modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -1,5 +1,5 @@
 [id="restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_{context}"]
-= Restoring {ProjectServer} or {SmartProxyServer} from a Backup
+= Restoring {ProjectServer} or {SmartProxyServerTitle} from a Backup
 
 You can restore {ProjectServer} or {SmartProxyServer} from the backup data that you create as part of xref:backing-up-{project-context}-server-and-{smart-proxy-context}_{context}[].
 This process outlines how to restore the backup on the same server that generated the backup, and all data covered by the backup is deleted on the target system.

--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -46,7 +46,7 @@ Example NFS path:
 nfs://download.example.com:/centos/$version/Server/$arch/os/
 ----
 +
-Synchronized content on {SmartProxyServer}s always uses an HTTP path.
+Synchronized content on {SmartProxyServers} always uses an HTTP path.
 {SmartProxyServer} managed content does not support NFS paths.
 +
 . From the *Operating system family* list, select the distribution or family of the installation medium.

--- a/guides/common/modules/proc_adding-life-cycle-environments.adoc
+++ b/guides/common/modules/proc_adding-life-cycle-environments.adoc
@@ -1,5 +1,5 @@
 [id="Adding_Life_Cycle_Environments_{context}"]
-= Adding Life Cycle Environments to {SmartProxyServer}s
+= Adding Life Cycle Environments to {SmartProxyServersTitle}
 
 If your {SmartProxyServer} has the content functionality enabled, you must add an environment so that {SmartProxy} can synchronize content from {ProjectServer} and provide content to host systems.
 
@@ -18,7 +18,7 @@ You can use Hammer CLI on {ProjectServer} or the {ProjectWebUI}.
 For definitions of each synchronization type, see {ContentManagementDocURL}Recovering_a_Corrupted_Repository_content-management[Recovering a Repository].
 
 .CLI procedure
-. To display a list of all {SmartProxyServer}s, on {ProjectServer}, enter the following command:
+. To display a list of all {SmartProxyServers}, on {ProjectServer}, enter the following command:
 +
 [options="nowrap"]
 ----

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -9,7 +9,7 @@ You must update each virtual machine configuration so that they receive updates 
 ** 6.4 or later
 ** 7.0 or later
 * All architectures of {EL} are supported (i386, x86_64, s390x, ppc_64).
-* Ensure that a time synchronization tool is enabled and runs on the {ProjectServer}s, any {SmartProxyServer}s, and the hosts.
+* Ensure that a time synchronization tool is enabled and runs on the {ProjectServer}s, any {SmartProxyServers}, and the hosts.
 ** For {EL} 6:
 +
 ----

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -1,5 +1,5 @@
 [id="configuring-capsule-default-certificate_{context}"]
-= Configuring {SmartProxyServer} with a Default SSL Certificate
+= Configuring {SmartProxyServerTitle} with a Default SSL Certificate
 
 Use this section to configure {SmartProxyServer} with an SSL certificate that is signed by {ProjectServer} default Certificate Authority (CA).
 

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_Remaining_{smart-proxy-context}_Servers_with_Custom_SSL_Certificates_for_Load_Balancing_{context}"]
-= Configuring Remaining {SmartProxyServerTitle}s with Custom SSL Certificates for Load Balancing
+= Configuring Remaining {SmartProxyServersTitle} with Custom SSL Certificates for Load Balancing
 
 Complete this procedure for each {SmartProxyServer} excluding the system where you configure {SmartProxyServer} to sign Puppet certificates.
 

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_Remaining_{smart-proxy-context}_Servers_with_Default_SSL_Certificates_for_Load_Balancing_{context}"]
-= Configuring Remaining {SmartProxyServerTitle}s with Default SSL Certificates for Load Balancing
+= Configuring Remaining {SmartProxyServersTitle} with Default SSL Certificates for Load Balancing
 
 Complete this procedure on each {SmartProxyServer} excluding the system where you configure {SmartProxyServer} to sign Puppet certificates.
 

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}"]
 = Configuring {SmartProxyServerTitle} with Custom SSL Certificates for Load Balancing without Puppet
 
-The following section describes how to configure {SmartProxyServer}s that use custom SSL certificates for load balancing without Puppet.
+The following section describes how to configure {SmartProxyServers} that use custom SSL certificates for load balancing without Puppet.
 Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.
 
 .Procedure

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_to_Generate_and_Sign_Puppet_Certificates_{context}"]
 = Configuring {SmartProxyServerTitle} with Custom SSL Certificates to Generate and Sign Puppet Certificates
 
-Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing.
+Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing.
 
 .Procedure
 . Append the following option to the `{certs-generate}` command that you obtain from the output of the `katello-certs-check` command:

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}"]
 = Configuring {SmartProxyServerTitle} with Default SSL Certificates for Load Balancing without Puppet
 
-The following section describes how to configure {SmartProxyServer}s that use default SSL certificates for load balancing without Puppet.
+The following section describes how to configure {SmartProxyServers} that use default SSL certificates for load balancing without Puppet.
 Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.
 
 .Procedure

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -1,7 +1,7 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_to_Generate_and_Sign_Puppet_Certificates_{context}"]
 = Configuring {SmartProxyServerTitle} with Default SSL Certificates to Generate and Sign Puppet Certificates
 
-Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate and sign Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing.
+Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate and sign Puppet certificates for all other {SmartProxyServers} that you configure for load balancing.
 
 .Procedure
 . On {ProjectServer}, generate Katello certificates for the system where you configure {SmartProxyServer} to generate and sign Puppet certificates:
@@ -60,7 +60,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 ----
 # puppet resource service puppetserver ensure=stopped
 ----
-. Generate Puppet certificates for all other {SmartProxyServer}s that you configure for load balancing, except the first system where you configure Puppet certificates signing:
+. Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the first system where you configure Puppet certificates signing:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
+++ b/guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
@@ -35,11 +35,11 @@ If none of the paths are specified in the configuration files, the following def
 
 .Procedure
 
-. Configure your xref:Ansible-paths_{context}[] on the {ProjectServer} and all {SmartProxyServer}s where you want to use the roles.
-. Add the roles to a directory in an xref:Ansible-paths_{context}[Ansible path] on the {ProjectServer} and all {SmartProxyServer}s from where you want to use the roles.
-If you want to use custom or third party Ansible roles, ensure to configure an external version control system to synchronize roles between {ProjectServer} and {SmartProxyServer}s.
+. Configure your xref:Ansible-paths_{context}[] on the {ProjectServer} and all {SmartProxyServers} where you want to use the roles.
+. Add the roles to a directory in an xref:Ansible-paths_{context}[Ansible path] on the {ProjectServer} and all {SmartProxyServers} from where you want to use the roles.
+If you want to use custom or third party Ansible roles, ensure to configure an external version control system to synchronize roles between {ProjectServer} and {SmartProxyServers}.
 
-. On all {SmartProxyServer}s that you want to use to run Ansible roles on hosts, enable the Ansible plug-in:
+. On all {SmartProxyServers} that you want to use to run Ansible roles on hosts, enable the Ansible plug-in:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -1,6 +1,6 @@
 [id="deploying-a-custom-ssl-certificate-to-capsule-server_{context}"]
 
-= Deploying a Custom SSL Certificate to {SmartProxyServer}
+= Deploying a Custom SSL Certificate to {SmartProxyServerTitle}
 
 Use this procedure to configure your {SmartProxyServer} with a custom SSL certificate signed by a Certificate Authority.
 The `{foreman-installer}` command, which the `{certs-generate}` command returns, is unique to each {SmartProxyServer}.

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -1,6 +1,6 @@
 [id="assigning-organization-location-capsule-server_{context}"]
 
-= Assigning the Correct Organization and Location to {SmartProxyServer} in the {ProjectWebUI}
+= Assigning the Correct Organization and Location to {SmartProxyServerTitle} in the {ProjectWebUI}
 
 After installing {SmartProxyServer} packages, if there is more than one organization or location, you must assign the correct organization and location to {SmartProxy} to make {SmartProxy} visible in the {ProjectWebUI}.
 

--- a/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
@@ -1,5 +1,5 @@
 [id="Enabling_Connections_from_Proxy_to_Server_{context}"]
-= Enabling Connections from {SmartProxyServer} to {ProjectServer}
+= Enabling Connections from {SmartProxyServerTitle} to {ProjectServer}
 
 On {ProjectServer}, you must enable the incoming connection from {SmartProxyServer} to {ProjectServer} and make this rule persistent across reboots.
 

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -1,6 +1,6 @@
 [id="enabling-connections-to-capsule_{context}"]
 
-= Enabling Connections from {ProjectServer} and Clients to a {SmartProxyServer}
+= Enabling Connections from {ProjectServer} and Clients to a {SmartProxyServerTitle}
 
 On the base operating system on which you want to install {SmartProxy}, you must enable incoming connections from {ProjectServer} and clients to {SmartProxyServer} and make these rules persistent across reboots.
 

--- a/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Installing_ACD_on_Smart_Proxy_{context}"]
-= Installing ACD on {SmartProxyServer}
+= Installing ACD on {SmartProxyServerTitle}
 
 .Prerequisite
 * {ProjectServer} with the Foreman ACD plugin installed.

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -1,5 +1,5 @@
 [id="Installing_Proxy_Packages_{context}"]
-= Installing {SmartProxyServer} Packages
+= Installing {SmartProxyServerTitle} Packages
 
 Before installing {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
 

--- a/guides/common/modules/proc_installing-openscap-plugin.adoc
+++ b/guides/common/modules/proc_installing-openscap-plugin.adoc
@@ -20,7 +20,7 @@ ifndef::satellite[]
 ----
 endif::[]
 
-. Install the OpenSCAP plug-in on any {SmartProxyServer}s:
+. Install the OpenSCAP plug-in on any {SmartProxyServers}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -1,6 +1,6 @@
 [id="installing-an-external-smart-proxy-upstream_{context}"]
 
-= Installing {SmartProxyServer}
+= Installing {SmartProxyServerTitle}
 
 .Procedure
 

--- a/guides/common/modules/proc_installing-the-infoblox-ca-certificate-on-smartproxy.adoc
+++ b/guides/common/modules/proc_installing-the-infoblox-ca-certificate-on-smartproxy.adoc
@@ -1,5 +1,5 @@
 [id="Installing_the_Infoblox_CA_Certificate_on_Smart_Proxy_{context}"]
-= Installing the Infoblox CA Certificate on {SmartProxyServer}
+= Installing the Infoblox CA Certificate on {SmartProxyServerTitle}
 
 You must install Infoblox HTTPS CA certificate on the base system for all {SmartProxies} that you want to integrate with Infoblox applications.
 

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -30,16 +30,16 @@ For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg`
 [cols="18%,16%,16%,20%,30%",options="header"]
 |====
 | Service | Port | Mode | Balance Mode | Destination
-| HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServer}s
+| HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServers}
 //| Anaconda | 8000 | TCP | roundrobin | port 8000 on all {SmartProxies}
-| HTTPS and RHSM | 443 | TCP | source | port 443 on all {SmartProxyServer}s
-| AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServer}s
-| Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServer}s
+| HTTPS and RHSM | 443 | TCP | source | port 443 on all {SmartProxyServers}
+| AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServers}
+| Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServers}
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates
-| SmartProxy (_Optional for OpenScap_)| 9090 | TCP | roundrobin | port 9090 on all {SmartProxyServer}s
+| SmartProxy (_Optional for OpenScap_)| 9090 | TCP | roundrobin | port 9090 on all {SmartProxyServers}
 |====
 . Configure the load balancer to disable SSL offloading and allow client-side SSL certificates to pass through to back end servers.
-This is required because communication from clients to {SmartProxyServer}s depends on client-side SSL certificates.
+This is required because communication from clients to {SmartProxyServers} depends on client-side SSL certificates.
 . Start and enable the HAProxy service:
 +
 ----

--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -1,5 +1,5 @@
 [id="Managing_Packages_on_the_Base_Operating_System_{context}"]
-= Managing Packages on the Base Operating System of {ProjectServer} or {SmartProxyServer}
+= Managing Packages on the Base Operating System of {ProjectServer} or {SmartProxyServerTitle}
 
 To install and update packages on the {ProjectServer} or {SmartProxyServer} base operating system, you must enter the `{foreman-maintain} packages` command.
 {Project} prevents users from installing and updating packages with `yum` because `yum` might also update the packages related to {ProjectServer} or {SmartProxyServer} and result in system inconsistency.

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -1,5 +1,5 @@
 [id="Performing_a_Full_Backup_{context}"]
-= Performing a Full Backup of {ProjectServer} or {SmartProxyServer}
+= Performing a Full Backup of {ProjectServer} or {SmartProxyServerTitle}
 
 {ProjectName} uses the `{foreman-maintain} backup` command to make backups.
 

--- a/guides/common/modules/proc_promoting-scap-content-to-clients.adoc
+++ b/guides/common/modules/proc_promoting-scap-content-to-clients.adoc
@@ -1,7 +1,7 @@
 [id="Promoting_SCAP_Content_to_Clients_{context}"]
 = Promoting SCAP Content to Clients
 
-The following section describes how to promote Security Content Automation Protocol (SCAP) content to clients registered to {SmartProxyServer}s that you configure for load balancing.
+The following section describes how to promote Security Content Automation Protocol (SCAP) content to clients registered to {SmartProxyServers} that you configure for load balancing.
 
 .Prerequisite
 * Ensure that you configure the SCAP content.

--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -16,7 +16,7 @@ endif::[]
 * You must have root privileges on the host that you want to register.
 ifdef::satellite,orcharhino[]
 * You must have an activation key created.
-* {ProjectServer}, any {SmartProxyServer}s, and all hosts must be synchronized with the same NTP server, and have a time synchronization tool enabled and running.
+* {ProjectServer}, any {SmartProxyServers}, and all hosts must be synchronized with the same NTP server, and have a time synchronization tool enabled and running.
 * The daemon *rhsmcertd* must be running on the hosts.
 * An activation key must be available for the host.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_removing-life-cycle-environments-from-smart-proxy.adoc
+++ b/guides/common/modules/proc_removing-life-cycle-environments-from-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Removing_Life_Cycle_Environments_from_smart_proxy_{context}"]
-= Removing Life Cycle Environments from {SmartProxyServer}
+= Removing Life Cycle Environments from {SmartProxyServerTitle}
 
 When life cycle environments are no longer relevant to the host system or environments are added incorrectly to {SmartProxyServer}, you can remove the life cycle environments from {SmartProxyServer}.
 

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -1,7 +1,7 @@
 [id="Renaming_Server_{context}"]
 = Renaming {ProjectServer}
 
-The host name of {ProjectServer} is used by {ProjectServer} components, all {SmartProxyServer}s, and hosts registered to it for communication.
+The host name of {ProjectServer} is used by {ProjectServer} components, all {SmartProxyServers}, and hosts registered to it for communication.
 This procedure ensures that you update all references to the new host name.
 
 If you use external authentication, you must reconfigure {ProjectServer} for external authentication after you run the `{project-change-hostname}` script.
@@ -51,7 +51,7 @@ endif::[]
 For more information about installing a custom SSL certificate, see {InstallingServerDocURL}Deploying_a_Custom_SSL_Certificate_to_Server_{project-context}[Deploying a Custom SSL Certificate to {ProjectServer}] in _{InstallingServerDocTitle}_.
 . Reregister all {Project} hosts.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
-. On all {SmartProxyServer}s, run the {Project} installation script to update references to the new host name:
+. On all {SmartProxyServers}, run the {Project} installation script to update references to the new host name:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -60,7 +60,7 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[
 --foreman-proxy-trusted-hosts _new-{foreman-example-com}_ \
 --puppet-server-foreman-url https://_new-{foreman-example-com}_
 ----
-. On {ProjectServer}, list all {SmartProxyServer}s:
+. On {ProjectServer}, list all {SmartProxyServers}:
 +
 ifdef::satellite[]
 ----

--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Renaming_Smart_Proxy_{context}"]
-= Renaming {SmartProxyServer}
+= Renaming {SmartProxyServerTitle}
 
 The host name of {SmartProxyServer} is referenced by {ProjectServer} components, and all hosts registered to it.
 This procedure ensures that you update all references to the new host name.

--- a/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
+++ b/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
@@ -8,9 +8,9 @@ The load balancer will decide through which {SmartProxy} to register the host at
 Upon registration, the subscription manager on the host will be configured to manage content through the load balancer.
 
 .Prerequisites
-* You configured SSL certificates on all {SmartProxyServer}s.
+* You configured SSL certificates on all {SmartProxyServers}.
 For more information, see xref:Configuring_{smart-proxy-context}_Servers_for_Load_Balancing_{context}[].
-* You enabled Registration and Templates plug-ins on all {SmartProxyServer}s:
+* You enabled Registration and Templates plug-ins on all {SmartProxyServers}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -20,7 +20,7 @@ For more information, see xref:Configuring_{smart-proxy-context}_Servers_for_Loa
 ----
 
 .Procedure
-. On all {SmartProxyServer}s, set the registration and template URLs using `{foreman-installer}`:
+. On all {SmartProxyServers}, set the registration and template URLs using `{foreman-installer}`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_viewing-general-smart-proxy-information.adoc
+++ b/guides/common/modules/proc_viewing-general-smart-proxy-information.adoc
@@ -1,7 +1,7 @@
 [id="viewing-general-{smart-proxy-context}-information_{context}"]
 = Viewing General {SmartProxy} Information
 
-In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* to view a table of {SmartProxyServer}s registered to {ProjectServer}.
+In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* to view a table of {SmartProxyServers} registered to {ProjectServer}.
 The information contained in the table answers the following questions:
 
 *Is {SmartProxyServer} running?*:: This is indicated by a green icon in the *Status* column.

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -1,10 +1,10 @@
 [appendix]
 [id="capsule-server-scalability-considerations_{context}"]
 
-= {SmartProxyServer} Scalability Considerations
+= {SmartProxyServerTitle} Scalability Considerations
 
-The maximum number of {SmartProxyServer}s that {ProjectServer} can support has no fixed limit.
-It was tested that a {ProjectServer} can support 17 {SmartProxyServer}s with 2 vCPUs.
+The maximum number of {SmartProxyServers} that {ProjectServer} can support has no fixed limit.
+It was tested that a {ProjectServer} can support 17 {SmartProxyServers} with 2 vCPUs.
 However, scalability is highly variable, especially when managing Puppet clients.
 
 {SmartProxyServer} scalability when managing Puppet clients depends on the number of CPUs, the run-interval distribution, and the number of Puppet managed resources.
@@ -12,7 +12,7 @@ However, scalability is highly variable, especially when managing Puppet clients
 Running more than 100 concurrent Puppet agents results in a 503 HTTP error.
 
 For example, assuming that Puppet agent runs are evenly distributed with less than 100 concurrent Puppet agents running at any single point during a run-interval, a {SmartProxyServer} with 4 CPUs has a maximum of 1250{range}1600 Puppet clients with a moderate workload of 10 Puppet classes assigned to each Puppet client.
-Depending on the number of Puppet clients required, the {Project} installation can scale out the number of {SmartProxyServer}s to support them.
+Depending on the number of Puppet clients required, the {Project} installation can scale out the number of {SmartProxyServers} to support them.
 
 If you want to scale your {SmartProxyServer} when managing Puppet clients, the following assumptions are made:
 

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -83,7 +83,7 @@ endif::[]
 
 ifdef::satellite[]
 ifeval::["{context}" == "{smart-proxy-context}"]
-For more information on scaling your {SmartProxyServer}s, see {InstallingSmartProxyDocURL}capsule-server-scalability-considerations_{smart-proxy-context}[{SmartProxyServer} Scalability Considerations].
+For more information on scaling your {SmartProxyServers}, see {InstallingSmartProxyDocURL}capsule-server-scalability-considerations_{smart-proxy-context}[{SmartProxyServer} Scalability Considerations].
 endif::[]
 endif::[]
 

--- a/guides/doc-Planning_for_Project/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_for_Project/topics/Capsule_Server_Overview.adoc
@@ -1,7 +1,7 @@
 [[chap-Documentation-Architecture_Guide-Capsule_Server_Overview]]
-== {SmartProxyServer} Overview
+== {SmartProxyServerTitle} Overview
 
-{SmartProxyServer}s provide *content federation* and run *localized services* to discover, provision, control, and configure hosts.
+{SmartProxyServers} provide *content federation* and run *localized services* to discover, provision, control, and configure hosts.
 You can use {SmartProxies} to extend the {Project} deployment to various geographical locations.
 This section contains an overview of features that can be enabled on {SmartProxies} as well as their simple classification.
 
@@ -10,7 +10,7 @@ For more information about {SmartProxy} requirements, installation process, and 
 [[sect-Documentation-Architecture_Guide-Capsule_Features]]
 === {SmartProxy} Features
 
-There are two sets of features provided by {SmartProxyServer}s.
+There are two sets of features provided by {SmartProxyServers}.
 You can use {SmartProxy} to run services required for host management.
 ifdef::satellite[]
 You can also configure {SmartProxy} to mirror content from {ProjectServer}.
@@ -55,7 +55,7 @@ endif::[]
 
 * *Host action delivery* – {SmartProxyServer} executes scheduled actions on hosts.
 
-* *Red Hat Subscription Management (RHSM) proxy* – hosts are registered to their associated {SmartProxyServer}s rather than to the central {ProjectServer} or the Red{nbsp}Hat Customer Portal (provided by Candlepin).
+* *Red Hat Subscription Management (RHSM) proxy* – hosts are registered to their associated {SmartProxyServers} rather than to the central {ProjectServer} or the Red{nbsp}Hat Customer Portal (provided by Candlepin).
 
 [[sect-Documentation-Architecture_Guide-Capsule_Types]]
 === {SmartProxy} Types

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -53,7 +53,7 @@ When creating a Red{nbsp}Hat Subscription Manifest:
 * Add the subscription for {ProjectServer} to the manifest if planning a disconnected or self-registered {ProjectServer}.
 This is not necessary for a connected {ProjectServer} that is subscribed using the Subscription Manager utility on the base system.
 
-* Add subscriptions for all {SmartProxyServer}s you want to create.
+* Add subscriptions for all {SmartProxyServers} you want to create.
 
 * Add subscriptions for all Red{nbsp}Hat Products you want to manage with {Project}.
 
@@ -97,13 +97,13 @@ The most common deployment scenarios are listed in xref:chap-Architecture_Guide-
 The defining questions are:
 
 
-* *How many {SmartProxyServer}s do I need?* – The number of geographic locations where your organization operates should translate to the number of {SmartProxyServer}s.
+* *How many {SmartProxyServers} do I need?* – The number of geographic locations where your organization operates should translate to the number of {SmartProxyServers}.
 By assigning a {SmartProxy} to each location, you decrease the load on {ProjectServer}, increase redundancy, and reduce bandwidth usage.
 {ProjectServer} itself can act as a {SmartProxy} (it contains an integrated {SmartProxy} by default).
-This can be used in single location deployments and to provision the base system's of {SmartProxyServer}s.
+This can be used in single location deployments and to provision the base system's of {SmartProxyServers}.
 Using the integrated {SmartProxy} to communicate with hosts in remote locations is not recommended as it can lead to suboptimal network utilization.
 
-* *What services will be provided by {SmartProxyServer}s?* – After establishing the number of {SmartProxies}, decide what services will be enabled on each {SmartProxy}.
+* *What services will be provided by {SmartProxyServers}?* – After establishing the number of {SmartProxies}, decide what services will be enabled on each {SmartProxy}.
 Even though the whole stack of content and configuration management capabilities is available, some infrastructure services (DNS, DHCP, TFTP) can be outside of a {Project} administrator's control.
 In such case, {SmartProxies} have to integrate with those external services (see xref:sect-Architecture_Guide-Capsule_with_External_Services[]).
 
@@ -197,7 +197,7 @@ The default method is *remote execution*, and the second method is the deprecate
 
 * *Remote execution* {endash} Remote execution allows installation, update, or removal of packages, the bootstrap of configuration management agents, and the trigger of Puppet runs.
 You can configure {Project} to perform remote execution either over SSH (push based) or over MQTT/HTTPS (pull based).
-While remote execution is enabled on {ProjectServer} by default, it is disabled on {SmartProxyServer}s and content hosts.
+While remote execution is enabled on {ProjectServer} by default, it is disabled on {SmartProxyServers} and content hosts.
 You must enable it manually.
 +
 This is the preferred method for content deployment.

--- a/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
@@ -15,7 +15,7 @@ The base systems of isolated {SmartProxies} can be directly managed by {ProjectS
 === Single Location with Segregated Subnets
 
 Your infrastructure might require multiple isolated subnets even if {ProjectName} is deployed in a single geographic location.
-This can be achieved for example by deploying multiple {SmartProxyServer}s with DHCP and DNS services, but the recommended way is to create segregated subnets using a single {SmartProxy}.
+This can be achieved for example by deploying multiple {SmartProxyServers} with DHCP and DNS services, but the recommended way is to create segregated subnets using a single {SmartProxy}.
 This {SmartProxy} is then used to manage hosts and compute resources in those segregated networks to ensure they only have to access the {SmartProxy} for provisioning, configuration, errata, and general management.
 For more information on configuring subnets see {ManagingHostsDocURL}[_Managing Hosts_].
 

--- a/guides/doc-Planning_for_Project/topics/Glossary.adoc
+++ b/guides/doc-Planning_for_Project/topics/Glossary.adoc
@@ -150,7 +150,7 @@ Foreman is the main upstream counterpart of Red Hat Satellite.
 endif::[]
 
 [[varl-Glossary_of_Terms-satellite-maintain_Services]]
-*{Project} services*:: A set of services that {ProjectServer} and {SmartProxyServer}s use for operation.
+*{Project} services*:: A set of services that {ProjectServer} and {SmartProxyServers} use for operation.
 You can use the `{foreman-maintain}` tool to manage these services.
 To see the full list of services, enter the `{foreman-maintain} service list` command on the machine where {Project} or {SmartProxyServer} is installed.
 

--- a/guides/doc-Planning_for_Project/topics/Hosts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Hosts.adoc
@@ -1,7 +1,7 @@
 [[chap-Architecture_Guide-Host_Grouping_Concepts]]
 == Host Grouping Concepts
 
-Apart from the physical topology of {SmartProxyServer}s, {ProjectName} provides several logical units for grouping hosts.
+Apart from the physical topology of {SmartProxyServers}, {ProjectName} provides several logical units for grouping hosts.
 Hosts that are members of those groups inherit the group configuration.
 For example, the simple parameters that define the provisioning environment can be applied at the following levels:
 

--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -13,9 +13,9 @@ _{ProjectServer}_ synchronizes the content from Red{nbsp}Hat Customer{nbsp}Porta
 _{SmartProxyServer}_ mirrors content from {ProjectServer} to facilitate content federation across various geographical locations.
 Host systems can pull content and configuration from {SmartProxyServer} in their location and not from the central {ProjectServer}.
 {SmartProxyServer} also provides localized services such as Puppet server, DHCP, DNS, or TFTP.
-{SmartProxyServer}s assist you in scaling your {Project} environment as the number of your managed systems increases.
+{SmartProxyServers} assist you in scaling your {Project} environment as the number of your managed systems increases.
 
-{SmartProxyServer}s decrease the load on the central server, increase redundancy, and reduce bandwidth usage.
+{SmartProxyServers} decrease the load on the central server, increase redundancy, and reduce bandwidth usage.
 For more information, see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
 
 [id="System_Architecture_{context}"]
@@ -42,7 +42,7 @@ In addition, you can use other supported content sources (Git repositories, Dock
 
 
 [[varl-Architecture_System_Architecture-RednbspHat_Satellite_Server]]
-*{ProjectServer}*:: The {ProjectServer} enables you to plan and manage the content life cycle and the configuration of {SmartProxyServer}s and hosts through GUI, CLI, or API.
+*{ProjectServer}*:: The {ProjectServer} enables you to plan and manage the content life cycle and the configuration of {SmartProxyServers} and hosts through GUI, CLI, or API.
 +
 {ProjectServer} organizes the life cycle management by using organizations as principal division units.
 Organizations isolate content for groups of hosts with specific requirements and administration tasks.
@@ -52,20 +52,20 @@ For example, the OS build team can use a different organization than the web dev
 
 
 [[varl-Architecture_System_Architecture-Capsule_Servers]]
-*{SmartProxyServer}s*:: {SmartProxyServer}s mirror content from {ProjectServer} to establish content sources in various geographical locations.
-This enables host systems to pull content and configuration from {SmartProxyServer}s in their location and not from the central {ProjectServer}.
-The recommended minimum number of {SmartProxyServer}s is therefore given by the number of geographic regions where the organization that uses {Project} operates.
+*{SmartProxyServers}*:: {SmartProxyServers} mirror content from {ProjectServer} to establish content sources in various geographical locations.
+This enables host systems to pull content and configuration from {SmartProxyServers} in their location and not from the central {ProjectServer}.
+The recommended minimum number of {SmartProxyServers} is therefore given by the number of geographic regions where the organization that uses {Project} operates.
 +
 Using Content Views, you can specify the exact subset of content that {SmartProxyServer} makes available to hosts.
 See xref:figu-Content_Life_Cycle_{context}[] for a closer look at life cycle management with the use of Content Views.
 +
 The communication between managed hosts and {ProjectServer} is routed through {SmartProxyServer} that can also manage multiple services on behalf of hosts.
 Many of these services use dedicated network ports, but {SmartProxyServer} ensures that a single source IP address is used for all communications from the host to {ProjectServer}, which simplifies firewall administration.
-For more information on {SmartProxyServer}s see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
+For more information on {SmartProxyServers} see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
 
 
 [[varl-Architecture_System_Architecture-Managed_Hosts]]
-*Managed Hosts*:: Hosts are the recipients of content from {SmartProxyServer}s.
+*Managed Hosts*:: Hosts are the recipients of content from {SmartProxyServers}.
 Hosts can be either physical or virtual.
 {ProjectServer} can have directly managed hosts.
 The base system running a {SmartProxyServer} is also a managed host of {ProjectServer}.
@@ -163,7 +163,7 @@ SELinux must be either in enforcing or permissive mode, installation with disabl
 
 [[form-Architecture_Supported_Usage-Puppet]]
 *Puppet*:: {ProjectName} includes supported Puppet packages.
-The installation program allows users to install and configure Puppet servers as a part of {SmartProxyServer}s.
+The installation program allows users to install and configure Puppet servers as a part of {SmartProxyServers}.
 A Puppet module, running on a Puppet server on the {ProjectServer} or {Project} {SmartProxyServer}, is also supported by Red{nbsp}Hat.
 For information on what versions of Puppet are supported, see the Red{nbsp}Hat Knowledgebase article https://access.redhat.com/articles/1343683[Satellite 6 Component Versions].
 +

--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -105,7 +105,7 @@ endif::[]
 
 ifdef::satellite[]
 [#updating_{project-context}]
-== Updating {ProjectServer}, {SmartProxyServer}, and Content Hosts
+== Updating {ProjectServer}, {SmartProxyServerTitle}, and Content Hosts
 
 // Updating Red Hat Satellite Introduction
 include::topics/introduction_updating_satellite.adoc[leveloffset=+2]

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -45,7 +45,7 @@ You can use a backup with or without Pulp data.
 Before you begin cloning, ensure the following conditions exist:
 
 * The target server is on an isolated network.
-This avoids unwanted communication with {SmartProxyServer}s and hosts.
+This avoids unwanted communication with {SmartProxyServers} and hosts.
 * The target server has the capacity to store all your backup files from the source server.
 
 .Customized configuration files

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
@@ -4,5 +4,5 @@ Use this chapter to update your existing {ProjectServer}, {SmartProxyServer}, an
 
 Updates patch security vulnerabilities and minor issues discovered after code is released, and are often fast and non-disruptive to your operating environment.
 
-Before updating, back up your {ProjectServer} and all {SmartProxyServer}s.
+Before updating, back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.

--- a/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/synchronizing_the_new_repositories.adoc
@@ -1,7 +1,7 @@
 [id="synchronizing_the_new_repositories_{context}"]
 = Synchronizing the New Repositories
 
-You must enable and synchronize the new {ProjectVersion} repositories before you can upgrade {SmartProxyServer}s and {Project} clients.
+You must enable and synchronize the new {ProjectVersion} repositories before you can upgrade {SmartProxyServers} and {Project} clients.
 
 .Procedure
 
@@ -11,7 +11,7 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 +
 * To upgrade {Project} clients, enable the *Red{nbsp}Hat {project-client-name}* repositories for all {RHEL} versions that clients use.
 +
-* If you have {SmartProxyServer}s, to upgrade them, enable the following repositories too:
+* If you have {SmartProxyServers}, to upgrade them, enable the following repositories too:
 +
 *{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 8 x86_64) (RPMs)*
 +

--- a/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_capsule_server_to_next_minor_version.adoc
@@ -1,7 +1,7 @@
 [[updating_capsule_server_to_next_minor_version]]
-= Updating {SmartProxyServer}
+= Updating {SmartProxyServerTitle}
 
-Use this procedure to update {SmartProxyServer}s to the next minor version.
+Use this procedure to update {SmartProxyServers} to the next minor version.
 
 .Procedure
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -69,7 +69,7 @@ If there are discovered hosts available, turn them off and then delete all entri
 Select all other organizations in turn using the organization setting menu and repeat this action as required.
 Reboot these hosts after the upgrade has completed.
 
-. Make sure all external {SmartProxyServer}s are assigned to an organization, otherwise they might get unregistered due to host-unification changes.
+. Make sure all external {SmartProxyServers} are assigned to an organization, otherwise they might get unregistered due to host-unification changes.
 
 . Remove old repositories:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -1,12 +1,12 @@
 [[upgrading_capsule_server]]
 
-= Upgrading {SmartProxyServer}s
+= Upgrading {SmartProxyServersTitle}
 
-This section describes how to upgrade {SmartProxyServer}s from {ProjectVersionPrevious} to {ProjectVersion}.
+This section describes how to upgrade {SmartProxyServers} from {ProjectVersionPrevious} to {ProjectVersion}.
 
 .Before You Begin
 
-* You must upgrade {ProjectServer} before you can upgrade any {SmartProxyServer}s.
+* You must upgrade {ProjectServer} before you can upgrade any {SmartProxyServers}.
 Note that you can upgrade {SmartProxies} separately from {Project}.
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
 ifdef::satellite[]
@@ -33,7 +33,7 @@ If these files have been deleted, they must be restored from a backup in order f
 ====
 endif::[]
 
-.Upgrading {SmartProxyServer}s
+.Upgrading {SmartProxyServers}
 
 . Create a backup.
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
@@ -33,7 +33,7 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _{InstallingSmartProxyDocTitle}_.
-* Back up your {ProjectServer} and all {SmartProxyServer}s.
+* Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 
@@ -49,14 +49,14 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 ifdef::satellite[]
 You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}.
 
-{ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
+{ProjectServer}s and {SmartProxyServers} on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/upgrading_and_updating_red_hat_satellite/[_{UpgradingDocTitle} to {ProjectVersionPrevious}_].
 endif::[]
 
 ifndef::satellite[]
 You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}.
 
-{ProjectServer}s and {SmartProxyServer}s on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
+{ProjectServer}s and {SmartProxyServers} on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
 For more information, see the {Project} {ProjectVersionPrevious} Upgrade documentation.
 endif::[]
 
@@ -69,7 +69,7 @@ ifdef::satellite[]
 endif::[]
 . Upgrade {ProjectServer} to {ProjectVersion}.
 For more information, see xref:Upgrading_Server_{context}[].
-. Upgrade all {SmartProxyServer}s to {ProjectVersion}.
+. Upgrade all {SmartProxyServers} to {ProjectVersion}.
 For more information, see xref:upgrading_capsule_server[].
 ifdef::katello,orcharhino[]
 . Upgrade to {project-client-name} on all content hosts.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_satellite_server_prerequisites.adoc
@@ -20,7 +20,7 @@ If you use the export method, restore your changes by comparing the exported tem
 ifdef::katello,orcharhino,satellite[]
 * If you use Content Views to control updates to a {SmartProxyServer}’s base operating system, or for {SmartProxyServer} repository, you must publish updated versions of those Content Views.
 endif::[]
-* Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServer}s still at {ProjectVersionPrevious}.
+* Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServers} still at {ProjectVersionPrevious}.
 
 ifdef::katello,orcharhino,satellite[]
 [WARNING]


### PR DESCRIPTION
Follow-up for #2067 

There were merge conflicts in the following files:

````
	both modified:   guides/common/modules/con_prerequisites-for-configuring-smart-proxy-server-for-load-balancing.adoc
	both modified:   guides/common/modules/proc_configuring-your-deployment-to-run-ansible-roles.adoc
	both modified:   guides/common/modules/proc_disabling-cockpit-on-project.adoc
	both modified:   guides/common/modules/proc_installing-the-load-balancer.adoc
	both modified:   guides/doc-Upgrading_and_Updating/topics/upgrading_overview.adoc
````

I've then checked them out from 3.4 again and rerun all four commands as specified in the original commit message.