### PR TITLE
Simplify firewall tables using smartproxy_port attribute

### DIFF
--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -47,15 +47,9 @@ endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
-ifndef::katello,satellite,orcharhino[]
-| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
-| 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
-endif::[]
-ifdef::katello,satellite,orcharhino[]
-| 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
-| 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
-| 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
-endif::[]
+| {smartproxy_port} | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
+| {smartproxy_port} | TCP | HTTPS | Client | OpenSCAP | Configure Client (if the OpenSCAP plugin is installed)
+| {smartproxy_port} | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning (if the discovery plugin is installed)
 |====
 
 Any host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -45,17 +45,13 @@ endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTP | Client | PXE Boot | Installation
 | 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
-ifndef::katello,satellite,orcharhino[]
-| 8443 | TCP | HTTPS | Client | OpenSCAP | Configure Client
-| 8443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
-endif::[]
 ifdef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | Content Host registration | Deprecated and only needed for Client hosts deployed before upgrades
-| 9090 | TCP | HTTPS | Client | Register Endpoint | Client registration with an external {SmartProxyServer}
-| 9090 | TCP | HTTPS | Client | OpenSCAP | Configure Client
-| 9090 | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning
-| 9090 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
 endif::[]
+| {smartproxy_port} | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
+| {smartproxy_port} | TCP | HTTPS | Client | Register Endpoint | Client registration with an external {SmartProxyServer}
+| {smartproxy_port} | TCP | HTTPS | Client | OpenSCAP | Configure Client (if the OpenSCAP plugin is installed)
+| {smartproxy_port} | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning (if the discovery plugin is installed)
 |====
 
 Any host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.


### PR DESCRIPTION
This removes duplication by using the already defined smartproxy_port attribute. It also adds notes about optional plugins.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.