### PR TITLE
Tweak install attributes to differentiate between project and client

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -77,7 +77,7 @@
 :oVirtEngine: {oVirt} Engine
 :oVirtShort: {oVirt}
 :package-clean: dnf clean
-:package-install-project: dnf install
+:project-package-install: dnf install
 :package-install: dnf install
 :package-remove-project: dnf remove
 :package-remove: dnf remove

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -78,7 +78,7 @@
 :oVirtShort: {oVirt}
 :package-clean: dnf clean
 :project-package-install: dnf install
-:package-install: dnf install
+:client-package-install: dnf install
 :package-remove-project: dnf remove
 :package-remove: dnf remove
 :package-update-project: dnf update

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -4,7 +4,7 @@
 :nfs-client-package: nfs-common
 :nfs-server-package: nfs-kernel-server
 :package-clean: apt-get clean
-:package-install-project: apt-get install
+:project-package-install: apt-get install
 :package-install: apt-get install
 :package-remove-project: apt-get remove
 :package-remove: apt-get remove

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -5,7 +5,7 @@
 :nfs-server-package: nfs-kernel-server
 :package-clean: apt-get clean
 :project-package-install: apt-get install
-:package-install: apt-get install
+:client-package-install: apt-get install
 :package-remove-project: apt-get remove
 :package-remove: apt-get remove
 :package-update-project: apt-get upgrade

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -76,7 +76,7 @@
 :oVirt: Red{nbsp}Hat{nbsp}Virtualization
 :oVirtEngine: Red{nbsp}Hat Virtualization Manager
 :oVirtShort: RHV
-:package-install-project: satellite-maintain packages install
+:project-package-install: satellite-maintain packages install
 :package-remove-project: satellite-maintain packages remove
 :package-update-project: satellite-maintain packages update
 :PIV: CAC

--- a/guides/common/modules/con_external-authentication-for-provisioned-hosts.adoc
+++ b/guides/common/modules/con_external-authentication-for-provisioned-hosts.adoc
@@ -15,7 +15,7 @@ To use {FreeIPA} for provisioned hosts, complete the following steps to install 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} ipa-client
+# {project-package-install} ipa-client
 ----
 . Configure the server as a {FreeIPA} client:
 +

--- a/guides/common/modules/con_troubleshooting-postgresql.adoc
+++ b/guides/common/modules/con_troubleshooting-postgresql.adoc
@@ -30,7 +30,7 @@ If a database was previously created using PostgreSQL 10, perform an upgrade:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {client-package-install} postgresql-upgrade
+# {project-package-install} postgresql-upgrade
 ----
 . Perform the upgrade:
 +

--- a/guides/common/modules/con_troubleshooting-postgresql.adoc
+++ b/guides/common/modules/con_troubleshooting-postgresql.adoc
@@ -30,7 +30,7 @@ If a database was previously created using PostgreSQL 10, perform an upgrade:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} postgresql-upgrade
+# {client-package-install} postgresql-upgrade
 ----
 . Perform the upgrade:
 +

--- a/guides/common/modules/proc_adding-rhel-system-roles.adoc
+++ b/guides/common/modules/proc_adding-rhel-system-roles.adoc
@@ -33,7 +33,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} rhel-system-roles
+# {project-package-install} rhel-system-roles
 ----
 +
 The `rhel-system-roles` package downloads to `/usr/share/ansible/roles/`.

--- a/guides/common/modules/proc_benchmarking-raw-db-performance.adoc
+++ b/guides/common/modules/proc_benchmarking-raw-db-performance.adoc
@@ -6,7 +6,7 @@ To get a list of the top table sizes in disk space for both Candlepin, Foreman, 
 endif::[]
 
 PGbench utility (note you may need to resize PostgreSQL data directory `{postgresql-lib-dir}` directory to 100 GiB or what does benchmark take to run) might be used to measure PostgreSQL performance on your system.
-Use `{package-install} postgresql-contrib` to install it.
+Use `{client-package-install} postgresql-contrib` to install it.
 ifndef::orcharhino[]
 For more information, see https://github.com/RedHatSatellite/satellite-support[github.com/RedHatSatellite/satellite-support].
 endif::[]

