### PR TITLE
Use chgrp to adjust file ownership

### DIFF
--- a/guides/common/modules/proc_using-ansible-vault-with-project.adoc
+++ b/guides/common/modules/proc_using-ansible-vault-with-project.adoc
@@ -17,7 +17,7 @@ Note that `ansible-vault` changes the file permissions to `600`.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# chown :foreman-proxy /etc/ansible/roles/_Role_Name_/vars/main.yml
+# chgrp foreman-proxy /etc/ansible/roles/_Role_Name_/vars/main.yml
 # chmod 0640 /etc/ansible/roles/_Role_Name_/vars/main.yml
 ----
 . Create the `/usr/share/foreman-proxy/.ansible_vault_password` file and enter the Vault password into it.


### PR DESCRIPTION
`chown :MY_GROUP` is identical to `chgrp MY_GROUP` but there's a small change the users messes up. See also https://unix.stackexchange.com/a/164859

cc @sbernhard

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)