### PR TITLE
Add step to enable maintenance modules for later versions

### DIFF
--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -168,8 +168,9 @@ You can either mount the shared storage or copy the backup files to the `/backup
 # subscription-manager attach --pool=__pool_ID__
 # subscription-manager repos --disable=*
 # subscription-manager repos --enable={RepoRHEL8AppStream} \
---enable={RepoRHEL8ServerSatelliteServerProductVersion} \
+--enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+# dnf module enable satellite-maintenance:el8
 ----
 +
 . Install the `satellite-clone` package:

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -22,6 +22,7 @@ ifndef::orcharhino[]
 # subscription-manager repos \
 ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteServerProductVersion} \
+--enable={RepoRHEL8ServerSatelliteMaintenanceProductVersion} \
 endif::[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8AppStream}

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -36,12 +36,13 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
-. Ensure that the {Project} Maintenance repository is enabled:
+. Ensure that the {Project} Maintenance repository is enabled and enable the maintenance module:
 +
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
 {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+# dnf module enable satellite-maintenance:el8
 ----
 
 . Check the available versions to confirm the version you want is listed:

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -36,12 +36,17 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
-. Ensure that the {Project} Maintenance repository is enabled and enable the maintenance module:
+. Ensure that the {Project} Maintenance repository is enabled:
 +
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
 {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+. Enable the maintenance module:
++
+[options="nowrap" subs="attributes"]
+----
 # dnf module enable satellite-maintenance:el8
 ----
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -150,6 +150,13 @@ baseurl=file:///media/sat6/Satellite
 baseurl=file:///media/sat6/Maintenance/
 ----
 
+. Enable the maintenance module:
++
+[options="nowrap"]
+----
+# dnf module enable satellite-maintenance:el8
+----
+
 . Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +


### PR DESCRIPTION
With the new upgrade workflow, the maintenance module should be enabled during upgrade and cloning so that the next version Satellite repo is not required for upgrading. Adding a step in the upgrade and cloning guides for enabling the module for versions greater than 3.3 to prevent merge conflict due to changes in the file structure between these versions. BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2143451


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
