### PR TITLE
Update description for Organization admin role

### DIFF
--- a/guides/common/modules/ref_predefined-roles.adoc
+++ b/guides/common/modules/ref_predefined-roles.adoc
@@ -29,8 +29,12 @@ View compliance reports.
 | Edit hosts | View, create, edit, destroy, and build hosts.
 | Edit partition tables | View, create, edit and destroy partition tables.
 | Manager | View and edit global settings.
-| Organization admin | An administrator role defined per organization.
+| Organization admin | All permissions except permissions for managing organizations.
+
+An administrator role defined per organization.
 The role has no visibility into resources in other organizations.
+
+By cloning this role and assigning an organization, you can delegate administration of that organization to a user.
 | Red{nbsp}Hat Access Logs | View the log viewer and the logs.
 | Remote Execution Manager | Control which roles have permission to run infrastructure jobs.
 | Remote Execution User | Run remote execution jobs against hosts.


### PR DESCRIPTION
A follow-up on https://github.com/theforeman/foreman-documentation/pull/2346. While that PR introduced significant rewrites so it's more appropriate to introduce it for future versions only, improving a single description was requested for previous versions as well.

This PR proposes to backport the description for the predefined role of Organization admin to previous versions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
