### PR TITLE
Configure SubMan to connect via HTTP proxy for registration

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -16,6 +16,12 @@ ifdef::satellite[]
 This is required to install the `insights-client` package on hosts.
 endif::[]
 include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
+ifdef::katello,orcharhino,satellite[]
+* If your {ProjectServer} or {SmartProxyServer} is behind an HTTP proxy, configure the Subscription Manager on your host to use the HTTP proxy for connection.
+endif::[]
+ifdef::satellite[]
+For more information, see https://access.redhat.com/solutions/65300[How to access Red Hat Subscription Manager (RHSM) through a firewall or proxy] in the _Red{nbsp}Hat Knowledgebase_.
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.


### PR DESCRIPTION
If Project is behind an HTTP proxy, configure the SubMan to connect through the proxy.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
