### PR TITLE
Clarify that Template SmartProxy procedure for upgrading Discovery is not always required

### DIFF
--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -3,18 +3,3 @@
 
 Some of the procedures in this section are optional.
 You can choose to perform only those procedures that are relevant to your installation.
-
-* xref:upgrading_discovery_parent[]
-ifdef::katello,satellite,orcharhino[]
-* xref:upgrading_virt_who[]
-endif::[]
-ifdef::satellite[]
-* xref:removing_satellite_tools_repository[]
-endif::[]
-ifdef::foreman-el,katello,orcharhino,satellite[]
-* xref:migrating-ansible-content_{context}[]
-endif::[]
-* xref:reclaiming-postgresql-space-after-an-upgrade_{context}[]
-ifndef::foreman-el,foreman-deb[]
-* xref:tuning-with-predefined-profiles_{context}[]
-endif::[]

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_parent.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_parent.adoc
@@ -13,3 +13,8 @@ During the upgrade, for every subnet with a TFTP proxy enabled, the template {Sm
 After the upgrade, check all subnets to verify this was set correctly.
 
 These procedures are not required if you do not use PXE booting of hosts to enable {Project} to discover new hosts.
+
+[role="_additional-resources"]
+.Additional resources
+
+For information about configuring the Discovery service, see {ProvisioningDocURL}Configuring_the_Discovery_Service_provisioning[Configuring the Discovery Service] in _{ProvisioningDocTitle}_.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_subnet_with_a_template_capsule.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_discovery_subnet_with_a_template_capsule.adoc
@@ -1,7 +1,8 @@
 [[verify_subnets_have_a_template_capsule]]
 = Verifying Subnets have a Template {SmartProxy}
 
-.Ensure all subnets with discovered hosts have a template {SmartProxy}:
+If the Templates feature is enabled in your environment, ensure all subnets with discovered hosts have a template {SmartProxy}:
+
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
 . Select the subnet you want to check.
 . On the *{SmartProxies}* tab, ensure a *Template {SmartProxy}* has been set for this subnet.


### PR DESCRIPTION
Per [BZ#2106016](https://bugzilla.redhat.com/show_bug.cgi?id=2106016), this PR is intended to clarify that a procedure related to upgrading the Discovery service is actually optional.

* The procedure introduction is rephrased to clarify its use case.
* A link is labeled as an additional resource and moved to a more suitable place.
* An internal table of contents is removed because it duplicates the automated ToC.

This PR targets version 3.3 because the procedure is not present in later versions.
If this PR gets merged, I will follow up with another one against version 3.1.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
