### PR TITLE
Keep firewall-cmd for mqtt consistent

### DIFF
--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
@@ -26,7 +26,7 @@ To use `pull-mqtt` mode on {ProjectServer}, follow the procedure below:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# firewall-cmd --add-port="1883/tcp"
+# firewall-cmd --add-service=mqtt
 # firewall-cmd --runtime-to-permanent
 ----
 +


### PR DESCRIPTION
In the Installation Guide, we use 1883/tcp port in the firewall-cmd but in the Capsule Guide, we use mqtt service. Both do the same job but the commands are different. Hence, we should keep it consistent and I prefer -add-service=mqtt to align with the procedure. And, according to https://github.com/firewalld/firewalld/blob/main/config/services/mqtt.xml#L5

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
