### PR TITLE
fix PostgreSQL (12→10) and Ruby (2.7→2.5) versions in troubleshooting

### DIFF
--- a/guides/common/modules/con_troubleshooting-postgresql.adoc
+++ b/guides/common/modules/con_troubleshooting-postgresql.adoc
@@ -11,14 +11,14 @@ List the enabled modules:
 # dnf module list --enabled
 ----
 
-If the PostgreSQL 12 module has already been enabled, perform a module reset:
+If the PostgreSQL 10 module has already been enabled, perform a module reset:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # dnf module reset postgresql
 ----
 
-If a database was previously created using PostgreSQL 12, perform an upgrade:
+If a database was previously created using PostgreSQL 10, perform an upgrade:
 
 . Enable the DNF modules:
 +

--- a/guides/common/modules/con_troubleshooting-ruby.adoc
+++ b/guides/common/modules/con_troubleshooting-ruby.adoc
@@ -11,7 +11,7 @@ List the enabled modules:
 # dnf module list --enabled
 ----
 
-If the Ruby 2.7 module has already been enabled, perform a module reset:
+If the Ruby 2.5 module has already been enabled, perform a module reset:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
we need to call out the *wrong* versions, not the expected ones


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
