### PR TITLE
Remove the time span setting

### DIFF
--- a/guides/common/modules/ref_advanced-settings-in-the-job-wizard.adoc
+++ b/guides/common/modules/ref_advanced-settings-in-the-job-wizard.adoc
@@ -37,11 +37,6 @@ Concurrency level::
 Defines the maximum number of jobs executed at once.
 This can prevent overload of system resources in a case of executing the job on a large number of hosts.
 
-Time span::
-Distributes the remote execution over the selected number of seconds.
-Jobs start one at a time in regular intervals to fit the given time window.
-Similarly to concurrency level, this can also prevent overload of system resources.
-
 Execution ordering::
 Determines the order in which the job is executed on hosts.
 It can be alphabetical or randomized.


### PR DESCRIPTION
Time span is being removed in Foreman 3.9.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

