### PR TITLE
Deployment guide ddf tweaks

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -27,9 +27,9 @@ endif::[]
 
 [[part-Deployment_Planning]]
 = {Project} Deployment Planning
-include::topics/Deployment_Considerations.adoc[]
-
 include::topics/Deployment_Scenarios.adoc[]
+
+include::topics/Deployment_Considerations.adoc[]
 
 include::topics/Required_Technical_Users.adoc[]
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -2,9 +2,6 @@
 == Deployment Considerations
 
 This section provides an overview of general topics to be considered when planning a {ProjectName} deployment together with recommendations and references to more specific documentation.
-ifdef::satellite[]
-For an example implementation based on a sample customer scenario (specific to {Project}), see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/articles/1585273[10 Steps to Build an SOE: How Red Hat Satellite 6 Supports Setting up a Standard Operating Environment].
-endif::[]
 
 ifdef::satellite[]
 [[sect-Satellite_Server_Configuration]]


### PR DESCRIPTION
This update attempts to address the following two BZs in the Overview, Concepts, and Deployment Considerations guide:

* https://bugzilla.redhat.com/show_bug.cgi?id=2216185 -- Removing a link to a very outdated pdf document in Red Hat Knowledgebase
* https://bugzilla.redhat.com/show_bug.cgi?id=2216192 -- Switching the order of two chapters on deploying the project

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
