### PR TITLE
Modify variables and remove CentOS

### DIFF
--- a/guides/common/modules/ref_variables-for-generation-of-conversion-data.adoc
+++ b/guides/common/modules/ref_variables-for-generation-of-conversion-data.adoc
@@ -16,19 +16,16 @@ You must create those additional variables manually and assign them to the `{ans
 | `{project-context}_username` * | string | Your user name
 | `{project-context}_password` * | string | Your password
 | `{project-context}_organization` * | string | Name of your organization
-| `{project-context}_rhel_wait_for_syncs` * | boolean | Set to `false` if you do not want {ProjectServer} to wait until repository sync finishes before continuing with data generation.
+| `{project-context}_content_rhel_wait_for_syncs` * | boolean | Set to `false` if you do not want {ProjectServer} to wait until repository sync finishes before continuing with data generation. (default: `true`)
 | `{project-context}_validate_certs` * | boolean | Set to `true` if you want to enable certificate checks in Ansible. (default: `true`)
 | `{project-context}_convert2rhel_manage_subscription` | boolean | Set to `false` if you already have a manifest on your {ProjectServer}.
 If you upload a new manifest from disk, the current manifest will be overwritten. (default: `true`)
-| `{project-context}_content_rhel_enable_rhel7` | boolean | Enables {RHEL} 7 repositories.
-Set to `true` if you intend to convert hosts to {RHEL} 7.
-| `{project-context}_convert2rhel_enable_centos7` * | boolean | Set to `true` if you want to prepare conversion data for CentOS Linux 7.
-Otherwise, you must set the value to `false`.
+| `{project-context}_content_rhel_enable_rhel7` * | boolean | Enables {RHEL} 7 repositories.
+Set to `false` if you do not intend to convert hosts to {RHEL} 7. (default: `true`)
 | `{project-context}_convert2rhel_enable_oracle7` | boolean | Set to `true` if you want to prepare conversion data for Oracle Linux 7.
 Otherwise, you must set the value to `false`.
-| `{project-context}_content_rhel_enable_rhel8` | boolean | Enables {RHEL} 8 repositories. Set to `true` if you intend to convert hosts to {RHEL} 8.
-| `{project-context}_convert2rhel_enable_centos8` * | boolean | Set to `true` if you want to prepare conversion data for CentOS Linux 8.
-Otherwise, you must set the value to `false`.
+| `{project-context}_content_rhel_enable_rhel8` * | boolean | Enables {RHEL} 8 repositories.
+Set to `false` if you do not intend to convert hosts to {RHEL} 8. (default: `true`)
 | `{project-context}_convert2rhel_enable_oracle8` | boolean | Set to `true` if you want to prepare conversion data for Oracle Linux 8.
 Otherwise, you must set the value to `false`.
 |====


### PR DESCRIPTION
In the managing host guide, we fixed the typo in the table of Variables for the Generation of Conversion Data as suggested by the reporter. Also, we took minor changes in the description of the listed variables in the table.

https://bugzilla.redhat.com/show_bug.cgi?id=2208368

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
