### PR TITLE
Fix wording on sync to Smart Proxy Server

### DIFF
--- a/guides/common/modules/proc_adding-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_adding-lifecycle-environments.adoc
@@ -70,7 +70,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 --lifecycle-environment-id _My_Lifecycle_Environment_ID_
 ----
 +
-* To synchronize all content from your {ProjectServer} to your {SmartProxyServer} without skipping checks on metadata:
+* To synchronize all content from your {ProjectServer} to your {SmartProxyServer} without checking metadata:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
In Foreman+Katello, a "complete sync" does not rely on already existing metadata. Instead, the content is synchronized as if there was no metadata existing.
In the Web UI, it's called "Complete Sync"; for Hammer CLI, you use "--skip-metadata-check".
"skipping checks on metadata" or "without checking metadata" is technically correct.

Fixes https://github.com/theforeman/foreman-documentation/pull/2664#issuecomment-1889317012

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)

![image](https://github.com/theforeman/foreman-documentation/assets/12595287/688e9b6e-b334-42cf-b1d0-e914bbea05f0)
