### PR TITLE
Add Repository Sets as a new procedure

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -93,7 +93,7 @@ include::modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc[le
 
 include::modules/proc_adding-custom-deb-repository-example-for-ubuntu-22-04.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-repository-sets-status-in-project.adoc[leveloffset=+1]
+include::modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_enabling-red-hat-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -92,6 +92,8 @@ include::modules/proc_adding-custom-deb-repositories.adoc[leveloffset=+1]
 include::modules/proc_adding-custom-deb-repository-example-for-debian-11.adoc[leveloffset=+1]
 
 include::modules/proc_adding-custom-deb-repository-example-for-ubuntu-22-04.adoc[leveloffset=+1]
+
+include::modules/proc_changing-the-repository-sets-status-in-project.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_enabling-red-hat-repositories.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
@@ -1,5 +1,5 @@
-[id="Changing_the_Repository_Sets_Status_in_{project-context}_{context}"]
-= Changing the Repository Sets Status in {Project}
+[id="Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_{context}"]
+= Changing the Repository Sets Status for a Host in {Project}
 
 Repository sets show repositories available to each host.
 A host will be able to access content from a given repository if that repository is enabled.
@@ -9,14 +9,13 @@ A host will be able to access content from a given repository if that repository
 . Select the *Content* tab, then select the *Repository sets* subtab.
 On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
 . You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.
-. You can also bulk select the checkboxes on each table row and use the action menu at the top.
+. You can also bulk select the checkboxes on each table row, and use the vertical ellipsis icon at the top.
 . On the *Overview* tab, click *Content view details* to view the environment for the host.
 +
 [NOTE]
 ====
 For hosts not in the default Content View and lifecycle environment, the *Repository sets* tab shows a toggle group with two options, *Limit to environment* and *Show all*.
-
-Limit to environment: Show only repositories that are relevant to the host.
-Show all: Show all available repositories including those that may not be in the host's Content View and lifecycle environment.
+The *Limit to environment* option shows only repositories that are relevant to the host.
+The *Show all* option shows all available repositories including those that may not be in the host's Content View and lifecycle environment.
 ====
 . Select *Show all* or *Limit to environment* to view available repositories.

--- a/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
@@ -18,4 +18,3 @@ The *Limit to environment* option shows only repositories that are relevant to t
 The *Show all* option shows all available repositories including those that may not be in the host's Content View and lifecycle environment.
 On the *Overview* tab, click *Content view details* to view the environment for the host.
 ====
-. Select *Show all* or *Limit to environment* to view available repositories.

--- a/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
@@ -10,12 +10,12 @@ A host will be able to access content from a given repository if that repository
 On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
 . You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.
 . You can also bulk select the checkboxes on each table row, and use the vertical ellipsis icon at the top.
-. On the *Overview* tab, click *Content view details* to view the environment for the host.
 +
 [NOTE]
 ====
 For hosts not in the default Content View and lifecycle environment, the *Repository sets* tab shows a toggle group with two options, *Limit to environment* and *Show all*.
 The *Limit to environment* option shows only repositories that are relevant to the host.
 The *Show all* option shows all available repositories including those that may not be in the host's Content View and lifecycle environment.
+On the *Overview* tab, click *Content view details* to view the environment for the host.
 ====
 . Select *Show all* or *Limit to environment* to view available repositories.

--- a/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
@@ -1,18 +1,22 @@
 [id="Changing_the_Repository_Sets_Status_in_{project-context}_{context}"]
 = Changing the Repository Sets Status in {Project}
 
-Repository sets show available repositories to each host.
-If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
+Repository sets show repositories available to each host.
+A host will be able to access content from a given repository if that repository is enabled.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select a host.
-. Select the *Repository sets* tab.
+. Select the *Content* tab, then select the *Repository sets* subtab.
 On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
 . You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.
+. You can also bulk select the checkboxes on each table row and use the action menu at the top.
 . On the *Overview* tab, click *Content view details* to view the environment for the host.
 +
 [NOTE]
 ====
-For hosts not in a default status or a lifecycle environment, the *Repository sets* tab shows only repositories that are relevant to the host.
+For hosts not in the default Content View and lifecycle environment, the *Repository sets* tab shows a toggle group with two options, *Limit to environment* and *Show all*.
+
+Limit to environment: Show only repositories that are relevant to the host.
+Show all: Show all available repositories including those that may not be in the host's Content View and lifecycle environment.
 ====
 . Select *Show all* or *Limit to environment* to view available repositories.

--- a/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
@@ -1,0 +1,18 @@
+[id="Changing_the_Repository_Sets_Status_in_Project_{context}"]
+= Changing the Repository Sets Status in {Project}
+
+Repository sets show available repositories to each host. If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* to choose from a list of available hosts.
+. Select the *Repository sets* tab.
+On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
+. You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.
+. Navigate to the *Overview* tab to *Content view details* to view the environment for the host.
++
+[NOTE]
+====
+For hosts not in a default view or a lifecycle environment, the *Repository sets* tab shows only repositories that are relevant to the host.
+====
++
+. Select *Show all* or *Limit to environment* to view available repositories.

--- a/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
@@ -5,7 +5,7 @@ Repository sets show available repositories to each host.
 If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* to choose from a list of available hosts.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select a host.
 . Select the *Repository sets* tab.
 On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
 . You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.

--- a/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-in-project.adoc
@@ -1,18 +1,18 @@
-[id="Changing_the_Repository_Sets_Status_in_Project_{context}"]
+[id="Changing_the_Repository_Sets_Status_in_{project-context}_{context}"]
 = Changing the Repository Sets Status in {Project}
 
-Repository sets show available repositories to each host. If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
+Repository sets show available repositories to each host.
+If your host is subscribed to a particular Content View and Lifecycle environment, the default repository set is limited to the repositories that are specifically available to that host.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* to choose from a list of available hosts.
 . Select the *Repository sets* tab.
 On the tab, there is a set of repositories available to each host with a status of *Enabled* or *Disabled*.
 . You can override the default status by using the action menus on each table row by changing the status to *Override to disabled*, *Override to enabled*, or *Reset to default*.
-. Navigate to the *Overview* tab to *Content view details* to view the environment for the host.
+. On the *Overview* tab, click *Content view details* to view the environment for the host.
 +
 [NOTE]
 ====
-For hosts not in a default view or a lifecycle environment, the *Repository sets* tab shows only repositories that are relevant to the host.
+For hosts not in a default status or a lifecycle environment, the *Repository sets* tab shows only repositories that are relevant to the host.
 ====
-+
 . Select *Show all* or *Limit to environment* to view available repositories.


### PR DESCRIPTION
New feature for Changing Repository Sets Status
added as a procedure


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
