### PR TITLE
Mention parameter type for customizing template

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -106,6 +106,7 @@
 :ProductVersionPrevious: {ProjectVersionPrevious}
 :provision-script: OS installer recipe
 :EL: Enterprise Linux
+:RHCloud: Red{nbsp}Hat Hybrid Cloud Console
 :RHEL: Red{nbsp}Hat Enterprise Linux
 :RHELServer: {RHEL} Server
 :SLES: SUSE Linux Enterprise Server

--- a/guides/common/modules/ref_customizing-the-registration-templates.adoc
+++ b/guides/common/modules/ref_customizing-the-registration-templates.adoc
@@ -21,9 +21,12 @@ You can configure the following global parameters by navigating to *Configure* >
 
 ifndef::satellite[]
 * The `host_registration_insights` parameter is used in the `insights` snippet, the default value is `false`.
+The type must be set to `Boolean` to override the parameter value.
 endif::[]
 ifdef::satellite[]
 * The `host_registration_insights` parameter is used in the `insights` snippet, the default value is `true`.
+The type must be set to `Boolean` to override the parameter value.
+If the parameter is set to `false`, it prevents hosts from appearing in the `rh-cloud reports` and also restricts `insights-client` from uploading its reports.
 endif::[]
 * The `host_packages` parameter is for installing packages on the host.
 * The `remote_execution_ssh_keys`, `remote_execution_ssh_user`, `remote_execution_create_user` and `remote_execution_effective_user_method` parameters are used in the `remote_execution_ssh_keys`. For more details se the details of the snippet.

--- a/guides/common/modules/ref_customizing-the-registration-templates.adoc
+++ b/guides/common/modules/ref_customizing-the-registration-templates.adoc
@@ -21,13 +21,13 @@ You can configure the following global parameters by navigating to *Configure* >
 
 ifndef::satellite[]
 * The `host_registration_insights` parameter is used in the `insights` snippet, the default value is `false`.
-The type must be set to `Boolean` to override the parameter value.
+Set the parameter type to `boolean` to override the parameter value.
 endif::[]
 ifdef::satellite[]
 * The `host_registration_insights` parameter is used in the `insights` snippet, the default value is `true`.
-The type must be set to `Boolean` to override the parameter value.
-If the parameter is set to `false`, it prevents hosts from appearing in the `rh-cloud reports` and also restricts `insights-client` from uploading its reports.
+Set the parameter type to `boolean` to override the parameter value.
 endif::[]
+If the parameter is set to `false`, it prevents {Project} and the Insights client from uploading Inventory reports to your {RHCloud}.
 * The `host_packages` parameter is for installing packages on the host.
 * The `remote_execution_ssh_keys`, `remote_execution_ssh_user`, `remote_execution_create_user` and `remote_execution_effective_user_method` parameters are used in the `remote_execution_ssh_keys`. For more details se the details of the snippet.
 * The `encrypt_grub` parameter is to enable setting of an encrypted bootloader password for the host, the default value is `false`.


### PR DESCRIPTION
By default, the parameter value is set to false and vice versa for downstream, the mentioning the of parameter type was missing in the documentation. We added it for both, upstream and downstream along with its impact on insight clients and cloud reports at downstream.

https://bugzilla.redhat.com/show_bug.cgi?id=2167389

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
