### PR TITLE
Consistently use the correct Apache user

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -25,6 +25,7 @@
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
 
 // Base attributes
+:apache-user: apache
 :ansible-collection-package: ansible-collection-theforeman-foreman
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -1,6 +1,7 @@
 // Attributes only for foreman-deb build
 
 // Overrides for foreman-deb build
+:apache-user: www-data
 :nfs-client-package: nfs-common
 :nfs-server-package: nfs-kernel-server
 :package-clean: apt-get clean

--- a/guides/common/modules/con_configuring-external-authentication.adoc
+++ b/guides/common/modules/con_configuring-external-authentication.adoc
@@ -10,12 +10,12 @@ All user and group accounts must be local accounts.
 This is to ensure that there are no authentication conflicts between local accounts on your {ProjectServer} and accounts in your Active Directory domain.
 
 Your system is not affected by this conflict if your user and group accounts exist in both `/etc/passwd` and `/etc/group` files.
-For example, to check if entries for `puppet`, `apache`, `foreman` and `foreman-proxy` groups exist in both `/etc/passwd` and `/etc/group` files, enter the following commands:
+For example, to check if entries for `puppet`, `{apache-user}`, `foreman` and `foreman-proxy` groups exist in both `/etc/passwd` and `/etc/group` files, enter the following commands:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# cat /etc/passwd | grep 'puppet\|apache\|foreman\|foreman-proxy'
-# cat /etc/group | grep 'puppet\|apache\|foreman\|foreman-proxy'
+# cat /etc/passwd | grep 'puppet\|{apache-user}\|foreman\|foreman-proxy'
+# cat /etc/group | grep 'puppet\|{apache-user}\|foreman\|foreman-proxy'
 ----
 
 .Scenarios for Configuring External Authentication

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -37,7 +37,7 @@ security = ads
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# id apache
+# id {apache-user}
 ----
 +
 Apache user must not have access to the keytab file.
@@ -58,7 +58,7 @@ WARNING: The host must not be enrolled to a domain before creating a keytab entr
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # KRB5_KTNAME=FILE:/etc/httpd/conf/http.keytab net ads keytab add HTTP -U administrator -d3 -s /etc/net-keytab.conf
-# chown root.apache /etc/httpd/conf/http.keytab
+# chown root.{apache-user} /etc/httpd/conf/http.keytab
 # chmod 640 /etc/httpd/conf/http.keytab
 ----
 . Enable IPA authentication in {Project}:

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -61,12 +61,7 @@ endif::[]
 {ProductName} must be installed on a freshly provisioned system that serves no other function except to run {ProductName}.
 The freshly provisioned system must not have the following users provided by external identity providers to avoid conflicts with the local users that {ProductName} creates:
 
-ifdef::foreman-deb[]
-* www-data
-endif::[]
-ifndef::foreman-deb[]
-* apache
-endif::[]
+* {apache-user}
 ifeval::["{context}" == "{project-context}"]
 * foreman
 endif::[]

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -26,10 +26,10 @@ Because of potential conflicts with local users that {Project} creates, you cann
 |foreman |N/A |foreman |N/A |yes |/usr/share/foreman |/sbin/nologin
 |foreman-proxy |N/A |foreman-proxy |N/A |yes |/usr/share/foreman-proxy |/sbin/nologin
 ifdef::foreman-deb[]
-|www-data |33 |www-data |33 |no |/var/www |/usr/sbin/nologin
+|{apache-user} |33 |{apache-user} |33 |no |/var/www |/usr/sbin/nologin
 endif::[]
 ifndef::foreman-deb[]
-|apache |48 |apache |48 |no |/usr/share/httpd |/sbin/nologin
+|{apache-user} |48 |{apache-user} |48 |no |/usr/share/httpd |/sbin/nologin
 endif::[]
 |postgres |26 |postgres |26 |no |{postgresql-lib-dir} |/bin/bash
 ifdef::katello,orcharhino,satellite[]


### PR DESCRIPTION
This differs between Debian and Red Hat. By using an attribute we can make it consistent and easy to maintain.

This skips 2 instances because they should be removed by https://github.com/theforeman/foreman-documentation/pull/2343.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.