### PR TITLE
Fix incorrect script in Managing Content

### DIFF
--- a/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
@@ -11,9 +11,9 @@ Use this procedure to assign a sync plan to the products in an organization that
 ORG="_My_Organization_"
 SYNC_PLAN="daily_sync_at_3_a.m"
 
-for i in $(hammer --no-headers --csv product list --organization $ORG --per-page 999 | grep -vi not_synced | awk -F, {'{ if ($5!=0) print $1}'})
+hammer sync-plan create --name $SYNC_PLAN --interval daily --sync-date "2023-04-5 03:00:00" --enabled true --organization $ORG
+for i in $(hammer --no-headers --csv --csv-separator="|" product list --organization $ORG --per-page 999 | grep -vi not_synced | awk -F'|' '$5 != "0" { print $1}')
 do
-  hammer sync-plan create --name $SYNC_PLAN --interval daily --sync-date "2018-06-20 03:00:00" --enabled true --organization $ORG
   hammer product set-sync-plan --sync-plan $SYNC_PLAN --organization $ORG --id $i
 done
 ----


### PR DESCRIPTION
The current script has two issues:
- Wrong sequence
- It's not selecting the product id properly if the name has a comma in it

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1987243

cc @adamruzicka 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
