### PR TITLE
Install Red Hat Insights plugin

### DIFF
--- a/guides/common/assembly_monitoring-hosts-using-red-hat-insights.adoc
+++ b/guides/common/assembly_monitoring-hosts-using-red-hat-insights.adoc
@@ -1,5 +1,9 @@
 include::modules/con_monitoring-hosts-using-red-hat-insights.adoc[]
 
+ifdef::orcharhino[]
+include::modules/proc_installing-red-hat-cloud-plug-in.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_using-red-hat-insights.adoc[leveloffset=+1]
 
 include::modules/proc_creating-an-insights-plan-for-hosts.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_installing-red-hat-cloud-plug-in.adoc
+++ b/guides/common/modules/proc_installing-red-hat-cloud-plug-in.adoc
@@ -1,0 +1,13 @@
+[id="Installing_Red_Hat_Cloud_Plug_in_{context}"]
+= Installing Red Hat Cloud Plug-in
+
+Install the Red Hat Cloud plug-in to generate and upload reports from {Project} to your {RHCloud}.
+
+.Procedure
+. Install the Red Hat Cloud plug-in on your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --enable-foreman-plugin-rh-cloud
+----
+. Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the _Plugins_ tab to verify the installation of the Red Hat Cloud plug-in.


### PR DESCRIPTION
I assume this plug-in is installed on Satellite by default.

For the second commit: I could not find the role on plain Foreman 3.7 and orcharhino. Can you confirm that it's part of the "Foreman Satellite plugin"? Or does it come from another plugin?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)