### PR TITLE
Fix the Cockpit attribute for Satellite

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -38,8 +38,8 @@
 :awx-context: Ansible_Tower
 :certs-generate: capsule-certs-generate
 :certs-proxy-context: capsule
-:Cockpit: Red{nbsp}Hat web console
-:CockpitTitle: Red{nbsp}Hat Web Console
+:Cockpit: RHEL web console
+:CockpitTitle: RHEL Web Console
 :customcontent: custom content
 :customfiletype: custom file type
 :customfiletypetitle: Custom File Type


### PR DESCRIPTION
On Satellite, we call this RHEL web console, not Red Hat web console, as can be seen for example here:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/8.7_release_notes/index#enhancement_the-web-console


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
