### PR TITLE
pgsql on smartproxy can grow significantly

### DIFF
--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -20,3 +20,6 @@ endif::[]
 |/usr |3 GB |Not Applicable
 |/opt/puppetlabs |500 MB |Not Applicable
 |====
+
+The size of the `postgres` database on {SmartProxy} can grow significantly with an increasing number of lifecycle environments, content views, or repositories that the {SmartProxy} is synchronizing.
+In the largest {Project} environments, the size of `{postgresql-lib-dir}` on {SmartProxy} can grow to double or triple the size of `{postgresql-lib-dir}` on the {Project} server.

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -15,7 +15,7 @@ endif::[]
 |Directory |Installation Size |Runtime Size
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
-|{postgresql-lib-dir} |100 MB |10 GB
+|{postgresql-lib-dir} |100 MB |20 GB
 endif::[]
 |/usr |3 GB |Not Applicable
 |/opt/puppetlabs |500 MB |Not Applicable

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -21,5 +21,5 @@ endif::[]
 |/opt/puppetlabs |500 MB |Not Applicable
 |====
 
-The size of the `postgres` database on {SmartProxy} can grow significantly with an increasing number of lifecycle environments, content views, or repositories that the {SmartProxy} is synchronizing.
-In the largest {Project} environments, the size of `{postgresql-lib-dir}` on {SmartProxy} can grow to double or triple the size of `{postgresql-lib-dir}` on the {Project} server.
+The size of the PostgreSQL database on your {SmartProxyServer} can grow significantly with an increasing number of lifecycle environments, content views, or repositories that are synchronized from your {ProjectServer}.
+In the largest {Project} environments, the size of `{postgresql-lib-dir}` on {SmartProxyServer} can grow to double or triple the size of `{postgresql-lib-dir}` on your {ProjectServer}.


### PR DESCRIPTION
[BZ#2238123](https://bugzilla.redhat.com/show_bug.cgi?id=2238123) requests setting the right expectation for postgres size on SmartProxy.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
