### PR TITLE
Hide file for orcharhino

### DIFF
--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -50,8 +50,10 @@ include::common/assembly_provisioning-cloud-instances-gce.adoc[leveloffset=+1]
 
 include::common/assembly_provisioning-cloud-instances-azure.adoc[leveloffset=+1]
 
+ifndef::orcharhino[]
 [appendix]
 include::common/modules/ref_initialization-script-for-provisioning-examples.adoc[leveloffset=+1]
+endif::[]
 
 [appendix]
 include::common/assembly_provisioning-fips-compliant-hosts.adoc[leveloffset=+1]


### PR DESCRIPTION
orcharhino contains Ansible roles and shellscripts to setup orcharhino Clients and operating systems.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
