### PR TITLE
Add inclusive language module for Satellite

### DIFF
--- a/guides/common/modules/con_making-open-source-more-inclusive.adoc
+++ b/guides/common/modules/con_making-open-source-more-inclusive.adoc
@@ -1,0 +1,4 @@
+[id="making-open-source-more-inclusive_{context}"]
+= Making open source more inclusive
+
+Red Hat is committed to replacing problematic language in our code, documentation, and web properties. Because of the enormity of this endeavor, these changes are being updated gradually and where possible. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].

--- a/guides/common/modules/con_making-open-source-more-inclusive.adoc
+++ b/guides/common/modules/con_making-open-source-more-inclusive.adoc
@@ -1,4 +1,6 @@
 [id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive
 
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. Because of the enormity of this endeavor, these changes are being updated gradually and where possible. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].
+Red Hat is committed to replacing problematic language in our code, documentation, and web properties.
+Because of the enormity of this endeavor, these changes are being updated gradually and where possible.
+For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -11,6 +11,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -12,6 +12,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -12,7 +12,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -11,6 +11,8 @@ endif::[]
 ifndef::foreman-deb,foreman-el[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 ifndef::foreman-deb,foreman-el[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -12,6 +12,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -12,7 +12,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -15,6 +15,8 @@ endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -15,7 +15,7 @@ endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -14,7 +14,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -14,6 +14,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -6,6 +6,8 @@ include::common/header.adoc[]
 = {ManagingConfigurationsAnsibleDocTitle}
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -6,7 +6,7 @@ include::common/header.adoc[]
 = {ManagingConfigurationsAnsibleDocTitle}
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -12,6 +12,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -12,7 +12,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -15,6 +15,8 @@ For more information, see {BaseURL}Installing_Server/index-katello.html[Installi
 endif::[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -15,7 +15,7 @@ For more information, see {BaseURL}Installing_Server/index-katello.html[Installi
 endif::[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -12,6 +12,8 @@ endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -12,7 +12,7 @@ endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -18,6 +18,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -18,7 +18,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Monitoring_Project/master.adoc
+++ b/guides/doc-Monitoring_Project/master.adoc
@@ -5,6 +5,8 @@ include::common/header.adoc[]
 :context: monitoring
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Monitoring_Project/master.adoc
+++ b/guides/doc-Monitoring_Project/master.adoc
@@ -5,7 +5,7 @@ include::common/header.adoc[]
 :context: monitoring
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -11,6 +11,8 @@ endif::[]
 ifndef::foreman-el,foreman-deb[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 ifndef::foreman-el,foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -11,6 +11,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -11,6 +11,8 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -13,7 +13,7 @@ endif::[]
 ifndef::foreman-el,foreman-deb,katello[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -13,6 +13,8 @@ endif::[]
 ifndef::foreman-el,foreman-deb,katello[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -14,7 +14,7 @@ endif::[]
 ifndef::foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -14,6 +14,8 @@ endif::[]
 ifndef::foreman-deb[]
 
 ifdef::satellite[]
+include::common/modules/con_making-open-source-more-inclusive.adoc[]
+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
Added the downstream "inclusive language" module for Satellite docs only.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)

