### PR TITLE
Note about capsule and embedded capsule in the same location

### DIFF
--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -4,6 +4,14 @@
 
 After installing {SmartProxyServer} packages, if there is more than one organization or location, you must assign the correct organization and location to {SmartProxy} to make {SmartProxy} visible in the {ProjectWebUI}.
 
+ifdef::satellite[]
+[NOTE]
+====
+Assigning a {SmartProxy} to the same location as your {ProjectServer} with an embedded {SmartProxy} prevents {Team}{nbsp}Insights from uploading the Insights inventory.
+To enable the inventory upload, synchronize SSH keys for both {SmartProxies}.
+====
+endif::[]
+
 .Procedure
 
 . Log into the {ProjectWebUI}.


### PR DESCRIPTION
 [BZ#2086843](https://bugzilla.redhat.com/show_bug.cgi?id=2086843) describes a problem customers are facing in (rare) setups where a Smart Proxy is added to the same location as a server with an embedded proxy.

This PR aims to address the problem by adding a note to the procedure for adding a Smart Proxy to a location.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
