### PR TITLE
Further enhance creating the custom SSL certs

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -9,8 +9,12 @@ If you configure {ProjectServer} to use a custom SSL certificate, you must also 
 
 To configure your {SmartProxyServer} with a custom certificate, complete the following procedures on each {SmartProxyServer}:
 
+. xref:creating-a-custom-ssl-certificate_{smart-proxy-context}[]
 . xref:deploying-a-custom-ssl-certificate-to-capsule-server_{smart-proxy-context}[]
 . xref:deploying-a-custom-ssl-certificate-to-hosts_{smart-proxy-context}[]
+
+//Creating a Custom SSL Certificate for {SmartProxyServer}
+include::modules/proc_creating-a-custom-ssl-certificate.adoc[leveloffset=+1]
 
 //Deploying a Custom SSL Certificate to {SmartProxyServer}
 include::modules/proc_deploying-a-custom-ssl-certificate-to-capsule-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -4,15 +4,29 @@ ifdef::context[:parent-context: {context}]
 = Configuring {ProjectServer} with a Custom SSL Certificate
 
 By default, {ProjectName} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServers}, and all hosts.
-If you cannot use a {Project} self-signed certificate, you can configure {ProjectServer} to use an SSL certificate signed by an external Certificate Authority.
+If you cannot use a {Project} self-signed certificate, you can configure {ProjectServer} to use an SSL certificate signed by an external certificate authority (CA).
+
+When you configure {ProjectName} with custom SSL certificates, you must fulfill the following requirements:
+
+* You must use the privacy-enhanced mail (PEM) encoding for the SSL certificates.
+* You must not use the same SSL certificate for both {ProjectServer} and {SmartProxyServer}.
+* The same CA must sign certificates for {ProjectServer} and {SmartProxyServer}.
+* An SSL certificate must not also be a CA certificate.
+* An SSL certificate must include a subject alt name (SAN) entry that matches the common name (CN).
+* An SSL certificate must be allowed for Key Encipherment using a Key Usage extension.
+* An SSL certificate must not have a shortname as the CN.
+* You must not set a passphrase for the private key.
 
 To configure your {ProjectServer} with a custom certificate, complete the following procedures:
 
+. xref:creating-a-custom-ssl-certificate_{project-context}[]
 . xref:Deploying_a_Custom_SSL_Certificate_to_Server_{project-context}[]
 . xref:deploying-a-custom-ssl-certificate-to-hosts_{project-context}[]
-. If you have external {SmartProxyServers} registered to {ProjectServer}, you must configure them with custom SSL certificates.
-The same Certificate Authority must sign certificates for {ProjectServer} and {SmartProxyServer}.
+. If you have external {SmartProxyServers} registered to {ProjectServer}, configure them with custom SSL certificates.
 For more information, see {InstallingSmartProxyDocURL}configuring-capsule-custom-server-certificate_{smart-proxy-context}[Configuring {SmartProxyServer} with a Custom SSL Certificate] in _{InstallingSmartProxyDocTitle}_.
+
+//Creating a Custom SSL Certificate for {ProjectServer}
+include::modules/proc_creating-a-custom-ssl-certificate.adoc[leveloffset=+1]
 
 //Deploying a Custom SSL Certificate to {ProjectServer}
 include::modules/proc_deploying-a-custom-ssl-certificate-to-satellite-server.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_configuring-project-with-an-alternate-cname.adoc
+++ b/guides/common/modules/proc_configuring-project-with-an-alternate-cname.adoc
@@ -15,4 +15,4 @@ Note that the procedures for users of a default {Project} certificate and custom
 
 .For Custom Certificate Users
 If you use {Project} with a custom certificate, when creating a custom certificate, include the alternate CNAME records to the custom certificate.
-For more information, see {InstallingServerDocURL}creating-a-custom-certificate_{project-context}[Creating a Custom SSL Certificate for {Project} Server].
+For more information, see {InstallingServerDocURL}creating-a-custom-ssl-certificate_{project-context}[Creating a Custom SSL Certificate for {ProjectServer}].

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -1,0 +1,81 @@
+[id="creating-a-custom-ssl-certificate_{context}"]
+= Creating a Custom SSL Certificate for {ProductName}
+
+ifeval::["{context}" == "{project-context}"]
+Use this procedure to create a custom SSL certificate for {ProductName}.
+If you already have a custom SSL certificate for {ProductName}, skip this procedure.
+endif::[]
+
+ifeval::["{context}" == "{smart-proxy-context}"]
+On {ProjectServer}, create a custom certificate for your {ProductName}.
+If you already have a custom SSL certificate for {ProductName}, skip this procedure.
+endif::[]
+
+.Procedure
+. To store all the source certificate files, create a directory that is accessible only to the `root` user:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# mkdir /root/{context}_cert
+----
+. Create a private key with which to sign the certificate signing request (CSR).
++
+Note that the private key must be unencrypted.
+If you use a password-protected private key, remove the private key password.
++
+If you already have a private key for this {ProductName}, skip this step.
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# openssl genrsa -out `/root/{context}_cert/{context}_cert_key.pem` 4096
+----
+. Create the `/root/{context}_cert/openssl.cnf` configuration file for the CSR and include the following content:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+[ req ]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+x509_extensions = usr_cert
+prompt = no
+
+[ req_distinguished_name ]
+CN = _{context}.example.com_
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+subjectAltName = @alt_names
+
+[ usr_cert ]
+basicConstraints=CA:FALSE
+nsCertType = client, server, email
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+nsComment = "OpenSSL Generated Certificate"
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+[ alt_names ]
+DNS.1 = _{context}.example.com_
+----
+. Generate CSR:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# openssl req -new \
+-key _/root/{context}_cert/{context}_cert_key.pem_ \ <1>
+-config _/root/{context}_cert/openssl.cnf_ \ <2>
+-out _/root/{context}_cert/{context}_cert_csr.pem_ <3>
+----
+<1> Path to the private key.
+<2> Path to the configuration file.
+<3> Path to the CSR to generate.
+
+. Send the certificate signing request to the certificate authority (CA).
+The same CA must sign certificates for {ProjectServer} and {SmartProxyServer}.
++
+When you submit the request, specify the lifespan of the certificate.
+The method for sending the certificate request varies, so consult the CA for the preferred method.
+In response to the request, you can expect to receive a CA bundle and a signed certificate, in separate files.


### PR DESCRIPTION
Earlier this section was removed but the decision is now reconsidered and we are now restoring it with better information that should be considered by end-users when they are creating and deploying custom SSL certificates.

This reverts commit 00f5ac352aff4d4819c602681dd25a2dd51b615e.

https://bugzilla.redhat.com/show_bug.cgi?id=2226794


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
