### PR TITLE
New assembly for restricting hosts content access

### DIFF
--- a/guides/common/assembly_restricting-hosts-access-to-content.adoc
+++ b/guides/common/assembly_restricting-hosts-access-to-content.adoc
@@ -1,0 +1,1 @@
+include::modules/con_restricting-hosts-access-to-content.adoc[]

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -3,9 +3,9 @@
 
 {Project} offers multiple options for restricting host access to content.
 To give hosts access to a specific subset of the content managed by {Project}, you can use the following strategies.
-It is recommended to consider implementing the strategies in the order listed here:
+{Team} recommends to consider implementing the strategies in the order listed here:
 
-Use Content Views and lifecycle environments::
+Content Views and lifecycle environments::
 Use Content Views and lifecycle environments, incorporating Content View filters as needed.
 +
 For more information about Content Views, see xref:Managing_Content_Views_{context}[].
@@ -39,14 +39,14 @@ Red{nbsp}Hat repositories set architecture and OS version restrictions automatic
 
 Release version::
 Certain Red{nbsp}Hat repositories, such as the {EL} dot release repositories, include a "release version" in their repository metadata.
-The release version is then compared with the release version specified in the system purpose attributes of the host.
+The release version is then compared with the release version specified in the *System purpose* properties of the host.
 Access to content may be limited or restricted based on this comparison.
 For more information about setting system purpose attributes,see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in {ProjectName}] in _{ManagingHostsDocTitle}_.
 
-.Putting everything together
+.Incorporating all components
 A particular package or repository is available to a host only if all of the following are true:
 
-* It is included in the host's Content View and lifecycle environment.
+* The repository is included in the host's Content View and lifecycle environment.
 * The host's Content View has been published after the repository was added to it.
 * It has not been filtered out by a Content View filter.
 * It is enabled by default or overridden to *Enabled* using a content override.
@@ -63,3 +63,4 @@ You can use activation keys to perform following actions:
 
 Activation keys only affect hosts during registration.
 If a host is already registered, the above attributes can be changed individually for each host or through content host bulk actions.
+For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -49,13 +49,13 @@ A particular package or repository is available to a host only if all of the fol
 * The repository is included in the host's Content View and lifecycle environment.
 * The host's Content View has been published after the repository was added to it.
 * It has not been filtered out by a Content View filter.
-* It is enabled by default or overridden to *Enabled* using a content override.
-* It has no architecture or OS version restrictions or it has architecture or OS version restrictions that match the host.
+* The repository is enabled by default or overridden to *Enabled* using a content override.
+* The repository has no architecture or OS version restrictions or it has architecture or OS version restrictions that match the host.
 * For certain Red{nbsp}Hat repositories either no release version is set or the release version matches that of the host.
 
 .Using activation keys
 Using activation keys can simplify the workflow for some of these strategies.
-You can use activation keys to perform following actions:
+You can use activation keys to perform the following actions:
 
 * Assign hosts to Content Views and lifecycle environments.
 * Add content overrides to hosts.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -34,11 +34,11 @@ In custom products, you can set restrictions on the architecture and OS versions
 For example, if you restrict a custom repository to *{EL} 9*, it is only available on hosts running {EL} 9.
 Architecture and OS version restrictions hold the highest priority among all other strategies.
 They cannot be overridden or invalidated by content overrides, changes to Content Views, or changes to lifecycle environments.
-For this reason, it is recommended to consider the other strategies mentioned before using archictecture or OS version restrictions.
+For this reason, it is recommended to consider the other strategies mentioned before using architecture or OS version restrictions.
 Red{nbsp}Hat repositories set architecture and OS version restrictions automatically.
 
 Release version::
-Certain Red{nbsp}Hat repositories, such as the {EL} dot release repositories, include a "release version" in their repository metadata.
+Certain Red{nbsp}Hat repositories, such as the {EL} dot release repositories, include a *Release version* in their repository metadata.
 The release version is then compared with the release version specified in the *System purpose* properties of the host.
 Access to content may be limited or restricted based on this comparison.
 For more information about setting system purpose attributes,see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in {ProjectName}] in _{ManagingHostsDocTitle}_.
