### PR TITLE
Update release notes for Katello 4.9.2

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,8 +13,12 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
-include::topics/foreman-3.7.0.adoc[leveloffset=+1]
+ifdef::katello[]
+include::topics/katello-4.9.2.adoc[leveloffset=+1]
+include::topics/katello-4.9.1.adoc[leveloffset=+1]
 include::topics/katello-4.9.0.adoc[leveloffset=+1]
+endif::[]
+include::topics/foreman-3.7.0.adoc[leveloffset=+1]
 
 [appendix]
 [id="foreman-contributors"]

--- a/guides/doc-Release_Notes/topics/katello-4.9.0.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.9.0.adoc
@@ -14,7 +14,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 * Enable tracer on host page (debian os) is always on - https://projects.theforeman.org/issues/36297[#36297]
 * Make the EventDeamon runner safer to run - https://projects.theforeman.org/issues/36277[#36277]
 * Hosts should upload package profile after content view / lifecycle environment change - https://projects.theforeman.org/issues/36256[#36256]
-* undefined method \`[]\' for nil:NilClass" or undefined method \`last\' for nil:NilClass" when generating Host - applied errata report - https://projects.theforeman.org/issues/36182[#36182]
+* undefined method `[]' for nil:NilClass" or undefined method `last' for nil:NilClass" when generating Host - applied errata report - https://projects.theforeman.org/issues/36182[#36182]
 * Content -&gt; Errata does not display the year for the dates listed under column "Updated" - https://projects.theforeman.org/issues/36156[#36156]
 
 === API
@@ -45,7 +45,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 * Needs_publish icon doesn\'t refresh when publish wizard is closed with task running - https://projects.theforeman.org/issues/36402[#36402]
 * Update UI to reflect needs_publish disabled flag for CVs with audits cleaned up - https://projects.theforeman.org/issues/36397[#36397]
 * Add filters_applied? to cv version API. - https://projects.theforeman.org/issues/36322[#36322]
-* Getting "NoMethodError undefined method \`get_status\' for nil:NilClass" when publishing content view - https://projects.theforeman.org/issues/36303[#36303]
+* Getting "NoMethodError undefined method `get_status' for nil:NilClass" when publishing content view - https://projects.theforeman.org/issues/36303[#36303]
 * Incremental update of the content view takes long time to complete - https://projects.theforeman.org/issues/36302[#36302]
 * Missing repository name (image name) in Container tags CVv comparison - https://projects.theforeman.org/issues/36290[#36290]
 * Hidden CV version number in CVv comparison - https://projects.theforeman.org/issues/36289[#36289]
@@ -71,7 +71,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 * Package upgradable versions are not set correctly based on architecture - https://projects.theforeman.org/issues/36100[#36100]
 * Host cloning is broken - https://projects.theforeman.org/issues/36064[#36064]
 * Setting a Content Source is not persistent - https://projects.theforeman.org/issues/35834[#35834]
-* \'System purpose\' modal doesn\'t reset after switching hosts with switcher - https://projects.theforeman.org/issues/35324[#35324]
+* 'System purpose' modal doesn\'t reset after switching hosts with switcher - https://projects.theforeman.org/issues/35324[#35324]
 * Global registration form needs call-to-action link when there are no activation keys created - https://projects.theforeman.org/issues/35310[#35310]
 
 === Inter Server Sync
@@ -85,7 +85,6 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === Repositories
 
-* Can\'t remove GPG and SSL Keys from existing Product using the API - https://projects.theforeman.org/issues/36497[#36497]
 * Make metadata_expire field optional - https://projects.theforeman.org/issues/36435[#36435]
 * useless redirect when fetching pulp3 status - https://projects.theforeman.org/issues/36425[#36425]
 * Bring back the option to Republish Repository\CV Version metadata in web UI - https://projects.theforeman.org/issues/36417[#36417]

--- a/guides/doc-Release_Notes/topics/katello-4.9.1.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.9.1.adoc
@@ -1,0 +1,39 @@
+= Katello 4.9.1
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1744[Redmine]
+
+== Katello
+
+=== Content Views
+
+* Hammer should treat indeterminate needs_publish as publish_needed. - https://projects.theforeman.org/issues/36581[#36581]
+* Content view dependency solving should be tracked for needs_publish - https://projects.theforeman.org/issues/36580[#36580]
+* CV page needs refresh to get the current filters state - https://projects.theforeman.org/issues/36529[#36529]
+
+=== Foreman Proxy Content
+
+* The "POST /katello/api/capsules/:id/reclaim_space" endpoint is wrong - https://projects.theforeman.org/issues/36545[#36545]
+
+=== Inter Server Sync
+
+* Exporting repositories that have architecture restrictions results in bogus data that can\'t be properly imported - https://projects.theforeman.org/issues/36477[#36477]
+
+=== Repositories
+
+* 4.9 is slow to sync and index repositories - https://projects.theforeman.org/issues/36563[#36563]
+
+=== Subscriptions
+
+* Reasons for not deleting the manifest don\'t apply with SCA enabled - https://projects.theforeman.org/issues/36604[#36604]
+
+=== Tests
+
+* Pin ostree binding on nightly for tests to pass. - https://projects.theforeman.org/issues/36586[#36586]
+
+=== Upgrades
+
+* Upgrade rake task will create bad content overrides on post-4.9 Katello upgrades - https://projects.theforeman.org/issues/36540[#36540]
+
+=== Web UI
+
+* Fix lint errors  - https://projects.theforeman.org/issues/36609[#36609]

