### PR TITLE
Add the Custom SSL certificate renewal process

### DIFF
--- a/guides/common/assembly_renewing-custom-ssl-certificate.adoc
+++ b/guides/common/assembly_renewing-custom-ssl-certificate.adoc
@@ -1,0 +1,5 @@
+include::modules/con_renewing-the-custom-ssl-certificate.adoc[]
+
+include::modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc[leveloffset=+1]
+
+include::modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc[leveloffset=+1]

--- a/guides/common/modules/con_renewing-the-custom-ssl-certificate.adoc
+++ b/guides/common/modules/con_renewing-the-custom-ssl-certificate.adoc
@@ -1,0 +1,4 @@
+[id="renewing-the-custom-ssl-certificate_{context}"]
+= Renewing the {customssltitle} Certificate
+
+This chapter provides information on how to renew the {customssl} certificate on {ProjectServer} as well as on {SmartProxyServer}.

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -1,0 +1,50 @@
+[id="Renewing_a_Custom_SSL_Certificate_on_{project-context}_{context}"]
+= Renewing a {customssltitle} Certificate on {ProjectServer}
+
+Use this procedure to update your {customssl} certificate for {ProjectServer}.
+
+.Prerequisite
+* You must create a new Certificate Signing Request (CSR) and send it to the Certificate Authority to sign the certificate.
+Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{context}[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the Server certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
+In return, you will receive the {ProjectServer} certificate and CA bundle.
+
+.Procedure
+* Before deploying a renewed custom certificate on your {ProjectServer}, validate the {customssl} input files.
+Note that for the `katello-certs-check` command to work correctly, Common Name (CN) in the certificate must match the FQDN of {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# katello-certs-check -t {project-context} \
+-b /root/_{project-context}_cert/ca_cert_bundle.pem_ \
+-c /root/_{project-context}_cert/{project-context}_cert.pem_ \
+-k /root/_{project-context}_cert/{project-context}_cert_key.pem_
+----
++
+If the command is successful, it returns the following `{foreman-installer}` command.
+You can use this command to deploy the renewed CA certificates to {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {installer-scenario} \
+--certs-server-cert "/root/_{project-context}_cert/{project-context}_cert.pem_" \
+--certs-server-key "/root/_{project-context}_cert/{project-context}_key.pem_" \
+--certs-server-ca-cert "/root/_{project-context}_cert/ca_cert_bundle.pem_" \
+--certs-update-server \
+--certs-update-server-ca
+----
+
+[IMPORTANT]
+====
+Do not delete the certificate files after you deploy the certificate.
+They are required when upgrading {ProjectServer}.
+====
+
+[NOTE]
+====
+If a new consumer package `katello-ca-consumer-latest.noarch.rpm` is generated due to a different Certificate Signing Authority, all the clients registered to {ProjectServer} must be updated.
+====
+
+.Verification
+. Access the {ProjectWebUI} from your local machine.
+For example, https://{foreman-example-com}.
+. In your browser, view the certificate details to verify the deployed certificate.

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -1,0 +1,64 @@
+[id="Renewing_a_Custom_SSL_Certificate_on_{smart-proxy-context}_{context}"]
+= Renewing a {customssltitle} certificate on {SmartProxyServer}
+
+Use this procedure to update your {customssl} certificate for {SmartProxyServer}.
+The `{foreman-installer}` command, which the `{certs-generate}` command returns, is unique to each {SmartProxyServer}.
+You cannot use the same command on more than one {SmartProxyServer}.
+
+.Prerequisite
+* You must create a new Certificate Signing Request and send it to the Certificate Authority to sign the certificate.
+Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{context}[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the {ProjectServer} certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
+In return, you will receive the {SmartProxyServer} certificate and CA bundle.
+
+.Procedure
+. On your {ProjectServer}, validate the {customssl} certificate input files:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# katello-certs-check -t {smart-proxy-context} \
+-b /root/_{smart-proxy-context}_cert/ca_cert_bundle.pem_ \
+-c /root/_{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_ \
+-k /root/_{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_
+----
+. On your {ProjectServer}, generate the certificate archive file for your {SmartProxyServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+{certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+--certs-tar  "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
+--server-cert "_/root/My_Certificates/{smart-proxy-context}_cert.pem_" \
+--server-key "_/root/My_Certificates/{smart-proxy-context}_cert_key.pem_" \
+--server-ca-cert "_/root/My_Certificates/ca_cert_bundle.pem_" \
+--certs-update-server
+----
+. On your {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# scp _/root/My_Certificates/{smartproxy-example-com}-certs.tar_ _user@{smartproxy-example-com}_:
+----
++
+You can move the copied file to the applicable path if required.
+. Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
+. Deploy the certificate on your {SmartProxyServer} using the `{foreman-installer}` command returned by the `{certs-generate}` command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {installer-scenario-smartproxy} \
+--foreman-proxy-content-parent-fqdn "{foreman-example-com}" \
+--foreman-proxy-register-in-foreman "true" \
+--foreman-proxy-foreman-base-url \ "https://{foreman-example-com}"
+--foreman-proxy-content-certs-tar "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
+--certs-update-server
+----
+
+[IMPORTANT]
+====
+Do not delete the certificate archive file on the {SmartProxyServer} after you deploy the certificate.
+They are required when upgrading {SmartProxyServer}.
+====
+
+[NOTE]
+====
+If a new consumer package `katello-ca-consumer-latest.noarch.rpm` is generated due to a different Certificate Signing Authority, all the clients registered to {SmartProxyServer} must be updated.
+====

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -46,6 +46,10 @@ endif::[]
 
 include::common/assembly_maintaining-server.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
+include::common/assembly_renewing-custom-ssl-certificate.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_logging-and-reporting-problems.adoc[leveloffset=+1]
 
 include::common/assembly_monitoring-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
Earlier, the process of renewing the Custom SSL certificate was not documented. Due to this, the end-users faced issues in the renewal process and end-up with errors. By documenting this process, the end-users can now carry out renewal by following the mentioned procedures for both, Project and Proxy Server.

https://bugzilla.redhat.com/show_bug.cgi?id=1802294

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
