### PR TITLE
Add IPAM method for Infoblox

### DIFF
--- a/guides/common/modules/con_using-infoblox-as-dhcp-and-dns-providers.adoc
+++ b/guides/common/modules/con_using-infoblox-as-dhcp-and-dns-providers.adoc
@@ -3,6 +3,4 @@
 
 You can use {SmartProxyServer} to connect to your Infoblox application to create and manage DHCP and DNS records, and to reserve IP addresses.
 
-ifdef::satellite[]
-The supported Infoblox version is NIOS 8.0 or higher and {ProjectXY} or higher.
-endif::[]
+The supported Infoblox version is NIOS 8.0 or higher.

--- a/guides/common/modules/proc_installing-the-dhcp-infoblox-module.adoc
+++ b/guides/common/modules/proc_installing-the-dhcp-infoblox-module.adoc
@@ -7,11 +7,11 @@ Note that you cannot manage records in separate views.
 You can also install DHCP and DNS Infoblox modules simultaneously by combining this procedure and xref:Installing_the_DNS_Infoblox_Module_{context}[].
 
 .DHCP Infoblox Record Type Considerations
-Use only the `--foreman-proxy-plugin-dhcp-infoblox-record-type fixedaddress` option to configure the DHCP and DNS modules.
+If you want to use the DHCP and DNS Infoblox modules together, configure the DHCP Infoblox module with the `fixedaddress` record type only.
+The `host` record type causes DNS conflicts and is not supported.
 
-Configuring both DHCP and DNS Infoblox modules with the `host` record type setting causes DNS conflicts and is not supported.
-If you install the Infoblox module on {SmartProxyServer} with the `--foreman-proxy-plugin-dhcp-infoblox-record-type` option set to `host`, you must unset both DNS {SmartProxy} and Reverse DNS {SmartProxy} options because Infoblox does the DNS management itself.
-You cannot use the `host` option without creating conflicts and, for example, being unable to rename hosts in {Project}.
+If you configure the DHCP Infoblox module with the `host` record type, you have to unset both DNS {SmartProxy} and Reverse DNS {SmartProxy} options on your Infoblox-managed subnets, because Infoblox does DNS management by itself.
+Using the `host` record type leads to creating conflicts and being unable to rename hosts in {Project}.
 
 .Procedure
 . On {SmartProxy}, enter the following command:
@@ -20,18 +20,14 @@ You cannot use the `host` option without creating conflicts and, for example, be
 ----
 # {foreman-installer} --enable-foreman-proxy-plugin-dhcp-infoblox \
 --foreman-proxy-dhcp true \
---foreman-proxy-dhcp-managed false \
 --foreman-proxy-dhcp-provider infoblox \
 --foreman-proxy-dhcp-server _infoblox.example.com_ \
---foreman-proxy-plugin-dhcp-infoblox-dns-view default \
---foreman-proxy-plugin-dhcp-infoblox-network-view default \
---foreman-proxy-plugin-dhcp-infoblox-password infoblox \
+--foreman-proxy-plugin-dhcp-infoblox-username _admin_ \
+--foreman-proxy-plugin-dhcp-infoblox-password _infoblox_ \
 --foreman-proxy-plugin-dhcp-infoblox-record-type fixedaddress \
---foreman-proxy-plugin-dhcp-infoblox-username admin
+--foreman-proxy-plugin-dhcp-infoblox-dns-view default \
+--foreman-proxy-plugin-dhcp-infoblox-network-view default
 ----
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* and select the {SmartProxy} with the Infoblox DHCP module and click *Refresh*.
-. Ensure that the *dhcp* features are listed.
-. For all domains managed through Infoblox, ensure that the DNS {SmartProxy} is set for that domain.
-To verify, in the {ProjectWebUI}, navigate to *Infrastructure* > *Domains*, and inspect the settings of each domain.
-. For all subnets managed through Infoblox, ensure that DHCP {SmartProxy} and Reverse DNS {SmartProxy} is set.
-To verify, in the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*, and inspect the settings of each subnet.
+. Optional: In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, select the {SmartProxy} with the DHCP Infoblox module, and ensure that the *dhcp* feature is listed.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
+. For all subnets managed through Infoblox, ensure that the IP address management (*IPAM*) method of the subnet is set to `DHCP`.

--- a/guides/common/modules/proc_installing-the-dns-infoblox-module.adoc
+++ b/guides/common/modules/proc_installing-the-dns-infoblox-module.adoc
@@ -4,8 +4,6 @@
 Use this procedure to install the DNS Infoblox module on {SmartProxy}.
 You can also install DHCP and DNS Infoblox modules simultaneously by combining this procedure and xref:Installing_the_DHCP_Infoblox_Module_{context}[].
 
-DNS records are managed only in the default DNS view, it's not possible to specify which DNS view to use.
-
 .Procedure
 . On {SmartProxy}, enter the following command to configure the Infoblox module:
 +
@@ -15,11 +13,14 @@ DNS records are managed only in the default DNS view, it's not possible to speci
 --foreman-proxy-dns true \
 --foreman-proxy-dns-provider infoblox \
 --foreman-proxy-plugin-dns-infoblox-dns-server _infoblox.example.com_ \
---foreman-proxy-plugin-dns-infoblox-dns-view default \
---foreman-proxy-plugin-dns-infoblox-password infoblox \
---foreman-proxy-plugin-dns-infoblox-username admin
+--foreman-proxy-plugin-dns-infoblox-username _admin_ \
+--foreman-proxy-plugin-dns-infoblox-password _infoblox_ \
+--foreman-proxy-plugin-dns-infoblox-dns-view _default_
 ----
 +
-Optionally, you can change the value of the `--foreman-proxy-plugin-dns-infoblox-dns-view` option to specify a DNS Infoblox view other than the default view.
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* and select the {SmartProxy} with the Infoblox DNS module and click *Refresh*.
-. Ensure that the *dns* features are listed.
+Optionally, you can change the value of the `--foreman-proxy-plugin-dns-infoblox-dns-view` option to specify an Infoblox DNS view other than the default view.
+. Optional: In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, select the {SmartProxy} with the Infoblox DNS module, and ensure that the *dns* feature is listed.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains*.
+. For all domains managed through Infoblox, ensure that the *DNS Proxy* is set for those domains.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
+. For all subnets managed through Infoblox, ensure that the *DNS {SmartProxy}* and *Reverse DNS {SmartProxy}* are set for those subnets.


### PR DESCRIPTION
It seems counter-intuitive that the IPAM method to use with the Infoblox DHCP provider is "DHCP" and not "External IPAM", when, technically, Infoblox is an "external" DHCP service.

https://bugzilla.redhat.com/show_bug.cgi?id=2134225

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
