### PR TITLE
Add "#" prefix to commands

### DIFF
--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -143,26 +143,26 @@ grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{installer-scenario} \
---foreman-proxy-dns=true \
+# {installer-scenario} \
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate_gss \
 --foreman-proxy-dns-server="_idm1.example.com_" \
+--foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab \
 --foreman-proxy-dns-tsig-principal="{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_" \
---foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab
+--foreman-proxy-dns=true
 ----
 
 * On {SmartProxy}, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{installer-scenario-smartproxy} \
---foreman-proxy-dns=true \
+# {installer-scenario-smartproxy} \
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate_gss \
 --foreman-proxy-dns-server="_idm1.example.com_" \
+--foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab \
 --foreman-proxy-dns-tsig-principal="{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_" \
---foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab
+--foreman-proxy-dns=true
 ----
 
 After you run the `{foreman-installer}` command to make any changes to your {SmartProxy} configuration, you must update the configuration of each affected {SmartProxy} in the {ProjectWebUI}.

--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -4,27 +4,27 @@
 Use the `{foreman-installer}` command to configure {Project} to connect to an external PostgreSQL database.
 
 .Prerequisite
-* You have installed and configured a PostgreSQL database on a {RHEL} server.
+* You have installed and configured a PostgreSQL database on a {EL} server.
 
 .Procedure
 . To configure the external databases for {Project}, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{installer-scenario} \
-  --foreman-db-host _postgres.example.com_ \
-  --foreman-db-password _Foreman_Password_ \
-  --foreman-db-database foreman \
-  --foreman-db-manage false \
-  --katello-candlepin-db-host _postgres.example.com_ \
-  --katello-candlepin-db-name candlepin \
-  --katello-candlepin-db-password _Candlepin_Password_ \
-  --katello-candlepin-manage-db false \
-  --foreman-proxy-content-pulpcore-manage-postgresql false \
-  --foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
-  --foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
-  --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_
-  --foreman-proxy-content-pulpcore-postgresql-user pulp
+# {installer-scenario} \
+--foreman-db-database foreman \
+--foreman-db-host _postgres.example.com_ \
+--foreman-db-manage false \
+--foreman-db-password _Foreman_Password_ \
+--foreman-proxy-content-pulpcore-manage-postgresql false \
+--foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
+--foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
+--foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
+--foreman-proxy-content-pulpcore-postgresql-user pulp \
+--katello-candlepin-db-host _postgres.example.com_ \
+--katello-candlepin-db-name candlepin \
+--katello-candlepin-db-password _Candlepin_Password_ \
+--katello-candlepin-manage-db false
 ----
 +
 
@@ -32,13 +32,11 @@ To enable the Secure Sockets Layer (SSL) protocol for these external databases, 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
---foreman-db-sslmode verify-full
 --foreman-db-root-cert <path_to_CA>
---katello-candlepin-db-ssl true
---katello-candlepin-db-ssl-verify true
---katello-candlepin-db-ssl-ca <path_to_CA>
+--foreman-db-sslmode verify-full
 --foreman-proxy-content-pulpcore-postgresql-ssl true
 --foreman-proxy-content-pulpcore-postgresql-ssl-root-ca <path_to_CA>
+--katello-candlepin-db-ssl true
+--katello-candlepin-db-ssl-ca <path_to_CA>
+--katello-candlepin-db-ssl-verify true
 ----
-
-

--- a/guides/common/modules/proc_configuring-users-os-for-keycloak-authentication-with-cac-cards.adoc
+++ b/guides/common/modules/proc_configuring-users-os-for-keycloak-authentication-with-cac-cards.adoc
@@ -4,12 +4,11 @@
 Complete this procedure on each system from which you want to be able to log in to {Project} using {Keycloak} {PIV} cards.
 
 .Procedure
-
-. Install required packages:
+. Install the required package:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-{package-install-project} opensc -y
+# {package-install-project} opensc
 ----
 . Install the Firefox browser if not installed.
 . Launch Firefox and navigate to *Preferences*.

--- a/guides/common/modules/proc_disabling-cockpit-on-project.adoc
+++ b/guides/common/modules/proc_disabling-cockpit-on-project.adoc
@@ -8,7 +8,7 @@ Perform the following procedure if you want to disable {Cockpit} on {Project}.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{foreman-installer} --no-enable-foreman-plugin-remote-execution-cockpit
+# {foreman-installer} --no-enable-foreman-plugin-remote-execution-cockpit
 ----
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings* and click the *Remote execution* tab.
 . In the *Cockpit URL* row, erase the setting under *Value* and click *Submit*.
@@ -17,7 +17,7 @@ This removes the *Web Console* button from the {ProjectWebUI}.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{package-remove} rubygem-foreman_remote_execution-cockpit
+# {package-remove} rubygem-foreman_remote_execution-cockpit
 ----
 +
 [IMPORTANT]
@@ -26,6 +26,6 @@ This removes the *Web Console* button from the {ProjectWebUI}.
 To prevent enabling {Cockpit} integration on a {SmartProxyServer}, run the following command after completing the procedure:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{foreman-installer} --foreman-proxy-plugin-remote-execution-script-cockpit-integration=false
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-cockpit-integration=false
 ----
 ====

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -23,7 +23,7 @@ The status is not persistent; if you leave the status page, you cannot return to
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-hammer export-templates \
+# hammer export-templates \
 --organization "_My_Organization_" \
 --repo "_https://git.example.com/path/to/repository_"
 ----

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -1,30 +1,27 @@
 [id="installing-an-external-smart-proxy-upstream_{context}"]
-
 = Installing {SmartProxyServerTitle}
 
 .Procedure
-
 ifdef::foreman-el,foreman-deb[]
-* To install an external {SmartProxy}, enter the following command:
+* To install {SmartProxyServer}, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{foreman-installer} \
-  --no-enable-foreman \
-  --no-enable-foreman-cli \
-  --enable-puppet \
-  --puppet-server-ca=false \
-  --enable-foreman-proxy \
-  --foreman-proxy-puppetca=false \
-  --foreman-proxy-tftp=false \
-  --foreman-proxy-foreman-base-url=https://__{foreman-example-com}__ \
-  --foreman-proxy-trusted-hosts=__{foreman-example-com}__ \
-  --foreman-proxy-oauth-consumer-key=_oAuth_Consumer_Key_ \
-  --foreman-proxy-oauth-consumer-secret=_oAuth_Consumer_Secret_
+# {foreman-installer} \
+--enable-foreman-proxy \
+--enable-puppet \
+--foreman-proxy-foreman-base-url=https://_{foreman-example-com}_ \
+--foreman-proxy-oauth-consumer-key=_My_oAuth_Consumer_Key_ \
+--foreman-proxy-oauth-consumer-secret=_My_oAuth_Consumer_Secret_ \
+--foreman-proxy-puppetca=false \
+--foreman-proxy-tftp=false \
+--foreman-proxy-trusted-hosts=_{foreman-example-com}_ \
+--no-enable-foreman \
+--no-enable-foreman-cli \
+--puppet-server-ca=false
 ----
 endif::[]
-
 ifdef::katello[]
-* To install an external Smart Proxy with content, please refer to xref:configuring-capsule-server-with-ssl-certificates[].
-Running `{certs-generate}` is a required prerequisite to installing an external Smart Proxy with content.
+* To install {SmartProxyServer} with content, refer to xref:configuring-capsule-server-with-ssl-certificates[].
+Running `{certs-generate}` is a required prerequisite to installing {SmartProxyServer} with content.
 endif::[]

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -4,32 +4,30 @@
 Back up and transfer existing data, then use the `{foreman-installer}` command to configure {Project} to connect to an external PostgreSQL database server.
 
 .Prerequisite
-
-* You have installed and configured a PostgreSQL server on a {RHEL} server.
+* You have installed and configured a PostgreSQL server on a {EL} server.
 
 .Procedure
-
 . On {ProjectServer}, stop {Project} services:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service stop
 ----
-+
 . Start the *PostgreSQL* services:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # systemctl start postgresql
 ----
-+
 . Back up the internal databases:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {foreman-maintain} backup online --skip-pulp-content --preserve-directory -y _/var/migration_backup_
+# {foreman-maintain} backup online \
+--preserve-directory \
+--skip-pulp-content \
+_/var/migration_backup_
 ----
-+
 . Transfer the data to the new external databases:
 +
 [options="nowrap", subs="+quotes,attributes"]
@@ -38,25 +36,24 @@ PGPASSWORD='_Foreman_Password_' pg_restore -h _postgres.example.com_ -U foreman 
 PGPASSWORD='_Candlepin_Password_' pg_restore -h _postgres.example.com_ -U candlepin -d candlepin < _/var/migration_backup/candlepin.dump_
 PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d pulpcore < _/var/migration_backup/pulpcore.dump_
 ----
-+
 . Use the `{foreman-installer}` command to update {Project} to point to the new databases:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-{installer-scenario} \
