### PR TITLE
Add ProjectWebUI attributes for Satellite build

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -89,6 +89,8 @@
 :ProjectServerTitle: {Project}{nbsp}Server
 :ProjectVersion: {ProductVersion}
 :ProjectVersionPrevious: {ProductVersionPrevious}
+:ProjectWebUI: {Project} web UI
+:ProjectWebUI-context: {project-context}_web_UI
 :ProjectX: Satellite{nbsp}6
 :ProjectXY: Satellite{nbsp}{ProductVersionRepoTitle}
 :provision-script: kickstart


### PR DESCRIPTION
Adding ProjectWebUI* attributes to the Satellite build, otherwise it renders incorrectly as "Foreman".

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
