### PR TITLE
Alternate the method to elevate user privilege in REX

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -24,6 +24,8 @@ include::modules/proc_configuring-the-global-smartproxy-remote-execution-setting
 
 include::modules/proc_configuring-an-alternative-directory-to-execute-remote-jobs-on-clients.adoc[leveloffset=+1]
 
+include::modules/proc_altering-the-privilege-elevation-method.adoc[leveloffset=+1]
+
 include::modules/proc_distributing-ssh-keys-for-remote-execution.adoc[leveloffset=+1]
 
 include::modules/proc_distributing-ssh-keys-for-remote-execution-manually.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_altering-the-privilege-elevation-method.adoc
+++ b/guides/common/modules/proc_altering-the-privilege-elevation-method.adoc
@@ -1,0 +1,18 @@
+[id="altering-the-privilege-elevation-method_{context}"]
+= Altering the Privilege Elevation Method
+
+By default, push-based remote execution uses `sudo` to switch from the SSH user to the effective user that executes the script on your host.
+In some situations, you might require to use another method, such as `su` or `dzdo`.
+You can globally configure an alternative method in your {Project} settings.
+
+.Prerequisites
+* Your user account has a role assigned that grants the `view_settings` and `edit_settings` permissions.
+* If you want to use `dzdo` for Ansible jobs, ensure the `community.general` Ansible collection, which contains the required *dzdo* become plug-in, is installed.
+For more information, see https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html[Installing collections] in _Ansible documentation_.
+
+.Procedure
+. Navigate to *Administer* > *Settings*.
+. Select the *Remote Execution* tab.
+. Click the value of the *Effective User Method* setting.
+. Select the new value.
+. Click *Submit*.


### PR DESCRIPTION
dzdo (sudo alternative) was failing for Ansible jobs, because the required plugin isn't available in ansible-core that is [available for Project since 3.3](https://docs.theforeman.org/3.3/Upgrading_and_Updating/index-satellite.html#migrating-ansible-content_upgrade-guide)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
