### PR TITLE
Fix a plugins enablement command (Host Registration on SmartProxy)

### DIFF
--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -33,8 +33,9 @@ Use a FQDN, not an IP address:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-registration \
---foreman-proxy-templates \
+# {foreman-installer} \
+--foreman-proxy-registration true \
+--foreman-proxy-templates true \
 --foreman-proxy-template-url 'http://{smartproxy-example-com}'
 ----
 


### PR DESCRIPTION
The arguments to enable the _Registration_ and _Templates_ plugins require the `true` value, otherwise the installer fails with an error like this: `Parameter foreman-proxy-registration is missing a value on the command line`

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
* **TODO** a separate PR for 2.5

