### PR TITLE
Add nested group to example LDAP filters

### DIFF
--- a/guides/common/modules/ref_examples-ldap-filters.adoc
+++ b/guides/common/modules/ref_examples-ldap-filters.adoc
@@ -11,7 +11,15 @@ As an administrator, you can create LDAP filters to restrict the access of speci
 | User1, User3 |(memberOf=cn=Group1,cn=Users,dc=domain,dc=example)
 | User2, User3 |(memberOf=cn=Group2,cn=Users,dc=domain,dc=example)
 | User1, User2, User3 | (\|(memberOf=cn=Group1,cn=Users,dc=domain,dc=example)(memberOf=cn=Group2,cn=Users,dc=domain,dc=example))
+| User1, User2, User3 | (memberOf:1.2.840.113556.1.4.1941:=cn=Users,dc=domain,dc=example)
 |====
+
+[NOTE]
+----
+Group `Users` is a nested group that contains groups `Group1` and `Group2`.
+If you want to filter all users from a nested group, you must add `memberOf:1.2.840.113556.1.4.1941:=` before the nested group name.
+See the last example in the table above.
+----
 
 .LDAP directory structure
 The LDAP directory structure that the filters in the example use:


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
