### PR TITLE
Improve Config SmartProxy for Reg&Prov

### DIFF
--- a/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
@@ -19,6 +19,11 @@ ifdef::foreman-deb,foreman-el[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # firewall-cmd --permanent --zone=public --add-port=8000/tcp
+----
+. On your {SmartProxyServer}, reload the firewall configuration:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
 # firewall-cmd --reload
 ----
 . On {ProjectServer}, add the {SmartProxy} to the list of trusted proxies.
@@ -31,7 +36,7 @@ This is required for {Project} to recognize hosts' IP addresses forwarded over t
 For security reasons, {Project} recognizes this HTTP header only from localhost by default.
 You can enter trusted proxies as valid IPv4 or IPv6 addresses of {SmartProxies}, or network ranges.
 +
-WARNING: Do not use a network range that is too wide, because this poses a potential security risk.
+WARNING: Do not use a network range that is too wide, because that poses a potential security risk.
 +
 Enter the following command.
 Note that the command overwrites the list that is currently stored in {Project}.


### PR DESCRIPTION
Feedback from #2219

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
