### PR TITLE
Add LB prerequisite

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -1,6 +1,12 @@
 You can register hosts with {Project} using the host registration feature in the {ProjectWebUI}, Hammer CLI, or the {Project} API.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 
+ifeval::["{context}" == "load-balancing"]
+.Prerequisite
+* You have set the load balancer for host registration.
+For more information, see xref:Setting_the_Load_Balancer_for_Host_Registration_{context}[].
+endif::[]
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts > Register Host*.
 ifeval::["{context}" == "load-balancing"]


### PR DESCRIPTION
Clarify that LB has to be set for registration before the user can select the LB during global registration.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
