### PR TITLE
Add Remote SCAP resources disconnected

### DIFF
--- a/guides/common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc
+++ b/guides/common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc
@@ -1,0 +1,60 @@
+[id="applying-remote-scap-resources-in-a-disconnected-environment_{context}"]
+= Applying Remote SCAP Resources in a Disconnected Environment
+
+SCAP data streams can contain remote resources, such as OVAL files, that the SCAP client can fetch over the internet when it runs on hosts.
+If your host does not have internet access, you must download remote SCAP resources and distribute them to your host as local files.
+
+.Prerequisites
+* You have registered your host with remote execution enabled.
+* Fetching remote resources must be disabled, which is the default.
+For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
+
+.Procedure
+. On your {ProjectServer}, examine the data stream you use in your compliance policy to find out which missing resource you must download:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# oscap info _/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml_ | grep "WARNING"
+WARNING: Datastream component 'scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2'
+points out to the remote 'https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2'.
+Use '--fetch-remote-resources' option to download it.
+WARNING: Skipping 'https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2' file
+which is referenced from datastream
+----
+. Examine what name of the local file is expected by the data stream:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# oscap info _/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml_
+...
+		Referenced check files:
+			ssg-rhel8-oval.xml
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+			ssg-rhel8-ocil.xml
+				system: http://scap.nist.gov/schema/ocil/2
+			*security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2*
+				system: http://oval.mitre.org/XMLSchema/oval-definitions-5
+...
+----
+. On an online machine, download the missing resource:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# curl -o _security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2_ _https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2_
+----
++
+Ensure to name the downloaded file as referenced by the data stream.
+. Add the file as new {customfiletype} content into your disconnected {ProjectServer}.
+For more information, see {ContentManagementDocURL}Managing_Custom_File_Type_Content_content-management[Managing {customfiletypetitle} Content] in _{ContentManagementDocTitle}_.
++
+Note the URL on which your repository is published, such as `http://_{foreman-example-com}_/pulp/content/_My_Organization_Label_/Library/custom/_My_Product_Label_/_My_Repo_Label_/`.
+. Schedule a remote job to upload the file to the home directory of `root` on your host.
+For example, use the `Run Command - Script Default` job template and enter the following command:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# curl -o /root/_security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2_ http://_{foreman-example-com}_/pulp/content/_My_Organization_Label_/Library/custom/_My_Product_Label_/_My_Repo_Label_/_security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2_
+----
++
+For more information about running remote jobs, see {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a Remote Job] in _{ManagingHostsDocTitle}_.
+. Continue with deploying your compliance policy.

--- a/guides/common/modules/ref_inclusion-of-remote-scap-resources.adoc
+++ b/guides/common/modules/ref_inclusion-of-remote-scap-resources.adoc
@@ -36,3 +36,7 @@ Configure the following Puppet Smart Class Parameter:
 
 +
 For more information, see {ManagingConfigurationsPuppetDocURL}Configuring_Puppet_Smart_Class_Parameters_managing-configurations-puppet[Configuring Puppet Smart Class Parameters] in _{ManagingConfigurationsPuppetDocTitle}_.
+
+ifdef::orcharhino,satellite[]
+For information about applying remote SCAP resources to hosts in a disconnected network environment, see xref:applying-remote-scap-resources-in-a-disconnected-environment_{context}[].
+endif::[]

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -55,6 +55,10 @@ include::common/modules/con_deploying-compliance-policies.adoc[leveloffset=+1]
 
 include::common/modules/ref_inclusion-of-remote-scap-resources.adoc[leveloffset=+2]
 
+ifdef::orcharhino,satellite[]
+include::common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc[leveloffset=+2]
+endif::[]
+
 include::common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc[leveloffset=+2]
 
 include::common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc[leveloffset=+2]


### PR DESCRIPTION
Follow-up to #2213
"Fetch remote resources" cannot be used in disconnected environments, the remote resources must be downloaded manually and uploaded to hosts.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
