### PR TITLE
Add link as example for HAProxy ports configuration

### DIFF
--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -24,6 +24,9 @@ However, you can install any suitable load balancing software solution that supp
 ----
 . Configure the load balancer to balance the network load for the ports as described in xref:ports-configuration-for-the-load-balancer[].
 For example, to configure ports for HAProxy, edit the `/etc/haproxy/haproxy.cfg` file to correspond with the table.
+ifdef::satellite[]
+For more information, see https://access.redhat.com/solutions/4062981[Configuration example for haproxy.cfg for HAProxy load balancer with Satellite 6] in the _Red{nbsp}Hat Knowledgebase_.
+endif::[]
 +
 [id='ports-configuration-for-the-load-balancer']
 .Ports Configuration for the Load Balancer


### PR DESCRIPTION
We cannot document the configuration example for the HAproxy ports as the cases will be unique with each deployment and we do not test & maintain this every release. Hence, we have added an example link for end-users that can help them configure ports for the HAProxy load balancer with the project.

https://bugzilla.redhat.com/show_bug.cgi?id=1993604

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
