### PR TITLE
Declare Foreman 3.6 as unsupported

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: stable
+:DocState: unsupported
 
 // Version numbers
 :ProjectVersion: 3.6


### PR DESCRIPTION
With Foreman 3.8 as a stable release, Foreman 3.6 is now unsupported.