### PR TITLE
Fix typo: resoled -> resolved

### DIFF
--- a/guides/common/modules/proc_resolving-package-dependency-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependency-errors.adoc
@@ -39,7 +39,7 @@ If you have successfully installed the {Project} packages, skip this procedure.
 # cd /media/sat6/
 ----
 
-. Verify that you have resoled the package dependency errors by installing {ProjectServer} packages.
+. Verify that you have resolved the package dependency errors by installing {ProjectServer} packages.
 If there are further package dependency errors, repeat this procedure.
 +
 [options="nowrap"]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

I didn't check exactly how this goes back, but I think very long.

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.