### PR TITLE
Remove useless line about previous upgrade docs

### DIFF
--- a/guides/doc-Upgrading_Project/topics/con_upgrade-paths.adoc
+++ b/guides/doc-Upgrading_Project/topics/con_upgrade-paths.adoc
@@ -8,10 +8,6 @@ ifdef::satellite[]
 For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/upgrading_and_updating_red_hat_satellite/[_{UpgradingDocTitle} to {ProjectVersionPrevious}_].
 endif::[]
 
-ifndef::satellite[]
-For more information, see the {Project} {ProjectVersionPrevious} Upgrade documentation.
-endif::[]
-
 .High-Level Upgrade Steps
 
 The high-level steps in upgrading {Project} to {ProjectVersion} are as follows:


### PR DESCRIPTION
This line doesn't add anything. If anything, the description should be a link.

I do wonder if we should instead do the effort of making sure we can make it a link.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.