### PR TITLE
Add links in Managing Container Images

### DIFF
--- a/guides/common/modules/con_managing-container-images.adoc
+++ b/guides/common/modules/con_managing-container-images.adoc
@@ -4,5 +4,9 @@
 With {Project}, you can import container images from various sources and distribute them to external containers using Content Views.
 
 ifndef::orcharhino[]
-For information about containers, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/index[Getting Started with Containers] in _{RHEL} Atomic Host 7_.
+For information about containers for {RHEL} Atomic Host 7, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/index[Getting Started with Containers] in _{RHEL} Atomic Host 7_.
+
+For information about containers for {RHEL} 8, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index[Building, running, and managing containers] in _{RHEL} 8_.
+
+For information about containers for {RHEL} 9, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/building_running_and_managing_containers/index[Building, running, and managing containers] in _{RHEL} 8_.
 endif::[]

--- a/guides/common/modules/con_managing-container-images.adoc
+++ b/guides/common/modules/con_managing-container-images.adoc
@@ -8,5 +8,5 @@ For information about containers for {RHEL} Atomic Host 7, see https://access.re
 
 For information about containers for {RHEL} 8, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index[Building, running, and managing containers] in _{RHEL} 8_.
 
-For information about containers for {RHEL} 9, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/building_running_and_managing_containers/index[Building, running, and managing containers] in _{RHEL} 8_.
+For information about containers for {RHEL} 9, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/building_running_and_managing_containers/index[Building, running, and managing containers] in _{RHEL} 9_.
 endif::[]


### PR DESCRIPTION
The initial DDF thought the first link for RHEL Atomic Host 7 was
invalid but it does work. Two newer links for RHEL 8 and RHEL 9 have
been added for users running RHEL 8 or RHEL 9 on their system.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
