### PR TITLE
Fix link in installing server

### DIFF
--- a/guides/common/assembly_configuring-external-idm-dns.adoc
+++ b/guides/common/assembly_configuring-external-idm-dns.adoc
@@ -25,7 +25,18 @@ To revert to internal DNS service, use the following procedure:
 You are not required to use {ProductName} to manage DNS.
 When you are using the realm enrollment feature of {Project}, where provisioned hosts are enrolled automatically to IdM, the `ipa-client-install` script creates DNS records for the client.
 Configuring {ProductName} with external IdM DNS and realm enrollment are mutually exclusive.
-For more information about configuring realm enrollment, see {AdministeringDocURL}External_Authentication_for_Provisioned_Hosts_admin[External Authentication for Provisioned Hosts] in _{AdministeringDocTitle}_.
+For more information about configuring realm enrollment, see
+ifeval::["{context}" == "{project-context}"]
+ifeval::["{mode}" == "connected"]
+xref:External_Authentication_for_Provisioned_Hosts_{context}[].
+endif::[]
+ifeval::["{mode}" == "disconnected"]
+{InstallingServerDocURL}External_Authentication_for_Provisioned_Hosts_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
+endif::[]
+endif::[]
+ifeval::["{context}" == "{smart-proxy-context}"]
+{InstallingServerDocURL}External_Authentication_for_Provisioned_Hosts_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
+endif::[]
 
 //Configuring Dynamic DNS Update with GSS-TSIG Authentication
 include::modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc[leveloffset=+1]


### PR DESCRIPTION
With external authetication moved to Installing Server, this link also
in Installing Server now becomes xref.

But there are more issues. The assembly is included in three guides:
Installing Server, Installing Server Disconnected, and Installing Proxy.
Installing Server and Installing Server Disconnected have the same
context for satellite. I am opening a separate issue to deal with this
later. For now, I came up with a net of ifevals that works. It is not a
clean solution but I could not come up with any other.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2188809

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
