### PR TITLE
Update preupgrade leapp procedure to the new version of the job form

### DIFF
--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-rhel-release.adoc
@@ -33,7 +33,7 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the hosts that you want to upgrade to the next major {RHEL} version.
 . In the upper right of the Hosts window, from the *Select Action* list, select *Preupgrade check with Leapp*.
-. Click *Submit* to start the pre-upgrade check.
+. Enter the required information and start the pre-upgrade check.
 . When the check is finished, click the *Leapp preupgrade report* tab to see if Leapp has found any issues on your hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
 Issues that have the *Has Remediation* flag contain remediation that can help you fix the issue.


### PR DESCRIPTION
The web UI no longer shows the Submit button at this point in the procedure. There are multiple options to finish running the job.

In this PR, I propose wording that avoids describing specific buttons. (The buttons themselves are described in the web UI through floating tooltips.)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
