### PR TITLE
Add Enable Ansible Callback in job template in Satellite 6.13 on 3.5

### DIFF
--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -23,6 +23,10 @@ For examples, see the *Help* tab.
 . Optional: Click *Foreign input set* to include other templates in this job.
 . Optional: In the *Effective user* area, configure a user if the command cannot use the default `remote_execution_effective_user` setting.
 . Optional: If this template is a snippet to be included in other templates, click the *Type* tab and select *Snippet*.
+ifdef::satellite[]
+. Optional: If you use the Ansible provider, click the *Ansible* tab.
+Select *Enable Ansible Callback* to allow hosts to send facts, which are used to create configuration reports, back to {Project} after a job finishes.
+endif::[]
 . Click the *Location* tab and add the locations where you want to use the template.
 . Click the *Organizations* tab and add the organizations where you want to use the template.
 . Click *Submit* to save your changes.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.