### PR TITLE
Remove -i argument in restoring backup of project

### DIFF
--- a/guides/common/modules/proc_restoring-from-incremental-backups.adoc
+++ b/guides/common/modules/proc_restoring-from-incremental-backups.adoc
@@ -14,11 +14,9 @@ When the restore process completes, all processes are online, and all databases 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-maintain} restore -i _/var/backup_directory_/FIRST_INCREMENTAL
-# {foreman-maintain} restore -i _/var/backup_directory_/SECOND_INCREMENTAL
+# {foreman-maintain} restore _/var/backup_directory_/FIRST_INCREMENTAL
+# {foreman-maintain} restore _/var/backup_directory_/SECOND_INCREMENTAL
 ----
-+
-If you created the backup using the `{foreman-maintain} backup` command, you do not need to use `-i` option in the command.
 
 .Additional Resources
 * For troubleshooting, you can check `/var/log/foreman/production.log` and `/var/log/messages`.


### PR DESCRIPTION
There is no other procedure for creating a backup of the project, the `-i` argument should be removed from commands. Additionally, it applies to the sentence related to the same just below.

https://bugzilla.redhat.com/show_bug.cgi?id=2230825

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
