### PR TITLE
Specify the list of collections

### DIFF
--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -34,7 +34,7 @@ If you do not specify the list of collections, everything from the endpoint will
 [source, Yaml]
 ----
 ---
-# Collection name and version
+collections:
 - name: my_namespace.my_collection
   version: 1.2.3
 ----


### PR DESCRIPTION
In synchronizing Ansible Collections you should specify the list of collections you want to sync from the endpoint, as well as their versions in the Requirements.yml field. Failing to do so will sync everything from the endpoint.

https://bugzilla.redhat.com/show_bug.cgi?id=2185648

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
