### PR TITLE
Remove unnecessary points from Binary DVD images

### DIFF
--- a/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
+++ b/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
@@ -24,8 +24,7 @@ Use this procedure to download the ISO images for {RHEL} and {ProjectName}.
 . Ensure that you have the correct product and version for your environment.
 +
 * *Product Variant* is set to *{ProjectName}*.
-* *Version*  is set to the latest minor version of the product you plan to use as the base operating system.
-* *Architecture* is set to the 64 bit version.
+* *Version*  is set to the latest minor version of the product you plan to use.
 
 . On the *Product Software* tab, download the Binary DVD image for the latest {ProjectName} version.
 


### PR DESCRIPTION
While downloading the DVD images of the Project, the Version point does not require mentioning the base operating system. Also, the Architecture point is not required at all. So, it seems that it needs to be removed.

https://bugzilla.redhat.com/show_bug.cgi?id=2178052

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
