### PR TITLE
always use `ansible-doc -l` to list modules in the collection

### DIFF
--- a/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
+++ b/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
@@ -1,38 +1,12 @@
 [id="Viewing_the_Ansible_Modules_{context}"]
 = Viewing the {Project} Ansible Modules
 
-ifdef::satellite,orcharhino[]
-You can view the installed {Project} Ansible modules by listing the content of the following directory:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# ls {ansiblefilepath}
-----
-
-[NOTE]
-====
-At the time of writing, the `ansible-doc -l` command does not list collections yet.
-====
-
-endif::[]
-
-ifndef::satellite,orcharhino[]
-
-Starting with Ansible 2.10, you can view the installed {Project} Ansible modules by running:
+You can view the installed {Project} Ansible modules by running:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # ansible-doc -l {ansible-namespace}
 ----
-
-When using Ansible before 2.10, you can view the installed {Project} Ansible modules by listing the content of the following directory:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# ls {ansiblefilepath}
-----
-
-endif::[]
 
 ifndef::orcharhino[]
 Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}.


### PR DESCRIPTION
by now everyone should have Ansible 2.10+


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
