### PR TITLE
Fix capitalization and mask for REX for restorecon example template

### DIFF
--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -21,7 +21,7 @@ The *Build* sub-status has two possible values {endash} *pending* and *built* th
 
 The *Configuration* status has more possible values that map to the global status as follows:
 
-.sub-statuses that map to the global *OK* status
+.Sub-statuses that map to the global *OK* status
 
 Active::
 During the last run, some resources were applied.
@@ -41,7 +41,7 @@ This occurs when there are no reports but the host uses, for example, an associa
 Error::
 This indicates an error during configuration, for example, a run failed to install a package.
 
-.sub-statuses that map to the global *Warning* status
+.Sub-statuses that map to the global *Warning* status
 
 Out of sync::
 A configuration report was not received within the expected interval, based on the `outofsync_interval`.

--- a/guides/common/modules/proc_executing-a-restorecon-template-on-multiple-hosts.adoc
+++ b/guides/common/modules/proc_executing-a-restorecon-template-on-multiple-hosts.adoc
@@ -5,10 +5,34 @@ This example shows how to run a job based on the template created in {ManagingHo
 The job restores the SELinux context in all files under the `/home/` directory.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select target hosts.
-Select *Schedule Remote Job* from the *Select Action* list.
-. In the *Job invocation* page, select the `Commands` job category and the `Run Command - restorecon` job template.
-. Type `/home` in the *directory* field.
-. Set *Schedule* to `Execute now`.
-. Click *Submit*.
-You are taken to the *Job invocation* page where you can monitor the status of job execution.
+. In the {ProjectWebUI}, navigate to *Monitor* > *Jobs* and click *Run job*.
+. Select *Commands* as *Job category* and *Run Command {endash} restorecon* as *Job template* and click *Next*.
+. Select the hosts on which you want to run the job.
+If you do not select any hosts, the job will run on all hosts you can see in the current context.
+. In the *directory* field, provide a directory, for example `/home`, and click *Next*.
+. Optional: To configure advanced settings for the job, fill in the *Advanced fields*.
+To learn more about advanced settings, see xref:advanced-settings-in-the-job-wizard_{context}[].
+When you are done entering the advanced settings or if it is not required, click *Next*.
+. Schedule time for the job.
+* To execute the job immediately, keep the pre-selected *Immediate execution*.
+* To execute the job in future time, select *Future execution*.
+* To execute the job on regular basis, select *Recurring execution*.
+. Optional: If you selected future or recurring execution, select the *Query type*, otherwise click *Next*.
+* *Static query* means that the job executes on the exact list of hosts that you provided.
+* *Dynamic query* means that the list of hosts is evaluated just before the job is executed.
+If you entered the list of hosts based on some filter, the results can be different from when you first used that filter.
++
+Click *Next* after you have selected the query type.
+. Optional: If you selected future or recurring execution, provide additional details:
+* For *Future execution*, enter the *Starts at* date and time.
+You also have the option to select the *Starts before* date and time.
+If the job cannot start before that time, it will be canceled.
+* For *Recurring execution*, select the start date and time, frequency, and condition for ending the recurring job.
+You can choose the recurrence to never end, end at a certain time, or end after a given number of repetitions.
+You can also add *Purpose* - a special label for tracking the job.
+There can only be one active job with a given purpose at a time.
++
+Click *Next* after you have entered the required information.
+. Review job details.
+You have the option to return to any part of the job wizard and edit the information.
+. Click *Submit* to schedule the job for execution.

--- a/guides/common/modules/ref_example-restorecon-template.adoc
+++ b/guides/common/modules/ref_example-restorecon-template.adoc
@@ -5,7 +5,7 @@ This example shows how to create a template called *Run Command - restorecon* th
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Job templates*.
-Click *New Job Template*.
+. Click *New Job Template*.
 . Enter *Run Command - restorecon* in the *Name* field.
 Select *Default* to make the template available to all organizations.
 Add the following text to the template editor:


### PR DESCRIPTION
I believe that the host sub-status page is no longer accurate but I'd like to not add this to the scope for now. See https://github.com/theforeman/foreman-documentation/issues/2459

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
