### PR TITLE
Clarify kubevirt hostname

### DIFF
--- a/guides/common/modules/proc_adding-kubevirt-connection.adoc
+++ b/guides/common/modules/proc_adding-kubevirt-connection.adoc
@@ -32,7 +32,7 @@ Make a note of this token to use later in this procedure.
 . In the *Name* field, enter a name for the new compute resource.
 . From the *Provider* list, select *{KubeVirt}*.
 . In the *Description* field, enter a description for the compute resource.
-. In the *Hostname* field, enter the address of the {KubeVirt} server that you want to use.
+. In the *Hostname* field, enter the FQDN, hostname, or IP address of the {KubeVirt} server that you want to use.
 . In the *API Port* field, enter the port number that you want to use for provisioning requests from {Project} to {KubeVirt}.
 . In the *Namespace* field, enter the user name of the {KubeVirt} virtual cluster that you want to use.
 . In the *Token* field, enter the bearer token for HTTP and HTTPs authentication.


### PR DESCRIPTION
Claryfying what kind of value is required.
https://bugzilla.redhat.com/show_bug.cgi?id=2134096

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
