### PR TITLE
Replace `useradd` with `usermod` in Provisioning

### DIFF
--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -36,7 +36,7 @@ If you want to use a non-root user on the KVM server, you must add the user to t
 +
 [options="nowrap" subs="+quotes"]
 ----
-useradd -a -G libvirt _non_root_user_
+# usermod -a -G libvirt _non_root_user_
 ----
 
 * A {Project} user account with the following roles:


### PR DESCRIPTION
This update aims to fix https://bugzilla.redhat.com/show_bug.cgi?id=2193414

The command to adding a user to a group is usermod, not useradd. Also, a root prompt was missing.

@Lennonka This BZ came from your queue, can you please review it? Also, I'd appreciate it if you could point me to the appropriate SME to check the update.

* [ x ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ x ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ x ] Foreman 3.6/Katello 4.8
* [ x ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ x ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ x ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ x ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ x ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
