### PR TITLE
Move Content Host Registration port from 8443 to 443

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -35,6 +35,11 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
+| 443 | TCP | HTTPS | Client | Content Host registration | Initiation
+
+Uploading facts
+
+Sending installed packages and traces
 | 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
@@ -48,11 +53,6 @@ ifndef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 endif::[]
 ifdef::katello,satellite,orcharhino[]
-| 8443 | TCP | HTTPS | Client | Content Host registration | Initiation
-
-Uploading facts
-
-Sending installed packages and traces
 | 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality


### PR DESCRIPTION
Remove port 8443 because it is no longer used by any services on the Project Server itself, even for establishing an incoming connection. Use the 443 port instead for Content Host Registration as the features are still functional over the same port.

https://bugzilla.redhat.com/show_bug.cgi?id=2166014

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
