### PR TITLE
Use shellscript to add operating systems

### DIFF
--- a/guides/common/modules/proc_creating-an-installation-medium-for-debian.adoc
+++ b/guides/common/modules/proc_creating-an-installation-medium-for-debian.adoc
@@ -4,11 +4,7 @@
 Create an installation medium in {Project} to provision hosts running {Debian}.
 
 ifdef::orcharhino[]
-[TIP]
-====
-You can use an Ansible role to configure operating systems to skip this step.
-The Ansible role is located on your orcharhino Server at `/usr/share/orcharhino-ansible/roles/or_operating_systems/`.
-====
+include::snip_creating-os-on-orcharhino.adoc[]
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_creating-an-operating-system-for-debian.adoc
+++ b/guides/common/modules/proc_creating-an-operating-system-for-debian.adoc
@@ -5,11 +5,7 @@ Create an operating system in {Project} to provision hosts running {os_name}.
 This example creates an operating system entry for {os_name} {os_major}.{os_minor}.
 
 ifdef::orcharhino[]
-[TIP]
-====
-You can use an Ansible role to configure operating systems to skip this step.
-The Ansible role is located on your orcharhino Server at `/usr/share/orcharhino-ansible/roles/or_operating_systems/`.
-====
+include::snip_creating-os-on-orcharhino.adoc[]
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -21,8 +21,11 @@ You can add operating systems using the following procedure.
 endif::[]
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-operating-systems_{context}[].
 
-.Procedure
+ifdef::orcharhino[]
+include::snip_creating-os-on-orcharhino.adoc[]
+endif::[]
 
+.Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Operating systems* and click *New Operating* system.
 . In the *Name* field, enter a name to represent the operating system entry.
 . In the *Major* field, enter the number that corresponds to the major version of the operating system.

--- a/guides/common/modules/snip_creating-os-on-orcharhino.adoc
+++ b/guides/common/modules/snip_creating-os-on-orcharhino.adoc
@@ -1,0 +1,7 @@
+[TIP]
+====
+You can use a script to add operating system entries to your {ProjectServer}.
+
+On your {ProjectServer}, uncomment the operating systems and {project-client-name} that you want to add in `/etc/orcharhino-ansible/or_operating_systems_vars.yaml`, replace the default organization and location names, and run `/opt/orcharhino/automation/play_operating_systems.sh`.
+For more information, see `/usr/share/orcharhino-ansible/README.md` on your {ProjectServer}.
+====


### PR DESCRIPTION
orcharhino Server contains a shellscript that runs an Ansible playbook that contains Ansible roles to add and/or update existing operating system entries and associated templates on orcharhino Server.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
