### PR TITLE
Bump up Satellite to 6.15

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -1,7 +1,7 @@
 // Attributes only for satellite build
 :install-on-os: RHEL
-:ProjectVersion: 6.14
-:ProjectVersionPrevious: 6.13
+:ProjectVersion: 6.15
+:ProjectVersionPrevious: 6.14
 // Add -beta for Beta releases
 :ProjectVersionRepoTitle: {ProjectVersion}
 

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,6 +18,5 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
-  # 6.14 docs are not yet published
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.14
-
+  # 6.15 docs are not yet published
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.15

--- a/guides/doc-Administering_Project/docinfo.xml
+++ b/guides/doc-Administering_Project/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Administering Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Administer users and permissions, manage organizations and locations, back up and restore Satellite, maintain Satellite, and more</subtitle>
 <abstract>
 

--- a/guides/doc-Administering_with_Ansible/docinfo.xml
+++ b/guides/doc-Administering_with_Ansible/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Administering Satellite using Ansible </title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Managing Satellite with Ansible</subtitle>
 <abstract>
     <para>This guide describes how to set up and configure Red Hat Satellite to use Ansible to perform remote execution and automate repetitive tasks.</para>

--- a/guides/doc-Configuring_Load_Balancer/docinfo.xml
+++ b/guides/doc-Configuring_Load_Balancer/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Configuring Capsules with a Load Balancer</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Distribute load among Capsules</subtitle>
 <abstract>
     <para>This guide describes how to configure Red Hat Satellite to use a load balancer to distribute load among Capsule Servers.</para>

--- a/guides/doc-Deploying_Project_on_AWS/docinfo.xml
+++ b/guides/doc-Deploying_Project_on_AWS/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Deploying Red Hat Satellite on Amazon Web Services</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Deploy Satellite Server and Capsule on Amazon Web Services</subtitle>
 <abstract>
     <para>Use this guide to deploy Red Hat Satellite Server and Capsules on Amazon Web Services (AWS) Elastic Compute Cloud (Amazon EC2).</para>

--- a/guides/doc-Installing_Proxy/docinfo.xml
+++ b/guides/doc-Installing_Proxy/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing Capsule Server</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Install and configure Capsule</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite Capsule Server, perform initial configuration, and configure external services.</para>

--- a/guides/doc-Installing_Server/docinfo.xml
+++ b/guides/doc-Installing_Server/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing Satellite Server in a Connected Network Environment</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Install and configure Satellite Server in a network with Internet access</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite from a connected network, perform initial configuration, and configure external services.</para>

--- a/guides/doc-Installing_Server_Disconnected/docinfo.xml
+++ b/guides/doc-Installing_Server_Disconnected/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Installing Satellite Server in a Disconnected Network Environment</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Install and configure Satellite Server in a network without Internet access</subtitle>
 <abstract>
     <para>This guide describes how to install Red Hat Satellite in a disconnected network, perform initial configuration, and configure external services.</para>

--- a/guides/doc-Managing_Configurations_Ansible/docinfo.xml
+++ b/guides/doc-Managing_Configurations_Ansible/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Configurations Using Ansible Integration in Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Configure Ansible integration in Satellite and use Ansible roles and playbooks to configure your hosts</subtitle>
 <abstract>
     <para>This guide describes how to integrate Red Hat Satellite with Ansible and how to perform remote execution and automate repetitive tasks using Ansible roles and playbooks in Satellite.</para>

--- a/guides/doc-Managing_Configurations_Puppet/docinfo.xml
+++ b/guides/doc-Managing_Configurations_Puppet/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Configurations Using Puppet Integration in Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Configure Puppet integration in Satellite and use Puppet classes to configure your hosts</subtitle>
 <abstract><para>This guide describes how to enable Puppet integration with Satellite, configure the Puppet agent on hosts, how to import Puppet modules, and how to use the Puppet modules to enforce configurations on hosts managed in your Red&nbsp;Hat Satellite infrastructure.</para></abstract>
 <authorgroup id="Author_Group">

