### PR TITLE
Rename Conversions thingy

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -11,7 +11,6 @@
 :AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
 :ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#
 :ContentManagementDocURL: {BaseURL}managing_content/index#
-:ConversionsApplianceDocURL: {BaseURL}converting_hosts_to_rhel_by_using_conversions_appliance/index#
 :InstallingServerDisconnectedDocURL: {BaseURL}installing_satellite_server_in_a_disconnected_network_environment/index#
 :InstallingServerDocURL: {BaseURL}installing_satellite_server_in_a_connected_network_environment/index#
 :InstallingSmartProxyDocURL: {BaseURL}installing_capsule_server/index#
@@ -32,6 +31,7 @@
 :APIDocURL: {BaseURL}api_guide/index#
 :HammerDocURL: {BaseURL}hammer_cli_guide/index#
 :ConfiguringVMSubscriptionsDocURL: {BaseURL}configuring_virtual_machine_subscriptions_in_red_hat_satellite/index#
+:ConversionsToolkitDocURL: {BaseURL}converting_hosts_to_rhel_by_using_conversions_toolkit/index#
 
 // Overrides for satellite build
 :ansible-collection-package: ansible-collection-redhat-satellite

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -32,7 +32,7 @@
 :APIDocTitle: API Guide
 :HammerDocTitle: Hammer CLI Guide
 :ConfiguringVMSubscriptionsDocTitle: Configuring Virtual Machine Subscriptions in {ProjectName}
-:ConversionsApplianceDocTitle: Converting Hosts to RHEL by Using Conversions Appliance
+:ConversionsToolkitDocTitle: Converting Hosts to RHEL by Using Conversions Toolkit
 
 // Overrides for titles per product
 


### PR DESCRIPTION
We need to rename this due to Marketing requirements.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
