### PR TITLE
Add step to skip tomcat from leapp upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -189,7 +189,7 @@ gpgcheck=1
 ----
 endif::[]
 
-. Add `tomcat` and `tomcat-lib` to the `/etc/leapp/transaction/to_remove` file:
+. Configure Leapp to skip updating the Tomcat packages to ensure the upgrade does not fail:
 +
 ----
 # echo tomcat >> /etc/leapp/transaction/to_remove

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -189,6 +189,13 @@ gpgcheck=1
 ----
 endif::[]
 
+. Add `tomcat` and `tomcat-lib` to the `/etc/leapp/transaction/to_remove` file:
++
+----
+# echo tomcat >> /etc/leapp/transaction/to_remove
+# echo tomcat-lib >> /etc/leapp/transaction/to_remove
+----
+
 . Let Leapp analyze your system:
 +
 ----


### PR DESCRIPTION
RHEL 8.8 has new tomcat packages which are marked as upgradable by the recent Leapp. This breaks Satellite installations. The fix is to tell LEapp not to update the Tomcat packages. Adding a step to skip the Leapp transaction for Tomcat.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2250254


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
