### PR TITLE
Fix a typo in recently added note for ACS

### DIFF
--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -8,7 +8,7 @@ You can set up alternate content sources for {ProjectServer} and {SmartProxy}.
 You must refresh the alternate content source after creation or after making any changes.
 A weekly cron job refreshes all alternate content sources.
 You can also refresh the alternate content sources manually using the {ProjectWebUI} or the Hammer CLI.
-Alternate content sources associated with your {ProjectServer} or {SmartProxyServers} to multiple organizations affect all organizations.
+Alternate content sources associated with your {ProjectServer}, or {SmartProxyServers} attached to multiple organizations, affect all organizations.
 
 There are three types of alternate content sources:
 


### PR DESCRIPTION
The change merged in https://github.com/theforeman/foreman-documentation/pull/2169 had a small typo. The sentence should read as "Alternate content sources associated with the {ProjectServer}, or with {SmartProxyServers} attached to multiple organizations, will affect all organizations.". Adding the missing "attached" and turning it into a subordinate clause.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
