### PR TITLE
Add line for ignoring treeinfo

### DIFF
--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -31,6 +31,8 @@ If you are using a `file://` repository, you have to place it under `/var/lib/pu
 +
 If you do not enter an upstream URL, you can manually upload packages.
 . Optional: Check the *Ignore SRPMs* checkbox to exclude source RPM packages from being synchronized to {Project}.
+. Optional: Check the *Ignore treeinfo* checkbox if you receive the error `Treeinfo file should have INI format`.
+All files related to Kickstart will be missing from the repository if `treeinfo` files are skipped. 
 . Select the *Verify SSL* checkbox if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.
 . Optional: In the *Upstream Username* field, enter the user name for the upstream repository if required for authentication.
 Clear this field if the repository does not require authentication.


### PR DESCRIPTION
treeinfo skipping during sync time works the same as srpm skipping, so
it is documented as an option for the user.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
