### PR TITLE
Clean up Install Media over NFS protocol in Provisioning

### DIFF
--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -15,7 +15,7 @@ You can view installation media by navigating to *Hosts* > *Provisioning Setup* 
 
 Installation media must be in the format of an operating system installation tree and must be accessible from the machine hosting the installer through an HTTP URL.
 
-ifndef::orcharhino,satellite[]
+ifndef::satellite[]
 [NOTE]
 ====
 Other protocols, such as HTTPS or NFS, are known to work but have not been tested.

--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -11,8 +11,20 @@ You can use this parameter to install third-party content.
 Red Hat content is delivered through repository syncing instead.
 endif::[]
 
-Installation media must be in the format of an operating system installation tree, and must be accessible to the machine hosting the installer through an HTTP URL.
-You can view installation media by navigating to *Hosts* > *Provisioning Setup* > *Installation Media* menu.
+You can view installation media by navigating to *Hosts* > *Provisioning Setup* > *Installation Media*.
+
+Installation media must be in the format of an operating system installation tree and must be accessible from the machine hosting the installer through an HTTP URL.
+
+ifndef::orcharhino,satellite[]
+[NOTE]
+====
+Other protocols, such as HTTPS or NFS, are known to work but have not been tested.
+{Team} recommends using HTTP.
+
+You can hypothetically use NFS share for PXE-based provisioning in a semi-automated way by copying the `initrd.img` and `vmlinuz` files from the NFS source to `/var/lib/tftpboot/boot` on {SmartProxy} with the expected names.
+Only then PXE booting can proceed further.
+====
+endif::[]
 
 ifndef::orcharhino[]
 By default, {Project} includes installation media for some official Linux distributions.
@@ -20,7 +32,7 @@ Note that some of those installation media are targeted for a specific version o
 For example *CentOS mirror (7.x)* must be used for CentOS 7 or earlier, and *CentOS mirror (8.x)* must be used for CentOS 8 or later.
 endif::[]
 
-If you want to improve download performance when using installation media to install operating systems on multiple host, you must modify the *Path* of the installation medium to point to the closest mirror or a local copy.
+If you want to improve download performance when using installation media to install operating systems on multiple hosts, you must modify the *Path* of the installation medium to point to the closest mirror or a local copy.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-installation-media_{context}[].
 
@@ -28,7 +40,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-installati
 . In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Setup* > *Installation Media*.
 . Click *Create Medium*.
 . In the *Name* field, enter a name to represent the installation media entry.
-. In the *Path* enter the URL or NFS share that contains the installation tree.
+. In the *Path* enter the URL that contains the installation tree.
 ifdef::client-content-dnf[]
 You can use following variables in the path to represent multiple different system architectures and versions:
   * `$arch` {endash} The system architecture.
@@ -42,6 +54,7 @@ Example HTTP path:
 ----
 http://download.example.com/{client-installation-medium}/$version/Server/$arch/os/
 ----
+ifndef::orcharhino,satellite[]
 +
 Example NFS path:
 +
@@ -51,9 +64,11 @@ nfs://download.example.com:/{client-installation-medium}/$version/Server/$arch/o
 ----
 +
 endif::[]
+endif::[]
+ifndef::orcharhino,satellite[]
 Synchronized content on {SmartProxyServers} always uses an HTTP path.
 {SmartProxyServer} managed content does not support NFS paths.
-+
+endif::[]
 . From the *Operating system family* list, select the distribution or family of the installation medium.
 ifndef::orcharhino[]
 For example, CentOS and Fedora are in the `Red Hat` family.


### PR DESCRIPTION
Pulling Installation Media over the NFS protocol is technically possible, however, it's untested (at least in Satellite) and it doesn't work in the fully-automated way. Therefore, I'm suggesting to remove NFS mentions for downstream in order to set the right expectations for our customers. However, I'd keep it in upstream builds with a note.

https://bugzilla.redhat.com/show_bug.cgi?id=1896771

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
