### PR TITLE
Update release notes for Foreman 3.8 GA

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman-3.8.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.8.0.adoc
@@ -2,144 +2,179 @@
 
 A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1731[Redmine]
 
+== Headline Features
+
+=== Show failed resources in failed installation report
+
+A failed foreman-installer run will capture Puppet reports making it much easier to troubleshoot failures.
+Users will not have to rely on the installer log anymore, as the failure output should be sufficient.
+
+=== Removed installer duplicate parameters
+
+Both `--foreman-logging-layout` and `--puppet-server-foreman-url` are no longer needed.
+The logging layout is now derived from the logging type (`--foreman-logging-type`).
+The Foreman URL for puppetserver is now read from the Foreman Proxy setting (`--foreman-proxy-foreman-base-url`).
+The parameters still exist and can be specified, but the average user shouldn't need it.
+
 == Foreman
 
-* Add "last_checkin" attribute to Entitlements Template - https://projects.theforeman.org/issues/30690[#30690]
+* pass:[Some events are not visible even being triggered] - https://projects.theforeman.org/issues/36796[#36796]
+* pass:[CVE-2022-4130: Blind SSRF via Referer header] - https://projects.theforeman.org/issues/36768[#36768]
+* pass:[Add "last_checkin" attribute to Entitlements Template] - https://projects.theforeman.org/issues/30690[#30690]
 
 === API
 
-* GraphQL: Incorrect totalCount when querying with first parameter - https://projects.theforeman.org/issues/36509[#36509]
-* Unable to access API using non-admin users. - https://projects.theforeman.org/issues/36449[#36449]
+* pass:[GraphQL: Incorrect totalCount when querying with first parameter] - https://projects.theforeman.org/issues/36509[#36509]
+* pass:[Unable to access API using non-admin users.] - https://projects.theforeman.org/issues/36449[#36449]
 
 === Audit Log
 
-* Audit shows N/A for host owner changes - https://projects.theforeman.org/issues/36522[#36522]
+* pass:[Audit shows N/A for host owner changes] - https://projects.theforeman.org/issues/36522[#36522]
 
 === Development tools
 
-* Update ansible dev setup guide - https://projects.theforeman.org/issues/36475[#36475]
-* Remove storybook - https://projects.theforeman.org/issues/36439[#36439]
+* pass:[Update ansible dev setup guide] - https://projects.theforeman.org/issues/36475[#36475]
+* pass:[Remove storybook] - https://projects.theforeman.org/issues/36439[#36439]
 
 === Host groups
 
-* 500 error when loading Hostgroups page for Ansible Roles Manager user - https://projects.theforeman.org/issues/36703[#36703]
-* Changing OS in hostgroup edit form reset pxe loader even when it is not necessary - https://projects.theforeman.org/issues/36560[#36560]
+* pass:[500 error when loading Hostgroups page for Ansible Roles Manager user] - https://projects.theforeman.org/issues/36703[#36703]
+* pass:[Changing OS in hostgroup edit form reset pxe loader even when it is not necessary] - https://projects.theforeman.org/issues/36560[#36560]
 
 === Host registration
 
-* global registration should not create hosts as "managed" or "to be built" - https://projects.theforeman.org/issues/36393[#36393]
+* pass:[global registration should not create hosts as "managed" or "to be built"] - https://projects.theforeman.org/issues/36393[#36393]
 
 === Inventory
 
