### PR TITLE
Fix inclusive language issues

### DIFF
--- a/guides/common/assembly_backing-up-server-and-proxy.adoc
+++ b/guides/common/assembly_backing-up-server-and-proxy.adoc
@@ -14,4 +14,4 @@ include::modules/proc_performing-an-online-backup.adoc[leveloffset=+1]
 
 include::modules/proc_performing-a-snapshot-backup.adoc[leveloffset=+1]
 
-include::modules/ref_white-listing-and-skipping-steps-when-performing-backups.adoc[leveloffset=+1]
+include::modules/ref_skipping-steps-when-performing-backups.adoc[leveloffset=+1]

--- a/guides/common/modules/con_content-filter-overview.adoc
+++ b/guides/common/modules/con_content-filter-overview.adoc
@@ -19,7 +19,7 @@ There are two types of content filters:
 | *Include* | You start with no content, then select which content to add from the selected repositories.
 Use this filter to combine multiple content items.
 | *Exclude* | You start with all content from selected repositories, then select which content to remove.
-Use this filter when you want to use most of a particular content repository but exclude certain packages, such as blacklisted packages.
+Use this filter when you want to use most of a particular content repository while excluding certain packages.
 The filter uses all content in the repository except for the content you select.
 |===
 

--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -7,7 +7,7 @@ include::snip_host-names-for-http-proxy.adoc[]
 
 {ProjectServer} uses SSL to communicate with the Red{nbsp}Hat CDN securely.
 An SSL interception proxy interferes with this communication.
-These hosts must be allowlisted on the proxy.
+These hosts must be allowlisted on your HTTP proxy.
 
 For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red{nbsp}Hat] on the Red{nbsp}Hat Customer Portal.
 

--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -6,12 +6,12 @@ Your network gateway and the HTTP proxy must allow access to the following hosts
 include::snip_host-names-for-http-proxy.adoc[]
 
 {ProjectServer} uses SSL to communicate with the Red{nbsp}Hat CDN securely.
-Use of an SSL interception proxy interferes with this communication.
-These hosts must be whitelisted on the proxy.
+An SSL interception proxy interferes with this communication.
+These hosts must be allowlisted on the proxy.
 
 For a list of IP addresses used by the Red{nbsp}Hat CDN (cdn.redhat.com), see the Knowledgebase article https://access.redhat.com/articles/1525183[Public CIDR Lists for Red{nbsp}Hat] on the Red{nbsp}Hat Customer Portal.
 
-To configure the subscription-manager with the HTTP proxy, follow the procedure below.
+To configure the Subscription Manager with the HTTP proxy, follow the procedure below.
 
 .Procedure
 . On {ProjectServer}, complete the following details in the `/etc/rhsm/rhsm.conf` file:

--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -4,8 +4,8 @@
 You can use {Project} to configure PXELinux to chainboot iPXE in BIOS mode and boot using the HTTP protocol if you have the following restrictions that prevent you from using PXE:
 
 * A network with unmanaged DHCP servers.
-* A PXE service that is blocklisted on your network or restricted by a firewall.
-* An unreliable TFTP UDP-based protocol because of, for example, a low-bandwidth network.
+* A PXE service that is unreachable because of, for example, a firewall restriction.
+* A TFTP UDP-based protocol that is unreliable because of, for example, a low-bandwidth network.
 
 ifndef::satellite[]
 Only BIOS systems are known to work reliably.

--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -4,7 +4,7 @@
 You can use {Project} to configure PXELinux to chainboot iPXE in BIOS mode and boot using the HTTP protocol if you have the following restrictions that prevent you from using PXE:
 
 * A network with unmanaged DHCP servers.
-* A PXE service that is blacklisted on your network or restricted by a firewall.
+* A PXE service that is blocklisted on your network or restricted by a firewall.
 * An unreliable TFTP UDP-based protocol because of, for example, a low-bandwidth network.
 
 ifndef::satellite[]

--- a/guides/common/modules/ref_skipping-steps-when-performing-backups.adoc
+++ b/guides/common/modules/ref_skipping-steps-when-performing-backups.adoc
@@ -1,8 +1,8 @@
-[id="White_Listing_and_Skipping_Steps_When_Performing_Backups_{context}"]
-= White-listing and skipping steps when performing backups
+[id="Skipping_Steps_When_Performing_Backups_{context}"]
+= Skipping steps when performing backups
 
 A backup using the `{foreman-maintain} backup` command proceeds in a sequence of steps.
-To skip part of the backup add the `--whitelist` option to the command and add the step label that you want to omit.
+To skip part of the backup add the `--whitelist` option to the command and the step label that you want to omit.
 
 .Procedure
 * To display a list of available step labels, enter the following command:

--- a/guides/common/modules/ref_skipping-steps-when-performing-backups.adoc
+++ b/guides/common/modules/ref_skipping-steps-when-performing-backups.adoc
@@ -2,7 +2,7 @@
 = Skipping steps when performing backups
 
 A backup using the `{foreman-maintain} backup` command proceeds in a sequence of steps.
-To skip part of the backup add the `--whitelist` option to the command and the step label that you want to omit.
+To skip part of the backup, add the `--whitelist` option to the command and the step label that you want to omit.
 
 .Procedure
 * To display a list of available step labels, enter the following command:


### PR DESCRIPTION
* Replace blacklist and whitelist according to inclusive language guidelines.
* Only generic text is changed.
* Command blocks are unchanged.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
