### PR TITLE
Add a note about usecases for the clone and backup tools for 3.1

### DIFF
--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -3,6 +3,11 @@
 
 You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.
+[NOTE]
+====
+If you use the backup tool to create a new instance of the {ProjectServer}, the created instances are not supposed to run in parallel in a production environment.
+You must decommission the old instance after restoring the backup.
+====
 
 To create a backup of your {ProjectServer} or {SmartProxyServer} and all associated data, use the `{foreman-maintain} backup` command.
 Backing up to a separate storage device on a separate system is highly recommended.

--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -3,6 +3,7 @@
 
 You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.
++
 [NOTE]
 ====
 If you use the backup tool to create a new instance of the {ProjectServer}, the created instances are not supposed to run in parallel in a production environment.

--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -6,8 +6,8 @@ If your deployment uses custom configurations, you must consider how to handle t
 +
 [NOTE]
 ====
-If you use the backup tool to create a new instance of the {ProjectServer}, the created instances are not supposed to run in parallel in a production environment.
-You must decommission the old instance after restoring the backup.
+The instances created using the backup tool are not supposed to run in parallel in a production environment.
+You must decommission any old instances after restoring the backup.
 ====
 
 To create a backup of your {ProjectServer} or {SmartProxyServer} and all associated data, use the `{foreman-maintain} backup` command.

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -4,7 +4,11 @@
 
 You can clone the {ProjectServer} to create  instances for trying out upgrades and the migration of instances to a different machine or operating system.
 This is an optional step to provide more flexibility during the upgrade.
-Note: The created instances are not supposed to run in parallel in a production environment, please decommission any testing instances after completing the tests or any old instances after completing the migration.
+[NOTE]
+====
+The created instances are not supposed to run in parallel in a production environment.
+You must decommission any testing instances after completing the tests or any old instances after completing the migration.
+====
 
 Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
 

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -2,8 +2,9 @@
 
 = Cloning {ProjectServer}
 
-When you upgrade {ProjectServer}, you can optionally create and upgrade a clone of your {Project} to ensure that you do not lose any data while you upgrade.
-After your upgrade is complete, you can then decommission the earlier version of {ProjectServer}.
+You can clone the {ProjectServer} to create  instances for trying out upgrades and the migration of instances to a different machine or operating system.
+This is an optional step to provide more flexibility during the upgrade.
+Note: The created instances are not supposed to run in parallel in a production environment, please decommission any testing instances after completing the tests or any old instances after completing the migration.
 
 Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
 

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -2,7 +2,7 @@
 
 = Cloning {ProjectServer}
 
-You can clone the {ProjectServer} to create  instances for trying out upgrades and the migration of instances to a different machine or operating system.
+You can clone the {ProjectServer} to create instances for trying out upgrades and the migration of instances to a different machine or operating system.
 This is an optional step to provide more flexibility during the upgrade.
 +
 [NOTE]

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -4,6 +4,7 @@
 
 You can clone the {ProjectServer} to create  instances for trying out upgrades and the migration of instances to a different machine or operating system.
 This is an optional step to provide more flexibility during the upgrade.
++
 [NOTE]
 ====
 The created instances are not supposed to run in parallel in a production environment.


### PR DESCRIPTION
The clone tool is meant for creating test instances for upgrades or migration to reduce any risk and possible downtime. However, some users use these tools to deploy new instances from existing ones. These instances might not be stable leading to failures after deployment. Adding a note to make the users aware of the use cases for these tools so that these are used as intended.

Bug link:
https://bugzilla.redhat.com/show_bug.cgi?id=2106222

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
