### PR TITLE
Add KB article link for error fix

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -6,10 +6,10 @@ For large systems, this can mean several days of downtime.
 To prevent this, pre-migrate Pulp content while running the latest version of {ProjectServer} {ProjectVersionPrevious}.
 This reduces the overall upgrade downtime.
 
-During migration to Pulp3, the amount of data stored in the `/var/lib/pulp/published/` directory can double in size.
+During migration to Pulp 3, the amount of data stored in the `/var/lib/pulp/published/` directory can double in size.
 Ensure that there is enough space on the `/var/lib/pulp` volume.
 If the user runs `{foreman-maintain} prep-6.10-upgrade`, the content in `/var/lib/pulp/content` does not need to be duplicated.
-After Pulp2 is removed, the extra space can be claimed back, however, shrinking of XFS volumes is not possible and copying data to a different partition might be necessary in order to bring volume size down to the previous value.
+After Pulp 2 is removed, the extra space can be claimed back, however, shrinking of XFS volumes is not possible, and copying data to a different partition might be necessary in order to bring volume size down to the previous value.
 
 During migration to Pulp 3, the amount of data stored in the PostgreSQL data directory can grow significantly.
 Ensure that you have enough space for the migration.
@@ -20,6 +20,7 @@ The sequence should always be if you have any Composite Content Views, take acti
 
 * Ensure that all enabled repositories complete the synchronization process.
 * If any repositories are synced with a *Warning* or *Error* state, fix the underlying problem and resync the repository.
+* If the Pulp 2 to Pulp 3 migration fails with the error `NoMethodError: undefined method `link?' for nil:NilClass`, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/6898881[The Pulp 2 to Pulp 3 migration fails with error "NoMethodError: undefined method `link?' for nil:NilClass" in Red Hat {ProjectVersionPrevious}] on the customer portal.
 * Ensure that no paused tasks in the system are related to any repositories or Content Views.
 * If some Content View or Composite Content View versions are not required anymore, please consider performing a cleanup of them.
 * For more information about how to perform the cleanup of older Content View or Composite Content View versions using `hammer_cli`, see https://access.redhat.com/solutions/2760531[How to remove old content view versions in Red Hat Satellite 6 using CLI/hammer?].

--- a/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/preparing_to_migrate_pulp_content.adoc
@@ -9,7 +9,9 @@ This reduces the overall upgrade downtime.
 During migration to Pulp 3, the amount of data stored in the `/var/lib/pulp/published/` directory can double in size.
 Ensure that there is enough space on the `/var/lib/pulp` volume.
 If the user runs `{foreman-maintain} prep-6.10-upgrade`, the content in `/var/lib/pulp/content` does not need to be duplicated.
-After Pulp 2 is removed, the extra space can be claimed back, however, shrinking of XFS volumes is not possible, and copying data to a different partition might be necessary in order to bring volume size down to the previous value.
+After Pulp 2 is removed, the extra space can be claimed back.
+However, shrinking of XFS volumes is not possible.
+Copying data to a different partition might be necessary in order to bring volume size down to the previous value.
 
 During migration to Pulp 3, the amount of data stored in the PostgreSQL data directory can grow significantly.
 Ensure that you have enough space for the migration.
@@ -20,7 +22,7 @@ The sequence should always be if you have any Composite Content Views, take acti
 
 * Ensure that all enabled repositories complete the synchronization process.
 * If any repositories are synced with a *Warning* or *Error* state, fix the underlying problem and resync the repository.
-* If the Pulp 2 to Pulp 3 migration fails with the error `NoMethodError: undefined method `link?' for nil:NilClass`, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/6898881[The Pulp 2 to Pulp 3 migration fails with error "NoMethodError: undefined method `link?' for nil:NilClass" in Red Hat {ProjectVersionPrevious}] on the customer portal.
+* If the Pulp 2 to Pulp 3 migration fails with the error `NoMethodError: undefined method `link?' for nil:NilClass`, see the Red Hat Knowledgebase solution https://access.redhat.com/solutions/6898881[The Pulp 2 to Pulp 3 migration fails with error "NoMethodError: undefined method `link?' for nil:NilClass" in Red Hat Satellite 6.9] on the customer portal.
 * Ensure that no paused tasks in the system are related to any repositories or Content Views.
 * If some Content View or Composite Content View versions are not required anymore, please consider performing a cleanup of them.
 * For more information about how to perform the cleanup of older Content View or Composite Content View versions using `hammer_cli`, see https://access.redhat.com/solutions/2760531[How to remove old content view versions in Red Hat Satellite 6 using CLI/hammer?].


### PR DESCRIPTION
If Pulp 2 to Pulp 3 migration fails with error "NoMethodError:
undefined method `link?' for nil:NilClass", there is a KB article on
the customer portal that will show the user how to fix the error. This
link was added to the Pre-Migration checks.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
