### PR TITLE
Fix local file repo path

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -76,7 +76,7 @@ PULP_MANIFEST test.txt
 ----
 
 Now, you can import your local source as a {customfiletype} repository.
-Use the `file://` URL scheme and the name of the directory to specify an *Upstream URL*, such as `\file:///__my_file_repo__`.
+Use the `file://` URL scheme and the name of the directory to specify an *Upstream URL*, such as `\file:///var/lib/pulp/__local_repos__/__my_file_repo__`.
 For more information, see xref:Creating_a_Custom_File_Type_Repository_{context}[].
 
 If you update the contents of your directory, re-run Pulp Manifest and sync the repository in {Project}.


### PR DESCRIPTION
Foreman requires an absolute path for local file repos on Foreman Server.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)