### PR TITLE
section for configuring no. of processes that can be launched by Apache httpd

### DIFF
--- a/guides/common/modules/proc_tuning-apache-httpd-child-processes.adoc
+++ b/guides/common/modules/proc_tuning-apache-httpd-child-processes.adoc
@@ -1,0 +1,29 @@
+[id="tuning_apache_httpd_child_processes_{context}"]
+= Tuning Apache Httpd Child Processes
+
+By default, httpd uses event request handling mechanism.
+When the number of requests to httpd exceeds the maximum number of child processes that can be launched to handle the incoming connections, httpd raises an HTTP 503 Service Unavailable error.
+Amidst httpd running out of processes to handle, the incoming connections can also result in multiple component failures on your {Project} services side due to the dependency of some components on the availability of httpd processes.
+
+You can adapt the configuration of httpd event to handle more concurrent requests based on your expected peak load.
+
+[WARNING]
+====
+Configuring these numbers in `custom-hiera.yaml` locks them.
+If you change these numbers using `{foreman-installer} --tuning=_My_Tuning_Option_`, your `custom-hiera.yaml` will overwrite this setting.
+Set your numbers only if you have specific need for it.
+====
+
+.Procedure
+. Modify the number of concurrent requests in '/etc/foreman-installer/custom-hiera.yaml' by changing or adding the following lines:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+apache::mod::event::serverlimit: 64
+apache::mod::event::maxrequestworkers: 1024
+apache::mod::event::maxrequestsperchild: 4000
+----
++
+The example is identical to running `{foreman-installer} --tuning=medium` or higher on {ProjectServer}.
+. Apply your changes to {ProjectServer}.
+For more information, see xref:Applying_configurations_{context}[].

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -51,6 +51,8 @@ include::common/modules/con_apache-httpd-performance-tuning.adoc[leveloffset=+2]
 include::common/modules/proc_configuring-the-open-files-limit-for-apache-httpd.adoc[leveloffset=+3]
 
 ifdef::katello,satellite,orcharhino[]
+include::common/modules/proc_tuning-apache-httpd-child-processes.adoc[leveloffset=+3]
+
 include::common/modules/con_qdrouterd-and-qpid-tuning.adoc[leveloffset=+2]
 
 include::common/modules/proc_calculating-the-maximum-open-files-limit-for-qdrouterd.adoc[leveloffset=+3]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
