### PR TITLE
Capitalize words after optional prefix

### DIFF
--- a/guides/common/modules/proc_creating-a-location.adoc
+++ b/guides/common/modules/proc_creating-a-location.adoc
@@ -7,10 +7,10 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-locati
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer > Locations*.
 . Click *New Location*.
-. Optional: from the *Parent* list, select a parent location.
+. Optional: From the *Parent* list, select a parent location.
 This creates a location hierarchy.
 . In the *Name* field, enter a name for the location.
-. Optional: in the *Description* field, enter a description for the location.
+. Optional: In the *Description* field, enter a description for the location.
 . Click *Submit*.
 . If you have hosts with no location assigned, add any hosts that you want to assign to the new location, then click *Proceed to Edit*.
 . Assign any infrastructure resources that you want to add to the location.

--- a/guides/common/modules/proc_creating-an-organization.adoc
+++ b/guides/common/modules/proc_creating-an-organization.adoc
@@ -18,7 +18,7 @@ For more information on SCA, see https://access.redhat.com/articles/simple-conte
 ====
 {Team} does not recommend disabling SCA as entitlement mode is deprecated.
 ====
-. Optional: in the *Description* field, enter a description for the organization.
+. Optional: In the *Description* field, enter a description for the organization.
 . Click *Submit*.
 . If you have hosts with no organization assigned, select the hosts that you want to add to the organization, then click *Proceed to Edit*.
 . In the *Edit* page, assign the infrastructure resources that you want to add to the organization.

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -33,7 +33,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-operatin
 . From the *Architectures* list, select the architectures that the operating system uses.
 . Click the *Partition table* tab and select the possible partition tables that apply to this operating system.
 ifdef::satellite[]
-. Optional: if you use non-Red{nbsp}Hat content, click the Installation Media tab and select the installation media that apply to this operating system.
+. Optional: If you use non-Red{nbsp}Hat content, click the Installation Media tab and select the installation media that apply to this operating system.
 endif::[]
 ifndef::satellite[]
 . Click the Installation Media tab and enter the information for the installation media source.

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -11,7 +11,7 @@ After installing webhooks, you can configure {ProjectServer} to send webhook req
 ----
 # {foreman-installer} --enable-foreman-plugin-webhooks
 ----
-* Optional: you can install the CLI plugin using the following command:
+* Optional: Install the webhooks CLI plug-in:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/doc-Deploying_Project_on_AWS/topics/AWS_Prerequisites.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/topics/AWS_Prerequisites.adoc
@@ -44,7 +44,7 @@ ifndef::foreman-deb[]
 * Use {InstallingServerDocURL}satellite-storage-requirements_{project-context}[Storage Requirements] in _{InstallingServerDocTitle}_ to understand and assign the correct storage to your AWS EBS volumes.
 * Store the synced content on an EBS volume that is separate to the boot volume.
 * Mount the synced content EBS volume separately in the operating system.
-* Optional: store other data on a separate EBS volume.
+* Optional: Store other data on a separate EBS volume.
 endif::[]
 * If you want {ProjectServer} and {SmartProxyServer} to communicate using external DNS hostnames, open the required ports for communication in the AWS Security Group that is associated with the instance.
 


### PR DESCRIPTION
`$ rg "Optional: [a-z]"`

I was unsure during a review if it's ". Optional: Do X" or ". Optional: do X", so I've checked. The results were clearly in favor of the capitalized version.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
