### PR TITLE
don't mention postgresql-evr during upgrade

### DIFF
--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -33,14 +33,6 @@ include::../common/modules/snip_warning-maintain-config-noop.adoc[]
 # {foreman-installer} --foreman-proxy-dns-managed=false \
 --foreman-proxy-dhcp-managed=false
 ----
-ifdef::katello[]
-. Optional: If you use PostgreSQL as an external database, install the `postgresql-evr` package on the PostgreSQL server:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} postgresql-evr
-----
-endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts* > *Discovered hosts*.
 On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.


### PR DESCRIPTION
users will have it installed by now


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
