### PR TITLE
Update obsolete anchor IDs

### DIFF
--- a/guides/common/modules/con_registering-hosts-by-using-global-registration.adoc
+++ b/guides/common/modules/con_registering-hosts-by-using-global-registration.adoc
@@ -1,6 +1,5 @@
 [id="Registering_Hosts_by_Using_Global_Registration_{context}"]
 = Registering hosts by using global registration
-[[Registering_Hosts_{context}]]
 
 You can register a host to {Project} by generating a `curl` command on {Project} and running this command on hosts.
 This method uses two provisioning templates: *Global Registration* template and *Linux host_init_config default* template.

--- a/guides/common/modules/proc_changing-the-default-download-policy.adoc
+++ b/guides/common/modules/proc_changing-the-default-download-policy.adoc
@@ -1,4 +1,4 @@
-[[Changing_the_Default_Download_Policy]]
+[id="Changing_the_Default_Download_Policy"]
 = Changing the default download policy
 
 You can set the default download policy that {Project} applies to repositories that you create in all organizations.

--- a/guides/common/modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc
+++ b/guides/common/modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc
@@ -1,4 +1,4 @@
-[id="Changing_the_Provisioning_Password_Hashing_Algorithm_{context}"]]
+[id="Changing_the_Provisioning_Password_Hashing_Algorithm_{context}"]
 = Changing the provisioning password hashing algorithm
 
 To provision FIPS-compliant hosts, you must first set the password hashing algorithm that you use in provisioning to SHA256.

--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -1,4 +1,4 @@
-[[cloning_satellite_server]]
+[id="cloning_satellite_server"]
 = Cloning {ProjectServer}
 
 You can clone your {ProjectServer} to create instances to test upgrades and migration of instances to a different machine or operating system.
@@ -17,7 +17,7 @@ Ensure that you understand the following terms:
 *Target server*:: The new server that you copy files to and clone the source server to.
 
 
-[[sec-Cloning_Workflow_Overview]]
+[id="sec-Cloning_Workflow_Overview"]
 == Cloning process overview
 
 . Back up the source server.
@@ -27,7 +27,7 @@ Ensure that you understand the following terms:
 . Test the new target server.
 
 
-[[sec-Cloning_Prerequisites]]
+[id="sec-Cloning_Prerequisites"]
 == Prerequisites
 
 To clone {ProjectServer}, ensure that you have the following resources available:
@@ -50,7 +50,7 @@ This avoids unwanted communication with {SmartProxyServers} and hosts.
 
 If you have any customized configurations on your source server that are not managed by the `{foreman-installer}` tool or {Project} backup process, you must manually back up these files.
 
-[[sec-Pulp_Data_Considerations]]
+[id="sec-Pulp_Data_Considerations"]
 == Pulp data considerations
 
 You can clone {Project} server without including Pulp data.
@@ -96,12 +96,12 @@ Follow the steps in the procedure in xref:sec_Cloning_Satellite_Server[] and rep
 Proceed to xref:sec-Cloning_to_Target[].
 
 
-[[sec_Cloning_Satellite_Server]]
+[id="sec_Cloning_Satellite_Server"]
 == Cloning {ProjectServer}
 
 Use the following procedures to clone {ProjectServer}. Note that because of the high volume of data that you must copy and transfer as part of these procedures, it can take a significant amount of time to complete.
 
-[[sec-Preparing_Source_Server]]
+[id="sec-Preparing_Source_Server"]
 === Preparing the source server for cloning
 
 On the source server, complete the following steps:
@@ -151,7 +151,7 @@ If you have more than 500 GB of Pulp data, skip the following steps and complete
 
 Proceed to xref:sec-Cloning_to_Target[].
 
-[[sec-Cloning_to_Target]]
+[id="sec-Cloning_to_Target"]
 === Cloning to the target server
 
 To clone your server, complete the following steps on your target server:

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -19,7 +19,8 @@ ifdef::foreman-deb[]
 endif::[]
 
 ifdef::foreman-el,katello[]
-== [[repositories-centos-stream-8]]CentOS Stream 8
+[id="repositories-centos-stream-8"]
+== CentOS Stream 8
 
 :distribution: el
 :distribution-major-version: 8
@@ -48,7 +49,8 @@ endif::[]
 endif::[]
 
 ifdef::foreman-el,katello[]
-== [[repositories-rhel-8]]{RHEL} 8
+[id="repositories-rhel-8"]
+== {RHEL} 8
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
@@ -111,12 +113,14 @@ For more information about modules and lifecycle streams on {RHEL} 8, see https:
 endif::[]
 
 ifdef::foreman-deb[]
-== [[repositories-debian-11]]Debian 11 (Bullseye)
+[id="repositories-debian-11"]
+== Debian 11 (Bullseye)
 
 :distribution-codename: bullseye
 include::proc_configuring-repositories-deb.adoc[]
 
-== [[repositories-ubuntu-2004]]Ubuntu 20.04 (Focal)
+[id="repositories-ubuntu-2004"]
+== Ubuntu 20.04 (Focal)
 
 :distribution-codename: focal
 include::proc_configuring-repositories-deb.adoc[]

--- a/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-satellite-tools-repository.adoc
@@ -8,7 +8,8 @@ Continue with a procedure below according to the operating system version for wh
 * xref:#enabling-repos-rhel9-rhel8[{RHEL} 9 & {RHEL} 8]
 * xref:#enabling-repos-rhel7-rhel6[{RHEL} 7 & {RHEL} 6]
 
-== [[enabling-repos-rhel9-rhel8]]{RHEL} 9 & {RHEL} 8
+[id="enabling-repos-rhel9-rhel8"]
+== {RHEL} 9 & {RHEL} 8
 
 To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for your {RHEL} version:
 
@@ -59,7 +60,8 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 --product "{RHEL} for x86_64"
 ----
 
-== [[enabling-repos-rhel7-rhel6]]{RHEL} 7 & {RHEL} 6
+[id="enabling-repos-rhel7-rhel6"]
+== {RHEL} 7 & {RHEL} 6
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-satellite-tools-repository.adoc
@@ -8,7 +8,8 @@ Continue with a procedure below according to the operating system version for wh
 * xref:#synchronizing-repos-rhel9-rhel8[{RHEL} 9 & {RHEL} 8]
 * xref:#synchronizing-repos-rhel7-rhel6[{RHEL} 7 & {RHEL} 6]
 
-== [[synchronizing-repos-rhel9-rhel8]]{RHEL} 9 & {RHEL} 8
+[id="synchronizing-repos-rhel9-rhel8"]
+== {RHEL} 9 & {RHEL} 8
 
 To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for your {RHEL} version:
 
@@ -45,7 +46,8 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 --product "{RHEL} for x86_64"
 ----
 
-== [[synchronizing-repos-rhel7-rhel6]]{RHEL} 7 & {RHEL} 6
+[id="synchronizing-repos-rhel7-rhel6"]
+== {RHEL} 7 & {RHEL} 6
 
 [NOTE]
 ====


### PR DESCRIPTION
- Change `[[anchor-id]]` to `[id="anchor-id"]` for files in `guides/common/modules` to comply with current Asciidoc formatting
- No changes to files in `guides/doc-Planning-for-Project` because that guide has its own modularization issue.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
