### PR TITLE
Providers that can use compute profiles in Provisioning

### DIFF
--- a/guides/common/assembly_introduction-to-provisioning.adoc
+++ b/guides/common/assembly_introduction-to-provisioning.adoc
@@ -2,4 +2,8 @@ include::modules/con_introduction-to-provisioning.adoc[]
 
 include::modules/con_provisioning-overview.adoc[leveloffset=+1]
 
+include::modules/ref_supported-cloud-providers.adoc[leveloffset=+1]
+
+include::modules/ref_supported-virtualization-infrastructure.adoc[leveloffset=+1]
+
 include::modules/con_network-boot-provisioning-workflow.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -8,6 +8,11 @@ A default installation of {ProjectName} contains three predefined profiles:
 * `2-Medium`
 * `3-Large`
 
+You can apply compute profiles to all supported compute resources:
+
+* xref:supported-cloud-providers_{context}[]
+* xref:supported-virtualization-infrastructure_{context}[]
+
 .Procedure
 
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Profiles* and click *Create Compute Profile*.

--- a/guides/common/modules/ref_supported-cloud-providers.adoc
+++ b/guides/common/modules/ref_supported-cloud-providers.adoc
@@ -1,0 +1,11 @@
+[id="supported-cloud-providers_{context}"]
+= Supported Cloud Providers
+
+You can connect the following cloud providers as compute resources to {Project}:
+
+ifndef::orcharhino[]
+* {OpenStack}
+endif::[]
+* Amazon EC2
+* Google Compute Engine
+* Microsoft Azure

--- a/guides/common/modules/ref_supported-virtualization-infrastructure.adoc
+++ b/guides/common/modules/ref_supported-virtualization-infrastructure.adoc
@@ -1,0 +1,15 @@
+[id="supported-virtualization-infrastructure_{context}"]
+= Supported Virtualization Infrastructure
+
+You can connect the following virtualization infrastructure as compute resources to {Project}:
+
+* KVM (libvirt)
+* {oVirt}
+ifdef::satellite[]
+(deprecated)
+endif::[]
+* VMware
+* {KubeVirt}
+ifndef::satellite[]
+* Proxmox
+endif::[]


### PR DESCRIPTION
Compute profiles are supported only for a certain compute resources in Satellite. **Should I add any other for Foreman/orcharhino?**
This info is not version specific.

https://bugzilla.redhat.com/show_bug.cgi?id=2172243

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
