### PR TITLE
Fix link osbuild.org [URGENT]

### DIFF
--- a/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
+++ b/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
@@ -34,4 +34,4 @@ The value of `--ostree-repository-name` must match the name of the OSTree reposi
 ifndef::orcharhino[]
 * https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images using Image Builder]
 endif::[]
-* https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html[Building OSTree images using the OSBuild tool]
+* https://osbuild.org/docs/on-premises/commandline/building-ostree-images[Building OSTree images using the OSBuild tool]


### PR DESCRIPTION
OSbuild.org has changed their docs and we need to update this external link to OStree image builder.
Urgent because it's breaking our builds and makes bad UX.

**Please check that it's the suitable target.**

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
