### PR TITLE
Fix attribute for Administering Guide in the disconnected update section

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -71,7 +71,7 @@ Complete the following steps on the connected {ProjectServer}.
 ----
 +
 . Download the debug certificate of the organization and store it locally at, for example, `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
-For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle)_.
+For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle}_.
 
 . Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
 +


### PR DESCRIPTION
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
