### PR TITLE
Add link to peer review guide to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ This git repository contains PoC of improving Foreman documentation.
 ## Foreman Guides
 
 This is a tree of documentation based on Red Hat Satellite 6 official books.
-Contributions are welcome.
 See README in the guides/ subdirectory for more information.
 
 * [guides](guides/README.md)
+
+## Contributing
+
+Contributions are welcome.
+
+New contributions are subject to technical review for accuracy and editorial review for consistency.
+For an overview of what to expect from editorial review, see [Peer review guide for technical documentation](https://redhat-documentation.github.io/peer-review/#checklist).
 
 ## Static Site
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Foreman documentation
 
-THIS IS A WORK IN PROGRESS. VISIT THE OFFICIAL [FOREMAN OR KATELLO DOCUMENTATION](https://theforeman.org/documentation.html) IF YOU ARE SEEKING HELP.
+This git repository contains the following documentation:
 
-This git repository contains PoC of improving Foreman documentation.
+* Official documentation for the Katello project
+* PoC of improving documentation for the Foreman project. See [this milestone](https://github.com/theforeman/foreman-documentation/milestone/3) to check the progress.
+
+For official Foreman documentation, see [Foreman Manual](https://theforeman.org/manuals/latest/index.html).
 
 ## Foreman Guides
 


### PR DESCRIPTION
I came across a peer review guide used internally at Red Hat, but available externally as well, and thought it could make a nice addition to README. It's been around for years, and as far as I can see, the things it recommends are aligned with Foreman docs conventions.

I imagine it could serve as a heads-up to any potential contributor from outside the regular writing team that they might want to expect wording and structure of their contributions to change before merging. In addition, I also simply consider this to be a good peer-review resource to keep at hand.

However, I don't feel particularly emotionally attached to this PR, so feel free to discard it if you disagree. I would be totally okay with that.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
