### PR TITLE
Fix navigation in Managing Hosts

### DIFF
--- a/guides/common/modules/proc_troubleshooting-erb-templates.adoc
+++ b/guides/common/modules/proc_troubleshooting-erb-templates.adoc
@@ -3,7 +3,7 @@
 
 The {ProjectWebUI} provides two ways to verify the template rendering for a specific host:
 
-* *Directly in the template editor* – when editing a template (under *Hosts* > *Partition tables*, *Hosts* > *Templates* > *Provisioning Templates*, or *Hosts* > *Templates* > *Job templates*), on the *Template* tab click *Preview* and select a host from the list.
+* *Directly in the template editor* – when editing a template (under *Hosts* > *Templates* > *Partition tables*, *Hosts* > *Templates* > *Provisioning Templates*, or *Hosts* > *Templates* > *Job templates*), on the *Template* tab click *Preview* and select a host from the list.
 The template then renders in the text field using the selected host's parameters.
 Preview failures can help to identify issues in your template.
 

--- a/guides/common/modules/proc_using-autocompletion-in-templates.adoc
+++ b/guides/common/modules/proc_using-autocompletion-in-templates.adoc
@@ -5,7 +5,7 @@ You can access a list of available macros and usage information in the template 
 This works for all templates within {Project}.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to either *Hosts* > *Partition tables*, *Hosts* > *Templates* > *Provisioning Templates*, or *Hosts* > *Templates* > *Job templates*.
+. In the {ProjectWebUI}, navigate to either *Hosts* > *Templates* > *Partition tables*, *Hosts* > *Templates* > *Provisioning Templates*, or *Hosts* > *Templates* > *Job templates*.
 . Click the *settings* icon at the top right corner of the template editor and select *Autocompletion*.
 . Press `*Ctrl*` + `*Space*` in the template editor to access a list of all available macros.
 You can narrow down the list of macros by typing in more information about what you are looking for.


### PR DESCRIPTION
This change is required for the new vertical navigation. It was probably missed during an earlier update.
https://bugzilla.redhat.com/show_bug.cgi?id=2256016

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
