### PR TITLE
update PR template with latest versions of foreman and sat

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,9 @@
 
 Please cherry-pick my commits into:
 
+* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
 * [ ] Foreman 3.6/Katello 4.8
-* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
+* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
 * [ ] Foreman 3.4/Katello 4.6 (EL8 only)
 * [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
 * [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (planned Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
