### PR TITLE
Rectify note about cloning Smart Proxy for 3.3

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -8,8 +8,8 @@ After your upgrade is complete, you can then decommission the earlier version of
 You can clone your {ProjectServer} to create instances to test upgrades and migration of instances to a different machine or operating system.
 This is an optional step to provide more flexibility during the upgrade or migration.
 
-The {Project} clone tool does not support migrating a {SmartProxyServer} to {EL} 8.
-Instead, you must backup the existing {SmartProxyServer}, restore it on {EL} 8, and then reconfigure {SmartProxyServer}.
+You cannot use the {Project} clone tool on a {SmartProxyServer}.
+Instead, you must backup the existing {SmartProxyServer}, restore it on the target server, and then reconfigure {SmartProxyServer}.
 
 include::../common/modules/snip_backup-usecase-note.adoc[]
 


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/2521.

The current wording seems to suggest that the clone tool does not work only for smart proxies installed on EL 8 systems. However, the tool does not work on smart proxies at all. Rewording to convey this information.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2227044


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
