### PR TITLE
Update the procedures in package management

### DIFF
--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -1,0 +1,12 @@
+[id="managing-packages_{context}"]
+= Managing Packages
+
+You can use {Project} to install, upgrade, and remove packages on hosts.
+
+include::modules/proc_enabling-and-disabling-repositories-on-hosts.adoc[leveloffset=+1]
+
+include::modules/proc_installing-packages-on-a-host.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-packages-on-a-host.adoc[leveloffset=+1]
+
+include::modules/proc_removing-packages-from-a-host.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
@@ -1,0 +1,12 @@
+[id="Enabling_and_Disabling_Repositories_on_Hosts_{context}"]
+= Enabling and Disabling Repositories on Hosts
+
+Use this procedure to enable or disable repositories on hosts.
+
+.Procedure
+. In the {Project} web UI, navigate to *Hosts* > *All Hosts*,
+. Select the host name.
+. Click the *Content* tab.
+. Click the *Repository Sets* tab.
+. Click the vertical ellipsis.
+. Choose *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.

--- a/guides/common/modules/proc_installing-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_installing-packages-on-a-host.adoc
@@ -7,8 +7,8 @@ The list of packages available for installation depends on the Content View and 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the host you want to install packages on.
-. On the *Content* tab, select the *Packages* tab.
-. Click the vertical ellipsis at the top and select *Install Packages*.
+. Select the *Content* tab, then select the *Packages* tab.
+. Click the vertical ellipsis at the top of the page and select *Install Packages*.
 . In the *Install packages* popup window, select the packages that you want to install on the host.
 . Click *Install*.
 

--- a/guides/common/modules/proc_installing-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_installing-packages-on-a-host.adoc
@@ -1,0 +1,15 @@
+[id="Installing_Packages_on_a_Host_{context}"]
+= Installing Packages on a Host
+
+Use this procedure to install packages on a host using the {ProjectWebUI}.
+The list of packages available for installation depends on the Content View and Lifecycle Environment assigned to the host.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select the host you want to install packages on.
+. On the *Content* tab, select the *Packages* tab.
+. Click the vertical ellipsis at the top and select *Install Packages*.
+. In the *Install packages* popup window, select the packages that you want to install on the host.
+. Click *Install*.
+
+By default, the packages are installed using remote execution.

--- a/guides/common/modules/proc_removing-packages-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-packages-from-a-host.adoc
@@ -1,0 +1,13 @@
+[id="removing-packages-from-a-host_{context}"]
+= Removing Packages from a Host
+
+Use this procedure to remove packages from a host using the {ProjectWebUI}.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select the host you want to remove packages from.
+. On the *Content* tab, navigate to the *Packages* subtab.
+. Check the packages you want to remove.
+. From the vertical ellipsis at the top, click *Remove*.
+
+You get a REX job notification once the packages are removed.

--- a/guides/common/modules/proc_removing-packages-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-packages-from-a-host.adoc
@@ -6,7 +6,7 @@ Use this procedure to remove packages from a host using the {ProjectWebUI}.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the host you want to remove packages from.
-. On the *Content* tab, navigate to the *Packages* subtab.
+. Select the *Content* tab, then select the *Packages* tab.
 . Check the packages you want to remove.
 . From the vertical ellipsis at the top, click *Remove*.
 

--- a/guides/common/modules/proc_upgrading-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_upgrading-packages-on-a-host.adoc
@@ -7,10 +7,10 @@ The packages are upgraded through Katello agent or remote execution, depending o
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Go to *Content* tab, then click the *Packages* tab.
+. Select the *Content* tab, then select the *Packages* tab.
 . Select the *Upgradable* filter from the *Status* box to list the upgradable packages.
 +
 If a package has more than one available upgrade version, only the latest upgradable version is displayed.
-. Click *Upgrade*.
-
-You can run a remote execution job immediately, or select to customize the remote execution job.
+. Click *Upgrade*. The remote execution job starts immediately.
++
+You can also customize the remote execution by selecting *Upgrade via customized remote execution* from the dropdown menu.

--- a/guides/common/modules/proc_upgrading-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_upgrading-packages-on-a-host.adoc
@@ -1,0 +1,16 @@
+[id="upgrading-packages-on-a-host_{context}"]
+= Upgrading Packages on a Host
+
+Use this procedure to upgrade packages on a host using the {ProjectWebUI}.
+The packages are upgraded through Katello agent or remote execution, depending on your configuration.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Click the name of the host you want to modify.
+. Go to *Content* tab, then click the *Packages* tab.
+. Select the *Upgradable* filter from the *Status* box to list the upgradable packages.
++
+If a package has more than one available upgrade version, only the latest upgradable version is displayed.
+. Click *Upgrade*.
+
+You can run a remote execution job immediately, or select to customize the remote execution job.

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -45,6 +45,8 @@ include::common/assembly_host-status.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-template-repositories.adoc[leveloffset=+1]
 
+include::common/assembly_managing-packages.adoc[leveloffset=+1]
+
 :numbered!:
 
 [appendix]


### PR DESCRIPTION
In the new version of Project, there are changes in the procedures of Installing, Removing and Upgrading the Packages of a Host. The applicable procedures are updated and added important information for end-users while Upgrading the packages.

https://issues.redhat.com/browse/SATDOC-747

https://www.youtube.com/watch?v=ykQFM7aFczY&t=1471s

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
