### PR TITLE
Rewrite paragraph on installer managed files

### DIFF
--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -21,14 +21,14 @@ If you do not specify a value, an organization called *Default Organization* wit
 You can rename the organization name but not the label.
 
 * By default, all configuration files configured by the installer are managed.
-When `{foreman-installer}` runs, it overwrites any manual changes to the managed files with the initial values.
+When `{foreman-installer}` runs, it overwrites any manual changes to the managed files with the intended values.
+This means that running the installer on a broken system should restore it to working order, regardless of changes made.
+For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
+
 ifdef::foreman-el,foreman-deb[]
-By default, {ProjectServer} is installed with the Puppet agent running as a service.
+* By default, {ProjectServer} is installed with the Puppet agent running as a service.
 If required, you can disable Puppet agent on {ProjectServer} using the `--puppet-runmode=none` option.
 endif::[]
-
-* If you want to manage DNS files and DHCP files manually, use the `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false` options so that the installer does not manage the files related to the respective services.
-For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
 
 .Procedure
 


### PR DESCRIPTION
This makes it clear why the installer manages the files. Rather than presenting it as a downside, it explains why it's a feature.

The part about DHCP and DNS is dropped since there are no instructions to set up DHCP and DNS here. If anything, they should be presented in the correct chapters.

Builds on https://github.com/theforeman/foreman-documentation/pull/2690 and currently a draft because of that.


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.