### PR TITLE
Remove DDF option from Feedback (Satellite)

### DIFF
--- a/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
+++ b/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
@@ -1,22 +1,15 @@
 [preface]
 
 [id="providing-feedback-on-red-hat-documentation_{context}"]
-= Providing feedback on Red Hat documentation
+= Providing Feedback on Red Hat Documentation
 
-We appreciate your input on our documentation. Please let us know how we could make it better.
+We appreciate your input on our documentation.
+Please let us know how we could make it better.
 
-* For simple comments on specific passages:
-+
-. Ensure you are viewing the documentation in the _Multi-page HTML_ format.
-+
-In addition, ensure you see the *Feedback* button in the upper right corner of the document.
-. Use your mouse cursor to highlight the part of text that you want to comment on.
-. Click the *Add Feedback* pop-up that appears below the highlighted text.
-. Follow the displayed instructions.
+You can submit feedback by filing a ticket in Bugzilla:
 
-* For submitting feedback via Bugzilla, create a new ticket:
-+
-. Go to the link:https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Satellite[Bugzilla] website.
-. As the Component, use *Documentation*.
-. Fill in the *Description* field with your suggestion for improvement. Include a link to the relevant part(s) of documentation.
+. Navigate to the link:https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Satellite[Bugzilla] website.
+. In the *Component* field, use `Documentation`.
+. In the *Description* field, enter your suggestion for improvement.
+Include a link to the relevant parts of the documentation.
 . Click *Submit Bug*.


### PR DESCRIPTION
We're removing Direct Documentation Feedback from the RH Customer Portal.

**Do not merge before Nov 8!**

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
