### PR TITLE
Fix duplicate install command

### DIFF
--- a/guides/common/modules/proc_securing-the-dhcp-api.adoc
+++ b/guides/common/modules/proc_securing-the-dhcp-api.adoc
@@ -11,12 +11,12 @@ You can add an `omapi_key` to provide basic security.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ifndef::foreman-deb[]
 ----
-# {package-install} install bind-utils
+# {package-install} bind-utils
 ----
 endif::[]
 ifdef::foreman-deb[]
 ----
-# {package-install} install bind9-utils
+# {package-install} bind9-utils
 ----
 endif::[]
 . Generate a key:


### PR DESCRIPTION
The package-install macro includes install, so it only needs to have the package name.

Fixes: 450433adfd378578d573b84adbe19b6b71807bfa

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.