### PR TITLE
Add procedure for Installable Applicable Errata

### DIFF
--- a/guides/common/assembly_configuring-host-collections.adoc
+++ b/guides/common/assembly_configuring-host-collections.adoc
@@ -26,11 +26,11 @@ include::modules/proc_adding-errata-to-a-host.adoc[leveloffset=+2]
 
 include::modules/proc_applying-installable-errata.adoc[leveloffset=+2]
 
-include::modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc[leveloffset=+2]
-
 include::modules/proc_filter-errata-by-type-severity.adoc[leveloffset=+2]
 
 include::modules/proc_viewing-errata-by-applicable-and-installable.adoc[leveloffset=+2]
+
+include::modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc[leveloffset=+2]
 
 include::modules/proc_removing-content-from-a-host-collection.adoc[leveloffset=+2]
 

--- a/guides/common/assembly_configuring-host-collections.adoc
+++ b/guides/common/assembly_configuring-host-collections.adoc
@@ -26,6 +26,8 @@ include::modules/proc_adding-errata-to-a-host.adoc[leveloffset=+2]
 
 include::modules/proc_applying-installable-errata.adoc[leveloffset=+2]
 
+include::modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc[leveloffset=+2]
+
 include::modules/proc_filter-errata-by-type-severity.adoc[leveloffset=+2]
 
 include::modules/proc_viewing-errata-by-applicable-and-installable.adoc[leveloffset=+2]

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -1,13 +1,12 @@
 [id="Generating_a_Report_for_Installable_and_Applicable_Errata_{context}"]
 = Generating a Report for Installable and Applicable Errata
 
-Use the following procedure to view a list of installable and applicable errata to install.
+Use the following procedure to view installable and applicable errata on managed hosts.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Click *Generate* for the *Host {endash} Applicable Errata* template.
-. Select *Applicable* to show all applicable errata.
-. Select *Installable* to limit the report exclusively to errata that are accessible in the content view environments of your host that can be installed.
+. In the *Instalability* drop down menu, select *Applicable* to show all applicable errata or *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that can be installed.
 . Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
 . Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
 . Click *Generate* to generate a CSV file that contains the report.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -6,10 +6,12 @@ Use the following procedure to view installable and applicable errata on managed
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Click *Generate* for the *Host {endash} Applicable Errata* template.
-. In the *Installability* drop down menu, select *Applicable* to show all applicable errata or *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that can be installed.
+. In the *Installability* drop down menu, select one of these options:
+* *Applicable* to show all applicable errata.
+* *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that may be installed.
 . Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
 . Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
 . Click *Generate* to generate a CSV file that contains the report.
-After {Project} has created the report, your browser automatically downloads it.
+Your browser automatically downloads the report after {Project} creates it.
 +
 If you have selected the *Send report via e-mail* checkbox, the report is sent to your e-mail address.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -1,7 +1,7 @@
 [id="Generating_a_Report_for_Installable_and_Applicable_Errata_{context}"]
 = Generating a Report for Installable and Applicable Errata
 
-Use the following procedure to view installable and applicable errata on managed hosts.
+Use the following procedure to generate a report of installable or applicable errata on managed hosts.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
@@ -9,9 +9,9 @@ Use the following procedure to view installable and applicable errata on managed
 . In the *Installability* drop down menu, select one of these options:
 * *Applicable* to show all applicable errata.
 * *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that may be installed.
-. Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
-. Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
 . Click *Generate* to generate a CSV file that contains the report.
 Your browser automatically downloads the report after {Project} creates it.
+. Optional: To schedule a report, click the *calendar* icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
+. Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
 +
 If you have selected the *Send report via e-mail* checkbox, the report is sent to your e-mail address.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -5,7 +5,7 @@ Use the following procedure to view a list of installable and applicable errata 
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
-. For the *Host {endash} Applicable Errata* template, click *Generate*.
+. Click *Generate* for the *Host {endash} Applicable Errata* template.
 . Select *Applicable* to show all applicable errata.
 . Select *Installable* to limit the report exclusively to errata that are accessible in the content view environments of your host that can be installed.
 . Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -8,6 +8,8 @@ Use the following procedure to generate a report of installable or applicable er
 . Click *Generate* for the *Host {endash} Applicable Errata* template.
 . Optional: To schedule a report, click the *calendar* icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
 . Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
+. Optional: Select another *Output format* for the report file.
+The default is CSV.
 . Optional: To limit the report only to hosts found by the search query, click on *Hosts filter* and search from the available list of hosts.
 For a report on all available hosts, leave *Hosts filter* empty.
 . Optional: To limit the report only to errata found by the search query, click on *Errata filter* and search from the available list of errata.
@@ -15,8 +17,6 @@ For a report on all available errata, leave *Errata filter* empty.
 . From the *Installability* list, select one of these options:
 * *Applicable* to show all applicable errata.
 * *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that may be installed.
