### PR TITLE
Fix reference rendering in satellite

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -100,7 +100,13 @@ endif::[]
 +
 [NOTE]
 ====
-If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-modules}` module, see xref:troubleshooting-dnf-modules_{context}[Troubleshooting DNF modules].
+If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-modules}` module, see
+ifeval::["{context}" == "{project-context}"]
+xref:troubleshooting-dnf-modules_{context}[].
+endif::[]
+ifeval::["{context}" != "{project-context}"]
+{InstallingServerDocURL}troubleshooting-dnf-modules_{project-context}[Troubleshooting DNF modules] in _{InstallingServerDocTitle}_.
+endif::[]
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 ====
 endif::[]

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -1,7 +1,7 @@
 include::common/attributes.adoc[]
 include::common/header.adoc[]
 :quickstart-installation-guide:
-:context: {project-context}
+:context: quick-start
 :mode: connected
 :ProductName: {ProjectServer}
 


### PR DESCRIPTION
This change is required for Satellite, where we have `proc_configuring-repositories.adoc` also in the QuickStart guide and while we do not use the guide, it builds as a part of the downstream pipeline so this change is required at the very least downstream. The reason I am putting it here is to prevent desynchronization in the future.


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
