### PR TITLE
Adding a decision tree to proc for creating an activation key

### DIFF
--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -101,7 +101,7 @@ endif::[]
 ----
 . List the product content associated with the activation key:
 +
-.. If Simple Content Access (SCA) is enabed:
+.. If Simple Content Access (SCA) is enabled:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -101,6 +101,18 @@ endif::[]
 ----
 . List the product content associated with the activation key:
 +
+.. If Simple Content Access (SCA) is enabed:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# hammer activation-key product-content \
+--content-access-mode-all true \
+--name "_My_Activation_Key_" \
+--organization "_My_Organization_"
+----
++
+.. If SCA is not enabled:
++
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # hammer activation-key product-content \

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -48,12 +48,12 @@ If you want unlimited hosts to register with the activation key, ensure the *Unl
 . From the *Content View* list, select a Content View to use.
 If you intend to use the deprecated `Katello Agent` instead of `Remote Execution`, the Content View must contain the {project-client-name} repository because it contains the `katello-agent` package.
 ifndef::orcharhino[]
-. If Simple Content Access (SCA) is not enabled:
+. If Simple Content Access (SCA) is enabled:
+.. In the *Repository Sets* tab, ensure only your named repository is enabled.
+. If SCA is not enabled:
 .. Click the *Subscriptions* tab, then click the *Add* submenu.
 .. Click the checkbox under the subscription you created before.
 .. Click *Add Selected*.
-. If SCA is enabled:
-.. In the *Repository Sets* tab, ensure only your named repository is enabled.
 endif::[]
 . Click *Save*.
 . Optional: For {RHEL} 8 hosts, in the *System Purpose* section, you can configure the activation key with system purpose to set on hosts during registration to enhance subscriptions auto attachment.


### PR DESCRIPTION
This update aims to fix [BZ#2211328](https://bugzilla.redhat.com/show_bug.cgi?id=2211328). 

* I added a decision tree to show different commands depending on whether SCA is or isn't enabled
* I switched the order of steps in the web UI equivalent of this decision tree in the same module (for consistency)

@bangelic I took the BZ from your BZ queue, so I'd appreciate it if you could take a look. I'll also appreciate a hint on who should do the SME review. Thanks!

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
