### PR TITLE
Remove list para chainer 3.1

### DIFF
--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -12,7 +12,7 @@ ifdef::satellite[]
 Note that the subscription model is deprecated and will be removed in a future release.
 {Team} recommends that you use https://access.redhat.com/articles/simple-content-access[Simple Content Access] as a substitute.
 endif::[]
-+
+
 ifndef::orcharhino[]
 To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/using_red_hat_subscription_management/using_manifests_con[Using Manifests] in the _Using Red Hat Subscription Management_ guide.
 endif::[]


### PR DESCRIPTION
The + can only be used in lists to chain paragraphs.
It rendered as a literal + in here, it looked bad and it's been bugging me.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
