### PR TITLE
Set secondary bonded interface as Managed

### DIFF
--- a/guides/common/modules/proc_adding-a-bonded-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bonded-interface.adoc
@@ -16,6 +16,9 @@ The applicable configuration options are the same as for the physical interfaces
 Bonded interfaces use IDs in the form of *bond0* in the *Device Identifier* field.
 +
 A single *MAC address* is sufficient.
++
+If you are adding a secondary interface, select *Managed*.
+Otherwise, {Project} does not apply the configuration.
 . Specify the configuration options specific to bonded interfaces:
 
 * *Mode*: Select the bonding mode that defines a policy for fault tolerance and load balancing.


### PR DESCRIPTION
If adding a secondary bonded interface, the user must set it as Managed, otherwise the configuration isn't applied.

https://bugzilla.redhat.com/show_bug.cgi?id=2169092

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
