### PR TITLE
Update supported OSs in Host Registration (Satellite only)

### DIFF
--- a/guides/common/modules/con_registering_hosts.adoc
+++ b/guides/common/modules/con_registering_hosts.adoc
@@ -37,11 +37,8 @@ Hosts must use one of the following {RHEL} versions:
 
 * 9.0 or later
 * 8.0 or later
-* 7.0 or later
-* 6.1 or later*
-
-NOTE: Red{nbsp}Hat Enterprise{nbsp}Linux versions 6.1, 6.2, and 6.3 require `subscription-manager` and related packages to be updated manually.
-For more information, see https://access.redhat.com/solutions/4480641[].
+* 7.2 or later
+* 6 with the https://www.redhat.com/en/resources/els-datasheet[ELS Add-On]
 
 include::snip_deprecated-entitlement-subscriptions.adoc[]
 


### PR DESCRIPTION
RHEL 6 is EOL and requires Extended Life Support. [BZ#2214813](https://bugzilla.redhat.com/show_bug.cgi?id=2214813)
RHEL 7 has to be at least 7.2 to work. [BZ#2188220](https://bugzilla.redhat.com/show_bug.cgi?id=2188220)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
