### PR TITLE
Fix link rendering in downstream Satellite

### DIFF
--- a/guides/common/modules/proc_creating-a-report-template.adoc
+++ b/guides/common/modules/proc_creating-a-report-template.adoc
@@ -8,14 +8,6 @@ Report templates use Embedded Ruby (ERB) syntax.
 To view information about working with ERB syntax and macros, in the {ProjectWebUI}, navigate to *Monitor* > *Reports* > *Report Templates*, and click *Create Template*, and then click the *Help* tab.
 
 When you create a report template in {Project}, safe mode is enabled by default.
-For more information about safe mode, see xref:Report_Template_Safe_Mode_{context}[].
-
-For more information about writing templates, see the xref:Template_Writing_Reference_{context}[].
-For more information about macros you can use in report templates, see xref:Template_Macros_{context}[].
-
-ifdef::satellite[]
-To view a step by step example of populating a template, see xref:Creating_a_Report_Template_to_Monitor_Entitlements_{context}[].
-endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Reports* > *Report Templates*.
@@ -39,3 +31,11 @@ If this field remains undefined, the users receive a free-text field in which th
 . Click the *Location* tab and add the locations where you want to use the template.
 . Click the *Organizations* tab and add the organizations where you want to use the template.
 . Click *Submit* to save your changes.
+
+.Additional resources
+* For more information about safe mode, see xref:Report_Template_Safe_Mode_{context}[].
+* For more information about writing templates, see xref:Template_Writing_Reference_{context}[].
+* For more information about macros you can use in report templates, see xref:Template_Macros_{context}[].
+ifdef::satellite[]
+* To view a step by step example of populating a template, see xref:Creating_a_Report_Template_to_Monitor_Entitlements_{context}[].
+endif::[]


### PR DESCRIPTION
Currently:
![image](https://github.com/theforeman/foreman-documentation/assets/108661422/0f89ab22-19e5-4647-afdb-4e3b3aa54b4e)


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
