### PR TITLE
Add automatic hosts deletion in Insights Inventory

### DIFF
--- a/guides/common/modules/proc_using-red-hat-insights.adoc
+++ b/guides/common/modules/proc_using-red-hat-insights.adoc
@@ -57,6 +57,20 @@ You can manually synchronize the recommendations using the following procedure:
 
 If you have not set up the API token, you are prompted to create one before using this page.
 
+.Removing hosts from Inventory of Red{nbsp}Hat Insights when they are removed from {Project}
+When hosts are removed from {Project}, they can also be removed from the inventory of Red{nbsp}Hat Insights, either automatically or manually.
+Use the following procedure to configure it automatically.
+
+.Prerequisite
+* You must have administrator privilege for the organization to enable this setting.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Configure* > *Inventory Upload*.
+. Enable the *Automatic Mismatch Deletion* setting.
+
+The hosts are automatically removed from the Insights Inventory during the next synchronization with {Project} that occurs daily by default.
+If the setting is disabled, you can still delete the hosts from the Inventory manually.
+
 .Additional Information
 * To view the logs for Red{nbsp}Hat Insights and all plug-ins, go to `/var/log/foreman/production.log`.
 * If you have problems connecting to Red{nbsp}Hat Insights, ensure that your certificates are up-to-date.

--- a/guides/common/modules/proc_using-red-hat-insights.adoc
+++ b/guides/common/modules/proc_using-red-hat-insights.adoc
@@ -59,16 +59,17 @@ If you have not set up the API token, you are prompted to create one before usin
 
 .Removing hosts from Inventory of Red{nbsp}Hat Insights when they are removed from {Project}
 When hosts are removed from {Project}, they can also be removed from the inventory of Red{nbsp}Hat Insights, either automatically or manually.
-Use the following procedure to configure it automatically.
+To configure it automatically, perform the following steps:
 
-.Prerequisite
-* You must have administrator privilege for the organization to enable this setting.
-
-.Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Inventory Upload*.
 . Enable the *Automatic Mismatch Deletion* setting.
 
-The hosts are automatically removed from the Insights Inventory during the next synchronization with {Project} that occurs daily by default.
+[NOTE]
+====
+Your user account must have a role assigned that grants the `view_settings` and `edit_settings` permissions.
+====
+
+The hosts are automatically removed from the Insights Inventory of {RHCloud} during the next synchronization with {Project} that occurs daily by default.
 If the setting is disabled, you can still delete the hosts from the Inventory manually.
 
 .Additional Information


### PR DESCRIPTION
This section discusses how the hosts are automatically deleted from the Insights Inventory simultaneously when deleted from the Project Server.

https://issues.redhat.com/browse/SAT-18017

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
