### PR TITLE
Remove images from command line

### DIFF
--- a/guides/common/modules/proc_importing-kickstart-repositories.adoc
+++ b/guides/common/modules/proc_importing-kickstart-repositories.adoc
@@ -63,14 +63,14 @@ endif::[]
 ifeval::["{el-major-version}" == "7"]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# cp -a /mnt/iso/images/* /var/www/html/pub/{project-context}-import/content/dist/rhel/server/{el-major-version}/{el-major-version}.{el-minor-version}/x86_64/kickstart/
+# cp -a /mnt/iso/* /var/www/html/pub/{project-context}-import/content/dist/rhel/server/{el-major-version}/{el-major-version}.{el-minor-version}/x86_64/kickstart/
 ----
 endif::[]
 . Add the following entries to the listing files:
 +
 ifeval::["{el-major-version}" >= "8"]
 To the `/var/www/html/pub/{project-context}-import/content/dist/rhel{el-major-version}/{el-major-version}.{el-minor-version}/x86_64/appstream/listing` file, append `kickstart` with a new line.
-+ 
++
 To the `/var/www/html/pub/{project-context}-import/content/dist/rhel{el-major-version}/{el-major-version}.{el-minor-version}/x86_64/baseos/listing` file, append `kickstart` with a new line.
 +
 To the `/var/www/html/pub/{project-context}-import/content/dist/rhel8/listing` file, append the version number with a new line.


### PR DESCRIPTION
In the appendix for **Importing Kickstart Repositories for Red Hat
Enterprise Linux 7**, the step that states "Copy the kickstart files from
the ISO image:" uses the word "images" in the command line. It was
recommended to remove the word from the command line and you will copy
the packages in addition to the images. See
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2208077


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
