### PR TITLE
Use attribute as shell variable

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -17,7 +17,15 @@ To configure your {SmartProxyServer} with a custom certificate, complete the fol
 include::modules/proc_creating-a-custom-ssl-certificate.adoc[leveloffset=+1]
 
 //Deploying a Custom SSL Certificate to {SmartProxyServer}
-include::modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc[leveloffset=+1]
+// stdout from "katello-certs-check" is branded on Satellite
+ifdef::satellite[]
+:smart-proxy-capitalized: CAPSULE
+endif::[]
+ifndef::satellite[]
+:smart-proxy-capitalized: FOREMAN_PROXY
+endif::[]
+include::modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc[leveloffset=+1]
+:!smart-proxy-capitalized:
 
 //Deploying a Custom SSL Certificate to Hosts
 include::modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -37,16 +37,16 @@ If the command is successful, it returns two `{certs-generate}` commands, one of
 ----
 Validation succeeded.
 
-To use them inside a NEW {SmartProxyServer}, run this command:
-  {certs-generate} --foreman-proxy-fqdn "{SmartProxyServer}" \
-    --certs-tar "~/{smartproxy-example-com}-certs.tar" \
+To use them inside a NEW ${smart-proxy-capitalized}, run this command:
+  {certs-generate} --foreman-proxy-fqdn "${smart-proxy-capitalized}" \
+    --certs-tar "~/{smart-proxy-capitalized}-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
 
-To use them inside an EXISTING {SmartProxyServer}, run this command INSTEAD:
-  {certs-generate} --foreman-proxy-fqdn "\{SmartProxyServer}" \
-    --certs-tar "~/{smartproxy-example-com}-certs.tar" \
+To use them inside an EXISTING ${smart-proxy-capitalized}, run this command INSTEAD:
+  {certs-generate} --foreman-proxy-fqdn "${smart-proxy-capitalized}" \
+    --certs-tar "~/{smart-proxy-capitalized}-certs.tar" \
     --server-cert "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_" \
     --server-key "_/root/{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_" \
     --server-ca-cert "_/root/{smart-proxy-context}_cert/ca_cert_bundle.pem_" \
@@ -54,7 +54,7 @@ To use them inside an EXISTING {SmartProxyServer}, run this command INSTEAD:
 ----
 . On your {ProjectServer}, from the output of the `katello-certs-check` command, depending on your requirements, enter the `{certs-generate}` command that generates a certificate for a new or existing {SmartProxy}.
 +
-In this command, change `{SmartProxyServer}` to the FQDN of your {SmartProxyServer}.
+In this command, change `{smart-proxy-capitalized}` to the FQDN of your {SmartProxyServer}.
 +
 . Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` command returns for deploying the certificate to your {SmartProxyServer}.
 +


### PR DESCRIPTION
* Rename file to align with upstream terminology
* Revert 41a0b96 partially to ensure the docs match the stdout from "katello-certs-check" on Foreman + Satellite
* Use proper attribute for Smart Proxy FQDN vs Smart Proxy name

Follow-up PR to https://github.com/theforeman/foreman-documentation/pull/2517 
Sorry for the trouble @ekohl Please review to ensure both issues are addressed.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
