### PR TITLE
Fix Puppet agent supported architectures (Satellite)

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Configuration_Management_Support.adoc
+++ b/guides/doc-Planning_for_Project/topics/Configuration_Management_Support.adoc
@@ -2,11 +2,12 @@
 ==== Configuration Management
 Supported combinations of major versions of {RHEL} and hardware architectures for configuration management with {Project}.
 
-.Puppet Support
-[options="header"]
+.Puppet Agent Support
+[options="header",cols="2,1"]
 |====
 |Platform |Architectures
-|{RHEL} 8 |x86_64, ppc_64, s390x
-|{RHEL} 7 |x86_64, aarch64, ppc64le
+|{RHEL} 9 |x86_64
+|{RHEL} 8 |x86_64, aarch64
+|{RHEL} 7 |x86_64
 |{RHEL} 6 |x86_64, i386
 |====


### PR DESCRIPTION
Update a table of architectures for which RH provides Puppet agent. (According to Ohsnap)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
