### PR TITLE
Add a step to enable Satellite module after LEAPP upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -315,6 +315,12 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
+. Enable the {Project} module:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module enable satellite:el8
+----
 . Complete these procedures in  _Upgrading from RHEL 7 to RHEL 8_:  
 .. Unlock packages:
 +


### PR DESCRIPTION
The step to enable the Satellite module for dnf is missing. Adding this to the LEAPP upgrade guide.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
