### PR TITLE
Limit available storage space to Katello

### DIFF
--- a/guides/common/modules/proc_viewing-general-smart-proxy-information.adoc
+++ b/guides/common/modules/proc_viewing-general-smart-proxy-information.adoc
@@ -23,5 +23,7 @@ In addition, you can answer to the following questions:
 *Which hosts are managed by {SmartProxyServer}?*:: The number of associated hosts is displayed next to the *Hosts managed* label.
 Click the number to view the details of associated hosts.
 
+ifdef::katello,orcharhino,satellite[]
 *How much storage space is available on {SmartProxyServer}?*:: The amount of storage space occupied by the Pulp content in `/var/lib/pulp` is displayed.
 Also the remaining storage space available on the {SmartProxy} can be ascertained.
+endif::[]


### PR DESCRIPTION
Viewing the available Pulp storage space is a Katello feature.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

This can be picked into any branch, but we don't really show those manuals anyway so there's little value in it. Still, could make future cherry picks safer so I'll leave it up to others if this is desired.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.