### PR TITLE
Fix Smart Proxy DNS setting

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -120,6 +120,7 @@
 :SLES: SUSE Linux Enterprise Server
 :server-example-com: server.example.com
 :smart-proxy-context: smart-proxy
+:smart-proxy-principal: smartproxy
 :SmartProxies: Smart{nbsp}Proxies
 :smartproxy_port: 8443
 :smartproxy-example-com: smartproxy.example.com

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -44,5 +44,6 @@
 :installer-scenario: foreman-installer --scenario katello
 :project-client-name: {Project}{nbsp}Client
 :smart-proxy-context: orcharhino-proxy
+:smart-proxy-principal: orcharhinoproxy
 :smartproxy-example-com: orcharhino-proxy.example.com
 :fdi-package-name: orcharhino-fdi

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -101,6 +101,7 @@
 :ProjectXY: Satellite{nbsp}{ProductVersionRepoTitle}
 :provision-script: kickstart
 :smart-proxy-context: capsule
+:smart-proxy-principal: {smart-proxy-context}
 :SmartProxies: Capsules
 :smartproxy_port: 9090
 :smartproxy-example-com: capsule.example.com

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -39,7 +39,7 @@ endif::[]
 ifeval::["{context}" == "{project-context}"]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# ipa service-add _{smart-proxy-context}/{foreman-example-com}_
+# ipa service-add _{smart-proxy-principal}/{foreman-example-com}_
 ----
 endif::[]
 
@@ -78,7 +78,7 @@ endif::[]
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# ipa-getkeytab -p {smart-proxy-context}/_{foreman-example-com}@EXAMPLE.COM_ \
+# ipa-getkeytab -p {smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_ \
 -s _idm1.example.com_ -k /etc/foreman-proxy/dns.keytab
 ----
 +
@@ -99,7 +99,7 @@ When adding a keytab to a standby system with the same host name as the original
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # kinit -kt /etc/foreman-proxy/dns.keytab \
-{smart-proxy-context}/_{foreman-example-com}@EXAMPLE.COM_
+{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_
 ----
 
 .Configuring DNS Zones in the IdM web UI
@@ -113,7 +113,7 @@ For example, `example.com`.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-grant {smart-proxy-context}/047__{foreman-example-com}@EXAMPLE.COM__ wildcard * ANY;
+grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard * ANY;
 ----
 
 .. Set *Dynamic update* to *True*.
@@ -129,7 +129,7 @@ grant {smart-proxy-context}/047__{foreman-example-com}@EXAMPLE.COM__ wildcard * 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-grant {smart-proxy-context}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard * ANY;
+grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard * ANY;
 ----
 
 .. Set *Dynamic update* to *True*.
@@ -148,7 +148,7 @@ grant {smart-proxy-context}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard * 
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate_gss \
 --foreman-proxy-dns-server="_idm1.example.com_" \
---foreman-proxy-dns-tsig-principal="{smart-proxy-context}/_{foreman-example-com}@EXAMPLE.COM_" \
+--foreman-proxy-dns-tsig-principal="{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_" \
 --foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab
 ----
 
@@ -161,7 +161,7 @@ grant {smart-proxy-context}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard * 
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate_gss \
 --foreman-proxy-dns-server="_idm1.example.com_" \
---foreman-proxy-dns-tsig-principal="{smart-proxy-context}/_{foreman-example-com}@EXAMPLE.COM_" \
+--foreman-proxy-dns-tsig-principal="{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_" \
 --foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab
 ----
 


### PR DESCRIPTION
Do not use attributes such as "smart-proxy-context" because the name depends on the service, not a branded product.

Resolves https://github.com/theforeman/foreman-documentation/issues/2172
ping @lessfoobar

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)