### PR TITLE
Fill in missing introduction module

### DIFF
--- a/guides/common/modules/con_using-repository-sources.adoc
+++ b/guides/common/modules/con_using-repository-sources.adoc
@@ -1,1 +1,4 @@
 [id="using-repository-sources_{context}"]
+= Using Repository Sources
+
+You can use existing repositories or local directories to synchronize templates with your {ProjectServer}.

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -1,7 +1,7 @@
 [id="synchronizing-templates-with-an-existing-repository_{context}"]
 = Synchronizing Templates with an Existing Repository
 
-You can use existing repositories to import and export templates from your {ProjectServer}.
+Use this procedure to synchronize templates between your {ProjectServer} and an existing repository.
 
 .Procedure
 . If you want to use HTTPS to connect to the repository and you use a self-signed certificate authentication on your Git server, validate the certificate:


### PR DESCRIPTION
While working on #2414, I did not realize that I forgot to write introduction to Using Repository Sources subchapter. The sections then went under *Configuring the Templates Plugin* which was mildly related so the procedures did not stick out as misplaced. After reviewing PR again I noticed an empty introduction module.

I also rephrased introduction in a subsequent module to not repeat the same thing twice in the docs.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
