### PR TITLE
Add the option to disable foreman-protector plugin

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -127,6 +127,7 @@ To obtain the organization label, enter the command:
 [options="nowrap" subs="attributes"]
 ----
 # reposync --delete --download-metadata -p ~/{Project}-repos -n \
+ --disableplugin=foreman-protector \
  --repoid {RepoRHEL8BaseOS} \
  --repoid {RepoRHEL8AppStream} \
  --repoid {RepoRHEL8ServerSatelliteServerProductVersion} \


### PR DESCRIPTION
The reposync command does not download a majority of the required packages if the foreman-protector plugin is enabled. This results in the disconnected Satellite update failing. Adding the option to disable the plugin so that the reposync command downloads all the necessary packages.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
