### PR TITLE
Readd deprecations heading for external links

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -32,6 +32,11 @@ Contains both fixes and features that Katello can use in the future to better ma
 * https://github.com/pulp/pulpcore/issues/3835[OpenTelemetry support]  
 * https://github.com/pulp/pulpcore/issues/3656[File size added to content application listing]  
 
+[id="katello-deprecations"]
+== Deprecations
+
+There are no deprecations with Katello {KatelloVersion}.
+
 [id="katello-upgrade-warnings"]
 == Upgrade Warnings
 


### PR DESCRIPTION
I suggest to keep the structure based on headings in all versions in case there are external links in the sense of "docs.theforeman.org/katello-release-notes/$Version#deprecations".

Follow-up PR to https://github.com/theforeman/foreman-documentation/pull/2481/files#diff-a3acd643a9303d35f8f0d8c49bd0099a29f8576e1fa1648475da1258c8fad7deL10