### PR TITLE
Replace Type with Kind for prov. templates

### DIFF
--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -44,7 +44,7 @@ include::modules/ref_dynamic_partition_example.adoc[leveloffset=+1]
 
 include::modules/con_provisioning-templates.adoc[leveloffset=+1]
 
-include::modules/con_types-of-provisioning-templates.adoc[leveloffset=+1]
+include::modules/ref_kinds-of-provisioning-templates.adoc[leveloffset=+1]
 
 include::modules/proc_creating-provisioning-templates.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
@@ -24,7 +24,7 @@ endif::[]
 .Procedure
 . Navigate to *Hosts* > *Templates* > *Provisioning Templates*.
 . Select a provisioning template depending on your host provisioning method.
-For more information, see {ProvisioningDocURL}types-of-provisioning-templates_provisioning[Types of Provisioning Templates] in _{ProvisioningDocTitle}_.
+For more information, see {ProvisioningDocURL}kinds-of-provisioning-templates_provisioning[Kinds of Provisioning Templates] in _{ProvisioningDocTitle}_.
 ifndef::katello,orcharhino,satellite[]
 . Ensure the `puppetlabs_repo` snippet is included as follows:
 +

--- a/guides/common/modules/ref_kinds-of-provisioning-templates.adoc
+++ b/guides/common/modules/ref_kinds-of-provisioning-templates.adoc
@@ -1,7 +1,7 @@
-[id="types-of-provisioning-templates_{context}"]
-= Types of provisioning templates
+[id="kinds-of-provisioning-templates_{context}"]
+= Kinds of provisioning templates
 
-There are various types of provisioning templates:
+There are various kinds of provisioning templates:
 
 Provision::
 The main template for the provisioning process.


### PR DESCRIPTION
WebUI uses a "Kind" of provisioning template.
https://bugzilla.redhat.com/show_bug.cgi?id=2228095
Also, this module looks more like the reference content type than concept.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
