### PR TITLE
Update Foreman 3.8.0 release notes for RC2

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman-3.8.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.8.0.adoc
@@ -41,6 +41,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 * Refactor PermissionDenied component  - https://projects.theforeman.org/issues/36551[#36551]
 * Update ConfigReports to pf4 - https://projects.theforeman.org/issues/36400[#36400]
+* "Scrollbar test exception: TypeError" when loading any page - https://projects.theforeman.org/issues/36093[#36093]
 
 === Notifications
 
@@ -126,6 +127,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === Foreman modules
 
+* Set ANSIBLE_PERMISSION_CLASSES as empty list to allow syncing collection repos on capsule without RBAC access to Galaxy endpoints - https://projects.theforeman.org/issues/36709[#36709]
 * Change the default Foreman Redis cache DB to 4 - https://projects.theforeman.org/issues/36645[#36645]
 * Puppet module for Puppet should use "allowlist" instead of "whitelist" - https://projects.theforeman.org/issues/36620[#36620]
 * Automatically detect Foreman logging layout based on logging type - https://projects.theforeman.org/issues/36582[#36582]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
