### PR TITLE
Use update-ca-trust to import LDAP certificate

### DIFF
--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -15,25 +15,18 @@ For example, `/tmp/example.crt`.
 The filename extensions `.cer` and `.crt` are only conventions and can refer to DER binary or PEM ASCII format certificates.
 . Trust the Certificate from the LDAP Server.
 +
-{ProjectServer} requires the CA certificates for LDAP authentication to be individual files in `/etc/pki/tls/certs/` directory.
+{ProjectServer} requires the CA certificates for LDAP authentication to be in the system trust store.
 
-.. Use the `install` command to install the imported certificate into the `/etc/pki/tls/certs/` directory with the correct permissions:
+.. Importe the certificate:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# install /tmp/_example.crt_ /etc/pki/tls/certs/
+# cp /tmp/_example.crt_ /etc/pki/tls/source/anchors
 ----
-.. Enter the following command as `root` to trust the _example.crt_ certificate obtained from the LDAP server:
+.. Update the certificate authority trust store:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ln -s _example.crt_ /etc/pki/tls/certs/$(openssl \ 
-x509 -noout -hash -in \
-/etc/pki/tls/certs/_example.crt_).0
-----
-.. Restart the `httpd` service:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# systemctl restart httpd
+# update-ca-trust enable
+# update-ca-trust
 ----


### PR DESCRIPTION
It's also not needed to restart the service.

@evgeni this is what you mentioned. Is this correct? If so, it probably should be picked back to all releases.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.