### PR TITLE
New email notifications for failed bg actions

### DIFF
--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -12,8 +12,8 @@ Compliance policy summary:: A summary of OpenSCAP policy reports and their resul
 Promote errata:: A notification sent only after a Content View promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted Content View.
 This allows a user to monitor what updates have been applied to which hosts.
-Repository sync failure:: A notification sent after repository synchronization fails.
 {SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
+Repository sync failure:: A notification sent after repository synchronization fails.
 Sync errata:: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
 

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -10,7 +10,7 @@ endif::[]
 Compliance policy summary:: A summary of OpenSCAP policy reports and their results.
 Content view promote failure:: A notification sent after content view promotion fails.
 Content view publish failure:: A notification sent after content view publication fails.
-Host built:: A notification sent when a host is built.
+Host built:: A notification sent after a host is built.
 Host errata advisory:: A summary of applicable and installable errata for hosts managed by the user.
 ifdef::orcharhino[]
 {SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -4,16 +4,24 @@
 {Project} can create the following email notifications:
 
 Audit summary:: A summary of all activity audited by {ProjectServer}.
+ifdef::satellite[]
+{SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
+endif::[]
+Compliance policy summary:: A summary of OpenSCAP policy reports and their results.
 Content view promote failure:: A notification sent after content view promotion fails.
 Content view publish failure:: A notification sent after content view publication fails.
 Host built:: A notification sent when a host is built.
 Host errata advisory:: A summary of applicable and installable errata for hosts managed by the user.
-Compliance policy summary:: A summary of OpenSCAP policy reports and their results.
+ifdef::orcharhino[]
+{SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
+endif::[]
 Promote errata:: A notification sent only after a Content View promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted Content View.
 This allows a user to monitor what updates have been applied to which hosts.
-{SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
 Repository sync failure:: A notification sent after repository synchronization fails.
+ifdef::foreman-el,foreman-deb,katello[]
+{SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
+endif::[]
 Sync errata:: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
 

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -3,18 +3,18 @@
 
 {Project} can create the following email notifications:
 
-* *Audit summary*: A summary of all activity audited by {ProjectServer}.
-* *Content view promote failure*: A notification sent after content view promotion fails.
-* *Content view publish failure*: A notification sent after content view publication fails.
-* *Host built*: A notification sent when a host is built.
-* *Host errata advisory*: A summary of applicable and installable errata for hosts managed by the user.
-* *Compliance policy summary*: A summary of OpenSCAP policy reports and their results.
-* *Promote errata*: A notification sent only after a Content View promotion.
+Audit summary:: A summary of all activity audited by {ProjectServer}.
+Content view promote failure:: A notification sent after content view promotion fails.
+Content view publish failure:: A notification sent after content view publication fails.
+Host built:: A notification sent when a host is built.
+Host errata advisory:: A summary of applicable and installable errata for hosts managed by the user.
+Compliance policy summary:: A summary of OpenSCAP policy reports and their results.
+Promote errata:: A notification sent only after a Content View promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted Content View.
 This allows a user to monitor what updates have been applied to which hosts.
-* *Repository sync failure*: A notification sent after repository synchronization fails.
-* *{SmartProxy} sync failure*: A notification sent after {SmartProxy} synchronization fails.
-* *Sync errata*: A notification sent only after synchronizing a repository.
+Repository sync failure:: A notification sent after repository synchronization fails.
+{SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
+Sync errata:: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
 
 For a complete list of email notification types, navigate to *Administer* > *Users* in the {ProjectWebUI}, click the *Username* of the required user, and select the *Email Preferences* tab.

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -4,12 +4,16 @@
 {Project} can create the following email notifications:
 
 * *Audit summary*: A summary of all activity audited by {ProjectServer}.
+* *Content view promote failure*: A notification sent after content view promotion fails.
+* *Content view publish failure*: A notification sent after content view publication fails.
 * *Host built*: A notification sent when a host is built.
 * *Host errata advisory*: A summary of applicable and installable errata for hosts managed by the user.
 * *Compliance policy summary*: A summary of OpenSCAP policy reports and their results.
 * *Promote errata*: A notification sent only after a Content View promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted Content View.
 This allows a user to monitor what updates have been applied to which hosts.
+* *Repository sync failure*: A notification sent after repository synchronization fails.
+* *{SmartProxy} sync failure*: A notification sent after {SmartProxy} synchronization fails.
 * *Sync errata*: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
 


### PR DESCRIPTION
This PR adds four new types of email notifications (based on https://projects.theforeman.org/issues/17748). Additionally, I changed the markup used for the list of notifications and made minor tweaks to ensure the list is ordered alphabetically.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
