### PR TITLE
Distinguish bind packages for EL8 and EL7

### DIFF
--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -2,7 +2,7 @@
 
 = Configuring an External DHCP Server to Use with {ProductName}
 
-To configure an external DHCP server running {EL} to use with {ProductName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) packages.
+To configure an external DHCP server running {EL} to use with {ProductName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) or its utility packages.
 You must also share the DHCP configuration and lease files with {ProductName}.
 The example in this procedure uses the distributed Network File System (NFS) protocol to share the DHCP configuration and lease files.
 
@@ -14,11 +14,20 @@ include::snip_firewalld.adoc[]
 
 .Procedure
 
-. On your {EL} host, install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) packages:
+. On your {EL} host, install the ISC DHCP Service and BIND packages or its utility packages depending on your host version.
++
+** For {EL} 7 host:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {package-install} dhcp bind
+----
++
+** For {El} 8 host:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} dhcp-server bind-utils
 ----
 
 . Generate a security token:
@@ -34,10 +43,10 @@ As a result, a key pair that consists of two files is created in the current dir
 +
 [options="nowrap"]
 ----
-# cat Komapi_key.+*.private |grep ^Key|cut -d ' ' -f2
+# grep ^Key Komapi_key.+*.private | cut -d ' ' -f2
 ----
 
-. Edit the `dhcpd` configuration file for all of the subnets and add the key.
+. Edit the `dhcpd` configuration file for all subnets and add the key.
 The following is an example:
 +
 [options="nowrap" subs="+quotes"]
@@ -176,12 +185,12 @@ Note that the IP address that you enter is the {Project} or {SmartProxy} IP addr
 # exportfs -rva
 ----
 
-. Configure the firewall for the DHCP omapi port 7911:
+. Configure the firewall for DHCP omapi port 7911:
 +
 [options="nowrap"]
 ----
-# firewall-cmd --add-port="7911/tcp" \
-&& firewall-cmd --runtime-to-permanent
+# firewall-cmd --add-port=7911/tcp
+# firewall-cmd --runtime-to-permanent
 ----
 
 . Optional: Configure the firewall for external access to NFS.


### PR DESCRIPTION
On EL 8.x, 'dnssec-keygen' is provided by the 'bind-utils' package. Simply 'Bind' package does not fulfill the required packages. This change is applicable to only EL8. On EL 7.x, the current packages mentioned are correct and need no further modification. However, we have enhanced some commands for a better user experience in CLI.

https://bugzilla.redhat.com/show_bug.cgi?id=2243039

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
