### PR TITLE
Rename C2R ref module

### DIFF
--- a/guides/common/assembly_converting-a-host-to-rhel.adoc
+++ b/guides/common/assembly_converting-a-host-to-rhel.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 include::modules/con_converting-a-host-to-rhel.adoc[]
 
-include::modules/ref_variables-for-generation-of-conversion-data.adoc[leveloffset=+1]
+include::modules/ref_ansible-variables-for-conversion.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -44,7 +44,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 . Import the `{ansible-namespace}.convert2rhel` Ansible role and variables.
 For more information, see {ManagingConfigurationsAnsibleDocURL}Importing_Ansible_Roles_and_Variables_ansible[Importing Ansible Roles and Variables] in _{ManagingConfigurationsAnsibleDocTitle}_.
 . Configure Ansible variables for generation of conversion data.
-For more information, see xref:variables-for-generation-of-conversion-data_{context}[].
+For more information, see xref:ansible-variables-for-conversion_{context}[].
 . Assign the `{ansible-namespace}.convert2rhel` role to the host that represents {ProjectServer}.
 For more information, see {ManagingConfigurationsAnsibleDocURL}Assigning_Ansible_Roles_to_an_Existing_Host_ansible[Assigning Ansible Roles to an Existing Host] in _{ManagingConfigurationsAnsibleDocTitle}_.
 . Run the Ansible role on {ProjectServer}.

--- a/guides/common/modules/ref_ansible-variables-for-conversion.adoc
+++ b/guides/common/modules/ref_ansible-variables-for-conversion.adoc
@@ -1,5 +1,5 @@
-[id="variables-for-generation-of-conversion-data_{context}"]
-= Variables for Generation of Conversion Data
+[id="ansible-variables-for-conversion_{context}"]
+= Ansible Variables for Conversion
 
 Before you run the Ansible role to generate conversion data, configure values of the following required Ansible variables.
 


### PR DESCRIPTION
This reference module title needed simplification as much as clarification.
Long due :)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
