### PR TITLE
Add procedure for refreshing content counts

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -114,7 +114,7 @@ include::modules/proc_changing-the-mirroring-policy-for-a-repository.adoc[levelo
 
 include::modules/proc_uploading-content-to-custom-rpm-repositories.adoc[leveloffset=+1]
 
-include::modules/proc_refreshing-smart-proxy-counts.adoc[leveloffset=+1]
+include::modules/proc_refreshing-content-counts-on-smart-proxy.adoc[leveloffset=+1]
 
 ifdef::katello,satellite,orcharhino[]
 include::modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -114,6 +114,8 @@ include::modules/proc_changing-the-mirroring-policy-for-a-repository.adoc[levelo
 
 include::modules/proc_uploading-content-to-custom-rpm-repositories.adoc[leveloffset=+1]
 
+include::modules/proc_refreshing-smart-proxy-counts.adoc[leveloffset=+1]
+
 ifdef::katello,satellite,orcharhino[]
 include::modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
@@ -1,4 +1,4 @@
-[id="Refreshing_Content_Counts-on_{smart-proxy-context-titlecase}_{context}"]
+[id="Refreshing_Content_Counts_on_{smart-proxy-context-titlecase}_{context}"]
 = Refreshing Content Counts on {SmartProxy}
 
 If your {SmartProxies} have synchronized content enabled, you can refresh the number of content counts available to the environments associated with the {SmartProxy}.

--- a/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
@@ -1,7 +1,9 @@
-[id="Refreshing_{smart-proxy-context-titlecase}_Counts_{context}"]
-= Refreshing {SmartProxy} Counts
+[id="Refreshing_Content_Counts-on_{smart-proxy-context-titlecase}_{context}"]
+= Refreshing Content Counts on {SmartProxy}
 
 If your {SmartProxies} have synchronized content enabled, you can refresh the number of content counts available to the environments associated with the {SmartProxy}.
+This displays the Content Views inside those environments available to the {SmartProxy}.
+You can then expand the Content View to view the repositories associated with that Content View version.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} where you want to see the synchronized content.

--- a/guides/common/modules/proc_refreshing-smart-proxy-counts.adoc
+++ b/guides/common/modules/proc_refreshing-smart-proxy-counts.adoc
@@ -1,13 +1,15 @@
-[id="Refreshing_Smart_Proxy_Counts_{context}"]
+[id="Refreshing_{smart-proxy-context-titlecase}_Counts_{context}"]
 = Refreshing {SmartProxy} Counts
 
 If your {SmartProxies} have synchronized content enabled, you can refresh the number of content counts available to the environments associated with the {SmartProxy}.
 
 .Procedure
-. In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} where you want to see the synchronized content.
-. Select the *Overview* tab and under *Content Sync*, toggle the *Synchronize* button to do an *Optimized Sync* or a *Complete Sync* to synchronize the {SmartProxy} which refreshes the content counts.
-. Select the *Content* tab and choose an *Environment* to view Content Views available to those {SmartProxies} by clicking the greater than symbol to expand.
-. Expand the Content View by clicking the greater than symbol to view repositories available to the Content View and the specific version for the environment.
-. View the number of content counts under *Packages* specific to yum repositories. 
-. View the number of files errata, package groups, files, container tags, container manifests, Ansible collections under *Additional content*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} where you want to see the synchronized content.
+. Select the *Overview* tab.
+. Under *Content Sync*, toggle the *Synchronize* button to do an *Optimized Sync* or a *Complete Sync* to synchronize the {SmartProxy} which refreshes the content counts.
+. Select the *Content* tab.
+. Choose an *Environment* to view Content Views available to those {SmartProxies} by clicking *>*.
+. Expand the Content View by clicking *>* to view repositories available to the Content View and the specific version for the environment.
+. View the number of content counts under *Packages* specific to yum repositories.
+. View the number of errata, package groups, files, container tags, container manifests, and Ansible collections under *Additional content*.
 . Click the vertical ellipsis in the column to the right next to the environment and click *Refresh counts* to refresh the content counts synchronized on the {SmartProxy} under *Packages*.

--- a/guides/common/modules/proc_refreshing-smart-proxy-counts.adoc
+++ b/guides/common/modules/proc_refreshing-smart-proxy-counts.adoc
@@ -1,0 +1,13 @@
+[id="Refreshing_Smart_Proxy_Counts_{context}"]
+= Refreshing {SmartProxy} Counts
+
+If your {SmartProxies} have synchronized content enabled, you can refresh the number of content counts available to the environments associated with the {SmartProxy}.
+
+.Procedure
+. In the {Project} web UI, navigate to *Infrastructure* > *{SmartProxies}*, and select the {SmartProxy} where you want to see the synchronized content.
+. Select the *Overview* tab and under *Content Sync*, toggle the *Synchronize* button to do an *Optimized Sync* or a *Complete Sync* to synchronize the {SmartProxy} which refreshes the content counts.
+. Select the *Content* tab and choose an *Environment* to view Content Views available to those {SmartProxies} by clicking the greater than symbol to expand.
+. Expand the Content View by clicking the greater than symbol to view repositories available to the Content View and the specific version for the environment.
+. View the number of content counts under *Packages* specific to yum repositories. 
+. View the number of files errata, package groups, files, container tags, container manifests, Ansible collections under *Additional content*.
+. Click the vertical ellipsis in the column to the right next to the environment and click *Refresh counts* to refresh the content counts synchronized on the {SmartProxy} under *Packages*.


### PR DESCRIPTION
A new procedure for refreshing content counts for
SmartProxies/Capsules
was needed and has been added to the Content Management Guide.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
