### PR TITLE
Update procedure to deploy custom SSL to hosts

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -2,13 +2,15 @@
 
 = Deploying a Custom SSL Certificate to Hosts
 
-After you configure {ProductName} to use a custom SSL certificate, you must also install the `katello-ca-consumer` package on every host that is registered to this {ProductName}.
+After you configure {ProductName} to use a {customssl} certificate, you must also deploy the new {customssl} certificate on every host that is registered to this {ProductName}.
 
 .Procedure
 
-* On each host, install the `katello-ca-consumer` package:
+* On each host, run the following commands:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {package-install} http://_{context}.example.com_/pub/katello-ca-consumer-latest.noarch.rpm
+# _SERVER=$(subscription-manager config | awk '/ hostname/{print $NF}'| tr -d '[]')
+# curl -k https://$_SERVER/pub/katello-rhsm-consumer | bash
+# subscription-manager refresh
 ----


### PR DESCRIPTION
As the `katello-ca-consumer` rpm is deprecated, there are 2 ways end-users can deploy the custom SSL certificate to the hosts after deploying it to the Project. We have documented the recommended way to deploy it to the hosts. Also, we have added the insecure arguments will curl command so that it uses port 443 which is reliable at this point.

https://bugzilla.redhat.com/show_bug.cgi?id=2216692

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
