### PR TITLE
Clarify target of securing DHCP API

### DIFF
--- a/guides/common/modules/proc_securing-the-dhcp-api.adoc
+++ b/guides/common/modules/proc_securing-the-dhcp-api.adoc
@@ -1,12 +1,12 @@
 [id="Securing_the_dhcpd_API_{context}"]
 = Securing the dhcpd API
 
-{SmartProxy} interacts with DHCP daemon using the dhcpd API to manage DHCP.
+{SmartProxyServer} interacts with DHCP daemon using the dhcpd API to manage DHCP.
 By default, the dhcpd API listens to any host without access control.
 You can add an `omapi_key` to provide basic security.
 
 .Procedure
-. On your {SmartProxy}, install the required packages:
+. On your {SmartProxyServer}, install the required packages:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
This procedure is only part of one assembly: "assembly_managing-dhcp-on-smart-proxies.adoc", which itself is only part of "doc-Installing_Proxy".


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)

follow-up PR based on https://github.com/theforeman/foreman-documentation/pull/2684#discussion_r1469487245