### PR TITLE
Adding release notes for Foreman 3.8

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/foreman-3.8.0.adoc[leveloffset=+1]
 
 [appendix]
 [id="foreman-contributors"]

--- a/guides/doc-Release_Notes/topics/foreman-3.8.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.8.0.adoc
@@ -1,0 +1,129 @@
+= Foreman 3.8.0
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1731[Redmine]
+
+== Foreman
+
+* Include BOOTIF-parameter in kernel_options for Ubuntu autoinstall - https://projects.theforeman.org/issues/36677[#36677]
+* Add LookupValue permissions - https://projects.theforeman.org/issues/36663[#36663]
+* Support Minitest 5.19+ - https://projects.theforeman.org/issues/36651[#36651]
+* Foreman: Open Redirect weakness in links_controller.rb - https://projects.theforeman.org/issues/36644[#36644]
+* The parameter value vanishes when clicking on the hide value checkbox on the new host page paramater tab - https://projects.theforeman.org/issues/36591[#36591]
+* AutoYaST provisioning template needs update for SLES 15 SP5 - https://projects.theforeman.org/issues/36536[#36536]
+* Show disk and partition info of vsphere host - https://projects.theforeman.org/issues/36518[#36518]
+* Virtual nic conf in preseed is outdated - https://projects.theforeman.org/issues/36508[#36508]
+* Add Windows PE Setup for static ip in win10 - https://projects.theforeman.org/issues/36496[#36496]
+* "Add parameter" button\'s data-ouia-component-id is changing - https://projects.theforeman.org/issues/36481[#36481]
+* Update ansible dev setup guide - https://projects.theforeman.org/issues/36475[#36475]
+* Unable to access Satellite 6 API using non-admin users. - https://projects.theforeman.org/issues/36449[#36449]
+* Invalid netplan config with shortened IPv6-addresses - https://projects.theforeman.org/issues/36441[#36441]
+* instance_id setting is not presistent. - https://projects.theforeman.org/issues/36395[#36395]
+* Cache reads from redis raise "incompatible marshal file format" exception - https://projects.theforeman.org/issues/36329[#36329]
+* "Host - compare content hosts packages" report template should restrict or notify if Host 1\* and Host 2\* name are same - https://projects.theforeman.org/issues/36244[#36244]
+* Use YAML.safe_load instead of YAML.load - https://projects.theforeman.org/issues/36219[#36219]
+* Windows default user data template - https://projects.theforeman.org/issues/36161[#36161]
+* As a user, I want to be able to trigger webhooks only on explicit host updates - https://projects.theforeman.org/issues/36104[#36104]
+* root_pass from settings not detected as unencrypted - https://projects.theforeman.org/issues/35942[#35942]
+* Fix preseed_kernel_options to work with full-host-bootdisk deployments - https://projects.theforeman.org/issues/35124[#35124]
+* Add "last_cheking" attribute to Entitlements Template - https://projects.theforeman.org/issues/30690[#30690]
+
+=== API
+
+* GraphQL: Incorrect totalCount when querying with first parameter - https://projects.theforeman.org/issues/36509[#36509]
+
+=== Audit Log
+
+* Audit shows N/A for host owner changes - https://projects.theforeman.org/issues/36522[#36522]
+
+=== Host groups
+
+* 500 error when loading Hostgroups page for Ansible Roles Manager user - https://projects.theforeman.org/issues/36703[#36703]
+* Changing OS in hostgroup edit form reset pxe loader even when it is not necessary - https://projects.theforeman.org/issues/36560[#36560]
+
+=== Host registration
+
+* global registration should not create hosts as "managed" or "to be built" - https://projects.theforeman.org/issues/36393[#36393]
+
+=== Inventory
+
+* Legacy Hosts UI loaded when you navigate from the Host\'s VMRC Console button - https://projects.theforeman.org/issues/36450[#36450]
+
+=== JavaScript stack
+
+* Update PermissionDenied component  - https://projects.theforeman.org/issues/36551[#36551]
+* Add eslint rule to alert about missing ouia-ids - https://projects.theforeman.org/issues/36471[#36471]
+* Add missing ouia-ids to all pf4 components - https://projects.theforeman.org/issues/36470[#36470]
+* Remove storybook - https://projects.theforeman.org/issues/36439[#36439]
+* Update ConfigReports to pf4 - https://projects.theforeman.org/issues/36400[#36400]
+
+=== Puppet integration
+
+* Move puppet rake task to plugin - https://projects.theforeman.org/issues/36222[#36222]
+
+=== Rails
+
+* Drop power_manager models from autoload paths - https://projects.theforeman.org/issues/36583[#36583]
+* Load Rails 6.1 defaults - https://projects.theforeman.org/issues/35432[#35432]
+
+=== Reporting
+
+* "Applicable errata" and "registered content hosts" reports syntax highlighting broken + applicable errata name needs changing - https://projects.theforeman.org/issues/36587[#36587]
+
+=== Statistics
+
+* Introduce human readable form for Host - Statuses report template - https://projects.theforeman.org/issues/36426[#36426]
+
+=== Templates
+
+* Debian 12 bookworm uses python3 - https://projects.theforeman.org/issues/36519[#36519]
+* Provisioning template for CoreOS has a typo - https://projects.theforeman.org/issues/36490[#36490]
+* Awk/grep should be more strict - https://projects.theforeman.org/issues/36293[#36293]
+* Template load_resource - explain :joins, :preload and includes - https://projects.theforeman.org/issues/36239[#36239]
+* AlmaLinux UEFI Grub2 chainloading is broken - https://projects.theforeman.org/issues/36189[#36189]
+
+=== Tests
+
+* Pin @adobe/css-tools package to 4.2.0 because jest refuses to work with it - https://projects.theforeman.org/issues/36656[#36656]
+* Pin minitest &lt; 5.19 to resolve test failures - https://projects.theforeman.org/issues/36617[#36617]
+
+=== Unattended installations
+
+* Installation medium "CentOS 8 mirror" no longer exists - https://projects.theforeman.org/issues/36659[#36659]
+* Template proxy is not used for IPv6 subnets - https://projects.theforeman.org/issues/36639[#36639]
+
+=== Users, Roles and Permissions
+
+* Personal access tokens don\'t handle invalid expire_at dates gracefully - https://projects.theforeman.org/issues/36699[#36699]
+
+=== Web Interface
+
+* Remove dividers between navigation items - https://projects.theforeman.org/issues/36571[#36571]
+* Add PermissionDenied to reports tab in host - https://projects.theforeman.org/issues/36550[#36550]
+* Show new, delete button for params only if user has permissions  - https://projects.theforeman.org/issues/36549[#36549]
+* Open navigation items in new tab - https://projects.theforeman.org/issues/36543[#36543]
+* Add line breaks to bookmarks if the name is too long - https://projects.theforeman.org/issues/36350[#36350]
+* The Reports link from new host detail page in the kebab menu should be dropped - https://projects.theforeman.org/issues/36067[#36067]
+* Make new pf4 modal for adding personal access token - https://projects.theforeman.org/issues/36001[#36001]
+* Use pf4 in vertical navigation - https://projects.theforeman.org/issues/30344[#30344]
+
+== Installer
+
+* Reuse foreman_proxy::foreman_base_url value for puppet::server_foreman_url - https://projects.theforeman.org/issues/36573[#36573]
+
+=== Foreman modules
+
+* Change the default Foreman Redis cache DB to 4 - https://projects.theforeman.org/issues/36645[#36645]
+* Puppet module for Puppet should use "allowlist" instead of "whitelist" - https://projects.theforeman.org/issues/36620[#36620]
+* Automatically detect Foreman logging layout based on logging type - https://projects.theforeman.org/issues/36582[#36582]
+* Allow enabling mod_status for better Apache monitoring - https://projects.theforeman.org/issues/36311[#36311]
+* Switch to puppetlabs vcsrepo for gitrepo tracking - https://projects.theforeman.org/issues/35943[#35943]
+
+=== foreman-installer script
+
+* katello-certs-check does not cause the installer to halt execution on failure - https://projects.theforeman.org/issues/36567[#36567]
+
+== Packaging
+
+=== RPMs
+
+* Remove Katello Agent from katello-debug - https://projects.theforeman.org/issues/36676[#36676]

