### PR TITLE
Add procedures for incremental exports

### DIFF
--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -18,17 +18,23 @@ include::modules/proc_importing-syncable-exports.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-the-library-environment-incrementally.adoc[leveloffset=+1]
 
+include::modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc[leveloffset=+1]
+
 include::modules/proc_exporting-a-content-view-version.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-a-content-view-version-incrementally.adoc[leveloffset=+1]
 
+include::modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc[leveloffset=+1]
+
 include::modules/proc_exporting-a-repository.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-a-repository-in-a-syncable-format.adoc[leveloffset=+1]
 
 include::modules/proc_exporting-a-repository-incrementally.adoc[leveloffset=+1]
+
+include::modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc[leveloffset=+1]
 
 include::modules/proc_keeping-track-of-your-exports.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -6,7 +6,7 @@ After you have exported the Content View, you can do either of the following:
 
 * Synchronize the content from your custom CDN over HTTP/HTTPS.
 * Import the content using `hammer content-import`.
-Note that this requires both the Export and Import servers are the same {ProductVersion} and above.
+Note that this requires both the Export and Import servers are the same {ProductVersion}.
 
 include::snip_generating-content.adoc[]
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -1,10 +1,12 @@
 [id="Exporting_a_Content_View_Version_in_a_Syncable_Format_{context}"]
 = Exporting a Content View Version in a Syncable Format
 
-You can export a version of a Content View to a syncable format that you can use to create your custom CDN. Once exported, do either of the following:
+You can export a version of a Content View to a syncable format that you can use to create your custom CDN.
+After you have exported the Content View, you can do either of the following:
 
-* Synchronize the content from the custom CDN over HTTP/HTTPS.
-* Import the content via `hammer content-import` which is available if both the Export and Import servers are {ProductVersion} and above.
+* Synchronize the content from your custom CDN over HTTP/HTTPS.
+* Import the content using `hammer content-import`.
+Note that this requires both the Export and Import servers are the same {ProductVersion} and above.
 
 include::snip_generating-content.adoc[]
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -6,7 +6,7 @@ After you have exported the Content View, you can do either of the following:
 
 * Synchronize the content from your custom CDN over HTTP/HTTPS.
 * Import the content using `hammer content-import`.
-Note that this requires both the Export and Import servers are the same {ProductVersion}.
+Note that this requires both the Export and Import servers to run {Project} {ProductVersion}.
 
 include::snip_generating-content.adoc[]
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -1,7 +1,10 @@
 [id="Exporting_a_Content_View_Version_in_a_Syncable_Format_{context}"]
 = Exporting a Content View Version in a Syncable Format
 
-You can export a version of a Content View to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
+You can export a version of a Content View to a syncable format that you can use to create your custom CDN. Once exported, do either of the following:
+
+* Synchronize the content from the custom CDN over HTTP/HTTPS.
+* Import the content via `hammer content-import` which is available if both the Export and Import servers are {ProductVersion} and above.
 
 include::snip_generating-content.adoc[]
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
@@ -10,7 +10,7 @@ Content View versions that have multiple {RHEL} trees can occupy several gigabyt
 In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
 Incremental exports typically result in smaller archive files than the full exports.
 
