### PR TITLE
Add postgresql-contrib package for ExternalDB

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -12,7 +12,7 @@ include::snip_firewalld.adoc[]
 +
 ----
 ifdef::katello,satellite,orcharhino[]
-# dnf install postgresql-server postgresql-evr
+# dnf install postgresql-server postgresql-evr postgresql-contrib
 endif::[]
 ifndef::katello,satellite,orcharhino[]
 # dnf install postgresql-server


### PR DESCRIPTION
Pulpcore migration is failing on Project on the remote database. Upon troubleshooting, we found that the `postgresql-contrib` package was missing and should be installed along with PostgreSQL. Therefore, we added it alongside the pgsql installation command as it was already mentioned on the older docs of Katello. This will resolve the issue of installing the Project on the external databases.

https://bugzilla.redhat.com/show_bug.cgi?id=2216745

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
