### PR TITLE
Fix Upgrading doc title

### DIFF
--- a/guides/doc-Upgrading_Project/docinfo.xml
+++ b/guides/doc-Upgrading_Project/docinfo.xml
@@ -1,4 +1,4 @@
-<title>Upgrading Red Hat Satellite</title>
+<title>Upgrading Red Hat Satellite to 6.14</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>6.14</productnumber>
 <subtitle>Upgrade Satellite Server and Capsule</subtitle>


### PR DESCRIPTION
The upgrading title for Satellite varies from the upstream doc. Fixing this in the `docinfo.xml` file.


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
