### PR TITLE
Provisioning VMs on KubeVirt

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -79,7 +79,10 @@
 :ISS: Inter-Server Synchronization
 :Keycloak-short: Keycloak
 :Keycloak: Keycloak
+:Kubernetes: Kubernetes
 :KubeVirt: KubeVirt
+:a-KubeVirt: a KubeVirt
+:kubevirt-command: kubectl
 :LoraxCompose: Lorax Composer
 :loadbalancer-example-com: loadbalancer.example.com
 :nfs-client-package: nfs-utils

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -79,7 +79,10 @@
 :ISS: Inter-Satellite Synchronization
 :Keycloak-short: RHSSO
 :Keycloak: Red{nbsp}Hat Single Sign-On
+:Kubernetes: OpenShift Container Platform
 :KubeVirt: OpenShift Virtualization
+:a-KubeVirt: an OpenShift Virtualization
+:kubevirt-command: oc
 :LoraxCompose: Red{nbsp}Hat Image Builder
 :OpenStack: Red{nbsp}Hat OpenStack Platform
 :ovirt-example-com: rhv.example.com

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -1,11 +1,11 @@
 [id="Provisioning_Virtual_Machines_Kubevirt_{context}"]
 = Provisioning Virtual Machines on {KubeVirt}
 
-{KubeVirt} addresses the needs of development teams that have adopted or want to adopt Kubernetes but possess existing virtual machine (VM)-based workloads that cannot be easily containerized.
+{KubeVirt} addresses the needs of development teams that have adopted or want to adopt {Kubernetes} but possess existing virtual machine (VM) workloads that cannot be easily containerized.
 This technology provides a unified development platform where developers can build, modify, and deploy applications residing in application containers and VMs in a shared environment.
 These capabilities support rapid application modernization across the open hybrid cloud.
 
-With {Project}, you can create a compute resource for {KubeVirt} so that you can provision and manage Kubernetes virtual machines using {Project}.
+With {Project}, you can create a compute resource for {KubeVirt} so that you can provision and manage virtual machines in {Kubernetes} using {Project}.
 
 ifdef::satellite[]
 Note that template provisioning is not supported for this release.
@@ -22,11 +22,8 @@ endif::[]
 
 .Prerequisites
 include::snip_prerequisites-common-compute-resource.adoc[]
-* A {KubeVirt} user that has the `cluster-admin` permissions for the Openshift Container Platform virtual cluster.
-ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.1/html/authentication/using-rbac[Using RBAC to Define and Apply Permissions] in the _Authentication_ guide of the Openshift Container Platform documentation.
-endif::[]
-* A {SmartProxyServer} managing a network on the {KubeVirt} server.
+* You must have `cluster-admin` permissions for the {Kubernetes} cluster.
+* A {SmartProxyServer} managing a network on the {Kubernetes} cluster.
 Ensure that no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 For more information about network service configuration for {SmartProxyServers}, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
 

--- a/guides/common/modules/proc_adding-kubevirt-connection.adoc
+++ b/guides/common/modules/proc_adding-kubevirt-connection.adoc
@@ -1,5 +1,5 @@
 [id="adding-kubevirt-connection_{context}"]
-= Adding a {KubeVirt} Connection to {ProjectServer}
+= Adding {a-KubeVirt} Connection to {ProjectServer}
 
 Use this procedure to add {KubeVirt} as a compute resource in {Project}.
 
@@ -12,28 +12,30 @@ Use this procedure to add {KubeVirt} as a compute resource in {Project}.
 # {foreman-installer} --enable-foreman-plugin-kubevirt
 ----
 
-. Generate a bearer token to use for HTTP and HTTPs authentication.
-On the {KubeVirt} server, list the secrets that contain tokens:
-+
-----
-# kubectl get secrets
-----
+. Obtain a token to use for HTTP and HTTPs authentication:
 
-. List the token for your secret:
+.. Log in to the {Kubernetes} cluster and list the secrets that contain tokens:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# kubectl get secrets _YOUR_SECRET_ -o jsonpath='{.data.token}' | base64 -d | xargs
+$ {kubevirt-command} get secrets
 ----
+
+.. Obtain the token for your secret:
 +
-Make a note of this token to use later in this procedure.
+[options="nowrap" subs="+quotes,attributes"]
+----
+$ {kubevirt-command} get secrets _MY_SECRET_ -o jsonpath='{.data.token}' | base64 -d | xargs
+----
+
+.. Record the token to use later in this procedure.
 
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*, and click *Create Compute Resource*.
 . In the *Name* field, enter a name for the new compute resource.
 . From the *Provider* list, select *{KubeVirt}*.
 . In the *Description* field, enter a description for the compute resource.
-. In the *Hostname* field, enter the FQDN, hostname, or IP address of the {KubeVirt} server that you want to use.
+. In the *Hostname* field, enter the FQDN, hostname, or IP address of the {Kubernetes} cluster.
 . In the *API Port* field, enter the port number that you want to use for provisioning requests from {Project} to {KubeVirt}.
-. In the *Namespace* field, enter the user name of the {KubeVirt} virtual cluster that you want to use.
+. In the *Namespace* field, enter the user name of the {Kubernetes} cluster.
 . In the *Token* field, enter the bearer token for HTTP and HTTPs authentication.
 . Optional: In the *X509 Certification Authorities* field, enter a certificate to enable client certificate authentication for API server calls.


### PR DESCRIPTION
Small fixes for KubeVirt/OpenShift Virtalization in the "Provisioning hosts" guide.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
