### PR TITLE
Fix asciidoc syntax

### DIFF
--- a/guides/common/modules/proc_live-patching-hosts-using-kernelcare.adoc
+++ b/guides/common/modules/proc_live-patching-hosts-using-kernelcare.adoc
@@ -15,7 +15,7 @@ For more information, see https://docs.tuxcare.com/eportal/[docs.tuxcare.com/epo
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
-. Select one or multiple hosts and under *Select Action*, click * Schedule Remote Job*.
+. Select one or multiple hosts and under *Select Action*, click *Schedule Remote Job*.
 . In the *Job category* field, select `Commands`.
 . In the *Job template* field, select `Run Command - SSH Default`.
 . In the *command* field, enter `/usr/bin/kcarectl --update`.


### PR DESCRIPTION
`2cc3c27bc3 (Maximilian Kolb 2022-11-29 13:50:19 +0100 18) . Select one or multiple hosts and under *Select Action*, click * Schedule Remote Job*.` :upside_down_face: 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
