### PR TITLE
Adding an empty line as a workaround for a rendering issue downstream

### DIFF
--- a/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
+++ b/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
@@ -8,6 +8,7 @@ If you need to attach new or additional subscriptions, such as future-dated subs
 include::snip_only-valid-if-sca-disabled.adoc[]
 
 For more information about updating multiple hosts, see xref:Updating_Red_Hat_Subscriptions_on_Multiple_Hosts_{context}[].
+
 For more information about activation keys, see xref:Managing_Activation_Keys_{context}[].
 
 .{Project} Subscriptions


### PR DESCRIPTION
[BZ#2226802](https://bugzilla.redhat.com/show_bug.cgi?id=2226802) reports a broken xref link in Managing Content on the Red Hat Customer Portal: [Attaching Red Hat Subscriptions to Content Hosts](https://access.redhat.com/documentation/en-us/red_hat_satellite/6.13/html/managing_content/managing_red_hat_subscriptions_content-management#Attaching_Red_Hat_Subscriptions_to_Content_Hosts_content-management).

This PR addresses the problem by adding an empty line between two xrefs. It resolved the issue in my local downstream build.

(For the record, the [upstream version](https://docs.theforeman.org/3.7/Managing_Content/index-katello.html#Attaching_Red_Hat_Subscriptions_to_Content_Hosts_content-management) shows the xref as expected.)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
