### PR TITLE
Add links to mod docs resources to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Contributions are welcome.
 New contributions are subject to technical review for accuracy and editorial review for consistency.
 For an overview of what to expect from editorial review, see [Peer review guide for technical documentation](https://redhat-documentation.github.io/peer-review/#checklist).
 
+Documentation in this repository follows a modular structure described in the [Modular documentation reference guide](https://redhat-documentation.github.io/modular-docs/).
+To write new documentation, you can use [modular documentation templates](https://github.com/redhat-documentation/modular-docs/tree/main/modular-docs-manual/files).
+If you are not familiar with modular documentation, the structure and templates might seem overwhelming.
+Feel free to reach out to the maintainers of the foreman-documentation repository, they can help you get started.
+
 ## Static Site
 
 The landing page for [docs.theforeman.org](https://docs.theforeman.org) is available as a generated static site.


### PR DESCRIPTION
It might be nice to add some resources about modular documentation to the readme. What do you all think?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
