### PR TITLE
Keep backup of orig cfg files

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -33,6 +33,10 @@ ifndef::orcharhino[]
 For more information, see {InstallingServerDocURL}Port_and_firewall_requirements_{project-context}[Port and firewall requirements] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}{smart-proxy-context}-port-and-firewall-requirements_{smart-proxy-context}[Port and firewall requirements] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
 include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
+* Back up the following configuration files:
+** `/etc/cloud/cloud.cfg.d/01_network.cfg`
+** `/etc/cloud/cloud.cfg.d/10_datasource.cfg`
+** `/etc/cloud/cloud.cfg`
 
 .Associating the `Userdata` and `Cloud-init` templates with the operating system
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.


### PR DESCRIPTION
User: "Is it a good idea to wipe the cfg files out to add/change these options?"
SME: "Not unless you have a backup."
https://bugzilla.redhat.com/show_bug.cgi?id=2239040

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
