### PR TITLE
add back missing slash for certs-tar parameter

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -68,7 +68,7 @@ Validation succeeded.
 
 To use them inside a NEW $FOREMAN_PROXY, run this command:
   {certs-generate} --foreman-proxy-fqdn "$FOREMAN_PROXY" \
-    --certs-tar  "~$FOREMAN_PROXY-certs.tar" \
+    --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \


### PR DESCRIPTION
otherwise the shell would look in the home of the user $FOREMAN_PROXY which doesn't exist :)


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
