### PR TITLE
Add lifecycle to procedure step

### DIFF
--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -41,7 +41,7 @@ If a {customproduct}, typically containing content not provided by Red Hat, is a
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-an-activation-key_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Activation keys* and click *Create Activation Key*.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys* and click *Create Activation Key*.
 . In the *Name* field, enter the name of the activation key.
 . If you want to set a limit, clear the *Unlimited hosts* checkbox, and in the *Limit* field, enter the maximum number of systems you can register with the activation key.
 If you want unlimited hosts to register with the activation key, ensure the *Unlimited Hosts* checkbox is selected.

--- a/guides/common/modules/proc_updating-subscriptions-associated-with-an-activation-key.adoc
+++ b/guides/common/modules/proc_updating-subscriptions-associated-with-an-activation-key.adoc
@@ -12,7 +12,7 @@ Note that changes to an activation key apply only to machines provisioned after 
 To update subscriptions on existing content hosts, see xref:Updating_Red_Hat_Subscriptions_on_Multiple_Hosts_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Activation keys* and click the name of the activation key.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys* and click the name of the activation key.
 . Click the *Subscriptions* tab.
 . To remove subscriptions, select *List/Remove*, and then select the checkboxes to the left of the subscriptions to be removed and then click *Remove Selected*.
 . To add subscriptions, select *Add*, and then select the checkboxes to the left of the subscriptions to be added and then click *Add Selected*.


### PR DESCRIPTION
The "Content > Activation keys" step is replaced with "Content >
Lifecycle > Activation Keys." in two sections of the Managing Content
guide. "Lifecycle" was missing.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
