### PR TITLE
Move Note to supported usage (Satellite)

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -193,6 +193,12 @@ Red{nbsp}Hat does not support direct interaction with Candlepin, its local API o
 *Embedded Tomcat Application Server*:: The only supported methods of using the embedded Tomcat application server are through the {ProjectWebUI}, API, and database.
 Red{nbsp}Hat does not support direct interaction with the embedded Tomcat application server's local API or database.
 
+[NOTE]
+====
+Usage of all {ProjectName} components is supported within the context of {ProjectName} only.
+Third-party usage of any components falls beyond supported usage.
+====
+
 [[sect-Architecture_Supported_Client_Architectures]]
 === Supported Client Architectures
 
@@ -201,12 +207,6 @@ include::Content_Management_Support.adoc[]
 include::Host_Provisioning_Support.adoc[]
 
 include::Configuration_Management_Support.adoc[]
-
-[NOTE]
-====
-Usage of all {ProjectName} components is supported within the context of {ProjectName} only.
-Third-party usage of any components falls beyond supported usage.
-====
 
 endif::[]
 


### PR DESCRIPTION
Moving a Note where it belongs.
It was under Supported Client Architectures, but it's about Supported Usage (of Satellite components).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
