### PR TITLE
Add step to click the New Policy button

### DIFF
--- a/guides/common/modules/proc_creating-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_creating-a-compliance-policy.adoc
@@ -12,6 +12,7 @@ Use this procedure to create a compliance policy, which you can use to ensure th
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Compliance {endash} Policies*.
+. Click *New Policy* or *New Compliance Policy*.
 . Select the deployment method: *Ansible*, *Puppet*, or *Manual*.
 Then click *Next*.
 . Enter a name for this policy, a description (optional), then click *Next*.


### PR DESCRIPTION
The step was missing.
The button is labeled "New Policy" when no policies are present yet, and "New Compliance Policy" when there are policies already added.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
