### PR TITLE
Bump orcharhino version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@ Please cherry-pick my commits into:
 * [ ] Foreman 3.6/Katello 4.8
 * [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
 * [ ] Foreman 3.4/Katello 4.6 (EL8 only)
-* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
+* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
 * [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
-* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)
+* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
 * For Foreman 3.0 or older, please create a separate PR.
 * We do not accept PRs for Foreman 2.4 or older.

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,8 +1,7 @@
 // Overrides for orcharhino build
 :BaseURL: https://docs.orcharhino.com/
-:KatelloVersion: Katello 4.3
-:ProductVersion: 6.2
-:ProductVersionPrevious: 6.1
+:ProductVersion: 6.3
+:ProductVersionPrevious: 6.2
 :Project: orcharhino
 :ProjectName: {Project}
 :ProjectNameX: {Project}


### PR DESCRIPTION
See https://orcharhino.com/orcharhino-6-3-0/ :champagne: 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8, orcharhino 6.2 on EL7/8)