### PR TITLE
Remove instances of "If you use the Katello plugin"

### DIFF
--- a/guides/common/modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc
+++ b/guides/common/modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc
@@ -39,25 +39,19 @@ EOS
 . Click the *Templates* tab, and from the *Finish Template* list, select your finish template.
 . In the {ProjectWebUI}, navigate to *Hosts* > *Create Host* and enter the information about the host that you want to create.
 . Click the *Parameters* tab and navigate to *Host parameters*.
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . In *Host parameters*, click the *Add Parameter* button three times to add three new parameter fields.
-Add the following three parameters:
 endif::[]
-ifdef::foreman-el,foreman-deb,katello[]
+ifndef::katello,satellite,orcharhino[]
 . If you have the Remote Execution plugin installed, in *Host parameters*, click the *Add Parameter* button two times to add two new parameter fields.
-If you use the Katello plugin, add a third parameter field.
-Add the following parameters:
 endif::[]
+Add the following parameters:
 .. In the *Name* field, enter `remote_execution_ssh_keys`.
 In the corresponding *Value* field, enter the output of `cat /usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy.pub`.
 .. In the *Name* field, enter `remote_execution_ssh_user`.
 In the corresponding *Value* field, enter `ec2-user`.
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 .. In the *Name* field, enter `activation_keys`.
-In the corresponding *Value* field, enter your activation key.
-endif::[]
-ifdef::foreman-el,katello[]
-.. If you use the Katello plugin, in the *Name* field, enter `activation_keys`.
 In the corresponding *Value* field, enter your activation key.
 endif::[]
 . Click *Submit* to save the changes.

--- a/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
@@ -50,8 +50,4 @@ ifdef::satellite,orcharhino,katello[]
 . On the *Parameters* tab, ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
-ifdef::foreman-el[]
-. If you use the Katello plugin, click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
 . Click *Submit* to provision your host on Proxmox.

--- a/guides/common/modules/proc_creating-hosts-on-vmware.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-vmware.adoc
@@ -50,15 +50,11 @@ endif::[]
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your requirements.
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . Click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
 If a parameter does not exist, click *+ Add Parameter*.
 In the field *Name*, enter *kt_activation_keys*.
 In the field *Value*, enter the name of the activation key used to register the Content Hosts.
-endif::[]
-ifdef::foreman-el,katello[]
-. If you use the Katello plugin, click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
 endif::[]
 . Click *Submit* to provision your host on VMware.
 

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -60,12 +60,8 @@ Confirm each aspect of the operating system.
 . Optional: Click *Resolve* in *Provisioning template* to check the new host can identify the right provisioning templates to use.
 +
 For more information about associating provisioning templates, see xref:creating-provisioning-templates_{context}[].
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
-ifdef::foreman-el,katello[]
-. If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host details.
@@ -79,12 +75,8 @@ This creates the host entry and the relevant provisioning settings.
 This also includes creating the necessary directories and files for UEFI booting the bare metal host.
 When you start the physical host and set its boot mode to UEFI HTTP, the host detects the defined DHCP service, receives HTTP endpoint of {SmartProxy} with the Kickstart tree and installs the operating system.
 
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
-endif::[]
-
-ifdef::foreman-el,katello[]
-If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
 [id="cli-creating-hosts-with-uefi-http-boot-provisioning_{context}"]
@@ -138,10 +130,6 @@ This creates the host entry and the relevant provisioning settings.
 This also includes creating the necessary directories and files for UEFI booting the bare metal host.
 When you start the physical host and set its boot mode to UEFI HTTP, the host detects the defined DHCP service, receives HTTP endpoint of {SmartProxy} with the Kickstart tree and installs the operating system.
 
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
-endif::[]
-
-ifdef::foreman-el,katello[]
-If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]

--- a/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
@@ -35,12 +35,8 @@ Confirm each aspect of the operating system.
 . Optional: Click *Resolve* in *Provisioning template* to check the new host can identify the right provisioning templates to use.
 +
 For more information about associating provisioning templates, see xref:provisioning-templates_{context}[].
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
-ifdef::foreman-el,katello[]
-. If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]
 . Click *Submit* to save the host details.
@@ -51,12 +47,8 @@ This creates the host entry and the relevant provisioning settings.
 This also includes creating the necessary directories and files for PXE booting the bare metal host.
 If you start the physical host and set its boot mode to PXE, the host detects the DHCP service of {ProjectServer}'s integrated {SmartProxy}, receives HTTP endpoint of the Kickstart tree and installs the operating system.
 
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 When the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
-endif::[]
-
-ifdef::foreman-el,katello[]
-If you use the Katello plug-in, when the installation completes, the host also registers to {ProjectServer} using the activation key and installs the necessary configuration and management tools from the {project-client-name} repository.
 endif::[]
 
 [id="cli-creating-hosts-with-unattended-provisioning_{context}"]

--- a/guides/common/modules/proc_creating-image-based-hosts-on-amazon-ec2.adoc
+++ b/guides/common/modules/proc_creating-image-based-hosts-on-amazon-ec2.adoc
@@ -15,11 +15,7 @@ Leave the *Mac Address* field blank.
 {ProjectServer} automatically selects and IP address and the *Managed*, *Primary*, and *Provision* options for the first interface on the host.
 . Click the *Operating System* tab and confirm that all fields are populated with values.
 . Click the *Virtual Machine* tab and confirm that all fields are populated with values.
-ifdef::foreman-el,katello[]
-. If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -34,11 +34,7 @@ ifdef::azure-provisioning[. In the *Root Password* field, enter the root passwor
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your needs.
-ifdef::foreman-el,katello[]
-. If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -42,11 +42,7 @@ Modify these settings if required.
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your needs.
-ifdef::foreman-el,katello[]
-. If you use the Katello plugin, click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
-endif::[]
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
 If not, add an activation key.
 endif::[]

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -16,15 +16,11 @@ endif::[]
 * An existing TAR image created using {LoraxCompose}.
 
 .Procedure
-ifdef::satellite,orcharhino[]
+ifdef::katello,satellite,orcharhino[]
 . On {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository.
 For more information, see {ContentManagementDocURL}Importing_Individual_ISO_Images_and_Files_content-management[Importing Individual ISO Images and Files] in _{ContentManagementDocTitle}_.
 endif::[]
-ifdef::foreman-el,katello[]
-. If you use the Katello plug-in, on {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository.
-For more information, see {ContentManagementDocURL}Importing_Individual_ISO_Images_and_Files_content-management[Importing Individual ISO Images and Files] in _{ContentManagementDocTitle}_.
-endif::[]
-ifdef::foreman-deb[]
+ifndef::katello,satellite,orcharhino[]
 . Copy the TAR image to an existing HTTP server which installed hosts can reach.
 endif::[]
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*, and select the host group that you want to use.


### PR DESCRIPTION
From the guide flavor we already know if this is the case or not. This simplifies for both the reader and maintainer.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.