### PR TITLE
Remove a redundant yum-utils installation

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -10,7 +10,7 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 +
 [options="nowrap" subs="attributes"]
 ----
-{package-install} yum-utils 'dnf-command(reposync)'
+{package-install} 'dnf-command(reposync)'
 ----
 
 .Procedure on the connected {ProjectServer}


### PR DESCRIPTION
When using the `dnf reposync` command there's no need to install yum-utils. That's only needed when using the `reposync` command.

Fixes: ec4aea364e2d ("Split Updating Guide")

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.