### PR TITLE
Align upstream document titles

### DIFF
--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -1,4 +1,5 @@
 // Attributes only for foreman-deb build
+:install-on-os: Debian/Ubuntu
 
 // Overrides for foreman-deb build
 :apache-user: www-data

--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -1,3 +1,4 @@
 // Overrides for foreman-el build
+:install-on-os: CentOS/RHEL
 :dnf-module: foreman:el8
 :dnf-modules: {dnf-module}

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -1,4 +1,5 @@
 // Overrides for katello build
+:install-on-os: CentOS/RHEL
 :client-content-apt:
 :client-content-zypper:
 :dnf-module: katello:el8

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,4 +1,5 @@
 // Overrides for orcharhino build
+:install-on-os: Enterprise Linux
 :BaseURL: https://docs.orcharhino.com/
 :ProductVersion: 6.5
 :ProductVersionPrevious: 6.4

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -1,4 +1,5 @@
 // Attributes only for satellite build
+:install-on-os: RHEL
 :ProductVersion: 6.14
 :ProductVersionPrevious: 6.13
 // Add -beta for Beta releases

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -7,11 +7,10 @@
 :ContentManagementDocTitle: Managing Content
 :ConvertingHostRHELDocTitle: Converting a Host to RHEL
 :DeployingAWSDocTitle: Deploying {ProjectName} on Amazon Web Services
-// InstallingServer - defined per product
-//:InstallingServerDocTitle: Installing {ProjectServerTitle} - base unused
+:InstallingServerDocTitle: Installing {ProjectServerTitle} {ProjectVersion} on {install-on-os}
 // Installing Disconnected - defined for Satellite only
 :InstallingServerDisconnectedDocTitle: Installing {ProjectServerTitle} in a Disconnected Network Environment
-:InstallingSmartProxyDocTitle: Installing an External {SmartProxyServerTitle} {ProjectVersion}
+:InstallingSmartProxyDocTitle: Installing a {SmartProxyServerTitle} {ProjectVersion} on {install-on-os}
 :ManagingConfigurationsAnsibleDocTitle: Configuring Hosts Using Ansible
 // Puppet Guide - overridden in Satellite
 :ManagingConfigurationsPuppetDocTitle: Configuring Hosts Using Puppet
@@ -20,8 +19,7 @@
 :ManagingSecurityDocTitle: Managing Security Compliance
 :PlanningDocTitle: Planning for {ProjectName}
 :ProvisioningDocTitle: Provisioning Hosts
-// Quickstart - defined for Foreman-DEB, Foreman-EL, and Katello
-//:QuickstartDocTitle: Quickstart Guide - base unused
+:QuickstartDocTitle: Quickstart Guide for {Project} on {install-on-os}
 // Release Notes - defined for Foreman and Katello
 //:ReleaseNotesDocTitle: Release Notes - base unused
 :TuningDocTitle: Tuning Performance of {ProjectName}
@@ -34,21 +32,9 @@
 
 // Overrides for titles per product
 
-ifdef::foreman-el[]
-:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server on RHEL/CentOS
-:QuickstartDocTitle: Quickstart Guide for {Project} on RHEL/CentOS
-endif::[]
-
-ifdef::foreman-deb[]
-// Overrides for titles
-:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server on Debian/Ubuntu
-:InstallingSmartProxyDocTitle: Installing an External Smart Proxy Server on Debian/Ubuntu
-:QuickstartDocTitle: Quickstart Guide for {Project} on Debian/Ubuntu
-endif::[]
-
 ifdef::katello[]
-:InstallingServerDocTitle: Installing Foreman {ProjectVersion} Server with Katello {KatelloVersion} Plugin on RHEL/CentOS
-:QuickstartDocTitle: Quickstart Guide for {Project} with Katello on RHEL/CentOS
+:InstallingServerDocTitle: Installing {ProjectServerTitle} with Katello {KatelloVersion} Plugin on {install-on-os}
+:QuickstartDocTitle: Quickstart Guide for {Project} with Katello on {install-on-os}
 endif::[]
 
 ifdef::satellite[]


### PR DESCRIPTION
This introduces an install-os attribute to make it easy to share the document titles.

It also drops "external" from InstallingSmartProxyDocTitle in vanilla Foreman. This is because Foreman doesn't have a concept of "internal" Smart Proxy. In Katello you could argue there is, because you need some primary Pulp installation but with vanilla Foreman that terminology has never been used.

I'm not sure how much this should be cherry picked.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.