### PR TITLE
Rename Smart Management to Satellite

### DIFF
--- a/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
+++ b/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
@@ -10,14 +10,14 @@ include::snip_only-valid-if-sca-disabled.adoc[]
 For more information about updating multiple hosts, see xref:Updating_Red_Hat_Subscriptions_on_Multiple_Hosts_{context}[].
 For more information about activation keys, see xref:Managing_Activation_Keys_{context}[].
 
-.Smart Management Subscriptions
+.{Project} Subscriptions
 
-In {Project}, you must maintain a {RHEL} Smart Management subscription for every {RHEL} host that you want to manage.
+In {Project}, you must maintain a {RHEL} {Project} subscription, formerly known as {RHEL} Smart Management, for every {RHEL} host that you want to manage.
 
-However, you are not required to attach Smart Management subscriptions to each content host.
-Smart Management subscriptions cannot attach automatically to content hosts in {Project} because they are not associated with any product certificates.
-Adding a Smart Management subscription to a content host does not provide any content or repository access.
-If you want, you can add a Smart Management subscription to a manifest for your own recording or tracking purposes.
+However, you are not required to attach {Project} subscriptions to each content host.
+{Project} subscriptions cannot attach automatically to content hosts in {Project} because they are not associated with any product certificates.
+Adding a {Project} subscription to a content host does not provide any content or repository access.
+If you want, you can add a {Project} subscription to a manifest for your own recording or tracking purposes.
 
 .Prerequisite
 * You must have a Red{nbsp}Hat Subscription Manifest file imported to {ProjectServer}.

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -17,7 +17,7 @@ For more information about SCA, see https://access.redhat.com/articles/simple-co
 After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName} and {RHEL} content.
 
-{ProjectName} Infrastructure is included with all subscriptions that include Smart Management.
+{ProjectName} Infrastructure is included with all subscriptions that include {Project}, formerly known as Smart Management.
 For more information, see https://access.redhat.com/solutions/3382781[{Project} Infrastructure Subscriptions MCT3718 MCT3719] in the _Red{nbsp}Hat Knowledgebase_.
 
 Subscriptions are classified as available if they are not already attached to a system.

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -35,8 +35,8 @@ If you plan to have more than one Red{nbsp}Hat{nbsp}Network account, or if you w
 A customer that does not have a {Project} subscription can create a Subscription Asset Manager manifest, which can be used with {Project}, if they have other valid subscriptions.
 You can then use the multiple manifests in one {ProjectServer} to manage multiple organizations.
 
-If you must manage systems but do not have access to the subscriptions for the RPMs, you must use {RHEL} Smart Management Add-On.
-For more information, see https://www.redhat.com/en/store/smart-management-add#?sku=RH00031[Smart Management Add-On].
+If you must manage systems but do not have access to the subscriptions for the RPMs, you must use {RHEL} {Project} Add-On.
+For more information, see https://www.redhat.com/en/technologies/management/satellite[{Project} Add-On].
 
 The following diagram shows two Red{nbsp}Hat{nbsp}Network account holders, who want their systems to be managed by the same {Project} installation.
 In this scenario, Example Corporation 1 can allocate any subset of their 60 subscriptions, in this example they have allocated 30, to a manifest.


### PR DESCRIPTION
RH changes an older variant of the product name to "Satellite".

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* **TODO** Another PR for 2.5 (Satellite 6.10)
