### PR TITLE
Move footnote below table

### DIFF
--- a/guides/common/modules/ref_predefined-roles.adoc
+++ b/guides/common/modules/ref_predefined-roles.adoc
@@ -3,7 +3,7 @@
 
 [cols="2,7" options="header"]
 |====
-|Role |Permissions Provided by Role footnote:[The exact set of allowed actions associated with predefined roles can be viewed by the privileged user as described in xref:Viewing_Permissions_of_a_Role_{context}[\]]
+|Role |Permissions Provided by Role
 
 | Access Insights Admin | Add and edit Insights rules.
 | Access Insights Viewer | View Insight reports.
@@ -46,3 +46,5 @@ It can be used if you configure virt-who manually and require a user role that h
 | Virt-who Viewer | View virt-who configurations.
 Users with this role can deploy virt-who instances using existing virt-who configurations.
 |====
+
+The exact set of allowed actions associated with predefined roles can be viewed by the privileged user as described in xref:Viewing_Permissions_of_a_Role_{context}[].


### PR DESCRIPTION
Neither asciidoctor nor Antora can handle this very well: https://docs.theforeman.org/nightly/Administering_Project/index-katello.html#Predefined_Roles_admin

The easiest solution is to just move it below the table.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
