### PR TITLE
Fix case in an instance of {ProjectWebUI}

### DIFF
--- a/guides/common/modules/ref_predefined-roles-available-in-project.adoc
+++ b/guides/common/modules/ref_predefined-roles-available-in-project.adoc
@@ -3,7 +3,7 @@
 
 The following table provides an overview of permissions that predefined roles in {Project} grant to a user.
 
-For a complete set of predefined roles and the permissions they grant, log in to {ProjectwebUI} as the privileged user and navigate to *Administer* > *Roles*.
+For a complete set of predefined roles and the permissions they grant, log in to {ProjectWebUI} as the privileged user and navigate to *Administer* > *Roles*.
 For more information, see xref:Viewing_Permissions_of_a_Role_{context}[].
 
 [cols="3,5,5" options="header"]


### PR DESCRIPTION
In a recently merged PR, I misspelled the {ProjectWebUI} attribute. This PR addresses that error.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
