### PR TITLE
Update :KubeVirt: to OpenShift Virtualization

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -69,7 +69,7 @@
 :ISS: Inter-Satellite Synchronization
 :Keycloak-short: RHSSO
 :Keycloak: Red{nbsp}Hat Single Sign-On
-:KubeVirt: Container-native Virtualization
+:KubeVirt: OpenShift Virtualization
 :LoraxCompose: Red{nbsp}Hat Image Builder
 :OpenStack: Red{nbsp}Hat OpenStack Platform
 :ovirt-example-com: rhv.example.com


### PR DESCRIPTION
This update aims to fix [BZ#2192817](https://bugzilla.redhat.com/show_bug.cgi?id=2192817). 

"Container-native Virtualization" is now called "OpenShift Virtualization". This pull request updates the corresponding attribute in attributes-satellite.adoc.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