--- a/guides/doc-Release_Notes/topics/katello-4.9.2.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.9.2.adoc
@@ -1,0 +1,57 @@
+= Katello 4.9.2
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1752[Redmine]
+
+== Katello
+
+=== Alternate Content Sources
+
+* Custom ACS path help text is missing file:// - https://projects.theforeman.org/issues/36631[#36631]
+
+=== Client/Agent
+
+* tasks Actions::Katello::BulkAgentAction without any sub-plans and stuck in running/pending - https://projects.theforeman.org/issues/36528[#36528]
+* Add UI banners warning users about katello-agent removal - https://projects.theforeman.org/issues/36526[#36526]
+
+=== Content Views
+
+* undefined method '#single_content_view' for Katello::Host::ContentFacet::Jail (Katello::Host::ContentFacet) (Safemode::NoMethodError) - https://projects.theforeman.org/issues/36684[#36684]
+* Re-synchronizing the repository whose sync had failed earlier, the Content View does not display new upgradable packages that are available. - https://projects.theforeman.org/issues/36622[#36622]
+* Filter gets applied to all the repository upon removal of repository for which the filter was created. - https://projects.theforeman.org/issues/36577[#36577]
+* Content View comparison - RPM packages search missing auto completion - https://projects.theforeman.org/issues/36516[#36516]
+
+=== Errata Management
+
+* Allow installable errata count methods - https://projects.theforeman.org/issues/36506[#36506]
+
+=== Foreman Proxy Content
+
+* Optimized capsule sync doesn\'t sync recently published/promoted docker repositories - https://projects.theforeman.org/issues/36523[#36523]
+
+=== Hosts
+
+* Hammer accepts non-existent LCE in host update - https://projects.theforeman.org/issues/36667[#36667]
+* Errors due to lack of safe navigation when you try to customize a discovered host - https://projects.theforeman.org/issues/36608[#36608]
+* Error when autoprovision/provision for a discovered host - https://projects.theforeman.org/issues/36601[#36601]
+* undefined method `each' for #&lt;Katello::ContentViewEnvironment when running hammer host subscription register - https://projects.theforeman.org/issues/36524[#36524]
+* undefined method `content_view=' for #&lt;Katello::Host::ContentFacet:0x00007fc530855ac8&gt; - https://projects.theforeman.org/issues/36504[#36504]
+* Editing a host results in an error "content_view_id and lifecycle_environment_id must be provided together" - https://projects.theforeman.org/issues/36498[#36498]
+* Can\'t add hostgroup to new host - https://projects.theforeman.org/issues/36462[#36462]
+* hammer host update fails with "unknown attribute ‘content_view_id’ for Katello::Host::ContentFacet" when you pass a content view / LCE - https://projects.theforeman.org/issues/36440[#36440]
+* Arch restriction label missing from Repository sets for repos without URL - https://projects.theforeman.org/issues/36430[#36430]
+
+=== Inter Server Sync
+
+* hammer content import fails with undefined method `substitutor' for nil:NilClass during import content if product being imported is not covered by subscriptions on the manifest - https://projects.theforeman.org/issues/36521[#36521]
+
+=== Repositories
+
+* hammer- allow user to run Verify Content Checksum, on container repositories. - https://projects.theforeman.org/issues/36625[#36625]
+* Repository details page shouldn\'t say 'enabled by default' - https://projects.theforeman.org/issues/36593[#36593]
+* Upgrade to Katello 4.5 can fail if some on_demand repositories have checksum_type set - https://projects.theforeman.org/issues/36562[#36562]
+* Optimize DockerMetaTag query and CV version deletion to run a single invocation of the method. - https://projects.theforeman.org/issues/36500[#36500]
+* Can\'t remove GPG and SSL Keys from existing Product using the API - https://projects.theforeman.org/issues/36497[#36497]
+
+=== Web UI
+
+* Update PermissionDenied snapshots  - https://projects.theforeman.org/issues/36552[#36552]

--- a/guides/doc-Release_Notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/katello-contributors.adoc
@@ -1,17 +1,24 @@
-Adam Ruzicka
-Amir Fefer
-Bernhard Suttner
-Chris Roberts
-Evgeni Golov
-Ewoud Kohl van Wijngaarden
-Hao Yu
-Ian Ballou
-Jeremy Lenz
-Karolína Małyjurková
-Lucy Fu
-Partha Aji
-Quinn James
-William Clark
-Markus Bucher
-stbergmann
-Trevor Allison
+Adam Růžička,
+Amir Fefer,
+Bernhard Suttner,
+Chris Roberts,
+Evgeni Golov,
+Ewoud Kohl van Wijngaarden,
+Girija Soni,
+Hao Yu,
+Ian Ballou,
+Jeremy Lenz,
+Karolína Małyjurková,
+Leoš Stejskal,
+Lucy Fu,
+Lukas Magauer,
+Maria Agaphontzev,
+Markus Bucher,
+Nagoor Shaik,
+Partha Aji,
+Quinn James,
+Samir Jha,
+Sayan Das,
+Stephan Bergmann,
+Trevor Allison,
+William Bradford Clark


### PR DESCRIPTION
Also includes release notes for Katello 4.9.1


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
