### PR TITLE
remove "Satellite" from install guide non-satellite builds

### DIFF
--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -22,4 +22,4 @@ Note that this requirement is for Katello users only.
 endif::[]
 
 * You must configure {Project} to use this IPv4 HTTP proxy server as the default proxy.
-For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{project-context}[Adding a Default HTTP Proxy to Satellite].
+For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{project-context}[Adding a Default HTTP Proxy to {Project}].

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -62,7 +62,7 @@ Enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# scp /etc/rndc.key root@_satellite.example.com_:/etc/rndc.key
+# scp /etc/rndc.key root@_{foreman-example-com}_:/etc/rndc.key
 ----
 
 . To set the correct ownership, permissions, and SELinux context for the `rndc.key` file, enter the following command:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -11,9 +11,9 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--c __/root/satellite_cert/satellite_cert.pem__ \      <1>
--k __/root/satellite_cert/satellite_cert_key.pem__ \  <2>
--b __/root/satellite_cert/ca_cert_bundle.pem__        <3>
+-c __/root/{project-context}_cert/{project-context}_cert.pem__ \      <1>
+-k __/root/{project-context}_cert/{project-context}_cert_key.pem__ \  <2>
+-b __/root/{project-context}_cert/ca_cert_bundle.pem__        <3>
 ----
 <1> Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
 <2> Path to the private key that was used to sign {ProjectServer} certificate.
@@ -30,16 +30,16 @@ Validation succeeded.
 To install the Red Hat Satellite Server with the custom certificates, run:
 
   {foreman-installer} --scenario satellite \
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+    --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
+    --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_"
 
 To update the certificates on a currently running Red Hat Satellite installation, run:
 
   {foreman-installer} --scenario satellite \
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
+    --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
+    --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_" \
     --certs-update-server --certs-update-server-ca
 ----
 endif::[]
@@ -52,17 +52,17 @@ Validation succeeded.
 
 To install the Katello main server with the custom certificates, run:
 
-  foreman-installer --scenario katello \\
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_"
+  foreman-installer --scenario katello \
+    --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
+    --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_"
 
 To update the certificates on a currently running Katello installation, run:
 
-  foreman-installer --scenario katello \\
-    --certs-server-cert "_/root/satellite_cert/satellite_cert.pem_" \
-    --certs-server-key "_/root/satellite_cert/satellite_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/satellite_cert/ca_cert_bundle.pem_" \
+  foreman-installer --scenario katello \
+    --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
+    --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
+    --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_" \
     --certs-update-server --certs-update-server-ca
 ----
 endif::[]

--- a/guides/common/modules/proc_enabling-red-hat-repositories.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories.adoc
@@ -2,7 +2,7 @@
 = Enabling Red{nbsp}Hat Repositories
 
 If outside network access requires usage of an HTTP proxy, configure a default HTTP proxy for your server.
-For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{build}[Adding a Default HTTP Proxy].
+For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{build}[Adding a Default HTTP Proxy to {Project}].
 
 To select the repositories to synchronize, you must first identify the Product that contains the repository, and then enable that repository based on the relevant release version and base architecture.
 


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
