### PR TITLE
Drop chown apache instruction for Puppet environments

### DIFF
--- a/guides/common/modules/proc_creating-a-host-group.adoc
+++ b/guides/common/modules/proc_creating-a-host-group.adoc
@@ -44,12 +44,11 @@ Use the *arrow* icon to manage the roles that you add or remove.
 ====
 Puppet fails to retrieve the Puppet CA certificate while registering a host with a host group associated with a Puppet environment created inside a `Production` environment.
 
-To create a suitable Puppet environment to be associated with a host group, manually create a directory and change the owner:
+To create a suitable Puppet environment to be associated with a host group, manually create a directory:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # mkdir /etc/puppetlabs/code/environments/_example_environment_
-# chown apache /etc/puppetlabs/code/environments/_example_environment_
 ----
 ====
 . Click *Submit* to save the host group.

--- a/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-a-host-using-the-bootstrap-script.adoc
@@ -30,12 +30,11 @@ If a host group is associated with a Puppet environment created inside a `Produc
 
 To create a suitable Puppet environment to be associated with a host group, follow these steps:
 
-. Manually create a directory and change the owner:
+. Manually create a directory:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # mkdir /etc/puppetlabs/code/environments/_example_environment_
-# chown apache /etc/puppetlabs/code/environments/_example_environment_
 ----
 . In the {ProjectWebUI}, navigate to *Configure* > *Environments* and click *Import environment from*.
 The button name includes the FQDN of the internal or external {SmartProxy}.


### PR DESCRIPTION
Back in the Pulp 2 days this was needed for Katello, but since Pulp 3 (so Katello 4) it's no longer a thing.

I still doubt these instructions. You can also go to the Foreman UI and create a new environment if needed. However, for now this is already an improvement.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.