### PR TITLE
Reword IPv4 and IPv6 HTTP Proxy requirement (#2608)

### DIFF
--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -8,23 +8,18 @@ ifndef::satellite[]
 For other operating systems, copy the newest GRUB build to `/var/lib/tftpboot/grub2/grubx64.efi`.
 endif::[]
 
-* You must deploy an external DHCP IPv6 server as a separate unmanaged service to bootstrap clients into GRUB2, which then configures IPv6 networking either using DHCPv6 or or assigning static IPv6 address.
+* You must deploy an external DHCP IPv6 server as a separate unmanaged service to bootstrap clients into GRUB2, which then configures IPv6 networking either using DHCPv6 or assigning static IPv6 address.
 This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide an integration API for managing IPv6 records, therefore the {SmartProxy} DHCP plug-in that provides DHCP management is limited to IPv4 subnets.
 
 ifdef::satellite[]
-* You must deploy an external IPv4 HTTP proxy server.
+* You must deploy an external HTTP proxy server that supports both IPv4 and IPv6.
 This is required because Red Hat Content Delivery Network distributes content only over IPv4 networks, therefore you must use this proxy to pull content into the {Project} on your IPv6 network.
 endif::[]
 
-ifdef::katello,foreman-el[]
+ifndef::satellite[]
 * Optional: If you rely on content from IPv4 networks, you must deploy an external IPv4 HTTP proxy server.
 This is required to access Content Delivery Networks that distribute content only over IPv4 networks, therefore you must use this proxy to pull content into {Project} on your IPv6 network.
 endif::[]
 
-ifndef::satellite[]
-+
-Note that this requirement is for Katello users only.
-endif::[]
-
-* You must configure {Project} to use this IPv4 HTTP proxy server as the default proxy.
+* You must configure {Project} to use this dual stack (supporting both IPv4 and IPv6) HTTP proxy server as the default proxy.
 For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{project-context}[Adding a Default HTTP Proxy to {Project}].


### PR DESCRIPTION
Presently, in setting up the Project in the IPv6 network, we mention only IPv4 type of HTTP Proxy server which is incorrect. Because, HTTP Proxy server configured with IPv4 only cannot communicate with Project configure in IPv6 network, except CDN.
Hence, it should support both, IPv4 and IPv6.

(cherry picked from commit 28d8c905c5bc6a9aea3315d2e8ceb0fcb0ba9d2c)
