### PR TITLE
Add procedure for enabling custom repos

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -4,6 +4,8 @@ include::modules/proc_creating-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_cloning-hosts.adoc[leveloffset=+1]
 
+include::modules/proc_enabling-custom-repositories-on-content-hosts.adoc[leveloffset=+1]
+
 include::modules/proc_associating-a-virtual-machine-from-a-hypervisor.adoc[leveloffset=+1]
 
 ifdef::satellite[]

--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -4,8 +4,6 @@ include::modules/proc_creating-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_cloning-hosts.adoc[leveloffset=+1]
 
-include::modules/proc_enabling-custom-repositories-on-content-hosts.adoc[leveloffset=+1]
-
 include::modules/proc_associating-a-virtual-machine-from-a-hypervisor.adoc[leveloffset=+1]
 
 ifdef::satellite[]
@@ -15,6 +13,8 @@ include::modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc[leveloff
 endif::[]
 
 include::modules/proc_changing-the-module-stream-for-a-host.adoc[leveloffset=+1]
+
+include::modules/proc_enabling-custom-repositories-on-content-hosts.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-host-group.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -50,6 +50,4 @@ include::modules/proc_importing-a-repository.adoc[leveloffset=+1]
 
 include::modules/proc_importing-a-repository-from-a-web-server.adoc[leveloffset=+1]
 
-include::modules/proc_enabling-custom-repositories-on-content-hosts.adoc[leveloffset=+1]
-
 include::modules/ref_iss-export-import-cheat-sheet.adoc[leveloffset=+1]

--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -50,4 +50,6 @@ include::modules/proc_importing-a-repository.adoc[leveloffset=+1]
 
 include::modules/proc_importing-a-repository-from-a-web-server.adoc[leveloffset=+1]
 
+include::modules/proc_enabling-custom-repositories-on-content-hosts.adoc[leveloffset=+1]
+
 include::modules/ref_iss-export-import-cheat-sheet.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_enabling-custom-repositories-on-content-hosts.adoc
+++ b/guides/common/modules/proc_enabling-custom-repositories-on-content-hosts.adoc
@@ -1,0 +1,10 @@
+[id="Enabling_Custom_Repositories_on_Content_Hosts_{context}"]
+= Enabling Custom Repositories on Content Hosts
+
+As a Simple Content Access (SCA) user, you can enable all custom repositories on content hosts using the {ProjectWebUI}.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select a host.
+. Select the *Content* tab, then select *Repository sets*.
+. From the dropdown, you can filter the *Repository type* column to *Custom*.
+. Select the desired number of repositories or click the *Select All* checkbox to select all repositories, then click the vertical ellipsis, and select *Override to Enabled*.


### PR DESCRIPTION
A new procedure was required to show how to enable custom repositories
on content hosts using the specified web UI. This
procedure gives the
user the steps to enable any and all custom
repositories on content
hosts using the specified web UI.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