-. Click *Generate* to generate a file that contains the report.
-The default file is CSV and the other options to choose from are JSON, YAML, and HTML.
-Your browser automatically downloads the report after {Project} creates it.
-+
-If you have selected the *Send report via e-mail* checkbox, the report is sent to your e-mail address.
+. Click *Generate*.
+Your browser automatically downloads the report file after {Project} creates it.
+If you have selected the *Send report via e-mail* option, the report is sent to your e-mail address.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -12,10 +12,11 @@ Use the following procedure to generate a report of installable or applicable er
 For a report on all available hosts, leave *Hosts filter* empty.
 . Optional: To limit the report only to errata found by the search query, click on *Errata filter* and search from the available list of errata.
 For a report on all available errata, leave *Errata filter* empty.
-. In the *Installability* drop-down menu, select one of these options:
+. From the *Installability* list, select one of these options:
 * *Applicable* to show all applicable errata.
 * *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that may be installed.
-. Click *Generate* to generate a CSV file that contains the report.
+. Click *Generate* to generate a file that contains the report.
+The default file is CSV and the other options to choose from are JSON, YAML, and HTML.
 Your browser automatically downloads the report after {Project} creates it.
 +
 If you have selected the *Send report via e-mail* checkbox, the report is sent to your e-mail address.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -1,0 +1,14 @@
+[id="Generating_a_Report_for_Installable_and_Applicable_Errata_{context}"]
+= Generating a Report for Installable and Applicable Errata
+
+Use the following procedure to view a list of installable and applicable errata to install.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
+. To the right of the report template that you want to use, click *Generate*.
+. Select *Applicable* to show all applicable errata.
+. Select *Installable*  to limit the report exclusively to errata that are accessible in the host's content view environment(s) that can be installed.
+. Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
+. Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
+A CSV file that contains the report is downloaded.
+If you have selected the *Send report via e-mail* checkbox, the host monitoring report is sent to your e-mail address.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -6,7 +6,7 @@ Use the following procedure to generate a report of installable or applicable er
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Click *Generate* for the *Host {endash} Applicable Errata* template.
-. In the *Installability* drop down menu, select one of these options:
+. In the *Installability* drop-down menu, select one of these options:
 * *Applicable* to show all applicable errata.
 * *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that may be installed.
 . Click *Generate* to generate a CSV file that contains the report.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -5,10 +5,12 @@ Use the following procedure to view a list of installable and applicable errata 
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
-. To the right of the report template that you want to use, click *Generate*.
+. For the *Host {endash} Applicable Errata* template, click *Generate*.
 . Select *Applicable* to show all applicable errata.
-. Select *Installable*  to limit the report exclusively to errata that are accessible in the host's content view environment(s) that can be installed.
+. Select *Installable* to limit the report exclusively to errata that are accessible in the content view environments of your host that can be installed.
 . Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
 . Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
-A CSV file that contains the report is downloaded.
-If you have selected the *Send report via e-mail* checkbox, the host monitoring report is sent to your e-mail address.
+. Click *Generate* to generate a CSV file that contains the report.
+After {Project} has created the report, your browser automatically downloads it.
++
+If you have selected the *Send report via e-mail* checkbox, the report is sent to your e-mail address.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -6,7 +6,7 @@ Use the following procedure to view installable and applicable errata on managed
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Click *Generate* for the *Host {endash} Applicable Errata* template.
-. In the *Instalability* drop down menu, select *Applicable* to show all applicable errata or *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that can be installed.
+. In the *Installability* drop down menu, select *Applicable* to show all applicable errata or *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that can be installed.
 . Optional: To schedule a report, click the icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
 . Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
 . Click *Generate* to generate a CSV file that contains the report.

--- a/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
+++ b/guides/common/modules/proc_generating-a-report-for-installable-and-applicable-errata.adoc
@@ -6,12 +6,16 @@ Use the following procedure to generate a report of installable or applicable er
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Report Templates*.
 . Click *Generate* for the *Host {endash} Applicable Errata* template.
+. Optional: To schedule a report, click the *calendar* icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
+. Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
+. Optional: To limit the report only to hosts found by the search query, click on *Hosts filter* and search from the available list of hosts.
+For a report on all available hosts, leave *Hosts filter* empty.
+. Optional: To limit the report only to errata found by the search query, click on *Errata filter* and search from the available list of errata.
+For a report on all available errata, leave *Errata filter* empty.
 . In the *Installability* drop-down menu, select one of these options:
 * *Applicable* to show all applicable errata.
 * *Installable* to limit the report exclusively to errata that are accessible in the Content View environments of your host that may be installed.
 . Click *Generate* to generate a CSV file that contains the report.
 Your browser automatically downloads the report after {Project} creates it.
-. Optional: To schedule a report, click the *calendar* icon to the right of the *Generate at* field and choose the date and time you want for the generated report.
-. Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.
 +
 If you have selected the *Send report via e-mail* checkbox, the report is sent to your e-mail address.


### PR DESCRIPTION
A new procedure was required to show the user how they can generate a
report for both Installable and Applicable errata.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
