### PR TITLE
Add ability to generate TOC file for testing links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN dnf upgrade -y && \
                    make \
                    redhat-rpm-config \
                    ruby-devel \
-                   rubygem-asciidoctor && \
+                   rubygem-asciidoctor \
+                   rubygem-nokogiri && \
     dnf groupinstall -y development-tools && \
     gem install sass
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 gem 'asciidoctor'
 gem 'sass'
+
+# For TOC generation
+gem 'nokogiri'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DEST := result
 PORT := 5000
 VERSION_LINKS := 3.11 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.5 2.4
 
-.PHONY: all clean html web compile serve prep FORCE
+.PHONY: all clean html web compile serve prep FORCE toc
 
 UNAME = $(shell uname)
 ifeq ($(UNAME), Linux)
@@ -39,5 +39,8 @@ compile: web html
 
 serve: compile
 	python3 -m http.server --directory ./$(DEST) $(PORT)
+
+toc: html
+	$(MAKE) -C guides/ toc
 
 FORCE:

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -24,3 +24,7 @@ linkchecker-tryer:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | ./scripts/linkchecker-tryer
 
 ccutil: $(SUBDIRS)
+
+toc:
+	make BUILD=satellite html
+	F2L=upstream_filename_to_satellite_link.json ./scripts/extract_links_toc build/**/index-satellite.html > build/toc.json

--- a/guides/README.md
+++ b/guides/README.md
@@ -115,6 +115,38 @@ This requires the cloned git repository plus an application such as Podman or Do
        rm -rf guides/build && podman run --rm -v $(pwd):/foreman-documentation:Z foreman_documentation make html
 
 
+## Generating a TOC file
+
+For properly testing link integrity in the code, you will need to generate a TOC file.
+This file can be generated using `make toc` command either from a container or locally.
+
+This command generates a JSON file that later can be consumed by link validation code.
+The basic structure of the file is a nested path parts in the documentation links. For example:
+``` json
+{
+  "administering_red_hat_satellite": {
+    "accessing_server_admin": [
+      "Logging_in_admin",
+      "Using_FreeIPA_credentials_to_log_in_to_the_foreman_Hammer_CLI_admin",
+      "Using_FreeIPA_credentials_to_log_in_to_the_foreman_web_UI-with-a-Firefox-browser_admin",
+      "Using_FreeIPA_credentials_to_log_in_to_the_foreman_web_UI-with-a-Chrome-browser_admin",
+      "Navigation_Tabs_in_the_Web_UI_admin",
+      "Changing_the_Password_admin",
+      "Resetting_the_Administrative_User_Password_admin",
+      "Setting_a_Custom_Message_on_the_Login_Page_admin"
+    ],
+  }
+}
+```
+which can be used for validating `administering_red_hat_satellite/accessing_server_admin#Logging_in_admin` link.
+
+Note: The translation of book file names to root part of the link path is dependent on [`upstream_filename_to_satellite_link.json`](./upstream_filename_to_satellite_link.json) file.
+For example `build/Administering_Project/index-satellite.html` would be translated to `.../administering_red_hat_satellite/...` path in the TOC.
+File names that are missing from this JSON file would be omitted from the TOC.
+
+Currently the main use of the TOC file is for downstream links validation in [`foreman_theme_satellite`](https://github.com/RedHatSatellite/foreman_theme_satellite/commit/7fb213daa8929b1e5ceb7999a79dbc8eebd3500d).
+In order to implement the same technique for the upstream documentation, there is need to extract links from the code.
+
 ## Contribution guidelines
 
 Please read these guidelines before opening a Pull Request.

--- a/guides/scripts/extract_links_toc
+++ b/guides/scripts/extract_links_toc
@@ -1,0 +1,35 @@
+#!/usr/bin/ruby
+
+# This is a utility to extract the structure of the documentation as a TOC-like json file
+# this json file will be used later to verify links to the documentation in the Foreman UI.
+
+require 'nokogiri'
+require 'json'
+
+unless (f2l_file = ENV['F2L'])
+  STDERR.puts "Must specify folder to link file: F2L="
+  exit 1
+end
+
+filename_to_link = JSON.parse(File.read(f2l_file))
+
+files = ARGV
+
+toc = {}
+
+files.each do |file|
+  next unless (link_name = filename_to_link[file])
+
+  document = Nokogiri::HTML.parse(File.open(file))
+
+  file_toc = document.css('h2').to_h do |chapter|
+    [
+      chapter['id'].downcase,
+      (chapter.parent.css('h3') + chapter.parent.css('div[id]')).map {|subchapter| subchapter['id']}
+    ]
+  end
+
+  toc[link_name] = file_toc
+end
+
+$stdout << JSON.pretty_generate(toc)

--- a/guides/upstream_filename_to_satellite_link.json
+++ b/guides/upstream_filename_to_satellite_link.json
@@ -1,0 +1,19 @@
+{
+  "build/Administering_Project/index-satellite.html": "administering_red_hat_satellite",
+  "build/Configuring_Load_Balancer/index-satellite.html": "configuring_capsules_with_a_load_balancer",
+  "build/Deploying_Project_on_AWS/index-satellite.html": "deploying_red_hat_satellite_on_amazon_web_services",
+  "build/Installing_Proxy/index-satellite.html": "installing_capsule_server",
+  "build/Installing_Server/index-satellite.html": "installing_satellite_server_in_a_connected_network_environment",
+  "build/Installing_Server_Disconnected/index-satellite.html": "installing_satellite_server_in_a_disconnected_network_environment",
+  "build/Managing_Configurations_Ansible/index-satellite.html": "managing_configurations_using_ansible_integration_in_red_hat_satellite",
+  "build/Managing_Configurations_Puppet/index-satellite.html": "managing_configurations_using_puppet_integration_in_red_hat_satellite",
+  "build/Managing_Content/index-satellite.html": "managing_content",
+  "build/Managing_Hosts/index-satellite.html": "managing_hosts",
+  "build/Provisioning_Hosts/index-satellite.html": "provisioning_hosts",
+  "build/Planning_for_Project/index-satellite.html": "overview_concepts_and_deployment_considerations",
+  "build/Tuning_Performance/index-satellite.html": "tuning_performance_of_red_hat_satellite",
+  "build/Managing_Security_Compliance/index-satellite.html": "managing_security_compliance",
+  "build/Upgrading_Project/index-satellite.html": "upgrading_connected_red_hat_satellite_to_6.15",
+  "build/Upgrading_Project_Disconnected/index-satellite.html": "upgrading_disconnected_red_hat_satellite_to_6.15",
+  "build/Updating_Project/index-satellite.html": "updating_red_hat_satellite"
+}


### PR DESCRIPTION
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

This commit adds the ability to generate a TOC file that can be used to test documentation links.
This is done in the theme PR: https://github.com/RedHatSatellite/foreman_theme_satellite/pull/31

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
