### PR TITLE
no need to reindex the db manually after restore

### DIFF
--- a/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
+++ b/guides/common/modules/proc_restoring-a-backup-of-a-server-on-el8.adoc
@@ -7,9 +7,3 @@ After you perform a fresh installation of {ProjectServer} or {SmartProxyServer} 
 * Restore a backup on the target server:
 ** To restore a full backup, see {AdministeringDocURL}Restoring_from_a_Full_Backup_admin[Restoring From a Full Backup] in _{AdministeringDocTitle}_.
 ** To restore an incremental backup, see {AdministeringDocURL}Restoring_from_Incremental_Backups_admin[Restoring From Incremental Backups] in _{AdministeringDocTitle}_.
-* Reindex the databases:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# runuser -u postgres -- reindexdb -a
-----


### PR DESCRIPTION
foreman_maintain does that since 1.1.10


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
