### PR TITLE
Fix a link to Subscription Manifest

### DIFF
--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -10,7 +10,7 @@ endif::[]
 .Prerequisites
 * You must have a Red{nbsp}Hat Subscription Manifest file exported from the Customer Portal.
 ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/using_red_hat_subscription_management/using_manifests_con[Using Manifests] in the _Using Red Hat Subscription Management_ guide.
+For more information, see https://access.redhat.com/documentation/en-us/subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/assembly-creating-managing-manifests-connected-satellite[Creating and Managing Manifests] in _Using Red Hat Subscription Management_.
 endif::[]
 ifeval::["{mode}" == "disconnected"]
 * Ensure that you disable subscription connection on your {ProjectServer}.


### PR DESCRIPTION
The older link redirects to the page Project Subscription Management page which is incorrect. The correct link is replaced.

https://bugzilla.redhat.com/show_bug.cgi?id=2208440

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
