### PR TITLE
fix FQND typo in templates docs

### DIFF
--- a/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
@@ -49,7 +49,7 @@ model: ReportTemplate
 <% load_hosts(search: input('host')).each_record do |host| -%>
 <%
       report_row(
-          'Server FQND': host.name
+          'Server FQDN': host.name
       )
 -%>
 <%  end -%>


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
