### PR TITLE
consistently use colons in the install packages docs

### DIFF
--- a/guides/common/modules/proc_installing-proxy-packages.adoc
+++ b/guides/common/modules/proc_installing-proxy-packages.adoc
@@ -15,7 +15,7 @@ ifdef::satellite[]
 ----
 endif::[]
 ifdef::foreman-deb,foreman-el[]
-. Install `{foreman-installer-package}`
+. Install `{foreman-installer-package}`:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -23,7 +23,7 @@ ifdef::foreman-deb,foreman-el[]
 ----
 endif::[]
 ifdef::katello[]
-. Install `foreman-proxy-content`
+. Install `foreman-proxy-content`:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-server-packages-el.adoc
+++ b/guides/common/modules/proc_installing-server-packages-el.adoc
@@ -15,7 +15,7 @@ ifdef::satellite[]
 ----
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
-. Install `{foreman-installer-package}`
+. Install `{foreman-installer-package}`:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -24,7 +24,7 @@ ifdef::foreman-deb[]
 ----
 # {package-update}
 ----
-. Install `{foreman-installer-package}`
+. Install `{foreman-installer-package}`:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
