### PR TITLE
Fix documentation page styling

### DIFF
--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -603,8 +603,7 @@ body>div[id] {
   max-width: 62.5em;
   position: relative;
   padding-left: .9375em;
-  padding-right: .9375em;
-  width: 100%
+  padding-right: .9375em
 }
 
 body>div[id]::before,

--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -828,7 +828,8 @@ body.toc2 #header>h1:nth-last-child(2) {
 #footer {
   max-width: none;
   background: rgb(2, 93, 140);
-  padding: 1.25em
+  padding: 1.25em;
+  margin-left: 2em
 }
 
 #footer-text {

--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -753,7 +753,7 @@ body.toc2 #header>h1:nth-last-child(2) {
     border-bottom-width: 0!important;
     z-index: 1000;
     padding: 1.25em 1em;
-    height: 100%;
+    height: calc(100% - (70px + 2.5em));
     overflow: auto
   }
   #toc.toc2 #toctitle {


### PR DESCRIPTION
I noticed, that the page formatting makes the body/nav/footer overlap a bit, tried to fix this with this PR.
If you want to compensate the individual spacings differently, I can of course change it! (tried to keep it simple and easily distinguishable from where the compensations come)
As this is my 2nd PR I might still be doing something wrong, please just correct me if there is anything 🙂 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
