### PR TITLE
Remove AMQP port

### DIFF
--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -32,7 +32,6 @@ For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg`
 | Service | Port | Mode | Balance Mode | Destination
 | HTTP | 80 | TCP | roundrobin | port 80 on all {SmartProxyServers}
 | HTTPS and RHSM | 443 | TCP | source | port 443 on all {SmartProxyServers}
-| AMQP | 5647 | TCP | roundrobin | port 5647 on all {SmartProxyServers}
 | Anaconda for template retrieval | 8000 | TCP | roundrobin | port 8000 on all {SmartProxyServers}
 | Puppet (_Optional_)| 8140 | TCP | roundrobin | port 8140 on all {SmartProxyServers}
 | PuppetCA (_Optional_)| 8141 | TCP | roundrobin | port 8140 only on the system where you configure {SmartProxyServer} to sign Puppet certificates


### PR DESCRIPTION
Since katello-agent has been removed in the guides for 6.15, the
reference to the AMQP port needs to be removed as well since it is
related to the katello-agent feature.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
