### PR TITLE
Add step for selecting activation keys

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -7,7 +7,7 @@ ifeval::["{context}" == "load-balancing"]
 . From the *{SmartProxy}* dropdown list, select the load balancer.
 . Select *Force* to register a host that has been previously registered to a {SmartProxyServer}.
 endif::[]
-. From the *Activation Keys* list, select the activation keys to use.
+. From the *Activation Keys* list, select the activation keys to assign to your host.
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Connect to your host using SSH and run the registration command.

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -7,6 +7,7 @@ ifeval::["{context}" == "load-balancing"]
 . From the *{SmartProxy}* dropdown list, select the load balancer.
 . Select *Force* to register a host that has been previously registered to a {SmartProxyServer}.
 endif::[]
+. From the *Activation Keys* list, select the activation keys to use.
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Connect to your host using SSH and run the registration command.


### PR DESCRIPTION
You must select which activation key(s) to use in the web UI before you
click Generate. This step was necessary to add.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
