### PR TITLE
Add note about Capsules behind load balancers

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -39,7 +39,6 @@ endif::[]
 ====
 A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the host's content source.
 ====
-
 ifdef::katello,satellite,orcharhino[]
 . In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
 endif::[]

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -34,10 +34,10 @@ ifndef::satellite,orcharhino[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.
 endif::[]
 . Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
++
 [NOTE]
 ====
-If you have {SmartProxies} behind a load balancer, the host's content source is set to one of the {SmartProxies} behind the load balancer. 
-This {SmartProxy} might not be the same as the one you select here.
+A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the host's content source.
 ====
 
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -34,6 +34,12 @@ ifndef::satellite,orcharhino[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.
 endif::[]
 . Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
+[NOTE]
+====
+If you have {SmartProxies} behind a load balancer, the host's content source is set to one of the {SmartProxies} behind the load balancer. 
+This {SmartProxy} might not be the same as the one you select here.
+====
+
 ifdef::katello,satellite,orcharhino[]
 . In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
 endif::[]


### PR DESCRIPTION
A note was required to describe what happens to a
content source when
there are Capsules behind a load balancer.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
