### PR TITLE
use installer scenario attribute for ssl cert deployment

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -20,52 +20,27 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 <3> Path to the Certificate Authority bundle.
 +
 If the command is successful, it returns two `{foreman-installer}` commands, one of which you must use to deploy a certificate to {ProjectServer}.
-ifdef::satellite[]
 +
 .Example output of `katello-certs-check`
 [options="nowrap", subs="+quotes,attributes"]
 ----
 Validation succeeded.
 
-To install the Red Hat Satellite Server with the custom certificates, run:
+To install the {ProjectName} server with the custom certificates, run:
 
-  {foreman-installer} --scenario satellite \
+  {installer-scenario} \
     --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
     --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
     --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_"
 
-To update the certificates on a currently running Red Hat Satellite installation, run:
+To update the certificates on a currently running {ProjectName} installation, run:
 
-  {foreman-installer} --scenario satellite \
+  {installer-scenario} \
     --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
     --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
     --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_" \
     --certs-update-server --certs-update-server-ca
 ----
-endif::[]
-ifndef::satellite[]
-+
-.Example output of `katello-certs-check`
-[options="nowrap", subs="+quotes,attributes"]
-----
-Validation succeeded.
-
-To install the Katello main server with the custom certificates, run:
-
-  foreman-installer --scenario katello \
-    --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
-    --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_"
-
-To update the certificates on a currently running Katello installation, run:
-
-  foreman-installer --scenario katello \
-    --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
-    --certs-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
-    --certs-server-ca-cert "_/root/{project-context}_cert/ca_cert_bundle.pem_" \
-    --certs-update-server --certs-update-server-ca
-----
-endif::[]
 
 . From the output of the `katello-certs-check` command, depending on your requirements, enter the `{foreman-installer}` command that installs a new {Project} with custom SSL certificates or updates certificates on a currently running {Project}.
 +


### PR DESCRIPTION
this allows to drop the ifdef/ifndef as the rest of the section is identical


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
