### PR TITLE
Fix upgrading guide links

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -25,7 +25,7 @@
 :TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpdatingDocURL: {BaseURL}updating_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_red_hat_satellite_to_{ProjectVersion}/index#
-:UpgradingPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_red_hat_satellite/index#
+:UpgradingPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_red_hat_satellite_to_{ProjectVersionPrevious}/index#
 
 // Not upstreamed
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -24,7 +24,7 @@
 :ProvisioningDocURL: {BaseURL}provisioning_hosts/index#
 :TuningDocURL: {BaseURL}tuning_performance_of_red_hat_satellite/index#
 :UpdatingDocURL: {BaseURL}updating_red_hat_satellite/index#
-:UpgradingDocURL: {BaseURL}upgrading_red_hat_satellite/index#
+:UpgradingDocURL: {BaseURL}upgrading_red_hat_satellite_to_{ProjectVersion}/index#
 :UpgradingPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_red_hat_satellite/index#
 
 // Not upstreamed


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits accordingly:

`Fix Upgrading guide URL for Satellite`

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)

`Fix UpgradingPreviousDoc URL`

no cherry-picks
