### PR TITLE
Clarify configuring settings for keycloak

### DIFF
--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
@@ -20,8 +20,7 @@ set the value to *External*.
 . Locate the *OIDC Audience* row, and in the *Value* column, set the value to the client ID for {Keycloak}.
 . Locate the *OIDC Issuer* row, and in the *Value* column, set the value to *_\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm_*.
 . Locate the *OIDC JWKs URL* row, and in the *Value* column, set the value to *_\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/protocol/openid-connect/certs_*.
-. In the {ProjectWebUI}, navigate to *Administer* > *Authentication Sources* and click *External*.
-. Click *Create LDAP Authentication Source* and select the {Keycloak} server.
+. In the {ProjectWebUI}, navigate to *Administer* > *Authentication Sources*, click the vertical ellipsis on the *External* card, and select *Edit*.
 . Click the *Locations* tab and add locations that can use the {Keycloak} authentication source.
 . Click the *Organizations* tab and add organizations that can use the {Keycloak} authentication source.
 . Click *Submit*.


### PR DESCRIPTION
When configuring settings for keycloak authentication, one does not create a new LDAP auth source. Instead, one only assigns locations and organizations to already created auth source on the external card.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2192360


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
