### PR TITLE
Add feedback module to guide (Satellite)

### DIFF
--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -11,6 +11,10 @@ This feature is not available for Debian/Ubuntu.
 endif::[]
 ifndef::foreman-deb[]
 
+ifdef::satellite[]
+include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
+endif::[]
+
 include::common/modules/con_security-compliance-management.adoc[leveloffset=+1]
 
 include::common/modules/con_security-content-automation-protocol.adoc[leveloffset=+1]


### PR DESCRIPTION
Adds _Providing feedback..._ to _Managing Security Compliance_.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
