### PR TITLE
Update code samples in VMware cloud-init

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -98,6 +98,7 @@ If you intend to provision through {SmartProxyServer}, use the URL of your {Smar
 # cat << EOM > /etc/cloud/cloud.cfg
 cloud_init_modules:
  - bootcmd
+ - ssh
 
 cloud_config_modules:
  - runcmd
@@ -179,7 +180,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# rm -f /etc/ssh/_SSH_keys_
+# rm -f /etc/ssh/ssh_host_*
 ----
 . Remove root user's SSH history:
 +


### PR DESCRIPTION
cloud.cfg is missing the SSH module for VMWare cloud-init 20 and newer.
Also, we can tell the user to remove all SSH keys in a clearer way.

https://bugzilla.redhat.com/show_bug.cgi?id=2237783

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
