### PR TITLE
Remove remote_execution_ssh_keys parameter step

### DIFF
--- a/guides/common/modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc
+++ b/guides/common/modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc
@@ -42,14 +42,12 @@ EOS
 ifdef::katello,satellite,orcharhino[]
 . In *Host parameters*, click the *Add Parameter* button two times to add two new parameter fields.
 Add the following parameters:
-endif::[]
-ifndef::katello,satellite,orcharhino[]
-. If you have the Remote Execution plugin installed, in *Host parameters*, click the *Add Parameter* button.
-endif::[]
-.. In the *Name* field, enter `remote_execution_ssh_user`.
-In the corresponding *Value* field, enter `ec2-user`.
-ifdef::katello,satellite,orcharhino[]
 .. In the *Name* field, enter `activation_keys`.
 In the corresponding *Value* field, enter your activation key.
 endif::[]
+ifndef::katello,satellite,orcharhino[]
+. If you have the Remote Execution plug-in installed, in *Host parameters*, click the *Add Parameter* button.
+endif::[]
+.. In the *Name* field, enter `remote_execution_ssh_user`.
+In the corresponding *Value* field, enter `ec2-user`.
 . Click *Submit* to save the changes.

--- a/guides/common/modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc
+++ b/guides/common/modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc
@@ -40,14 +40,12 @@ EOS
 . In the {ProjectWebUI}, navigate to *Hosts* > *Create Host* and enter the information about the host that you want to create.
 . Click the *Parameters* tab and navigate to *Host parameters*.
 ifdef::katello,satellite,orcharhino[]
-. In *Host parameters*, click the *Add Parameter* button three times to add three new parameter fields.
+. In *Host parameters*, click the *Add Parameter* button two times to add two new parameter fields.
+Add the following parameters:
 endif::[]
 ifndef::katello,satellite,orcharhino[]
-. If you have the Remote Execution plugin installed, in *Host parameters*, click the *Add Parameter* button two times to add two new parameter fields.
+. If you have the Remote Execution plugin installed, in *Host parameters*, click the *Add Parameter* button.
 endif::[]
-Add the following parameters:
-.. In the *Name* field, enter `remote_execution_ssh_keys`.
-In the corresponding *Value* field, enter the output of `cat /usr/share/foreman-proxy/.ssh/id_rsa_foreman_proxy.pub`.
 .. In the *Name* field, enter `remote_execution_ssh_user`.
 In the corresponding *Value* field, enter `ec2-user`.
 ifdef::katello,satellite,orcharhino[]


### PR DESCRIPTION
This is done automatically by REX.

Includes https://github.com/theforeman/foreman-documentation/pull/2329, so currently a draft.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.