### PR TITLE
Add commands to regenerate certificates for smart proxies with LB setup

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -46,18 +46,18 @@ ifdef::katello,satellite[]
 +
 [options="nowrap" subs="attributes"]
 ----
-# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+# {certs-generate} --foreman-proxy-fqdn "_{smartproxy-example-com}_" \
 --certs-update-all \
---certs-tar "~/{smartproxy-example-com}-certs.tar"
+--certs-tar "~/_{smartproxy-example-com}-certs.tar_"
 ----
 ... For {SmartProxyServer}s that use load balancing:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+# {certs-generate} --foreman-proxy-fqdn "_{smartproxy-example-com}_" \
 --certs-update-all \
---foreman-proxy-cname "load-balancer.example.com" \
---certs-tar "~/{smartproxy-example-com}-certs.tar"
+--foreman-proxy-cname "_load-balancer.example.com_" \
+--certs-tar "~/_{smartproxy-example-com}-certs.tar_"
 ----
 
 .. Regenerate certificates for {SmartProxies} that use custom certificates:
@@ -65,23 +65,23 @@ ifdef::katello,satellite[]
 +
 [options="nowrap" subs="attributes"]
 ----
-# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
---certs-tar "~/{smartproxy-example-com}-certs.tar" \
---server-cert "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert.pem" \
---server-key "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert_key.pem" \
---server-ca-cert "/root/{certs-proxy-context}_cert/ca_cert_bundle.pem" \
+# {certs-generate} --foreman-proxy-fqdn "_{smartproxy-example-com}_" \
+--certs-tar "~/_{smartproxy-example-com}-certs.tar_" \
+--server-cert "/root/{certs-proxy-context}_cert/_{certs-proxy-context}_cert.pem_" \
+--server-key "/root/{certs-proxy-context}_cert/_{certs-proxy-context}_cert_key.pem_" \
+--server-ca-cert "/root/{certs-proxy-context}_cert/_ca_cert_bundle.pem_" \
 --certs-update-server
 ----
 ... For {SmartProxyServer}s that use load balancing:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
---certs-tar "~/{smartproxy-example-com}-certs.tar" \
---server-cert "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert.pem" \
---server-key "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert_key.pem" \
---server-ca-cert "/root/{certs-proxy-context}_cert/ca_cert_bundle.pem" \
---foreman-proxy-cname "load-balancer.example.com" \
+# {certs-generate} --foreman-proxy-fqdn "_{smartproxy-example-com}_" \
+--certs-tar "~/_{smartproxy-example-com}-certs.tar_" \
+--server-cert "/root/{certs-proxy-context}_cert/_{certs-proxy-context}_cert.pem_" \
+--server-key "/root/{certs-proxy-context}_cert/_{certs-proxy-context}_cert_key.pem_" \
+--server-ca-cert "/root/{certs-proxy-context}_cert/_ca_cert_bundle.pem_" \
+--foreman-proxy-cname "_load-balancer.example.com_" \
 --certs-update-server
 ----
 
@@ -121,7 +121,7 @@ For this example, we will use `/root/{smartproxy-example-com}-certs.tar`.
 +
 [options="nowrap" subs="attributes"]
 ----
-# foreman-installer --certs-tar-file /root/{smartproxy-example-com}-certs.tar \
+# foreman-installer --certs-tar-file /root/_{smartproxy-example-com}-certs.tar_ \
                     --certs-update-all --certs-regenerate true --certs-deploy true
 ----
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -42,6 +42,7 @@ ifdef::katello,satellite[]
 +
 . Regenerate certificates on your {ProjectServer}:
 .. Regenerate certificates for {SmartProxies} that use default certificates:
+... For {SmartProxyServer}s that do not use load balancing:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -49,7 +50,18 @@ ifdef::katello,satellite[]
 --certs-update-all \
 --certs-tar "~/{smartproxy-example-com}-certs.tar"
 ----
+... For {SmartProxyServer}s that use load balancing:
++
+[options="nowrap" subs="attributes"]
+----
+# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+--certs-update-all \
+--foreman-proxy-cname "load-balancer.example.com" \
+--certs-tar "~/{smartproxy-example-com}-certs.tar"
+----
+
 .. Regenerate certificates for {SmartProxies} that use custom certificates:
+... For {SmartProxyServer}s that do not use load balancing:
 +
 [options="nowrap" subs="attributes"]
 ----
@@ -60,6 +72,19 @@ ifdef::katello,satellite[]
 --server-ca-cert "/root/{certs-proxy-context}_cert/ca_cert_bundle.pem" \
 --certs-update-server
 ----
+... For {SmartProxyServer}s that use load balancing:
++
+[options="nowrap" subs="attributes"]
+----
+# {certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
+--certs-tar "~/{smartproxy-example-com}-certs.tar" \
+--server-cert "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert.pem" \
+--server-key "/root/{certs-proxy-context}_cert/{certs-proxy-context}_cert_key.pem" \
+--server-ca-cert "/root/{certs-proxy-context}_cert/ca_cert_bundle.pem" \
+--foreman-proxy-cname "load-balancer.example.com" \
+--certs-update-server
+----
+
 For more information on custom SSL certificates signed by a Certificate Authority, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 +
 endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -50,7 +50,7 @@ ifdef::katello,satellite[]
 --certs-update-all \
 --certs-tar "~/_{smartproxy-example-com}-certs.tar_"
 ----
-... For {SmartProxyServer}s that use load balancing:
+... For {SmartProxyServer}s that are load-balanced:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -72,7 +72,7 @@ ifdef::katello,satellite[]
 --server-ca-cert "/root/{certs-proxy-context}_cert/_ca_cert_bundle.pem_" \
 --certs-update-server
 ----
-... For {SmartProxyServer}s that use load balancing:
+... For {SmartProxyServer}s that are load-balanced:
 +
 [options="nowrap" subs="attributes"]
 ----


### PR DESCRIPTION
Currently the LB guide points to the Upgrading guide to upgrade smart proxies with LB setup. However, the commands for regenerating certificates for smart proxies with an LB setup, require an additional "--foreman-proxy-cname", which points to the load balancer, to be provided. Splitting each of the command into two substeps.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2143785

* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
