### PR TITLE
Reflect the upgrade target in upgrading title

### DIFF
--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -24,7 +24,7 @@
 :ReleaseNotesDocTitle: Release Notes
 :TuningDocTitle: Tuning Performance of {ProjectName}
 :UpdatingDocTitle: Updating {ProjectName}
-:UpgradingDocTitle: Upgrading {ProjectName}
+:UpgradingDocTitle: Upgrading {ProjectName} to {ProjectVersion}
 
 // Not upstreamed
 :APIDocTitle: API Guide


### PR DESCRIPTION
This is useful if you have multiple tabs open or link to it from something like Discourse.

I'm only selecting the support stable releases, but I wonder if we should pick it to all branches.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.