### PR TITLE
Add RH CP links to resources for outgoing traffic

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -97,8 +97,8 @@ Remote Execution result upload
 ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
 | 443 | TCP | HTTPS | console.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
-| 443 | TCP | HTTPS | Red{nbsp}Hat Portal | SOS report | Assisting support cases (optional)
-| 443 | TCP | HTTPS | Red{nbsp}Hat CDN | Content Sync | Red{nbsp}Hat CDN
+| 443 | TCP | HTTPS | cdn.redhat.com | Content Sync | https://access.redhat.com/articles/1525183[Red{nbsp}Hat CDN]
+| 443 | TCP | HTTPS | api.access.redhat.com | SOS report | Assisting support cases filed through the https://access.redhat.com/solutions/1179133[Red{nbsp}Hat Customer Portal] (optional)
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
 endif::[]
 endif::[]


### PR DESCRIPTION
[BZ#2233263](https://bugzilla.redhat.com/show_bug.cgi?id=2233263) and [BZ#2233264](https://bugzilla.redhat.com/show_bug.cgi?id=2233264) request adding links to Red Hat Customer Portal.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
