### PR TITLE
Improve RN doc attributes (mainly Satellite)

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -14,7 +14,7 @@
 :ManagingSecurityDocURL: {BaseURL}Managing_Security_Compliance/{BaseFilenameURL}#
 :PlanningDocURL: {BaseURL}Planning_for_Project/{BaseFilenameURL}#
 :ProvisioningDocURL: {BaseURL}Provisioning_Hosts/{BaseFilenameURL}#
-:ReleaseNotesURL: {BaseURL}Release_Notes/{BaseFilenameURL}#
+:ReleaseNotesDocURL: {BaseURL}Release_Notes/{BaseFilenameURL}#
 :TuningDocURL: {BaseURL}Tuning_Performance/{BaseFilenameURL}#
 :UpgradingDocURL: {BaseURL}Upgrading_Project/{BaseFilenameURL}#
 

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -24,7 +24,7 @@
 :UpgradingDocURL: {BaseURL}upgrading_red_hat_satellite/index#
 
 // Not upstreamed
-:ReleaseNotesURL: {BaseURL}release_notes/index#
+:ReleaseNotesDocURL: {BaseURL}release_notes/index#
 :APIDocURL: {BaseURL}api_guide/index#
 :HammerDocURL: {BaseURL}hammer_cli_guide/index#
 :ConfiguringVMSubscriptionsDocURL: {BaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index#
@@ -83,12 +83,12 @@
 :package-remove-project: satellite-maintain packages remove
 :package-update-project: satellite-maintain packages update
 :PIV: CAC
-
 :project-context: satellite
 :project-change-hostname: satellite-change-hostname
 :Project: Satellite
 :ProjectFeed: https://www.redhat.com/en/rss/blog/channel/red-hat-satellite
 :ProjectName: Red{nbsp}Hat Satellite
+:ProductName: {ProjectName}
 :ProjectNameX: Red{nbsp}Hat Satellite{nbsp}6
 :ProjectServer: Satellite{nbsp}Server
 :ProjectServerTitle: {Project}{nbsp}Server

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -21,8 +21,7 @@
 :PlanningDocTitle: Planning for {ProjectName}
 :ProvisioningDocTitle: Provisioning Hosts
 :QuickstartDocTitle: Quickstart Guide for {Project} on {install-on-os}
-// Release Notes - defined for Foreman and Katello
-//:ReleaseNotesDocTitle: Release Notes - base unused
+:ReleaseNotesDocTitle: Release Notes
 :TuningDocTitle: Tuning Performance of {ProjectName}
 :UpgradingDocTitle: Upgrading {ProjectName}
 

--- a/guides/doc-Upgrading_Project/topics/con_upgrading-prerequisites.adoc
+++ b/guides/doc-Upgrading_Project/topics/con_upgrading-prerequisites.adoc
@@ -4,7 +4,7 @@
 Upgrading to {Project} {ProjectVersion} affects your entire {Project} infrastructure.
 Before proceeding, complete the following:
 
-* Read the {ProjectName} {ProjectVersion} {ReleaseNotesURL}[Release Notes].
+* Read the {ProjectName} {ProjectVersion} {ReleaseNotesDocURL}[Release Notes].
 * Plan your upgrade path.
 For more information, see xref:upgrade_paths_{context}[].
 * Plan for the required downtime. {Project} services are shut down during the upgrade.


### PR DESCRIPTION
Working on Release Notes in Satellite, I discovered that the attributes could use some tweaks.
This change just beautifies attribute names and shouldn't affect any upstream content.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
