### PR TITLE
Remove optional REX plug-in for orcharhino

### DIFF
--- a/guides/common/modules/proc_adding-a-subnet.adoc
+++ b/guides/common/modules/proc_adding-a-subnet.adoc
@@ -20,10 +20,10 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-subnet_{
 For more information about IPAM, see xref:Configuring_Networking_{context}[].
 +
 . Enter the information for the IPAM method that you select.
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 Click the *Remote Execution* tab and select the {SmartProxy} that controls the remote execution.
 endif::[]
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 . If you use the remote execution plug-in, click the *Remote Execution* tab and select the {SmartProxy} that controls the remote execution.
 endif::[]
 . Click the *Domains* tab and select the domains that apply to this subnet.
@@ -55,9 +55,9 @@ For example, user defined Boolean or string parameters to use in templates.
 --mask "255.255.255.0" \
 --name "_My_Network_" \
 --network "192.168.140.0" \
---organizations "_My_Organization_"
+--organizations "_My_Organization_" \
 --tftp-id _My_TFTP_ID_ \
---to "192.168.140.250" \
+--to "192.168.140.250"
 ----
 
 [NOTE]

--- a/guides/common/modules/proc_enabling-remote-execution.adoc
+++ b/guides/common/modules/proc_enabling-remote-execution.adoc
@@ -16,7 +16,7 @@ To do this, run the following command:
 endif::[]
 
 .Procedure
-* Enable remote execution with {foreman-installer}:
+* Enable remote execution with `{foreman-installer}`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
orcharhino comes, by default, with foreman_remote_execution installed. Users cannot unselect or uninstall this during/after the installation.

* Fix emphasis for foreman-installer command
* Fix issue with trailing backslash for Hammer CLI command

Proof: image 8 on https://docs.orcharhino.com/or/docs/sources/installation_and_maintenance/installing_orcharhino_server.html#orcharhino_Installer_GUI

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
