### PR TITLE
Document permissions required to provision Amazon EC2

### DIFF
--- a/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
+++ b/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
@@ -4,6 +4,10 @@
 Use this procedure to add the Amazon EC2 connection in {ProjectServer}'s compute resources.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-amazon-ec2-connection_{context}[].
 
+.Prerequisite
+* An AWS EC2 user performing this procedure needs the `AmazonEC2FullAccess` permissions.
+You can attach these permissions from AWS.
+
 .Time Settings and Amazon Web Services
 Amazon Web Services uses time settings as part of the authentication process.
 Ensure that {ProjectServer}'s time is correctly synchronized.


### PR DESCRIPTION
[BZ#2196328](https://bugzilla.redhat.com/show_bug.cgi?id=2196328) requests specifying the permissions required for a user to configure an AWS EC2 compute resource. This PR adds a prerequisite to the procedure.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
