### PR TITLE
Fix viewing or changing email notification settings

### DIFF
--- a/guides/common/modules/proc_changing-email-notification-settings-for-a-host.adoc
+++ b/guides/common/modules/proc_changing-email-notification-settings-for-a-host.adoc
@@ -5,12 +5,15 @@
 You can configure {Project} to send email notifications either to an individual user or a user group.
 When set to a user group, all group members who are subscribed to the email type receive a message.
 
-To view the notification status for a host, navigate to *Hosts* > *All Hosts* and click the host you want to view.
-In the host details page, click the *Additional Information* tab, you can view the email notification status. 
-
 Receiving email notifications for a host can be useful, but also overwhelming if you are expecting to receive frequent errors, for example, because of a known issue or error you are working around.
-To change the email notification settings for a host, complete the following steps.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*, and select the host with the notification setting you want to change.
-. Select the host's checkbox, and from the *Select Action* list, select *Enable Notifications* or *Disable Notifications*, depending on what you want.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*, locate the host that you want to view, and click *Edit* in the *Actions* column.
+. Go to the *Additional Information* tab.
+If the checkbox *Include this host within {Project} reporting* is checked, then the email notifications are enabled on that host.
+. Optional: Toggle the checkbox to enable or disable the email notifications.
++
+[NOTE]
+====
+If you want to receive email notifications, ensure that you have an email address set in your user settings.
+====


### PR DESCRIPTION
The current procedure is not correct as there is no Additional Information tab on the host detail page. This tab is located on the host edit page.

Also added instructions to change host's owner who receives the email notifications in question.

https://bugzilla.redhat.com/show_bug.cgi?id=2212587


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
