### PR TITLE
Tweak ifdef not to display a lead-in list for Satellite

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -2,12 +2,16 @@
 
 = Configuring Repositories
 
-Use this procedure to enable the repositories that are required to install {ProductName}. Choose from the available list which operating system and version you are installing on:
+Use this procedure to enable the repositories that are required to install {ProductName}.
+
+ifdef::foreman-el,katello,foreman-deb[]
+Choose from the following list which operating system and version you are installing on:
+endif::[]
 
 ifdef::foreman-el,katello[]
 * xref:#repositories-centos-stream-8[CentOS Stream 8]
 endif::[]
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello[]
 * xref:#repositories-rhel-8[{RHEL} 8]
 endif::[]
 ifdef::foreman-deb[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -2,7 +2,7 @@
 
 = Configuring Repositories
 
-Use this procedure to enable the repositories that are required to install {ProductName}.
+Use these procedures to enable the repositories required to install {ProductName}.
 
 ifdef::foreman-el,katello,foreman-deb[]
 Choose from the following list which operating system and version you are installing on:


### PR DESCRIPTION
[BZ#2223197](https://bugzilla.redhat.com/show_bug.cgi?id=2223197) reports an unnecessary lead-in paragraph.

I updated the ifdef directive not to include satellite, so that the lead-in paragraph doesn't appear in the Satellite version of the guide.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
