### PR TITLE
PostgreSQL on smartproxy can grow significantly

### DIFF
--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -19,7 +19,7 @@ endif::[]
 |Directory |Installation Size |Runtime Size
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
-|{postgresql-lib-dir} |100 MB |10 GB
+|{postgresql-lib-dir} |100 MB |20 GB
 endif::[]
 |/usr |3 GB |Not Applicable
 |/opt/puppetlabs |500 MB |Not Applicable
@@ -35,9 +35,12 @@ ifndef::satellite[]
 ifdef::katello,satellite,orcharhino[]
 |/var/lib/pulp |1 MB |300 GB
 endif::[]
-|/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |10 GB
+|/var/opt/rh/rh-postgresql12/lib/pgsql |100 MB |20 GB
 |/usr |3 GB | Not Applicable
 |/opt |3 GB | Not Applicable
 |/opt/puppetlabs |500 MB | Not Applicable
 |====
 endif::[]
+
+The size of the PostgreSQL database on your {SmartProxyServer} can grow significantly with an increasing number of lifecycle environments, content views, or repositories that are synchronized from your {ProjectServer}.
+In the largest {Project} environments, the size of `{postgresql-lib-dir}` on {SmartProxyServer} can grow to double or triple the size of `{postgresql-lib-dir}` on your {ProjectServer}.

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -9,6 +9,9 @@ ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
+The size of the PostgreSQL database on your {SmartProxyServer} can grow significantly with an increasing number of lifecycle environments, content views, or repositories that are synchronized from your {ProjectServer}.
+In the largest {Project} environments, the size of the PostgreSQL directory on {SmartProxyServer} can grow to double or triple the size of the PostgreSQL directory on your {ProjectServer}.
+
 ifndef::satellite[]
 == [[storage-el-8]]{EL} 8
 endif::[]
@@ -41,6 +44,3 @@ endif::[]
 |/opt/puppetlabs |500 MB | Not Applicable
 |====
 endif::[]
-
-The size of the PostgreSQL database on your {SmartProxyServer} can grow significantly with an increasing number of lifecycle environments, content views, or repositories that are synchronized from your {ProjectServer}.
-In the largest {Project} environments, the size of `{postgresql-lib-dir}` on {SmartProxyServer} can grow to double or triple the size of `{postgresql-lib-dir}` on your {ProjectServer}.


### PR DESCRIPTION
This PR is a follow-up on https://github.com/theforeman/foreman-documentation/pull/2546 to get the fix on 3.3 and below. I had to make a slight change to the wording and include it above the actual storage requirements to make it work for the Satellite build. It's probably not the prettiest solution but in my opinion, good enough for older releases.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
