### PR TITLE
Configure SmartProxy for registration and provisioning

### DIFF
--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -6,6 +6,9 @@ ifdef::context[:parent-context: {context}]
 
 Use this chapter to configure additional settings on your {SmartProxyServer}.
 
+// Configuring SmartProxy for Host Registration and Provisioning
+include::modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc[leveloffset=+1]
+
 ifdef::katello,orcharhino,satellite[]
 // Enabling Katello Agent Infrastructure
 include::modules/proc_enabling-katello-agent.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_booting-virtual-machines.adoc
+++ b/guides/common/modules/proc_booting-virtual-machines.adoc
@@ -9,21 +9,22 @@ Using virtualization hypervisors removes the need for TFTP and PXELinux.
 It has the following workflow:
 
 . Virtual machine starts
-. iPXE retrieves the network credentials using DHCP
-. iPXE retrieves the HTTP address using DHCP
-. iPXE loads the iPXE bootstrap template from {SmartProxy}
-. iPXE loads the iPXE template with MAC as a URL parameter from {SmartProxy}
+. iPXE retrieves the network credentials, including an HTTP URL, using DHCP
+. iPXE loads the iPXE bootstrap template from {ProjectServer} or {SmartProxy}
+. iPXE loads the iPXE template with MAC as a URL parameter from {ProjectServer} or {SmartProxy}
 . iPXE loads the kernel and initial RAM disk of the installer
 
-Ensure that the hypervisor that you want to use supports iPXE.
+.Prerequisites
+* Ensure that the hypervisor that you want to use supports iPXE.
 The following virtualization hypervisors support iPXE:
 
-* libvirt
-* {oVirt}
-* RHEV
+** libvirt
+** {oVirt}
+** RHEV (deprecated)
 ifndef::satellite[]
