### PR TITLE
Re-add the section to upgrade Smart Proxy using remote execution

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -194,16 +194,17 @@ endif::[]
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups made earlier.
 . Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
 
-.Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI}
+.Upgrading {SmartProxyServersTitle}  Using Remote Execution in the {ProjectWebUI}
 
 . Create a backup.
 +
 * On a virtual machine, take a snapshot.
 * On a physical machine, create a backup.
 +
-For information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
+For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
 
-. Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
+. Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files.
+The installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
 
 . Optional: If you made manual edits to DNS or DHCP configuration files and do not want to overwrite the changes, enter the following command:
 +
@@ -213,13 +214,13 @@ For information on backups, see {AdministeringDocURL}backing-up-satellite-server
 --foreman-proxy-dhcp-managed=false
 ----
 
-. In the {Project} web UI, navigate to *Monitor* > *Jobs*.
+. In the {ProjectWebUI}, navigate to *Monitor* > *Jobs*.
 
 . Click *Run Job*.
 
 . From the *Job category* list, select *Maintenance Operations*.
 
-. From the *Job template* list, select *Capsule Upgrade Playbook*.
+. From the *Job template* list, select *{SmartProxy} Upgrade Playbook*.
 
 . In the *Search Query* field, enter the host name of the {SmartProxy}.
 
@@ -229,6 +230,6 @@ For information on backups, see {AdministeringDocURL}backing-up-satellite-server
 
 . In the *whitelist_options* field, enter the whitelist options.
 
-. For *Type of query*, click *Static Query* or *Dynamic Query* depending on the type of query.
+. For *Type of query*, click *Static Query*.
 
 . Select the schedule for the job execution in *Schedule*.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -194,7 +194,7 @@ endif::[]
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups made earlier.
 . Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
 
-.Upgrading {SmartProxyServersTitle}  Using Remote Execution in the {ProjectWebUI}
+.Upgrading {SmartProxyServersTitle} Using Remote Execution in the {ProjectWebUI}
 
 . Create a backup.
 +

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -193,3 +193,42 @@ endif::[]
 
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups made earlier.
 . Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
+
+.Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI}
+
+. Create a backup.
++
+* On a virtual machine, take a snapshot.
+* On a physical machine, create a backup.
++
+For information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
+
+. Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files because the installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
+
+. Optional: If you made manual edits to DNS or DHCP configuration files and do not want to overwrite the changes, enter the following command:
++
+[options="nowrap"]
+----
+# {foreman-installer} --foreman-proxy-dns-managed=false \
+--foreman-proxy-dhcp-managed=false
+----
+
+. In the {Project} web UI, navigate to *Monitor* > *Jobs*.
+
+. Click *Run Job*.
+
+. From the *Job category* list, select *Maintenance Operations*.
+
+. From the *Job template* list, select *Capsule Upgrade Playbook*.
+
+. In the *Search Query* field, enter the host name of the {SmartProxy}.
+
+. Ensure that *Resolves to* shows *1 host*.
+
+. In the *target_version* field, enter the target version of the {SmartProxy}.
+
+. In the *whitelist_options* field, enter the whitelist options.
+
+. For *Type of query*, click *Static Query* or *Dynamic Query* depending on the type of query.
+
+. Select the schedule for the job execution in *Schedule*.


### PR DESCRIPTION
The `Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI}` section has been left out of the post 2.5 versions. However, this is still relevant in the later versions. Adding it back in for 3.1, will push separate PRs for other versions to avoid merge conflicts due to file structure changes.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2248524


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [ ] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [X] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
