### PR TITLE
Improve guide Subtitles in Satellite

### DIFF
--- a/guides/doc-Administering_Project/docinfo.xml
+++ b/guides/doc-Administering_Project/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Administering Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>A guide to administering Red Hat Satellite.</subtitle>
+<subtitle>Administer users and permissions, manage organizations and locations, back up and restore Satellite, maintain Satellite, and more</subtitle>
 <abstract>
 
     <para>This guide provides instructions on how to configure and administer a Red Hat Satellite 6 Server. Before continuing with this workflow you must have successfully installed a Red Hat Satellite 6 Server and any required Capsule Servers.</para>

--- a/guides/doc-Configuring_Load_Balancer/docinfo.xml
+++ b/guides/doc-Configuring_Load_Balancer/docinfo.xml
@@ -1,9 +1,9 @@
 <title>Configuring Capsules with a Load Balancer</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Distributing load between Capsule Servers</subtitle>
+<subtitle>Distribute load among Capsules</subtitle>
 <abstract>
-    <para>This guide describes how to configure Red Hat Satellite to use a load balancer to distribute load between Capsule Servers.</para>
+    <para>This guide describes how to configure Red Hat Satellite to use a load balancer to distribute load among Capsule Servers.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/guides/doc-Deploying_Project_on_AWS/docinfo.xml
+++ b/guides/doc-Deploying_Project_on_AWS/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Deploying Red Hat Satellite on Amazon Web Services</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Reference guide for deploying Red Hat Satellite Server and Capsules on Amazon Web Services</subtitle>
+<subtitle>Deploy Satellite Server and Capsule on Amazon Web Services</subtitle>
 <abstract>
     <para>Use this guide to deploy Red Hat Satellite Server and Capsules on Amazon Web Services (AWS) Elastic Compute Cloud (Amazon EC2).</para>
 </abstract>

--- a/guides/doc-Installing_Proxy/docinfo.xml
+++ b/guides/doc-Installing_Proxy/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Installing Capsule Server</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Installing Red Hat Satellite Capsule Server</subtitle>
+<subtitle>Install and configure Capsule</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite Capsule Server, perform initial configuration, and configure external services.</para>
 </abstract>

--- a/guides/doc-Installing_Server/docinfo.xml
+++ b/guides/doc-Installing_Server/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Installing Satellite Server in a Connected Network Environment</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Install Red Hat Satellite Server that is deployed inside a network connected to the Internet</subtitle>
+<subtitle>Install and configure Satellite Server in a network with Internet access</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite from a connected network, perform initial configuration, and configure external services.</para>
 </abstract>

--- a/guides/doc-Installing_Server_Disconnected/docinfo.xml
+++ b/guides/doc-Installing_Server_Disconnected/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Installing Satellite Server in a Disconnected Network Environment</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Install Red Hat Satellite Server that is deployed inside a network without an Internet connection</subtitle>
+<subtitle>Install and configure Satellite Server in a network without Internet access</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite in a disconnected network, perform initial configuration, and configure external services.</para>
 </abstract>

--- a/guides/doc-Managing_Configurations_Ansible/docinfo.xml
+++ b/guides/doc-Managing_Configurations_Ansible/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Managing Configurations Using Ansible Integration in Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Use Ansible integration in Satellite to configure host systems</subtitle>
+<subtitle>Configure Ansible integration in Satellite and use Ansible roles and playbooks to configure your hosts</subtitle>
 <abstract>
     <para>This guide describes how to integrate Red Hat Satellite with Ansible and how to perform remote execution and automate repetitive tasks using Ansible roles and playbooks in Satellite.</para>
 </abstract>

--- a/guides/doc-Managing_Configurations_Puppet/docinfo.xml
+++ b/guides/doc-Managing_Configurations_Puppet/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Managing Configurations Using Puppet Integration in Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Using Puppet integration to manage configurations of hosts and to report host system status to Satellite</subtitle>
+<subtitle>Configure Puppet integration in Satellite and use Puppet classes to configure your hosts</subtitle>
 <abstract><para>This guide describes how to enable Puppet integration with Satellite, configure the Puppet agent on hosts, how to import Puppet modules, and how to use the Puppet modules to enforce configurations on hosts managed in your Red&nbsp;Hat Satellite infrastructure.</para></abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/guides/doc-Managing_Content/docinfo.xml
