### PR TITLE
Remove the reindex step for Satellite during leapp upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -289,12 +289,14 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 # journalctl -u leapp_resume -f
 ----
 
+ifndef::satellite[]
 . Reindex the databases:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # runuser -u postgres -- reindexdb -a
 ----
+endif::[]
 
 ifdef::foreman-el[]
 . Enable the Foreman module:


### PR DESCRIPTION
Leapp has been upgraded and does not require reindexing the DB after a leapp upgrade. However, the fix hasn't been published in the upstream leapp yet. Hence adding an ifndef directive for Satellite, as Satellite no longer requires this step.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
