### PR TITLE
Remove unsupported LB feature 3.4

### DIFF
--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -41,8 +41,6 @@ include::common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-cert
 
 include::common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc[leveloffset=+3]
 
-include::common/modules/proc_setting-the-load-balancer-for-host-registration.adoc[leveloffset=+1]
-
 include::common/modules/proc_installing-the-load-balancer.adoc[leveloffset=+1]
 
 include::common/modules/proc_verifying-the-load-balancer-configuration.adoc[leveloffset=+1]


### PR DESCRIPTION
Setting the load balancer for registration by using the `--foreman-proxy-registration-url` installer argument is not supported until Foreman 3.5.
https://bugzilla.redhat.com/show_bug.cgi?id=2255528

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
