### PR TITLE
Reflect that only Katello has organization labels

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -16,9 +16,15 @@ If you do not specify any values, the default values are used.
 
 * Specify a meaningful value for the option: `--foreman-initial-organization`.
 This can be your company name.
+ifdef::katello,satellite,orcharhino[]
 An internal label that matches the value is also created and cannot be changed afterwards.
 If you do not specify a value, an organization called *Default Organization* with the label *Default_Organization* is created.
 You can rename the organization name but not the label.
+endif::[]
+ifndef::katello,satellite,orcharhino[]
+If you do not specify a value, an organization called *Default Organization* is created.
+You can change the organization name later.
+endif::[]
 
 * By default, all configuration files configured by the installer are managed.
 When `{foreman-installer}` runs, it overwrites any manual changes to the managed files with the initial values.


### PR DESCRIPTION
In Foreman organizations don't have labels. This is added by Katello via an extension of the model.

I only selected supported branches, but I think it applies all the way back.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.