### PR TITLE
Mark optional steps in Host Registration

### DIFF
--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -85,14 +85,14 @@ The following is an example of the `curl` command with the `--insecure` option:
 # curl -sS --insecure https://{foreman-example-com}/register ...
 ----
 . Select the *Advanced* tab.
-. From the *Setup REX* list, select whether you want to deploy {Project} SSH keys to hosts or not.
+. Optional: From the *Setup REX* list, select whether you want to deploy {Project} SSH keys to hosts or not.
 +
 If set to `Yes`, public SSH keys will be installed on the registered host.
 The inherited value is based on the `host_registration_remote_execution` parameter.
 It can be inherited, for example from a host group, an operating system, or an organization.
 When overridden, the selected value will be stored on host parameter level.
 ifdef::client-content-dnf[]
-. From the *Setup Insights* list, select whether you want to install `insights-client` and register the hosts to Insights.
+. Optional: From the *Setup Insights* list, select whether you want to install `insights-client` and register the hosts to Insights.
 +
 The Insights tool is available for {RHEL} only.
 It has no effect on other operating systems.
@@ -130,7 +130,7 @@ Therefore, do not delete, block, or change permissions of the user during the to
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
 . Optional: In the *Remote Execution Interface* field, enter the identifier of a network interface that hosts must use for the SSH connection.
 If you keep this field blank, {Project} uses the default network interface.
-. From the *REX pull mode* list, select whether you want to deploy {Project} remote execution pull client.
+. Optional: From the *REX pull mode* list, select whether you want to deploy {Project} remote execution pull client.
 +
 If set to `Yes`, the remote execution pull client is installed on the registered host.
 The inherited value is based on the `host_registration_remote_execution_pull` parameter.


### PR DESCRIPTION
All registration fields except for **Activation Key** are optional.
Adding "Optional" for steps that were previously mentioned as mandatory.

https://bugzilla.redhat.com/show_bug.cgi?id=1992283

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
