### PR TITLE
Hide OSTree content for Satellite

### DIFF
--- a/guides/common/modules/con_content-types-overview.adoc
+++ b/guides/common/modules/con_content-types-overview.adoc
@@ -43,8 +43,10 @@ ISO and KVM Images::
 Download and manage media for installation and provisioning.
 For example, {Project} downloads, stores, and manages ISO images and guest images for specific {RHEL} and non-Red Hat operating systems.
 
+ifndef::satellite[]
 OSTree::
 You can import OSTree branches and publish this content to an HTTP location for consumption by OSTree clients.
+endif::[]
 
 {customfiletypetitle}::
 You can manage {customcontent} for any type of file you require, such as SSL certificates and OVAL files.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -49,7 +49,9 @@ endif::[]
 
 include::common/assembly_managing-errata.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::common/assembly_managing-ostree-content.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]
 


### PR DESCRIPTION
OSTree content management is not available in any Satellite and is not planned to be included.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
