### PR TITLE
Import OS from CDN in Provisioning

### DIFF
--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -7,11 +7,18 @@ Operating system entries combine previously defined resources, such as installat
 ifndef::foreman-deb,orcharhino[]
 Importing operating systems from Red Hat's CDN creates new entries on the *Hosts* > *Operating Systems* page.
 endif::[]
-ifdef::foreman-el,katello[]
+ifdef::foreman-el[]
 Importing operating systems from Red Hat's CDN is only possible when Katello is installed.
 endif::[]
+ifndef::foreman-deb,orcharhino[]
+To import operating systems from Red Hat's CDN, enable the Red Hat repositories of the operating systems and synchronize the repositories to {Project}.
+For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 
 You can also add custom operating systems using the following procedure.
+endif::[]
+ifdef::foreman-deb,orcharhino[]
+You can add operating systems using the following procedure.
+endif::[]
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-operating-systems_{context}[].
 
 .Procedure


### PR DESCRIPTION
It wasn't clear how to import OS from RH CDN, so I added links to _Managing Content_ and did some tweaks around.

https://bugzilla.redhat.com/show_bug.cgi?id=2213394

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
