### PR TITLE
Move Activation Key point from no. 18 to no. 7

### DIFF
--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -37,7 +37,7 @@ ifndef::satellite,orcharhino[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.
 endif::[]
 . Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
 endif::[]
 . Optional: Select the *Insecure* option, if you want to make the first call insecure.
@@ -135,9 +135,11 @@ endif::[]
 ifndef::managing-hosts[]
 For more information about the pull mode, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.
 endif::[]
+ifdef::katello,satellite,orcharhino[]
 . Optional: Select the *Lifecycle environment*.
 . Optional: Select the *Ignore errors* option if you want to ignore subscription manager errors.
 . Optional: Select the *Force* option if you want to remove any `katello-ca-consumer` rpms before registration and run `subscription-manager` with the `--force` argument.
+endif::[]
 
 ifdef::foreman-el,foreman-deb,katello[]
 . Optional: This step is for the Katello users only.

--- a/guides/common/modules/proc_registering-hosts.adoc
+++ b/guides/common/modules/proc_registering-hosts.adoc
@@ -37,6 +37,9 @@ ifndef::satellite,orcharhino[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.
 endif::[]
 . Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
+ifdef::satellite,orcharhino[]
+. In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
+endif::[]
 . Optional: Select the *Insecure* option, if you want to make the first call insecure.
 During this first call, hosts download the CA file from {Project}.
 Hosts will use this CA file to connect to {Project} with all future calls making them secure.
@@ -132,12 +135,9 @@ endif::[]
 ifndef::managing-hosts[]
 For more information about the pull mode, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.
 endif::[]
-ifdef::satellite,orcharhino[]
-. In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
 . Optional: Select the *Lifecycle environment*.
 . Optional: Select the *Ignore errors* option if you want to ignore subscription manager errors.
 . Optional: Select the *Force* option if you want to remove any `katello-ca-consumer` rpms before registration and run `subscription-manager` with the `--force` argument.
-endif::[]
 
 ifdef::foreman-el,foreman-deb,katello[]
 . Optional: This step is for the Katello users only.


### PR DESCRIPTION
There has been a recent change in Satellite 6.14,
where if you navigate
to Satellite WebUI -> Hosts -> Register Host, the
"Activation Keys" has
been moved to the "General" tab. In Satellite 6.13 and previous
Satellite versions, the "Activation Keys" option was present in the
"Advanced" tab which is now moved to the "Basic" tab. As a result,
point 18 should be moved up along with other options present for the
"General" tab.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
