### PR TITLE
Hide Building Discovery Image for Satellite

### DIFF
--- a/guides/common/assembly_configuring-the-discovery-service.adoc
+++ b/guides/common/assembly_configuring-the-discovery-service.adoc
@@ -14,7 +14,9 @@ include::modules/proc_creating-discovery-rules.adoc[leveloffset=+1]
 
 include::modules/proc_implementing-pxe-less-discovery.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_building-a-discovery-image.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/con_unattended-use-customization-and-image-remastering.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/proc_configuring-the-discovery-service.adoc
@@ -42,9 +42,11 @@ endif::[]
 ifdef::satellite,orcharhino[]
 +
 The `{fdi-package-name}` package installs the Discovery ISO to the `/usr/share/foreman-discovery-image/` directory.
+ifndef::satellite[]
 You can build a PXE boot image from this ISO using the `livecd-iso-to-pxeboot` tool.
 The tool saves this PXE boot image in the `/var/lib/tftpboot/boot` directory.
 For more information, see xref:Building_a_Discovery_Image_{context}[].
+endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_implementing-pxe-less-discovery.adoc
+++ b/guides/common/modules/proc_implementing-pxe-less-discovery.adoc
@@ -32,7 +32,9 @@ ifndef::satellite,orcharhino[]
 image::common/pxeless-mode.svg[]
 endif::[]
 
+ifndef::satellite[]
 If you have not yet installed the Discovery service or image, see xref:Building_a_Discovery_Image_{context}[].
+endif::[]
 
 ifdef::satellite[]
 The ISO for the Discovery service resides at `/usr/share/foreman-discovery-image/` and is installed using the `foreman-discovery-image` package.


### PR DESCRIPTION
This was done on 2.5 in #1572 and it must be done for all newer versions as well.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
