### PR TITLE
'Append domain names' replaced by 'Display FQDN'

### DIFF
--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -18,7 +18,7 @@ System-wide proxies must be configured at the operating system level.
 | *HTTP(S) proxy except hosts* | [] | Set hostnames to which requests are not to be proxied.
 Requests to the local host are excluded by default.
 | *Show Experimental Labs* | No | Whether or not to show a menu to access experimental lab features (requires reload of page).
-| *Display FQDN for hosts* | Yes | If set to `Yes`, {Project} displays names of hosts as fully-qualified domain names.
+| *Display FQDN for hosts* | Yes | If set to `Yes`, {Project} displays names of hosts as fully qualified domain names (FQDNs).
 | *Out of sync interval* | 30 | Managed hosts report periodically, and if the time between reports exceeds this duration in minutes, hosts are considered out of sync.
 You can override this on your hosts by adding the `outofsync_interval` parameter, per host, at *Hosts > All hosts > $host > Edit > Parameters > Add Parameter*.
 | *{Project} UUID* | | {Project} instance ID.

--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -18,7 +18,7 @@ System-wide proxies must be configured at the operating system level.
 | *HTTP(S) proxy except hosts* | [] | Set hostnames to which requests are not to be proxied.
 Requests to the local host are excluded by default.
 | *Show Experimental Labs* | No | Whether or not to show a menu to access experimental lab features (requires reload of page).
-| *Append domain names to the host* | Yes | If set to `Yes`, {Project} appends domain names when new hosts are provisioned.
+| *Display FQDN for hosts* | Yes | If set to `Yes`, {Project} displays names of hosts as fully-qualified domain names.
 | *Out of sync interval* | 30 | Managed hosts report periodically, and if the time between reports exceeds this duration in minutes, hosts are considered out of sync.
 You can override this on your hosts by adding the `outofsync_interval` parameter, per host, at *Hosts > All hosts > $host > Edit > Parameters > Add Parameter*.
 | *{Project} UUID* | | {Project} instance ID.


### PR DESCRIPTION
`append_domain_name_for_hosts` is being replaced with `display_fqdn_for_hosts`. This PR updates a reference list of Web UI settings accordingly.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
