### PR TITLE
manually create the hstore extension for pulpcore externaldb

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -96,6 +96,20 @@ CREATE DATABASE candlepin OWNER candlepin;
 CREATE DATABASE pulpcore OWNER pulp;
 ----
 +
+. Connect to the Pulp database:
++
+[options="nowrap" subs="verbatim,quotes"]
+----
+postgres=# \c pulpcore
+You are now connected to database "pulpcore" as user "postgres".
+----
+. Create the `hstore` extension:
++
+[options="nowrap" subs="verbatim,quotes"]
+----
+pulpcore=# CREATE EXTENSION IF NOT EXISTS "hstore";
+CREATE EXTENSION
+----
 . Exit the `postgres` user:
 +
 [options="nowrap" subs="verbatim,quotes"]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
