### PR TITLE
Add the FIPS mode principle

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -101,7 +101,8 @@ SELinux must be enabled, either in enforcing or permissive mode.
 Installation with disabled SELinux is not supported.
 
 .FIPS Mode
-You can install {ProductName} on a {RHEL} system that is operating in FIPS mode.
+You can install {Project} on a {RHEL} system that is operating in FIPS mode.
+You cannot enable FIPS mode after the installation of {Project}.
 ifndef::satellite[]
 {RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {RHEL}.
 endif::[]


### PR DESCRIPTION
We are documenting the principle of installation of the Project Server in FIPS mode in which the end-user cannot enable the FIPS mode after installation and vice-versa for non-FIPS mode. This was not clear enough earlier and therefore we added one more sentence to alert the end-user while installing the Project Server.

https://bugzilla.redhat.com/show_bug.cgi?id=2181262

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
