### PR TITLE
Update index and versions for Foreman 3.8 GA

### DIFF
--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -6,8 +6,8 @@ title: Home
 
 The following releases are supported, meaning they receive (security) updates. Visit the https://community.theforeman.org/c/support/10[support forum] for questions.
 
+* link:/release/3.6/[Foreman 3.8 & Katello 4.10]
 * link:/release/3.7/[Foreman 3.7 & Katello 4.9]
-* link:/release/3.6/[Foreman 3.6 & Katello 4.8]
 
 === Unsupported releases
 
@@ -17,6 +17,7 @@ The future version is built in nightly.
 
 These releases are unsupported and no longer receive updates. Users should update to a supported release.
 
+* link:/release/3.6/[Foreman 3.6 & Katello 4.8]
 * link:/release/3.5/[Foreman 3.5 & Katello 4.7]
 * link:/release/3.4/[Foreman 3.4 & Katello 4.6]
 * link:/release/3.3/[Foreman 3.3 & Katello 4.5]

--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -184,6 +184,94 @@ const navVersions = [
     ]
   },
   {
+    "title": "Foreman 3.8 - Katello 4.10 (supported)",
+    "path": "3.8",
+    "builds": [
+      {
+        "title": "Katello on EL",
+        "filename": "index-katello.html",
+        "guides": [
+          {
+            "title": "Release Notes",
+            "path": "Release_Notes"
+          },
+          {
+            "title": "Planning Guide",
+            "path": "Planning_for_Project"
+          },
+          {
+            "title": "Quickstart Guide",
+            "path": "Quickstart"
+          },
+          {
+            "title": "Installing Katello Server",
+            "path": "Installing_Server"
+          },
+          {
+            "title": "Installing Smart Proxy with Content",
+            "path": "Installing_Proxy"
+          },
+          {
+            "title": "Upgrading Foreman",
+            "path": "Upgrading_Project"
+          },
+          {
+            "title": "Tuning Performance",
+            "path": "Tuning_Performance"
+          },
+          {
+            "title": "Configuring Smart Proxies with a Load Balancer",
+            "path": "Configuring_Load_Balancer"
+          },
+          {
+            "title": "Managing Organizations and Locations in Foreman",
+            "path": "Managing_Organizations_and_Locations"
+          },
+          {
+            "title": "Managing Content",
+            "path": "Managing_Content"
+          },
+          {
+            "title": "Deploying Foreman on AWS",
+            "path": "Deploying_Project_on_AWS"
+          },
+          {
+            "title": "Provisioning Hosts",
+            "path": "Provisioning_Hosts"
+          },
+          {
+            "title": "Managing Hosts",
+            "path": "Managing_Hosts"
+          },
+          {
+            "title": "Configuring Hosts Using Ansible",
+            "path": "Managing_Configurations_Ansible"
+          },
+          {
+            "title": "Configuring Hosts Using Puppet",
+            "path": "Managing_Configurations_Puppet"
+          },
+          {
+            "title": "Configuring Hosts Using Salt",
+            "path": "Managing_Configurations_Salt"
+          },
+          {
+            "title": "Managing Security Compliance",
+            "path": "Managing_Security_Compliance"
+          },
+          {
+            "title": "Administering Foreman",
+            "path": "Administering_Project"
+          },
+          {
+            "title": "Application Centric Deployment",
+            "path": "Deploying_Hosts_AppCentric"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "title": "Foreman 3.7 - Katello 4.9 (supported)",
     "path": "3.7",
     "builds": [
@@ -272,7 +360,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.6 - Katello 4.8 (supported)",
+    "title": "Foreman 3.6 - Katello 4.8 (unsupported)",
     "path": "3.6",
     "builds": [
       {


### PR DESCRIPTION
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
