### PR TITLE
Fix keytab location

### DIFF
--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -47,7 +47,7 @@ Apache user must not have access to the keytab file.
 ----
 [service/HTTP]
 mechs = krb5
-cred_store = keytab:/etc/krb5.keytab
+cred_store = keytab:/etc/httpd/conf/http.keytab
 cred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U
 euid = __ID_of_Apache_User__
 ----


### PR DESCRIPTION
Keytab locations in steps 5 and 6 do not match, resulting in the right key to reside in a keytab that is not the one used by gssproxy, thus rendering kerberos auth with gssproxy permanently unsuccessful on Project.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2083336


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
