### PR TITLE
Refs #33337 - Reflect Puppet isn't enabled by default

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -20,14 +20,14 @@ An internal label that matches the value is also created and cannot be changed a
 If you do not specify a value, an organization called *Default Organization* with the label *Default_Organization* is created.
 You can rename the organization name but not the label.
 
-* By default, all configuration files configured by the installer are managed by Puppet.
-When `{foreman-installer}` runs, it overwrites any manual changes to the Puppet managed files with the initial values.
+* By default, all configuration files configured by the installer are managed.
+When `{foreman-installer}` runs, it overwrites any manual changes to the managed files with the initial values.
 ifdef::foreman-el,foreman-deb[]
 By default, {ProjectServer} is installed with the Puppet agent running as a service.
 If required, you can disable Puppet agent on {ProjectServer} using the `--puppet-runmode=none` option.
 endif::[]
 
-* If you want to manage DNS files and DHCP files manually, use the `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false` options so that Puppet does not manage the files related to the respective services.
+* If you want to manage DNS files and DHCP files manually, use the `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false` options so that the installer does not manage the files related to the respective services.
 For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
 
 .Procedure

--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -22,8 +22,10 @@ You can rename the organization name but not the label.
 
 * By default, all configuration files configured by the installer are managed by Puppet.
 When `{foreman-installer}` runs, it overwrites any manual changes to the Puppet managed files with the initial values.
+ifdef::foreman-el,foreman-deb[]
 By default, {ProjectServer} is installed with the Puppet agent running as a service.
 If required, you can disable Puppet agent on {ProjectServer} using the `--puppet-runmode=none` option.
+endif::[]
 
 * If you want to manage DNS files and DHCP files manually, use the `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false` options so that Puppet does not manage the files related to the respective services.
 For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].


### PR DESCRIPTION
Since Foreman 3.1 Puppet hasn't been enabled in the Katello scenario, but it is in vanilla Foreman. It also rephrases the installer managed parts to avoid the implication that Puppet runs as a deamon.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.