### PR TITLE
Add ports to allow incoming traffic

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -31,7 +31,7 @@ The following tables indicate the destination port and the direction of network 
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
-| 443, 80 | TCP | HTTPS, HTTP| Client | Global Registration | Registering hosts to {Project}
+| 443, 80 | TCP | HTTPS, HTTP | Client | Global Registration | Registering hosts to {Project}
 
 Port 443 is required for registration initiation, uploading facts, and sending installed packages and traces
 

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -31,18 +31,16 @@ The following tables indicate the destination port and the direction of network 
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
+| 443, 80 | TCP | HTTPS, HTTP| Client | Global Registration | Registering hosts to {Project}
+
+Port 443 is required for registration initiation, uploading facts, and sending installed packages and traces
+
+Port 80 notifies {Project} on the `/unattended/built` endpoint that registration has finished
 ifdef::katello,satellite,orcharhino[]
-| 443 | TCP | HTTPS | Client | Content Host registration | Initiation
-
-Uploading facts
-
-Sending installed packages and traces
 | 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | Katello CA Consumer RPM
-| 443, 80 | TCP | HTTPS, HTTP| Client | Global Registration | Allow incoming traffic to {Project} for host registration
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |

--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -32,9 +32,6 @@ The following tables indicate the destination port and the direction of network 
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
 ifdef::katello,satellite,orcharhino[]
-| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
 | 443 | TCP | HTTPS | Client | Content Host registration | Initiation
 
 Uploading facts
@@ -42,6 +39,10 @@ Uploading facts
 Sending installed packages and traces
 | 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
+| 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | Katello CA Consumer RPM
+| 443, 80 | TCP | HTTPS, HTTP| Client | Global Registration | Allow incoming traffic to {Project} for host registration
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |


### PR DESCRIPTION
Earlier, no ports were mentioned in the document about allowing incoming traffic to Satellite from the Client for Global Registration. We added those ports now. Also, we modified the description for Content Host Registration. I have made some adjustments in the table sequence for better readability.

https://bugzilla.redhat.com/show_bug.cgi?id=2247445

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
