### PR TITLE
Fix typo in repo name

### DIFF
--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -93,7 +93,7 @@ Do not install or update any packages at this stage.
 .. Edit the `/etc/yum.repos.d/satellite.repo` file:
 +
 ----
-# vi /etc/yum.repos.d/sat6.repo
+# vi /etc/yum.repos.d/satellite.repo
 ----
 
 ... Change the default `InstallMedia` repository name to `{Project}-{ProjectVersion}`:


### PR DESCRIPTION
We are clearly mentioning the filename of repo in the procedure to modify but in its codeblock, the name is not matching.

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
