### PR TITLE
Add release notes for Foreman 3.9.1

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/foreman-3.9.1.adoc[leveloffset=+1]
 include::topics/foreman-3.9.0.adoc[leveloffset=+1]
 
 [appendix]

--- a/guides/doc-Release_Notes/topics/foreman-3.9.1.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.9.1.adoc
@@ -1,0 +1,12 @@
+= Foreman 3.9.1
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1797[Redmine]
+
+== Foreman
+
+* pass:[Broken link in Register Host documentation ] - https://projects.theforeman.org/issues/36966[#36966]
+
+=== Web Interface
+
+* pass:[Table index new button alignment in large screens] - https://projects.theforeman.org/issues/36963[#36963]
+* pass:[User dropdown shifted to the left when using foreman with plugins] - https://projects.theforeman.org/issues/36896[#36896]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
