### PR TITLE
Manually create the hstore extension before upgrading

### DIFF
--- a/guides/doc-Upgrading_Project/topics/con_upgrading-prerequisites.adoc
+++ b/guides/doc-Upgrading_Project/topics/con_upgrading-prerequisites.adoc
@@ -19,6 +19,27 @@ For more information, see {InstallingServerDocURL}Preparing_your_Environment_for
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
+* If you use an external database, perform the following steps on the {Project} server:
+. Install the `postgresql-contrib` package
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf install postgresql-contrib
+----
+. Connect to the Pulp database:
++
+[options="nowrap" subs="verbatim,quotes"]
+----
+postgres=# \c pulpcore
+You are now connected to database "pulpcore" as user "postgres".
+----
+. Create the `hstore` extension:
++
+[options="nowrap" subs="verbatim,quotes"]
+----
+pulpcore=# CREATE EXTENSION IF NOT EXISTS "hstore";
+CREATE EXTENSION
+----
 
 ifdef::satellite[]
 Ensure that all {ProjectServer}s are on the same version.


### PR DESCRIPTION
When using an External DB setup, users need to create the "HStore" extension manually on their setups brfore upgrading, as the installer can't handle this. BZ link:https://bugzilla.redhat.com/show_bug.cgi?id=2247623


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
