### PR TITLE
Remove unnecessary section

### DIFF
--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -26,8 +26,5 @@ include::modules/proc_enabling-connections-from-capsule-to-satellite.adoc[levelo
 // Enabling Connections from {ProjectServer} and Clients to a {SmartProxyServer}
 include::modules/proc_enabling-connections-to-capsule.adoc[leveloffset=+1]
 
-// Verifying Firewall Settings
-include::modules/proc_verifying-firewall-settings.adoc[leveloffset=+1]
-
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -21,8 +21,6 @@ include::modules/ref_ports-and-firewall-requirements.adoc[leveloffset=+1]
 
 include::modules/proc_enabling-client-connections-to-satellite.adoc[leveloffset=+1]
 
-include::modules/proc_verifying-firewall-settings.adoc[leveloffset=+1]
-
 include::modules/proc_verifying-dns-resolution.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -35,3 +35,5 @@ endif::[]
 ----
 # firewall-cmd --runtime-to-permanent
 ----
+
+include::snip_verify-firewall-settings.adoc[]

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -36,3 +36,5 @@ endif::[]
 ----
 # firewall-cmd --runtime-to-permanent
 ----
+
+include::snip_verify-firewall-settings.adoc[]

--- a/guides/common/modules/snip_verify-firewall-settings.adoc
+++ b/guides/common/modules/snip_verify-firewall-settings.adoc
@@ -1,14 +1,5 @@
-[id="verifying-firewall-settings_{context}"]
-
-= Verifying Firewall Settings
-
-Use this procedure to verify your changes to the firewall settings.
-
-include::snip_firewalld.adoc[]
-
-.Procedure
-
-. Enter the following command:
+.Verification
+* Enter the following command:
 +
 [options="nowrap"]
 ----


### PR DESCRIPTION
This should be the verification step in the Enabling Connections section for Project Server and Smart Proxy. Reading it as a separate section is irrelevant.

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
