### PR TITLE
Add -t parameter to katello-certs-check

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc
@@ -11,7 +11,7 @@ Note that for the `katello-certs-check` command to work correctly, Common Name (
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--c __/root/{project-context}_cert/{project-context}_cert.pem__ \      <1>
+-t {project-context} -c __/root/{project-context}_cert/{project-context}_cert.pem__ \      <1>
 -k __/root/{project-context}_cert/{project-context}_cert_key.pem__ \  <2>
 -b __/root/{project-context}_cert/ca_cert_bundle.pem__        <3>
 ----


### PR DESCRIPTION
In deploying the custom SSL certificate, we require the parameter -t [project|proxy] to validate the custom SSL certificate input files. This parameter was missing in the Project server while it is present in the Proxy server. Therefore, we added it. This is applicable to Upstream v3.3 and later.

https://bugzilla.redhat.com/show_bug.cgi?id=2190520

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
