### PR TITLE
Correct wording of deprecation in Content Mng (Satellite)

### DIFF
--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -9,8 +9,8 @@ All subscription information is available in your Red Hat Customer Portal accoun
 Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat Subscription Manifest in the Customer Portal.
 
 ifdef::satellite[]
-Note that legacy subscription management, including the need to attach subscriptions to hosts and activation keys, is deprecated and will be removed in a future release.
-{Team} recommends that you use https://access.redhat.com/articles/simple-content-access[Simple Content Access] as a substitute.
+Note that the entitlement-based subscription model is deprecated and will be removed in a future release.
+{Team} recommends that you use the access-based subscription model of https://access.redhat.com/articles/simple-content-access[Simple Content Access] instead.
 endif::[]
 
 ifdef::satellite[]


### PR DESCRIPTION
I want to unify the wording with #2124 
The new wording was suggested by RH management and I think it's prettier and more precise.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