--- a/guides/common/modules/proc_building-a-discovery-image.adoc
+++ b/guides/common/modules/proc_building-a-discovery-image.adoc
@@ -93,7 +93,7 @@ ifdef::satellite[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} livecd-tools
+# {project-package-install} livecd-tools
 ----
 
 * For the following {RHEL} 7 repositories required to build the Discovery image, change the download policy to *Immediate*.

--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -177,7 +177,7 @@ You can either mount the shared storage or copy the backup files to the `/backup
 +
 [options="nowrap" subs="attributes"]
 ----
-# {package-install} satellite-clone
+# {client-package-install} satellite-clone
 ----
 +
 After you install the `satellite-clone` tool, you can adjust any configuration to suit your own deployment in the `/etc/satellite-clone/satellite-clone-vars.yml` file.

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -18,7 +18,7 @@ include::snip_firewalld.adoc[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} dhcp bind
+# {client-package-install} dhcp bind
 ----
 
 . Generate a security token:
@@ -120,7 +120,7 @@ _990_
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} {nfs-server-package}
+# {client-package-install} {nfs-server-package}
 # systemctl enable --now nfs-server
 ----
 

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -49,7 +49,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} ipa-client
+# {project-package-install} ipa-client
 ----
 
 . Configure the IdM client by running the installation script and following the on-screen prompts:

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -53,7 +53,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} ipa-client
+# {project-package-install} ipa-client
 ----
 . On {ProjectServer}, enter the following command as root to configure {FreeIPA}-enrollment:
 +

--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -59,7 +59,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {client-package-install} ipxe-bootimgs
+# {project-package-install} ipxe-bootimgs
 ----
 . Correct the SELinux file contexts:
 +
@@ -72,7 +72,7 @@ ifdef::foreman-deb[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {client-package-install} ipxe
+# {project-package-install} ipxe
 ----
 endif::[]
 

--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -59,7 +59,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} ipxe-bootimgs
+# {client-package-install} ipxe-bootimgs
 ----
 . Correct the SELinux file contexts:
 +
@@ -72,7 +72,7 @@ ifdef::foreman-deb[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} ipxe
+# {client-package-install} ipxe
 ----
 endif::[]
 

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
@@ -34,7 +34,7 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} puppetserver
+# {project-package-install} puppetserver
 ----
 . On {SmartProxyServer}, create directories for puppet certificates:
 +

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
@@ -25,7 +25,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} puppetserver
+# {project-package-install} puppetserver
 ----
 . On {SmartProxyServer}, create directories for puppet certificates:
 +

--- a/guides/common/modules/proc_configuring-repositories-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-deb.adoc
@@ -6,7 +6,7 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} wget ca-certificates
+# {client-package-install} wget ca-certificates
 ----
 
 . Change directory to `/tmp` and retrieve the `{PuppetReleaseDeb}` package:
@@ -20,7 +20,7 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} /tmp/{PuppetReleaseDeb}
+# {client-package-install} /tmp/{PuppetReleaseDeb}
 ----
 
 . Enable the Foreman repository:

--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -12,7 +12,7 @@ ifdef::foreman-el,katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
+# {client-package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
 ----
 endif::[]
 ifdef::katello[]
@@ -21,7 +21,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
+# {client-package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
 ifdef::foreman-el,katello[]
@@ -30,6 +30,6 @@ ifdef::foreman-el,katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} https://yum.puppet.com/puppet7-release-el-{distribution-major-version}.noarch.rpm
+# {client-package-install} https://yum.puppet.com/puppet7-release-el-{distribution-major-version}.noarch.rpm
 ----
 endif::[]

--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -12,7 +12,7 @@ For more information, see xref:configuring-an-external-dhcp-server_{context}[].
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} {nfs-client-package}
+# {client-package-install} {nfs-client-package}
 ----
 . Create the DHCP directories for NFS:
 +

--- a/guides/common/modules/proc_configuring-server-for-kvm-connections.adoc
+++ b/guides/common/modules/proc_configuring-server-for-kvm-connections.adoc
@@ -34,7 +34,7 @@ $ exit
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} libvirt-client
+# {project-package-install} libvirt-client
 ----
 +
 . Use the following command to test the connection to the KVM server:

--- a/guides/common/modules/proc_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/proc_configuring-the-discovery-service.adoc
@@ -59,7 +59,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} {fdi-package-name}
+# {project-package-install} {fdi-package-name}
 ----
 endif::[]
 

--- a/guides/common/modules/proc_configuring-users-os-for-keycloak-authentication-with-cac-cards.adoc
+++ b/guides/common/modules/proc_configuring-users-os-for-keycloak-authentication-with-cac-cards.adoc
@@ -9,7 +9,7 @@ Complete this procedure on each system from which you want to be able to log in 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-{package-install-project} opensc -y
+{project-package-install} opensc -y
 ----
 . Install the Firefox browser if not installed.
 . Launch Firefox and navigate to *Preferences*.

--- a/guides/common/modules/proc_creating-a-complete-permission-table.adoc
+++ b/guides/common/modules/proc_creating-a-complete-permission-table.adoc
@@ -9,7 +9,7 @@ Execute the following command on {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} foreman-console
+# {project-package-install} foreman-console
 ----
 . Start the {Project} console with the following command:
 +

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -29,7 +29,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} python39-pulp_manifest
+# {project-package-install} python39-pulp_manifest
 ----
 ifdef::satellite[]
 +

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -39,7 +39,7 @@ Alternatively, to prevent downtime caused by stopping the service, you can use t
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} packages unlock
-# {package-install} python39-pulp_manifest
+# {client-package-install} python39-pulp_manifest
 # {foreman-maintain} packages lock
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-custom-rhel-images.adoc
+++ b/guides/common/modules/proc_creating-custom-rhel-images.adoc
@@ -16,13 +16,13 @@ Before you can create custom images, install the following packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} virt-manager virt-viewer libvirt qemu-kvm
+# {client-package-install} virt-manager virt-viewer libvirt qemu-kvm
 ----
 * Install the following command line tools:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} virt-install libguestfs-tools-c
+# {client-package-install} virt-install libguestfs-tools-c
 ----
 
 [NOTE]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -10,5 +10,5 @@ After you configure {ProductName} to use a custom SSL certificate, you must also
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {package-install} http://_{context}.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
+# {client-package-install} http://_{context}.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
 ----

--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -10,7 +10,7 @@ Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} gssproxy {nfs-client-package}
+# {project-package-install} gssproxy {nfs-client-package}
 ----
 
 .Procedure
@@ -18,7 +18,7 @@ Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install-project} sssd adcli realmd ipa-python-compat krb5-workstation samba-common-tools
+# {project-package-install} sssd adcli realmd ipa-python-compat krb5-workstation samba-common-tools
 ----
 . Enroll {ProjectServer} with the AD server.
 You may need to have administrator permissions to perform the following command:

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -26,7 +26,7 @@ ifdef::satellite,orcharhino[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} {fdi-package-name}
+# {project-package-install} {fdi-package-name}
 ----
 endif::[]
 

--- a/guides/common/modules/proc_installing-the-katello-agent.adoc
+++ b/guides/common/modules/proc_installing-the-katello-agent.adoc
@@ -26,7 +26,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} katello-agent
+# {client-package-install} katello-agent
 ----
 . Start the `goferd` service:
 +

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -9,13 +9,13 @@ However, you can install any suitable load balancing software solution that supp
 +
 [options="nowrap" subs="attributes"]
 ----
-# {package-install} haproxy
+# {client-package-install} haproxy
 ----
 . Install the following package that includes the `semanage` tool:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {package-install} policycoreutils-python-utils
+# {client-package-install} policycoreutils-python-utils
 ----
 . Configure SELinux to allow HAProxy to bind any port:
 +

--- a/guides/common/modules/proc_installing-the-project-ansible-modules.adoc
+++ b/guides/common/modules/proc_installing-the-project-ansible-modules.adoc
@@ -8,5 +8,5 @@ Use this procedure to install the {Project} Ansible modules.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} {ansible-collection-package}
+# {project-package-install} {ansible-collection-package}
 ----

--- a/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
+++ b/guides/common/modules/proc_installing-the-satellite-server-packages.adoc
@@ -28,7 +28,7 @@ ifdef::foreman-deb[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} {foreman-installer-package}
+# {client-package-install} {foreman-installer-package}
 ----
 endif::[]
 

--- a/guides/common/modules/proc_installing-the-sos-package.adoc
+++ b/guides/common/modules/proc_installing-the-sos-package.adoc
@@ -11,5 +11,5 @@ For more information on using `sos`, see the Knowledgebase solution https://acce
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} sos
+# {client-package-install} sos
 ----

--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -14,7 +14,7 @@ The `{foreman-maintain} packages` command restarts some services on the operatin
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {package-install-project} _package_1_ _package_2_
+# {project-package-install} _package_1_ _package_2_
 ----
 * To update specific packages on {ProjectServer} or {SmartProxyServer}, enter the following command:
 +

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -33,7 +33,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
+# {client-package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
 ----
 endif::[]

--- a/guides/common/modules/proc_preparing-cloud-init-images-in-rhv.adoc
+++ b/guides/common/modules/proc_preparing-cloud-init-images-in-rhv.adoc
@@ -10,7 +10,7 @@ To use `cloud-init` during provisioning, you must prepare an image with `cloud-i
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{package-install} cloud-init
+{client-package-install} cloud-init
 ----
 +
 . To the `/etc/cloud/cloud.cfg` file, add the following information:

