### PR TITLE
Remove invalid option preventing local build

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -61,7 +61,7 @@ linkchecker: html
 	linkchecker -r1 -f $(COMMON_DIR)/linkchecker.ini --check-extern "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
 $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
-	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
+	bundle exec sass --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 
 $(IMAGES_TS): $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"


### PR DESCRIPTION
```
$ cd guides/doc-Administering_Project
$ make
cp -rf -lL ./images/* ../build/Administering_Project/images
bundle exec sass --sourcemap=none --no-cache --style compressed -I ../common/css ../common/css/default.scss ../build/Administering_Project/foreman-el.css
OptionParser::InvalidOption: invalid option: --sourcemap=none
  Use --trace for backtrace.
make: *** [../common/Makefile:64: ../build/Administering_Project/foreman-el.css] Error 1
```


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
