### PR TITLE
Use inline passthrough macro to avoid escaping

### DIFF
--- a/guides/doc-Release_Notes/redmine_release_notes
+++ b/guides/doc-Release_Notes/redmine_release_notes
@@ -61,7 +61,7 @@ def category_from_issue(issue)
 end
 
 def format_issue(issue)
-  subject = issue['subject'].gsub('`','\\\`').gsub('<','&lt;').gsub('>','&gt;').gsub('*','\\\*').gsub("'", "\\\\'")
+  subject = "pass:[#{issue['subject']}]"
   link = build_uri("/issues/#{issue['id']}")
   "* #{subject} - #{link}[##{issue['id']}]"
 end


### PR DESCRIPTION
Instead of trying to figure out which characters to escape, this uses the [inline passthrough macro](https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.