### PR TITLE
move linkchecker to an own workflow file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,51 +40,6 @@ jobs:
             popd &>/dev/null
           done
 
-  check-html:
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request'
-    defaults:
-      run:
-        shell: bash
-        working-directory: guides
-    steps:
-      - name: Get branch name (merge)
-        if: github.event_name != 'pull_request'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-        working-directory: .
-
-      - name: Get branch name (pull request)
-        if: github.event_name == 'pull_request'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-        working-directory: .
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-          bundler-cache: true
-
-      - name: Install linkchecker
-        run: sudo apt update && sudo apt install linkchecker -y
-
-      - name: Clean the environment
-        run: make clean
-
-      - name: Build HTML with local links
-        run: |
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-el LINKS=LOCAL
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb LINKS=LOCAL
-          make -j ${{ env.MAKE_J }} html BUILD=katello LINKS=LOCAL
-          make -j ${{ env.MAKE_J }} html BUILD=satellite LINKS=LOCAL
-          make -j ${{ env.MAKE_J }} html BUILD=orcharhino LINKS=LOCAL
-
-      - name: Check HTML links of all builds
-        run: |
-          make linkchecker-tryer
-
   build-html:
     runs-on: ubuntu-22.04
     defaults:

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,0 +1,49 @@
+---
+name: linkchecker
+
+on:
+  pull_request:
+    branches:
+      - master
+      - "[0-9]+.[0-9]+"
+env:
+  RUBY_VERSION: 3.1
+  BUNDLE_WITHOUT: "nanoc"
+  MAKE_J: 3
+
+jobs:
+  check-html:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: guides
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Install linkchecker
+        run: |
+          sudo apt-get update
+          sudo apt-get install linkchecker -y
+
+      - name: Clean the environment
+        run: make clean
+
+      - name: Build HTML with local links
+        run: |
+          make -j ${{ env.MAKE_J }} html BUILD=foreman-el LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=katello LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=satellite LINKS=LOCAL
+          make -j ${{ env.MAKE_J }} html BUILD=orcharhino LINKS=LOCAL
+
+      - name: Check HTML links of all builds
+        run: |
+          make linkchecker-tryer


### PR DESCRIPTION
otherwise it prevents previews from being built without a good reason


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
