### PR TITLE
WIP Describe which settings get updated after host group change

### DIFF
--- a/guides/common/modules/proc_adding-a-host-to-a-host-group.adoc
+++ b/guides/common/modules/proc_adding-a-host-to-a-host-group.adoc
@@ -12,3 +12,4 @@ You can add a host to a host group in the {ProjectWebUI}.
 
 .Verification
 * The *Details* card under the *Overview* tab now shows the host group your host belongs to.
+The host settings defined in the host group are now applied to the host.

--- a/guides/common/modules/proc_changing-the-host-group-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-host-group-of-a-host.adoc
@@ -1,9 +1,12 @@
 [id="Changing_the_Host_Group_of_a_Host_{context}"]
 = Changing the host group of a host
 
-Use this procedure to change the Host Group of a host.
+Use this procedure to change the host group of a host.
 
+[NOTE]
+====
 If you reprovision a host after changing the host group, the fresh values that the host inherits from the host group will be applied.
+====
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
@@ -14,3 +17,4 @@ If you reprovision a host after changing the host group, the fresh values that t
 
 .Verification
 * The *Details* card under the *Overview* tab now shows the host group your host belongs to.
+The host settings now show the settings defined by the host group.

--- a/guides/common/modules/proc_creating-a-host.adoc
+++ b/guides/common/modules/proc_creating-a-host.adoc
@@ -2,6 +2,7 @@
 = Creating a host in {ProjectName}
 
 Use this procedure to create a host in {ProjectName}.
+
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-host_{context}[].
 
 .Procedure


### PR DESCRIPTION
Still work in progress, don't review yet.

Partially a follow-up for https://github.com/theforeman/foreman-documentation/pull/2685

Will include https://bugzilla.redhat.com/show_bug.cgi?id=2253496, https://github.com/Katello/katello/pull/10841, and https://github.com/theforeman/foreman-documentation/pull/2685#pullrequestreview-1835363249. Also, I want to make sure the procedures use consistent terminology for "host [group] settings" (not "attributes" or "properties").

* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
