### PR TITLE
Correct the field in Project Cloud Settings table

### DIFF
--- a/guides/common/modules/ref_redhat-cloud-settings.adoc
+++ b/guides/common/modules/ref_redhat-cloud-settings.adoc
@@ -8,5 +8,5 @@
 | *Synchronize recommendations Automatically* | No | Enable automatic synchronization of Insights recommendations from the {Team} cloud.
 | *Obfuscate host names* | No | Obfuscate hostnames sent to the {Team} cloud.
 | *Obfuscate host ipv4 addresses* | No | Obfuscate IPv4 addresses sent to the {Team} cloud.
-| *ID of the RHC(Yggdrasil) daemon* | \\***** | RHC daemon id.
+| *ID of the RHC daemon* | \\***** | RHC daemon id.
 |====

--- a/guides/common/modules/ref_redhat-cloud-settings.adoc
+++ b/guides/common/modules/ref_redhat-cloud-settings.adoc
@@ -8,8 +8,5 @@
 | *Synchronize recommendations Automatically* | No | Enable automatic synchronization of Insights recommendations from the {Team} cloud.
 | *Obfuscate host names* | No | Obfuscate hostnames sent to the {Team} cloud.
 | *Obfuscate host ipv4 addresses* | No | Obfuscate IPv4 addresses sent to the {Team} cloud.
-| *{Team} Cloud token* | \\***** | Authentication token sent to the {Team} cloud services.
-Used to authenticate requests to cloud APIs.
-| *Exclude installed Packages* | No | Exclude installed packages from upload to the {Team} cloud.
-| *Include parameters in insights-client reports* | No | Include parameter tags from {Project} during import.
+| *ID of the RHC(Yggdrasil) daemon* | \\***** | RHC daemon id.
 |====


### PR DESCRIPTION
At present, there is a mention of Project Cloud Token in the table of Cloud Settings placed in the Appendix section. It is incorrect as per the latest information in the Project WebUI. Also, the purpose of RHC ID is totally different than that of Cloud Token. Additionally, we removed the other two fields that are not present in the WebUI at present and should be removed from the table as well.

https://bugzilla.redhat.com/show_bug.cgi?id=2162925

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
