### PR TITLE
Update Manager Role

### DIFF
--- a/guides/common/modules/ref_predefined-roles.adoc
+++ b/guides/common/modules/ref_predefined-roles.adoc
@@ -22,8 +22,7 @@ View compliance reports.
 | Discovery Reader | View hosts and discovery rules.
 | Edit hosts | View, create, edit, destroy, and build hosts.
 | Edit partition tables | View, create, edit and destroy partition tables.
-| Manager | A role similar to administrator, but does not have permissions to edit global settings.
-In the {ProjectWebUI}, global settings can be found under *Administer* > *Settings*.
+| Manager | View and edit global settings.
 | Organization admin | An administrator role defined per organization.
 The role has no visibility into resources in other organizations.
 | Red{nbsp}Hat Access Logs | View the log viewer and the logs.


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1986664, the Manager role can edit global settings.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
