### PR TITLE
Deprecate Puppet host macros

### DIFF
--- a/guides/common/modules/ref_host-specific-variables.adoc
+++ b/guides/common/modules/ref_host-specific-variables.adoc
@@ -16,7 +16,7 @@ See xref:Parsing_Arrays_{context}[].
 |@host.diskLayout |The disk layout of the host.
 Can be inherited from the operating system.
 |@host.domain |The domain of the host.
-|@host.environment |The Puppet environment of the host.
+|@host.environment *Deprecated* Use the `host_puppet_environment` variable instead. |The Puppet environment of the host.
 |@host.facts |Returns a Ruby hash of facts from Facter.
 For example to access the 'ipaddress' fact from the output, specify @host.facts['ipaddress'].
 |@host.grub_pass |Returns the host's bootloader password.
@@ -50,8 +50,8 @@ See xref:Parsing_Arrays_{context}[].
 |@host.provision_interface |Returns the provisioning interface of the host.
 Returns an interface object.
 |@host.ptable |The partition table name.
-|@host.puppet_ca_server |The Puppet CA server the host must use.
-|@host.puppetmaster |The Puppet server the host must use.
+|@host.puppet_ca_server *Deprecated* Use the `host_puppet_ca_server` variable instead. |The Puppet CA server the host must use.
+|@host.puppetmaster *Deprecated* Use the `host_puppet_server` variable instead. |The Puppet server the host must use.
 |@host.pxe_build? |Returns `true` if the host is provisioned using the network or PXE.
 |@host.shortname |The short name of the host.
 |@host.sp_ip |The IP address of the BMC interface.


### PR DESCRIPTION
Deprecated since [Foreman 2.5](https://www.theforeman.org/manuals/2.5/index.html#Deprecations).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
