### PR TITLE
Add Puppet params for non-integrated setup

### DIFF
--- a/guides/common/modules/proc_installing-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-puppet-agent-during-host-provisioning.adoc
@@ -40,6 +40,10 @@ endif::[]
 ----
 +
 Note that this snippet is already included in the templates shipped with {Project}, such as `Kickstart default` or `Preseed default`.
+ifdef::katello,orcharhino,satellite[]
+. Enable the Puppet agent using a host parameter in global parameters, a host group, or for a single host.
+Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
+endif::[]
 ifndef::katello,orcharhino,satellite[]
 . Enable the Puppet agent from the official Puppet repository using one of the following host parameters in global parameters, a host group, or for a single host:
 
@@ -48,10 +52,6 @@ ifndef::katello,orcharhino,satellite[]
 
 +
 Select the *boolean* type and set the value to `true`.
-endif::[]
-ifdef::katello,orcharhino,satellite[]
-. Enable the Puppet agent using a host parameter in global parameters, a host group, or for a single host.
-Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 . Ensure your host has access to the Puppet agent packages from {ProjectServer} by using an appropriate activation key.

--- a/guides/common/modules/proc_installing-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-puppet-agent-during-host-provisioning.adoc
@@ -53,7 +53,13 @@ ifndef::katello,orcharhino,satellite[]
 +
 Select the *boolean* type and set the value to `true`.
 endif::[]
+. Set configuration for the Puppet agent.
+* If you use an integrated Puppet server, ensure that you select a Puppet {SmartProxy}, Puppet CA {SmartProxy}, and Puppet environment when you create a host.
+* If you use a non-integrated Puppet server, either set the following host parameters in global parameters, or a host group, or when you create a host:
+** Add a host parameter named `puppet_server`, select the *string* type, and set the value to the hostname of your Puppet server, such as `puppet.example.com`.
+** Optional: Add a host parameter named `puppet_ca_server`, select the *string* type, and set the value to the hostname of your Puppet CA server, such as `puppet-ca.example.com`.
+If `puppet_ca_server` is not set, the Puppet agent will use the same server as `puppet_server`.
+** Optional: Add a host parameter named `puppet_environment`, select the *string* type, and set the value to the Puppet environment you want the host to use.
 ifdef::katello,orcharhino,satellite[]
 . Ensure your host has access to the Puppet agent packages from {ProjectServer} by using an appropriate activation key.
 endif::[]
-. Ensure that you assign a Puppet environment, Puppet server and Puppet CA server to your host.


### PR DESCRIPTION
Puppet agent can be configured for non-integrated setup during Provisioning as well.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
