### PR TITLE
Add message about cloning templates for master

### DIFF
--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -2,3 +2,5 @@
 = Performing post-upgrade tasks
 
 Optional: If the default provisioning templates have been changed during the upgrade, recreate any templates cloned from the default templates.
+If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
+For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.

--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -1,23 +1,4 @@
 [id="performing-post-upgrade-tasks_{context}"]
 = Performing post-upgrade tasks
 
-Some of the procedures in this section are optional.
-You can choose to perform only those procedures that are relevant to your installation.
-
-If you use custom templates created from a cloned default template, create the custom template again after the upgrade.
-Sometimes the default templates are changed during the upgrade, this will ensure that the custom templates are compatible with the latest version.
-
-* xref:upgrading_discovery_parent[]
-ifdef::katello,satellite,orcharhino[]
-* xref:upgrading_virt_who[]
-endif::[]
-ifdef::satellite[]
-* xref:removing_satellite_tools_repository[]
-endif::[]
-ifndef::foreman-deb[]
-* xref:migrating-ansible-content_{context}[]
-endif::[]
-* xref:reclaiming-postgresql-space_{context}[]
-ifndef::foreman-el,foreman-deb[]
-* xref:tuning-with-predefined-profiles_{context}[]
-endif::[]
+If the default provisioning templates have been changed during the upgrade, recreate any templates cloned from the default templates.

--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -4,6 +4,9 @@
 Some of the procedures in this section are optional.
 You can choose to perform only those procedures that are relevant to your installation.
 
+If you use custom templates created from a cloned default template, create the custom template again after the upgrade.
+Sometimes the default templates are changed during the upgrade, this will ensure that the custom templates are compatible with the latest version.
+
 * xref:upgrading_discovery_parent[]
 ifdef::katello,satellite,orcharhino[]
 * xref:upgrading_virt_who[]

--- a/guides/common/modules/con_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/con_performing-post-upgrade-tasks.adoc
@@ -1,4 +1,4 @@
 [id="performing-post-upgrade-tasks_{context}"]
 = Performing post-upgrade tasks
 
-If the default provisioning templates have been changed during the upgrade, recreate any templates cloned from the default templates.
+Optional: If the default provisioning templates have been changed during the upgrade, recreate any templates cloned from the default templates.

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -43,6 +43,9 @@ ifdef::satellite[]
 include::common/modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+2]
 endif::[]
 
+// Performing Post-Upgrade Tasks
+include::common/modules/con_performing-post-upgrade-tasks.adoc[leveloffset=+2]
+
 // Upgrading Smart Proxy Server
 include::common/modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/2697 for master. Custom templates created from default templates need to be cloned again after upgrade to ensure that any changes in the default templates apply to custom template as well. BZ link : https://bugzilla.redhat.com/show_bug.cgi?id=2257737


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
