### PR TITLE
Remove ACD developers from docs

### DIFF
--- a/guides/common/modules/proc_acd-developers.adoc
+++ b/guides/common/modules/proc_acd-developers.adoc
@@ -1,7 +1,0 @@
-[id="ACD_Developers_{context}"]
-= ACD developers
-
-The Foreman ACD plug-in was initially developed by https://atix.de/[ATIX AG] with <3 and is completely open source software:
-
-* The https://github.com/ATIX-AG/foreman_acd[Foreman ACD Plug-in] provides the ACD functionality to {Project}.
-* The https://github.com/ATIX-AG/smart_proxy_acd[Foreman ACD Smart Proxy Plug-in] is necessary to receive commands from {Project}.

--- a/guides/doc-Deploying_Hosts_AppCentric/master.adoc
+++ b/guides/doc-Deploying_Hosts_AppCentric/master.adoc
@@ -68,6 +68,4 @@ include::common/modules/proc_overwriting-ansible-group-variables-in-application-
 include::common/modules/proc_viewing-application-instance-reports.adoc[leveloffset=+2]
 
 include::common/modules/proc_viewing-the-last-deployment-task.adoc[leveloffset=+2]
-
-include::common/modules/proc_acd-developers.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
I am sure all other code and documentation is also made with love!


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
