### PR TITLE
Replace ports of deprecated registration methods (#2680)

### DIFF
--- a/guides/common/modules/ref_ports-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_ports-and-firewall-requirements.adoc
@@ -31,18 +31,17 @@ The following tables indicate the destination port and the direction of network 
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
+| 443, 80 | TCP | HTTPS, HTTP | Client | Global Registration | Registering hosts to {Project}
+
+Port 443 is required for registration initiation, uploading facts, and sending installed packages and traces
+
+Port 80 notifies {Project} on the `/unattended/built` endpoint that registration has finished
 ifdef::katello,satellite,orcharhino[]
-| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
-| 443, 80 | TCP | HTTPS, HTTP| Client | Content Host Registration | {SmartProxy} CA RPM installation
-| 443 | TCP | HTTPS | Client | Content Host registration | Initiation
-
-Uploading facts
-
-Sending installed packages and traces
-| 443 | TCP | HTTPS | {ProjectName} |Content Mirroring | Management
+| 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
-| 5646 | TCP | AMQP |{SmartProxy}| Katello agent | Forward message to Qpid dispatch router on {Project} (optional)
+| 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
+| 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
+| 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot


### PR DESCRIPTION
Earlier, there were no ports mentioned in the document about allowing incoming traffic to Satellite from Client for Global Registration. We added those ports.

https://bugzilla.redhat.com/show_bug.cgi?id=2247445

(cherry picked from commit 43aa6a93ff7a000192442285ed9e1680a08ab9c1)