### PR TITLE
Revise the type of HTTP Proxy mentioned

### DIFF
--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,23 +3,18 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-* You must deploy an external DHCP IPv6 server as a separate unmanaged service to bootstrap clients into GRUB2, which then configures IPv6 networking either using DHCPv6 or or assigning static IPv6 address.
+* You must deploy an external DHCP IPv6 server as a separate unmanaged service to bootstrap clients into GRUB2, which then configures IPv6 networking either using DHCPv6 or assigning static IPv6 address.
 This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide an integration API for managing IPv6 records, therefore the {SmartProxy} DHCP plug-in that provides DHCP management is limited to IPv4 subnets.
 
 ifdef::satellite[]
-* You must deploy an external IPv4 HTTP proxy server.
+* You must deploy an external HTTP proxy server that supports both IPv4 and IPv6.
 This is required because Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into the {Project} on your IPv6 network.
 endif::[]
 
-ifdef::katello,foreman-el[]
+ifndef::satellite[]
 * Optional: If you rely on content from IPv4 networks, you must deploy an external IPv4 HTTP proxy server.
 This is required to access Content Delivery Networks that distribute content only over IPv4 networks, therefore you must use this proxy to pull content into {Project} on your IPv6 network.
 endif::[]
 
-ifndef::satellite[]
-+
-Note that this requirement is for Katello users only.
-endif::[]
-
-* You must configure {Project} to use this IPv4 HTTP proxy server as the default proxy.
+* You must configure {Project} to use this dual stack (supporting both IPv4 and IPv6) HTTP proxy server as the default proxy.
 For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{project-context}[Adding a Default HTTP Proxy to {Project}].


### PR DESCRIPTION
Presently, in setting up the Project in the IPv6 network, we mention only the IPv4 type of HTTP Proxy server which is incorrect. Because, the HTTP Proxy server configured with IPv4 only cannot communicate with the Project configured in the IPv6 network, except CDN. Hence, it should support both, IPv4 and IPv6.

Please cherry-pick my commits into:

* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
