### PR TITLE
Fix xref rendering for Satellite

### DIFF
--- a/guides/common/modules/con_transport-modes-for-remote-execution.adoc
+++ b/guides/common/modules/con_transport-modes-for-remote-execution.adoc
@@ -22,9 +22,15 @@ ifdef::katello,orcharhino,satellite[]
 endif::[]
 ifdef::managing-hosts[]
 * To migrate a host from Katello Agent, see xref:Migrating_Hosts_From_Katello_Agent_to_Remote_Execution_{context}[].
-* To enable pull mode on a new host, continue either with xref:Creating_a_Host_{context}[] or xref:Registering_Hosts_by_Using_Global_Registration_{context}[].
+* To enable pull mode on a new host, continue with either of the following procedures:
+
+** xref:Creating_a_Host_{context}[]
+** xref:Registering_Hosts_by_Using_Global_Registration_{context}[].
 endif::[]
 ifndef::managing-hosts[]
 * To migrate a host from Katello Agent, see {ManagingHostsDocURL}Migrating_Hosts_From_Katello_Agent_to_Remote_Execution_managing-hosts[Migrating from Katello Agent to Remote Execution].
-* To enable pull mode on a new host, continue either with {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host] or {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+* To enable pull mode on a new host, continue with either of the following procedures:
+
+** {ManagingHostsDocURL}Creating_a_Host_managing-hosts[Creating a Host]
+** {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 endif::[]


### PR DESCRIPTION
Satellite publishing tool has issues with 2 xrefs on the same line. For correct rendering, there needs to be only one xref per line.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
