### PR TITLE
Hide load-balanced config description on foreman-{deb,el}

### DIFF
--- a/guides/doc-Upgrading_Project/topics/con_upgrading-smartproxies-separately-from-project.adoc
+++ b/guides/doc-Upgrading_Project/topics/con_upgrading-smartproxies-separately-from-project.adoc
@@ -10,5 +10,7 @@ Upgrading {SmartProxies} after upgrading {Project} can be useful in the followin
 
 . If you want to have several smaller outage windows instead of one larger window.
 . If {SmartProxies} in your organization are managed by several teams and are located in different locations.
+ifdef::katello,orcharhino,satellite[]
 . If you use a load-balanced configuration, you can upgrade one load-balanced {SmartProxy} and keep other load-balanced {SmartProxies} at one version lower.
 This allows you to upgrade all {SmartProxies} one after another without any outage.
+endif::[]


### PR DESCRIPTION
The load-balanced Smart Proxy is not supported for foreman-{deb,el} so it doesn't need to be described.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.