### PR TITLE
Show hint that you cannot manage content with Katello when using Foreman on Debian

### DIFF
--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -4,24 +4,26 @@ include::common/header.adoc[]
 
 = {ContentManagementDocTitle}
 
+ifdef::foreman-deb[]
+The Katello plug-in required to manage content in Foreman is not supported on Debian/Ubuntu.
+endif::[]
+
+ifdef::foreman-el,foreman-deb[]
+If you want to manage content using Foreman/Katello, you have to run Foreman/Katello on {EL}.
+Converting an existing Foreman installation on {EL} to Foreman/Katello is not supported.
+For more information, see {BaseURL}Installing_Server/index-katello.html[Installing Foreman Server with Katello Plugin on {EL}].
+endif::[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-// Render only for relevant and finished contexts
-ifndef::katello,satellite,orcharhino[]
-Content management requires the Katello plugin.
-Conversion of an existing installation is not supported.
-// Can't use the regular macros because they are for the wrong flavor
-See the {BaseURL}Installing_Server/index-katello.html[Katello installation guide] on how to install Katello.
-endif::[]
 ifdef::katello,satellite,orcharhino[]
-
 include::common/modules/con_introduction-to-content-management.adoc[leveloffset=+1]
 
 include::common/modules/con_content-types-overview.adoc[leveloffset=+1]
 
-ifdef::foreman-el,katello[]
+ifdef::katello[]
 include::common/assembly_basic-content-management-workflow.adoc[leveloffset=+1]
 endif::[]
 
@@ -41,7 +43,7 @@ include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=
 
 include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
 
-ifndef::satellite[]
+ifdef::katello,orcharhino[]
 include::common/assembly_managing-suse-content.adoc[leveloffset=+1]
 endif::[]
 
@@ -55,20 +57,18 @@ include::common/assembly_managing-isos-and-files.adoc[leveloffset=+1]
 
 include::common/assembly_managing-custom-file-type-content.adoc[leveloffset=+1]
 
-ifndef::satellite[]
+ifdef::katello,orcharhino[]
 include::common/assembly_managing-python-type-content.adoc[leveloffset=+1]
 endif::[]
 
 [appendix]
 include::common/modules/proc_using-an-nfs-share-for-content-storage.adoc[leveloffset=+1]
 
-ifdef::satellite,katello[]
 [appendix]
 include::common/assembly_importing-kickstart-repositories.adoc[leveloffset=+1]
 endif::[]
 
-endif::[]
-ifndef::satellite[]
+ifdef::katello,orcharhino[]
 [appendix]
 == Configuring {ISS} (ISS) in {Project}
 


### PR DESCRIPTION
As discussed on Monday: Improve https://docs.theforeman.org/3.7/Managing_Content/index-foreman-deb.html

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)