### PR TITLE
[3.7] Hide guides which aren't ready for consumption

### DIFF
--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -15,3 +15,8 @@
 :postgresql-lib-dir: /var/lib/postgresql
 :postgresql-data-dir: {postgresql-lib-dir}/13/main
 :postgresql-log-dir: /var/log/postgresql
+
+// Some documents are not ready for stable releases, but can be published on nightly
+ifeval::["{DocState}" != "nightly"]
+:HideDocumentOnStable:
+endif::[]

--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -2,3 +2,8 @@
 :install-on-os: CentOS/RHEL
 :dnf-module: foreman:el8
 :dnf-modules: {dnf-module}
+
+// Some documents are not ready for stable releases, but can be published on nightly
+ifeval::["{DocState}" != "nightly"]
+:HideDocumentOnStable:
+endif::[]

--- a/guides/common/modules/snip_guide-not-ready.adoc
+++ b/guides/common/modules/snip_guide-not-ready.adoc
@@ -1,0 +1,5 @@
+This guide is not ready yet.
+
+Foreman is a community project.
+The source is maintained in https://github.com/theforeman/foreman-documentation/[foreman-documentation on GitHub] where you can create https://github.com/theforeman/foreman-documentation/issues[issues] and https://github.com/theforeman/foreman-documentation/pulls[pull requests].
+Thanks for your contribution.

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -4,6 +4,12 @@ include::common/header.adoc[]
 
 = {AdministeringDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -60,3 +66,4 @@ include::common/assembly_searching-and-bookmarking.adoc[leveloffset=+1]
 
 [appendix]
 include::common/assembly_administer-settings-information.adoc[leveloffset=+1]
+endif::[]

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -5,6 +5,12 @@ include::common/header.adoc[]
 
 = {AdministeringAnsibleDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -14,3 +20,4 @@ include::common/modules/con_managing-project-with-ansible-collections.adoc[]
 include::common/modules/proc_installing-the-project-ansible-modules.adoc[leveloffset=+1]
 
 include::common/modules/proc_viewing-the-project-ansible-modules.adoc[leveloffset=+1]
+endif::[]

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -4,6 +4,12 @@ include::common/header.adoc[]
 
 = {ConfiguringLoadBalancerDocTitle}
 
+// This guide only works on content proxies, which is Katello only
+ifdef::foreman-deb,foreman-el[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::foreman-deb,foreman-el[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -62,3 +68,4 @@ include::common/modules/con_propagating-scap-content-through-the-load-balancer.a
 include::common/modules/proc_propagating-scap-content-using-ansible-deployment.adoc[leveloffset=+2]
 
 include::common/modules/proc_propagating-scap-content-using-puppet-deployment.adoc[leveloffset=+2]
+endif::[]

--- a/guides/doc-Deploying_Hosts_AppCentric/master.adoc
+++ b/guides/doc-Deploying_Hosts_AppCentric/master.adoc
@@ -3,10 +3,13 @@ include::common/header.adoc[]
 :application_centric_deployment:
 :context: application_centric_deployment
 
-// Render only for relevant and finished contexts
-ifdef::foreman-el,katello,orcharhino[]
-
 = {AppCentricDeploymentDocTitle}
+
+// Render only for relevant and finished contexts
+ifdef::HideDocumentOnStable,foreman-deb,satellite[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable,foreman-deb,satellite[]
 
 include::common/modules/con_introduction-to-application-centric-deployment.adoc[leveloffset=+1]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -5,6 +5,12 @@ include::common/header.adoc[]
 
 = {DeployingAWSDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -20,3 +26,4 @@ include::topics/AWS_Installing_Satellite_AWS.adoc[leveloffset=+1]
 include::topics/AWS_Installing_Capsule_on_AWS.adoc[leveloffset=+1]
 
 include::topics/AWS-registering-hosts.adoc[leveloffset=+1]
+endif::[]

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -7,6 +7,13 @@ include::common/header.adoc[]
 
 = {InstallingSmartProxyDocTitle}
 
+// This guide is not ready for stable releases and on Debian
+// Though it also contains many errors on EL
+ifdef::HideDocumentOnStable,foreman-deb[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable,foreman-deb[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -38,4 +45,5 @@ include::common/modules/ref_dhcp-isc-settings.adoc[leveloffset=+1]
 
 [appendix]
 include::common/modules/ref_dhcp-options-for-network-configuration.adoc[leveloffset=+1]
+endif::[]
 endif::[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -7,6 +7,12 @@ include::common/header.adoc[]
 
 = {InstallingServerDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -82,3 +88,5 @@ include::common/modules/con_applying-custom-configuration.adoc[leveloffset=+1]
 
 [appendix]
 include::common/modules/proc_restoring-manual-changes-overwritten-by-a-puppet-run.adoc[leveloffset=+1]
+
+endif::[]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -5,14 +5,15 @@ include::common/header.adoc[]
 :mode: disconnected
 :ProductName: {ProjectServer}
 
-// Render only for relevant and finished contexts
-ifdef::satellite[]
-
 = {InstallingServerDisconnectedDocTitle}
 
-ifdef::satellite[]
-include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
+// This guide is not ready for stable releases
+ifndef::satellite[]
+include::common/modules/snip_guide-not-ready.adoc[]
 endif::[]
+ifdef::satellite[]
+
+include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 
 include::common/assembly_preparing-environment-for-installation.adoc[leveloffset=+1]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -5,6 +5,12 @@ include::common/header.adoc[]
 
 = {ManagingConfigurationsPuppetDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -78,3 +84,4 @@ include::common/modules/proc_setting-the-puppet-out-of-sync-interval.adoc[levelo
 include::common/modules/proc_overriding-out-of-sync-interval-for-a-host-group.adoc[leveloffset=+2]
 
 include::common/modules/proc_overriding-out-of-sync-interval-for-an-individual-host.adoc[leveloffset=+2]
+endif::[]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -3,10 +3,13 @@ include::common/header.adoc[]
 :context: managing-hosts
 :managing-hosts:
 
-// Render only for relevant and finished contexts
-ifdef::foreman-el,katello,satellite,orcharhino[]
-
 = {ManagingHostsDocTitle}
+
+// This guide is not ready for stable releases and not on Debian
+ifdef::HideDocumentOnStable,foreman-deb[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Organizations_and_Locations/master.adoc
+++ b/guides/doc-Managing_Organizations_and_Locations/master.adoc
@@ -4,7 +4,13 @@ include::common/header.adoc[]
 
 = {ManagingOrganizationsLocationsDocTitle}
 
-ifndef::satellite[]
+// This guide is not ready for stable releases
+// Satellite publishes this documentation elsewhere
+ifdef::HideDocumentOnStable,satellite[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable,satellite[]
+
 include::common/modules/con_introduction-to-organization-and-location-context.adoc[leveloffset=+1]
 
 include::common/assembly_managing-organizations.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -11,6 +11,12 @@ This feature is not available for Debian/Ubuntu.
 endif::[]
 ifndef::foreman-deb[]
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -87,4 +93,5 @@ include::common/modules/proc_deleting-a-compliance-report.adoc[leveloffset=+2]
 
 include::common/modules/proc_deleting-multiple-compliance-reports.adoc[leveloffset=+2]
 
+endif::[]
 endif::[]

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -4,6 +4,12 @@ include::common/header.adoc[]
 
 = {PlanningDocTitle}
 
+// This guide is Katello specific, in particular the diagrams
+ifdef::foreman-el,foreman-deb[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::foreman-el,foreman-deb[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -34,3 +40,4 @@ include::topics/Deployment_Considerations.adoc[]
 include::topics/Required_Technical_Users.adoc[]
 
 include::topics/Glossary.adoc[]
+endif::[]

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -4,6 +4,12 @@ include::common/header.adoc[]
 
 = {ProvisioningDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -62,3 +68,4 @@ endif::[]
 
 [appendix]
 include::common/modules/ref_host-parameter-hierarchy.adoc[leveloffset=+1]
+endif::[]

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -7,6 +7,12 @@ include::common/header.adoc[]
 
 = {QuickstartDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 The Foreman installer is a collection of Puppet modules that installs everything required for a full working Foreman setup. It uses native OS packaging (e.g. RPM and .deb packages) and adds necessary configuration for the complete installation.
 
 Components include the Foreman web UI, Smart Proxy, a Puppet server, TFTP, DNS and DHCP servers. It is configurable and the Puppet modules can be read or run in “no-op” mode to see what changes it will make.
@@ -34,3 +40,4 @@ To run the installer, execute:
 ----
 
 When the installer has completed, details will be printed about where to find Foreman and the Smart Proxy.
+endif::[]

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -4,6 +4,12 @@ include::common/header.adoc[]
 
 = {TuningDocTitle}
 
+// This guide is not ready for stable releases
+ifdef::HideDocumentOnStable[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::HideDocumentOnStable[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -80,4 +86,5 @@ ifdef::katello,satellite,orcharhino[]
 include::common/modules/con_smart-proxy-configuration-tuning.adoc[leveloffset=+2]
 
 include::common/modules/con_smartproxy_performance_tests.adoc[leveloffset=+3]
+endif::[]
 endif::[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -5,6 +5,12 @@ include::common/header.adoc[]
 
 = {UpgradingDocTitle}
 
+// This guide is not ready for Debian
+ifdef::foreman-deb[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::foreman-deb[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -53,4 +59,5 @@ endif::[]
 ifdef::foreman-el,katello,satellite,orcharhino[]
 // Upgrading the External database
 include::common/modules/proc_upgrading-the-external-database.adoc[leveloffset=+2]
+endif::[]
 endif::[]


### PR DESCRIPTION
Some guides aren't usable in some flavors. They aren't linked in the navigation, but this also makes sure the files don't have any content.  That makes diffs smaller, which makes reviewing easier.

(cherry picked from commit f5790e05e0b8fa50513efb048ab68f00057ec32c)

This is just as a PR to see the diff of https://github.com/theforeman/foreman-documentation/pull/2321 for now.