@@ -48,7 +48,7 @@ A particular package or repository is available to a host only if all of the fol
 
 * The repository is included in the host's Content View and lifecycle environment.
 * The host's Content View has been published after the repository was added to it.
-* It has not been filtered out by a Content View filter.
+* The repository has not been filtered out by a Content View filter.
 * The repository is enabled by default or overridden to *Enabled* using a content override.
 * The repository has no architecture or OS version restrictions or it has architecture or OS version restrictions that match the host.
 * For certain Red{nbsp}Hat repositories either no release version is set or the release version matches that of the host.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -1,19 +1,23 @@
 [id="Restricting_Hosts_Access_to_Content_{context}"]
 = Restricting Hosts' Access to Content
-{Project} offers multiple options for restricting hosts' access to content.
+
+{Project} offers multiple options for restricting host access to content.
 To give hosts access to a specific subset of the content managed by {Project}, you can use the following strategies.
 It is recommended to consider implementing the strategies in the order listed here:
 
-
-* *Use Content Views and lifecycle environments*: Use Content Views and lifecycle environments, incorporating Content View filters as needed.
+Use Content Views and lifecycle environments::
+Use Content Views and lifecycle environments, incorporating Content View filters as needed.
++
 For more information about Content Views, see xref:Managing_Content_Views_{context}[].
++
 For more information about lifecycle environments, see xref:Creating_an_Application_Life_Cycle_{context}[].
 
-* *Content overrides*:By default, content hosted by {Project} can be either enabled or disabled.
-In custom products, repositories are always disabled by default, while Red{nbsp}Hat products may be either enabled or disabled by default depending on the specific repository.
-Enabling a repository gives the host access to the repository’s packages or other content, allowing them to download and install the available content.
+Content overrides::
+By default, content hosted by {Project} can be either enabled or disabled.
+In custom products, repositories are always disabled by default, while Red{nbsp}Hat products can be either enabled or disabled by default depending on the specific repository.
+Enabling a repository gives the host access to the repository packages or other content, allowing hosts to download and install the available content.
 +
-If a repository is disabled, the host will not be able to access the repository's content.
+If a repository is disabled, the host is not be able to access the repository content.
 A content override provides you with the option to override the default enablement value of either *Enabled* or *Disabled* for any repository.
 You can add content overrides to hosts or activation keys.
 +
@@ -21,36 +25,41 @@ For more information about adding content overrides to hosts, see {ManagingHosts
 +
 For more information about adding content overrides to activation keys, see xref:enabling-and-disabling-repositories-on-activation-key_{context}[].
 
-* *Composite Content Views*: You can use composite Content Views to combine and give hosts access to the content from multiple Content Views.
+Composite Content Views::
+You can use composite Content Views to combine and give hosts access to the content from multiple Content Views.
 For more information about composite Content Views, see xref:Creating_a_Composite_Content_View_{context}[].
 
-* *Architecture and OS version restrictions*: In custom products, you can set restrictions on the architecture and OS versions for `yum` repositories on which the product will be available.
-For example, if you restrict a custom repository to *{EL} 9*, it will only be available on hosts running {EL} 9.
+Architecture and OS version restrictions::
+In custom products, you can set restrictions on the architecture and OS versions for `yum` repositories on which the product will be available.
+For example, if you restrict a custom repository to *{EL} 9*, it is only available on hosts running {EL} 9.
 Architecture and OS version restrictions hold the highest priority among all other strategies.
 They cannot be overridden or invalidated by content overrides, changes to Content Views, or changes to lifecycle environments.
 For this reason, it is recommended to consider the other strategies mentioned before using archictecture or OS version restrictions.
 Red{nbsp}Hat repositories set architecture and OS version restrictions automatically.
 
-* *Release version*: Certain Red{nbsp}Hat repositories, such as the {EL} dot release repositories, include a "release version" in their repository metadata.
+Release version::
+Certain Red{nbsp}Hat repositories, such as the {EL} dot release repositories, include a "release version" in their repository metadata.
 The release version is then compared with the release version specified in the system purpose attributes of the host.
 Access to content may be limited or restricted based on this comparison.
-For more information about setting system purpose attributes,see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in Red{nbsp}Hat {ProjectName}] in _{ManagingHostsDocTitle}_.
+For more information about setting system purpose attributes,see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in {ProjectName}] in _{ManagingHostsDocTitle}_.
 
