### PR TITLE
CV publish with filters takes much longer

### DIFF
--- a/guides/common/modules/con_content-filter-examples.adoc
+++ b/guides/common/modules/con_content-filter-examples.adoc
@@ -3,6 +3,9 @@
 
 Use any of the following examples with the procedure that follows to build custom content filters.
 
+NOTE: Filters can significantly increase Content View publishing time.
+For example, if a Content View publish task completes in a few minutes without filters, it can take 30 minutes after adding an exclude or include errata filter.
+
 .Example 1
 Create a repository with the base {RHEL} packages.
 This filter requires a {RHEL} repository added to the Content View.

--- a/guides/common/modules/con_content-filter-examples.adoc
+++ b/guides/common/modules/con_content-filter-examples.adoc
@@ -3,7 +3,7 @@
 
 Use any of the following examples with the procedure that follows to build custom content filters.
 
-NOTE: Filters can significantly increase Content View publishing time.
+NOTE: Filters can significantly increase the time to publish a Content View.
 For example, if a Content View publish task completes in a few minutes without filters, it can take 30 minutes after adding an exclude or include errata filter.
 
 .Example 1


### PR DESCRIPTION
BZ#222893[https://bugzilla.redhat.com/show_bug.cgi?id=2222893#c1] requests documenting that filters can cause CV publish tasks to take much longer. This PR adds this as a note in a section describing filter examples.

(I'm using Content Views in uppercase because the whole section does so.)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
