### PR TITLE
Remove "show host power status" setting

### DIFF
--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -13,8 +13,6 @@ When set to `Yes`, {Project} recreates this cache on the next restart.
 | *DB pending seed* | No | Should the `foreman-rake db:seed` be executed on the next run of the installer modules?
 | *{SmartProxy} request timeout* | 60 | Open and read timeout for HTTP requests from {Project} to {SmartProxy} (in seconds).
 | *Login page footer text* | | Text to be shown in the login-page footer.
-| *Show host power status* | Yes | Show power status on the host index page.
-This feature calls to compute resource providers which may lead to decreased performance on the host listing page.
 | *HTTP(S) proxy* | | Set a proxy for outgoing HTTP(S) connections from the {Project} product.
 System-wide proxies must be configured at the operating system level.
 | *HTTP(S) proxy except hosts* | [] | Set hostnames to which requests are not to be proxied.


### PR DESCRIPTION
This setting was removed in 3.5/6.13.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2212352


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
