### PR TITLE
Add REX Pull Client for Project Server

### DIFF
--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -12,6 +12,7 @@ include::modules/proc_configuring-smart-proxy-for-host-registration-and-provisio
 ifdef::katello,satellite[]
 // Enabling Katello Agent Infrastructure
 include::modules/proc_enabling-katello-agent.adoc[leveloffset=+1]
+include::modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::foreman-deb[]

--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
@@ -1,0 +1,40 @@
+[id="configuring-remote-execution-for-pull-client-on-{project-context}-server_{context}"]
+= Configuring Remote Execution for Pull Client on {ProjectServer}
+
+By default, Remote Execution uses SSH as the transport mechanism for the Script provider.
+However, Remote Execution also offers pull-based transport, which you can use if your infrastructure prohibits outgoing connections from {Project} to hosts.
+
+This comprises `pull-mqtt` mode on {Project} in combination with a pull client running on hosts.
+If you still use Katello Agent, configure the `pull-mqtt` mode for migration which is a deprecated method of pull-based transport.
+
+[NOTE]
+====
+The `pull-mqtt` mode works only with the Script provider.
+Ansible and other providers will continue to use their default transport settings.
+====
+
+To use `pull-mqtt` mode on {ProjectServer}, follow the procedure below:
+
+.Procedure
+. Enable the pull-based transport on your {ProjectServer}:
++
+[options="nowrap" subs="quotes,attributes"]
+----
+ # {installer-scenario} \
+--foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
+----
+. Configure the firewall to allow MQTT service on port 1883:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# firewall-cmd --add-port="1883/tcp"
+# firewall-cmd --runtime-to-permanent
+----
++
+In `pull-mqtt` mode, hosts subscribe for job notifications to either your {Project} or any {SmartProxyServer} through which they are registered.
+Therefore, it is recommended to ensure that {ProjectServer} sends remote execution jobs to that same {Project} (or {SmartProxy}).
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
+. On the *Content* tab, set the value of *Prefer registered through {SmartProxy} for remote execution* to *Yes*.
+
+After you set up the pull-based transport on {Project}, you must also configure it on each host.
+For more information, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc
@@ -1,0 +1,38 @@
+[id="configuring-remote-execution-for-pull-client_{context}"]
+= Configuring Remote Execution for Pull Client
+
+By default, Remote Execution uses SSH as the transport mechanism for the Script provider.
+However, Remote Execution also offers pull-based transport, which you can use if your infrastructure prohibits outgoing connections from {SmartProxy} to hosts.
+
+This is comprised of `pull-mqtt` mode on {SmartProxy} in combination with a pull client running on hosts.
+Configure the `pull-mqtt` mode to migrate from Katello Agent, which is a deprecated method of pull-based transport.
+
+NOTE: The `pull-mqtt` mode works only with the Script provider.
+Ansible and other providers will continue to use their default transport settings.
+
+The mode is configured per {SmartProxy}.
+Some {SmartProxies} can be configured to use `pull-mqtt` mode while others use SSH.
+If this is the case, it is possible that one remote job on a given host will use the pull client and the next job on the same host will use SSH.
+If you wish to avoid this scenario, configure all {SmartProxies} to use the same mode.
+
+.Procedure
+. Enable the pull-based transport on each relevant {SmartProxyServer}:
++
+[options="nowrap" subs="quotes,attributes"]
+----
+ # {installer-scenario-smartproxy} \
+--foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
+----
+. Configure the firewall to allow MQTT service on port 1883:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# firewall-cmd --add-port="1883/tcp"
+# firewall-cmd --runtime-to-permanent
+----
+. In `pull-mqtt` mode, hosts subscribe for job notifications to the {SmartProxy} through which they are registered.
+Therefore, it is recommended to ensure that {ProjectServer} sends remote execution jobs to that same {SmartProxy}.
+To do this, in the {ProjectWebUI}, navigate to *Administer* > *Settings*.
+On the *Content* tab, set the value of *Prefer registered through {SmartProxy} for remote execution* to *Yes*.
+. After you set up the pull-based transport on {SmartProxy}, you must also configure it on each host.
+For more information, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -33,6 +33,8 @@ include::common/modules/proc_disabling-registration-to-insights.adoc[leveloffset
 include::common/modules/proc_enabling-the-satellite-tools-repository.adoc[leveloffset=+2]
 
 include::common/modules/proc_synchronizing-the-satellite-tools-repository.adoc[leveloffset=+2]
+
+include::common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc[leveloffset=+2]
 endif::[]
 
 include::common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc[leveloffset=+2]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -34,6 +34,8 @@ include::common/modules/proc_enabling-the-satellite-tools-repository.adoc[levelo
 
 include::common/modules/proc_synchronizing-the-satellite-tools-repository.adoc[leveloffset=+2]
 
+include::common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc[leveloffset=+2]
+
 include::common/modules/proc_enabling-power-management-on-managed-hosts.adoc[leveloffset=+2]
 
 include::common/modules/proc_configuring-dns-dhcp-and-tftp.adoc[leveloffset=+2]


### PR DESCRIPTION
The pull-mqtt mode is not limited to Smart Proxy but also for Project. End-users can confuse of pull-mqtt being not present in the Project Server but that is not true. It applies to Project as well alongside the Smart Proxy.

https://bugzilla.redhat.com/show_bug.cgi?id=2187708

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
