### PR TITLE
Port 5646 not relevant to Katello

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -43,7 +43,7 @@ Sending installed packages and traces
 | 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
-| 5646, 5647 | TCP | AMQP | {SmartProxy} | Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
+| 5647 | TCP | AMQP | {SmartProxy} | Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
@@ -107,7 +107,7 @@ endif::[]
 | 623 |  |  | Client | Power management | BMC On/Off/Cycle/Status
 | 5000 | TCP | HTTPS | OpenStack Compute Resource | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::katello,satellite,orcharhino[]
-| 5646 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
+| 5647 | TCP | AMQP | {ProjectServer} | Katello agent | Forward message to Qpid dispatch router on {SmartProxy} (optional)
 | 5671 |  |  | Qpid |Remote install | Send install command to client
 | 5671 |  |  | Dispatch router (hub) | Remote install | Forward message to dispatch router on {Project}
 | 5671 | | | {ProjectServer} | Remote install for Katello agent | Send install command to client


### PR DESCRIPTION
Port 5646 is not relevant to Katello since Port 5647 is the only one
referenced in the procedure to add in the section that follows.
Terefore, Port 5646 was removed.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* For Foreman 3.0 or older, please create a separate PR.
* We do not accept PRs for Foreman 2.4 or older.
