### PR TITLE
Add sync modes for Smart Proxy Servers

### DIFF
--- a/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -6,4 +6,4 @@ include::modules/proc_restoring-from-incremental-backups.adoc[leveloffset=+1]
 
 include::modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc[leveloffset=+1]
 
-include::modules/proc_synchronizing-an-external-smart-proxy.adoc[leveloffset=+2]
+include::modules/proc_synchronizing-content-from-project-server-to-smart-proxy-servers.adoc[leveloffset=+2]

--- a/guides/common/modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc
+++ b/guides/common/modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc
@@ -8,4 +8,4 @@ In the event of failure, you can install, or configure a new {SmartProxyServer},
 If required, deploy a new {SmartProxyServer}, ensuring the host name is the same as before, and then install the {SmartProxy} certificates.
 You may still have them on {ProjectServer}, the package name ends in -certs.tar, alternately create new ones.
 Follow the procedures in {InstallingSmartProxyDocURL}[Installing {SmartProxyServer}] until you can confirm, in the {ProjectWebUI}, that {SmartProxyServer} is connected to {ProjectServer}.
-Then use the procedure xref:synchronizing-an-external-{smart-proxy-context}_{context}[] to synchronize from {Project}.
+Then use the procedure xref:Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_{context}[] to synchronize from {Project}.

--- a/guides/common/modules/proc_synchronizing-an-external-smart-proxy.adoc
+++ b/guides/common/modules/proc_synchronizing-an-external-smart-proxy.adoc
@@ -1,9 +1,0 @@
-[id="synchronizing-an-external-{smart-proxy-context}_{context}"]
-= Synchronizing an External {SmartProxy}
-
-Synchronize an external {SmartProxy} with {Project}.
-
-.Procedure
-. To synchronize an external {SmartProxy}, select the relevant organization and location in the {ProjectWebUI}, or choose *Any Organization* and *Any Location*.
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* and click the name of the {SmartProxy} to synchronize.
-. On the *Overview* tab, select *Synchronize*.

--- a/guides/common/modules/proc_synchronizing-content-from-project-server-to-smart-proxy-servers.adoc
+++ b/guides/common/modules/proc_synchronizing-content-from-project-server-to-smart-proxy-servers.adoc
@@ -1,0 +1,14 @@
+[id="Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_{context}"]
+= Synchronizing Content from {ProjectServer} to {SmartProxyServers}
+
+Use this procedure to synchronize content from your {ProjectServer} to your {SmartProxyServer}.
+
+.Prerequisite
+* Ensure that you either select the relevant organization and location context of your {SmartProxyServer} or choose *Any Organization* and *Any Location*.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
+. Select your {SmartProxyServer}.
+. On the *Overview* tab, click *Synchronize*.
+* Select *Optimized Sync* to synchronize content from your {ProjectServer} to your {SmartProxyServer} that bypasses unnecesary steps to speed up performance.
+* Select *Complete Sync* to perform a complete sync from your {ProjectServer} to your {SmartProxyServer} that synchronizes content even if the metadata has not changed.


### PR DESCRIPTION
Tested on Foreman 3.9:

![image](https://github.com/theforeman/foreman-documentation/assets/12595287/dc4483f5-2368-4995-bb46-6c7d4541a5ca)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
