### PR TITLE
Fix spelling

### DIFF
--- a/guides/common/modules/con_resolving-package-dependencies.adoc
+++ b/guides/common/modules/con_resolving-package-dependencies.adoc
@@ -60,7 +60,7 @@ endif::[]
 
 ifeval::["{client-os-family}" == "Red Hat"]
 [id="Excluding_packages_and_dependency_solving_with_DNF_{context}"]
-.Excluding packages sometimes makes dependency solving imposible for DNF
+.Excluding packages sometimes makes dependency solving impossible for DNF
 ====
 If you make a {RHEL}{nbsp}8.3 repository with a few excluded packages, `dnf update` can sometimes fail.
 

--- a/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
+++ b/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
@@ -4,7 +4,7 @@
 If errata are available but not installable, you can create an incremental Content View version to add the errata to your content hosts.
 For example, if the Content View is version 1.0, it becomes Content View version 1.1, and when you publish, it becomes Content View version 2.0.
 
-IMPORTANT: If your content view version is old, you might encounter incompatibilities when incrementally adding enhanacement errata. 
+IMPORTANT: If your Content View version is old, you might encounter incompatibilities when incrementally adding enhancement errata.
 This is because enhancements are typically designed for the most current software in a repository.
 
 To use the CLI instead of the {ProjectWebUI}, see xref:cli-adding-errata-to-an-incremental-content-view[].


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
