### PR TITLE
Remove unnecessary warning from Upgrading Guide

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_upgrading_satellite.adoc
@@ -1,10 +1,5 @@
 [[introduction_upgrading_satellite]]
 
-ifdef::satellite[]
-[WARNING]
-If you have {Project} installed in a high availability configuration, contact Red{nbsp}Hat Support before upgrading to {Project} {ProjectVersion}.
-endif::[]
-
 Use the following procedures to upgrade your existing {ProjectName} to {ProjectName} {ProjectVersion}:
 
 . Review xref:upgrading_prerequisites[].


### PR DESCRIPTION
Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
