### PR TITLE
Update procedure for repos on AK

### DIFF
--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -1,7 +1,7 @@
 [id="enabling-and-disabling-repositories-on-activation-key_{context}"]
 = Enabling and Disabling Repositories on Activation Key
 
-As a Simple Content Access (SCA) user, you can enable all custom repositories on an activation key using the {ProjectWebUI}.
+As a Simple Content Access (SCA) user, you can enable all custom repositories on an activation key in the {ProjectWebUI}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Activation Keys* and select an activation key.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -4,8 +4,8 @@
 Use this procedure to enable or disable repositories on an activation key.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Activation Keys*.
-. Select your organization.
-. Select the activation key.
-. Click the *Repository sets* tab.
-. From the *Select Action* menu, choose *Override to Enabled* or *Override to Disabled* to enable or disable repositories on the activation key.
+. In the {ProjectWebUI}, navigate to *Content* > *Activation Keys* and select an activation key.
+. Select the *Repository Sets* tab.
+. From the dropdown, you can filter the *Repository type* column to *Custom*.
+. Select the desired repositories or click the *Select All* checkbox to select all repositories.
+. From the *Select Action* list, select *Override to Enabled*.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -1,11 +1,11 @@
 [id="enabling-and-disabling-repositories-on-activation-key_{context}"]
 = Enabling and Disabling Repositories on Activation Key
 
-Use this procedure to enable or disable repositories on an activation key.
+As a Simple Content Access (SCA) user, you can enable all custom repositories on an activation key using the {ProjectWebUI}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Activation Keys* and select an activation key.
 . Select the *Repository Sets* tab.
-. From the dropdown, you can filter the *Repository type* column to *Custom*.
+. From the dropdown, you can filter the *Repository type* column to *Custom* or *Red Hat*, if desired.
 . Select the desired repositories or click the *Select All* checkbox to select all repositories.
-. From the *Select Action* list, select *Override to Enabled*.
+. From the *Select Action* list, select *Override to Enabled*, *Override to Disabled*, or *Reset to Default*.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -1,7 +1,7 @@
 [id="enabling-and-disabling-repositories-on-activation-key_{context}"]
 = Enabling and Disabling Repositories on Activation Key
 
-As a Simple Content Access (SCA) user, you can enable all custom repositories on an activation key in the {ProjectWebUI}.
+As a Simple Content Access (SCA) user, you can enable or disable repositories on an activation key in the {ProjectWebUI}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Activation Keys* and select an activation key.


### PR DESCRIPTION
The procedure for enabling and disabling repositories on activation
keys was updated to reflect the simplification
for enabling and
disabling repositories.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