-The example below targets the version `2.0` for export, because the version `1.0` was exported previously.
+The example below targets the version `2.0` for export because the version `1.0` was exported previously.
 
 .Procedure
 . Create an incremental export:

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
@@ -26,7 +26,7 @@ The example below targets the version `2.0` for export, because the version `1.0
 +
 [options="nowrap" subs="+quotes"]
 ----
-# cd /var/lib/pulp/exports/Default_Organization/view/3.0/2023-03-02T14-19-50-05-00/
+# cd /var/lib/pulp/exports/Default_Organization/view/2.0/2023-03-02T14-19-50-05-00/
 # find . -name *.rpm
 ./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
 ----

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
@@ -18,12 +18,14 @@ The example below targets the version `2.0` for export because the version `1.0`
 [options="nowrap" subs="+quotes"]
 ----
 # hammer content-export incremental version \
---content-view="_Content_View_Name_" \
+--content-view="_My_Content_View_Name_" \
 --organization="_My_Organization_" \
---version=2.0 --format=syncable
+--version=2.0 \
+--format=syncable
 ----
 . Optional: View the exported Content View:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# find /var/lib/pulp/exports/Default_Organization/view/2.0/2023-03-02T14-19-50-05-00/ -name "*.{pkg_ext}"----
+# find /var/lib/pulp/exports/Default_Organization/view/2.0/2023-03-02T14-19-50-05-00/ -name "*.{pkg_ext}"
+----

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
@@ -1,0 +1,32 @@
+[id="Exporting_Version_Incrementally_in_a_Syncable_Format_{context}"]
+= Exporting a Content View Version Incrementally in a Syncable Format
+
+Exporting complete Content View versions can be a very costly operation in terms of system resources.
+ifdef::orcharhino[]
+The size of the exported Content View versions depends on the number of products.
+endif::[]
+Content View versions that have multiple {RHEL} trees can occupy several gigabytes of space on {ProjectServer}.
+
+In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
+Incremental exports typically result in smaller archive files than the full exports.
+
+The example below targets the version `2.0` for export, because the version `1.0` was exported previously.
+
+.Procedure
+. Create an incremental export:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer content-export incremental version \
+--content-view="_Content_View_Name_" \
+--organization="_My_Organization_" \
+--version=2.0 --format=syncable
+----
+. Optional: View the exported Content View:
++
+[options="nowrap" subs="+quotes"]
+----
+# cd /var/lib/pulp/exports/Default_Organization/view/3.0/2023-03-02T14-19-50-05-00/
+# find . -name *.rpm
+./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
+----

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
@@ -1,4 +1,4 @@
-[id="Exporting_Version_Incrementally_in_a_Syncable_Format_{context}"]
+[id="Exporting_a_Content_View_Version_Incrementally_in_a_Syncable_Format_{context}"]
 = Exporting a Content View Version Incrementally in a Syncable Format
 
 Exporting complete Content View versions can be a very costly operation in terms of system resources.

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally-in-a-syncable-format.adoc
@@ -24,9 +24,6 @@ The example below targets the version `2.0` for export, because the version `1.0
 ----
 . Optional: View the exported Content View:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# cd /var/lib/pulp/exports/Default_Organization/view/2.0/2023-03-02T14-19-50-05-00/
-# find . -name *.rpm
-./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
-----
+# find /var/lib/pulp/exports/Default_Organization/view/2.0/2023-03-02T14-19-50-05-00/ -name "*.{pkg_ext}"----

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -10,7 +10,7 @@ Content View versions that have multiple {RHEL} trees can occupy several gigabyt
 In such cases, you can create an incremental export which contains only pieces of content that changed since the previous export.
 Incremental exports typically result in smaller archive files than the full exports.
 
-The example below targets the version `2.0` for export, because the version `1.0` was exported previously.
+The example below targets the version `2.0` for export because the version `1.0` was exported previously.
 
 .Procedure
 . Create an incremental export:

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -1,4 +1,4 @@
-[id="Exporting_Version_Incrementally_{context}"]
+[id="Exporting_a_Content_View_Version_Incrementally_in_a_Syncable_Format_{context}"]
 = Exporting a Content View Version Incrementally
 
 Exporting complete versions can be a very expensive operation in terms of system resources.
@@ -7,7 +7,7 @@ The size of the exported Content View versions depends on the number of products
 endif::[]
 Content View versions that have multiple {RHEL} trees can occupy several gigabytes of space on {ProjectServer}.
 
-In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
+In such cases, you can create an incremental export which contains only pieces of content that changed since the previous export.
 Incremental exports typically result in smaller archive files than the full exports.
 
 The example below targets the version `2.0` for export, because the version `1.0` was exported previously.
