### PR TITLE
Fixed typo in proc_configuring-direct-ad-integration-with-gss-proxy.adoc

### DIFF
--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -61,7 +61,7 @@ WARNING: The host must not be enrolled to a domain before creating a keytab entr
 # chown root.apache /etc/httpd/conf/http.keytab
 # chmod 640 /etc/httpd/conf/http.keytab
 ----
-. Enable IPA authenication in {Project}:
+. Enable IPA authentication in {Project}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
Fixed typo


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; planned orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
