### PR TITLE
Remove references to Pulpcore module stream for Pulpcore 3.39

### DIFF
--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -1,7 +1,6 @@
 // Overrides for foreman-el build
 :install-on-os: CentOS/RHEL
 :dnf-module: foreman:el8
-:dnf-modules: {dnf-module}
 
 // Some documents are not ready for stable releases, but can be published on nightly
 ifeval::["{DocState}" != "nightly"]

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -3,7 +3,6 @@
 :client-content-apt:
 :client-content-zypper:
 :dnf-module: katello:el8
-:dnf-modules: {dnf-module} pulpcore:el8
 :foreman-installer-package: foreman-installer-katello
 :installer-log-file: /var/log/foreman-installer/katello.log
 :installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -36,7 +36,6 @@
 :customssl: custom SSL
 :customssltitle: Custom SSL
 :dnf-module: orcharhino:el8
-:dnf-modules: {dnf-module}
 :foreman-example-com: orcharhino.example.com
 :installer-log-file: /var/log/foreman-installer/katello.log
 :installer-scenario-smartproxy: orcharhino-installer --no-enable-foreman

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -147,4 +147,3 @@
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProjectVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProjectVersion}
 :dnf-module: satellite:el8
-:dnf-modules: {dnf-module}

--- a/guides/common/modules/con_troubleshooting-postgresql.adoc
+++ b/guides/common/modules/con_troubleshooting-postgresql.adoc
@@ -24,7 +24,7 @@ If a database was previously created using PostgreSQL 10, perform an upgrade:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf module enable {dnf-modules}
+# dnf module enable {dnf-module}
 ----
 . Install the PostgreSQL upgrade package:
 +

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -43,7 +43,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf module enable {dnf-modules}
+# dnf module enable {dnf-module}
 ----
 
 endif::[]
@@ -94,13 +94,13 @@ ifdef::foreman-el,katello,satellite[]
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# dnf module enable {dnf-modules}
+# dnf module enable {dnf-module}
 ----
 endif::[]
 +
 [NOTE]
 ====
-If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-modules}` module, see
+If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-module}` module, see
 ifeval::["{context}" == "{project-context}"]
 xref:troubleshooting-dnf-modules_{context}[].
 endif::[]

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -38,11 +38,11 @@ https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-r
 ----
 endif::[]
 +
-. Enable the following modules:
+. Enable the following module:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf module enable {dnf-modules}
+# dnf module enable {dnf-module}
 ----
 +
 [NOTE]

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -109,11 +109,19 @@ ifdef::foreman-el[]
 # {package-update} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
 endif::[]
 ----
+ifdef::katello[]
+. Disable the pulpcore module if it is enabled:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module disable pulpcore
+----
+endif::[]
 . Ensure the module streams are enabled:
 +
 [options="nowrap" subs="attributes"]
 ----
-# dnf module enable {dnf-modules}
+# dnf module enable {dnf-module}
 ----
 . Stop all services:
 +

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-smartproxy-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-smartproxy-server.adoc
@@ -55,11 +55,19 @@ ifdef::foreman-el[]
 # {package-update} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
 endif::[]
 ----
+ifdef::katello[]
+. Disable the pulpcore module if it is enabled:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf module disable pulpcore
+----
+endif::[]
 . Ensure the module streams are enabled:
 +
 [options="nowrap" subs="attributes"]
 ----
-# dnf module enable {dnf-modules}
+# dnf module enable {dnf-module}
 ----
 . Update the required packages:
 +


### PR DESCRIPTION
No CP should be needed, this is for Foreman 3.9

Pulpcore 3.39 is almost definitely losing its module stream, so it will no longer be needed in the docs.

Don't merge until after https://github.com/theforeman/puppet-pulpcore/pull/315 get in.

Please cherry-pick my commits into:

- [x] Foreman 3.9/Katello 4.11