### PR TITLE
don't depend on compass and zurb, we don't use it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN dnf upgrade -y && \
                    rubygem-asciidoctor-pdf && \
     dnf groupinstall -y development-tools
 
-RUN gem install compass:0.12.7 \
-                zurb-foundation:4.3.2
+RUN gem install sass
 
 WORKDIR /foreman-documentation/guides

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gem 'asciidoctor-pdf'
 # missing dependency for asciidoctor-pdf
 gem 'matrix'
 
-gem 'compass', '0.12.7'
-gem 'zurb-foundation', '4.3.2'
+gem 'sass'

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -45,7 +45,7 @@ endif
 all: html
 
 prepare:
-	@mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR) $(DEST_DIR)/sass-cache
+	@mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR)
 
 html: prepare $(IMAGES_TS) $(DEST_HTML)
 
@@ -67,7 +67,7 @@ open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"
 
 $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
-	bundle exec sass --sourcemap=none --cache-location $(DEST_DIR)/sass-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
+	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 
 $(IMAGES_TS): $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -67,7 +67,7 @@ open-pdf: pdf
 	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"
 
 $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
-	bundle exec sass --cache-location $(DEST_DIR)/sass-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
+	bundle exec sass --sourcemap=none --cache-location $(DEST_DIR)/sass-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 
 $(IMAGES_TS): $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"


### PR DESCRIPTION
but it wants a super old sass which doesn't work on modern Ruby

pull in sass directly instead

Fixes: ac63a51ce4d5e9d46112639a5e2f459ae2fdd43d


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
