### PR TITLE
Add Warning to avoid mismatch in versions

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -49,6 +49,14 @@ When using custom certificates, the Common Name (CN) of the custom certificate m
 This does not apply to the clients of a {Project}.
 
 Before you install {ProductName}, ensure that your environment meets the requirements for installation.
+ifeval::["{context}" == "{smart-proxy-context}"]
+[WARNING]
+====
+The version of {SmartProxy} must match with the version of {Project} installed.
+It should not be different.
+For example, the {SmartProxy} version {ProductVersion} cannot be registered with the {Project} version {ProductVersionPrevious}.
+====
+endif::[]
 
 {ProductName} must be installed on a freshly provisioned system that serves no other function except to run {ProductName}.
 The freshly provisioned system must not have the following users provided by external identity providers to avoid conflicts with the local users that {ProductName} creates:


### PR DESCRIPTION
While installing the Proxy, end-users often end-up installing a different version of it than that of the Project. Therefore, it became necessary to add a warning about the version that should not be different in any case. While setting up the Proxy, its version should match the present version of Project.

https://bugzilla.redhat.com/show_bug.cgi?id=2184445

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