-* Add PermissionDenied to reports tab in host - https://projects.theforeman.org/issues/36550[#36550]
-* show new,delete button for params on host details only if user has permissions  - https://projects.theforeman.org/issues/36549[#36549]
-* Show disk and partition info of vsphere host - https://projects.theforeman.org/issues/36518[#36518]
-* Legacy Hosts UI loaded when you navigate from the Host\'s VMRC Console button - https://projects.theforeman.org/issues/36450[#36450]
-* The Reports link from new host detail page in the kebab menu should be dropped - https://projects.theforeman.org/issues/36067[#36067]
+* pass:[Add PermissionDenied to reports tab in host] - https://projects.theforeman.org/issues/36550[#36550]
+* pass:[show new,delete button for params on host details only if user has permissions ] - https://projects.theforeman.org/issues/36549[#36549]
+* pass:[Show disk and partition info of vsphere host] - https://projects.theforeman.org/issues/36518[#36518]
+* pass:[Legacy Hosts UI loaded when you navigate from the Host's VMRC Console button] - https://projects.theforeman.org/issues/36450[#36450]
+* pass:[The Reports link from new host detail page in the kebab menu should be dropped] - https://projects.theforeman.org/issues/36067[#36067]
 
 === JavaScript stack
 
-* Refactor PermissionDenied component  - https://projects.theforeman.org/issues/36551[#36551]
-* Update ConfigReports to pf4 - https://projects.theforeman.org/issues/36400[#36400]
-* "Scrollbar test exception: TypeError" when loading any page - https://projects.theforeman.org/issues/36093[#36093]
+* pass:[Refactor PermissionDenied component ] - https://projects.theforeman.org/issues/36551[#36551]
+* pass:[Update ConfigReports to pf4] - https://projects.theforeman.org/issues/36400[#36400]
+* pass:["Scrollbar test exception: TypeError" when loading any page] - https://projects.theforeman.org/issues/36093[#36093]
 
 === Notifications
 
-* Cache reads from redis raise "incompatible marshal file format" exception - https://projects.theforeman.org/issues/36329[#36329]
+* pass:[Cache reads from redis raise "incompatible marshal file format" exception] - https://projects.theforeman.org/issues/36329[#36329]
 
 === Parameters
 
-* Add LookupValue permissions - https://projects.theforeman.org/issues/36663[#36663]
-* The parameter value vanishes when clicking on the hide value checkbox on the new host page paramater tab - https://projects.theforeman.org/issues/36591[#36591]
+* pass:[Add LookupValue permissions] - https://projects.theforeman.org/issues/36663[#36663]
+* pass:[The parameter value vanishes when clicking on the hide value checkbox on the new host page paramater tab] - https://projects.theforeman.org/issues/36591[#36591]
 
 === Plugin integration
 
-* As a user, I want to be able to trigger webhooks only on explicit host updates - https://projects.theforeman.org/issues/36104[#36104]
+* pass:[As a user, I want to be able to trigger webhooks only on explicit host updates] - https://projects.theforeman.org/issues/36104[#36104]
 
 === Puppet integration
 
-* Move puppet rake task to plugin - https://projects.theforeman.org/issues/36222[#36222]
+* pass:[Move puppet rake task to plugin] - https://projects.theforeman.org/issues/36222[#36222]
 
 === Rails
 
-* Drop power_manager models from autoload paths - https://projects.theforeman.org/issues/36583[#36583]
-* Load Rails 6.1 defaults - https://projects.theforeman.org/issues/35432[#35432]
+* pass:[Drop power_manager models from autoload paths] - https://projects.theforeman.org/issues/36583[#36583]
+* pass:[Load Rails 6.1 defaults] - https://projects.theforeman.org/issues/35432[#35432]
+
+=== Rake tasks
+
+* pass:[count db:abort_if_pending_migrations as a setup rake task] - https://projects.theforeman.org/issues/36774[#36774]
 
 === Reporting
 
-* "Applicable errata" and "registered content hosts" reports syntax highlighting broken + applicable errata name needs changing - https://projects.theforeman.org/issues/36587[#36587]
-* "Host - compare content hosts packages" report template should restrict or notify if Host 1* and Host 2* name are same - https://projects.theforeman.org/issues/36244[#36244]
+* pass:["Applicable errata" and "registered content hosts" reports syntax highlighting broken + applicable errata name needs changing] - https://projects.theforeman.org/issues/36587[#36587]
+* pass:["Host - compare content hosts packages" report template should restrict or notify if Host 1* and Host 2* name are same] - https://projects.theforeman.org/issues/36244[#36244]
 
 === Security
 
-* Open Redirect weakness in links_controller.rb - https://projects.theforeman.org/issues/36644[#36644]
-* use YAML.safe_load instead of YAML.load - https://projects.theforeman.org/issues/36219[#36219]
+* pass:[Open Redirect weakness in links_controller.rb] - https://projects.theforeman.org/issues/36644[#36644]
+* pass:[use YAML.safe_load instead of YAML.load] - https://projects.theforeman.org/issues/36219[#36219]
 
 === Settings
 
-* instance_id setting is not presistent. - https://projects.theforeman.org/issues/36395[#36395]
+* pass:[CVE-2022-3874: OS command injection via ct_command and fcct_command] - https://projects.theforeman.org/issues/36759[#36759]
+* pass:[instance_id setting is not presistent.] - https://projects.theforeman.org/issues/36395[#36395]
+
+=== Statistics
+
+* pass:[Report Template output generation can take hours to complete if the template is only about printing different host facts
+] - https://projects.theforeman.org/issues/36715[#36715]
 
 === Templates
 
-* Introduce human readable form for Host - Statuses report template - https://projects.theforeman.org/issues/36426[#36426]
-* Template load_resource - explain :joins, :preload and includes - https://projects.theforeman.org/issues/36239[#36239]
+* pass:[Safemode doesn't allow to access 'katello_agent_enabled?'] - https://projects.theforeman.org/issues/36717[#36717]
+* pass:[Introduce human readable form for Host - Statuses report template] - https://projects.theforeman.org/issues/36426[#36426]
+* pass:[kickstart_kernel_options snippet breaks UEFI VLAN tagged provisioning] - https://projects.theforeman.org/issues/36361[#36361]
+* pass:[Template load_resource - explain :joins, :preload and includes] - https://projects.theforeman.org/issues/36239[#36239]
+* pass:["snippet" keyword causes error in search bar] - https://projects.theforeman.org/issues/35805[#35805]
 
 === Tests
 
-* Pin @adobe/css-tools package to 4.2.0 to build on NodeJS 12 - https://projects.theforeman.org/issues/36656[#36656]
-* Support Minitest 5.19+ - https://projects.theforeman.org/issues/36651[#36651]
-* Pin minitest &lt; 5.19 to resolve test failures - https://projects.theforeman.org/issues/36617[#36617]
-* "Add parameter" button\'s data-ouia-component-id is changing - https://projects.theforeman.org/issues/36481[#36481]
-* Add eslint rule to alert about missing ouia-ids - https://projects.theforeman.org/issues/36471[#36471]
-* Add missing ouia-ids to all pf4 components - https://projects.theforeman.org/issues/36470[#36470]
+* pass:[Pin @adobe/css-tools package to 4.2.0 to build on NodeJS 12] - https://projects.theforeman.org/issues/36656[#36656]
+* pass:[Support Minitest 5.19+] - https://projects.theforeman.org/issues/36651[#36651]
+* pass:[Pin minitest < 5.19 to resolve test failures] - https://projects.theforeman.org/issues/36617[#36617]
+* pass:["Add parameter" button's data-ouia-component-id is changing] - https://projects.theforeman.org/issues/36481[#36481]
+* pass:[Add eslint rule to alert about missing ouia-ids] - https://projects.theforeman.org/issues/36471[#36471]
+* pass:[Add missing ouia-ids to all pf4 components] - https://projects.theforeman.org/issues/36470[#36470]
 
 === Unattended installations
 
-* Include BOOTIF-parameter in kernel_options for Ubuntu autoinstall - https://projects.theforeman.org/issues/36677[#36677]
-* Installation medium "CentOS 8 mirror" no longer exists - https://projects.theforeman.org/issues/36659[#36659]
-* Template proxy is not used for IPv6 subnets - https://projects.theforeman.org/issues/36639[#36639]
-* AutoYaST provisioning template needs update for SLES 15 SP5 - https://projects.theforeman.org/issues/36536[#36536]
-* Debian 12 bookworm uses python3 - https://projects.theforeman.org/issues/36519[#36519]
-* Virtual nic conf in preseed is outdated - https://projects.theforeman.org/issues/36508[#36508]
-* Provisioning template for CoreOS has a typo - https://projects.theforeman.org/issues/36490[#36490]
-* Invalid netplan config with shortened IPv6-addresses - https://projects.theforeman.org/issues/36441[#36441]
-* Awk/grep should be more strict - https://projects.theforeman.org/issues/36293[#36293]
-* AlmaLinux UEFI Grub2 chainloading is broken - https://projects.theforeman.org/issues/36189[#36189]
-* Windows default user data template - https://projects.theforeman.org/issues/36161[#36161]
-* root_pass from settings not detected as unencrypted - https://projects.theforeman.org/issues/35942[#35942]
-* Fix preseed_kernel_options to work with full-host-bootdisk deployments - https://projects.theforeman.org/issues/35124[#35124]
+* pass:[Include BOOTIF-parameter in kernel_options for Ubuntu autoinstall] - https://projects.theforeman.org/issues/36677[#36677]
+* pass:[Installation medium "CentOS 8 mirror" no longer exists] - https://projects.theforeman.org/issues/36659[#36659]
+* pass:[Template proxy is not used for IPv6 subnets] - https://projects.theforeman.org/issues/36639[#36639]
+* pass:[AutoYaST provisioning template needs update for SLES 15 SP5] - https://projects.theforeman.org/issues/36536[#36536]
+* pass:[Debian 12 bookworm uses python3] - https://projects.theforeman.org/issues/36519[#36519]
+* pass:[Virtual nic conf in preseed is outdated] - https://projects.theforeman.org/issues/36508[#36508]
+* pass:[Provisioning template for CoreOS has a typo] - https://projects.theforeman.org/issues/36490[#36490]
+* pass:[Invalid netplan config with shortened IPv6-addresses] - https://projects.theforeman.org/issues/36441[#36441]
+* pass:[Awk/grep should be more strict] - https://projects.theforeman.org/issues/36293[#36293]
+* pass:[AlmaLinux UEFI Grub2 chainloading is broken] - https://projects.theforeman.org/issues/36189[#36189]
+* pass:[Windows default user data template] - https://projects.theforeman.org/issues/36161[#36161]
+* pass:[root_pass from settings not detected as unencrypted] - https://projects.theforeman.org/issues/35942[#35942]
+* pass:[Fix preseed_kernel_options to work with full-host-bootdisk deployments] - https://projects.theforeman.org/issues/35124[#35124]
 
 === Users, Roles and Permissions
 
-* Personal access tokens don\'t handle invalid expire_at dates gracefully - https://projects.theforeman.org/issues/36699[#36699]
-* Make new pf4 modal for adding personal access token - https://projects.theforeman.org/issues/36001[#36001]
+* pass:[Personal access tokens don't handle invalid expire_at dates gracefully] - https://projects.theforeman.org/issues/36699[#36699]
+* pass:[Make new pf4 modal for adding personal access token] - https://projects.theforeman.org/issues/36001[#36001]
 
 === Web Interface
 
-* Remove dividers between navigation items - https://projects.theforeman.org/issues/36571[#36571]
-* Navigation items don\'t open in a new tab on ctrl+click - https://projects.theforeman.org/issues/36543[#36543]
-* Add line breaks to bookmarks if the name is too long - https://projects.theforeman.org/issues/36350[#36350]
-* Use pf4 in vertical navigation - https://projects.theforeman.org/issues/30344[#30344]
+* pass:[Typo in variable name in form for taxonomies] - https://projects.theforeman.org/issues/36791[#36791]
+* pass:[Remove dividers between navigation items] - https://projects.theforeman.org/issues/36571[#36571]
+* pass:[Navigation items don't open in a new tab on ctrl+click] - https://projects.theforeman.org/issues/36543[#36543]
+* pass:[Add line breaks to bookmarks if the name is too long] - https://projects.theforeman.org/issues/36350[#36350]
+* pass:[Use pf4 in vertical navigation] - https://projects.theforeman.org/issues/30344[#30344]
 
 == Installer
 
-* Reuse foreman_proxy::foreman_base_url value for puppet::server_foreman_url - https://projects.theforeman.org/issues/36573[#36573]
+* pass:[Reuse foreman_proxy::foreman_base_url value for puppet::server_foreman_url] - https://projects.theforeman.org/issues/36573[#36573]
 
 === Foreman modules
 
-* Set ANSIBLE_PERMISSION_CLASSES as empty list to allow syncing collection repos on capsule without RBAC access to Galaxy endpoints - https://projects.theforeman.org/issues/36709[#36709]
-* Change the default Foreman Redis cache DB to 4 - https://projects.theforeman.org/issues/36645[#36645]
-* Puppet module for Puppet should use "allowlist" instead of "whitelist" - https://projects.theforeman.org/issues/36620[#36620]
-* Automatically detect Foreman logging layout based on logging type - https://projects.theforeman.org/issues/36582[#36582]
-* Switch to puppetlabs vcsrepo for gitrepo tracking - https://projects.theforeman.org/issues/35943[#35943]
+* pass:[allow setting (fc)ct_location] - https://projects.theforeman.org/issues/36812[#36812]
+* pass:[CVE-2023-4886: World readable tomcat server.xml contains passwords] - https://projects.theforeman.org/issues/36760[#36760]
+* pass:[Set ANSIBLE_PERMISSION_CLASSES as empty list to allow syncing collection repos on capsule without RBAC access to Galaxy endpoints] - https://projects.theforeman.org/issues/36709[#36709]
+* pass:[Expose candlepin logging parameter in the installer] - https://projects.theforeman.org/issues/36697[#36697]
+* pass:[Change the default Foreman Redis cache DB to 4] - https://projects.theforeman.org/issues/36645[#36645]
+* pass:[Puppet module for Puppet should use "allowlist" instead of "whitelist"] - https://projects.theforeman.org/issues/36620[#36620]
+* pass:[Automatically detect Foreman logging layout based on logging type] - https://projects.theforeman.org/issues/36582[#36582]
+* pass:[Switch to puppetlabs vcsrepo for gitrepo tracking] - https://projects.theforeman.org/issues/35943[#35943]
 
 === foreman-installer script
 
-* katello-certs-check does not cause the installer to halt execution on failure - https://projects.theforeman.org/issues/36567[#36567]
-* Allow enabling mod_status for better Apache monitoring - https://projects.theforeman.org/issues/36311[#36311]
+* pass:[Drop Apache mpm_event MaxRequestPerChild values from tuning profiles] - https://projects.theforeman.org/issues/36784[#36784]
+* pass:[Show failed resources in failed installation report] - https://projects.theforeman.org/issues/36694[#36694]
+* pass:[katello-certs-check does not cause the installer to halt execution on failure] - https://projects.theforeman.org/issues/36567[#36567]
+* pass:[Allow enabling mod_status for better Apache monitoring] - https://projects.theforeman.org/issues/36311[#36311]
 
 == Packaging
 
 === RPMs
 
-* Remove Katello Agent from katello-debug - https://projects.theforeman.org/issues/36676[#36676]
+* pass:[Remove Katello Agent from katello-debug] - https://projects.theforeman.org/issues/36676[#36676]

--- a/guides/doc-Release_Notes/topics/foreman-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-contributors.adoc
@@ -1,4 +1,4 @@
-We'd like to thank the following people who contributed to the Foreman {{page.version}} release:
+We'd like to thank the following people who contributed to the Foreman {ProjectVersion} release:
 
 Adam Ruzicka, Alexey Masolov, Archana Kumari, Ashish Humbe, Bernhard Suttner, Daniel Alley, Eric D. Helms, Et7f3, Evgeni Golov, Ewoud Kohl van Wijngaarden, Girija Soni, Gordon Bleux, Griffin Sullivan, Ian Ballou, Jeremy Lenz, Jonas Trüstedt, Kamil Szubrycht, Karolina Malyjurkova, Leos Stejskal, Lior Keren, Lucy Fu, Marcel Kühlhorn, Maria Agaphontzev, Markus Bucher, Maximilian Kolb, Mike Rochefort, Nadja Heitmann, Nofar Alfassi, Oleh Fedorenko, Pat Riehecky, Romain Tartière, Ron Lavi, Samir Jha, Shimon Shtein, Tim Meusel, Trey Dockendorf, Vitaly Pyslar, William Clark, archanaserver, chr1s692, wlma
 


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
