### PR TITLE
Update Foreman 3.9 to supported

### DIFF
--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -6,8 +6,8 @@ title: Home
 
 The following releases are supported, meaning they receive (security) updates. Visit the https://community.theforeman.org/c/support/10[support forum] for questions.
 
+* link:/release/3.9/[Foreman 3.9 & Katello 4.11]
 * link:/release/3.8/[Foreman 3.8 & Katello 4.10]
-* link:/release/3.7/[Foreman 3.7 & Katello 4.9]
 
 === Unsupported releases
 
@@ -15,12 +15,11 @@ The future version is built in nightly.
 
 * link:/release/nightly/[Nightly]
 
-There is a release candidate available for testing.
-
-* link:/release/3.9/[Foreman 3.9 & Katello 4.11]
+// There is a release candidate available for testing.
 
 These releases are unsupported and no longer receive updates. Users should update to a supported release.
 
+* link:/release/3.7/[Foreman 3.7 & Katello 4.9]
 * link:/release/3.6/[Foreman 3.6 & Katello 4.8]
 * link:/release/3.5/[Foreman 3.5 & Katello 4.7]
 * link:/release/3.4/[Foreman 3.4 & Katello 4.6]

--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -200,7 +200,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.9 - Katello 4.11 (RC)",
+    "title": "Foreman 3.9 - Katello 4.11 (supported)",
     "path": "3.9",
     "builds": [
       {
@@ -224,7 +224,7 @@ const navVersions = [
             "path": "Installing_Proxy"
           },
           {
-            "title": "Upgrading Foreman to Nightly",
+            "title": "Upgrading Foreman to 3.9",
             "path": "Upgrading_Project"
           },
           {
@@ -336,7 +336,7 @@ const navVersions = [
             "path": "Installing_Proxy"
           },
           {
-            "title": "Upgrading Katello to Nightly",
+            "title": "Upgrading Katello to 4.11",
             "path": "Upgrading_Project"
           },
           {
@@ -516,7 +516,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.7 - Katello 4.9 (supported)",
+    "title": "Foreman 3.7 - Katello 4.9 (unsupported)",
     "path": "3.7",
     "builds": [
       {


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
