### PR TITLE
fix chrony link after rhel docs update

### DIFF
--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -5,7 +5,7 @@
 To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProductName} with Network Time Protocol (NTP) servers.
 If the base operating system clock is configured incorrectly, certificate verification might fail.
 
-For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in _{RHEL} 8 Configuring basic system settings_.
+For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings#using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in _{RHEL} 8 Configuring basic system settings_.
 
 .Procedure
 


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.

3.1-3.3 will probably have conflicts when picking…