@@ -20,7 +20,8 @@ The example below targets the version `2.0` for export, because the version `1.0
 # hammer content-export incremental version \
 --content-view="_Content_View_Name_" \
 --organization="_My_Organization_" \
---version=2.0
+--version=2.0 \
+--format=syncable
 ----
 . Optional: View the exported Content View:
 +

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -1,4 +1,4 @@
-[id="Exporting_a_Content_View_Version_Incrementally_in_a_Syncable_Format_{context}"]
+[id="Exporting_a_Content_View_Version_Incrementally_{context}"]
 = Exporting a Content View Version Incrementally
 
 Exporting complete versions can be a very expensive operation in terms of system resources.

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -1,0 +1,31 @@
+[id="Exporting_Repository_Incrementally_in_a_Syncable_Format_{context}"]
+= Exporting a Repository Incrementally in a Syncable Format
+
+Exporting a repository can be a very costly operation in terms of system resources.
+A typical {RHEL} tree may occupy several gigabytes of space on {ProjectServer}.
+
+In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
+Incremental exports typically result in smaller archive files than full exports.
+
+The procedure below shows an incremental export of a repository in the Library lifecycle environment.
+
+.Procedure
+. Create an incremental export:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer content-export incremental repository \
+ --organization="_My_Organization_" \
+ --product="_My_Product_" \
+ --name="_My_Repository_" \
+ --format=syncable
+Generated /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/metadata.json
+----
+. Optional: View the exported data:
++
+[options="nowrap" subs="+quotes"]
+----
+# cd /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/
+# find . -name *.rpm
+./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
+----

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -2,6 +2,9 @@
 = Exporting a Repository Incrementally in a Syncable Format
 
 Exporting a repository can be a very costly operation in terms of system resources.
+ifdef::orcharhino[]
+The size of the exported Content View versions depends on the number of products.
+endif::[]
 A typical {RHEL} tree may occupy several gigabytes of space on {ProjectServer}.
 
 In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -1,4 +1,4 @@
-[id="Exporting_Repository_Incrementally_in_a_Syncable_Format_{context}"]
+[id="Exporting_a_Repository_Incrementally_in_a_Syncable_Format_{context}"]
 = Exporting a Repository Incrementally in a Syncable Format
 
 Exporting a repository can be a very costly operation in terms of system resources.

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -19,13 +19,10 @@ The procedure below shows an incremental export of a repository in the Library l
  --product="_My_Product_" \
  --name="_My_Repository_" \
  --format=syncable
-Generated /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/metadata.json
 ----
 . Optional: View the exported data:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# cd /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/
-# find . -name *.rpm
-./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
+# find /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/ -name "*.rpm"
 ----

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -2,9 +2,6 @@
 = Exporting a Repository Incrementally in a Syncable Format
 
 Exporting a repository can be a very costly operation in terms of system resources.
-ifdef::orcharhino[]
-The size of the exported Content View versions depends on the number of products.
-endif::[]
 A typical {RHEL} tree may occupy several gigabytes of space on {ProjectServer}.
 
 In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -15,14 +15,14 @@ The procedure below shows an incremental export of a repository in the Library l
 [options="nowrap" subs="+quotes"]
 ----
 # hammer content-export incremental repository \
- --organization="_My_Organization_" \
- --product="_My_Product_" \
- --name="_My_Repository_" \
- --format=syncable
+--organization="_My_Organization_" \
+--product="_My_Product_" \
+--name="_My_Repository_" \
+--format=syncable
 ----
 . Optional: View the exported data:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# find /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/ -name "*.rpm"
+# find /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/ -name "*.{pkg_ext}"
 ----

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc
@@ -25,5 +25,5 @@ The procedure below shows incremental export of all repositories in the organiza
 +
 [options="nowrap" subs="+quotes"]
 ----
-# find /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/ -name "*.rpm"
+# find /var/lib/pulp/exports/Default_Organization/Export-Library-SYNCABLE/2.0/2023-03-09T10-55-48-05-00/ -name "*.rpm"
 ----

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc
@@ -1,4 +1,4 @@
-[id="Exporting_Library_Incrementally_in_a_Syncable_Format_{context}"]
+[id="Exporting_the_Library_Environment_Incrementally_in_a_Syncable_Format_{context}"]
 = Exporting the Library Environment Incrementally in a Syncable Format
 
 Exporting Library content can be a very costly operation in terms of system resources.
@@ -17,14 +17,13 @@ The procedure below shows incremental export of all repositories in the organiza
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export incremental library --organization="_My_Organization_" --format=syncable
-Generated /var/lib/pulp/exports/Default_Organization/Export-Library-SYNCABLE/2.0/2023-03-09T11-00-21-05-00/metadata.json
+# hammer content-export incremental library \
+--format=syncable \
+--organization="_My_Organization_"
 ----
 . Optional: View the exported data:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# cd /var/lib/pulp/exports/Default_Organization/Export-Library-SYNCABLE/2.0/2023-03-09T11-00-21-05-00/
-# find . -name *.rpm
-./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
+# find /var/lib/pulp/exports/Default_Organization/Export-SYNCABLE-Red_Hat_Ansible_Engine_2_for_RHEL_8_x86_64_RPMs-1/2.0/2023-03-09T10-55-48-05-00/ -name "*.rpm"
 ----

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally-in-a-syncable-format.adoc
@@ -1,0 +1,30 @@
+[id="Exporting_Library_Incrementally_in_a_Syncable_Format_{context}"]
+= Exporting the Library Environment Incrementally in a Syncable Format
+
+Exporting Library content can be a very costly operation in terms of system resources.
+ifdef::orcharhino[]
+The size of the exported Library depends on the number of products.
+endif::[]
+Organizations that have multiple {RHEL} trees can occupy several gigabytes of space on {ProjectServer}.
+
+In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
+Incremental exports typically result in smaller archive files than full exports.
+
+The procedure below shows incremental export of all repositories in the organization's Library.
+
+.Procedure
+. Create an incremental export:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer content-export incremental library --organization="_My_Organization_" --format=syncable
+Generated /var/lib/pulp/exports/Default_Organization/Export-Library-SYNCABLE/2.0/2023-03-09T11-00-21-05-00/metadata.json
+----
+. Optional: View the exported data:
++
+[options="nowrap" subs="+quotes"]
+----
+# cd /var/lib/pulp/exports/Default_Organization/Export-Library-SYNCABLE/2.0/2023-03-09T11-00-21-05-00/
+# find . -name *.rpm
+./content/dist/layered/rhel8/x86_64/ansible/2/os/Packages/s/sshpass-1.06-3.el8ae.x86_64.rpm
+----

--- a/guides/common/modules/proc_using-upstream-server-to-sync-content-view-versions.adoc
+++ b/guides/common/modules/proc_using-upstream-server-to-sync-content-view-versions.adoc
@@ -23,7 +23,7 @@ This generates content archives that you can import into one or more downstream 
 .. Export all future updates in the connected {ProjectServer}s incrementally.
 This generates leaner content archives that contain changes only from the recent set of updates.
 For example, if your Content View has a new repository, this exported content archive contains only the latest changes.
-For more information, see xref:Exporting_Version_Incrementally_{context}[].
+For more information, see xref:Exporting_a_Content_View_Version_Incrementally_{context}[].
 .. When you have new content, republish the Content Views that include this content before exporting the increment.
 For more information, see xref:Managing_Content_Views_{context}[].
 This creates a new Content View Version with the appropriate content to export.


### PR DESCRIPTION
New procedures were required for incremental exports and have been
created for the Managing Content Guide. This is a pull request taking
over for #2049. 


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
