### PR TITLE
Add the missing umask

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -38,6 +38,7 @@ ifdef::satellite[]
 * A current {ProjectName} subscription
 endif::[]
 * Administrative user (root) access
+* A system umask of 0022
 * Full forward and reverse DNS resolution using a fully-qualified domain name
 
 {Project} only supports `UTF-8` encoding.


### PR DESCRIPTION
We need to add the missing umask of 0022 in the system requirements as it is already part of other older versions.

https://bugzilla.redhat.com/show_bug.cgi?id=2207694

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
