### PR TITLE
Include external links in Converting Hosts

### DIFF
--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -56,7 +56,12 @@ The role enables the `{RepoRHEL7Server}` repository with the *7Server* release a
 +
 Use the global registration template to register and subscribe your host before the conversion.
 Select the host group that was generated for the conversion you intend, such as `CentOS 8 converting` if you convert the host from CentOS{nbsp}8.
+ifdef::managing-hosts[]
 For more information, see xref:Registering_Hosts_by_Using_Global_Registration_{context}[].
+endif::[]
+ifndef::managing-hosts[]
+For more information, see {ManagingHostsDocURL}Registering_Hosts_by_Using_Global_Registration_managing-hosts[Registering Hosts by Using Global Registration] in _{ManagingHostsDocTitle}_.
+endif::[]
 . Run the Convert2RHEL playbook on the host.
 Execute a remote job with the following settings:
 ** **Job category**: `Convert 2 RHEL`
@@ -64,7 +69,12 @@ Execute a remote job with the following settings:
 ** **Activation key**: `convert2rhel_rhel7` or `convert2rhel_rhel8`
 
 +
+ifdef::managing-hosts[]
 For more information, see xref:executing-a-remote-job_{context}[].
+endif::[]
+ifndef::managing-hosts[]
+For more information, see {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a Remote Job] in _{ManagingHostsDocTitle}_.
+endif::[]
 
 .Additional resources
 * https://access.redhat.com/articles/2360841[How to perform an unsupported conversion from a RHEL-derived Linux distribution to RHEL]


### PR DESCRIPTION
Need this for the new Conversions guide.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
