### PR TITLE
Add information about stopping and starting services

### DIFF
--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -13,7 +13,6 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 ----
 # {foreman-maintain} service stop
 ----
-+
 . Take a snapshot or create a backup:
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -9,8 +9,19 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 
 . Create a backup.
 +
-* On a virtual machine, take a snapshot.
-* On a physical machine, create a backup.
+.. Stop the {Project} services:
+----
+# {foreman-maintain} stop service
+----
++
+. Take a snapshot or create a backup:
+** On a virtual machine, take a snapshot.
+** On a physical machine, create a backup.
++
+.. Start the {Project} services:
+----
+# {foreman-maintain} start service
+----
 +
 Note that when creating a snapshot or conventional backup, you must stop all services as follows:
 +

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -7,23 +7,23 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 
 .Upgrade {ProjectServer}
 
-. Create a backup.
+. Stop all {Project} services:
 +
-.. Stop the {Project} services:
+[options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-maintain} stop service
+# {foreman-maintain} service stop
 ----
 +
 . Take a snapshot or create a backup:
-** On a virtual machine, take a snapshot.
-** On a physical machine, create a backup.
+* On a virtual machine, take a snapshot.
+* On a physical machine, create a backup.
 +
-.. Start the {Project} services:
-----
-# {foreman-maintain} start service
-----
+. Start all {Project} services:
 +
-For more information about backups, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service start
+----
 
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
 

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -23,19 +23,6 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 # {foreman-maintain} start service
 ----
 +
-Note that when creating a snapshot or conventional backup, you must stop all services as follows:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service stop
-----
-Start the services after creating a snapshot or conventional backup:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service start
-----
-+
 For more information about backups, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -12,6 +12,19 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 +
+Note that when creating a snapshot or conventional backup, you must stop all services as follows:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service stop
+----
+Start the services after creating a snapshot or conventional backup:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service start
+----
++
 For more information about backups, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -38,8 +38,19 @@ endif::[]
 
 . Create a backup.
 +
-* On a virtual machine, take a snapshot.
-* On a physical machine, create a backup.
+.. Stop the {Project} services:
+----
+# {foreman-maintain} stop service
+----
++
+. Take a snapshot or create a backup:
+** On a virtual machine, take a snapshot.
+** On a physical machine, create a backup.
++
+.. Start the {Project} services:
+----
+# {foreman-maintain} start service
+----
 
 . A pre-upgrade script is available to detect conflicts and list hosts which have duplicate entries in {ProjectServer} that can be unregistered and deleted after upgrade.
 In addition, it will detect hosts which are not assigned to an organization.

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -36,20 +36,22 @@ endif::[]
 
 .Upgrade Disconnected {ProjectServer}
 
-. Create a backup.
+. Stop all {Project} services:
 +
-.. Stop the {Project} services:
+[options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-maintain} stop service
+# {foreman-maintain} service stop
 ----
 +
 . Take a snapshot or create a backup:
-** On a virtual machine, take a snapshot.
-** On a physical machine, create a backup.
+* On a virtual machine, take a snapshot.
+* On a physical machine, create a backup.
 +
-.. Start the {Project} services:
+. Start all {Project} services:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-maintain} start service
+# {foreman-maintain} service start
 ----
 
 . A pre-upgrade script is available to detect conflicts and list hosts which have duplicate entries in {ProjectServer} that can be unregistered and deleted after upgrade.

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -46,7 +46,6 @@ endif::[]
 . Take a snapshot or create a backup:
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
-+
 . Start all {Project} services:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
When creating a snapshot, stopping the services before taking the snapshot and then starting them after, is a good idea. Adding information about this in the upgrade guide.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2175369


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
