### PR TITLE
Replace invisible unicode character with space

### DIFF
--- a/guides/common/modules/proc_adding-a-host-to-a-host-collection.adoc
+++ b/guides/common/modules/proc_adding-a-host-to-a-host-collection.adoc
@@ -27,7 +27,7 @@ Note that if you add a host to a host collection, the {Project} auditing system 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host-collection add-host \
+# hammer host-collection add-host \
 --host-ids _My_Host_ID_1_ \
 --id _My_Host_Collection_ID_
 ----

--- a/guides/common/modules/proc_adding-hosts-to-a-host-collection-in-bulk.adoc
+++ b/guides/common/modules/proc_adding-hosts-to-a-host-collection-in-bulk.adoc
@@ -26,7 +26,7 @@ Note that if you add a host to a host collection, the {Project} auditing system 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host-collection add-host \
+# hammer host-collection add-host \
 --host-ids _My_Host_ID_1_,_My_Host_ID_2_ \
 --id _My_Host_Collection_ID_
 ----

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -35,7 +35,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ipa service-add HTTP/_hostname_
+# ipa service-add HTTP/_hostname_
 ----
 +
 ifdef::satellite[]

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -35,5 +35,5 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_ACS_ID_ 
+# hammer alternate-content-source refresh --id _My_ACS_ID_ 
 ----

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -73,7 +73,7 @@ For the `--repository-ids` option, you can find the IDs in the output of the `ha
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view add-repository \
+# hammer content-view add-repository \
 --name "_My_Content_View_" \
 --organization "_My_Organization_" \
 --repository-id _repository_ID_

--- a/guides/common/modules/proc_creating-a-host-collection.adoc
+++ b/guides/common/modules/proc_creating-a-host-collection.adoc
@@ -16,7 +16,7 @@ The following procedure shows how to create host collections.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host-collection create \
+# hammer host-collection create \
 --name "_My_Host_Collection_" \
 --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_creating-a-host.adoc
+++ b/guides/common/modules/proc_creating-a-host.adoc
@@ -82,7 +82,7 @@ For more information, see xref:transport-modes-for-remote-execution_{context}[].
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host create \
+# hammer host create \
 --ask-root-password yes \
 --hostgroup "_My_Host_Group_" \
 --interface="primary=true, \

--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -38,7 +38,7 @@ For more information, see {ManagingHostsDocURL}template_writing_reference_managi
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-template create \
+# hammer job-template create \
 --file "_Path_to_My_Template_File_" \
 --job-category "_My_Category_Name_" \
 --name "_My_Template_Name_" \

--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -10,7 +10,7 @@ Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} gssproxy {nfs-client-package}
+# {project-package-install} gssproxy {nfs-client-package}
 ----
 
 .Procedure
@@ -25,7 +25,7 @@ You may need to have administrator permissions to perform the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# realm join -v _EXAMPLE.ORG_ --membership-software=samba -U Administrator
+# realm join -v _EXAMPLE.ORG_ --membership-software=samba -U Administrator
 ----
 +
 NOTE: You must use the Samba client software to enroll with the AD server to be able to create the HTTP keytab in xref:Configuring_Direct_AD_Integration_with_GSS_Proxy_{context}[].

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -81,7 +81,7 @@ You have the option to return to any part of the job wizard and edit the informa
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-invocation create \
+# hammer job-invocation create \
 --inputs _My_Key_1_="_My_Value_1_",_My_Key_2_="_My_Value_2_",... \
 --job-template "_My_Template_Name_" \
 --search-query "_My_Search_Query_"

--- a/guides/common/modules/proc_monitoring-remote-jobs.adoc
+++ b/guides/common/modules/proc_monitoring-remote-jobs.adoc
@@ -23,13 +23,13 @@ This displays the *Detail of Commands* page where you can monitor the job execut
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-invocation list
+# hammer job-invocation list
 ----
 . Monitor the job output:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-invocation output \
+# hammer job-invocation output \
 --host _My_Host_Name_ \
 --id _My_Job_ID_
 ----
@@ -37,6 +37,6 @@ This displays the *Detail of Commands* page where you can monitor the job execut
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-invocation cancel \
+# hammer job-invocation cancel \
 --id _My_Job_ID_
 ----

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -14,7 +14,7 @@ endif::[]
 |====
 |Directory |Installation Size |Runtime Size
 ifdef::katello,satellite,orcharhino[]
-|/var/lib/pulp |1 MB |300 GB
+|/var/lib/pulp |1 MB |300 GB
 |{postgresql-lib-dir} |100 MB |20 GB
 endif::[]
 |/usr |3 GB |Not Applicable

--- a/guides/common/modules/ref_rendering-a-restorecon-template.adoc
+++ b/guides/common/modules/ref_rendering-a-restorecon-template.adoc
@@ -8,5 +8,5 @@ Create a new template as described in {ManagingHostsDocURL}setting-up-job-templa
 
 [source, Ruby]
 ----
-<%= render_template("Run Command - restorecon", :directory => "/home") %>
+<%= render_template("Run Command - restorecon", :directory => "/home") %>
 ----

--- a/guides/common/modules/ref_supported-operators-for-granular-search.adoc
+++ b/guides/common/modules/ref_supported-operators-for-granular-search.adoc
@@ -21,12 +21,12 @@ An inversion of the = operator.
 | ~ | _Like_.
 A case-insensitive occurrence search for text fields.
 | !~ | _Not like_.
-An inversion of the ~ operator.
+An inversion of the ~ operator.
 | ^ | _In_.
 An equality comparison that is case-sensitive search for text fields.
 This generates a different SQL query to the _Is equal to_ comparison, and is more efficient for multiple value comparison.
 | !^ | _Not in_.
-An inversion of the ^ operator.
+An inversion of the ^ operator.
 | >, >= | _Greater than_, _greater than or equal to_.
 Supported for numerical fields only.
 | <, <= | _Less than_, _less than or equal to_.


### PR DESCRIPTION
Some places contain invisible U+00a0 character where regular space should have been used. This character can render copied command unusable.

find . -type f -iname "*.adoc" | xargs sed -i 's/\xc2\xa0/ /g'

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* [x] Foreman 3.2/Katello 4.4 on EL7 & EL8
* [x] Foreman 3.1/Katello 4.3 on EL7 & EL8 (Satellite 6.11 EL7/8; orcharhino 6.3 on EL7/8)
* We do not accept PRs for Foreman older than 3.1.