--- a/guides/doc-Managing_Content/docinfo.xml
+++ b/guides/doc-Managing_Content/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Content Management Guide</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Import content from Red Hat and custom sources, manage applications life cycle across lifecycle environments, filter content by using Content Views, synchronize content between Satellite Servers, and more</subtitle>
 <abstract>
     <para>Use this guide to understand and manage content in Satellite 6. Examples of such content include RPM files, and ISO images. Red Hat Satellite 6 manages this content using a set of Content Views promoted across the application lifecycle. This guide demonstrates how to create an application lifecycle that suits your organization and content views that fulfils host states within lifecycle environments. These content views eventually form the basis for provisioning and updating hosts in your Red Hat Satellite 6 environment.</para>

--- a/guides/doc-Managing_Hosts/docinfo.xml
+++ b/guides/doc-Managing_Hosts/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Hosts</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Register hosts to Satellite, configure host groups and collections, set up remote execution, manage packages on hosts, monitor hosts, and more</subtitle>
 <abstract><para>This guide describes how to configure and work with hosts in a Red&nbsp;Hat Satellite environment. Before continuing with this workflow you must have successfully installed a Red&nbsp;Hat Satellite 6 Server and any required Capsule Servers.</para></abstract>
 <authorgroup id="Author_Group">

--- a/guides/doc-Managing_Security_Compliance/docinfo.xml
+++ b/guides/doc-Managing_Security_Compliance/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Managing Security Compliance</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Plan and configure SCAP compliance policies, deploy the policies to hosts, and monitor compliance of your hosts</subtitle>
 <abstract>
 

--- a/guides/doc-Monitoring_Project/docinfo.xml
+++ b/guides/doc-Monitoring_Project/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Monitoring Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Collect metrics from Satellite and allow their analysis in external tools</subtitle>
 <abstract>
     <para>This guide describes how to gather metrics from Red Hat Satellite 6 for analysis. It is aimed at Satellite administrators.</para>

--- a/guides/doc-Planning_for_Project/docinfo.xml
+++ b/guides/doc-Planning_for_Project/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Satellite Overview, Concepts, and Deployment Considerations</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Explore the Satellite architecture and plan Satellite deployment</subtitle>
 <abstract><para>This document explains architecture concepts of Red&nbsp;Hat Satellite and provides recommendations for your deployment planning.</para></abstract>
 <authorgroup id="Author_Group">

--- a/guides/doc-Provisioning_Hosts/docinfo.xml
+++ b/guides/doc-Provisioning_Hosts/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Provisioning Guide</title>
 <subtitle>Configure provisioning resources and networking, provision physical machines, provision virtual machines on cloud providers or virtualization infrastructure, create hosts manually or by using the Discovery service</subtitle>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <abstract>
   <para>
     The Red&nbsp;Hat Satellite Provisioning Guide has instructions on provisioning physical and virtual hosts. This includes setting up the required network topology, configuring the necessary services, and providing all of the other configuration information to provision hosts on your network.

--- a/guides/doc-Tuning_Performance/docinfo.xml
+++ b/guides/doc-Tuning_Performance/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Tuning Performance of Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Optimize performance for Satellite Server and Capsule</subtitle>
 <abstract>
 	<para>This guide aims to cover the set of tunings and tips that can be used as a reference to scale up your Red Hat Satellite environment.</para>

--- a/guides/doc-Updating_Project/docinfo.xml
+++ b/guides/doc-Updating_Project/docinfo.xml
@@ -1,6 +1,6 @@
 <title>Updating Red Hat Satellite</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Update Satellite Server and Capsule to a new minor release</subtitle>
 <abstract>
 

--- a/guides/doc-Upgrading_Project/docinfo.xml
+++ b/guides/doc-Upgrading_Project/docinfo.xml
@@ -1,6 +1,6 @@
-<title>Upgrading Red Hat Satellite to 6.14</title>
+<title>Upgrading Red Hat Satellite to 6.15</title>
 <productname>Red Hat Satellite</productname>
-<productnumber>6.14</productnumber>
+<productnumber>6.15</productnumber>
 <subtitle>Upgrade Satellite Server and Capsule</subtitle>
 <abstract>
         <para>This guide describes how to upgrade Red Hat Satellite Server, both connected and disconnected, and Capsule Server.</para>


### PR DESCRIPTION
For .xml files I used:
find . -type f -iname "*.xml" | xargs sed -i 's/6\.14/6\.15/g'


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
