### PR TITLE
Clarify opening sentence

### DIFF
--- a/guides/common/modules/con_managing-content-views.adoc
+++ b/guides/common/modules/con_managing-content-views.adoc
@@ -1,7 +1,7 @@
 [id="Managing_Content_Views_{context}"]
 = Managing Content Views
 
-{ProjectName} uses Content Views to create customized groupings of repository snapshots.
+{ProjectName} uses Content Views to allow your hosts access to a deliberately curated subset of content.
 To do this, you must define which repositories to use and then apply certain filters to the content.
 These filters include package filters, package group filters, errata filters, module stream filters, and container image tag filters.
 You can use Content Views to define which software versions a particular environment uses.


### PR DESCRIPTION
In an earlier version of documentation, this opening sentence was
confusing. It has been rewritten to be clearer for all doc versions.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
