### PR TITLE
Revert changed attribute to fix build

### DIFF
--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -10,7 +10,7 @@ Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} gssproxy {nfs-client-package}
+# {package-install-project} gssproxy {nfs-client-package}
 ----
 
 .Procedure


### PR DESCRIPTION
In #2721 I changed this line to remove the invisible unicode character, but I did not notice that the attribute changed while cherry-picking.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
