### PR TITLE
Add a step to synchronize Smart Proxy repo before updating

### DIFF
--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -4,9 +4,10 @@
 Update {SmartProxyServers} to the next minor version.
 
 .Procedure
+ifdef::satellite[]
 . Synchronize the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
 Publish and promote a new version of the content view with which the {SmartProxy} is registered.
- 
+endif::[]
 . Ensure that the {Project} Maintenance repository is enabled:
 ifdef::satellite[]
 +

--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -4,6 +4,9 @@
 Update {SmartProxyServers} to the next minor version.
 
 .Procedure
+. Synchronise the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
+Publish and promote a new version of the content view with which the {SmartProxy} is registered.
+ 
 . Ensure that the {Project} Maintenance repository is enabled:
 ifdef::satellite[]
 +

--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -4,7 +4,7 @@
 Update {SmartProxyServers} to the next minor version.
 
 .Procedure
-. Synchronise the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
+. Synchronize the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
 Publish and promote a new version of the content view with which the {SmartProxy} is registered.
  
 . Ensure that the {Project} Maintenance repository is enabled:

--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -6,7 +6,7 @@ Update {SmartProxyServers} to the next minor version.
 .Procedure
 ifdef::satellite[]
 . Synchronize the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
-Publish and promote a new version of the content view with which the {SmartProxy} is registered.
+. Publish and promote a new version of the content view with which the {SmartProxy} is registered.
 endif::[]
 . Ensure that the {Project} Maintenance repository is enabled:
 ifdef::satellite[]


### PR DESCRIPTION
The Smart Proxy repo needs to be updated to have the latest updated packages before performing the update. Ading a step at the beginning to sync the repo and publish and promote the CV that the Smart Proxy uses.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2254225


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] 3.10
* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
