### PR TITLE
Fix Certified Hypervisor link

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -97,11 +97,9 @@ endif::[]
 endif::[]
 
 ifdef::satellite[]
-
 .Certified hypervisors
 {ProductName} is fully supported on both physical systems and virtual machines that run on hypervisors that are supported to run {RHEL}.
-For more information about certified hypervisors, see https://access.redhat.com/certified-hypervisors[Which hypervisors are certified to run {RHEL}?].
-
+For more information about certified hypervisors, see https://access.redhat.com/articles/973163[Certified Guest Operating Systems in {OpenStack}, {oVirt}, Red Hat {KubeVirt} and {RHEL} with KVM].
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]


### PR DESCRIPTION
The current link is obsolete. Replaced the new link.

https://bugzilla.redhat.com/show_bug.cgi?id=2243681

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
