### PR TITLE
Do not build PDF documents

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,57 +185,6 @@ jobs:
           name: foreman-docs-html-base
           path: guides/build/
 
-  build-pdf:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash
-        working-directory: guides
-    steps:
-      - name: Get branch name (merge)
-        if: github.event_name != 'pull_request'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-        working-directory: .
-
-      - name: Get branch name (pull request)
-        if: github.event_name == 'pull_request'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-        working-directory: .
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: true
-
-      - name: Clean the environment
-        run: make clean
-
-      - name: Build PDFs (master/stable)
-        run: |
-          make -j ${{ env.MAKE_J }} pdf BUILD=foreman-el
-
-      - name: Build PDFs (PR)
-        if: >
-          github.repository_owner == 'theforeman' &&
-          (github.ref == 'refs/heads/master' ||
-          startsWith(github.ref, 'refs/heads/2.') ||
-          startsWith(github.ref, 'refs/heads/3.'))
-        run: |
-          make -j ${{ env.MAKE_J }} pdf BUILD=foreman-deb
-          make -j ${{ env.MAKE_J }} pdf BUILD=katello
-          make -j ${{ env.MAKE_J }} pdf BUILD=satellite
-          make -j ${{ env.MAKE_J }} pdf BUILD=orcharhino
-
-      - name: Upload PDFs
-        uses: actions/upload-artifact@v3
-        with:
-          name: foreman-docs-pdf-${{ env.BRANCH_NAME }}
-          path: guides/build/*.pdf
-
   build-web:
     runs-on: ubuntu-22.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN dnf upgrade -y && \
                    make \
                    redhat-rpm-config \
                    ruby-devel \
-                   rubygem-asciidoctor \
-                   rubygem-asciidoctor-pdf && \
+                   rubygem-asciidoctor && \
     dnf groupinstall -y development-tools
 
 RUN gem install sass

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'asciidoctor'
-gem 'asciidoctor-pdf'
-# missing dependency for asciidoctor-pdf
-gem 'matrix'
-
 gem 'sass'

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Stable versions are symlink to the nightly (current) version, this can cause iss
 
 ## Deployment
 
-Github actions perform HTML (with link validation), PDF and WEB artifact creation and if succeeded and branch is master or stable, artifacts are downloaded, extracted and deployed (commited into gh-pages). Deployment does not delete files, in order to remove some unwanted content, manual deletion and push into gh-pages must be performed.
+Github actions perform HTML (with link validation) and WEB artifact creation and if succeeded and branch is master or stable, artifacts are downloaded, extracted and deployed (commited into gh-pages). Deployment does not delete files, in order to remove some unwanted content, manual deletion and push into gh-pages must be performed.
 
 When a commit is pushed into `master`:
 

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -1,13 +1,11 @@
 SHELL := /bin/bash
 SUBDIRS = $(shell ls -d doc-*)
 
-.PHONY: all clean html pdf linkchecker linkchecker-tryer serve subdirs $(SUBDIRS)
+.PHONY: all clean html linkchecker linkchecker-tryer serve subdirs $(SUBDIRS)
 
 all: html
 
 html: subdirs
-
-pdf: subdirs
 
 subdirs: $(SUBDIRS)
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -41,18 +41,12 @@ Install ruby gems, in the `foreman-documentation` folder:
 	make prep
 
 Then simply run `make` or `make html` which builds HTML artifacts.
-Generating PDF output is slow, therefore command `make pdf` must be used separately.
-To make both formats in one command, use `make html pdf`.
 
 Few additional make targets are available on the guide level.
 To quickly build HTML version and open new tab in a browser do:
 
 	cd doc-Provisioning_Hosts
 	make browser
-
-Similarly, to build and open PDF version do:
-
-	make open-pdf
 
 To speed up the build process, make sure to use `-j` option. Ideally, set it to amount of cores plus one:
 
@@ -65,7 +59,7 @@ An alias is often useful:
 Currently there are three different versions:
 
 
-`make BUILD=foreman-el` - This is the default that is generated with `make html` or `pdf`.
+`make BUILD=foreman-el` - This is the default that is generated with `make html`.
 
 `make BUILD=satellite` - This generates a downstream preview of the guide.
 
@@ -99,12 +93,6 @@ This requires the cloned git repository plus an application such as Podman or Do
    On SELinux enabled systems, run this command:
 
 	rm -rf guides/build && podman run --rm -v $(pwd):/foreman-documentation:Z foreman_documentation make html
-
-## Reading or Publishing
-
-We do not publish the content yet to prevent users confusion, however this section will cover steps required to publish the content.
-We should make sure that only the last stable version of the HTML document is indexed by search engines, old and nightly builds should not be indexed.
-All PDFs should be available for download though.
 
 ## Disabling the linkchecker for a specific URL pattern
 

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -7,7 +7,6 @@ ROOTDIR = $(realpath .)
 NAME = $(notdir $(ROOTDIR))
 DEST_DIR = $(BUILD_DIR)/$(subst doc-,,$(NAME))
 DEST_HTML = $(DEST_DIR)/index-$(BUILD).html
-DEST_PDF = $(BUILD_DIR)/$(subst doc-,,$(NAME))-$(BUILD).pdf
 IMAGES_DIR = $(DEST_DIR)/images
 IMAGES_TS = $(DEST_DIR)/.timestamp-images
 CSS_SOURCES = $(shell find $(COMMON_DIR)/css -type f)
@@ -40,7 +39,7 @@ endif
 endif
 
 .SHELLFLAGS = -o pipefail -c
-.PHONY = all prepare html pdf clean browser server linkchecker open-pdf
+.PHONY = all prepare html clean browser server linkchecker
 
 all: html
 
@@ -49,10 +48,8 @@ prepare:
 
 html: prepare $(IMAGES_TS) $(DEST_HTML)
 
-pdf: prepare $(DEST_PDF)
-
 clean:
-	@rm -rf "$(DEST_DIR)" "$(DEST_PDF)"
+	@rm -rf "$(DEST_DIR)"
 
 browser: html
 	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
@@ -62,9 +59,6 @@ serve: html
 
 linkchecker: html
 	linkchecker -r1 -f $(COMMON_DIR)/linkchecker.ini --check-extern "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
-
-open-pdf: pdf
-	${BROWSER_OPEN} "$(realpath $(ROOTDIR)/$(DEST_PDF))"
 
 $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
 	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
@@ -80,8 +74,3 @@ $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD)
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 	@echo CHECKING FOR ORPHAN XREFS HTML LINKS
 	@! grep -RE '<a href="#[a-zA-Z0-9_-]+">\[[a-zA-Z0-9_-]+\]</a>' $@
-
-$(DEST_PDF): $(SOURCES) $(DEPENDENCIES)
-	bundle exec asciidoctor-pdf -a build=$(BUILD) -a imagesdir=./images -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
-	@echo CHECKING FOR ASCIIDOCTOR-PDF ERRORS AND WARNINGS
-	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log


### PR DESCRIPTION
As discussed earlier: we do not publish PDF documents in upstream or downstream, so we can stop building them to speed up GHA and save resources.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.