### PR TITLE
Re-add the section to upgrade Smart Proxy using remote execution for …

### DIFF
--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -152,7 +152,7 @@ For more information on backups, see {AdministeringDocURL}backing-up-satellite-s
 . From the *Job category* list, select *Maintenance Operations*.
 . From the *Job template* list, select *{SmartProxy} Upgrade Playbook*.
 . In the *Search Query* field, enter the host name of the {SmartProxy}.
-. Ensure that *Resolves to* field displays *1 host*.
+. Ensure that *1 host* is displayed in the *Resolves to* field.
 . In the *target_version* field, enter the target version of the {SmartProxy}.
 . In the *whitelist_options* field, enter the options.
 . For *Type of query*, click *Static Query*.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -139,28 +139,14 @@ include::snip_steps-needs-reboot.adoc[]
 
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups made earlier.
 ifdef::orcharhino,satellite[]
-. Optional: If you use custom repositories,ensure that you enable these custom repositories after the upgrade completes.
+. Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
 endif::[]
 
-.Upgrading {SmartProxyServersTitle} Using Remote Execution
+.Upgrading {SmartProxyServersTitle} using remote execution
 
-. Create a backup.
-+
-* On a virtual machine, take a snapshot.
-* On a physical machine, create a backup.
+. Create a backup or take a snapshot.
 +
 For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
-
-. Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files.
-The installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
-
-. Optional: If you made manual edits to DNS or DHCP configuration files and do not want to overwrite the changes, enter the following command:
-+
-[options="nowrap"]
-----
-# {foreman-installer} --foreman-proxy-dns-managed=false \
---foreman-proxy-dhcp-managed=false
-----
 
 . In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
 
@@ -172,11 +158,11 @@ The installer only supports one domain or subnet, and therefore restoring change
 
 . In the *Search Query* field, enter the host name of the {SmartProxy}.
 
-. Ensure that *Resolves to* shows *1 host*.
+. Ensure that *Resolves to* field displays *1 host*.
 
 . In the *target_version* field, enter the target version of the {SmartProxy}.
 
-. In the *whitelist_options* field, enter the whitelist options.
+. In the *whitelist_options* field, enter the options.
 
 . For *Type of query*, click *Static Query*.
 . Select the schedule for the job execution in *Schedule*.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -139,5 +139,44 @@ include::snip_steps-needs-reboot.adoc[]
 
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups made earlier.
 ifdef::orcharhino,satellite[]
-. Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
+. Optional: If you use custom repositories,ensure that you enable these custom repositories after the upgrade completes.
 endif::[]
+
+.Upgrading {SmartProxyServersTitle} Using Remote Execution
+
+. Create a backup.
++
+* On a virtual machine, take a snapshot.
+* On a physical machine, create a backup.
++
+For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
+
+. Optional: If you made manual edits to DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, back up the configuration files.
+The installer only supports one domain or subnet, and therefore restoring changes from these backups might be required.
+
+. Optional: If you made manual edits to DNS or DHCP configuration files and do not want to overwrite the changes, enter the following command:
++
+[options="nowrap"]
+----
+# {foreman-installer} --foreman-proxy-dns-managed=false \
+--foreman-proxy-dhcp-managed=false
+----
+
+. In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
+
+. Click *Run Job*.
+
+. From the *Job category* list, select *Maintenance Operations*.
+
+. From the *Job template* list, select *{SmartProxy} Upgrade Playbook*.
+
+. In the *Search Query* field, enter the host name of the {SmartProxy}.
+
+. Ensure that *Resolves to* shows *1 host*.
+
+. In the *target_version* field, enter the target version of the {SmartProxy}.
+
+. In the *whitelist_options* field, enter the whitelist options.
+
+. For *Type of query*, click *Static Query*.
+. Select the schedule for the job execution in *Schedule*.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -152,8 +152,8 @@ For more information on backups, see {AdministeringDocURL}backing-up-satellite-s
 . From the *Job category* list, select *Maintenance Operations*.
 . From the *Job template* list, select *{SmartProxy} Upgrade Playbook*.
 . In the *Search Query* field, enter the host name of the {SmartProxy}.
-. Ensure that *1 host* is displayed in the *Resolves to* field.
+. Ensure that *Apply to 1 host* is displayed in the *Resolves to* field.
 . In the *target_version* field, enter the target version of the {SmartProxy}.
 . In the *whitelist_options* field, enter the options.
-. For *Type of query*, click *Static Query*.
+. In the *Type of query* section, click *Static Query*.
 . Select the schedule for the job execution in *Schedule*.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -147,22 +147,13 @@ endif::[]
 . Create a backup or take a snapshot.
 +
 For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
-
 . In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
-
 . Click *Run Job*.
-
 . From the *Job category* list, select *Maintenance Operations*.
-
 . From the *Job template* list, select *{SmartProxy} Upgrade Playbook*.
-
 . In the *Search Query* field, enter the host name of the {SmartProxy}.
-
 . Ensure that *Resolves to* field displays *1 host*.
-
 . In the *target_version* field, enter the target version of the {SmartProxy}.
-
 . In the *whitelist_options* field, enter the options.
-
 . For *Type of query*, click *Static Query*.
 . Select the schedule for the job execution in *Schedule*.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -146,7 +146,7 @@ endif::[]
 
 . Create a backup or take a snapshot.
 +
-For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _Administering {ProjectName} {ProjectVersionPrevious}_ guide.
+For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _{AdministeringDocTitle}_.
 . In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
 . Click *Run Job*.
 . From the *Job category* list, select *Maintenance Operations*.
@@ -155,5 +155,5 @@ For more information on backups, see {AdministeringDocURL}backing-up-satellite-s
 . Ensure that *Apply to 1 host* is displayed in the *Resolves to* field.
 . In the *target_version* field, enter the target version of the {SmartProxy}.
 . In the *whitelist_options* field, enter the options.
-. In the *Type of query* section, click *Static Query*.
 . Select the schedule for the job execution in *Schedule*.
+. In the *Type of query* section, click *Static Query*.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -146,7 +146,7 @@ endif::[]
 
 . Create a backup or take a snapshot.
 +
-For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in the _{AdministeringDocTitle}_.
+For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 . In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
 . Click *Run Job*.
 . From the *Job category* list, select *Maintenance Operations*.


### PR DESCRIPTION
…Master

Same change as https://github.com/theforeman/foreman-documentation/pull/2718, for master.

The Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI} section has been left out of the post 2.5 versions. However, this is still relevant in the later versions. Adding it back in for 3.1, will push separate PRs for other versions to avoid merge conflicts due to file structure changes.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2248524


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
