### PR TITLE
Correct Foreman 3.8 navigation

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -196,52 +196,8 @@ const navVersions = [
             "path": "Release_Notes"
           },
           {
-            "title": "Quickstart Guide",
-            "path": "Quickstart"
-          },
-          {
-            "title": "Installing Foreman Server",
-            "path": "Installing_Server"
-          },
-          {
-            "title": "Installing Smart Proxy",
-            "path": "Installing_Proxy"
-          },
-          {
-            "title": "Deploying Foreman on AWS",
-            "path": "Deploying_Project_on_AWS"
-          },
-          {
-            "title": "Provisioning Hosts",
-            "path": "Provisioning_Hosts"
-          },
-          {
-            "title": "Managing Hosts",
-            "path": "Managing_Hosts"
-          },
-          {
             "title": "Configuring Hosts Using Ansible",
             "path": "Managing_Configurations_Ansible"
-          },
-          {
-            "title": "Configuring Hosts Using Puppet",
-            "path": "Managing_Configurations_Puppet"
-          },
-          {
-            "title": "Configuring Hosts Using Salt",
-            "path": "Managing_Configurations_Salt"
-          },
-          {
-            "title": "Managing Security Compliance",
-            "path": "Managing_Security_Compliance"
-          },
-          {
-            "title": "Administering Foreman",
-            "path": "Administering_Project"
-          },
-          {
-            "title": "Application Centric Deployment",
-            "path": "Deploying_Hosts_AppCentric"
           }
         ]
       },
@@ -254,32 +210,8 @@ const navVersions = [
             "path": "Release_Notes"
           },
           {
-            "title": "Quickstart Guide",
-            "path": "Quickstart"
-          },
-          {
-            "title": "Installing Foreman Server",
-            "path": "Installing_Server"
-          },
-          {
-            "title": "Deploying Foreman on AWS",
-            "path": "Deploying_Project_on_AWS"
-          },
-          {
-            "title": "Provisioning Hosts",
-            "path": "Provisioning_Hosts"
-          },
-          {
             "title": "Configuring Hosts Using Ansible",
             "path": "Managing_Configurations_Ansible"
-          },
-          {
-            "title": "Configuring Hosts Using Puppet",
-            "path": "Managing_Configurations_Puppet"
-          },
-          {
-            "title": "Administering Foreman",
-            "path": "Administering_Project"
           }
         ]
       },

--- a/web/content/release-3.8.adoc
+++ b/web/content/release-3.8.adoc
@@ -10,27 +10,14 @@ Use the top menu bar for navigation for all guides.
 
 === Quickstart
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on RHEL/CentOS Quickstart Guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu Quickstart Guide]
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
 
 === Installation
 
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
 
 === Upgrading
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-
-// Upgrading guides are not ready for non-Katello
-//* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-el.html[Upgrading and Updating Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-deb.html[Upgrading and Updating Foreman on Debian]
 * link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]


### PR DESCRIPTION
Various guides are hidden because they're not ready. These should not show up in the navigation.

Fixes: ddba2d718d91ade9bdfd3375f875cc883993449a ("Branch Foreman 3.8")