### PR TITLE
Correctly format admonition in procedure

### DIFF
--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -96,7 +96,7 @@ Environment=GSS_USE_PROXY=1
 # systemctl restart httpd
 ----
 
-IMPORTANT
+[IMPORTANT]
 ====
 With direct AD integration, HBAC through {FreeIPA} is not available.
 As an alternative, you can use Group Policy Objects (GPO) that enable administrators to centrally manage policies in AD environments.


### PR DESCRIPTION
Missing brackets caused admonition to not render properly.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
