### PR TITLE
Remove the strong negative usage for backup restoration

### DIFF
--- a/guides/common/modules/proc_performing-a-backup-without-pulp-content.adoc
+++ b/guides/common/modules/proc_performing-a-backup-without-pulp-content.adoc
@@ -3,7 +3,7 @@
 
 You can perform an offline backup that excludes the contents of the Pulp directory.
 The backup without Pulp content is useful for debugging purposes and is only intended to provide access to configuration files without backing up the Pulp database.
-You cannot restore from a directory that does not contain Pulp content.
+For production usecases, do not restore from a directory that does not contain Pulp content.
 
 [WARNING]
 ====


### PR DESCRIPTION
It is not impossible to restore backup without pulp. However, this is not recommended.
Rewording to convey correct information.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2227276


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
