### PR TITLE
Remove redundant escaping

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -74,5 +74,5 @@ If the file exists, run the second `{foreman-installer}` command that updates ce
 +
 IMPORTANT: Do not delete the certificate archive file after you deploy the certificate.
 It is required, for example, when upgrading {ProjectServer}.
-. On a computer with network access to {ProjectServer}, navigate to the following URL: `\https://{foreman-example-com}`.
+. On a computer with network access to {ProjectServer}, navigate to the following URL: `https://{foreman-example-com}`.
 . In your browser, view the certificate details to verify the deployed certificate.


### PR DESCRIPTION
The URL is already part of a code block, so escaping is not needed. It now renders literally.

Introduced in 1ea4428abe25485eb2285b45a9ef1b7a246f84ff

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.