### PR TITLE
Replace Library with repository

### DIFF
--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -27,7 +27,7 @@ total 68M
 -rw-r--r--. 1 pulp pulp 443 Mar  2 04:29 metadata.json
 ----
 . Identify the Organization that you wish to import into.
-. To import the Library content to {ProjectServer}, enter the following command:
+. To import the repository content to {ProjectServer}, enter the following command:
 +
 [subs="+quotes"]
 ----


### PR DESCRIPTION
We are performing steps for importing a repository, not a Library.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
