### PR TITLE
Remove reference to an outdated document

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -2,9 +2,6 @@
 == Deployment Considerations
 
 This section provides an overview of general topics to be considered when planning a {ProjectName} deployment together with recommendations and references to more specific documentation.
-ifdef::satellite[]
-For an example implementation based on a sample customer scenario (specific to {Project}), see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/articles/1585273[10 Steps to Build an SOE: How Red Hat Satellite 6 Supports Setting up a Standard Operating Environment].
-endif::[]
 
 ifdef::satellite[]
 [[sect-Satellite_Server_Configuration]]


### PR DESCRIPTION
This is a follow-up on [PR#22761](https://github.com/theforeman/foreman-documentation/pull/2271). That PR removed a link to a pdf document in Red Hat Knowledgebase, but only from version 3.7. After taking a closer look at that pdf document, I realized it needs to be removed from the previous versions as well.

In this PR, I cherry-picked the commit accepted in PR#2276 and added it to branch 3.6. The commit also needs to be included in the branches for lower versions, as indicated in the checklist below.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
