### PR TITLE
Add note about enabled Puppet in Satellite (Admin)

### DIFF
--- a/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc
@@ -293,6 +293,12 @@ You can find the logs in `/var/log/puppetlabs/puppet/`
 
 You can increase the logging level for Puppet server on your {ProjectServer}.
 
+ifdef::satellite[]
+.Prerequisite
+* Puppet must be enabled in your {Project}.
+For more information, see {ManagingConfigurationsPuppetDocURL}Enabling_Puppet_Integration_managing-configurations-puppet[Enabling Puppet Integration with Satellite] in _{ManagingConfigurationsPuppetDocTitle}_.
+endif::[]
+
 .Procedure
 . Add the following line to the `[master]` block in `/etc/puppetlabs/puppet/puppet.conf` file:
 +

--- a/guides/common/modules/proc_monitoring-puppet.adoc
+++ b/guides/common/modules/proc_monitoring-puppet.adoc
@@ -14,3 +14,8 @@ At the *Puppet CA* tab you can find the following:
 Here you can inspect the certificate expiry data, or cancel the certificate by clicking *Revoke*.
 * A list of autosign entries at the *Autosign entries* sub-tab.
 Here you can create an entry by clicking *New* or delete one by clicking *Delete*.
+
+ifdef::satellite[]
+NOTE: The *Puppet* and *Puppet CA* tabs are available only if you have Puppet enabled in your {Project}.
+For more information, see {ManagingConfigurationsPuppetDocURL}Enabling_Puppet_Integration_managing-configurations-puppet[Enabling Puppet Integration with Satellite] in _{ManagingConfigurationsPuppetDocTitle}_.
+endif::[]


### PR DESCRIPTION
Requested by RH QA. **Satellite only**

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
