### PR TITLE
Improve sentence in PXE-less provisioning

### DIFF
--- a/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
@@ -54,7 +54,7 @@ see https://ipxe.org/appnote/hardware_drivers[supported hardware on ipxe.org] fo
 ====
 
 ifdef::satellite[]
-*Full host image* contains provisioning tokens, therefore the generated image has limited lifespan.
+*Full host image* contains a provisioning token, therefore the generated image has limited lifespan.
 endif::[]
 ifndef::satellite[]
 *Host image* and *Full host image* contain provisioning tokens, therefore the generated image has limited lifespan.


### PR DESCRIPTION
Missed this in #2077 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
