### PR TITLE
Hide updating guide upstream & correct links to upgrading guide

### DIFF
--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -5,6 +5,13 @@ include::common/header.adoc[]
 
 = {UpdatingDocTitle}
 
+// This guide is not ready because it uses foreman-maintain to update to .z
+// releases but that is not implemented upstream
+ifdef::foreman-el,foreman-deb,katello[]
+include::common/modules/snip_guide-not-ready.adoc[]
+endif::[]
+ifndef::foreman-el,foreman-deb,katello[]
+
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -18,3 +25,4 @@ include::common/modules/proc_updating-disconnected-server.adoc[leveloffset=+1]
 endif::[]
 
 include::common/modules/proc_updating-smart-proxy.adoc[leveloffset=+1]
+endif::[]

--- a/web/content/release-3.7.adoc
+++ b/web/content/release-3.7.adoc
@@ -20,4 +20,4 @@ Use the top menu bar for navigation for all guides.
 === Upgrading
 
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]

--- a/web/content/release-3.8.adoc
+++ b/web/content/release-3.8.adoc
@@ -20,4 +20,4 @@ Use the top menu bar for navigation for all guides.
 === Upgrading
 
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]

--- a/web/content/release-nightly.adoc
+++ b/web/content/release-nightly.adoc
@@ -31,6 +31,6 @@ Use the top menu bar for navigation for all guides.
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
 
 // Upgrading guides are not ready for non-Katello
-//* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-el.html[Upgrading and Updating Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-foreman-deb.html[Upgrading and Updating Foreman on Debian]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
+//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]


### PR DESCRIPTION
The updating procedure relies on code that's not implemented for upstream installations. By hiding it we can't confuse users with something that doesn't work.

It also reflects the correct links to the new upgrading guide.

This should replace https://github.com/theforeman/foreman-documentation/pull/2374.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

This first commit should be picked into 3.8 & 3.7 because the changes were only made in those branches. The web changes in the second commit don't really matter.

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.