### PR TITLE
Drop extra backtick from extended cronlines

### DIFF
--- a/guides/common/modules/con_using-extended-cron-lines.adoc
+++ b/guides/common/modules/con_using-extended-cron-lines.adoc
@@ -3,7 +3,7 @@
 
 When scheduling a cron job with remote execution, you can use an extended cron line to specify the cadence of the job.
 The standard cron line contains five fields that specify minute, hour, day of the month, month, and day of the week.
-For example, `0 5 * * *`` stands for every day at 5 AM.
+For example, `0 5 * * *` stands for every day at 5 AM.
 ifdef::foreman-deb,foreman-el,katello[]
 If you want to learn more about the standard cron line, check https://crontab.guru[crontab guru].
 endif::[]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
