### PR TITLE
Fix location of Activation Keys in vertical nav

### DIFF
--- a/guides/common/modules/proc_creating-an-activation-key-short.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-short.adoc
@@ -3,7 +3,8 @@
 
 Use the following procedure to create an activation key that you can use to subscribe your hosts to content managed by {Project}.
 
-. In the {ProjectWebUI}, navigate to *Content* > *Activation keys* and click *Create Activation Key*.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.
+. Click *Create Activation Key*.
 . In the *Name* field, enter the name of the activation key.
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the *Library*.

--- a/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
@@ -4,7 +4,8 @@
 Use the following procedure to create an activation key that you can use to subscribe your hosts to content managed by {Project}.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Activation keys* and click *Create Activation Key*.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.
+. Click *Create Activation Key*.
 . In the *Name* field, enter *CentOS* or the name of your new activation key.
 . In the *Description* field, enter a description for the activation key.
 . From the *Environment* list, select the *Library*.


### PR DESCRIPTION
![image](https://github.com/theforeman/foreman-documentation/assets/108661422/73d58fea-c8d3-4301-85e6-1182a928f5cb)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
