### PR TITLE
Fix 'hammer content-import' command

### DIFF
--- a/guides/common/modules/proc_importing-syncable-exports.adoc
+++ b/guides/common/modules/proc_importing-syncable-exports.adoc
@@ -6,7 +6,7 @@
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-import complete library
+# hammer content-import library
 --organization="_My_Organization_"
 --path="_My_Path_To_Syncable_Export_"
 ----


### PR DESCRIPTION
This PR addresses [BZ#2208315](https://bugzilla.redhat.com/show_bug.cgi?id=2208315). There is a mistake in a `hammer content-import` command that needs fixing.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
