### PR TITLE
Add link to KB article for changing export path

### DIFF
--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -26,4 +26,5 @@ ifdef::satellite[]
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure.
 Configure your {Project} for ISS as appropriate for your use case scenario.
 For more information, see {InstallingServerDisconnectedDocURL}how-to-configure-inter-server-sync_{project-context}[How to Configure {ISS}] in _{InstallingServerDisconnectedDocTitle}_.
+To change the pulp export path, see the Knowledgebase article https://access.redhat.com/solutions/7013903[Hammer content export fails with "Path '/the/path' is not an allowed export path"] on the Red{nbsp}Hat Customer Portal.
 endif::[]


### PR DESCRIPTION
There were no  instructions on how to change the export path so it was
suggested to include those instructions from the KB article at
https://access.redhat.com/solutions/7013903


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
