### PR TITLE
Supported VMware vCenter versions in Provisioning

### DIFF
--- a/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
@@ -5,6 +5,6 @@ The requirements for VMware vSphere provisioning include:
 
 * A {SmartProxyServer} managing a network on the vSphere environment.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
+For more information, see xref:Configuring_Networking_provisioning[].
 * An existing VMware template if you want to use image-based provisioning.
 include::snip_prerequisites-common-compute-resource.adoc[]

--- a/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
@@ -3,6 +3,16 @@
 
 The requirements for VMware vSphere provisioning include:
 
+* A supported version of VMware vCenter Server.
+The following versions have been fully tested with {Project}:
+** vCenter Server 7.0
+** vCenter Server 6.7 (EOL)
+** vCenter Server 6.5 (EOL)
+ifndef::satellite[]
+
++
+vCenter Server 8.0.0 and 8.0.1 are known to work with {Project}, but have not been fully tested yet and are not officially supported.
+endif::[]
 * A {SmartProxyServer} managing a network on the vSphere environment.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 For more information, see xref:Configuring_Networking_provisioning[].


### PR DESCRIPTION
VMware vCenter Server 8 hasn't been properly tested yet, so we should explicitly state which vCenter versions are supported in Foreman. See also: https://bugzilla.redhat.com/show_bug.cgi?id=2247345#c6

Originally, I wanted to create a RH KB article, but it's probably better to include it in the docs directly for upstream.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
