### PR TITLE
Rectify reposync option in the updating section

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -127,10 +127,10 @@ To obtain the organization label, enter the command:
 [options="nowrap" subs="attributes"]
 ----
 # reposync --delete --download-metadata -p ~/{Project}-repos -n \
- -r {RepoRHEL8BaseOS} \
- -r {RepoRHEL8AppStream} \
- -r {RepoRHEL8ServerSatelliteServerProductVersion} \
- -r {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+ --repoid {RepoRHEL8BaseOS} \
+ --repoid {RepoRHEL8AppStream} \
+ --repoid {RepoRHEL8ServerSatelliteServerProductVersion} \
+ --repoid {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 ----
 +
 This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.


### PR DESCRIPTION
With RHEL8, the reposync option "-r" has been replaced by either "--repoid" or "--repo". 
The documentation still shows the "-r" option, valid only for the RHEL7 yum package. 
As the repo IDs are mentioned in the command, replacing "-r" with "--repoid".
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2179018

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
