### PR TITLE
Explain why outgoing traffic returns to Project

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -66,6 +66,8 @@ This includes the base operating system on which a {SmartProxyServer} is running
 A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
 This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
 
+NOTE: Some outgoing traffic returns to {Project} to enable internal communication and security operations.
+
 .{ProjectServer} outgoing traffic
 [cols="15%,15%,15%,15%,20%,20%",options="header"]
 


### PR DESCRIPTION
[BZ#2233266](https://bugzilla.redhat.com/show_bug.cgi?id=2233266) reports confusion over Satellite outgoing communication returning back to Satellite. To address this issue, I want to add an explanation of this behavior.

Side note: I'm not very happy about fixing this problem by just slapping an admonition onto the section, but this part of the document is scheduled for a thorough editorial review in the upcoming weeks. So any readability issues that might also be contributing to users' confusion over the content will be fixed soon.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
