### PR TITLE
Fix URL schemes in VMware cloud-init

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -90,7 +90,7 @@ datasource:
 EOM
 ----
 +
-If you intend to provision through {SmartProxyServer}, use the URL of your {SmartProxyServer} in the `seedfrom` option, such as `https://_{smartproxy-example-com}_:8000/userdata/`.
+If you intend to provision through {SmartProxyServer}, use the URL of your {SmartProxyServer} in the `seedfrom` option, such as `https://_{smartproxy-example-com}_:{smartproxy_port}/userdata/`.
 . Configure modules to use in `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]
@@ -129,10 +129,10 @@ ifdef::katello,satellite,orcharhino[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# wget -O /etc/pki/ca-trust/source/anchors/cloud-init-ca.crt http://_{foreman-example-com}_/pub/katello-server-ca.crt
+# wget -O /etc/pki/ca-trust/source/anchors/cloud-init-ca.crt https://_{foreman-example-com}_/pub/katello-server-ca.crt
 ----
 +
-If you intend to provision through {SmartProxyServer}, download the file from your {SmartProxyServer} URL, such as `https://_{smartproxy-example-com}_/pub/katello-server-ca.crt`.
+If you intend to provision through {SmartProxyServer}, download the file from your {SmartProxyServer}, such as `https://_{smartproxy-example-com}_/pub/katello-server-ca.crt`.
 endif::[]
 ifndef::katello,satellite,orcharhino[]
 . Copy the CA certificate from the Apache configuration to `/etc/pki/ca-trust/source/anchors/cloud-init-ca.crt`.


### PR DESCRIPTION
HTTPS cannot be used in these cases. The user must enter HTTP URLs.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
