### PR TITLE
Do not list Foreman 3.8 as a supported release

### DIFF
--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -6,7 +6,6 @@ title: Home
 
 The following releases are supported, meaning they receive (security) updates. Visit the https://community.theforeman.org/c/support/10[support forum] for questions.
 
-* link:/release/3.8/[Foreman 3.8 & Katello 4.10 (RC)]
 * link:/release/3.7/[Foreman 3.7 & Katello 4.9]
 * link:/release/3.6/[Foreman 3.6 & Katello 4.8]
 
@@ -15,6 +14,10 @@ The following releases are supported, meaning they receive (security) updates. V
 The future version is built in nightly.
 
 * link:/release/nightly/[Nightly]
+
+There is a release candidate available for testing.
+
+* link:/release/3.8/[Foreman 3.8 & Katello 4.10]
 
 These releases are unsupported and no longer receive updates. Users should update to a supported release.
 


### PR DESCRIPTION
Fixes: ddba2d718d91 ("Branch Foreman 3.8")

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.