### PR TITLE
Update cmd to deploy a certificate on SmartProxy

### DIFF
--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -45,10 +45,9 @@ You can move the copied file to the applicable path if required.
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {installer-scenario-smartproxy} \
---foreman-proxy-content-parent-fqdn "{foreman-example-com}" \
 --foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-foreman-base-url \ "https://{foreman-example-com}"
---foreman-proxy-content-certs-tar "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
+--certs-tar-file "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
 --certs-update-server
 ----
 

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -46,7 +46,7 @@ You can move the copied file to the applicable path if required.
 ----
 # {installer-scenario-smartproxy} \
 --foreman-proxy-register-in-foreman "true" \
---foreman-proxy-foreman-base-url \ "https://{foreman-example-com}"
+--foreman-proxy-foreman-base-url "https://{foreman-example-com}" \
 --certs-tar-file "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
 --certs-update-server
 ----


### PR DESCRIPTION
Per [BZ#2236881](https://bugzilla.redhat.com/show_bug.cgi?id=2236881), the command to deploy a certificate on SmartProxy includes obsolete options. This PR updates the command.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
