### PR TITLE
Fix the sequence of fapolicyd in Disconnected Server

### DIFF
--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -19,11 +19,11 @@ include::modules/proc_downloading-the-binary-dvd-images.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc[leveloffset=+1]
 
-include::modules/proc_installing-from-the-offline-repositories.adoc[leveloffset=+1]
-
 include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
 
 include::modules/proc_installing-fapolicyd-on-server.adoc[leveloffset=+2]
+
+include::modules/proc_installing-from-the-offline-repositories.adoc[leveloffset=+1]
 
 include::modules/proc_resolving-package-dependency-errors.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
