### PR TITLE
Document enabling REX ssh mode for upstream 3.5 and lower

### DIFF
--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -12,6 +12,13 @@ include::modules/proc_configuring-smart-proxy-for-host-registration-and-provisio
 ifdef::katello,orcharhino,satellite[]
 // Enabling Katello Agent Infrastructure
 include::modules/proc_enabling-katello-agent.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::foreman-el,foreman-deb,katello[]
+include::modules/proc_enabling-remote-execution.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/modules/proc_enabling-remote-execution.adoc
+++ b/guides/common/modules/proc_enabling-remote-execution.adoc
@@ -1,0 +1,24 @@
+[id="enabling-remote-execution_{context}"]
+= Enabling Remote Execution
+
+Use this procedure to enable remote execution on your {SmartProxyServer}.
+To learn more about remote execution, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in _{ManagingHostsDocTitle}_.
+
+ifdef::foreman-el,foreman-deb[]
+.Prerequisite
+* You have enabled the remote execution plug-in on your {ProjectServer}.
+To do this, run the following command:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --enable-foreman-plugin-remote-execution
+----
+endif::[]
+
+.Procedure
+* Enable remote execution with {foreman-installer}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --enable-foreman-proxy-plugin-remote-execution-ssh
+----


### PR DESCRIPTION
Same change as in #2372 for versions 3.5 and lower.
Replaced `--enable-foreman-proxy-plugin-remote-execution-script` with `--enable-foreman-proxy-plugin-remote-execution-ssh`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2216976


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
