### PR TITLE
Hide guides that aren't ready from the navigations

### DIFF
--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -212,56 +212,12 @@ const navVersions = [
             "path": "Release_Notes"
           },
           {
-            "title": "Quickstart Guide",
-            "path": "Quickstart"
-          },
-          {
-            "title": "Installing Foreman Server",
-            "path": "Installing_Server"
-          },
-          {
-            "title": "Installing Smart Proxy",
-            "path": "Installing_Proxy"
-          },
-          {
             "title": "Upgrading Foreman to 3.9",
             "path": "Upgrading_Project"
           },
           {
-            "title": "Deploying Foreman on AWS",
-            "path": "Deploying_Project_on_AWS"
-          },
-          {
-            "title": "Provisioning Hosts",
-            "path": "Provisioning_Hosts"
-          },
-          {
-            "title": "Managing Hosts",
-            "path": "Managing_Hosts"
-          },
-          {
             "title": "Configuring Hosts Using Ansible",
             "path": "Managing_Configurations_Ansible"
-          },
-          {
-            "title": "Configuring Hosts Using Puppet",
-            "path": "Managing_Configurations_Puppet"
-          },
-          {
-            "title": "Configuring Hosts Using Salt",
-            "path": "Managing_Configurations_Salt"
-          },
-          {
-            "title": "Managing Security Compliance",
-            "path": "Managing_Security_Compliance"
-          },
-          {
-            "title": "Administering Foreman",
-            "path": "Administering_Project"
-          },
-          {
-            "title": "Application Centric Deployment",
-            "path": "Deploying_Hosts_AppCentric"
           },
           {
             "title": "Monitoring Foreman Performance",
@@ -278,32 +234,8 @@ const navVersions = [
             "path": "Release_Notes"
           },
           {
-            "title": "Quickstart Guide",
-            "path": "Quickstart"
-          },
-          {
-            "title": "Installing Foreman Server",
-            "path": "Installing_Server"
-          },
-          {
-            "title": "Deploying Foreman on AWS",
-            "path": "Deploying_Project_on_AWS"
-          },
-          {
-            "title": "Provisioning Hosts",
-            "path": "Provisioning_Hosts"
-          },
-          {
             "title": "Configuring Hosts Using Ansible",
             "path": "Managing_Configurations_Ansible"
-          },
-          {
-            "title": "Configuring Hosts Using Puppet",
-            "path": "Managing_Configurations_Puppet"
-          },
-          {
-            "title": "Administering Foreman",
-            "path": "Administering_Project"
           },
           {
             "title": "Monitoring Foreman Performance",

--- a/web/content/release-3.9.adoc
+++ b/web/content/release-3.9.adoc
@@ -10,18 +10,11 @@ Use the top menu bar for navigation for all guides.
 
 === Quickstart
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on RHEL/CentOS Quickstart Guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu Quickstart Guide]
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
 
 === Installation
 
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
 
 === Upgrading


### PR DESCRIPTION
These guides don't render anything other than a warning that they're not ready, so not helpful to users. It's best to not give the illusion they are.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.