### PR TITLE
Update module on Email notification types

### DIFF
--- a/guides/common/assembly_configuring-email-notifications.adoc
+++ b/guides/common/assembly_configuring-email-notifications.adoc
@@ -1,6 +1,6 @@
 include::modules/con_configuring-email-notifications.adoc[]
 
-include::modules/ref_notification-types.adoc[leveloffset=+1]
+include::modules/ref_email-notification-types.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-email-notification-preferences.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_configuring-email-notifications.adoc
+++ b/guides/common/modules/con_configuring-email-notifications.adoc
@@ -4,7 +4,7 @@
 Email notifications are created by {ProjectServer} periodically or after completion of certain events.
 The periodic notifications can be sent daily, weekly or monthly.
 
-For the events that trigger a notification and notification types, see xref:Notification_Types_{context}[].
+For the events that trigger a notification and notification types, see xref:Email_Notification_Types_{context}[].
 
 Users do not receive any email notifications by default.
 An administrator can configure users to receive notifications based on criteria such as the type of notification, and frequency.

--- a/guides/common/modules/con_configuring-email-notifications.adoc
+++ b/guides/common/modules/con_configuring-email-notifications.adoc
@@ -4,7 +4,7 @@
 Email notifications are created by {ProjectServer} periodically or after completion of certain events.
 The periodic notifications can be sent daily, weekly or monthly.
 
-For the events that trigger a notification and notification types, see xref:Email_Notification_Types_{context}[].
+For an overview of available notification types, see xref:Email_Notification_Types_{context}[].
 
 Users do not receive any email notifications by default.
 An administrator can configure users to receive notifications based on criteria such as the type of notification, and frequency.

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -1,5 +1,5 @@
-[id="Notification_Types_{context}"]
-= Notification Types
+[id="Email_Notification_Types_{context}"]
+= Email Notification Types
 
 The following are the notifications created by {Project}:
 

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -1,7 +1,7 @@
 [id="Email_Notification_Types_{context}"]
 = Email Notification Types
 
-Events for which you can receive email notifications from {Project} include the following:
+{Project} can create the following email notifications:
 
 * *Audit summary*: A summary of all activity audited by {ProjectServer}.
 * *Host built*: A notification sent when a host is built.
@@ -13,4 +13,4 @@ This allows a user to monitor what updates have been applied to which hosts.
 * *Sync errata*: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
 
-For a complete list of notification events, navigate to *Administer* > *Users* in the {ProjectWebUI}, click the *Username* of the required user, and select the *Email Preferences* tab.
+For a complete list of email notification types, navigate to *Administer* > *Users* in the {ProjectWebUI}, click the *Username* of the required user, and select the *Email Preferences* tab.

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -1,16 +1,16 @@
 [id="Email_Notification_Types_{context}"]
 = Email Notification Types
 
-The following are the notifications created by {Project}:
+Events for which you can receive email notifications from {Project} include the following:
 
 * *Audit summary*: A summary of all activity audited by {ProjectServer}.
 * *Host built*: A notification sent when a host is built.
 * *Host errata advisory*: A summary of applicable and installable errata for hosts managed by the user.
-* *OpenSCAP policy summary*: A summary of OpenSCAP policy reports and their results.
+* *Compliance policy summary*: A summary of OpenSCAP policy reports and their results.
 * *Promote errata*: A notification sent only after a Content View promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted Content View.
 This allows a user to monitor what updates have been applied to which hosts.
-* *Puppet error state*: A notification sent after a host reports an error related to Puppet.
-* *Puppet summary*: A summary of Puppet reports.
 * *Sync errata*: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
+
+For a complete list of notification events, navigate to *Administer* > *Users* in the {ProjectWebUI}, click the *Username* of the required user, and select the *Email Preferences* tab.


### PR DESCRIPTION
Changes in this PR lay the groundwork for documenting new email notification types:

* I renamed the reference section "Notification Types" to "Email Notification Types" to make its purpose clearer.
* I renamed and removed some notification types in the outdated list.
* I added tips for where to find the complete list, to help users if/when the list changes with future releases.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
