### PR TITLE
Document importing ansible collections in the content guide

### DIFF
--- a/guides/common/assembly_managing-ansible-content.adoc
+++ b/guides/common/assembly_managing-ansible-content.adoc
@@ -1,0 +1,3 @@
+include::modules/con_managing-ansible-content.adoc[]
+
+include::modules/proc_synchronizing-ansible-collections.adoc[leveloffset=+1]

--- a/guides/common/modules/con_managing-ansible-content.adoc
+++ b/guides/common/modules/con_managing-ansible-content.adoc
@@ -3,4 +3,4 @@
 
 You can import Ansible collections from several sources to {ProjectServer}.
 
-For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[{ManagingConfigurationsAnsibleDocTitle}].
+For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[_{ManagingConfigurationsAnsibleDocTitle}_].

--- a/guides/common/modules/con_managing-ansible-content.adoc
+++ b/guides/common/modules/con_managing-ansible-content.adoc
@@ -1,0 +1,6 @@
+[id="Managing_Ansible_Content{context}"]
+= Managing Ansible Content
+
+You can import Ansible collections from several sources to {ProjectServer}.
+
+For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[Managing Configurations Using Ansible Integration in Red Hat Satellite].

--- a/guides/common/modules/con_managing-ansible-content.adoc
+++ b/guides/common/modules/con_managing-ansible-content.adoc
@@ -3,4 +3,4 @@
 
 You can import Ansible collections from several sources to {ProjectServer}.
 
-For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[Managing Configurations Using Ansible Integration in {Project}].
+For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[{ManagingConfigurationsAnsibleDocTitle}].

--- a/guides/common/modules/con_managing-ansible-content.adoc
+++ b/guides/common/modules/con_managing-ansible-content.adoc
@@ -1,6 +1,6 @@
-[id="Managing_Ansible_Content{context}"]
+[id="Managing_Ansible_Content_{context}"]
 = Managing Ansible Content
 
 You can import Ansible collections from several sources to {ProjectServer}.
 
-For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[Managing Configurations Using Ansible Integration in Red Hat Satellite].
+For information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[Managing Configurations Using Ansible Integration in {Project}].

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -55,6 +55,8 @@ include::common/assembly_managing-container-images.adoc[leveloffset=+1]
 
 include::common/assembly_managing-isos-and-files.adoc[leveloffset=+1]
 
+include::common/assembly_managing-ansible-content.adoc[leveloffset=+1]
+
 include::common/assembly_managing-custom-file-type-content.adoc[leveloffset=+1]
 
 ifdef::katello,orcharhino[]


### PR DESCRIPTION
[BZ#2237906](https://bugzilla.redhat.com/show_bug.cgi?id=2237906) points out missing resources for importing Ansible collections in the content guide. This PR creates a new assembly for Managing Content which reuses a procedure already included in Managing Configurations with Ansible. The changes involve adding a few new includes and a little fluff to serve as the assembly introduction.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