-* VMWare (https://ipxe.org/howto/vmware[via custom firmware])
+** VMWare (https://ipxe.org/howto/vmware[via custom firmware])
 endif::[]
+include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 
 .Configuring {ProjectServer} to use iPXE
 You can use the default template to configure iPXE booting for hosts.
@@ -48,14 +49,17 @@ If you want to change the default values in the template, clone the template and
 . Set *PXE Loader* to *iPXE Embedded*.
 . Select the *Templates* tab.
 . From the *iPXE template* list, select *Review* to verify that the *Kickstart default iPXE* template is the correct template.
-. On {ProjectServer}, run:
+. Set the HTTP URL.
+* If you want to use {ProjectServer} for booting, run the following command on {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{foreman-installer} --foreman-proxy-dhcp-ipxefilename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1"
+# {foreman-installer} \
+--foreman-proxy-dhcp-ipxefilename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1"
 ----
+* If you want to use {SmartProxy} for booting, run the following command on {SmartProxy}:
 +
-[NOTE]
-====
-Ensure that `--foreman-trusted-proxies` is configured correctly on the {ProjectServer}.
-====
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-proxy-dhcp-ipxe-bootstrap true
+----

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -12,10 +12,12 @@ You can choose to either load `ipxe.lkrn` or `undionly-ipxe.0` file depending on
 . PXE driver retrieves the PXELinux firmware `pxelinux.0` using TFTP
 . PXELinux searches for the configuration file on the TFTP server
 . PXELinux chainloads iPXE `ipxe.lkrn` or `undionly-ipxe.0`
-. iPXE retrieves the network credentials using DHCP again
-. iPXE retrieves HTTP address using DHCP
+. iPXE retrieves the network credentials, including an HTTP URL, using DHCP again
 . iPXE chainloads the iPXE template from the template {SmartProxy}
 . iPXE loads the kernel and initial RAM disk of the installer
+
+.Prerequisite
+include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 
 .Configuring {ProjectServer} to use iPXE
 You can use the default template to configure iPXE booting for hosts.
@@ -48,14 +50,18 @@ If you want to change the default values in the template, clone the template and
 . Select the *Operating System* tab.
 . Select the *Architecture* and *Operating system*.
 . Set *PXE Loader* to *PXELinux BIOS* to chainboot iPXE via PXELinux, or to *iPXE Chain BIOS* to load `undionly-ipxe.0` directly.
-. On {ProjectServer}, run:
+. Set the HTTP URL.
+* If you want to use {ProjectServer} for booting, run the following command on {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{foreman-installer} --foreman-proxy-dhcp-ipxefilename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1"
+# {foreman-installer} \
+--foreman-proxy-dhcp-ipxefilename "http://{foreman-example-com}/unattended/iPXE?bootstrap=1"
 ----
+* If you want to use {SmartProxy} for booting, run the following command on {SmartProxy}:
 +
-[NOTE]
-====
-Ensure that `--foreman-trusted-proxies` is configured correctly on the {ProjectServer}.
-====
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-proxy-dhcp-ipxe-bootstrap true
+----
+

--- a/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
@@ -1,0 +1,58 @@
+[id="configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{context}"]
+= Configuring {SmartProxy} for Host Registration and Provisioning
+
+Use this procedure to configure {SmartProxy} so that you can register and provision hosts using your {SmartProxyServer} instead of your {ProjectServer}.
+
+.Procedure
+ifdef::foreman-deb,foreman-el[]
+. Enable the Registration and Templates features on your {SmartProxyServer} and set the template URL:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {installer-scenario-smartproxy} \
+--foreman-proxy-registration true \
+--foreman-proxy-templates true \
+--foreman-proxy-template-url "https://_{smartproxy-example-com}_:8000"
+----
+. On your {SmartProxyServer}, open the corresponding ports:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# firewall-cmd --permanent --zone=public --add-port=8000/tcp
+# firewall-cmd --reload
+----
+. On {ProjectServer}, add the {SmartProxy} to the list of trusted proxies.
+endif::[]
+ifndef::foreman-deb,foreman-el[]
+* On {ProjectServer}, add the {SmartProxy} to the list of trusted proxies.
+endif::[]
++
+This is required for {Project} to recognize hosts' IP addresses forwarded over the `X-Forwarded-For` HTTP header set by {SmartProxy}.
+For security reasons, {Project} recognizes this HTTP header only from localhost by default.
+You can enter trusted proxies as valid IPv4 or IPv6 addresses of {SmartProxies}, or network ranges.
++
+WARNING: Do not use a network range that is too wide, because this poses a potential security risk.
++
+Enter the following command.
+Note that the command overwrites the list that is currently stored in {Project}.
+Therefore, if you have set any trusted proxies previously, you must include them in the command as well:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--foreman-trusted-proxies "127.0.0.1/8" \
+--foreman-trusted-proxies "::1" \
+--foreman-trusted-proxies "_My_IP_address_" \
+--foreman-trusted-proxies "_My_IP_range_"
+----
++
+The localhost entries are required, do not omit them.
+
+.Verification
+. List the current trusted proxies using the full help of {Project} installer:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --full-help | grep -A 2 "trusted-proxies"
+----
+. The current listing contains all trusted proxies you require.

--- a/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
+++ b/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
@@ -3,31 +3,16 @@
 
 Perform these steps to provision hosts running Ubuntu 20.04.3+ or Ubuntu 22.04.
 
+.Prerequisite
+* Ensure you have configured your {SmartProxyServers} for provisioning.
+ifdef::orcharhino[]
+For more information, see xref:configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{context}[].
+endif::[]
+ifndef::orcharhino[]
+For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for Host Registration and Provisioning] in _{InstallingSmartProxyDocTitle}_.
+endif::[]
+
 .Procedure
-. On your {SmartProxyServer}, ensure _Smart Proxy HTTP forward_ is enabled:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# grep "^:enabled: true$" /etc/foreman-proxy/settings.d/templates.yml
-----
-+
-Note that this is enabled by default.
-. On your {SmartProxyServer}, open the corresponding port:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# firewall-cmd --permanent --zone=public --add-port=8000/tcp
-# firewall-cmd --reload
-----
-. On your {ProjectServer}, add your {SmartProxyServer} to the list of trusted proxies:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-installer} \
---foreman-trusted-proxies "127.0.0.1" \
---foreman-trusted-proxies "::1" \
---foreman-trusted-proxies "_Your_IP_"
-----
 . Provide the extracted ISO and ISO image itself on each {SmartProxyServer}.
 For more information, see xref:Creating_an_Installation_Medium_for_Ubuntu_22_04_{context}[].
 . In the {ProjectWebUI}, navigate to *Hosts > Installation Media* and create an installation medium.

--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -24,20 +24,7 @@ ifdef::satellite[]
 * Optional: If you want to register hosts to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
 This is required to install the `insights-client` package on hosts.
 endif::[]
-* Optional: If you want to register hosts through {SmartProxy}, ensure that the *Registration* and *Templates* features are enabled on this {SmartProxy}.
-+
-In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, click the {SmartProxy} that you want to use, and locate the *Registration* feature in the *Active features* list.
-+
-Optional: If the *Registration* feature is not enabled on your {SmartProxy}, enter the following command on the {SmartProxy} to enable it.
-Use a FQDN, not an IP address:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# {foreman-installer} \
---foreman-proxy-registration true \
---foreman-proxy-templates true \
---foreman-proxy-template-url 'http://{smartproxy-example-com}'
-----
+include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -190,15 +190,4 @@ You can now create an image from this virtual machine.
 You can use the xref:Adding_VMware_Images_to_Server_{context}[] section to add the image to {Project}.
 
 .Configuring {SmartProxy} to Forward the user data Template
-If you deploy {Project} with the {SmartProxy} templates feature, you must configure {Project} to recognize hosts' IP addresses forwarded over the X-Forwarded-For HTTP header to serve correct template payload.
-
-For security reasons, {Project} recognizes this HTTP header only from localhost.
-For each individual {SmartProxy}, you must configure a setting to recognize hosts' IP addresses.
-To add an IP address (e.g. 192.0.2.10) or range (e.g. 192.0.2.0/24), use the following command:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --foreman-trusted-proxies 127.0.0.1/8 --foreman-trusted-proxies ::1 --foreman-trusted-proxies 192.0.2.10
-----
-
-The localhost entries are required, do not omit them.
+include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]

--- a/guides/common/modules/snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
+++ b/guides/common/modules/snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
@@ -1,0 +1,7 @@
+* If you want to use {SmartProxyServers} instead of your {ProjectServer}, ensure that you have configured your {SmartProxyServers} accordingly.
+ifdef::orcharhino[]
+For more information, see xref:configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{context}[].
+endif::[]
+ifndef::orcharhino[]
+For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for Host Registration and Provisioning] in _{InstallingSmartProxyDocTitle}_.
+endif::[]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -52,6 +52,11 @@ include::common/assembly_managing-packages.adoc[leveloffset=+1]
 
 :numbered!:
 
+ifdef::orcharhino[]
+[appendix]
+include::common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc[leveloffset=+1]
+endif::[]
+
 [appendix]
 include::common/assembly_template-writing-reference.adoc[leveloffset=+1]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -44,6 +44,11 @@ include::common/assembly_provisioning-cloud-instances-gce.adoc[leveloffset=+1]
 
 include::common/assembly_provisioning-cloud-instances-azure.adoc[leveloffset=+1]
 
+ifdef::orcharhino[]
+[appendix]
+include::common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc[leveloffset=+1]
+endif::[]
+
 [appendix]
 include::common/modules/ref_initialization-script-for-provisioning-examples.adoc[leveloffset=+1]
 


### PR DESCRIPTION
- Adds a module about SmartProxy configuration for registration/provisioning, incl. adding SmartProxy to _trusted proxies_ on ProjectServer
- Adds also a snippet with a prerequisite for the scenario that uses SmartProxy instead of ProjectServer for Registration/Provisioning
- Tries to smoothen it for orcharhino

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8) -- will require a separate PR
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
