### PR TITLE
Stop services before updating

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -113,17 +113,17 @@ endif::[]
 ----
 # dnf module enable {dnf-modules}
 ----
-. Update the required packages:
-+
-[options="nowrap" subs="attributes"]
-----
-# {package-update}
-----
 . Stop all services:
 +
 [options="nowrap" subs="attributes"]
 ----
 # {foreman-maintain} service stop
+----
+. Update the required packages:
++
+[options="nowrap" subs="attributes"]
+----
+# {package-update}
 ----
 +
 . Run the installer:


### PR DESCRIPTION
This is safer, because package updates may restart running services.  Since services don't have to be restarted, it's also faster.

I think this is applicable all the way back to 3.1, but haven't checked.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.