+++ b/guides/doc-Managing_Content/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Content Management Guide</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>A guide to managing content from Red Hat and custom sources</subtitle>
+<subtitle>Import content from Red Hat and custom sources, manage applications life cycle across lifecycle environments, filter content by using Content Views, synchronize content between Satellite Servers, and more</subtitle>
 <abstract>
     <para>Use this guide to understand and manage content in Satellite 6. Examples of such content include RPM files, and ISO images. Red Hat Satellite 6 manages this content using a set of Content Views promoted across the application lifecycle. This guide demonstrates how to create an application lifecycle that suits your organization and content views that fulfils host states within lifecycle environments. These content views eventually form the basis for provisioning and updating hosts in your Red Hat Satellite 6 environment.</para>
 </abstract>

--- a/guides/doc-Managing_Hosts/docinfo.xml
+++ b/guides/doc-Managing_Hosts/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Managing Hosts</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>A guide to managing hosts in a Red Hat Satellite 6 environment.</subtitle>
+<subtitle>Register hosts to Satellite, configure host groups and collections, set up remote execution, manage packages on hosts, monitor hosts, and more</subtitle>
 <abstract><para>This guide describes how to configure and work with hosts in a Red&nbsp;Hat Satellite environment. Before continuing with this workflow you must have successfully installed a Red&nbsp;Hat Satellite 6 Server and any required Capsule Servers.</para></abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/guides/doc-Managing_Security_Compliance/docinfo.xml
+++ b/guides/doc-Managing_Security_Compliance/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Managing Security Compliance</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>A guide to managing security compliance on hosts in Red Hat Satellite.</subtitle>
+<subtitle>Plan and configure SCAP compliance policies, deploy the policies to hosts, and monitor compliance of your hosts</subtitle>
 <abstract>
 
     <para>With Satellite, you can create security compliance policies, deploy the policies on hosts, and monitor compliance of hosts using those policies to make the hosts adhere to security standards.</para>

--- a/guides/doc-Planning_for_Project/docinfo.xml
+++ b/guides/doc-Planning_for_Project/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Satellite Overview, Concepts, and Deployment Considerations</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Planning Satellite Deployment</subtitle>
+<subtitle>Explore the Satellite architecture and plan Satellite deployment</subtitle>
 <abstract><para>This document explains architecture concepts of Red&nbsp;Hat Satellite and provides recommendations for your deployment planning.</para></abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/guides/doc-Provisioning_Hosts/docinfo.xml
+++ b/guides/doc-Provisioning_Hosts/docinfo.xml
@@ -1,5 +1,5 @@
 <title>Provisioning Guide</title>
-<subtitle>A guide to provisioning physical and virtual hosts on Red&nbsp;Hat Satellite Servers.</subtitle>
+<subtitle>Configure provisioning resources and networking, provision physical machines, provision virtual machines on cloud providers or virtualization infrastructure, create hosts manually or by using the Discovery service</subtitle>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
 <abstract>

--- a/guides/doc-Tuning_Performance/docinfo.xml
+++ b/guides/doc-Tuning_Performance/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Tuning Performance of Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>A guide to optimize performance for Red Hat Satellite</subtitle>
+<subtitle>Optimize performance for Satellite Server and Capsule</subtitle>
 <abstract>
 	<para>This guide aims to cover the set of tunings and tips that can be used as a reference to scale up your Red Hat Satellite environment.</para>
 </abstract>

--- a/guides/doc-Updating_Project/docinfo.xml
+++ b/guides/doc-Updating_Project/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Updating Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>A guide to updating the Red Hat Satellite Server and Capsule Server.</subtitle>
+<subtitle>Update Satellite Server and Capsule to a new minor release</subtitle>
 <abstract>
 
     <para>Update Red Hat Satellite Server and Capsule Server regularly to ensure optimal performance and security.</para>

--- a/guides/doc-Upgrading_Project/docinfo.xml
+++ b/guides/doc-Upgrading_Project/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Upgrading Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
-<subtitle>Upgrading Red Hat Satellite Server and Capsule Server</subtitle>
+<subtitle>Upgrade Satellite Server and Capsule</subtitle>
 <abstract>
         <para>This guide describes how to upgrade Red Hat Satellite Server, both connected and disconnected, and Capsule Server.</para>
 </abstract>


### PR DESCRIPTION
Improving the guide descriptions in `docinfo.xml` that appear on the Satellite product documentation splash page.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
