### PR TITLE
Remove optional step for 6.15

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -133,7 +133,6 @@ ifndef::managing-hosts[]
 For more information about the pull mode, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.
 endif::[]
 ifdef::katello,satellite,orcharhino[]
-. Optional: Select the *Lifecycle environment*.
 . Optional: Select the *Ignore errors* option if you want to ignore subscription manager errors.
 . Optional: Select the *Force* option if you want to remove any `katello-ca-consumer` rpms before registration and run `subscription-manager` with the `--force` argument.
 endif::[]


### PR DESCRIPTION
The optional step for selecting a lifecycle environment is not needed
starting in Satellite 6.15.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
