### PR TITLE
Improve :Team: attribute values

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -118,7 +118,7 @@
 :SmartProxyServerTitle: {SmartProxy}{nbsp}Server
 :SmartProxyServers: {SmartProxyServer}s
 :SmartProxyServersTitle: {SmartProxyServerTitle}s
-:Team: {Project} developers
+:Team: {Project} community
 :sectanchors:
 :client-content-dnf:
 :client-installation-medium: centos

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -20,7 +20,7 @@
 :SmartProxyServerTitle: {SmartProxyServer}
 :SmartProxyServers: orcharhino{nbsp}Proxies
 :SmartProxyServersTitle: {SmartProxyServers}
-:Team: ATIX AG
+:Team: ATIX{nbsp}AG
 :certs-proxy-context: orcharhino-proxy
 :customcontent: custom content
 :customcontenttitle: Custom Content


### PR DESCRIPTION
The upstream Team "Foreman developers" value implies plural, while other products use values that imply singular.
I suggest changing the Team for upstream to "Foreman community" to match the singular for cases like _{Team} recommends..._
Furthermore, I suggest using a non-breakable space in "ATIX AG".

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
