### PR TITLE
Correct `ln` call when installing Foreman's hotproc config

### DIFF
--- a/guides/common/modules/proc_configuring-pcp-data-collection.adoc
+++ b/guides/common/modules/proc_configuring-pcp-data-collection.adoc
@@ -7,7 +7,7 @@ This procedure describes how to configure PCP to collect metrics about processes
 . To configure PCP to collect data about {Project} processes, configure the process monitoring PMDA to use the {Project} specific config:
 +
 ----
-# ln -s /var/lib/pcp/pmdas/proc/hotproc.conf /etc/pcp/proc/foreman-hotproc.conf
+# ln -s /etc/pcp/proc/foreman-hotproc.conf /var/lib/pcp/pmdas/proc/hotproc.conf
 ----
 +
 By default, PCP collects basic system metrics.


### PR DESCRIPTION
The `ln -s` command in the monitoring guide seems to use the arguments in the wrong order.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
