### PR TITLE
Be more specific about creating a yum config file

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -22,8 +22,7 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 * {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 . Download the debug certificate of the organization and store it locally at `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
 For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle}_.
-. Create a Yum configuration file under `/etc/yum.repos.d`, such as `_sat-disconnected_.repo`.
-Include the following repository information in the file:
+. Create a Yum configuration file under `/etc/yum.repos.d`, such as `_{project-context}-disconnected_.repo`, with the following contents:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -22,7 +22,8 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 * {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
 . Download the debug certificate of the organization and store it locally at `/etc/pki/katello/certs/org-debug-cert.pem` or a location of your choosing.
 For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Certificate_admin[Creating an Organization Debug Certificate] in _{AdministeringDocTitle}_.
-. Create a Yum configuration file under `/etc/yum.repos.d` with the following repository information:
+. Create a Yum configuration file under `/etc/yum.repos.d`, such as `_sat-disconnected_.repo`.
+Include the following repository information in the file:
 +
 [options="nowrap" subs="attributes"]
 ----


### PR DESCRIPTION
[BZ#2238788](https://bugzilla.redhat.com/show_bug.cgi?id=2238788) reports a user was confused about how to name a file in the procedure for updating a disconnected server. This PR adds more details on that.

Because of the structural changes for the Updating guide, I'm only submitted this PR against 3.7 and later. After the wording gets acked, I will follow up with a PR for versions 3.6 and previous.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
