### PR TITLE
Use python3 to encrypt password

### DIFF
--- a/guides/common/modules/proc_setting-a-default-encrypted-root-password.adoc
+++ b/guides/common/modules/proc_setting-a-default-encrypted-root-password.adoc
@@ -12,7 +12,7 @@ If you change the password and reprovision the hosts in the group that inherits 
 . Generate an encrypted password:
 +
 -----------------
-# python -c 'import crypt,getpass;pw=getpass.getpass(); print(crypt.crypt(pw)) if (pw==getpass.getpass("Confirm: ")) else exit()'
+$ python3 -c 'import crypt,getpass;pw=getpass.getpass(); print(crypt.crypt(pw)) if (pw==getpass.getpass("Confirm: ")) else exit()'
 -----------------
 +
 . Copy the password for later use.


### PR DESCRIPTION
Just "python" isn't available on later EL OS (RHEL 8.8) by default and the command throws an error.
https://bugzilla.redhat.com/show_bug.cgi?id=2254446

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
