### PR TITLE
Hide untested VMware vSphere for orcharhino

### DIFF
--- a/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
@@ -8,7 +8,7 @@ The following versions have been fully tested with {Project}:
 ** vCenter Server 7.0
 ** vCenter Server 6.7 (EOL)
 ** vCenter Server 6.5 (EOL)
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 
 +
 vCenter Server 8.0.0 and 8.0.1 are known to work with {Project}, but have not been fully tested yet and are not officially supported.


### PR DESCRIPTION
Refs a480bf96b56a834a3670053837d2101f780b7edb


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
