### PR TITLE
Add procedure to install foreman_snapshot_management

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -55,5 +55,7 @@ include::modules/proc_removing-a-host-from-server.adoc[leveloffset=+1]
 include::modules/proc_disassociating-a-virtual-machine-without-removing-it-from-a-hypervisor.adoc[leveloffset=+2]
 
 ifndef::satellite[]
+include::modules/proc_installing-the-snapshot-management-plugin.adoc[leveloffset=+1]
+
 include::modules/proc_creating-snapshots-of-a-managed-host.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/proc_creating-snapshots-of-a-managed-host.adoc
+++ b/guides/common/modules/proc_creating-snapshots-of-a-managed-host.adoc
@@ -5,9 +5,7 @@ You can use the Snapshot Management plug-in to create snapshots of managed hosts
 
 .Prerequisites
 * You have installed the Snapshot Management plug-in successfully.
-ifndef::orcharhino[]
-For more information, see https://github.com/ATIX-AG/foreman_snapshot_management[github.com/ATIX-AG/foreman_snapshot_management].
-endif::[]
+For more information, see xref:Installing_the_Snapshot_Management_Plugin_{context}[].
 * Your managed host is running on VMware vSphere or Proxmox.
 
 .Procedure

--- a/guides/common/modules/proc_installing-the-snapshot-management-plugin.adoc
+++ b/guides/common/modules/proc_installing-the-snapshot-management-plugin.adoc
@@ -1,0 +1,12 @@
+[id="Installing_the_Snapshot_Management_Plugin_{context}"]
+= Installing the Snapshot Management Plug-in
+
+Perform the following step to install the _Snapshot Management_ plug-in on your {Project}.
+
+.Procedure
+* Install the Snapshot Management plug-in on your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --enable-foreman-plugin-snapshot-management
+----


### PR DESCRIPTION
See https://github.com/theforeman/foreman-installer/blob/3.5-stable/config/katello-answers.yaml#L74 & https://github.com/ATIX-AG/foreman_snapshot_management/pull/87

```
# foreman-installer --full-help | grep -i snapshot
    --[no-]enable-foreman-plugin-snapshot-management                             Enable 'foreman_plugin_snapshot_management' puppet module (default: false)
```
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)