### PR TITLE
Disclaim other OSs for Satellite

### DIFF
--- a/guides/common/modules/con_types-of-provisioning-templates.adoc
+++ b/guides/common/modules/con_types-of-provisioning-templates.adoc
@@ -17,13 +17,17 @@ For UEFI provisioning, select *PXEGrub2*.
 
 Finish::
 Post-configuration scripts to execute using an SSH connection when the main provisioning process completes.
-You can use Finishing templates only for imaged-based provisioning in virtual or cloud environments that do not support user_data.
+You can use Finish templates only for image-based provisioning in virtual or cloud environments that do not support user_data.
 Do not confuse an image with a foreman discovery ISO, which is sometimes called a Foreman discovery image.
 An image in this context is an install image in a virtualized environment for easy deployment.
 +
 When a finish script successfully exits with the return code `0`, {ProjectName} treats the code as a success and the host exits the build mode.
++
 Note that there are a few finish scripts with a build mode that uses a _call back_ HTTP call.
 These scripts are not used for image-based provisioning, but for post configuration of operating-system installations such as Debian, Ubuntu, and BSD.
+ifdef::satellite[]
+{Team} does not support provisioning of operating systems other than {RHEL}.
+endif::[]
 
 user_data::
 Post-configuration scripts for providers that accept custom data, also known as seed data.


### PR DESCRIPTION
RH does not support provisioning of other OS than RHEL. + cosmetic improvements

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
