### PR TITLE
Split troubleshooting file 3.2

### DIFF
--- a/guides/common/modules/ref_troubleshooting-sync-errors.adoc
+++ b/guides/common/modules/ref_troubleshooting-sync-errors.adoc
@@ -1,31 +1,31 @@
-[id="Troubleshooting_{context}"]
-= Troubleshooting
+[id="Troubleshooting_Sync_Errors_{context}"]
+= Troubleshooting Sync Errors
 
-== "[Errno 1] Operation not permitted: ..." during repository syncing:
+"[Errno 1] Operation not permitted: ..." during repository syncing::
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # chown --recursive pulp.pulp /var/lib/pulp/media/
 ----
 
-== "{“policy”:[""" is not a valid choice."]}" during Debian repository syncing:
+"{“policy”:[""" is not a valid choice."]}" during Debian repository syncing::
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # foreman-rake katello:migrate_deb_content_attributes_to_pulp3
 ----
 
-== 500 API error during syncing with "cryptography.fernet.InvalidToken" in /var/log/messages traceback:
+500 API error during syncing with "cryptography.fernet.InvalidToken" in /var/log/messages traceback::
 
 Run this on the Katello server and every smart proxy.
-
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' pulpcore-manager datarepair-2327 --dry-run
 ----
-
++
 If you see values greater than 0 returned from the dry-run:
-
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' pulpcore-manager datarepair-2327

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -63,7 +63,7 @@ include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
 
 ifdef::katello[]
 [appendix]
-include::common/modules/con_troubleshooting.adoc[leveloffset=+1]
+include::common/modules/ref_troubleshooting-sync-errors.adoc[leveloffset=+1]
 endif::[]
 
 [appendix]


### PR DESCRIPTION
The purpose to split this file is downstream inclusion. Also, there were more than one heading per file which not a standard modularization practise. In addition to this, it will help reviewing the diff files more conveniently. Therefore, it became necessary to split this file, addressing many purposes.

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
