### PR TITLE
Clarify target of MQTT subscriptions

### DIFF
--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
@@ -30,8 +30,8 @@ To use `pull-mqtt` mode on {ProjectServer}, follow the procedure below:
 # firewall-cmd --runtime-to-permanent
 ----
 +
-In `pull-mqtt` mode, hosts subscribe for job notifications to either your {Project} or any {SmartProxyServer} through which they are registered.
-Therefore, it is recommended to ensure that {ProjectServer} sends remote execution jobs to that same {Project} (or {SmartProxy}).
+In `pull-mqtt` mode, hosts subscribe for job notifications to either your {ProjectServer} or any {SmartProxyServer} through which they are registered.
+Therefore, it is recommended to ensure that {ProjectServer} sends remote execution jobs to that same {ProjectServer} or {SmartProxyServer}.
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
 . On the *Content* tab, set the value of *Prefer registered through {SmartProxy} for remote execution* to *Yes*.
 


### PR DESCRIPTION
Rendered docs for Satellite: https://docs.theforeman.org/nightly/Installing_Server/index-satellite.html#configuring-remote-execution-for-pull-client-on-satellite-server_satellite

In orcharhino, this should say "either orcharhino Server or orcharhino Proxies". It is not visible in upstream.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
