### PR TITLE
Refs #36582 - Remove --foreman-logging-layout parameter

### DIFF
--- a/guides/common/modules/proc_configuring-logging-to-journal-or-file-based-logging.adoc
+++ b/guides/common/modules/proc_configuring-logging-to-journal-or-file-based-logging.adoc
@@ -10,7 +10,6 @@ You can use the `{foreman-installer}` command to reconfigure logging.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} \
---foreman-logging-layout pattern \
 --foreman-logging-type journald \
 --foreman-proxy-log JOURNAL
 ----
@@ -26,7 +25,6 @@ For example:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} \
---reset-foreman-logging-layout \
 --reset-foreman-logging-type \
 --reset-foreman-proxy-log
 ----


### PR DESCRIPTION
Since Foreman 3.8 the logging layout is automatically derived from the logging type. This means the `--foreman-logging-layout` parameter is no longer needed.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.