### PR TITLE
Correct multi line escaping

### DIFF
--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -25,6 +25,6 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 # {foreman-installer} --foreman-proxy-puppet true \
 --foreman-proxy-puppetca true \
 --enable-puppet \
---puppet-server true
+--puppet-server true \
 --puppet-server-foreman-url "https://_{foreman-example-com}_"
 ----


### PR DESCRIPTION
Fixes: dd093af738ce ("Refs #35985 - Update Puppet enablement options")

This is only submitted against 3.7 because nightly and 3.8 need another fix.