### PR TITLE
Add Streamed Download Policy

### DIFF
--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -41,3 +41,7 @@ When you use an *On Demand* download policy, content is downloaded from {Project
 
 Inherit::
 {SmartProxyServer} inherits the download policy for the repository from the corresponding repository on {ProjectServer}.
+
+Streamed Download Policy::
+{SmartProxyServer}'s Streamed Download Policy for {SmartProxies} permits {SmartProxies} to avoid caching any content.
+When content is requested from the {SmartProxy}, it functions as a proxy and requests the content directly from the {Project}.

--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -43,5 +43,5 @@ Inherit::
 {SmartProxyServer} inherits the download policy for the repository from the corresponding repository on {ProjectServer}.
 
 Streamed Download Policy::
-{SmartProxyServer}'s Streamed Download Policy for {SmartProxies} permits {SmartProxies} to avoid caching any content.
+Streamed Download Policy for {SmartProxies} permits {SmartProxies} to avoid caching any content.
 When content is requested from the {SmartProxy}, it functions as a proxy and requests the content directly from the {Project}.


### PR DESCRIPTION
There was no information about a Streamed Download Policy for Capsules so this change was needed to show that particular policy.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
