### PR TITLE
Rerun buttons

### DIFF
--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -46,7 +46,7 @@ There can only be one active job with a given purpose at a time.
 Click *Next* after you have entered the required information.
 . Review job details.
 You have the option to return to any part of the job wizard and edit the information.
-. Click *Run* to schedule the job for execution.
+. Click *Submit* to schedule the job for execution.
 
 [id="cli-executing-a-remote-job_{context}"]
 .CLI procedure


### PR DESCRIPTION
This update aims to document the enhancement in [BZ#2203183](https://bugzilla.redhat.com/show_bug.cgi?id=2203183).

The buttons in the form for running jobs on hosts have been changed, as described [in the Foreman community](https://github.com/theforeman/foreman_remote_execution/pull/794).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
