### PR TITLE
Remove puppet-server-foreman-url

### DIFF
--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -43,8 +43,7 @@ _output omitted_
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
 --foreman-proxy-oauth-consumer-key "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_" \
---foreman-proxy-oauth-consumer-secret "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_" \
---puppet-server-foreman-url "https://_{foreman-example-com}_"
+--foreman-proxy-oauth-consumer-secret "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"
 ----
 
 . On {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -105,8 +105,7 @@ _output omitted_
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
 --foreman-proxy-oauth-consumer-key "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_" \
---foreman-proxy-oauth-consumer-secret "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_" \
---puppet-server-foreman-url "https://_{foreman-example-com}_"
+--foreman-proxy-oauth-consumer-secret "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"
 ----
 
 . On {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:


### PR DESCRIPTION
By enabling the puppet server, you no longer need to have the command. At the runtime installation, this option is not observed because it has been deprecated.

https://bugzilla.redhat.com/show_bug.cgi?id=2211155

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
