### PR TITLE
Fix inconsistent capsule_cert example

### DIFF
--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -37,7 +37,7 @@ Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` c
 ----
 _output omitted_
 {installer-scenario-smartproxy} \
---certs-tar-file "/root/_{smartproxy-example-com}_-certs.tar" \
+--certs-tar-file "/root/{smart-proxy-context}_cert/_{smartproxy-example-com}_-certs.tar" \
 --foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \


### PR DESCRIPTION
[BZ#2213065](https://bugzilla.redhat.com/show_bug.cgi?id=2213065) reports that an example cert file is referenced inconsistently within a single procedure. This PR attempts to fix that.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
