### PR TITLE
Remove mentions of Content Host from the updating section

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -128,11 +128,11 @@ endif::[]
 
 [#updating_{project-context}]
 ifdef::satellite[]
-== Updating {ProjectServer}, {SmartProxyServer}, and Content Hosts
+== Updating {ProjectServer} and {SmartProxyServer}
 endif::[]
 
 ifdef::foreman-el,katello[]
-== Updating {ProjectServer} and Content Hosts
+== Updating {ProjectServer}
 endif::[]
 
 // Updating Red Hat Satellite Introduction

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
@@ -1,6 +1,6 @@
 [[introduction_updating_satellite]]
 
-Use this chapter to update your existing {ProjectServer}, {SmartProxyServer}, and Content Hosts to a new patch version, for example, from {ProjectVersion}.0 to {ProjectVersion}.1.
+Use this chapter to update your existing {ProjectServer} and {SmartProxyServer} to a new patch version, for example, from {ProjectVersion}.0 to {ProjectVersion}.1.
 
 Updates patch security vulnerabilities and minor issues discovered after code is released, and are often fast and non-disruptive to your operating environment.
 


### PR DESCRIPTION
The procedure to update the content hosts was removed from the Upgrading and Updating guide, however, content hosts are still mentioned in the chapter title. Removing this mention as it is confusing to the user.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2209380


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
