### PR TITLE
Remove context change in assembly

### DIFF
--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: azure-provisioning
 :azure-provisioning:
 :CRname: Microsoft Azure Resource Manager
 
@@ -23,5 +21,3 @@ include::modules/proc_uninstalling-microsoft-azure-plugin.adoc[leveloffset=+1]
 
 :!azure-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: ec2-provisioning
 :ec2-provisioning:
 :CRname: EC2
 
@@ -35,5 +33,3 @@ include::modules/con_more-information-about-amazon-web-services.adoc[leveloffset
 
 :!ec2-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-cloud-instances-gce.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-gce.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: gce-provisioning
 :gce-provisioning:
 :CRname: Google Compute Engine
 
@@ -21,5 +19,3 @@ include::modules/proc_deleting-a-vm-on-google-gce.adoc[leveloffset=+1]
 
 :!gce-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: openstack-provisioning
 :openstack-provisioning:
 :CRname: {OpenStack}
 
@@ -15,5 +13,3 @@ include::modules/proc_creating-image-only-hosts.adoc[leveloffset=+1]
 
 :!openstack-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: kubevirt-provisioning
 :kubevirt-provisioning:
 :CRname: {KubeVirt}
 
@@ -9,5 +7,3 @@ include::modules/proc_adding-kubevirt-connection.adoc[leveloffset=+1]
 
 :!kubevirt-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: kvm-provisioning
 :kvm-provisioning:
 :CRname: KVM
 
@@ -17,5 +15,3 @@ include::modules/proc_creating-network-or-image-based-hosts.adoc[leveloffset=+1]
 
 :!kvm-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: proxmox-provisioning
 :proxmox-provisioning:
 :CRname: Proxmox
 
@@ -23,5 +21,3 @@ include::modules/proc_adding-a-remote-console-connection-for-a-managed-host-on-p
 
 :!proxmox-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: rhv-provisioning
 :rhv-provisioning:
 :CRname: {oVirt}
 
@@ -19,5 +17,3 @@ include::modules/proc_creating-network-or-image-based-hosts.adoc[leveloffset=+1]
 
 :!rhv-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:

--- a/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
@@ -1,5 +1,3 @@
-:parent-context: {context}
-:context: vmware-provisioning
 :vmware-provisioning:
 :CRname: VMware
 
@@ -33,5 +31,3 @@ include::modules/proc_refreshing-the-compute-resources-cache.adoc[leveloffset=+2
 
 :!vmware-provisioning:
 :!CRname:
-:context: {parent-context}
-:!parent-context:


### PR DESCRIPTION
In #2492, we didn't realize that changing the context in assemblies will mess up the link anchors.
So this PR undoes that.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
