### PR TITLE
Refs #36573 - Remove --puppet-server-foreman-url parameter

### DIFF
--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
@@ -93,6 +93,5 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --puppet-dns-alt-names "_{loadbalancer-example-com}_" \
---puppet-server-ca "false" \
---puppet-server-foreman-url "_https://{foreman-example-com}_"
+--puppet-server-ca "false"
 ----

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
@@ -84,6 +84,5 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --puppet-dns-alt-names "_{loadbalancer-example-com}_" \
---puppet-server-ca "false" \
---puppet-server-foreman-url "_https://{foreman-example-com}_"
+--puppet-server-ca "false"
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -54,8 +54,7 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --puppet-dns-alt-names "_{loadbalancer-example-com}_" \
 --puppet-server true \
---puppet-server-ca "true" \
---puppet-server-foreman-url "_https://{foreman-example-com}_"
+--puppet-server-ca "true"
 ----
 . On {SmartProxyServer}, generate Puppet certificates for all other {SmartProxies} that you configure for load balancing, except this first system where you configure Puppet certificates signing:
 +

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -51,8 +51,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \
 --puppet-dns-alt-names "_{loadbalancer-example-com}_" \
 --puppet-server true \
---puppet-server-ca "true" \
---puppet-server-foreman-url "_https://{foreman-example-com}_"
+--puppet-server-ca "true"
 ----
 . On {SmartProxyServer}, stop the Puppet server:
 +

--- a/guides/common/modules/proc_enabling-puppet.adoc
+++ b/guides/common/modules/proc_enabling-puppet.adoc
@@ -26,5 +26,4 @@ Additionally, you can deploy Puppet server to {Project} externally and integrate
 --foreman-proxy-puppetca true \
 --enable-puppet \
 --puppet-server true
---puppet-server-foreman-url "https://_{foreman-example-com}_"
 ----

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -14,7 +14,6 @@ ifdef::foreman-el,foreman-deb[]
   --no-enable-foreman-cli \
   --enable-puppet \
   --puppet-server-ca=false \
-  --puppet-server-foreman-url=https://__{foreman-example-com}__ \
   --enable-foreman-proxy \
   --foreman-proxy-puppetca=false \
   --foreman-proxy-tftp=false \

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -59,8 +59,7 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[
 ----
 # {foreman-installer} \
 --foreman-proxy-foreman-base-url https://_new-{foreman-example-com}_ \
---foreman-proxy-trusted-hosts _new-{foreman-example-com}_ \
---puppet-server-foreman-url https://_new-{foreman-example-com}_
+--foreman-proxy-trusted-hosts _new-{foreman-example-com}_
 ----
 . On {ProjectServer}, list all {SmartProxyServers}:
 +


### PR DESCRIPTION
Since Foreman 3.8 the --foreman-proxy-foreman-base-url parameter is reused.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.