### PR TITLE
Fix link of Ansible Modules and add the Link Text

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -34,6 +34,7 @@
 :ansible-collection-package: ansible-collection-theforeman-foreman
 :ansible-doc-activation_key: ansible-doc theforeman.foreman.activation_key
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
+:ansible-galaxy-name: Ansible Galaxy
 :ansible-namespace-example: theforeman.foreman._module_name_
 :ansible-namespace: theforeman.foreman
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -38,6 +38,7 @@
 :ansible-collection-package: ansible-collection-redhat-satellite
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
+:ansible-galaxy-name: Red{nbsp}Hat Ansible Automation Platform
 :ansible-namespace-example: redhat.satellite._module_name_
 :ansible-namespace: redhat.satellite
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -37,7 +37,7 @@
 // Overrides for satellite build
 :ansible-collection-package: ansible-collection-redhat-satellite
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
-:ansible-galaxy: https://console.redhat.com/ansible/automation-hub/redhat/satellite/docs
+:ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
 :ansible-namespace-example: redhat.satellite._module_name_
 :ansible-namespace: redhat.satellite
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/

--- a/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
+++ b/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
@@ -1,11 +1,6 @@
 [id="Viewing_the_Ansible_Modules_{context}"]
 = Viewing the {Project} Ansible Modules
 
-:link-desc: Ansible Galaxy Portal
-ifdef::satellite[]
-:link-desc: {RHCloud}
-endif::[]
-
 You can view the installed {Project} Ansible modules by running:
 
 [options="nowrap" subs="+quotes,attributes"]
@@ -14,7 +9,7 @@ You can view the installed {Project} Ansible modules by running:
 ----
 
 ifndef::orcharhino[]
-Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}[{link-desc}].
+Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}[{ansible-galaxy-name}].
 
 All modules are in the `{ansible-namespace}` namespace and can be referred to in the format `{ansible-namespace-example}`.
 For example, to display information about the `activation_key` module, enter the following command:

--- a/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
+++ b/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
@@ -1,6 +1,11 @@
 [id="Viewing_the_Ansible_Modules_{context}"]
 = Viewing the {Project} Ansible Modules
 
+:link-desc: Ansible Galaxy Portal
+ifdef::satellite[]
+:link-desc: {RHCloud}
+endif::[]
+
 You can view the installed {Project} Ansible modules by running:
 
 [options="nowrap" subs="+quotes,attributes"]
@@ -9,7 +14,7 @@ You can view the installed {Project} Ansible modules by running:
 ----
 
 ifndef::orcharhino[]
-Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}.
+Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}[{link-desc}].
 
 All modules are in the `{ansible-namespace}` namespace and can be referred to in the format `{ansible-namespace-example}`.
 For example, to display information about the `activation_key` module, enter the following command:


### PR DESCRIPTION
The current link is incorrect and leads to endless loading. We have replaced the correct link. Also, the link was a bare URL and did not have the link text. Hence, I have tried to add it with module-level attributes to satisfy different builds.

https://bugzilla.redhat.com/show_bug.cgi?id=2260347

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [X] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
