### PR TITLE
Replace Subscription Manifest to lower case

### DIFF
--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -2,21 +2,21 @@
 = Managing Red Hat Subscriptions
 
 {ProjectName} can import content from the Red{nbsp}Hat Content Delivery Network (CDN).
-{Project} requires a Red{nbsp}Hat Subscription Manifest to find, access, and download content from the corresponding repositories.
-You must have a Red{nbsp}Hat Subscription Manifest containing a subscription allocation for each organization on {ProjectServer}.
+{Project} requires a Red{nbsp}Hat subscription manifest to find, access, and download content from the corresponding repositories.
+You must have a Red{nbsp}Hat subscription manifest containing a subscription allocation for each organization on {ProjectServer}.
 All subscription information is available in your Red Hat Customer Portal account.
 
-Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat Subscription Manifest in the Customer Portal.
+Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat subscription manifest in the Customer Portal.
 
 ifdef::satellite[]
 include::snip_deprecated-entitlement-subscriptions.adoc[]
 endif::[]
 
 ifdef::satellite[]
-To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+To create, manage, and export a Red{nbsp}Hat subscription manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 
-Use this chapter to import a Red{nbsp}Hat Subscription Manifest and manage the manifest within the {ProjectWebUI}.
+Use this chapter to import a Red{nbsp}Hat subscription manifest and manage the manifest within the {ProjectWebUI}.
 
 .Subscription Allocations and Organizations
 

--- a/guides/common/modules/proc_adding-red-hat-subscriptions-to-subscription-allocations.adoc
+++ b/guides/common/modules/proc_adding-red-hat-subscriptions-to-subscription-allocations.adoc
@@ -4,7 +4,7 @@
 Use the following procedure to add Red Hat subscriptions to a subscription allocation in the {ProjectWebUI}.
 
 .Prerequisite
-* You must have a Red{nbsp}Hat Subscription Manifest file imported to {ProjectServer}.
+* You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 
 .Procedure

--- a/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
+++ b/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
@@ -23,7 +23,7 @@ Adding a {Project} subscription to a content host does not provide any content o
 If you want, you can add a {Project} subscription to a manifest for your own recording or tracking purposes.
 
 .Prerequisite
-* You must have a Red{nbsp}Hat Subscription Manifest file imported to {ProjectServer}.
+* You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 
 .Procedure
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -1,7 +1,7 @@
 [id="Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}"]
 = Importing a Red{nbsp}Hat Subscription Manifest into {ProjectServer}
 
-Use the following procedure to import a Red{nbsp}Hat Subscription Manifest into {ProjectServer}.
+Use the following procedure to import a Red{nbsp}Hat subscription manifest into {ProjectServer}.
 
 ifdef::foreman-el,katello[]
 This is for users of the Katello plug-in and Red Hat operating systems only.
@@ -14,7 +14,7 @@ Importing a manifest does not change your organization's Simple Content Access s
 ====
 
 .Prerequisites
-* You must have a Red{nbsp}Hat Subscription Manifest file exported from the https://access.redhat.com[Red{nbsp}Hat Customer Portal].
+* You must have a Red{nbsp}Hat subscription manifest file exported from the https://access.redhat.com[Red{nbsp}Hat Customer Portal].
 ifndef::orcharhino[]
 For more information, see https://access.redhat.com/documentation/en-us/subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/assembly-creating-managing-manifests-connected-satellite[Creating and Managing Manifests] in _Using Red Hat Subscription Management_.
 endif::[]
@@ -27,16 +27,16 @@ endif::[]
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions* and click *Manage Manifest*.
 . In the *Manage Manifest* window, click *Choose File*.
-. Navigate to the location that contains the Red{nbsp}Hat Subscription Manifest file, then click *Open*.
+. Navigate to the location that contains the Red{nbsp}Hat subscription manifest file, then click *Open*.
 
 .CLI procedure
-. Copy the Red{nbsp}Hat Subscription Manifest file from your local machine to {ProjectServer}:
+. Copy the Red{nbsp}Hat subscription manifest file from your local machine to {ProjectServer}:
 +
 [subs="+quotes,attributes"]
 ----
 $ scp ~/_manifest_file_.zip root@_{foreman-example-com}_:~/.
 ----
-. Log in to {ProjectServer} as the `root` user and import the Red{nbsp}Hat Subscription Manifest file:
+. Log in to {ProjectServer} as the `root` user and import the Red{nbsp}Hat subscription manifest file:
 +
 [subs="+quotes"]
 ----

--- a/guides/common/modules/proc_locating-a-red-hat-subscription.adoc
+++ b/guides/common/modules/proc_locating-a-red-hat-subscription.adoc
@@ -1,11 +1,11 @@
 [id="Locating_a_Red_Hat_Subscription_{context}"]
 = Locating a Red Hat Subscription
 
-When you import a Red{nbsp}Hat Subscription Manifest into {ProjectServer}, the subscriptions from your manifest are listed in the Subscriptions window.
+When you import a Red{nbsp}Hat subscription manifest into {ProjectServer}, the subscriptions from your manifest are listed in the Subscriptions window.
 If you have a high volume of subscriptions, you can filter the results to find a specific subscription.
 
 .Prerequisite
-* You must have a Red{nbsp}Hat Subscription Manifest file imported to {ProjectServer}.
+* You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 
 .Procedure

--- a/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-allocations.adoc
+++ b/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-allocations.adoc
@@ -10,7 +10,7 @@ If you delete the manifest from the Red Hat Customer Portal or in the {ProjectWe
 ====
 
 .Prerequisite
-* You must have a Red{nbsp}Hat Subscription Manifest file imported to {ProjectServer}.
+* You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 
 .Procedure


### PR DESCRIPTION
In all instances of subscription manifest, it is
capitalized and should
not be outside of section titles. All mentions
otherwise have been
changed to lower case.
Jira ticket-SAT-19849
https://issues.redhat.com/browse/SAT-19849


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
