### PR TITLE
Narrow down the required perl packages

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -63,11 +63,11 @@ These instructions are for {EL} or Fedora, follow similar steps for other Linux 
 endif::[]
 
 .Procedure
-. On the virtual machine that you use to create the image, install the `cloud-init`, `open-vm-tools`, and `perl` packages:
+. On the virtual machine that you use to create the image, install the required packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-install} cloud-init open-vm-tools perl
+# {package-install} cloud-init open-vm-tools perl-interpreter perl-File-Temp
 ----
 . Disable network configuration by `cloud-init`:
 +


### PR DESCRIPTION
[BZ#2236724](https://bugzilla.redhat.com/show_bug.cgi?id=2236724) asks to narrow down the list of required perl packages installed during vmware cloud-init provisioning. The goal is to keep the list of dependencies installed to a minimum.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
