### PR TITLE
Hide invalid chapters for the Installing Foreman guide

### DIFF
--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -60,9 +60,9 @@ include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/assembly_using-external-databases.adoc[leveloffset=+2]
-endif::[]
 
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
+endif::[]
 
 include::common/assembly_configuring-external-authentication.adoc[leveloffset=+1]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -38,7 +38,7 @@ include::common/modules/proc_synchronizing-the-satellite-tools-repository.adoc[l
 include::common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc[leveloffset=+2]
 endif::[]
 
-ifndef::satellite[]
+ifdef::katello,orcharhino[]
 include::common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn.adoc[leveloffset=+2]
 endif::[]
 


### PR DESCRIPTION
Both consuming content and tuning profiles are Katello-only features and shouldn't be shown on foreman-{deb,el}

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.