### PR TITLE
Add procedure to uninstall foreman_openscap

### DIFF
--- a/guides/common/modules/proc_uninstalling-openscap-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-openscap-plugin.adoc
@@ -1,0 +1,15 @@
+[id="Uninstalling_OpenSCAP_Plugin_{context}"]
+= Uninstalling OpenSCAP Plugin
+
+If you have previously installed the OpenSCAP plug-in but do not use it anymore to scan managed hosts, you can uninstall it from your {ProjectServer}.
+
+.Procedure
+. Uninstall the OpenSCAP plug-in from your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --no-enable-foreman-cli-openscap \
+--no-enable-foreman-plugin-openscap \
+--no-enable-foreman-proxy-plugin-openscap
+----
+. Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the *Plugins* tab to verify the removal of the OpenSCAP plug-in.

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -93,5 +93,9 @@ include::common/modules/proc_deleting-a-compliance-report.adoc[leveloffset=+2]
 
 include::common/modules/proc_deleting-multiple-compliance-reports.adoc[leveloffset=+2]
 
+ifndef::satellite[]
+include::common/modules/proc_uninstalling-openscap-plugin.adoc[leveloffset=+1]
+endif::[]
+
 endif::[]
 endif::[]


### PR DESCRIPTION
procedure is based on `guides/common/modules/proc_uninstalling-amazon-ec2-plugin.adoc`

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
