### PR TITLE
Add information about stopping and starting services for earlier vers…

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_connected_satellite_server.adoc
@@ -7,12 +7,23 @@ include::../common/modules/snip_using_installer_noop.adoc[]
 
 .Upgrade {ProjectServer}
 
-. Create a backup.
+. Stop all {Project} services:
 +
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service stop
+----
+
+. Take a snapshot or create a backup:
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
+
+. Start all {Project} services:
 +
-For more information about backups, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service start
+----
 
 . Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
 

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_a_disconnected_satellite.adoc
@@ -36,10 +36,23 @@ endif::[]
 
 .Upgrade Disconnected {ProjectServer}
 
-. Create a backup.
+. Stop all {Project} services:
 +
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service stop
+----
+
+. Take a snapshot or create a backup:
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
+
+. Start all {Project} services:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service start
+----
 
 . A pre-upgrade script is available to detect conflicts and list hosts which have duplicate entries in {ProjectServer} that can be unregistered and deleted after upgrade.
 In addition, it will detect hosts which are not assigned to an organization.


### PR DESCRIPTION
…ions

Same change as https://github.com/theforeman/foreman-documentation/pull/2306 for earlier versions. When creating a snapshot, stopping the services before taking the snapshot and then starting them after, is a good idea. Adding information about this in the upgrade guide.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2175369


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* {X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
