### PR TITLE
Add step to enable maintenance modules for Capsule upgrade

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -97,6 +97,13 @@ Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProductVe
 # grep foreman_url /etc/foreman-proxy/settings.yml
 ----
 
+. Enable maintenance module:
++
+[options="nowrap" subs="attributes"]
+----
+# dnf module enable satellite-maintenance:el8
+----
+
 . Check the available versions to confirm the version you want is listed:
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/2129. 
With the new upgrade workflow, the maintenance module should be enabled during the upgrade so that the next version Satellite repo is not required for upgrading. Adding a step in the Capsule upgrade guide for enabling the module.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