-* *Packaging everything together*: A particular package or repository will be available to a host only if all of the following are true:
+.Putting everything together
+A particular package or repository is available to a host only if all of the following are true:
 
-. It is included in the host's Content View and lifecycle environment.
-. The host's Content View has been published after the repository was added to it.
-. It has not been filtered out by a Content View filter.
-. It is enabled by default or overridden to *Enabled* using a content override.
-. It has no architecture or OS version restrictions or it has architecture or OS version restrictions that match the host.
-. For certain Red{nbsp}Hat repositories either no release version is set or the release version matches that of the host.
+* It is included in the host's Content View and lifecycle environment.
+* The host's Content View has been published after the repository was added to it.
+* It has not been filtered out by a Content View filter.
+* It is enabled by default or overridden to *Enabled* using a content override.
+* It has no architecture or OS version restrictions or it has architecture or OS version restrictions that match the host.
+* For certain Red{nbsp}Hat repositories either no release version is set or the release version matches that of the host.
 
-* *Using activation keys*: Using activation keys can simplify the workflow for some of these strategies.
-You can use activation keys to:
+.Using activation keys
+Using activation keys can simplify the workflow for some of these strategies.
+You can use activation keys to perform following actions:
 
-- Assign hosts to Content Views and lifecycle environments.
-- Add content overrides to hosts.
-- Set system purpose attributes on hosts, including release version.
+* Assign hosts to Content Views and lifecycle environments.
+* Add content overrides to hosts.
+* Set system purpose attributes on hosts, including release version.
 
 Activation keys only affect hosts during registration.
 If a host is already registered, the above attributes can be changed individually for each host or through content host bulk actions.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -43,7 +43,7 @@ The release version is then compared with the release version specified in the *
 Access to content may be limited or restricted based on this comparison.
 For more information about setting system purpose attributes,see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in {ProjectName}] in _{ManagingHostsDocTitle}_.
 
-.Incorporating all components
+.Incorporating all strategies
 A particular package or repository is available to a host only if all of the following are true:
 
 * The repository is included in the host's Content View and lifecycle environment.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -1,0 +1,56 @@
+[id="Restricting_Hosts_Access_to_Content_{context}"]
+= Restricting Hosts' Access to Content
+{Project} offers multiple options for restricting hosts' access to content.
+To give hosts access to a specific subset of the content managed by {Project}, you can use the following strategies.
+It is recommended to consider implementing the strategies in the order listed here:
+
+
+* *Use Content Views and lifecycle environments*: Use Content Views and lifecycle environments, incorporating Content View filters as needed.
+For more information about Content Views, see xref:Managing_Content_Views_{context}[].
+For more information about lifecycle environments, see xref:Creating_an_Application_Life_Cycle_{context}[].
+
+* *Content overrides*:By default, content hosted by {Project} can be either enabled or disabled.
+In custom products, repositories are always disabled by default, while Red{nbsp}Hat products may be either enabled or disabled by default depending on the specific repository.
+Enabling a repository gives the host access to the repository’s packages or other content, allowing them to download and install the available content.
++
+If a repository is disabled, the host will not be able to access the repository's content.
+A content override provides you with the option to override the default enablement value of either *Enabled* or *Disabled* for any repository.
+You can add content overrides to hosts or activation keys.
++
+For more information about adding content overrides to hosts, see {ManagingHostsDocURL}Enabling_and_Disabling_Repositories_on_Hosts_managing-hosts[Enabling and Disabling Repositories on Hosts] in _{ManagingHostsDocTitle}_.
++
+For more information about adding content overrides to activation keys, see xref:enabling-and-disabling-repositories-on-activation-key_{context}[].
+
+* *Composite Content Views*: You can use composite Content Views to combine and give hosts access to the content from multiple Content Views.
+For more information about composite Content Views, see xref:Creating_a_Composite_Content_View_{context}[].
+
+* *Architecture and OS version restrictions*: In custom products, you can set restrictions on the architecture and OS versions for `yum` repositories on which the product will be available.
+For example, if you restrict a custom repository to *{EL} 9*, it will only be available on hosts running {EL} 9.
+Architecture and OS version restrictions hold the highest priority among all other strategies.
+They cannot be overridden or invalidated by content overrides, changes to Content Views, or changes to lifecycle environments.
+For this reason, it is recommended to consider the other strategies mentioned before using archictecture or OS version restrictions.
+Red{nbsp}Hat repositories set architecture and OS version restrictions automatically.
+
+* *Release version*: Certain Red{nbsp}Hat repositories, such as the {EL} dot release repositories, include a "release version" in their repository metadata.
+The release version is then compared with the release version specified in the system purpose attributes of the host.
+Access to content may be limited or restricted based on this comparison.
+For more information about setting system purpose attributes,see {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host in Red{nbsp}Hat {ProjectName}] in _{ManagingHostsDocTitle}_.
+
+* *Packaging everything together*: A particular package or repository will be available to a host only if all of the following are true:
+
+. It is included in the host's Content View and lifecycle environment.
+. The host's Content View has been published after the repository was added to it.
+. It has not been filtered out by a Content View filter.
+. It is enabled by default or overridden to *Enabled* using a content override.
+. It has no architecture or OS version restrictions or it has architecture or OS version restrictions that match the host.
+. For certain Red{nbsp}Hat repositories either no release version is set or the release version matches that of the host.
+
+* *Using activation keys*: Using activation keys can simplify the workflow for some of these strategies.
+You can use activation keys to:
+
+- Assign hosts to Content Views and lifecycle environments.
+- Add content overrides to hosts.
+- Set system purpose attributes on hosts, including release version.
+
+Activation keys only affect hosts during registration.
+If a host is already registered, the above attributes can be changed individually for each host or through content host bulk actions.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -17,7 +17,7 @@ By default, content hosted by {Project} can be either enabled or disabled.
 In custom products, repositories are always disabled by default, while Red{nbsp}Hat products can be either enabled or disabled by default depending on the specific repository.
 Enabling a repository gives the host access to the repository packages or other content, allowing hosts to download and install the available content.
 +
