### PR TITLE
Add note for matching upstream downstream server

### DIFF
--- a/guides/common/modules/con_how-to-synchronize-content-using-export-and-import.adoc
+++ b/guides/common/modules/con_how-to-synchronize-content-using-export-and-import.adoc
@@ -16,8 +16,10 @@ For more information, see xref:synchronizing-a-single-repository_{context}[].
 +
 [NOTE]
 ====
+Synchronizing content using export and import requires the same major, minor, and patch version of {Project} on both the downstream and upstream {ProjectServer}s.
+
 When you are unable to match upstream and downstream {Project} versions, you can use:
 
 . Syncable exports and imports.
-. Inter-Satellite Synchronization (ISS) with your upstream {Project} connected to the Internet, and your downstream {Project} connected to the upstream {Project}.
+. . {ISS} (ISS) with your upstream {Project} connected to the Internet and your downstream {Project} connected to the upstream {Project}.
 ====

--- a/guides/common/modules/con_how-to-synchronize-content-using-export-and-import.adoc
+++ b/guides/common/modules/con_how-to-synchronize-content-using-export-and-import.adoc
@@ -13,3 +13,11 @@ For more information, see xref:Using_Upstream_Server_to_Sync_Content_View_Versio
 * You sync a single repository.
 This can be useful if you use the Content-View syncing approach, but you want to sync an additional repository without adding it to an existing Content View.
 For more information, see xref:synchronizing-a-single-repository_{context}[].
++
+[NOTE]
+====
+When you are unable to match upstream and downstream {Project} versions, you can use:
+
+. Syncable exports and imports.
+. Inter-Satellite Synchronization (ISS) with your upstream {Project} connected to the Internet, and your downstream {Project} connected to the upstream {Project}.
+====

--- a/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
+++ b/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
@@ -31,3 +31,12 @@ For more information on performing an incremental Library export, see xref:Expor
 . Import the content to an organization using the procedure outlined in xref:Importing_into_the_Library_Environment_{context}[].
 +
 You can then manage content using Content Views or Lifecycle Environments as you require.
+
++
+[NOTE]
+====
+When you are unable to match upstream and downstream {Project} versions, you can use:
+
+. Syncable exports and imports.
+. Inter-Satellite Synchronization (ISS) with your upstream {Project} connected to the Internet, and your downstream {Project} connected to the upstream {Project}.
+====

--- a/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
+++ b/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
@@ -31,12 +31,3 @@ For more information on performing an incremental Library export, see xref:Expor
 . Import the content to an organization using the procedure outlined in xref:Importing_into_the_Library_Environment_{context}[].
 +
 You can then manage content using Content Views or Lifecycle Environments as you require.
-
-+
-[NOTE]
-====
-When you are unable to match upstream and downstream {Project} versions, you can use:
-
-. Syncable exports and imports.
-. Inter-Satellite Synchronization (ISS) with your upstream {Project} connected to the Internet, and your downstream {Project} connected to the upstream {Project}.
-====


### PR DESCRIPTION
A note was added to show what you can do when you are unable to match upstream and downstream Satellite versions.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