--- a/guides/doc-Release_Notes/topics/foreman-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-contributors.adoc
@@ -1,0 +1,5 @@
+We'd like to thank the following people who contributed to the Foreman {{page.version}} release:
+
+Adam Ruzicka, Alexey Masolov, Archana Kumari, Ashish Humbe, Bernhard Suttner, Daniel Alley, Eric D. Helms, Et7f3, Evgeni Golov, Ewoud Kohl van Wijngaarden, Girija Soni, Gordon Bleux, Griffin Sullivan, Ian Ballou, Jeremy Lenz, Jonas Trüstedt, Kamil Szubrycht, Karolina Malyjurkova, Leos Stejskal, Lior Keren, Lucy Fu, Marcel Kühlhorn, Maria Agaphontzev, Markus Bucher, Maximilian Kolb, Mike Rochefort, Nadja Heitmann, Nofar Alfassi, Oleh Fedorenko, Pat Riehecky, Romain Tartière, Ron Lavi, Samir Jha, Shimon Shtein, Tim Meusel, Trey Dockendorf, Vitaly Pyslar, William Clark, archanaserver, chr1s692, wlma
+
+As well as all users who helped test releases, report bugs and provide feedback on the project.


### PR DESCRIPTION
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.

I'm not sure if I did this correctly. I did it against the 3.8 branch cause the release process didn't specify.
