### PR TITLE
Fix upgrading-to-previous version link (Satellite)

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -25,6 +25,7 @@
 :TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpdatingDocURL: {BaseURL}updating_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_red_hat_satellite/index#
+:UpgradingPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_red_hat_satellite/index#
 
 // Not upstreamed
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -26,6 +26,7 @@
 :TuningDocTitle: Tuning Performance of {ProjectName}
 :UpdatingDocTitle: Updating {ProjectName}
 :UpgradingDocTitle: Upgrading {ProjectName} to {ProjectVersion}
+:UpgradingPreviousDocTitle: Upgrading {ProjectName} to {ProjectVersionPrevious}
 
 // Not upstreamed
 :APIDocTitle: API Guide

--- a/guides/doc-Upgrading_Project/topics/con_upgrade-paths.adoc
+++ b/guides/doc-Upgrading_Project/topics/con_upgrade-paths.adoc
@@ -5,7 +5,7 @@ You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVer
 
 ifdef::satellite[]
 {ProjectServer}s and {SmartProxyServers} on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html/upgrading_and_updating_red_hat_satellite/[_{UpgradingDocTitle} to {ProjectVersionPrevious}_].
+For more information, see {UpgradingPreviousDocURL}[_{UpgradingPreviousDocTitle}_].
 endif::[]
 
 .High-Level Upgrade Steps


### PR DESCRIPTION
This needs to be introduced, because we now include version number in the doc title.

Now it produces the correct link, but the target isn't available yet, because Sat 6.14 docs aren't published yet.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Do not cherry-pick.