### PR TITLE
Remove outdated information from the disconnected upgrade section

### DIFF
--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -41,19 +41,6 @@ endif::[]
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 
-. A pre-upgrade script is available to detect conflicts and list hosts which have duplicate entries in {ProjectServer} that can be unregistered and deleted after upgrade.
-In addition, it will detect hosts which are not assigned to an organization.
-If a host is listed under *Hosts* > *All hosts* without an organization association and if a content host with same name has an organization already associated with it then the content host will automatically be unregistered.
-This can be avoided by associating such hosts to an organization before upgrading.
-+
-Run the pre-upgrade check script to get a list of hosts that can be deleted after upgrading.
-If any unassociated hosts are found, associating them to an organization before upgrading is recommended.
-+
-[options="nowrap"]
-----
-# foreman-rake katello:upgrade_check
-----
-
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
 
 . Optional: If you made manual edits to DNS or DHCP configuration files and do not want to overwrite the changes, enter the following command:
@@ -69,20 +56,11 @@ If there are discovered hosts available, turn them off and then delete all entri
 Select all other organizations in turn using the organization setting menu and repeat this action as required.
 Reboot these hosts after the upgrade has completed.
 
-. Make sure all external {SmartProxyServers} are assigned to an organization, otherwise they might get unregistered due to host-unification changes.
-
 . Remove old repositories:
 +
 [options="nowrap" subs="attributes"]
 ----
 # rm /etc/yum.repos.d/*
-----
-
-. Stop {Project} services:
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} service stop
 ----
 
 . Obtain the latest ISO files by following the {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.


### PR DESCRIPTION
Some of the information listed in the disconnected upgrade procedure is outdated and needs to be removed. The below lines in the procedure are no longer required:

- Stopping the services: This was required as {foreman-maintain} had some difficulties with disconnected upgrades. However, this is now irrelevant and actually causes the upgrade_check to fail as services are no longer running.

- Running the `foreman-rake katello:upgrade_check` script manually: The explanation what "foreman-rake katello:upgrade_check" does is wrong and shouldn't be needed, as this check is now part of `foreman-maintain`.

- "Make sure all external Capsule Servers are assigned to an organization, otherwise they might get unregistered due to host-unification changes."; This was removed in BZ#1490043 - 74c511fd7792cbb845f450eb656e72b8fe5f7eac.

Bugzilla comment with these details:
https://bugzilla.redhat.com/show_bug.cgi?id=2071559#c5


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