-    --foreman-db-host _postgres.example.com_ \
-    --foreman-db-password _Foreman_Password_ \
-    --foreman-db-database foreman \
-    --foreman-db-manage false \
-    --foreman-db-username foreman \
-    --katello-candlepin-db-host _postgres.example.com_ \
-    --katello-candlepin-db-name candlepin \
-    --katello-candlepin-db-password _Candlepin_Password_ \
-    --katello-candlepin-manage-db false \
-    --katello-candlepin-db-user candlepin \
-    --foreman-proxy-content-pulpcore-manage-postgresql false \
-    --foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
-    --foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
-    --foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
-    --foreman-proxy-content-pulpcore-postgresql-user pulp
+# {installer-scenario} \
+--foreman-db-database foreman \
+--foreman-db-host _postgres.example.com_ \
+--foreman-db-manage false \
+--foreman-db-password _Foreman_Password_ \
+--foreman-db-username foreman \
+--foreman-proxy-content-pulpcore-manage-postgresql false \
+--foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
+--foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
+--foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
+--foreman-proxy-content-pulpcore-postgresql-user pulp \
+--katello-candlepin-db-host _postgres.example.com_ \
+--katello-candlepin-db-name candlepin \
+--katello-candlepin-db-password _Candlepin_Password_ \
+--katello-candlepin-db-user candlepin \
+--katello-candlepin-manage-db false
 ----

--- a/guides/common/modules/proc_performing-a-snapshot-backup.adoc
+++ b/guides/common/modules/proc_performing-a-snapshot-backup.adoc
@@ -7,9 +7,10 @@ Creating a backup from LVM snapshots mitigates the risk of an inconsistent backu
 The snapshot backup method is faster than a full offline backup and therefore reduces {Project} downtime.
 
 To view the usage statement, enter the following command:
+
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{foreman-maintain} backup snapshot -h
+# {foreman-maintain} backup snapshot -h
 ----
 
 [WARNING]
@@ -19,7 +20,7 @@ Ensure no other tasks are scheduled for the same time as the backup.
 ====
 
 .Prerequisites
-* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/`, and `{postgresql-lib-dir}`.
+* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/` and `{postgresql-lib-dir}`.
 * The free disk space in the relevant volume group (VG) is three times the size of the snapshot.
 More precisely, the VG must have enough space unreserved by the member logical volumes (LVs) to accommodate new snapshots.
 In addition, one of the LVs must have enough free space for the backup directory.

--- a/guides/common/modules/proc_preparing-cloud-init-images-in-rhv.adoc
+++ b/guides/common/modules/proc_preparing-cloud-init-images-in-rhv.adoc
@@ -4,21 +4,18 @@
 To use `cloud-init` during provisioning, you must prepare an image with `cloud-init` installed in {oVirt}, and then import the image to {Project} to use for provisioning.
 
 .Procedure
-
 . In {oVirt}, create a virtual machine to use for image-based provisioning in {Project}.
 . On the virtual machine, install `cloud-init`:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{package-install} cloud-init
+# {package-install} cloud-init
 ----
-+
 . To the `/etc/cloud/cloud.cfg` file, add the following information:
 +
 ----
 datasource_list: ["NoCloud", "ConfigDrive"]
 ----
-+
 . In {oVirt}, create an image from this virtual machine.
 
 When you add this image to {Project}, ensure that you select the *User Data* checkbox.

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -24,12 +24,13 @@ In return, you will receive the {SmartProxyServer} certificate and CA bundle.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-{certs-generate} --foreman-proxy-fqdn "{smartproxy-example-com}" \
---certs-tar  "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
---server-cert "_/root/My_Certificates/{smart-proxy-context}_cert.pem_" \
---server-key "_/root/My_Certificates/{smart-proxy-context}_cert_key.pem_" \
+# {certs-generate} \
+--certs-tar "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
+--certs-update-server \
+--foreman-proxy-fqdn "_{smartproxy-example-com}_" \
 --server-ca-cert "_/root/My_Certificates/ca_cert_bundle.pem_" \
---certs-update-server
+--server-cert "_/root/My_Certificates/{smart-proxy-context}_cert.pem_" \
+--server-key "_/root/My_Certificates/{smart-proxy-context}_cert_key.pem_"
 ----
 . On your {ProjectServer}, copy the certificate archive file to your {SmartProxyServer}:
 +
@@ -45,10 +46,10 @@ You can move the copied file to the applicable path if required.
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {installer-scenario-smartproxy} \
---foreman-proxy-register-in-foreman "true" \
---foreman-proxy-foreman-base-url "https://{foreman-example-com}" \
 --certs-tar-file "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
---certs-update-server
+--certs-update-server \
+--foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
+--foreman-proxy-register-in-foreman "true"
 ----
 
 [IMPORTANT]

--- a/guides/common/modules/proc_rex-pull-based-transport.adoc
+++ b/guides/common/modules/proc_rex-pull-based-transport.adoc
@@ -6,12 +6,11 @@ This transport uses MQTT as its messaging protocol and includes an MQTT client r
 In order to tune the MQTT server (`mosquitto`) and increase the number of hosts connected to it, you can follow the following procedure on the {ProjectServer}:
 
 .Procedure
