### PR TITLE
don't require check-html for publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -267,7 +267,6 @@ jobs:
       startsWith(github.ref, 'refs/heads/2.') ||
       startsWith(github.ref, 'refs/heads/3.'))
     needs:
-      - check-html
       - build-html
       - build-web
       - build-ccutil


### PR DESCRIPTION
check-html fails quite often, either because a link is temporarily not available or because the linkchecker tool is unstable.

having this block the actual publishing is wrong. we will see the "the link is bad" during PR phase, and if we decide to ignore it (for whatever) reason, we still should be able to publish.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
