### PR TITLE
Update repository restrictions

### DIFF
--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -52,4 +52,4 @@ You can also select the *Auto Publish* option when creating a Composite Content 
 
 .Repository Restrictions
 You cannot include more than one of each container repository in Composite Content Views.
-For example, if you attempt to include two Content Views using the same container repository in a Composite Content View,, {ProjectServer} reports an error.
+For example, if you attempt to include two Content Views using the same container repository in a Composite Content View, {ProjectServer} reports an error.

--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -51,5 +51,5 @@ When you create a version of the application, you publish a new version of the C
 You can also select the *Auto Publish* option when creating a Composite Content View, and then the Composite Content View is automatically republished when a Content View it includes is republished.
 
 .Repository Restrictions
-You cannot include more than one of each container repository in Composite Content Views.
+Each container repository cannot be included more than once in a Composite Content View.
 For example, if you attempt to include two Content Views using the same container repository in a Composite Content View, {ProjectServer} reports an error.

--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -52,4 +52,4 @@ You can also select the *Auto Publish* option when creating a Composite Content 
 
 .Repository Restrictions
 You cannot include more than one of each container repository in Composite Content Views.
-For example, if you attempt to include two Content Views using the same repository in a Composite Content View, {ProjectServer} reports an error.
+For example, if you attempt to include two Content Views using the same container repository in a Composite Content View,, {ProjectServer} reports an error.

--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -51,6 +51,5 @@ When you create a version of the application, you publish a new version of the C
 You can also select the *Auto Publish* option when creating a Composite Content View, and then the Composite Content View is automatically republished when a Content View it includes is republished.
 
 .Repository Restrictions
-You cannot include more than one of each repository in Composite Content Views.
+You cannot include more than one of each container repository in Composite Content Views.
 For example, if you attempt to include two Content Views using the same repository in a Composite Content View, {ProjectServer} reports an error.
-This is only applicable to Docker repositories.

--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -53,3 +53,4 @@ You can also select the *Auto Publish* option when creating a Composite Content 
 .Repository Restrictions
 You cannot include more than one of each repository in Composite Content Views.
 For example, if you attempt to include two Content Views using the same repository in a Composite Content View, {ProjectServer} reports an error.
+This is only applicable to Docker repositories.

--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -50,6 +50,6 @@ Each Content View is then managed and published separately.
 When you create a version of the application, you publish a new version of the Composite Content Views.
 You can also select the *Auto Publish* option when creating a Composite Content View, and then the Composite Content View is automatically republished when a Content View it includes is republished.
 
-.Repository Restrictions
+.Repository restrictions
 Each container repository cannot be included more than once in a Composite Content View.
 For example, if you attempt to include two Content Views using the same container repository in a Composite Content View, {ProjectServer} reports an error.

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -22,7 +22,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-contain
 . In the *Registry Search Parameter* field, enter any search criteria that you want to use to filter your search, and then click *Discover*.
 . Optional: To further refine the *Discovered Repository* list, in the *Filter* field, enter any additional search criteria that you want to use.
 . From the *Discovered Repository* list, select any repositories that you want to import, and then click *Create Selected*.
-. Optional: To change the download policy for this docker repository to _on demand_, see xref:changing_the_download_policy_for_a_repository_{context}[].
+. Optional: To change the download policy for this Docker repository to _on demand_, see xref:changing_the_download_policy_for_a_repository_{context}[].
 . Optional: If you want to create a product, from the *Product* list, select *New Product*.
 . In the *Name* field, enter a product name.
 . Optional: In the *Repository Name* and *Repository Label* columns, you can edit the repository names and labels.

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -22,7 +22,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-contain
 . In the *Registry Search Parameter* field, enter any search criteria that you want to use to filter your search, and then click *Discover*.
 . Optional: To further refine the *Discovered Repository* list, in the *Filter* field, enter any additional search criteria that you want to use.
 . From the *Discovered Repository* list, select any repositories that you want to import, and then click *Create Selected*.
-. Optional: To change the download policy for this Docker repository to _on demand_, see xref:changing_the_download_policy_for_a_repository_{context}[].
+. Optional: To change the download policy for this container repository to _on demand_, see xref:changing_the_download_policy_for_a_repository_{context}[].
 . Optional: If you want to create a product, from the *Product* list, select *New Product*.
 . In the *Name* field, enter a product name.
 . Optional: In the *Repository Name* and *Repository Label* columns, you can edit the repository names and labels.


### PR DESCRIPTION
Added that Docker repositories are only applicable to the Repository
Restrictions paragraph. Changed "docker" to "Docker" in Importing
Container Images for consistency.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