-
 . Enable pull-based remote execution on your {ProjectServer} or {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
 ----
 +
 Note that your {ProjectServer} or {SmartProxyServer} can only use one transport mode, either SSH or MQTT.

--- a/guides/common/modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc
+++ b/guides/common/modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc
@@ -17,7 +17,7 @@ By default, the maximum number of active jobs is unlimited.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{foreman-installer} \
+# {foreman-installer} \
 --foreman-proxy-plugin-remote-execution-script-mqtt-rate-limit _MAX_JOBS_NUMBER_
 ----
 +
@@ -25,6 +25,6 @@ For example:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-{foreman-installer} \
+# {foreman-installer} \
 --foreman-proxy-plugin-remote-execution-script-mqtt-rate-limit 200
 ----

--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -6,11 +6,11 @@ Update your air-gapped {Project} setup where the connected {ProjectServer}, whic
 .Prerequisites
 * Back up your {ProjectServer}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
-* Install `reposync` that is required for the updating procedure.
+* Install `reposync` that is required for the updating procedure:
 +
 [options="nowrap" subs="attributes"]
 ----
-{package-install} 'dnf-command(reposync)'
+# {package-install} 'dnf-command(reposync)'
 ----
 
 .Procedure on the connected {ProjectServer}
@@ -75,16 +75,19 @@ sslverify = 1
 +
 [options="nowrap" subs="attributes"]
 ----
-# dnf reposync --delete --download-metadata -p ~/{Project}-repos -n \
- --disableplugin=foreman-protector \
- --repoid {RepoRHEL8BaseOS} \
- --repoid {RepoRHEL8AppStream} \
- --repoid {RepoRHEL8ServerSatelliteServerProjectVersion} \
- --repoid {RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
+# dnf reposync \
+--delete \
+--disableplugin=foreman-protector \
+--download-metadata \
+--repoid {RepoRHEL8AppStream} \
+--repoid {RepoRHEL8BaseOS} \
+--repoid {RepoRHEL8ServerSatelliteMaintenanceProjectVersion} \
+--repoid {RepoRHEL8ServerSatelliteServerProjectVersion} \
+-n \
+-p ~/{Project}-repos
 ----
 +
 This downloads the contents of the repositories from the connected {ProjectServer} and stores them in the directory `~/{Project}-repos`.
-+
 . Verify that the RPMs have been downloaded and the repository data directory is generated in each of the sub-directories of `~/{Project}-repos`.
 . Archive the contents of the directory:
 +
@@ -127,7 +130,6 @@ name={ProjectName} Maintenance 6 for RHEL 8 Server RPMs x86_64
 baseurl=file:///root/{Project}-repos/{RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
 enabled=1
 ----
-+
 . In the configuration file, replace the `/root/{Project}-repos` with the extracted location.
 . Check the available versions to confirm the next minor version is listed:
 +
@@ -135,13 +137,14 @@ enabled=1
 ----
 # {foreman-maintain} upgrade list-versions
 ----
-+
 . Use the health check option to determine if the system is ready for upgrade.
 On first use of this command, `{foreman-maintain}` prompts you to enter the hammer admin user credentials and saves them in the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade check --whitelist="check-upstream-repository,repositories-validate" --target-version {ProjectVersion}.__z__
+# {foreman-maintain} upgrade check \
+--target-version {ProjectVersion}._z_ \
+--whitelist="check-upstream-repository,repositories-validate"
 ----
 +
 . Review the results and address any highlighted error conditions before performing the upgrade.
@@ -153,7 +156,9 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade run --whitelist="check-upstream-repository,repositories-setup,repositories-validate" --target-version {ProjectVersion}.__z__
+# {foreman-maintain} upgrade run \
+--target-version {ProjectVersion}._z_ \
+--whitelist="check-upstream-repository,repositories-setup,repositories-validate"
 ----
 
 include::snip_steps-needs-reboot.adoc[]

--- a/guides/common/modules/ref_white-listing-and-skipping-steps-when-performing-backups.adoc
+++ b/guides/common/modules/ref_white-listing-and-skipping-steps-when-performing-backups.adoc
@@ -16,5 +16,7 @@ For example:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-maintain} backup online --whitelist backup-metadata -y _/var/backup_directory_
+# {foreman-maintain} backup online \
+--whitelist backup-metadata \
+_/var/backup_directory_
 ----


### PR DESCRIPTION
* Add newlines for commands with more than one option
* Remove unnecessary "+" signs between list items
* Sort options in alphabetical order
* Use EL attribute for OS refers to Enterprise Linux, not RHEL specifically
* Use "SmartProxyServer" instead of "external Smart Proxy" (affects upstream only)

I have used `rg "^\{pro"`, `rg "^\{pack"`, `rg "^\{inst"` and `rg "^hammer"` to find those files. I fixed some other minors issues while editing the files.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
