### PR TITLE
Remove trailing whitespaces from files

### DIFF
--- a/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
@@ -1,5 +1,5 @@
 [id="limitations-of-installation-in-an-ipv6-network_{context}"]
-= Limitations of {Project} installation in an IPv6 network 
+= Limitations of {Project} installation in an IPv6 network
 
 {Project} installation in an IPv6 network has the following limitations:
 

--- a/guides/common/modules/con_resolving-package-dependencies.adoc
+++ b/guides/common/modules/con_resolving-package-dependencies.adoc
@@ -65,7 +65,7 @@ ifeval::["{client-os-family}" == "Red Hat"]
 If you make a {RHEL}{nbsp}8.3 repository with a few excluded packages, `dnf update` can sometimes fail.
 
 Do not enable dependency solving to resolve the problem.
-Instead, investigate the error from `dnf` and adjust the filters to stop excluding the missing dependency. 
+Instead, investigate the error from `dnf` and adjust the filters to stop excluding the missing dependency.
 
 Else, dependency solving might cause the repository to diverge from {RHEL}{nbsp}8.3.
 ====

--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -32,7 +32,7 @@ If you are using a `file://` repository, you have to place it under `/var/lib/pu
 If you do not enter an upstream URL, you can manually upload packages.
 . Optional: Check the *Ignore SRPMs* checkbox to exclude source RPM packages from being synchronized to {Project}.
 . Optional: Check the *Ignore treeinfo* checkbox if you receive the error `Treeinfo file should have INI format`.
-All files related to Kickstart will be missing from the repository if `treeinfo` files are skipped. 
+All files related to Kickstart will be missing from the repository if `treeinfo` files are skipped.
 . Select the *Verify SSL* checkbox if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.
 . Optional: In the *Upstream Username* field, enter the user name for the upstream repository if required for authentication.
 Clear this field if the repository does not require authentication.

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -3,7 +3,7 @@
 
 .Prerequisites
 * If the repository requires SSL authentication, import the SSL certificate and key to the {Project}.
-For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_. 
+For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
 * Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide.
 For example, if your base URL is `https://{server-example-com}` and your subpaths are `rhel7/` and `rhel8/`, then both `https://{server-example-com}/rhel7/` and `https://{server-example-com}/rhel8/` will be searched.
 

--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
@@ -33,7 +33,7 @@ Note that you can navigate to the following URL within your realm to obtain valu
 
 . Open the `_{Keycloak-short}.example.com_/auth/realms/_{Keycloak-short}_REALM_/.well-known/openid-configuration` URL and note the values to populate the options in the following steps.
 
-. Add the value for the Hammer client in the Open IDC audience: 
+. Add the value for the Hammer client in the Open IDC audience:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -35,5 +35,5 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_ACS_ID_ 
+# hammer alternate-content-source refresh --id _My_ACS_ID_
 ----

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -27,7 +27,7 @@ The filename extensions `.cer` and `.crt` are only conventions and can refer to 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ln -s _example.crt_ /etc/pki/tls/certs/$(openssl \ 
+# ln -s _example.crt_ /etc/pki/tls/certs/$(openssl \
 x509 -noout -hash -in \
 /etc/pki/tls/certs/_example.crt_).0
 ----

--- a/guides/common/modules/proc_logging-in-to-the-project-CLI-using-keycloak.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-project-CLI-using-keycloak.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to authenticate to the {Project} CLI using the code grant type.
 
-.Procedure 
+.Procedure
 
 . To authenticate to the {Project} CLI using the code grant type, enter the following command:
 +

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -15,7 +15,7 @@ The services restart after the renaming is complete.
 If you fail to successfully rename it, restore it from the backup.
 For more information, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_{context}[].
 
-* Run the `hostname` and `hostname -f` commands on {ProjectServer}. 
+* Run the `hostname` and `hostname -f` commands on {ProjectServer}.
 If both commands do not return the FQDN of {ProjectServer}, the `{project-change-hostname}` script will fail to complete.
 +
 If the `hostname` command returns the shortname of {ProjectServer} instead of the FQDN, use `hostnamectl set-hostname _My_Old_FQDN_` to set the old FQDN correctly before using the `{project-change-hostname}` script.
@@ -26,7 +26,7 @@ For more information, see {InstallingServerDocURL}configuring-satellite-custom-s
 endif::[]
 
 .Procedure
-. On {ProjectServer}, run the `{project-change-hostname}` script, and provide the new host name. 
+. On {ProjectServer}, run the `{project-change-hostname}` script, and provide the new host name.
 Choose one of the following methods:
 +
 * If your {ProjectServer} is installed with the default self-signed SSL certificates, enter the following command:
@@ -77,7 +77,7 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[
 . If you use the _virt-who_ agent, update the _virt-who_ configuration files with the new host name.
 ifdef::satellite[]
 For more information, see {ConfiguringVMSubscriptionsDocURL}troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _{ConfiguringVMSubscriptionsDocTitle}_.
-endif::[] 
+endif::[]
 . If you use external authentication, reconfigure {ProjectServer} for external authentication after you run the `{project-change-hostname}` script.
 ifndef::orcharhino[]
 For more information, see {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.

--- a/guides/common/modules/proc_testing-email-notifications.adoc
+++ b/guides/common/modules/proc_testing-email-notifications.adoc
@@ -20,7 +20,7 @@ Replace _My_Frequency_ with one of the following:
 This triggers all notifications scheduled for the specified frequency for all the subscribed users.
 If every subscribed user receives the notifications, the verification succeeds.
 
-[NOTE] 
+[NOTE]
 ====
 Sending manually triggered notifications to individual users is currently not supported.
 ====

--- a/guides/common/modules/ref_example-settings-for-ldap-connections.adoc
+++ b/guides/common/modules/ref_example-settings-for-ldap-connections.adoc
@@ -12,9 +12,9 @@ Note that LDAP attribute names are case sensitive.
 | Account | DOMAIN\redhat | uid=redhat,cn=users,
 cn=accounts,dc=example,
 dc=com | uid=redhat,ou=users,
-dc=example,dc=com 
-| Account password | P@ssword | - | - 
-| Base DN | DC=example,DC=COM | dc=example,dc=com | dc=example,dc=com 
+dc=example,dc=com
+| Account password | P@ssword | - | -
+| Base DN | DC=example,DC=COM | dc=example,dc=com | dc=example,dc=com
 | Groups Base DN | CN=Users,DC=example,DC=com | cn=groups,cn=accounts,
 dc=example,dc=com | cn=employee,ou=userclass,
 dc=example,dc=com
@@ -22,7 +22,7 @@ dc=example,dc=com
 | First name attribute | givenName | givenName | givenName
 | Last name attribute | sn | sn | sn
 | Email address attribute | mail | mail | mail
-| Photo attribute | thumbnailPhoto | - | - 
+| Photo attribute | thumbnailPhoto | - | -
 |====
 
 [NOTE]

--- a/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
+++ b/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
@@ -106,7 +106,7 @@ endif::[]
 |Subnet
 |view_subnets
 |
-|=== 
+|===
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
```
find . -type f -iname '*.adoc' | xargs sed -i 's/[ \t]*$//'
```

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
