### PR TITLE
Update Foreman 3.6.2 Release Notes

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/foreman-3.6.2.adoc[leveloffset=+1]
 include::topics/foreman-3.6.1.adoc[leveloffset=+1]
 ifdef::katello[]
 include::topics/katello-4.8.0.adoc[leveloffset=+1]

--- a/guides/doc-Release_Notes/topics/foreman-3.6.2.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.6.2.adoc
@@ -1,0 +1,35 @@
+= Foreman 3.6.2
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1703[Redmine]
+
+== Foreman
+
+=== Host registration
+
+* global registration should not create hosts as "managed" or "to be built" - https://projects.theforeman.org/issues/36393[#36393]
+
+=== Inventory
+
+* Redirect when editing a host is not reliable - https://projects.theforeman.org/issues/36265[#36265]
+* hosts names are hidden in small screens  - https://projects.theforeman.org/issues/36263[#36263]
+* Host Detail button landed to old Host UI page - https://projects.theforeman.org/issues/36225[#36225]
+
+=== Packaging
+
+* Pin sass version to 1.60.z to avoid node 14 dependency - https://projects.theforeman.org/issues/36305[#36305]
+
+=== Tests
+
+* Pin minitest &lt; 5.19 to resolve test failures - https://projects.theforeman.org/issues/36617[#36617]
+
+== Installer
+
+=== foreman-installer script
+
+* katello-certs-check does not cause the installer to halt execution on failure - https://projects.theforeman.org/issues/36567[#36567]
+
+== Packaging
+
+=== Debian/Ubuntu
+
+* ruby-foreman-templates DEB package includes old versions of git and diffy GEMs - https://projects.theforeman.org/issues/36405[#36405]


### PR DESCRIPTION
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
