### PR TITLE
Update CR OpenStack procedure to match UI

### DIFF
--- a/guides/common/modules/proc_adding-openstack-connection.adoc
+++ b/guides/common/modules/proc_adding-openstack-connection.adoc
@@ -1,21 +1,24 @@
 [id="adding-openstack-connection_{context}"]
 = Adding the {OpenStack} Connection to {ProjectServer}
 
-Use this procedure to add {OpenStack} as a compute resource in {Project}.
+You can add {OpenStack} as a compute resource in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-openstack-connection_{context}[].
 
 .Procedure
 
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources* and click *Create Compute Resource*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
+. Click *Create Compute Resource*.
 . In the *Name* field, enter a name for the new compute resource.
 . From the *Provider* list, select *RHEL OpenStack Platform*.
-. In the *Description* field, enter a description for the compute resource.
-. In the *URL* field, enter the URL for the OpenStack Authentication keystone service's API at the `tokens` resource.
-Use the following format: `\http://openstack.example.com:5000/v3.0/tokens`.
-. In the *User* and *Password* fields, enter the authentication user and password for {Project} to access the environment.
-. In the *Domain* field, enter the domain for V3 authentication.
-. From the *Tenant* list, select the tenant or project for {ProjectServer} to manage.
-. To use external networks as primary networks for hosts, select the *Allow external network as main network* checkbox.
+. Optional: In the *Description* field, enter a description for the compute resource.
+. In the *URL* field, enter the URL for the OpenStack Authentication keystone service's API at the `tokens` resource, such as `\http://openstack.example.com:5000/v2.0/tokens` or `\http://openstack.example.com:5000/v3/auth/tokens`.
+. In the *Username* and *Password* fields, enter the user authentication for {Project} to access the environment.
+. Optional: In the *Project (Tenant) name* field, enter the name of your tenant (v2) or project (v3) for {ProjectServer} to manage.
+. In the *User domain* field, enter the user domain for v3 authentication.
+. In the *Project domain name* field, enter the project domain name for v3 authentication.
+. In the *Project domain ID* field, enter the project domain ID for v3 authentication.
+. Optional: Select *Allow external network as main network* to use external networks as primary networks for hosts.
+. Optional: Click *Test Connection* to verify that {Project} can connect to your compute resource.
 . Click the *Locations* and *Organizations* tabs and verify that the location and organization that you want to use are set to your current context.
 Add any additional contexts that you want to these tabs.
 . Click *Submit* to save the {OpenStack} connection.
@@ -29,8 +32,11 @@ Add any additional contexts that you want to these tabs.
 ----
 # hammer compute-resource create --name "_My_OpenStack_" \
 --provider "OpenStack" \
---description "My OpenStack environment at _openstack.example.com_" \
---url "_http://openstack.example.com_:5000/v3.0/tokens" --user "_My_Username_" \
---password "_My_Password_" --tenant "openstack" --locations "New York" \
---organizations "_My_Organization_"
+--description "_My OpenStack environment at openstack.example.com_" \
+--url "_http://openstack.example.com_:5000/v3/auth/tokens" \
+--user "_My_Username_" --password "_My_Password_" \
+--tenant "_My_Openstack_" --domain "_My_User_Domain_" \
+--project-domain-id "_My_Project_Domain_ID_" \
+--project-domain-name "_My_Project_Domain_Name_" \
+--locations "New York" --organizations "_My_Organization_"
 ----


### PR DESCRIPTION
Originally, an update to a single step was requested, but the whole procedure required a refresh, because it was outdated in comparison to the UIs.

https://bugzilla.redhat.com/show_bug.cgi?id=1846066

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
