### PR TITLE
Rearrange the tuning profile section

### DIFF
--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -23,5 +23,9 @@ include::modules/proc_enabling-client-connections-to-satellite.adoc[leveloffset=
 
 include::modules/proc_verifying-dns-resolution.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
+include::modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
+endif::[]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -56,8 +56,6 @@ include::common/assembly_configuring-satellite-custom-server-certificate.adoc[le
 include::common/assembly_using-external-databases.adoc[leveloffset=+2]
 endif::[]
 
-include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
-
 include::common/assembly_configuring-external-authentication.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-external-services.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -51,9 +51,6 @@ include::common/assembly_configuring-satellite-custom-server-certificate.adoc[le
 include::common/assembly_using-external-databases.adoc[leveloffset=+2]
 endif::[]
 
-include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+2]
-
-
 include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
 
 :numbered!:


### PR DESCRIPTION
This section was part of Performing Additional Configuration but it should be kept under the Preparing Environment section. The reason is that end-users will look for setting pre-defined tuning profiles well in advance while they are preparing the project installation environment.

https://bugzilla.redhat.com/show_bug.cgi?id=2244184 (cherry picked from commit bf2edef36724401ae493703a1b46bdc2bc19fa66)

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [ ] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
