### PR TITLE
indicate that Satellite 6.14 was released in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 Please cherry-pick my commits into:
 
 * [ ] Foreman 3.8/Katello 4.10
-* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
+* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
 * [ ] Foreman 3.6/Katello 4.8
 * [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
 * [ ] Foreman 3.4/Katello 4.6 (EL8 only)


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (planned Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
