### PR TITLE
Refs #36090 - Use installer support to remove REX cockpit

### DIFF
--- a/guides/common/modules/proc_disabling-cockpit-on-project.adoc
+++ b/guides/common/modules/proc_disabling-cockpit-on-project.adoc
@@ -17,6 +17,6 @@ Perform the following procedure if you want to disable {Cockpit} on {Project}.
 To prevent enabling {Cockpit} integration on a {SmartProxyServer}, run the following command after completing the procedure:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-cockpit-integration=false
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-cockpit-integration false
 ----
 ====

--- a/guides/common/modules/proc_disabling-cockpit-on-project.adoc
+++ b/guides/common/modules/proc_disabling-cockpit-on-project.adoc
@@ -4,22 +4,13 @@
 Perform the following procedure if you want to disable {Cockpit} on {Project}.
 
 .Procedure
-. Run this `{foreman-installer}` command:
+* Disable {Cockpit} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --no-enable-foreman-plugin-remote-execution-cockpit
+# {foreman-installer} --foreman-plugin-remote-execution-cockpit-ensure absent
 ----
-. In the {ProjectWebUI}, navigate to *Administer* > *Settings* and click the *Remote execution* tab.
-. In the *Cockpit URL* row, erase the setting under *Value* and click *Submit*.
-This removes the *Web Console* button from the {ProjectWebUI}.
-. Uninstall the {Cockpit} package from {Project}:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {project-package-remove} rubygem-foreman_remote_execution-cockpit
-----
-+
+
 [IMPORTANT]
 ====
 {Cockpit} integration can be independently enabled or disabled on {SmartProxyServers}.

--- a/guides/common/modules/proc_enabling-cockpit-on-server.adoc
+++ b/guides/common/modules/proc_enabling-cockpit-on-server.adoc
@@ -9,5 +9,5 @@ If you want to access {Cockpit} features for your hosts from within {Project}, y
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --enable-foreman-plugin-remote-execution-cockpit
+# {foreman-installer} --enable-foreman-plugin-remote-execution-cockpit --reset-foreman-plugin-remote-execution-cockpit-ensure
 ----


### PR DESCRIPTION
There is now proper support to disable the REX cockpit plugin. This is in the form of the ensure parameter. It also modifies the enable command since the installer may have remembered the ensure=absent part.

I'd like QE to verify and ACK this before we merge it.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.