### PR TITLE
Add a note about using Samba to join AD realm

### DIFF
--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -27,3 +27,5 @@ You may need to have administrator permissions to perform the following command:
 ----
 # realm join -v _EXAMPLE.ORG_ --membership-software=samba -U Administrator
 ----
++
+NOTE: You must use the Samba client software to enroll with the AD server to be able to create the HTTP keytab in xref:Configuring_Direct_AD_Integration_with_GSS_Proxy_{context}[].


### PR DESCRIPTION
[BZ#2185051](https://bugzilla.redhat.com/show_bug.cgi?id=2185051) requests specifying that using Samba is required to be able to create an HTTP keytab later in the process.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
