### PR TITLE
fapolicyd on Project and SmartProxy [Priority]

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -25,6 +25,10 @@ ifdef::foreman-el,foreman-deb[]
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
+include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
+
+include::modules/proc_installing-fapolicyd-on-server.adoc[leveloffset=+2]
+
 // Installing {SmartProxyServer} Packages
 include::modules/proc_installing-capsule-server-packages.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -21,6 +21,10 @@ include::modules/proc_configuring-the-base-operating-system-with-offline-reposit
 
 include::modules/proc_installing-from-the-offline-repositories.adoc[leveloffset=+1]
 
+include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
+
+include::modules/proc_installing-fapolicyd-on-server.adoc[leveloffset=+2]
+
 include::modules/proc_resolving-package-dependency-errors.adoc[leveloffset=+1]
 
 include::modules/proc_synchronizing-the-system-clock-with-chronyd.adoc[leveloffset=+1]

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -55,6 +55,10 @@ endif::[]
 
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 
+include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
+
+include::modules/proc_installing-fapolicyd-on-server.adoc[leveloffset=+2]
+
 include::modules/proc_installing-the-satellite-server-packages.adoc[leveloffset=+1]
 
 ifdef::foreman-el,katello,satellite[]

--- a/guides/common/modules/con_using-fapolicyd-on-server.adoc
+++ b/guides/common/modules/con_using-fapolicyd-on-server.adoc
@@ -1,0 +1,12 @@
+[id="using-fapolicyd-on-server_{context}"]
+ifeval::["{context}" == "{project-context}"]
+= Optional: Using fapolicyd on {ProjectServer}
+endif::[]
+ifeval::["{context}" == "{smart-proxy-context}"]
+= Optional: Using fapolicyd on {SmartProxyServer}
+endif::[]
+
+By enabling `fapolicyd` on your {ProjectServer}, you can provide an additional layer of security by monitoring and controlling access to files and directories.
+The fapolicyd daemon uses the RPM database as a repository of trusted binaries and scripts.
+
+You can turn on or off the fapolicyd on your {ProjectServer} or {SmartProxyServer} at any point.

--- a/guides/common/modules/proc_installing-fapolicyd-on-server.adoc
+++ b/guides/common/modules/proc_installing-fapolicyd-on-server.adoc
@@ -1,0 +1,49 @@
+[id="installing-fapolicyd-on-server_{context}"]
+ifeval::["{context}" == "{project-context}"]
+= Installing fapolicyd on {ProjectServer}
+endif::[]
+ifeval::["{context}" == "{smart-proxy-context}"]
+= Installing fapolicyd on {SmartProxyServer}
+endif::[]
+
+ifeval::["{context}" == "{project-context}"]
+You can install `fapolicyd` along with {ProjectServer} or can be installed on an existing {ProjectServer}.
+If you are installing `fapolicyd` along with the new {ProjectServer}, the installation process will detect the fapolicyd in your {EL} host and deploy the {ProjectServer} rules automatically.
+endif::[]
+ifeval::["{context}" == "{smart-proxy-context}"]
+You can install `fapolicyd` along with {SmartProxyServer} or can be installed on an existing {SmartProxyServer}.
+If you are installing `fapolicyd` along with the new {SmartProxyServer}, the installation process will detect the fapolicyd in your {EL} host and deploy the {SmartProxyServer} rules automatically.
+endif::[]
+
+.Prerequisite
+* Ensure your host has access to the BaseOS repositories of {EL}.
+
+.Procedure
+. Install fapolicyd:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+ifndef::foreman-deb[]
+# dnf install fapolicyd
+endif::[]
+----
+. Start the `fapolicyd` service:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# systemctl enable --now fapolicyd
+----
+
+.Verification
+* Verify that the `fapolicyd` service is running correctly:
++
+[options="nowrap" subs="+quotes"]
+----
+# systemctl status fapolicyd
+----
+
+.New {ProjectServer} or {SmartProxyServer} installations
+In case of new {ProjectServer} or {SmartProxyServer} installation, follow the standard installation procedures after installing and enabling fapolicyd on your {EL} host.
+
+.Additional resources
+For more information on fapolicyd, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_blocking-and-allowing-applications-using-fapolicyd_security-hardening#doc-wrapper[Blocking and allowing applications using fapolicyd] in _Red Hat Enterprise Linux 8 Security hardening_.


### PR DESCRIPTION
For version 3.9 and above, we have started supporting fapolicyd on the Project Server and SmartProxy Server. The procedure to install and enable faplicyd for both remains the same. You can install fapolicyd along with the fresh installation of Project or SmartProxy or install it on existing Project or SmartProxy.

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
