### PR TITLE
Change "Prerequisite" to "Prerequisites" in headers

### DIFF
--- a/guides/common/modules/con_using-freeipa.adoc
+++ b/guides/common/modules/con_using-freeipa.adoc
@@ -14,7 +14,7 @@ For more information, see xref:Using_LDAP_{context}[].
 include::snip_do-not-use-both-ldap-and-freeipa.adoc[]
 ====
 
-.Prerequisite
+.Prerequisites
 * The base operating system of {ProjectServer} must be enrolled in the {FreeIPA} domain by the {FreeIPA} administrator of your organization.
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.

--- a/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
+++ b/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
@@ -4,7 +4,7 @@
 Use this procedure to add the Amazon EC2 connection in {ProjectServer}'s compute resources.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-amazon-ec2-connection_{context}[].
 
-.Prerequisite
+.Prerequisites
 * An AWS EC2 user performing this procedure needs the `AmazonEC2FullAccess` permissions.
 You can attach these permissions from AWS.
 

--- a/guides/common/modules/proc_adding-an-scc-account.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account.adoc
@@ -4,7 +4,7 @@
 Use the following procedure to add your SCC account to {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_an_SCC_Account_to_Server_{context}[].
 
-.Prerequisite
+.Prerequisites
 * You have installed the SCC Manager plug-in on your {Project}.
 For more information, see xref:Installing_the_SCC_Manager_Plug-in_{context}[].
 

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-el.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-el.adoc
@@ -3,7 +3,7 @@
 
 This example creates a product and repositories for {os_name} {os_major}.
 
-.Prerequisite
+.Prerequisites
 * Download and import the {gpg_url}[GPG public key] for yum repositories for {os_name} {os_major} into {Project}.
 For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
 

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-for-centos-stream-9.adoc
@@ -3,7 +3,7 @@
 
 This example creates a product and repositories for CentOS Stream 9.
 
-.Prerequisite
+.Prerequisites
 * Download and import the https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official[GPG public key] for yum repositories for CentOS Stream 9 into {Project}.
 For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
 

--- a/guides/common/modules/proc_adding-red-hat-subscriptions-to-subscription-allocations.adoc
+++ b/guides/common/modules/proc_adding-red-hat-subscriptions-to-subscription-allocations.adoc
@@ -3,7 +3,7 @@
 
 Use the following procedure to add Red Hat subscriptions to a subscription allocation in the {ProjectWebUI}.
 
-.Prerequisite
+.Prerequisites
 * You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 

--- a/guides/common/modules/proc_assigning-ansible-roles-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-ansible-roles-to-a-host-group.adoc
@@ -3,7 +3,7 @@
 
 You can use Ansible roles for remote management of {Project} clients.
 
-.Prerequisite
+.Prerequisites
 * You must configure your deployment to run Ansible roles.
 For more information, see xref:Configuring_Your_{project-context}_to_Run_Ansible_Roles_{context}[].
 

--- a/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
+++ b/guides/common/modules/proc_attaching-red-hat-subscriptions-to-content-hosts.adoc
@@ -19,7 +19,7 @@ However, you are not required to attach {Project} subscriptions to each content 
 Adding a {Project} subscription to a content host does not provide any content or repository access.
 If you want, you can add a {Project} subscription to a manifest for your own recording or tracking purposes.
 
-.Prerequisite
+.Prerequisites
 * You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 

--- a/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
+++ b/guides/common/modules/proc_browsing-repository-content-using-an-organization-debug-certificate.adoc
@@ -3,7 +3,7 @@
 
 You can view an organization's repository content using a web browser or using the API if you have a debug certificate for that organization.
 
-.Prerequisite
+.Prerequisites
 * You created and downloaded an organization certificate.
 For more information, see xref:Creating_an_Organization_Debug_Certificate_{context}[].
 

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -16,7 +16,7 @@ You can choose to either load `ipxe.lkrn` or `undionly-ipxe.0` file depending on
 . iPXE chainloads the iPXE template from the template {SmartProxy}
 . iPXE loads the kernel and initial RAM disk of the installer
 
-.Prerequisite
+.Prerequisites
 include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 
 .Configuring {ProjectServer} to use iPXE

--- a/guides/common/modules/proc_configuring-automatic-removal-of-hosts-from-the-insights-inventory.adoc
+++ b/guides/common/modules/proc_configuring-automatic-removal-of-hosts-from-the-insights-inventory.adoc
@@ -5,7 +5,7 @@ When hosts are removed from {Project}, they can also be removed from the invento
 You can configure automatic removal of hosts from the Insights Inventory during {RHCloud} synchronization with {Project} that occurs daily by default.
 If you leave the setting disabled, you can still remove the bulk of hosts from the Inventory manually.
 
-.Prerequisite
+.Prerequisites
 * Your user account must have the permission of `view_foreman_rh_cloud` to view the Inventory Upload page in {ProjectWebUI}.
 
 .Procedure

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -3,7 +3,7 @@
 
 In the {Project} CLI, configure the direct Active Directory integration with GSS-proxy.
 
-.Prerequisite
+.Prerequisites
 * {Project} is enrolled with the Active Directory server.
 For more information, see xref:Enrolling_Server_with_the_AD_Server_{context}[].
 

--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
@@ -5,7 +5,7 @@ Use this procedure to configure {Project} settings for {Keycloak} authentication
 
 Note that you can navigate to the following URL within your realm to obtain values to configure {Project} settings: `\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/.well-known/openid-configuration`
 
-.Prerequisite
+.Prerequisites
 
 * Ensure that the *Access Type* setting in the {Project} client in the {Keycloak} web UI is set to *public*
 

--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-web-ui.adoc
@@ -5,7 +5,7 @@ Use this procedure to configure {Project} settings for {Keycloak} authentication
 
 Note that you can navigate to the following URL within your realm to obtain values to configure {Project} settings: `\https://{Keycloak-short}.example.com/auth/realms/{Project}_Realm/.well-known/openid-configuration`
 
-.Prerequisite
+.Prerequisites
 
 * Ensure that the *Access Type* setting in the {Project} client in the {Keycloak} web UI is set to *confidential*
 

--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -3,7 +3,7 @@
 
 You can configure {ProductName} with an external DHCP server.
 
-.Prerequisite
+.Prerequisites
 * Ensure that you have configured an external DHCP server and that you have shared the DHCP configuration and lease files with {ProductName}.
 For more information, see xref:configuring-an-external-dhcp-server_{context}[].
 

--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -3,7 +3,7 @@
 
 To send email messages from {ProjectServer}, you can use either an SMTP server, or the `sendmail` command.
 
-.Prerequisite
+.Prerequisites
 * Some SMTP servers with anti-spam protection or grey-listing features are known to cause problems.
 To setup outgoing email with such a service either install and configure a vanilla SMTP service on {ProjectServer} for relay or use the `sendmail` command instead.
 

--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -3,7 +3,7 @@
 
 Use the `{foreman-installer}` command to configure {Project} to connect to an external PostgreSQL database.
 
-.Prerequisite
+.Prerequisites
 * You have installed and configured a PostgreSQL database on a {EL} server.
 
 .Procedure

--- a/guides/common/modules/proc_configuring-the-hammer-cli-to-use-freeipa-user-authentication.adoc
+++ b/guides/common/modules/proc_configuring-the-hammer-cli-to-use-freeipa-user-authentication.adoc
@@ -3,7 +3,7 @@
 
 This section describes how to configure the {Project} Hammer command-line interface (CLI) tool to use {FreeIPA} (IdM) to authenticate users.
 
-.Prerequisite
+.Prerequisites
 * You are logged in to the host from which you want to access {Project} by using Hammer.
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-shellhook-to-print-arguments.adoc
+++ b/guides/common/modules/proc_creating-a-shellhook-to-print-arguments.adoc
@@ -3,7 +3,7 @@
 
 Create a simple shellhook script that prints `Hello World!` when you run a remote execution job.
 
-.Prerequisite
+.Prerequisites
 * You have the webhooks and shellhooks plug-ins installed.
 For more information, see:
 

--- a/guides/common/modules/proc_creating-a-suse-operating-system.adoc
+++ b/guides/common/modules/proc_creating-a-suse-operating-system.adoc
@@ -7,7 +7,7 @@ For more information, see:
 * {ProvisioningDocURL}adding-installation-media_provisioning[Adding Installation Media to {Project}] in _{ProvisioningDocTitle}_
 * {ProvisioningDocURL}creating-operating-systems_provisioning[Creating Operating Systems] in _{ProvisioningDocTitle}_
 
-.Prerequisite
+.Prerequisites
 * An extracted `.iso` image on {Project} or an HTTP server that can be reached from hosts during their provisioning process.
 For more information, see xref:Preparing_SUSE_Installation_Media_{context}[].
 

--- a/guides/common/modules/proc_creating-an-api-only-user.adoc
+++ b/guides/common/modules/proc_creating-an-api-only-user.adoc
@@ -3,7 +3,7 @@
 
 You can create users that can interact only with the {Project} API.
 
-.Prerequisite
+.Prerequisites
 * You have created a user and assigned roles to them.
 Note that this user must be authorized internally.
 For more information, see xref:Creating_a_User_{context}[] and xref:Assigning_Roles_to_a_User_{context}[].

--- a/guides/common/modules/proc_creating-an-application-definition.adoc
+++ b/guides/common/modules/proc_creating-an-application-definition.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to create xref:Application_Definitions_{context}[] to use as part of your application centric deployment.
 
-.Prerequisite
+.Prerequisites
 You need existing host groups in order to use application centric deployment.
 
 .Procedure

--- a/guides/common/modules/proc_creating-custom-provisioning-snippets.adoc
+++ b/guides/common/modules/proc_creating-custom-provisioning-snippets.adoc
@@ -4,7 +4,7 @@
 Custom provisioning snippets allow you to execute custom code during host provisioning.
 You can run code before and/or after the provisioning process.
 
-.Prerequisite
+.Prerequisites
 * Depending on your provisioning template, multiple custom snippet hooks exist which you can use to include custom provisioning snippets.
 Ensure that you check your provisioning template first to verify which custom snippets you can use.
 

--- a/guides/common/modules/proc_deleting-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_deleting-a-compliance-policy.adoc
@@ -3,7 +3,7 @@
 
 In the {ProjectWebUI}, you can delete existing compliance policies.
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_policies` and `destroy_policies` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_deleting-a-compliance-report.adoc
+++ b/guides/common/modules/proc_deleting-a-compliance-report.adoc
@@ -3,7 +3,7 @@
 
 You can delete compliance reports on your {Project}.
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_arf_reports` and `destroy_arf_reports` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_deleting-multiple-compliance-reports.adoc
+++ b/guides/common/modules/proc_deleting-multiple-compliance-reports.adoc
@@ -7,7 +7,7 @@ ifdef::satellite[]
 If you want to delete all OpenSCAP reports, use the script in {APIDocURL}chap-red_hat_satellite-api_guide-using_the_red_hat_satellite_api#sect-API_Guide-Deleting-OpenSCAP-Reports[Deleting OpenSCAP Reports] in the _{APIDocTitle}_.
 endif::[]
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_arf_reports` and `destroy_arf_reports` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_disabling-puppet.adoc
+++ b/guides/common/modules/proc_disabling-puppet.adoc
@@ -12,7 +12,7 @@ If you disable Puppet with the `--remove-all-data` argument, you will not be abl
 This is a known issue, see the https://bugzilla.redhat.com/show_bug.cgi?id=2087067[Bug 2087067].
 ====
 
-.Prerequisite
+.Prerequisites
 * Puppet is enabled on {Project}.
 
 .Procedure

--- a/guides/common/modules/proc_editing-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_editing-a-compliance-policy.adoc
@@ -7,7 +7,7 @@ Puppet agent applies an edited policy to the host on the next run.
 By default, this occurs every 30 minutes.
 If you use Ansible, you must run the Ansible role manually again or have configured a recurring remote execution job that runs the Ansible role on hosts.
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_policies` and `edit_policies` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_enabling-dependency-solving-for-a-content-view.adoc
+++ b/guides/common/modules/proc_enabling-dependency-solving-for-a-content-view.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to enable dependency solving for a Content View.
 
-.Prerequisite
+.Prerequisites
 
 * Dependency solving is useful only in limited contexts.
 Before enabling it, ensure you read and understand xref:Resolving_Package_Dependencies_{context}[]

--- a/guides/common/modules/proc_enabling-remote-execution.adoc
+++ b/guides/common/modules/proc_enabling-remote-execution.adoc
@@ -5,7 +5,7 @@ Use this procedure to enable remote execution on your {SmartProxyServer}.
 To learn more about remote execution, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in _{ManagingHostsDocTitle}_.
 
 ifdef::foreman-el,foreman-deb[]
-.Prerequisite
+.Prerequisites
 * You have enabled the remote execution plug-in on your {ProjectServer}.
 To do this, run the following command:
 +

--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -3,7 +3,7 @@
 
 In the {Project} CLI, enroll {ProjectServer} with the Active Directory server.
 
-.Prerequisite
+.Prerequisites
 * GSS-proxy and {nfs-client-package} are installed.
 +
 Installing GSS-proxy and {nfs-client-package}:

--- a/guides/common/modules/proc_examining-compliance-failures-of-a-host.adoc
+++ b/guides/common/modules/proc_examining-compliance-failures-of-a-host.adoc
@@ -16,7 +16,7 @@ A compliance report consists of the following areas:
 * Compliance and Scoring
 * Rule Overview
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_arf_reports` and `view_hosts` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_examining-hosts-per-rule-compliance-result.adoc
+++ b/guides/common/modules/proc_examining-hosts-per-rule-compliance-result.adoc
@@ -3,7 +3,7 @@
 
 You can examine a simplified report and use policy rules to list hosts that have a certain compliance result, such as failing a particular rule.
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_arf_reports` and `view_hosts` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
@@ -5,7 +5,7 @@ You can export the content of a repository in the Library environment of an orga
 
 include::snip_generating-content.adoc[]
 
-.Prerequisite
+.Prerequisites
 * Ensure that you set the download policy to *Immediate* for the repository within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 

--- a/guides/common/modules/proc_importing-all-available-ansible-playbooks.adoc
+++ b/guides/common/modules/proc_importing-all-available-ansible-playbooks.adoc
@@ -3,7 +3,7 @@
 
 You can import all the available Ansible playbooks to {Project} from collections installed on {SmartProxy}.
 
-.Prerequisite
+.Prerequisites
 * Ansible plug-in in {Project} is enabled
 
 .Procedure

--- a/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
+++ b/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
@@ -3,7 +3,7 @@
 
 You can import Ansible playbooks by name to {Project} from collections installed on {SmartProxy}.
 
-.Prerequisite
+.Prerequisites
 * Ansible plug-in in {Project} is enabled
 
 .Procedure

--- a/guides/common/modules/proc_importing-ansible-roles-and-variables.adoc
+++ b/guides/common/modules/proc_importing-ansible-roles-and-variables.adoc
@@ -5,7 +5,7 @@ You can import Ansible roles and variables from the xref:Ansible-paths_{context}
 
 Note that some roles take longer to import than others.
 
-.Prerequisite
+.Prerequisites
 * Ensure that the roles and variables that you import are located in the xref:Ansible-paths_{context}[Ansible paths] on all {SmartProxies} from where you want to use the roles.
 
 .Procedure

--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -3,7 +3,7 @@
 
 You can import and synchronize OSTree content from custom online sources over HTTPS.
 
-.Prerequisite
+.Prerequisites
 * A published HTTP location, known as an _upstream URL_, for the OSTree to import.
 
 .Procedure

--- a/guides/common/modules/proc_importing-puppet-classes-and-environments.adoc
+++ b/guides/common/modules/proc_importing-puppet-classes-and-environments.adoc
@@ -3,7 +3,7 @@
 
 Import Puppet classes and environments from the installed Puppet modules to {ProjectServer} or any attached {SmartProxyServer} before you assign any of the classes to hosts.
 
-.Prerequisite
+.Prerequisites
 * Ensure to select *Any Organization* and *Any Location* as context, otherwise the import might fail.
 
 .Procedure

--- a/guides/common/modules/proc_importing-report-templates.adoc
+++ b/guides/common/modules/proc_importing-report-templates.adoc
@@ -6,7 +6,7 @@ Note that using the {ProjectWebUI}, you can only import templates individually.
 For bulk actions, use the {Project} API.
 For more information, see xref:Importing_Report_Templates_Using_the_API_{context}[].
 
-.Prerequisite
+.Prerequisites
 * You must have exported templates from {Project} to import them to use in new templates.
 For more information see xref:Exporting_Report_Templates_{context}[].
 

--- a/guides/common/modules/proc_importing-suse-products.adoc
+++ b/guides/common/modules/proc_importing-suse-products.adoc
@@ -4,7 +4,7 @@
 Use this procedure to import products from SUSE into {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Importing_SUSE_Products_{context}[].
 
-.Prerequisite
+.Prerequisites
 * You have added your SCC account to {Project}.
 For more information, see xref:Adding_an_SCC_Account_to_Server_{context}[].
 

--- a/guides/common/modules/proc_importing-the-katello-root-ca-certificate.adoc
+++ b/guides/common/modules/proc_importing-the-katello-root-ca-certificate.adoc
@@ -6,7 +6,7 @@ Use the following procedure to locate the root CA certificate on {Project} and t
 
 To use the CLI instead of the {ProjectWebUI}, see xref:CLI_Importing_the_Katello_Root_CA_Certificate_{context}[CLI Procedure].
 
-.Prerequisite
+.Prerequisites
 * Your {ProjectName} is installed and configured.
 
 .Procedure

--- a/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
@@ -1,7 +1,7 @@
 [id="Installing_ACD_on_Smart_Proxy_{context}"]
 = Installing ACD on {SmartProxyServerTitle}
 
-.Prerequisite
+.Prerequisites
 * {ProjectServer} with the Foreman ACD plug-in installed.
 For more information, see xref:Installing_ACD_on_Server_{context}[].
 

--- a/guides/common/modules/proc_installing-fapolicyd-on-server.adoc
+++ b/guides/common/modules/proc_installing-fapolicyd-on-server.adoc
@@ -15,7 +15,7 @@ You can install `fapolicyd` along with {SmartProxyServer} or can be installed on
 If you are installing `fapolicyd` along with the new {SmartProxyServer}, the installation process will detect the fapolicyd in your {EL} host and deploy the {SmartProxyServer} rules automatically.
 endif::[]
 
-.Prerequisite
+.Prerequisites
 * Ensure your host has access to the BaseOS repositories of {EL}.
 
 .Procedure

--- a/guides/common/modules/proc_installing-pcp.adoc
+++ b/guides/common/modules/proc_installing-pcp.adoc
@@ -3,7 +3,7 @@
 
 Install the PCP packages on your {ProjectServer} and enable PCP daemons.
 
-.Prerequisite
+.Prerequisites
 * Ensure you have the minimum of 20 GB space available in the `/var/log/pcp` directory.
 +
 With the default PCP data retention settings, data storage is estimated to use between 100 MB and 500 MB of disk space per day, but may use up to several gigabytes over time.

--- a/guides/common/modules/proc_installing-python-packages-from-server.adoc
+++ b/guides/common/modules/proc_installing-python-packages-from-server.adoc
@@ -3,7 +3,7 @@
 
 You can install Python packages from {Project} on hosts using `pip`.
 
-.Prerequisite
+.Prerequisites
 * You have uploaded or synchronized a Python package to {Project}.
 
 .Procedure

--- a/guides/common/modules/proc_installing-the-kernelcare-package-on-hosts.adoc
+++ b/guides/common/modules/proc_installing-the-kernelcare-package-on-hosts.adoc
@@ -3,7 +3,7 @@
 
 You can use `kernelcare` to patch the Linux kernel on hosts without rebooting them.
 
-.Prerequisite
+.Prerequisites
 * Your hosts have access to the KernelCare repository.
 For more information, see xref:KernelCare_Client_{context}[].
 

--- a/guides/common/modules/proc_listing-available-scap-contents.adoc
+++ b/guides/common/modules/proc_listing-available-scap-contents.adoc
@@ -4,7 +4,7 @@
 Use this procedure to view what SCAP contents are already loaded in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-listing-available-scap-contents_{context}[CLI procedure].
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_scap_contents` permission.
 
 .Procedure

--- a/guides/common/modules/proc_locating-a-red-hat-subscription.adoc
+++ b/guides/common/modules/proc_locating-a-red-hat-subscription.adoc
@@ -4,7 +4,7 @@
 When you import a Red{nbsp}Hat subscription manifest into {ProjectServer}, the subscriptions from your manifest are listed in the Subscriptions window.
 If you have a high volume of subscriptions, you can filter the results to find a specific subscription.
 
-.Prerequisite
+.Prerequisites
 * You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 

--- a/guides/common/modules/proc_logging-in.adoc
+++ b/guides/common/modules/proc_logging-in.adoc
@@ -4,7 +4,7 @@
 Use the web user interface to log in to {Project} for further configuration.
 
 ifdef::katello,orcharhino,satellite[]
-.Prerequisite
+.Prerequisites
 * Ensure that the Katello root CA certificate is installed in your browser.
 For more information, see xref:Importing_the_Katello_Root_CA_Certificate_{context}[].
 endif::[]

--- a/guides/common/modules/proc_managing-ostree-content-with-content-views.adoc
+++ b/guides/common/modules/proc_managing-ostree-content-with-content-views.adoc
@@ -4,7 +4,7 @@
 Use Content Views to manage OSTree branches across the application lifecycle.
 This process uses the same publication and promotion method as RPMs or Puppet modules.
 
-.Prerequisite
+.Prerequisites
 * You have created a Product and added an OSTree repository to it.
 
 .Procedure

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -3,7 +3,7 @@
 
 Back up and transfer existing data, then use the `{foreman-installer}` command to configure {Project} to connect to an external PostgreSQL database server.
 
-.Prerequisite
+.Prerequisites
 * You have installed and configured a PostgreSQL server on a {EL} server.
 
 .Procedure

--- a/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
@@ -10,7 +10,7 @@ For more information, see {ManagingHostsDocURL}[_{ManagingHostsDocTitle}_].
 If you use an Ansible role to run a task as a user that is not the `Effective User`, there is a strict order of precedence for overriding Ansible variables.
 To ensure the variable that you override follows the correct order of precedence, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#ansible-variable-precedence[Variable precedence: Where should I put a variable?]
 
-.Prerequisite
+.Prerequisites
 * You must have Ansible variables in {Project}.
 For more information, see xref:Importing_Ansible_Roles_and_Variables_{context}[]
 

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -8,7 +8,7 @@ Subscriptions for {RHEL} do not provide the correct service level agreement for 
 You must also attach a {Project} subscription to the base operating system that you want to use for the external databases.
 endif::[]
 
-.Prerequisite
+.Prerequisites
 * The prepared host must meet {Project}'s {InstallingServerDocURL}storage-requirements_{project-context}[Storage Requirements].
 
 .Procedure

--- a/guides/common/modules/proc_propagating-scap-content-using-ansible-deployment.adoc
+++ b/guides/common/modules/proc_propagating-scap-content-using-ansible-deployment.adoc
@@ -3,7 +3,7 @@
 
 Using this procedure, you can promote Security Content Automation Protocol (SCAP) content through the load balancer in the scope of the Ansible deployment method.
 
-.Prerequisite
+.Prerequisites
 * Ensure that you have configured {Project} for Ansible deployment of compliance policies.
 For more information, see {ManagingSecurityDocURL}configuring-compliance-policy-deployment-methods_security-compliance[Configuring Compliance Policy Deployment Methods] in _{ManagingSecurityDocTitle}_.
 

--- a/guides/common/modules/proc_propagating-scap-content-using-puppet-deployment.adoc
+++ b/guides/common/modules/proc_propagating-scap-content-using-puppet-deployment.adoc
@@ -3,7 +3,7 @@
 
 Using this procedure, you can promote Security Content Automation Protocol (SCAP) content through the load balancer in the scope of the Puppet deployment method.
 
-.Prerequisite
+.Prerequisites
 * Ensure that you have configured {Project} for Puppet deployment of compliance policies.
 For more information, see {ManagingSecurityDocURL}configuring-compliance-policy-deployment-methods_security-compliance[Configuring Compliance Policy Deployment Methods] in _{ManagingSecurityDocTitle}_.
 

--- a/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
+++ b/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
@@ -3,7 +3,7 @@
 
 Perform these steps to provision hosts running Ubuntu 20.04.3+ or Ubuntu 22.04.
 
-.Prerequisite
+.Prerequisites
 * Ensure you have configured your {SmartProxyServers} for provisioning.
 For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for Host Registration and Provisioning] in _{InstallingSmartProxyDocTitle}_.
 

--- a/guides/common/modules/proc_registering-clients-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-clients-using-the-bootstrap-script.adoc
@@ -4,7 +4,7 @@
 To register clients, enter the following command on the client.
 You must complete the registration procedure for each client.
 
-.Prerequisite
+.Prerequisites
 * Ensure that you install the bootstrap script on the client and change file permissions of the script to executable.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_by_Using_the_Bootstrap_Script_managing-hosts[Registering Hosts to {ProjectName} Using The Bootstrap Script] in _{ManagingHostsDocTitle}_.
 

--- a/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-allocations.adoc
+++ b/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-allocations.adoc
@@ -9,7 +9,7 @@ Manifests must not be deleted.
 If you delete the manifest from the Red Hat Customer Portal or in the {ProjectWebUI}, all of the entitlements for all of your content hosts will be removed.
 ====
 
-.Prerequisite
+.Prerequisites
 * You must have a Red{nbsp}Hat subscription manifest file imported to {ProjectServer}.
 For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}[].
 

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to update your {customssl} certificate for {ProjectServer}.
 
-.Prerequisite
+.Prerequisites
 * You must create a new Certificate Signing Request (CSR) and send it to the Certificate Authority to sign the certificate.
 Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{context}[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the Server certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
 In return, you will receive the {ProjectServer} certificate and CA bundle.

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -5,7 +5,7 @@ Use this procedure to update your {customssl} certificate for {SmartProxyServer}
 The `{foreman-installer}` command, which the `{certs-generate}` command returns, is unique to each {SmartProxyServer}.
 You cannot use the same command on more than one {SmartProxyServer}.
 
-.Prerequisite
+.Prerequisites
 * You must create a new Certificate Signing Request and send it to the Certificate Authority to sign the certificate.
 Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{context}[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the {ProjectServer} certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
 In return, you will receive the {SmartProxyServer} certificate and CA bundle.

--- a/guides/common/modules/proc_scheduling-a-recurring-ansible-job-for-a-host.adoc
+++ b/guides/common/modules/proc_scheduling-a-recurring-ansible-job-for-a-host.adoc
@@ -3,7 +3,7 @@
 
 You can schedule a recurring job to run Ansible roles on hosts.
 
-.Prerequisite
+.Prerequisites
 * Ensure you have the `view_foreman_tasks`, `view_job_invocations`, and `view_recurring_logics` permissions.
 
 .Procedure

--- a/guides/common/modules/proc_switching-scc-accounts.adoc
+++ b/guides/common/modules/proc_switching-scc-accounts.adoc
@@ -11,7 +11,7 @@ If you want to switch your SCC account and retain the synchronized content, do n
 If you delete your old SCC account, you cannot reuse existing repositories, products, Content Views, and composite Content Views.
 ====
 
-.Prerequisite
+.Prerequisites
 * You have added your SCC account to {Project}.
 For more information, see xref:Adding_an_SCC_Account_to_Server_{context}[].
 

--- a/guides/common/modules/proc_synchronizing-content-from-project-server-to-smart-proxy-servers.adoc
+++ b/guides/common/modules/proc_synchronizing-content-from-project-server-to-smart-proxy-servers.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to synchronize content from your {ProjectServer} to your {SmartProxyServer}.
 
-.Prerequisite
+.Prerequisites
 * Ensure that you either select the relevant organization and location context of your {SmartProxyServer} or choose *Any Organization* and *Any Location*.
 
 .Procedure

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -3,7 +3,7 @@
 
 Use this procedure to synchronize SUSE content to your {Project} to deploy, register, and serve content to hosts.
 
-.Prerequisite
+.Prerequisites
 * You have imported SUSE products into {Project}.
 For more information, see xref:Importing_SUSE_Products_{context}[].
 

--- a/guides/common/modules/proc_updating-server.adoc
+++ b/guides/common/modules/proc_updating-server.adoc
@@ -9,7 +9,7 @@ ifndef::satellite[]
 Update your {ProjectServer} to the next minor version.
 endif::[]
 
-.Prerequisite
+.Prerequisites
 * Back up your {ProjectServer}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 

--- a/guides/common/modules/proc_uploading-a-tailoring-file.adoc
+++ b/guides/common/modules/proc_uploading-a-tailoring-file.adoc
@@ -3,7 +3,7 @@
 
 After uploading a tailoring file, you can apply it in a compliance policy to customize an XCCDF profile.
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `create_tailoring_files` permission.
 
 .Procedure

--- a/guides/common/modules/proc_uploading-additional-scap-content.adoc
+++ b/guides/common/modules/proc_uploading-additional-scap-content.adoc
@@ -10,7 +10,7 @@ For example, you can get the latest OpenSCAP contents for additional systems fro
 endif::[]
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Uploading_Additional_SCAP_Content_{context}[CLI procedure].
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `create_scap_contents` permission.
 * You have acquired a SCAP data-stream file.
 

--- a/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
+++ b/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
@@ -13,7 +13,7 @@ You can also create an OSTree image archive by downloading a repository from an 
 # tar --exclude="index.html" -cvf "_example_archive_repo_.tar" -C _repos.example.com/ostree_ "_repo_name_"
 ----
 
-.Prerequisite
+.Prerequisites
 * You have an OSTree image archive ready and present on your file system.
 
 .Procedure

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -12,7 +12,7 @@ ifndef::foreman-deb[]
 For more information about integrating {Cockpit} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host Management and Monitoring Using {Cockpit}] in _{ManagingHostsDocTitle}_.
 endif::[]
 
-.Prerequisite
+.Prerequisites
 * An existing TAR image created using {LoraxCompose}.
 
 .Procedure

--- a/guides/common/modules/proc_viewing-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_viewing-a-compliance-policy.adoc
@@ -4,7 +4,7 @@
 You can preview the rules which will be applied by specific OpenSCAP content and profile combination.
 This is useful when you plan policies.
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_policies` permission.
 
 .Procedure

--- a/guides/common/modules/proc_viewing-compliance-policy-statistics.adoc
+++ b/guides/common/modules/proc_viewing-compliance-policy-statistics.adoc
@@ -9,7 +9,7 @@ Consider prioritizing the following hosts when viewing compliance reports:
 * Hosts which were evaluated as `Failed`
 * Hosts labelled as `Never audited` because their status is unknown
 
-.Prerequisite
+.Prerequisites
 * Your user account has a role assigned that has the `view_policies` permission.
 
 .Procedure

--- a/guides/common/modules/proc_viewing-patched-kernel-version.adoc
+++ b/guides/common/modules/proc_viewing-patched-kernel-version.adoc
@@ -3,7 +3,7 @@
 
 You can use a job template to view the patched kernel version on hosts.
 
-.Prerequisite
+.Prerequisites
 * Ensure the `kernelcare` package is installed on your hosts.
 For more information, see xref:Installing_the_KernelCare_Package_on_Hosts_{context}[].
 

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -2,7 +2,7 @@ You can register hosts with {Project} using the host registration feature in the
 For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 
 ifeval::["{context}" == "load-balancing"]
-.Prerequisite
+.Prerequisites
 * You have set the load balancer for host registration.
 For more information, see xref:Setting_the_Load_Balancer_for_Host_Registration_{context}[].
 endif::[]


### PR DESCRIPTION
Change "Prerequisite" to "Prerequisites" in "dot" headers to align with the IBM Style Guide and Red Hat Modular Documentation Reference Guide.


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
