### PR TITLE
Add conversions appliance guide info

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -11,6 +11,7 @@
 :AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
 :ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#
 :ContentManagementDocURL: {BaseURL}managing_content/index#
+:ConversionsApplianceDocURL: {BaseURL}converting_hosts_to_rhel_by_using_conversions_appliance/index#
 :InstallingServerDisconnectedDocURL: {BaseURL}installing_satellite_server_in_a_disconnected_network_environment/index#
 :InstallingServerDocURL: {BaseURL}installing_satellite_server_in_a_connected_network_environment/index#
 :InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -31,6 +31,7 @@
 :APIDocTitle: API Guide
 :HammerDocTitle: Hammer CLI Guide
 :ConfiguringVMSubscriptionsDocTitle: Configuring Virtual Machine Subscriptions in {ProjectName}
+:ConversionsApplianceDocTitle: Converting hosts to RHEL by using Conversions Appliance
 
 // Overrides for titles per product
 

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -31,7 +31,7 @@
 :APIDocTitle: API Guide
 :HammerDocTitle: Hammer CLI Guide
 :ConfiguringVMSubscriptionsDocTitle: Configuring Virtual Machine Subscriptions in {ProjectName}
-:ConversionsApplianceDocTitle: Converting hosts to RHEL by using Conversions Appliance
+:ConversionsApplianceDocTitle: Converting Hosts to RHEL by Using Conversions Appliance
 
 // Overrides for titles per product
 


### PR DESCRIPTION
We're creating a new downstream Satellite guide. We need to add title and URL attributes for it.
The title was agreed upon in our team. The URL must match the title in snake_case.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
