### PR TITLE
Reword cloning process overview (goferd has been deprecated)

### DIFF
--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -22,7 +22,7 @@ Ensure that you understand the following terms:
 . Clone the source server to the target server.
 . Power off the source server.
 . Update the network configuration on the target server to match the target server’s IP address with its new host name.
-. Restart *goferd* in Content hosts and {SmartProxies} to refresh the connection.
+. If any content hosts use the deprecated Katello Agent, restart the `goferd` service on all those content hosts and their {SmartProxies} to refresh the connection.
 . Test the new target server.
 
 


### PR DESCRIPTION
This update aims to fix [BZ#2178929](https://bugzilla.redhat.com/show_bug.cgi?id=2178929). I rephrased a step in a procedure to clone a server as suggested in the BZ.

@AkshayGadhaveRH I took the BZ from your queue, can you please review this PR?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