--- a/guides/common/modules/proc_registering-clients-manually-using-katello-consumer-ca-rpm.adoc
+++ b/guides/common/modules/proc_registering-clients-manually-using-katello-consumer-ca-rpm.adoc
@@ -14,7 +14,7 @@ To register clients manually, complete the following procedure on each client th
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {package-install} http://_{loadbalancer-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
+# {client-package-install} http://_{loadbalancer-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
 ----
 . Register the client and include the `--serverurl` and `--baseurl` options:
 +

--- a/guides/common/modules/proc_registering-project-as-a-keycloak-client.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-keycloak-client.adoc
@@ -18,7 +18,7 @@ You can also register two different {Project} clients to {Keycloak} if you want 
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# {package-install-project} mod_auth_openidc keycloak-httpd-client-install
+# {project-package-install} mod_auth_openidc keycloak-httpd-client-install
 ----
 
 . Register {Project} to {Keycloak} as a client.

--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -63,7 +63,7 @@ For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote
 ----
 # {package-remove} katello-ca-consumer*
 
-# {package-install} http://_new-{smartproxy-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
+# {client-package-install} http://_new-{smartproxy-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
 
 # subscription-manager register --org="_My_Organization_" \
 --environment="_Library_" \

--- a/guides/common/modules/proc_resolving-package-dependency-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependency-errors.adoc
@@ -29,7 +29,7 @@ If you have successfully installed the {Project} packages, skip this procedure.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} _package_name_
+# {client-package-install} _package_name_
 ----
 
 . Change to the directory where the {Project} ISO is mounted:

