### PR TITLE
Additional arguments in foreman-maintain

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -61,9 +61,9 @@ ifdef::satellite[]
 When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials.
 These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
-[options="nowrap" subs="attributes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {ProductVersion}
+# {foreman-maintain} upgrade check --target-version {ProductVersion} --whitelist _whitelist_arguments_
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.


### PR DESCRIPTION
The additional arguments that can be used for foreman-maintain can be listed while updating server to next minor version.

https://bugzilla.redhat.com/show_bug.cgi?id=2189967

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
