### PR TITLE
Show Glossary for all builds

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -38,6 +38,6 @@ include::topics/Deployment_Scenarios.adoc[]
 include::topics/Deployment_Considerations.adoc[]
 
 include::topics/Required_Technical_Users.adoc[]
+endif::[]
 
 include::topics/Glossary.adoc[]
-endif::[]


### PR DESCRIPTION
We need to display the Glossary for all builds, because we started referring to it in upstream builds. Follow-up to #2706 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
