### PR TITLE
Improve VMware cloud-init/userdata section

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -3,7 +3,7 @@
 
 You can use VMware with the `Cloud-init` and `Userdata` templates to insert user data into the new virtual machine, to make further VMware customization, and to enable the VMware-hosted virtual machine to call back to {Project}.
 
-You can use the same procedures to set up a VMware compute resource within {Project}, with a few modifications to the work flow.
+You can use the same procedures to set up a VMware compute resource within {Project}, with a few modifications to the workflow.
 
 .VMware cloud-init Provisioning Overview
 ifdef::satellite[]
@@ -16,7 +16,7 @@ ifndef::satellite,orcharhino[]
 image::common/user-data-sequence-foreman.svg[]
 endif::[]
 
-When you set up the compute resource and images for VMware provisioning in {Project}, the following sequence of provisioning events occur:
+When you set up the compute resource and images for VMware provisioning in {Project}, the following sequence of provisioning events occurs:
 
 * The user provisions one or more virtual machines using the {ProjectWebUI}, API, or hammer
 * {Project} calls the VMware vCenter to clone the virtual machine template
@@ -26,18 +26,24 @@ When you set up the compute resource and images for VMware provisioning in {Proj
 * VMware vCenter applies customization for the virtual machine's identity, including the host name, IP, and DNS
 * The virtual machine builds, `cloud-init` is invoked and calls back {Project} on port `80`, which then redirects to `443`
 
-.Port and Firewall Requirements
+.Prerequisites
+* Configure port and firewall settings to open any necessary connections.
 Because of the `cloud-init` service, the virtual machine always calls back to {Project} even if you register the virtual machine to {SmartProxy}.
-Ensure that you configure port and firewall settings to open any necessary connections.
-
 ifndef::orcharhino[]
-For more information about port and firewall requirements, see {InstallingServerDocURL}satellite-ports-and-firewalls-requirements_{project-context}[Port and Firewall Requirements] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements] in _Installing {SmartProxyServer}_.
+For more information about port and firewall requirements, see {InstallingServerDocURL}Ports_and_Firewalls_Requirements_{project-context}[Port and Firewall Requirements] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}capsule-ports-and-firewalls-requirements_{smart-proxy-context}[Ports and Firewalls Requirements] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
+include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 
-.Associating the `userdata` and `Cloud-init` Templates with the Operating System
-. In the {ProjectWebUI}, navigate to *Hosts* > *Operating Systems*, and select the operating system that you want to use for provisioning.
-. Click the *Template* tab.
-. From the *Cloud-init template* list, select *Cloudinit default*.
+.Associating the `Userdata` and `Cloud-init` Templates with the Operating System
+. In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
+. Search for the *CloudInit default* template and click its name.
+. Click the *Association* tab.
+. Select all operating systems to which the template applies and click *Submit*.
+. Repeat the steps above for the *UserData open-vm-tools* template.
+. Navigate to *Hosts* > *Provisioning Setup* > *Operating Systems*.
+. Select the operating system that you want to use for provisioning.
+. Click the *Templates* tab.
+. From the *Cloud-init template* list, select *CloudInit default*.
 . From the *User data template* list, select *UserData open-vm-tools*.
 . Click *Submit* to save the changes.
 
@@ -47,7 +53,7 @@ To prepare an image, you must first configure the settings that you require on a
 
 To use the `cloud-init` template for provisioning, you must configure a virtual machine so that `cloud-init` is installed, enabled, and configured to call back to {ProjectServer}.
 
-For security purposes, you must install a CA certificate to use HTTPs for all communication.
+For security purposes, you must install a CA certificate to use HTTPS for all communication.
 This procedure includes steps to clean the virtual machine so that no unwanted information transfers to the image you use for provisioning.
 
 If you have an image with `cloud-init`, you must still follow this procedure to enable `cloud-init` to communicate with {Project} because `cloud-init` is disabled by default.
@@ -57,7 +63,7 @@ These instructions are for {EL} or Fedora, follow similar steps for other Linux 
 endif::[]
 
 .Procedure
-. On the virtual machine that you use to create the image, install `cloud-init`, `open-vm-tools`, and `perl`:
+. On the virtual machine that you use to create the image, install the `cloud-init`, `open-vm-tools`, and `perl` packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -83,6 +89,8 @@ datasource:
     seedfrom: https://{foreman-example-com}/userdata/
 EOM
 ----
++
+If you intend to provision through {SmartProxyServer}, use the URL of your {SmartProxyServer} in the `seedfrom` option, such as `https://_{smartproxy-example-com}_:8000/userdata/`.
 . Configure modules to use in `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]
@@ -122,17 +130,19 @@ ifdef::katello,satellite,orcharhino[]
 ----
 # wget -O /etc/pki/ca-trust/source/anchors/cloud-init-ca.crt http://_{foreman-example-com}_/pub/katello-server-ca.crt
 ----
++
+If you intend to provision through {SmartProxyServer}, download the file from your {SmartProxyServer} URL, such as `https://_{smartproxy-example-com}_/pub/katello-server-ca.crt`.
 endif::[]
 ifndef::katello,satellite,orcharhino[]
 . Copy the CA certificate from the Apache configuration to `/etc/pki/ca-trust/source/anchors/cloud-init-ca.crt`.
 endif::[]
-. To update the record of certificates, enter the following command:
+. Update the record of certificates:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # update-ca-trust extract
 ----
-. Use the following commands to clean the image:
+. Clean the image:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -141,7 +151,7 @@ endif::[]
 # package-cleanup --oldkernels --count=1
 # {package-clean} all
 ----
-. Use the following commands to reduce logspace, remove old logs, and truncate logs:
+. Reduce logspace, remove old logs, and truncate logs:
 +
 ----
 # logrotate -f /etc/logrotate.conf
@@ -184,10 +194,5 @@ endif::[]
 # rm -f ~root/.bash_history
 # unset HISTFILE
 ----
-+
-
-You can now create an image from this virtual machine.
-You can use the xref:Adding_VMware_Images_to_Server_{context}[] section to add the image to {Project}.
-
-.Configuring {SmartProxy} to Forward the user data Template
-include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
+. Create an image from this virtual machine.
+. xref:Adding_VMware_Images_to_Server_{context}[Add your image to {Project}].


### PR DESCRIPTION
Request to mention SmartProxy URLs if the user wants to provision through SmartProxy.
I've attempted a couple more minor formal improvements and stumbled on a problem...

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
