### PR TITLE
Start checking Satellite 6.14 links

### DIFF
--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,6 +18,5 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.14
   # 6.15 docs are not yet published
   access.redhat.com/documentation/en-us/red_hat_satellite/6.15


### PR DESCRIPTION
Now that Satellite 6.14 was released we can start checking 6.14 links.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines
