### PR TITLE
Add one more service for Port 9090

### DIFF
--- a/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
+++ b/guides/common/modules/ref_capsule-ports-and-firewalls-requirements.adoc
@@ -54,6 +54,7 @@ ifndef::katello,satellite,orcharhino[]
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | Content Host registration | Deprecated and only needed for Client hosts deployed before upgrades
+| 9090 | TCP | HTTPS | Client | Register Endpoint | Client Registration with an external {SmartProxyServer}
 | 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
 | 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
 | 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality


### PR DESCRIPTION
Port 9090 is mentioned for various reasons in table 1.3 of Ports and Firewall requirements but it is missing the declaration for Register Endpoint. If a client would need to be registered with an external Proxy Server via the Global Registration method, then port 9090 should be opened from the Client to the Proxy server. Else, the Register Endpoint cannot be accessed over port 443 of a Proxy.

https://bugzilla.redhat.com/show_bug.cgi?id=2214542

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
