### PR TITLE
Add manifest & repo details in system requirements

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -44,6 +44,12 @@ endif::[]
 If your territory is USA and your language is English, set `en_US.utf-8` as the system-wide locale settings.
 For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring System Locale guide].
 
+ifdef::satellite[]
+Your {Project} must have the {SatelliteSub} manifest in your Customer Portal.
+{Project} must have {project-context}-{smart-proxy-context}-6.x repository enabled and synced.
+To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+endif::[]
+
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.
 When using custom certificates, the Common Name (CN) of the custom certificate must be a fully qualified domain name (FQDN) instead of a shortname.
 This does not apply to the clients of a {Project}.


### PR DESCRIPTION
The end-users must have the manifest in their customer portal account and the repo enabled and synced as it is the prerequisite to install the Project Server. When the Satellite was utilized as a proof-of-concept in a production environment, the capsule installation failed from their side. It was later discovered that the end-user didn't have a manifest in its customer portal account along with the mentioned repo being enabled. Hence, the added information in this PR can be accommodated in the system requirement section to bring a better installation experience.

https://bugzilla.redhat.com/show_bug.cgi?id=2211939

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