-If a repository is disabled, the host is not be able to access the repository content.
+If a repository is disabled, the host is not able to access the repository content.
 A content override provides you with the option to override the default enablement value of either *Enabled* or *Disabled* for any repository.
 You can add content overrides to hosts or activation keys.
 +

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -25,13 +25,13 @@ include::common/assembly_managing-alternate-content-sources.adoc[leveloffset=+1]
 
 include::common/assembly_importing-content.adoc[leveloffset=+1]
 
-include::common/assembly_managing-application-life-cycles.adoc[leveloffset=+1]
-
-include::common/assembly_managing-content-views.adoc[leveloffset=+1]
-
 include::common/assembly_restricting-hosts-access-to-content.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
+
+include::common/assembly_managing-application-life-cycles.adoc[leveloffset=+1]
+
+include::common/assembly_managing-content-views.adoc[leveloffset=+1]
 
 include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -27,6 +27,8 @@ include::common/assembly_importing-content.adoc[leveloffset=+1]
 
 include::common/assembly_managing-application-life-cycles.adoc[leveloffset=+1]
 
+include::common/assembly_restricting-hosts-access-to-content.adoc[leveloffset=+1]
+
 include::common/assembly_managing-content-views.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -27,11 +27,11 @@ include::common/assembly_importing-content.adoc[leveloffset=+1]
 
 include::common/assembly_restricting-hosts-access-to-content.adoc[leveloffset=+1]
 
-include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
-
 include::common/assembly_managing-application-life-cycles.adoc[leveloffset=+1]
 
 include::common/assembly_managing-content-views.adoc[leveloffset=+1]
+
+include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
 
 include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -27,9 +27,9 @@ include::common/assembly_importing-content.adoc[leveloffset=+1]
 
 include::common/assembly_managing-application-life-cycles.adoc[leveloffset=+1]
 
-include::common/assembly_restricting-hosts-access-to-content.adoc[leveloffset=+1]
-
 include::common/assembly_managing-content-views.adoc[leveloffset=+1]
+
+include::common/assembly_restricting-hosts-access-to-content.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Previously, custom products were enabled by default. Now, they're going
to be disabled by default. A new concept module and assembly was
required to show the user strategies to restrict hosts access to
content.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
