### PR TITLE
Add repositories-setup in whitelist while upgrading

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -153,7 +153,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-validate" --target-version {ProductVersion}.__z__
+# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-setup,repositories-validate" --target-version {ProductVersion}.__z__
 ----
 
 include::snip_steps-needs-reboot.adoc[]


### PR DESCRIPTION
Apart from `check-upstream-repository` and `repositories-validate`, there is a suggestion to add `repositories-setup` in the whitelist while executing the Upgrade command on the Project Server to update it to the next minor version.

https://bugzilla.redhat.com/show_bug.cgi?id=2242367

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
