### PR TITLE
Replace Proxy shortname with FQDN while renaming

### DIFF
--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -47,7 +47,7 @@ For example, to copy the archive file to the `root` user's home directory:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-change-hostname} _new-{smart-proxy-context}_ --username _admin_ \
+# {project-change-hostname} _new-{smartproxy-example-com}_ --username _admin_ \
 --password _password_ \
 --certs-tar /root/_new-{smartproxy-example-com}-certs.tar_
 ----


### PR DESCRIPTION
Using the Shortname instead of FQDN for Proxy throws the error: `new-proxy is not a valid fully qualified domain name. Please use a valid FQDN and try again. No changes have been made to your system.`

https://bugzilla.redhat.com/show_bug.cgi?id=2215750

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
