### PR TITLE
Remove old Ansible setting

### DIFF
--- a/guides/common/modules/proc_setting-up-job-templates.adoc
+++ b/guides/common/modules/proc_setting-up-job-templates.adoc
@@ -27,5 +27,3 @@ For more information, see {ManagingHostsDocURL}Synchronizing_Templates_Repositor
 .Parameter Variables
 At run time, job templates can accept parameter variables that you define for a host.
 Note that only the parameters visible on the *Parameters* tab at the host's edit page can be used as input parameters for job templates.
-If you do not want your Ansible job template to accept parameter variables at run time, in the {ProjectWebUI}, navigate to *Administer* > *Settings* and click the *Ansible* tab.
-In the *Top level Ansible variables* row, change the *Value* parameter to *No*.


### PR DESCRIPTION
This setting has been [removed in Foreman 3.0](https://projects.theforeman.org/issues/26068).
https://bugzilla.redhat.com/show_bug.cgi?id=2127802

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
