### PR TITLE
Fix firewall commands for ports and services

### DIFF
--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -14,7 +14,7 @@ ifdef::katello,satellite,orcharhino[]
 +
 [options="nowrap"]
 ----
-# firewall-cmd --permanent \
+# firewall-cmd \
 --add-port="5647/tcp" \
 --add-port="8000/tcp" \
 --add-port="9090/tcp"
@@ -24,7 +24,7 @@ endif::[]
 +
 [options="nowrap"]
 ----
-# firewall-cmd --permanent \
+# firewall-cmd \
 --add-service=dns \
 --add-service=dhcp \
 --add-service=tftp \
@@ -34,6 +34,12 @@ ifndef::katello,satellite,orcharhino[]
 --add-service=foreman-proxy \
 endif::[]
 --add-service=puppetmaster
+----
+. Make the changes persistent:
++
+[options="nowrap"]
+----
+# firewall-cmd --runtime-to-permanent
 ----
 
 include::snip_verify-firewall-settings.adoc[]

--- a/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-client-connections-to-satellite.adoc
@@ -9,31 +9,31 @@ For more information on the ports used, see {InstallingServerDocURL}satellite-po
 include::snip_firewalld.adoc[]
 
 .Procedure
-. To open the ports for client to {Project} communication, enter the following command on the base operating system that you want to install {Project} on:
+ifdef::katello,satellite,orcharhino[]
+. Open the ports for clients on {ProjectServer}:
 +
 [options="nowrap"]
 ----
-# firewall-cmd \
+# firewall-cmd --permanent \
+--add-port="5647/tcp" \
+--add-port="8000/tcp" \
+--add-port="9090/tcp"
+----
+endif::[]
+. Allow access to services on {ProjectServer}:
++
+[options="nowrap"]
+----
+# firewall-cmd --permanent \
 --add-service=dns \
 --add-service=dhcp \
 --add-service=tftp \
 --add-service=http \
 --add-service=https \
-ifdef::katello,satellite,orcharhino[]
---add-port="5647/tcp" \
---add-port="8000/tcp" \
---add-port="9090/tcp" \
-endif::[]
 ifndef::katello,satellite,orcharhino[]
 --add-service=foreman-proxy \
 endif::[]
 --add-service=puppetmaster
-----
-. Make the changes persistent:
-+
-[options="nowrap"]
-----
-# firewall-cmd --runtime-to-permanent
 ----
 
 include::snip_verify-firewall-settings.adoc[]


### PR DESCRIPTION
Earlier in the last release version, we had no services to add for the firewall. But with the latest version i.e. going to be released, we add services and ports in the firewall. But, the firewall command does not accept the services and ports together in a single instance and is therefore split here. Also, adding --permanent to the command in the first place replaces the requirement of a new step for making it persistent.

https://bugzilla.redhat.com/show_bug.cgi?id=2253246

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
