### PR TITLE
Add missing permission for VMware provisioning with cloud-init

### DIFF
--- a/guides/common/modules/proc_creating-a-vmware-user.adoc
+++ b/guides/common/modules/proc_creating-a-vmware-user.adoc
@@ -14,6 +14,7 @@ For VMware vCenter Server version 6.7, set the following permissions:
 * All Privileges -> Virtual Machine -> Interaction (All)
 * All Privileges -> Virtual Machine -> Edit Inventory (All)
 * All Privileges -> Virtual Machine -> Provisioning (All)
+* All Privileges -> Virtual Machine -> Guest Operations (All)
 
 Note that the same steps also apply to VMware vCenter Server version 7.0.
 
@@ -26,3 +27,4 @@ For VMware vCenter Server version 6.5, set the following permissions:
 * All Privileges -> Virtual Machine -> Interaction (All)
 * All Privileges -> Virtual Machine -> Inventory (All)
 * All Privileges -> Virtual Machine -> Provisioning (All)
+* All Privileges -> Virtual Machine -> Guest Operations (All)


### PR DESCRIPTION
This vCenter permission is required for successful provisioning with cloud-init.
https://bugzilla.redhat.com/show_bug.cgi?id=2256509

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
