### PR TITLE
Add troubleshooting for ruby & pgsql

### DIFF
--- a/guides/common/assembly_troubleshoot-dnf-modules.adoc
+++ b/guides/common/assembly_troubleshoot-dnf-modules.adoc
@@ -1,0 +1,16 @@
+[id="troubleshoot-dnf-modules_{context}"]
+
+include::modules/con_troubleshooting-dnf-modules.adoc[]
+include::modules/con_troubleshooting-ruby.adoc[leveloffset=+1]
+
+ifeval::["{context}" == "{project-context}"]
+ifdef::foreman-el,katello,orcharhino,satellite[]
+include::modules/con_troubleshooting-postgresql.adoc[leveloffset=+1]
+endif::[]
+endif::[]
+
+ifeval::["{context}" == "{smart-proxy-context}"]
+ifdef::katello,orcharhino,satellite[]
+include::modules/con_troubleshooting-postgresql.adoc[leveloffset=+1]
+endif::[]
+endif::[]

--- a/guides/common/modules/con_troubleshooting-dnf-modules.adoc
+++ b/guides/common/modules/con_troubleshooting-dnf-modules.adoc
@@ -1,0 +1,10 @@
+[id="troubleshooting-dnf-modules_{context}"]
+= DNF Modules
+
+If DNF modules fails to enable, it can mean an incorrect module is enabled.
+In that case, you have to resolve dependencies manually as follows.
+List the enabled modules:
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module list --enabled
+----

--- a/guides/common/modules/con_troubleshooting-postgresql.adoc
+++ b/guides/common/modules/con_troubleshooting-postgresql.adoc
@@ -1,7 +1,7 @@
 [id="Troubleshooting_Postgresql_{context}"]
-= Troubleshooting PostgreSQL
+= PostgreSQL
 
-If the module fails to enable, it can mean an incorrect module is enabled.
+If PostgreSQL module fails to enable, it can mean an incorrect module is enabled.
 In that case, you have to resolve dependencies manually as follows:
 
 List the enabled modules:

--- a/guides/common/modules/con_troubleshooting-ruby.adoc
+++ b/guides/common/modules/con_troubleshooting-ruby.adoc
@@ -1,7 +1,7 @@
 [id="Troubleshooting_Ruby_{context}"]
-= Troubleshooting Ruby
+= Ruby
 
-If the module fails to enable, it can mean an incorrect module is enabled.
+If Ruby module fails to enable, it can mean an incorrect module is enabled.
 In that case, you have to resolve dependencies manually as follows:
 
 List the enabled modules:

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -30,10 +30,12 @@ Use this procedure to enable the repositories that are required to install {Prod
 ----
 # dnf module enable {dnf-module}
 ----
+
 +
 [NOTE]
 ====
-include::snip_dnf-module-enable-note.adoc[]
+If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-module}` module, see xref:troubleshooting-dnf-modules_{context}[Troubleshooting DNF modules].
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 +
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -46,12 +46,13 @@ endif::[]
 # dnf module enable {dnf-modules}
 ----
 
-If this fails to enable, see {InstallingServerDocURL}troubleshooting_dnf_modules[DNF module enablement troubleshooting].
+endif::[]
 
+ifdef::foreman-el,katello[]
+== [[repositories-rhel-8]]{RHEL} 8
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
-== [[repositories-rhel-8]]{RHEL} 8
 
 :distribution: rhel
 :distribution-major-version: 8
@@ -95,17 +96,12 @@ ifdef::foreman-el,katello,satellite[]
 ----
 # dnf module enable {dnf-modules}
 ----
+endif::[]
 +
 [NOTE]
 ====
-include::snip_dnf-module-enable-note.adoc[]
-====
-endif::[]
-
-[NOTE]
-====
-If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository, and install {oVirt} guest agents and drivers.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
+If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-modules}` module, see xref:troubleshooting-dnf-modules_{context}[Troubleshooting DNF modules].
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 endif::[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -39,6 +39,12 @@ include::common/assembly_managing-dns-on-smart-proxies.adoc[leveloffset=+1]
 // {SmartProxyServer} Scalability Considerations
 include::common/modules/ref_capsule-server-scalability-considerations.adoc[leveloffset=+1]
 
+ifndef::foreman-deb[]
+[appendix]
+== Troubleshooting
+include::common/assembly_troubleshoot-dnf-modules.adoc[leveloffset=+1]
+endif::[]
+
 ifndef::satellite[]
 [appendix]
 include::common/modules/ref_dhcp-isc-settings.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -72,10 +72,8 @@ include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
 
 ifndef::foreman-deb[]
 [appendix]
-include::common/modules/con_troubleshooting-ruby.adoc[leveloffset+=1]
-
-[appendix]
-include::common/modules/con_troubleshooting-postgresql.adoc[leveloffset+=1]
+== Troubleshooting
+include::common/assembly_troubleshoot-dnf-modules.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello[]


### PR DESCRIPTION
Project needs ruby:2.7 and postgresql:12 modules to work\get installed. If end-users proceed with enabling present el8 module in installing project and proxy, it will pop-up a huge warning related to conflict with ruby:2.5 and postgresql:10 modules. At the end, the command does enable the ruby:2.7 and postgresql:12 but the list of warnings itself is not a healthy status of the output and this occurrence should be prevented. However, in the document, these warnings are mentioned as expected and can be ignored but it should not be the standard practise of user experience. Therefore, this warning can be easily avoided in documentation by adding the dedicated section in appendix.

https://bugzilla.redhat.com/show_bug.cgi?id=2126884
