### PR TITLE
Add warning republishing metadata and mirroring

### DIFF
--- a/guides/common/modules/con_mirroring-policies-overview.adoc
+++ b/guides/common/modules/con_mirroring-policies-overview.adoc
@@ -24,6 +24,6 @@ This mirroring policy is only available for Yum content.
 +
 [WARNING]
 ====
-{Team} does not recommend republishing metadata for repositories with Complete Mirror mirroring policy.
+Avoid republishing metadata for repositories with Complete Mirror mirroring policy.
 This also applies to Content Views containing repositories with the Complete Mirror mirroring policy.
 ====

--- a/guides/common/modules/con_mirroring-policies-overview.adoc
+++ b/guides/common/modules/con_mirroring-policies-overview.adoc
@@ -21,6 +21,9 @@ Complete Mirroring::
 Mirrors content as well as repodata.
 This is the fastest method.
 This mirroring policy is only available for Yum content.
-Republishing metadata in repositories with Complete Mirroring is high-risk.
-Hammer allows it using the `--force flag` command.
-This also applies to Content Views containing repositories with the Complete Mirroring policy.
++
+[WARNING]
+====
+{Team} does not recommend republishing metadata for repositories with Complete Mirror mirroring policy.
+This also applies to Content Views containing repositories with the Complete Mirror mirroring policy.
+====

--- a/guides/common/modules/con_mirroring-policies-overview.adoc
+++ b/guides/common/modules/con_mirroring-policies-overview.adoc
@@ -1,10 +1,10 @@
 [id="Mirroring_Policies_Overview_{context}"]
 = Mirroring Policies Overview
 
-Mirroring keeps the local repository exactly in synchronization with the upstream repository. 
+Mirroring keeps the local repository exactly in synchronization with the upstream repository.
 If any content is removed from the upstream repository since the last synchronization, with the next synchronization, it will be removed from the local repository as well.
 
-You can use mirroring policies for finer control over mirroring of repodata and content when synchronizing a repository. 
+You can use mirroring policies for finer control over mirroring of repodata and content when synchronizing a repository.
 For example, if it is not possible to mirror the repodata for a repository, you can set the mirroring policy to mirror only content for this repository.
 
 {ProjectServer} has the following mirroring policies:
@@ -21,3 +21,6 @@ Complete Mirroring::
 Mirrors content as well as repodata.
 This is the fastest method.
 This mirroring policy is only available for Yum content.
+Republishing metadata in repositories with Complete Mirroring is high-risk.
+Hammer allows it using the `--force flag` command.
+This also applies to Content Views containing repositories with the Complete Mirroring policy.


### PR DESCRIPTION
A warning has been added for republishing metadata for repositories
with Complete Mirroring because the risk is too great and causes issues.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
