### PR TITLE
Use --fields while syncing repos in organization

### DIFF
--- a/guides/common/modules/proc_synchronizing-all-repositories-in-an-organization.adoc
+++ b/guides/common/modules/proc_synchronizing-all-repositories-in-an-organization.adoc
@@ -11,7 +11,7 @@ Use this procedure to synchronize all repositories within an organization.
 ----
 ORG="_My_Organization_"
 
-for i in $(hammer --no-headers --csv repository list --organization $ORG | awk -F, {'print $1'})
+for i in $(hammer --no-headers --csv repository list --organization $ORG --fields Id)
 do
   hammer repository synchronize --id ${i} --organization $ORG --async
 done


### PR DESCRIPTION
The current argument "awk -F, {'print $1'}" is working but it is recommended to use "--fields Id" to utilize the capability of Hammer completely. Hence, it is recommended to use the latter one.

https://bugzilla.redhat.com/show_bug.cgi?id=2226805

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
