### PR TITLE
Remove specific mentions of "if you use Katello"

### DIFF
--- a/guides/common/modules/con_configuring-host-collections.adoc
+++ b/guides/common/modules/con_configuring-host-collections.adoc
@@ -1,11 +1,6 @@
 [id="Configuring_Host_Collections_{context}"]
 = Configuring Host Collections
 
-ifdef::foreman-deb,foreman-el,katello[]
-This is for users of the Katello plug-in and hosts running RPM-based linux distributions.
-Hosts collections work via the Pulp back end.
-endif::[]
-
 A host collection is a group of content hosts.
 This feature enables you to perform the same action on multiple hosts at once.
 These actions can include the installation, removal, and update of packages and errata, change of assigned lifecycle environment, and change of Content View.

--- a/guides/common/modules/proc_creating-hosts-on-vmware.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-vmware.adoc
@@ -28,7 +28,7 @@ include::snip_steps-create-a-host-tab-interfaces.adoc[]
 ifdef::satellite[]
 * For boot-disk provisioning, click *Boot disk based*.
 endif::[]
-ifdef::foreman-el,foreman-deb,katello,orcharhino[]
+ifndef::satellite[]
 * If the `foreman_bootdisk` plug-in is installed, and you want to use boot-disk provisioning, click *Boot disk based*.
 endif::[]
 +

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -136,10 +136,8 @@ ifdef::katello,satellite,orcharhino[]
 . Optional: Select the *Ignore errors* option if you want to ignore subscription manager errors.
 . Optional: Select the *Force* option if you want to remove any `katello-ca-consumer` rpms before registration and run `subscription-manager` with the `--force` argument.
 endif::[]
-
-ifdef::foreman-el,foreman-deb,katello[]
-. Optional: This step is for the Katello users only.
-If you register {RHEL} or CentOS hosts, in the *Activation Keys* field, enter one or more activation keys to assign to registered hosts.
+ifdef::katello[]
+If you register {EL} hosts, in the *Activation Keys* field, enter one or more activation keys to assign to registered hosts.
 endif::[]
 
 . Click *Generate*.


### PR DESCRIPTION
We have attributes that indicate if Katello is present or not. This makes it easier for both users and maintainers.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.