### PR TITLE
Rewrite footnote into table introduction

### DIFF
--- a/guides/common/modules/ref_predefined-roles.adoc
+++ b/guides/common/modules/ref_predefined-roles.adoc
@@ -1,13 +1,12 @@
 [id="Predefined_Roles_{context}"]
 = Predefined Roles Available in {Project}
 
-xref:table_permissions-provided-by-role[] provides an overview of permissions that predefined roles in {Project} grant to a user.
+The following table provides an overview of permissions that predefined roles in {Project} grant to a user.
 
 To view the exact set of permissions a predefined role grants, display the role in {ProjectwebUI} as the privileged user.
 For more information, see xref:Viewing_Permissions_of_a_Role_{context}[].
 
 .Permissions provided by role
-[id="table_permissions-provided-by-role"]
 [cols="2,7" options="header"]
 |====
 |Role |Permissions Provided by Role

--- a/guides/common/modules/ref_predefined-roles.adoc
+++ b/guides/common/modules/ref_predefined-roles.adoc
@@ -1,9 +1,16 @@
 [id="Predefined_Roles_{context}"]
 = Predefined Roles Available in {Project}
 
+xref:table_permissions-provided-by-role[] provides an overview of permissions that predefined roles in {Project} grant to a user.
+
+To view the exact set of permissions a predefined role grants, display the role in {ProjectwebUI} as the privileged user.
+For more information, see xref:Viewing_Permissions_of_a_Role_{context}[].
+
+.Permissions provided by role
+[id="table_permissions-provided-by-role"]
 [cols="2,7" options="header"]
 |====
-|Role |Permissions Provided by Role footnote:[The exact set of allowed actions associated with predefined roles can be viewed by the privileged user as described in xref:Viewing_Permissions_of_a_Role_{context}[\]]
+|Role |Permissions Provided by Role
 
 | Access Insights Admin | Add and edit Insights rules.
 | Access Insights Viewer | View Insight reports.


### PR DESCRIPTION
Neither asciidoctor nor Antora handle footnotes in tables very well. Also, the information in the footnote is very easy to miss like this.

With this PR, the information from the footnote precedes the table, thus providing an introduction to the contents of the table.

I also took the liberty of tweaking the wording of the footnote a little, so that the whole section consistently uses the terminology "permissions granted" or "permissions provided" instead of "set of allowed actions".

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
