### PR TITLE
Clarify steps in procedure for Sync Now

### DIFF
--- a/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
@@ -33,8 +33,11 @@ Default is `Library`.
 Default is `Default_Organization_View`.
 . From the *SSL CA Content Credential* menu, select a CA certificate used by the upstream {ProjectServer}.
 . Click *Update*.
+. If necessary, enable repositories.
+For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] in _{ContentManagementDocTitle}_.
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click *Sync Now* to synchronize the repositories.
+. Select the Product that contains the repositories that you want to synchronize.
+. From the *Select Action* menu, select *Sync Now* to synchronize the repositories.
 +
 You can also create a synchronization plan to ensure updates on a regular basis.
 For more information, see {ContentManagementDocURL}Creating_a_Sync_Plan_content-management[Creating a Synchronization Plan] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
@@ -35,8 +35,8 @@ Default is `Default_Organization_View`.
 . From the *SSL CA Content Credential* menu, select a CA certificate used by the upstream {ProjectServer}.
 . Click *Update*.
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the Product that contains the repositories that you want to synchronize.
-. From the *Select Action* menu, select *Sync Now* to synchronize the repositories.
+. Select the product that contains the repositories that you want to synchronize.
+. From the *Select Action* menu, select *Sync Now* to synchronize all repositories within the product.
 +
 You can also create a synchronization plan to ensure updates on a regular basis.
 For more information, see {ContentManagementDocURL}Creating_a_Sync_Plan_content-management[Creating a Synchronization Plan] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
@@ -7,6 +7,7 @@ Configure a downstream {ProjectServer} to synchronize repositories from a connec
 * A network connection exists between the upstream {ProjectServer} and the downstream {ProjectServer}.
 * You imported the subscription manifest on both the upstream and downstream {ProjectServer}.
 * On the upstream {ProjectServer}, you enabled the required repositories for the organization.
+For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] in _{ContentManagementDocTitle}_.
 * The upstream user is an admin or has the following permissions:
 ** `view_organizations`
 ** `view_products`
@@ -33,8 +34,6 @@ Default is `Library`.
 Default is `Default_Organization_View`.
 . From the *SSL CA Content Credential* menu, select a CA certificate used by the upstream {ProjectServer}.
 . Click *Update*.
-. If necessary, enable repositories.
-For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] in _{ContentManagementDocTitle}_.
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
 . Select the Product that contains the repositories that you want to synchronize.
 . From the *Select Action* menu, select *Sync Now* to synchronize the repositories.


### PR DESCRIPTION
The original steps in the procedure tell the user to click Sync Now to
synchronize the repositories but some steps are missing before the user
can do that. Those steps have been added.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
