### PR TITLE
Add message about cloning templates

### DIFF
--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -4,3 +4,7 @@
 Some of the procedures in this section are optional.
 You can choose to perform only those procedures that are relevant to your installation.
 
+ifdef::Satellite[]
+If you use custom templates created from a cloned default template, create the custom template again after the upgrade.
+Sometimes the default templates are changed during the upgrade, this will ensure that the custom templates are compatible with the latest version.
+endif::[]

--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -4,7 +4,6 @@
 Some of the procedures in this section are optional.
 You can choose to perform only those procedures that are relevant to your installation.
 
-ifdef::Satellite[]
-If you use custom templates created from a cloned default template, create the custom template again after the upgrade.
-Sometimes the default templates are changed during the upgrade, this will ensure that the custom templates are compatible with the latest version.
-endif::[]
+If you use custom templates created from a cloned default template, you must re-create the custom template after the upgrade.
+Sometimes the default templates are changed during the upgrade.
+Re-create the custom templates so that they are compatible with the latest version.


### PR DESCRIPTION
Custom templates created from default templates need to be cloned again after upgrade to ensure that any changes in the default templates apply to custom template as well. BZ link : https://bugzilla.redhat.com/show_bug.cgi?id=2257737


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
