### PR TITLE
Add the AD user attributes value

### DIFF
--- a/guides/common/modules/proc_configuring-the-freeipa-server-to-use-cross-forest-trust.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-server-to-use-cross-forest-trust.adoc
@@ -14,7 +14,9 @@ For example:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-[domain/lab.example.com]
+[nss]
+user_attributes=+mail, +sn, +givenname
+[domain/EXAMPLE.com]
 ...
 krb5_store_password_if_offline = True
 ldap_user_extra_attrs=email:mail, lastname:sn, firstname:givenname

--- a/guides/common/modules/proc_configuring-the-freeipa-server-to-use-cross-forest-trust.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-server-to-use-cross-forest-trust.adoc
@@ -14,9 +14,17 @@ For example:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-[nss]
-user_attributes=+mail, +sn, +givenname
+[domain/lab.example.com]
+...
+krb5_store_password_if_offline = True
+ldap_user_extra_attrs=email:mail, lastname:sn, firstname:givenname
 
-[domain/EXAMPLE]
-ldap_user_extra_attrs=mail, sn, givenname
+[ifp]
+allowed_uids = ipaapi, root
+user_attributes=+email, +firstname, +lastname
+----
+* Verify the AD attributes value.
++
+----
+# dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:ad-user@ad-domain array:string:email,firstname,lastname
 ----


### PR DESCRIPTION
The current AD attribute value in sssd/cross-forest trust is causing the problem on IDM client. Therefore, it is required to add the correct values and also add the command to verify it.

https://bugzilla.redhat.com/show_bug.cgi?id=2170698

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
