### PR TITLE
Add steps for adding repo manually when importing container images

### DIFF
--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -30,6 +30,14 @@ Click to edit, and add any tags that you want to limit the content that synchron
 . In the {ProjectWebUI}, navigate to *Content* > *Products* and select the name of your product.
 . Select the new repositories and then click *Sync Now* to start the synchronization process.
 
+.Procedure with creating a repository manually
+. In the {ProjectWebUI}, navigate to *Content* > *Products*.
+Click the name of the required product.
+. Click *New repository*.
+. From the *Type* list, select *docker*.
+Enter the details for the repository, and click *Save*.
+. Select the new repository, and click *Sync Now*.
+
 [role="_additional-resources"]
 .Next steps
 * To view the progress of the synchronization, navigate to *Content* > *Sync Status* and expand the repository tree.

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -8,12 +8,9 @@ ifdef::orcharhino[]
 You can import container image repositories from any container image registry.
 endif::[]
 
-This procedure uses repository discovery to find container images and import them as repositories.
-For more information about creating a product and repository manually, see xref:Importing_Content_{context}[].
-
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-container-images[].
 
-.Procedure
+.Procedure with repository discovery
 . In the {ProjectWebUI}, navigate to *Content* > *Products* and click *Repo Discovery*.
 . From the *Repository Type* list, select *Container Images*.
 . In the *Registry to Discover* field, enter the URL of the registry to import images from.
@@ -33,9 +30,10 @@ Click to edit, and add any tags that you want to limit the content that synchron
 . In the {ProjectWebUI}, navigate to *Content* > *Products* and select the name of your product.
 . Select the new repositories and then click *Sync Now* to start the synchronization process.
 
-To view the progress of the synchronization, navigate to *Content* > *Sync Status* and expand the repository tree.
-
-When the synchronization completes, you can click *Container Image Manifests* to list the available manifests.
+[role="_additional-resources"]
+.Next steps
+* To view the progress of the synchronization, navigate to *Content* > *Sync Status* and expand the repository tree.
+* When the synchronization completes, you can click *Container Image Manifests* to list the available manifests.
 From the list, you can also remove any manifests that you do not require.
 
 [id="cli-importing-container-images"]
@@ -71,3 +69,7 @@ From the list, you can also remove any manifests that you do not require.
 --organization "_My_Organization_" \
 --product "{client-container-product-name}"
 ----
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about creating a product and repository manually, see xref:Importing_Content_{context}[].


### PR DESCRIPTION
[BZ#2022803](https://bugzilla.redhat.com/show_bug.cgi?id=2022803) requests adding steps on importing container images not using repo discovery, but manually for existing products. This PR updates the procedure with these steps, while also making other minor edits to accommodate the new steps.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
