### PR TITLE
Add a note about usecases for the clone and backup tools for 3.4

### DIFF
--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -3,6 +3,8 @@
 
 You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.
++
+include::snip_backup-usecase-note.adoc[]
 
 To create a backup of your {ProjectServer} or {SmartProxyServer} and all associated data, use the `{foreman-maintain} backup` command.
 Backing up to a separate storage device on a separate system is highly recommended.

--- a/guides/common/modules/snip_backup-usecase-note.adoc
+++ b/guides/common/modules/snip_backup-usecase-note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+If you create a new instance of the {ProjectServer}, decomission the old instances after restoring the backup.
+Cloned instances are not supposed to run in parallel in a production environment.
+====

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -5,10 +5,13 @@
 When you upgrade {ProjectServer}, you can optionally create and upgrade a clone of your {Project} to ensure that you do not lose any data while you upgrade.
 After your upgrade is complete, you can then decommission the earlier version of {ProjectServer}.
 
-Use the following procedures to clone your {Project} instances to preserve your environments in preparation for upgrade.
+You can clone your {ProjectServer} to create instances to test upgrades and migration of instances to a different machine or operating system.
+This is an optional step to provide more flexibility during the upgrade or migration.
 
 The {Project} clone tool does not support migrating a {SmartProxyServer} to {EL} 8.
 Instead, you must backup the existing {SmartProxyServer}, restore it on {EL} 8, and then reconfigure {SmartProxyServer}.
+
+include::../common/modules/snip_backup-usecase-note.adoc[]
 
 .Terminology
 Ensure that you understand the following terms:


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/2296. Pushing separate PR due to a merge conflict for 3.4.

The clone tool is meant for creating test instances for upgrades or migration to reduce any risk and possible downtime. However, some users use these tools to deploy new instances from existing ones. These instances might not be stable leading to failures after deployment. Adding a note to make the users aware of the use cases for these tools so that these are used as intended.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
