### PR TITLE
Use attribute to reduce duplicate content

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -9,7 +9,7 @@ If you configure {ProjectServer} to use a custom SSL certificate, you must also 
 
 To configure your {SmartProxyServer} with a custom certificate, complete the following procedures on each {SmartProxyServer}:
 
-. xref:deploying-a-custom-ssl-certificate-to-capsule-server_{smart-proxy-context}[]
+. xref:deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[]
 . xref:deploying-a-custom-ssl-certificate-to-hosts_{smart-proxy-context}[]
 
 //Deploying a Custom SSL Certificate to {SmartProxyServer}

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc
@@ -1,5 +1,4 @@
-[id="deploying-a-custom-ssl-certificate-to-capsule-server_{context}"]
-
+[id="deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{context}"]
 = Deploying a Custom SSL Certificate to {SmartProxyServerTitle}
 
 Use this procedure to configure your {SmartProxyServer} with a custom SSL certificate signed by a Certificate Authority.
@@ -7,7 +6,6 @@ The `{foreman-installer}` command, which the `{certs-generate}` command returns,
 Do not use the same command on more than one {SmartProxyServer}.
 
 .Prerequisites
-
 * {ProjectServer} is configured with a custom certificate.
 For more information, see {InstallingServerDocURL}configuring-satellite-custom-server-certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
@@ -16,15 +14,15 @@ For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-s
 For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure
-
-. On {ProjectServer}, validate the custom SSL certificate input files:
+. On your {ProjectServer}, validate the custom SSL certificate input files:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # katello-certs-check \
--t {certs-proxy-context} -c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \      <1>
--k __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \  <2>
--b __/root/{smart-proxy-context}_cert/ca_cert_bundle.pem__      <3>
+-t {certs-proxy-context} \
+-c __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \ <1>
+-k __/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \ <2>
+-b __/root/{smart-proxy-context}_cert/ca_cert_bundle.pem__ <3>
 ----
 <1> Path to {SmartProxyServer} certificate file that is signed by a Certificate Authority.
 <2> Path to the private key that was used to sign {SmartProxyServer} certificate.
@@ -33,64 +31,30 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 If you set a wildcard value `*` for the certificate's Common Name `CN =` in the `/root/{context}_cert/openssl.cnf` configuration file, you must add the `-t {certs-proxy-context}` option to the `katello-certs-check` command.
 +
 If the command is successful, it returns two `{certs-generate}` commands, one of which you must use to generate the certificate archive file for your {SmartProxyServer}.
-ifdef::satellite[]
 +
 .Example output of `katello-certs-check`
 [options="nowrap", subs="+quotes,attributes"]
 ----
 Validation succeeded.
 
-To use them inside a NEW $CAPSULE, run this command:
-
-{certs-generate} --foreman-proxy-fqdn "$CAPSULE" \
-    --certs-tar  "~/$CAPSULE-certs.tar" \
+To use them inside a NEW {SmartProxyServer}, run this command:
+  {certs-generate} --foreman-proxy-fqdn "{SmartProxyServer}" \
+    --certs-tar "~/{smartproxy-example-com}-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
 
-To use them inside an EXISTING $CAPSULE, run this command INSTEAD:
-
-  {certs-generate} --foreman-proxy-fqdn "$CAPSULE" \
-    --certs-tar "~/$CAPSULE-certs.tar" \
-    --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
-    --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
-    --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
-    --certs-update-server
-----
-endif::[]
-
-ifndef::satellite[]
-+
-.Example output of `katello-certs-check`
-[options="nowrap", subs="+quotes,attributes"]
-----
-Validation succeeded.
-
-To use them inside a NEW $FOREMAN_PROXY, run this command:
-  {certs-generate} --foreman-proxy-fqdn "$FOREMAN_PROXY" \
-    --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
-    --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
-    --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
-    --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
-
-To use them inside an EXISTING $FOREMAN_PROXY, run this command INSTEAD:
-  {certs-generate} --foreman-proxy-fqdn "\$FOREMAN_PROXY" \
-    --certs-tar  "~/$FOREMAN_PROXY-certs.tar" \
+To use them inside an EXISTING {SmartProxyServer}, run this command INSTEAD:
+  {certs-generate} --foreman-proxy-fqdn "\{SmartProxyServer}" \
+    --certs-tar "~/{smartproxy-example-com}-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
     --certs-update-server
 ----
-endif::[]
-
-. On {ProjectServer}, from the output of the `katello-certs-check` command, depending on your requirements, enter the `{certs-generate}` command that generates a certificate for a new or existing {SmartProxy}.
+. On your {ProjectServer}, from the output of the `katello-certs-check` command, depending on your requirements, enter the `{certs-generate}` command that generates a certificate for a new or existing {SmartProxy}.
 +
-ifdef::satellite[]
-In this command, change `$CAPSULE` to the FQDN of your {SmartProxyServer}.
-endif::[]
-ifndef::satellite[]
-In this command, change `$FOREMAN_PROXY` to the FQDN of your {SmartProxyServer}.
-endif::[]
+In this command, change `{SmartProxyServer}` to the FQDN of your {SmartProxyServer}.
 +
 . Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
 +
@@ -104,22 +68,23 @@ _output omitted_
 --foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
---foreman-proxy-oauth-consumer-key "_s97QxvUAgFNAQZNGg4F9zLq2biDsxM7f_" \
---foreman-proxy-oauth-consumer-secret "_6bpzAdMpRAfYaVZtaepYetomgBVQ6ehY_"
+--foreman-proxy-oauth-consumer-key "_My_OAuth_Consumer_Key_" \
+--foreman-proxy-oauth-consumer-secret "_My_OAuth_Consumer_Secret_"
 ----
-
-. On {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
+. On your {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # scp /root/{smart-proxy-context}_cert/_{smartproxy-example-com}_-certs.tar \
 root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 ----
-
-. On {SmartProxyServer}, to deploy the certificate, enter the `{foreman-installer}` command that the `{certs-generate}` command returns.
+. On your {SmartProxyServer}, to deploy the certificate, enter the `{foreman-installer}` command that the `{certs-generate}` command returns.
 +
-When network connections or ports to {Project} are not yet open, you can set the `--foreman-proxy-register-in-foreman` option to `false` to prevent {SmartProxy} from attempting to connect to {Project} and reporting errors.
+If network connections or ports to {Project} are not yet open, you can set the `--foreman-proxy-register-in-foreman` option to `false` to prevent {SmartProxy} from attempting to connect to {Project} and reporting errors.
 Run the installer again with this option set to `true` when the network and firewalls are correctly configured.
 +
-IMPORTANT: Do not delete the certificate archive file after you deploy the certificate.
+[IMPORTANT]
+====
+Do not delete the certificate archive file after you deploy the certificate.
 It is required, for example, when upgrading {SmartProxyServer}.
+====

--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -54,7 +54,7 @@ For example, to copy the archive file to the `root` user's home directory:
 +
 Ensure that you enter the full path to the `.tar` file.
 . If you have created a custom certificate for {SmartProxyServer}, deploy the certificate on {SmartProxyServer} by entering the `{foreman-installer}` command that the `{certs-generate}` command returned in a previous step.
-For more information, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-capsule-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 . On all {SmartProxy} clients, enter the following commands to reinstall the bootstrap RPM, reregister clients, and refresh their subscriptions.
 +
 You can use the remote execution feature to perform this step.


### PR DESCRIPTION
Output should not differ much. Using an attribute is IMO much nicer than duplicate content.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
