### PR TITLE
Add procedure for enhanced errata report

### DIFF
--- a/guides/common/assembly_using-report-templates.adoc
+++ b/guides/common/assembly_using-report-templates.adoc
@@ -14,6 +14,8 @@ include::modules/proc_importing-report-templates-using-the-api.adoc[leveloffset=
 
 include::modules/proc_generating-a-list-of-installed-packages.adoc[leveloffset=+1]
 
+include::modules/proc_generating-a-report-for-installable-errata-on-content-hosts.adoc[leveloffset=+1]
+
 ifdef::satellite[]
 include::modules/proc_creating-a-report-template-to-monitor-entitlements.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/proc_generating-a-report-for-installable-errata-on-content-hosts.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-errata-on-content-hosts.adoc
@@ -1,0 +1,15 @@
+[id="Generating_a_Report_for_Installable_Errata_on_Content_Hosts_{context}"]
+= Generating a Report for Installable Errata on Content Hosts
+
+Use this procedure to generate a report for content hosts showing installable errata in *Report Templates*.
+
+.Procedure
+. In the {ProjectwebUI}, navigate to *Monitor* > *Report Templates*.
+. To the right of *Host* - *Applicable Errata*, click *Generate*.
+. Optional: To schedule a report, click the icon to the right of the *Generate at* field, and select the specific date and time for generating the report.
+. Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
+. Select your output format.
+. Optional: Apply search query filters.
+To view all available results, do not populate the filter field with any values.
+. To filter errata or not, select your preferred installability option from the dropdown menu.
+If necessary, refer to the tooltips for additional information on each section.


### PR DESCRIPTION
A new procedure was required to show the user how they can generate a
report for content hosts showing installable errata.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
