### PR TITLE
Fix URL to download generic bootdisk

### DIFF
--- a/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
@@ -31,7 +31,7 @@ Generic image::
 A boot ISO that is not associated with a specific host.
 The ISO sends the host's MAC address to {ProjectServer}, which matches it against the host entry.
 The image does not store IP address details and requires access to a DHCP server on the network to bootstrap.
-This image is also available from the `/bootdisk/disks/generic` URL on your {ProjectServer}, for example, `\https://{foreman-example-com}/bootdisk/disks/generic`.
+This image is also available from the `/disks/generic` URL on your {ProjectServer}, for example, `\https://{foreman-example-com}/disks/generic`.
 endif::[]
 
 Subnet image::


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