--- a/guides/common/modules/proc_securing-the-dhcp-api.adoc
+++ b/guides/common/modules/proc_securing-the-dhcp-api.adoc
@@ -11,12 +11,12 @@ You can add an `omapi_key` to provide basic security.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ifndef::foreman-deb[]
 ----
-# {package-install} bind-utils
+# {client-package-install} bind-utils
 ----
 endif::[]
 ifdef::foreman-deb[]
 ----
-# {package-install} bind9-utils
+# {client-package-install} bind9-utils
 ----
 endif::[]
 . Generate a key:

--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -13,7 +13,7 @@ For more information about the `chrony` suite, see https://access.redhat.com/doc
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} chrony
+# {client-package-install} chrony
 ----
 
 . Start and enable the `chronyd` service:

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -23,7 +23,7 @@ Ensure this share provides the appropriate permissions to {ProjectServer} and it
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} {nfs-server-package}
+# {project-package-install} {nfs-server-package}
 ----
 . You need to copy the existing contents of `/var/lib/pulp` to the NFS share.
 First, mount the NFS share to a temporary location:

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -22,7 +22,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install-project} insights-client
+# {project-package-install} insights-client
 ----
 +
 . To register {ProjectServer} with Red{nbsp}Hat Insights, enter the following command:

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -61,7 +61,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} cloud-init open-vm-tools perl
+# {client-package-install} cloud-init open-vm-tools perl
 ----
 . Disable network configuration by `cloud-init`:
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -28,7 +28,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} postgresql-evr
+# {client-package-install} postgresql-evr
 ----
 endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts* > *Discovered hosts*.


### PR DESCRIPTION
First attempt at tweaking the install attributes. The goal is to be able to differentiate between commands run on the server (like {project-package-install}) and the client (like {client-package-install}).

* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
