### PR TITLE
Declare Foreman 3.4 as unsupported

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: stable
+:DocState: unsupported
 
 // Version numbers
 :ProjectVersion: 3.4


### PR DESCRIPTION
Now that Foreman 3.6 has been released, 3.4 is end of life.

Should be merged after https://github.com/theforeman/foreman-documentation/pull/2079.