### PR TITLE
[BLOCKER] Fix Ansible link Satellite

### DIFF
--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -49,7 +49,7 @@ endif::[]
 .. To sync {Project} from `console.redhat.com`, enter your token in the *Auth Token* field and enter your SSO URL in the the *Auth URL* field.
 ifdef::satellite[]
 +
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/getting_started_with_automation_hub/proc-create-api-token[Retrieving your Red{nbsp}Hat Certified Collections Sync URL and API token] in _Managing Red{nbsp}Hat Certified and Ansible Galaxy collections in Automation Hub_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/getting_started_with_automation_hub/[_Getting started with automation hub_].
 endif::[]
 .. To sync {Project} from {Project}, leave both authentication fields blank.
 . Click *Save*.


### PR DESCRIPTION
It's breaking the build.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
