### PR TITLE
Add EL9 Support in Project and SmartProxy Installation

### DIFF
--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -20,7 +20,7 @@ You cannot register {ProjectServer} to itself.
 
 include::modules/proc_downloading-the-binary-dvd-images.adoc[leveloffset=+1]
 
-include::modules/proc_configuring-the-base-operating-system-with-offline-repositories-in-rhel-8.adoc[leveloffset=+1]
+include::modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc[leveloffset=+1]
 
 include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -15,7 +15,7 @@ endif::[]
 To create and use external databases for {Project}, you must complete the following procedures:
 
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare a {RHEL} 9 or {RHEL} 8 server to host the external databases.
+Prepare a {EL} 9 or {EL} 8 server to host the external databases.
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:Configuring_Server_to_Use_External_Databases_{context}[].

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -15,7 +15,7 @@ endif::[]
 To create and use external databases for {Project}, you must complete the following procedures:
 
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare a {RHEL} 8 server to host the external databases.
+Prepare a {RHEL} 9 or {RHEL} 8 server to host the external databases.
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:Configuring_Server_to_Use_External_Databases_{context}[].

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -15,7 +15,7 @@ endif::[]
 To create and use external databases for {Project}, you must complete the following procedures:
 
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare a {EL} 9 or {EL} 8 server to host the external databases.
+Prepare an {EL} server to host the external databases.
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:Configuring_Server_to_Use_External_Databases_{context}[].

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -15,7 +15,7 @@ endif::[]
 To create and use external databases for {Project}, you must complete the following procedures:
 
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare an {EL} server to host the external databases.
+Prepare the {EL} to host the external databases.
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:Configuring_Server_to_Use_External_Databases_{context}[].

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -15,7 +15,7 @@ endif::[]
 To create and use external databases for {Project}, you must complete the following procedures:
 
 . xref:preparing-a-host-for-external-databases_{context}[].
-Prepare the {EL} to host the external databases.
+Prepare a host for the external databases.
 . xref:installing-postgresql_{context}[].
 Prepare PostgreSQL with databases for {Project}, Candlepin and Pulp with dedicated users owning them.
 . xref:Configuring_Server_to_Use_External_Databases_{context}[].

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -26,6 +26,8 @@
 :RepoRHEL7Server: rhel-7-server-rpms
 :RepoRHEL8AppStream: rhel-8-for-x86_64-appstream-rpms
 :RepoRHEL8BaseOS: rhel-8-for-x86_64-baseos-rpms
+:RepoRHEL9AppStream: rhel-9-for-x86_64-appstream-rpms
+:RepoRHEL9BaseOS: rhel-9-for-x86_64-baseos-rpms
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
 
 // Base attributes

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -127,6 +127,9 @@
 :RepoSatelliteVersion: {ProjectVersion}
 
 // RHEL 9 Satellite repos
+:RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
+:RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
+:RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-9-<arch>-rpms
 
 // RHEL 8 Satellite repos

--- a/guides/common/modules/con_active-directory-with-cross-forest-trust.adoc
+++ b/guides/common/modules/con_active-directory-with-cross-forest-trust.adoc
@@ -5,7 +5,7 @@ Kerberos can create `cross-forest trust` that defines a relationship between two
 A domain forest is a hierarchical structure of domains; both AD and {FreeIPA} constitute a forest.
 With a trust relationship enabled between AD and {FreeIPA}, users of AD can access Linux hosts and services using a single set of credentials.
 ifdef::satellite[]
-For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/planning_identity_management/planning-a-cross-forest-trust-between-idm-and-ad_planning-identity-management[Planning a cross-forest trust between IdM and AD] in _{RHEL} Planning Identity Management_.
+For more information on cross-forest trusts, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/planning_identity_management/planning-a-cross-forest-trust-between-idm-and-ad_planning-identity-management[Planning a cross-forest trust between IdM and AD] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/planning_identity_management/planning-a-cross-forest-trust-between-idm-and-ad_planning-identity-management[Planning a cross-forest trust between IdM and AD] in _{RHEL} 8 guide_.
 endif::[]
 
 From the {Project} point of view, the configuration process is the same as integration with {FreeIPA} server without cross-forest trust configured.

--- a/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
+++ b/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
@@ -2,7 +2,7 @@
 = Kerberos configuration in web browsers
 
 ifndef::orcharhino[]
-For information on configuring Firefox, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_authentication_and_authorization_in_rhel/index#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to Use Kerberos for Single Sign-On] in the _{RHEL} Configuring authentication and authorization in RHEL_ guide.
+For information on configuring Firefox, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_authentication_and_authorization_in_rhel/configuring_applications_for_sso#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to use Kerberos for single sign-on] in the _{RHEL} Configuring authentication and authorization in RHEL_ guide.
 endif::[]
 
 If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.

--- a/guides/common/modules/con_using-freeipa.adoc
+++ b/guides/common/modules/con_using-freeipa.adoc
@@ -19,5 +19,6 @@ include::snip_do-not-use-both-ldap-and-freeipa.adoc[]
 
 The examples in this chapter assume separation between {FreeIPA} and {Project} configuration.
 ifndef::orcharhino[]
-However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/installing_identity_management/index[{RHEL} 8 Installing Identity Management Guide].
+However, if you have administrator privileges for both servers, you can configure {FreeIPA} as described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/installing_identity_management/index[{RHEL} 9 Installing Identity Management Guide].
+For {RHEL} 8, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/installing_identity_management/index[Installing Identity Management Guide].
 endif::[]

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -52,9 +52,9 @@ Provides:            Red Hat Satellite
                      Red Hat Satellite Proxy
                      Red Hat Enterprise Linux High Availability for x86_64
                      Red Hat Discovery
-SKU:                 _SKU_ID_
+SKU:                 _Your_SKU_ID_
 Contract:
-Pool ID:             _Pool_ID_
+Pool ID:             _Your_Pool_ID_
 Provides Management: Yes
 Available:           10
 Suggested:           1

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -52,9 +52,9 @@ Provides:            Red Hat Satellite
                      Red Hat Satellite Proxy
                      Red Hat Enterprise Linux High Availability for x86_64
                      Red Hat Discovery
-SKU:                 MCT3718
+SKU:                 _SKU_ID_
 Contract:
-Pool ID:             8aca43dd771bf31101771c0231f906a5
+Pool ID:             _Pool_ID_
 Provides Management: Yes
 Available:           10
 Suggested:           1

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -109,7 +109,7 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifdef::satellite[]
-For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory_.
+For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[How SSSD interprets GPO access control rules] in _{RHEL} 8 guide_.
 endif::[]
 ====
 

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -109,7 +109,7 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifdef::satellite[]
-For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[How SSSD interprets GPO access control rules] in _{RHEL} 8 guide_.
+For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{EL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{EL} 8 guide_.
 endif::[]
 ====
 

--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -109,7 +109,7 @@ ad_gpo_map_service = +foreman
 
 Here, _foreman_ is the PAM service name.
 ifdef::satellite[]
-For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{EL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{EL} 8 guide_.
+For more information on GPOs, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _{RHEL} 8 guide_.
 endif::[]
 ====
 

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -8,7 +8,7 @@ To configure the IdM server to use the GSS-TSIG technology, you must install the
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
 ifdef::satellite[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/installing_identity_management/index#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in the _Installing Identity Management Guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/installing_identity_management/preparing-the-system-for-ipa-server-installation_installing-identity-management#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/preparing-the-system-for-ipa-server-installation_installing-identity-management#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in _{RHEL} 8 guide_.
 endif::[]
 * You must contact the IdM server administrator to ensure that you obtain an account on the IdM server with permissions to create zones on the IdM server.
 * You should create a backup of the answer file.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -8,7 +8,7 @@ To configure the IdM server to use the GSS-TSIG technology, you must install the
 
 * You must ensure the IdM server is deployed and the host-based firewall is configured correctly.
 ifdef::satellite[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/installing_identity_management/preparing-the-system-for-ipa-server-installation_installing-identity-management#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/preparing-the-system-for-ipa-server-installation_installing-identity-management#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port Requirements for IdM] in _{RHEL} 8 guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/installing_identity_management/preparing-the-system-for-ipa-server-installation_installing-identity-management#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port requirements for IdM] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/preparing-the-system-for-ipa-server-installation_installing-identity-management#port-requirements-for-idm_preparing-the-system-for-ipa-server-installation[Port requirements for IdM] in _{RHEL} 8 guide_.
 endif::[]
 * You must contact the IdM server administrator to ensure that you obtain an account on the IdM server with permissions to create zones on the IdM server.
 * You should create a backup of the answer file.

--- a/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
@@ -25,5 +25,5 @@ ifndef::foreman-deb[]
 ----
 endif::[]
 ifdef::katello,orcharhino,satellite[]
-. Synchronize the {EL} 9 or {EL} 8 kickstart repository.
+. Synchronize the {EL} kickstart repository.
 endif::[]

--- a/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
@@ -24,6 +24,3 @@ ifndef::foreman-deb[]
 # {project-package-update} grub2-efi
 ----
 endif::[]
-ifdef::katello,orcharhino,satellite[]
-. Synchronize the {EL} kickstart repository.
-endif::[]

--- a/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
@@ -25,5 +25,5 @@ ifndef::foreman-deb[]
 ----
 endif::[]
 ifdef::katello,orcharhino,satellite[]
-. Synchronize the {EL} 8 kickstart repository.
+. Synchronize the {EL} 9 or {EL} 8 kickstart repository.
 endif::[]

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -39,7 +39,7 @@ endif::[]
 ----
 +
 ifdef::satellite[]
-For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/accessing_identity_management_services/index[Accessing Identity Management Services guide] in _{RHEL} guide_.
+For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/accessing_identity_management_services/index[Accessing Identity Management services] in _{RHEL} guide_.
 endif::[]
 . On {ProjectServer}, install the IPA client:
 ifdef::satellite[]

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -39,7 +39,7 @@ endif::[]
 ----
 +
 ifdef::satellite[]
-For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/accessing_identity_management_services/index[{RHEL} 8 Accessing Identity Management Services guide].
+For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/accessing_identity_management_services/index[Accessing Identity Management Services guide] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/accessing_identity_management_services/index[Accessing Identity Management Services guide] in _{RHEL} 8 guide_.
 endif::[]
 . On {ProjectServer}, install the IPA client:
 ifdef::satellite[]

--- a/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
+++ b/guides/common/modules/proc_configuring-freeipa-authentication-on-server.adoc
@@ -39,7 +39,7 @@ endif::[]
 ----
 +
 ifdef::satellite[]
-For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/accessing_identity_management_services/index[Accessing Identity Management Services guide] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/accessing_identity_management_services/index[Accessing Identity Management Services guide] in _{RHEL} 8 guide_.
+For more information on managing services, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/accessing_identity_management_services/index[Accessing Identity Management Services guide] in _{RHEL} guide_.
 endif::[]
 . On {ProjectServer}, install the IPA client:
 ifdef::satellite[]

--- a/guides/common/modules/proc_configuring-host-based-authentication-control.adoc
+++ b/guides/common/modules/proc_configuring-host-based-authentication-control.adoc
@@ -5,7 +5,7 @@ HBAC rules define which machine within the domain a {FreeIPA} user is allowed to
 You can configure HBAC on the {FreeIPA} server to prevent selected users from accessing {ProjectServer}.
 With this approach, you can prevent {Project} from creating database entries for users that are not allowed to log in.
 ifndef::orcharhino[]
-For more information on HBAC, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/managing_idm_users_groups_hosts_and_access_control_rules/index#host-based-access-control-rules-in-idm_ensuring-the-presence-of[Managing IdM Users, Groups, Hosts, and Access Control Rules Guide].
+For more information on HBAC, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_idm_users_groups_hosts_and_access_control_rules/index[Managing IdM users, groups, hosts, and access control rules] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_idm_users_groups_hosts_and_access_control_rules/index[Managing IdM users, groups, hosts, and access control rules] in _{RHEL} 8 guide_.
 endif::[]
 
 On the {FreeIPA} server, configure Host-Based Authentication Control (HBAC).

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -6,11 +6,11 @@
 Use this procedure to enable the repositories that are required to install {ProductName}.
 Select the operating system and version you are installing on:
 
-* xref:#repositories-capsule-rhel-9[{RHEL} 9]
-* xref:#repositories-capsule-rhel-8[{RHEL} 8]
+* xref:#repositories-{smart-proxy-context}-el-9[{EL} 9]
+* xref:#repositories-{smart-proxy-context}-el-8[{EL} 8]
 
-[id="repositories-capsule-rhel-9"]
-== {RHEL} 9
+[id="repositories-{smart-proxy-context}-el-9"]
+== {EL} 9
 
 . Disable all repositories:
 +
@@ -19,12 +19,12 @@ Select the operating system and version you are installing on:
 # subscription-manager repos --disable "*"
 ----
 +
-
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL9BaseOS} \
+# subscription-manager repos \
+--enable={RepoRHEL9BaseOS} \
 --enable={RepoRHEL9AppStream} \
 --enable={RepoRHEL9ServerSatelliteCapsuleProjectVersion} \
 --enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
@@ -32,8 +32,8 @@ Select the operating system and version you are installing on:
 
 include::snip_step-verify-enabled-repolist.adoc[]
 
-[id="repositories-capsule-rhel-8"]
-== {RHEL} 8
+[id="repositories-{smart-proxy-context}-el-8"]
+== {EL} 8
 
 . Disable all repositories:
 +
@@ -41,8 +41,6 @@ include::snip_step-verify-enabled-repolist.adoc[]
 ----
 # subscription-manager repos --disable "*"
 ----
-+
-
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -4,6 +4,36 @@
 :package-manager: dnf
 
 Use this procedure to enable the repositories that are required to install {ProductName}.
+Select the operating system and version you are installing on:
+
+* xref:#repositories-capsule-rhel-9[{RHEL} 9]
+* xref:#repositories-capsule-rhel-8[{RHEL} 8]
+
+[id="repositories-capsule-rhel-9"]
+== {RHEL} 9
+
+. Disable all repositories:
++
+[options="nowrap"]
+----
+# subscription-manager repos --disable "*"
+----
++
+
+. Enable the following repositories:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager repos --enable={RepoRHEL9BaseOS} \
+--enable={RepoRHEL9AppStream} \
+--enable={RepoRHEL9ServerSatelliteCapsuleProjectVersion} \
+--enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+----
+
+include::snip_step-verify-enabled-repolist.adoc[]
+
+[id="repositories-capsule-rhel-8"]
+== {RHEL} 8
 
 . Disable all repositories:
 +
@@ -22,6 +52,8 @@ Use this procedure to enable the repositories that are required to install {Prod
 --enable={RepoRHEL8ServerSatelliteCapsuleProjectVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
 ----
+
+include::snip_step-verify-enabled-repolist.adoc[]
 
 . Enable the module:
 +
@@ -43,10 +75,3 @@ For more information about modules and lifecycle streams on {RHEL} 8, see https:
 If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository and then install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
 ====
-
-. Optional: Verify that the required repositories are enabled:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} repolist enabled
-----

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -9,14 +9,14 @@ If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you 
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
 ====
 
-Use this procedure to enable the repositories that are required to install {ProductName}.
+.Procedure
 Select the operating system and version you are installing on:
 
-* xref:#repositories-{smart-proxy-context}-el-9[{EL} 9]
-* xref:#repositories-{smart-proxy-context}-el-8[{EL} 8]
+* xref:#repositories-{smart-proxy-context}-rhel-9[{RHEL} 9]
+* xref:#repositories-{smart-proxy-context}-rhel-8[{RHEL} 8]
 
-[id="repositories-{smart-proxy-context}-el-9"]
-== {EL} 9
+[id="repositories-{smart-proxy-context}-rhel-9"]
+== {RHEL} 9
 
 . Disable all repositories:
 +
@@ -38,8 +38,8 @@ Select the operating system and version you are installing on:
 
 include::snip_step-verify-enabled-repolist.adoc[]
 
-[id="repositories-{smart-proxy-context}-el-8"]
-== {EL} 8
+[id="repositories-{smart-proxy-context}-rhel-8"]
+== {RHEL} 8
 
 . Disable all repositories:
 +
@@ -51,7 +51,8 @@ include::snip_step-verify-enabled-repolist.adoc[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+# subscription-manager repos \
+--enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8AppStream} \
 --enable={RepoRHEL8ServerSatelliteCapsuleProjectVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProjectVersion}

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -3,6 +3,12 @@
 :dnf-module: satellite-capsule:el8
 :package-manager: dnf
 
+[NOTE]
+====
+If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository and then install {oVirt} guest agents and drivers.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
+====
+
 Use this procedure to enable the repositories that are required to install {ProductName}.
 Select the operating system and version you are installing on:
 
@@ -65,11 +71,4 @@ include::snip_step-verify-enabled-repolist.adoc[]
 ====
 If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-module}` module, see xref:troubleshooting-dnf-modules_{context}[Troubleshooting DNF modules].
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Lifecycle].
-====
-+
-
-[NOTE]
-====
-If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository and then install {oVirt} guest agents and drivers.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
 ====

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -4,13 +4,15 @@
 Use these procedures to enable the repositories required to install {ProductName}.
 
 ifdef::foreman-el,katello,foreman-deb[]
-Choose from the following list which operating system and version you are installing on:
+Select the operating system and version you are installing on:
 endif::[]
 
 ifdef::foreman-el,katello[]
+* xref:#repositories-centos-stream-9[CentOS Stream 9]
 * xref:#repositories-centos-stream-8[CentOS Stream 8]
 endif::[]
-ifdef::foreman-el,katello[]
+ifdef::foreman-el,katello,satellite[]
+* xref:#repositories-rhel-9[{RHEL} 9]
 * xref:#repositories-rhel-8[{RHEL} 8]
 endif::[]
 ifdef::foreman-deb[]
@@ -19,6 +21,27 @@ ifdef::foreman-deb[]
 endif::[]
 
 ifdef::foreman-el,katello[]
+[id="repositories-centos-stream-9"]
+== CentOS Stream 9
+
+:distribution: el
+:distribution-major-version: 9
+:package-manager: dnf
+
+include::proc_configuring-repositories-el.adoc[]
+
+ifdef::katello[]
++
+. Enable `powertools` repository:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} config-manager --set-enabled powertools
+----
+endif::[]
+
+include::snip_step-verify-enabled-repolist.adoc[]
+
 [id="repositories-centos-stream-8"]
 == CentOS Stream 8
 
@@ -38,6 +61,8 @@ ifdef::katello[]
 ----
 endif::[]
 
+include::snip_step-verify-enabled-repolist.adoc[]
+
 +
 . Enable the DNF modules:
 +
@@ -48,12 +73,49 @@ endif::[]
 
 endif::[]
 
+ifdef::foreman-el,katello,satellite[]
+[id="repositories-rhel-9"]
+== {RHEL} 9
+
+:distribution: rhel
+:distribution-major-version: 9
+:package-manager: dnf
+
+. Disable all repositories:
++
+[options="nowrap"]
+----
+# subscription-manager repos --disable "*"
+----
++
+
+. Enable the following repositories:
++
+[options="nowrap" subs="+quotes,attributes"]
 ifdef::foreman-el,katello[]
-[id="repositories-rhel-8"]
-== {RHEL} 8
+----
+# subscription-manager repos --enable={RepoRHEL9BaseOS} \
+--enable={RepoRHEL9AppStream}
+----
+endif::[]
+ifdef::satellite[]
+----
+# subscription-manager repos --enable={RepoRHEL9BaseOS} \
+--enable={RepoRHEL9AppStream} \
+--enable={RepoRHEL9ServerSatelliteServerProjectVersion} \
+--enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+----
+endif::[]
++
+
+ifdef::foreman-el,katello[]
+include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
-ifdef::foreman-el,katello,satellite[]
+include::snip_step-verify-enabled-repolist.adoc[]
+
+[id="repositories-rhel-8"]
+== {RHEL} 8
 
 :distribution: rhel
 :distribution-major-version: 8
@@ -89,6 +151,8 @@ endif::[]
 ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]
 endif::[]
+
+include::snip_step-verify-enabled-repolist.adoc[]
 
 ifdef::foreman-el,katello,satellite[]
 . Enable the DNF modules:

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -1,9 +1,17 @@
 [id="configuring-repositories_{context}"]
 = Configuring repositories
 
-Use these procedures to enable the repositories required to install {ProductName}.
+ifdef::orcharhino[]
+Ensure the repositories required to install {ProductName} are enabled on your {EL} host.
+endif::[]
 
-ifdef::foreman-el,katello,foreman-deb[]
+ifdef::foreman-el,katello[]
+.Prerequisites
+* Ensure that you have access to your {EL} `BaseOS` and `AppStream` repositories.
+endif::[]
+
+ifndef::orcharhino[]
+.Procedure
 Select the operating system and version you are installing on:
 endif::[]
 
@@ -24,7 +32,7 @@ ifdef::foreman-el,katello[]
 [id="repositories-centos-stream-9"]
 == CentOS Stream 9
 
-:distribution: el
+:distribution: centos
 :distribution-major-version: 9
 :package-manager: dnf
 
@@ -35,7 +43,7 @@ include::snip_step-verify-enabled-repolist.adoc[]
 [id="repositories-centos-stream-8"]
 == CentOS Stream 8
 
-:distribution: el
+:distribution: centos
 :distribution-major-version: 8
 :package-manager: dnf
 
@@ -57,10 +65,11 @@ ifdef::foreman-el,katello,satellite[]
 [id="repositories-el-9"]
 == {EL} 9
 
-:distribution: rhel
+:distribution: el
 :distribution-major-version: 9
 :package-manager: dnf
 
+ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -71,14 +80,6 @@ ifdef::foreman-el,katello,satellite[]
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
-ifdef::foreman-el,katello[]
-----
-# subscription-manager repos \
---enable={RepoRHEL9BaseOS} \
---enable={RepoRHEL9AppStream}
-----
-endif::[]
-ifdef::satellite[]
 ----
 # subscription-manager repos \
 --enable={RepoRHEL9BaseOS} \
@@ -97,10 +98,11 @@ include::snip_step-verify-enabled-repolist.adoc[]
 [id="repositories-el-8"]
 == {EL} 8
 
-:distribution: rhel
+:distribution: el
 :distribution-major-version: 8
 :package-manager: dnf
 
+ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -111,21 +113,14 @@ include::snip_step-verify-enabled-repolist.adoc[]
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
-ifdef::foreman-el,katello[]
 ----
-# subscription-manager repos --enable={RepoRHEL8BaseOS} \
---enable={RepoRHEL8AppStream}
-----
-endif::[]
-ifdef::satellite[]
-----
-# subscription-manager repos --enable={RepoRHEL8BaseOS} \
+# subscription-manager repos \
+--enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8AppStream} \
 --enable={RepoRHEL8ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
 ----
 endif::[]
-+
 
 ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -30,16 +30,6 @@ ifdef::foreman-el,katello[]
 
 include::proc_configuring-repositories-el.adoc[]
 
-ifdef::katello[]
-+
-. Enable `powertools` repository:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} config-manager --set-enabled powertools
-----
-endif::[]
-
 include::snip_step-verify-enabled-repolist.adoc[]
 
 [id="repositories-centos-stream-8"]
@@ -50,16 +40,6 @@ include::snip_step-verify-enabled-repolist.adoc[]
 :package-manager: dnf
 
 include::proc_configuring-repositories-el.adoc[]
-
-ifdef::katello[]
-+
-. Enable `powertools` repository:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-manager} config-manager --set-enabled powertools
-----
-endif::[]
 
 include::snip_step-verify-enabled-repolist.adoc[]
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,11 +5,6 @@ ifdef::orcharhino[]
 Ensure the repositories required to install {ProductName} are enabled on your {EL} host.
 endif::[]
 
-ifdef::foreman-el,katello[]
-.Prerequisites
-* Ensure that you have access to your {EL} `BaseOS` and `AppStream` repositories.
-endif::[]
-
 ifndef::orcharhino[]
 .Procedure
 Select the operating system and version you are installing on:

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -15,10 +15,6 @@ ifndef::orcharhino[]
 Select the operating system and version you are installing on:
 endif::[]
 
-ifdef::foreman-el,katello[]
-* xref:#repositories-centos-stream-9[CentOS Stream 9]
-* xref:#repositories-centos-stream-8[CentOS Stream 8]
-endif::[]
 ifdef::foreman-el,katello,satellite[]
 * xref:#repositories-el-9[{EL} 9]
 * xref:#repositories-el-8[{EL} 8]
@@ -26,39 +22,6 @@ endif::[]
 ifdef::foreman-deb[]
 * xref:#repositories-debian-11[Debian 11 (Bullseye)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
-endif::[]
-
-ifdef::foreman-el,katello[]
-[id="repositories-centos-stream-9"]
-== CentOS Stream 9
-
-:distribution: centos
-:distribution-major-version: 9
-:package-manager: dnf
-
-include::proc_configuring-repositories-el.adoc[]
-
-include::snip_step-verify-enabled-repolist.adoc[]
-
-[id="repositories-centos-stream-8"]
-== CentOS Stream 8
-
-:distribution: centos
-:distribution-major-version: 8
-:package-manager: dnf
-
-include::proc_configuring-repositories-el.adoc[]
-
-include::snip_step-verify-enabled-repolist.adoc[]
-
-+
-. Enable the DNF module:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# dnf module enable {dnf-module}
-----
-
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -12,8 +12,8 @@ ifdef::foreman-el,katello[]
 * xref:#repositories-centos-stream-8[CentOS Stream 8]
 endif::[]
 ifdef::foreman-el,katello,satellite[]
-* xref:#repositories-rhel-9[{RHEL} 9]
-* xref:#repositories-rhel-8[{RHEL} 8]
+* xref:#repositories-el-9[{EL} 9]
+* xref:#repositories-el-8[{EL} 8]
 endif::[]
 ifdef::foreman-deb[]
 * xref:#repositories-debian-11[Debian 11 (Bullseye)]
@@ -54,8 +54,8 @@ include::snip_step-verify-enabled-repolist.adoc[]
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
-[id="repositories-rhel-9"]
-== {RHEL} 9
+[id="repositories-el-9"]
+== {EL} 9
 
 :distribution: rhel
 :distribution-major-version: 9
@@ -68,25 +68,25 @@ ifdef::foreman-el,katello,satellite[]
 # subscription-manager repos --disable "*"
 ----
 +
-
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ifdef::foreman-el,katello[]
 ----
-# subscription-manager repos --enable={RepoRHEL9BaseOS} \
+# subscription-manager repos \
+--enable={RepoRHEL9BaseOS} \
 --enable={RepoRHEL9AppStream}
 ----
 endif::[]
 ifdef::satellite[]
 ----
-# subscription-manager repos --enable={RepoRHEL9BaseOS} \
+# subscription-manager repos \
+--enable={RepoRHEL9BaseOS} \
 --enable={RepoRHEL9AppStream} \
 --enable={RepoRHEL9ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
 endif::[]
-+
 
 ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]
@@ -94,8 +94,8 @@ endif::[]
 
 include::snip_step-verify-enabled-repolist.adoc[]
 
-[id="repositories-rhel-8"]
-== {RHEL} 8
+[id="repositories-el-8"]
+== {EL} 8
 
 :distribution: rhel
 :distribution-major-version: 8
@@ -108,7 +108,6 @@ include::snip_step-verify-enabled-repolist.adoc[]
 # subscription-manager repos --disable "*"
 ----
 +
-
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -44,7 +44,7 @@ include::proc_configuring-repositories-el.adoc[]
 include::snip_step-verify-enabled-repolist.adoc[]
 
 +
-. Enable the DNF modules:
+. Enable the DNF module:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -1,51 +1,51 @@
-[id="configuring-the-base-operating-system-with-offline-repositories-in-rhel-8_{context}"]
-= Configuring the base operating system with offline repositories in RHEL 8
+[id="configuring-the-base-operating-system-with-offline-repositories_{context}"]
+= Configuring the base operating system with offline repositories
 
-Use this procedure to configure offline repositories for the {RHEL} 8 and {ProjectName} ISO images.
+Use this procedure to configure offline repositories for the {RHEL} 9 or {RHEL} 8, and {ProjectName} ISO images.
 
 .Procedure
 
 . Create a directory to serve as the mount point for the ISO file corresponding to the version of the base operating system.
 +
-[options="nowrap"]
+[options="nowrap" subs="+quotes"]
 ----
-# mkdir /media/rhel8
+# mkdir /media/rhel__<version>__
 ----
 
 . Mount the ISO image for {RHEL} to the mount point.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# mount -o loop _rhel8-DVD_.iso /media/rhel8
+# mount -o loop _rhel__<version>__-DVD_.iso /media/rhel__<version>__
 ----
 +
 . To copy the ISO file's repository data file and change permissions, enter:
 +
-[options="nowrap"]
+[options="nowrap" subs="+quotes"]
 ----
-# cp /media/rhel8/media.repo /etc/yum.repos.d/rhel8.repo
-# chmod u+w /etc/yum.repos.d/rhel8.repo
+# cp /media/rhel__<version>__/media.repo /etc/yum.repos.d/rhel__<version>__.repo
+# chmod u+w /etc/yum.repos.d/rhel__<version>__.repo
 ----
 
 . Edit the repository data file and add the `baseurl` directive.
 +
-[options="nowrap"]
+[options="nowrap" subs="+quotes"]
 ----
-[RHEL8-BaseOS]
+[RHEL__<version>__-BaseOS]
 name=Red Hat Enterprise Linux BaseOS
 mediaid=None
 metadata_expire=-1
 gpgcheck=0
 cost=500
-baseurl=file:///media/rhel8/BaseOS/
+baseurl=file:///media/rhel__<version>__/BaseOS/
 
-[RHEL8-AppStream]
+[RHEL__<version>__-AppStream]
 name=Red Hat Enterprise Linux Appstream
 mediaid=None
 metadata_expire=-1
 gpgcheck=0
 cost=500
-baseurl=file:///media/rhel8/AppStream/
+baseurl=file:///media/rhel__<version>__/AppStream/
 ----
 +
 . Verify that the repository has been configured.

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -1,7 +1,7 @@
 [id="configuring-the-base-operating-system-with-offline-repositories_{context}"]
 = Configuring the base operating system with offline repositories
 
-Use this procedure to configure offline repositories for the {RHEL} 9 or {RHEL} 8, and {ProjectName} ISO images.
+Use this procedure to configure offline repositories for {RHEL} 9 or {RHEL} 8, and {ProjectName} ISO images.
 
 .Procedure
 

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -9,43 +9,43 @@ Use this procedure to configure offline repositories for the {RHEL} 9 or {RHEL} 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# mkdir /media/rhel__<version>__
+# mkdir /media/rhel
 ----
 
 . Mount the ISO image for {RHEL} to the mount point.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# mount -o loop _rhel__<version>__-DVD_.iso /media/rhel__<version>__
+# mount -o loop _rhel-DVD_.iso /media/rhel
 ----
 +
 . To copy the ISO file's repository data file and change permissions, enter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# cp /media/rhel__<version>__/media.repo /etc/yum.repos.d/rhel__<version>__.repo
-# chmod u+w /etc/yum.repos.d/rhel__<version>__.repo
+# cp /media/rhel/media.repo /etc/yum.repos.d/rhel.repo
+# chmod u+w /etc/yum.repos.d/rhel.repo
 ----
 
 . Edit the repository data file and add the `baseurl` directive.
 +
 [options="nowrap" subs="+quotes"]
 ----
-[RHEL__<version>__-BaseOS]
+[RHEL-BaseOS]
 name=Red Hat Enterprise Linux BaseOS
 mediaid=None
 metadata_expire=-1
 gpgcheck=0
 cost=500
-baseurl=file:///media/rhel__<version>__/BaseOS/
+baseurl=file:///media/rhel/BaseOS/
 
-[RHEL__<version>__-AppStream]
+[RHEL-AppStream]
 name=Red Hat Enterprise Linux Appstream
 mediaid=None
 metadata_expire=-1
 gpgcheck=0
 cost=500
-baseurl=file:///media/rhel__<version>__/AppStream/
+baseurl=file:///media/rhel/AppStream/
 ----
 +
 . Verify that the repository has been configured.

--- a/guides/common/modules/proc_installing-fapolicyd-on-server.adoc
+++ b/guides/common/modules/proc_installing-fapolicyd-on-server.adoc
@@ -44,4 +44,4 @@ endif::[]
 In case of new {ProjectServer} or {SmartProxyServer} installation, follow the standard installation procedures after installing and enabling fapolicyd on your {EL} host.
 
 .Additional resources
-For more information on fapolicyd, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_blocking-and-allowing-applications-using-fapolicyd_security-hardening#doc-wrapper[Blocking and allowing applications using fapolicyd] in _Red Hat Enterprise Linux 8 Security hardening_.
+For more information on fapolicyd, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_blocking-and-allowing-applications-using-fapolicyd_security-hardening[Blocking and allowing applications using fapolicyd] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_blocking-and-allowing-applications-using-fapolicyd_security-hardening[Blocking and allowing applications using fapolicyd] in _{RHEL} 8 guide_.

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -1,7 +1,7 @@
 [id="Installing_the_Load_Balancer_{context}"]
 = Installing the load balancer
 
-The following example provides general guidance for configuring an HAProxy load balancer using {EL} 8 server.
+The following example provides general guidance for configuring an HAProxy load balancer using {EL} 9 or {EL} 8 server.
 However, you can install any suitable load balancing software solution that supports TCP forwarding.
 
 .Procedure

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -1,7 +1,7 @@
 [id="Installing_the_Load_Balancer_{context}"]
 = Installing the load balancer
 
-The following example provides general guidance for configuring an HAProxy load balancer using {EL} 9 or {EL} 8 server.
+The following example provides general guidance for configuring an HAProxy load balancer using {EL} 9 or {EL} 8.
 However, you can install any suitable load balancing software solution that supports TCP forwarding.
 
 .Procedure

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -25,7 +25,6 @@ Select the operating system and version you are installing external database on:
 [id="repositories-externaldb-el-9"]
 == {EL} 9
 
-:package-manager: dnf
 :distribution-major-version: 9
 
 . Disable all repositories:
@@ -61,7 +60,6 @@ include::snip_step-verify-enabled-repolist.adoc[]
 [id="repositories-externaldb-el-8"]
 == {EL} 8
 
-:package-manager: dnf
 :distribution-major-version: 8
 
 . Disable all repositories:

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -14,6 +14,9 @@ endif::[]
 
 .Prerequisites
 * The prepared host must meet {Project}'s {InstallingServerDocURL}storage-requirements_{project-context}[Storage Requirements].
+ifdef::foreman-el,katello[]
+* Ensure that you have access to your {EL} `BaseOS` and `AppStream` repositories.
+endif::[]
 
 .Procedure
 ifndef::orcharhino[]
@@ -27,6 +30,7 @@ Select the operating system and version you are installing external database on:
 
 :distribution-major-version: 9
 
+ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -38,13 +42,13 @@ Select the operating system and version you are installing external database on:
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos \
-ifdef::satellite[]
 --enable={RepoRHEL9ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion} \
-endif::[]
 --enable={RepoRHEL9BaseOS} \
 --enable={RepoRHEL9AppStream}
 ----
+endif::[]
+
 ifdef::katello[]
 . Install the `katello-repos-latest.rpm` package
 +
@@ -62,6 +66,7 @@ include::snip_step-verify-enabled-repolist.adoc[]
 
 :distribution-major-version: 8
 
+ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -73,15 +78,14 @@ include::snip_step-verify-enabled-repolist.adoc[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos \
-ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProjectVersion} \
-endif::[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8AppStream}
 ----
+endif::[]
+
 ifdef::katello[]
-+
 . Install the `katello-repos-latest.rpm` package
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -90,7 +94,9 @@ ifdef::katello[]
 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
+
 include::snip_step-verify-enabled-repolist.adoc[]
+
 . Enable the following module:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -104,5 +110,5 @@ include::snip_dnf-module-enable-note.adoc[]
 ====
 endif::[]
 ifdef::orcharhino[]
-* Ensure the prepared host has the same content available as your {ProjectServer}.
+Ensure the prepared host has the same content available as your {ProjectServer}.
 endif::[]

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -8,7 +8,7 @@ Subscriptions for {RHEL} do not provide the correct service level agreement for 
 You must also attach a {Project} subscription to the base operating system that you want to use for the external databases.
 endif::[]
 
-ifndef::orcharhino[]
+ifdef::satellite[]
 Use the instructions in {InstallingServerDocURL}attaching-infrastructure-subscription_{project-context}[Attaching the {Project} Infrastructure Subscription] to attach a {Project} subscription to your server.
 endif::[]
 
@@ -19,11 +19,11 @@ endif::[]
 ifndef::orcharhino[]
 Select the operating system and version you are installing external database on:
 
-* xref:#repositories-externaldb-rhel-9[{RHEL} 9]
-* xref:#repositories-externaldb-rhel-8[{RHEL} 8]
+* xref:#repositories-externaldb-el-9[{EL} 9]
+* xref:#repositories-externaldb-el-8[{EL} 8]
 
-[id="repositories-externaldb-rhel-9"]
-== {RHEL} 9
+[id="repositories-externaldb-el-9"]
+== {EL} 9
 
 :package-manager: dnf
 :distribution-major-version: 9
@@ -34,8 +34,6 @@ Select the operating system and version you are installing external database on:
 ----
 # subscription-manager repos --disable "*"
 ----
-+
-
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -48,9 +46,7 @@ endif::[]
 --enable={RepoRHEL9BaseOS} \
 --enable={RepoRHEL9AppStream}
 ----
-
 ifdef::katello[]
-+
 . Install the `katello-repos-latest.rpm` package
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -62,8 +58,8 @@ endif::[]
 
 include::snip_step-verify-enabled-repolist.adoc[]
 
-[id="repositories-externaldb-rhel-8"]
-== {RHEL} 8
+[id="repositories-externaldb-el-8"]
+== {EL} 8
 
 :package-manager: dnf
 :distribution-major-version: 8
@@ -74,8 +70,6 @@ include::snip_step-verify-enabled-repolist.adoc[]
 ----
 # subscription-manager repos --disable "*"
 ----
-+
-
 . Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -88,7 +82,6 @@ endif::[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8AppStream}
 ----
-
 ifdef::katello[]
 +
 . Install the `katello-repos-latest.rpm` package
@@ -99,9 +92,7 @@ ifdef::katello[]
 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
-+
 include::snip_step-verify-enabled-repolist.adoc[]
-+
 . Enable the following module:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -14,9 +14,6 @@ endif::[]
 
 .Prerequisites
 * The prepared host must meet {Project}'s {InstallingServerDocURL}storage-requirements_{project-context}[Storage Requirements].
-ifdef::foreman-el,katello[]
-* Ensure that you have access to your {EL} `BaseOS` and `AppStream` repositories.
-endif::[]
 
 .Procedure
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
+++ b/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc
@@ -1,11 +1,15 @@
 [id="preparing-a-host-for-external-databases_{context}"]
 = Preparing a host for external databases
 
-Install a freshly provisioned system with the latest {EL} 8 to host the external databases.
+Install a freshly provisioned system with the latest {EL} 9 or {EL} 8 to host the external databases.
 
 ifdef::satellite[]
 Subscriptions for {RHEL} do not provide the correct service level agreement for using {Project} with external databases.
 You must also attach a {Project} subscription to the base operating system that you want to use for the external databases.
+endif::[]
+
+ifndef::orcharhino[]
+Use the instructions in {InstallingServerDocURL}attaching-infrastructure-subscription_{project-context}[Attaching the {Project} Infrastructure Subscription] to attach a {Project} subscription to your server.
 endif::[]
 
 .Prerequisites
@@ -13,12 +17,69 @@ endif::[]
 
 .Procedure
 ifndef::orcharhino[]
-. Use the instructions in {InstallingServerDocURL}attaching-infrastructure-subscription_{project-context}[Attaching the {Project} Infrastructure Subscription] to attach a {Project} subscription to your server.
-. Disable all repositories and enable only the following repositories:
+Select the operating system and version you are installing external database on:
+
+* xref:#repositories-externaldb-rhel-9[{RHEL} 9]
+* xref:#repositories-externaldb-rhel-8[{RHEL} 8]
+
+[id="repositories-externaldb-rhel-9"]
+== {RHEL} 9
+
+:package-manager: dnf
+:distribution-major-version: 9
+
+. Disable all repositories:
++
+[options="nowrap"]
+----
+# subscription-manager repos --disable "*"
+----
++
+
+. Enable the following repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# subscription-manager repos --disable '*'
+# subscription-manager repos \
+ifdef::satellite[]
+--enable={RepoRHEL9ServerSatelliteServerProjectVersion} \
+--enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion} \
+endif::[]
+--enable={RepoRHEL9BaseOS} \
+--enable={RepoRHEL9AppStream}
+----
+
+ifdef::katello[]
++
+. Install the `katello-repos-latest.rpm` package
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {client-package-install-el8} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm \
+https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
+----
+endif::[]
+
+include::snip_step-verify-enabled-repolist.adoc[]
+
+[id="repositories-externaldb-rhel-8"]
+== {RHEL} 8
+
+:package-manager: dnf
+:distribution-major-version: 8
+
+. Disable all repositories:
++
+[options="nowrap"]
+----
+# subscription-manager repos --disable "*"
+----
++
+
+. Enable the following repositories:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
 # subscription-manager repos \
 ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteServerProjectVersion} \
@@ -27,16 +88,19 @@ endif::[]
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8AppStream}
 ----
+
 ifdef::katello[]
 +
 . Install the `katello-repos-latest.rpm` package
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {client-package-install-el8} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
-https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
+# {client-package-install-el8} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm \
+https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
++
+include::snip_step-verify-enabled-repolist.adoc[]
 +
 . Enable the following module:
 +

--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -4,7 +4,7 @@
 To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProductName} with Network Time Protocol (NTP) servers.
 If the base operating system clock is configured incorrectly, certificate verification might fail.
 
-For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings#using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in _{RHEL} 8 Configuring basic system settings_.
+For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings#using-chrony-to-configure-ntp_configuring-time-synchronization[Using the Chrony suite to configure NTP] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings#using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in _{RHEL} 8 guide_.
 
 .Procedure
 

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -77,7 +77,7 @@ Reboot these hosts after the upgrade has completed.
 
 . Obtain the latest ISO files by following the {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.
 
-. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel8` repository by following the {InstallingServerDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories-in-rhel-8_satellite[Configuring the Base Operating System with Offline Repositories in RHEL 8] procedure in _{InstallingServerDisconnectedDocTitle}_.
+. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel8` repository by following the {InstallingServerDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories_satellite[Configuring the base operating system with offline repositories] procedure in _{InstallingServerDisconnectedDocTitle}_.
 +
 Do not install or update any packages at this stage.
 

--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -43,7 +43,7 @@ rtt min/avg/max/mdev = 0.019/0.019/0.019/0.000 ms
 ----
 
 ifdef::satellite[]
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/assembly_changing-a-hostname_configuring-and-managing-networking#proc_changing-a-hostname-using-hostnamectl_assembly_changing-a-hostname[Changing a hostname using hostnamectl] in the _{RHEL} Configuring and managing networking_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/assembly_changing-a-hostname_configuring-and-managing-networking#proc_changing-a-hostname-using-hostnamectl_assembly_changing-a-hostname[Changing a hostname using hostnamectl] in the _{RHEL} Configuring and managing networking_ guide.
 endif::[]
 
 ifndef::foreman-deb[]

--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -43,7 +43,7 @@ rtt min/avg/max/mdev = 0.019/0.019/0.019/0.000 ms
 ----
 
 ifdef::satellite[]
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/assembly_changing-a-hostname_configuring-and-managing-networking#proc_changing-a-hostname-using-hostnamectl_assembly_changing-a-hostname[Changing a hostname using hostnamectl] in the _{RHEL} 8 Configuring and managing networking_.
+For more information, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/assembly_changing-a-hostname_configuring-and-managing-networking#proc_changing-a-hostname-using-hostnamectl_assembly_changing-a-hostname[Changing a hostname using hostnamectl] in the _{RHEL} Configuring and managing networking_.
 endif::[]
 
 ifndef::foreman-deb[]

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -5,7 +5,7 @@ The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
 ifdef::katello,satellite[]
-The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
+The runtime size was measured with {RHEL} 6, 7, 8 and 9 repositories synchronized.
 endif::[]
 
 .Storage requirements for {SmartProxyServer} installation

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -5,7 +5,7 @@ The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
 ifdef::katello,satellite[]
-The runtime size was measured with {RHEL} 6, 7, 8 and 9 repositories synchronized.
+The runtime size was measured with {RHEL} 7, 8, and 9 repositories synchronized.
 endif::[]
 
 .Storage requirements for {SmartProxyServer} installation

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -5,7 +5,7 @@ The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
 ifdef::katello,satellite[]
-The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
+The runtime size was measured with {RHEL} 6, 7, 8, and 9 repositories synchronized.
 endif::[]
 
 .Storage requirements for a {ProjectServer} installation
@@ -30,5 +30,5 @@ endif::[]
 ifdef::foreman-el,katello,satellite[]
 For external database servers: `{postgresql-lib-dir}` with installation size of 100 MB and runtime size of 20 GB.
 
-For detailed information on partitioning and size, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/partitioning-reference_system-design-guide[Partitioning reference] in the _{RHEL} 8 System Design Guide_.
+For detailed information on partitioning and size, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/performing_a_standard_rhel_9_installation/partitioning-reference_installing-rhel[Partitioning reference] in the _{RHEL} System Design Guide_.
 endif::[]

--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -5,7 +5,7 @@ The following table details storage requirements for specific directories.
 These values are based on expected use case scenarios and can vary according to individual environments.
 
 ifdef::katello,satellite[]
-The runtime size was measured with {RHEL} 6, 7, 8, and 9 repositories synchronized.
+The runtime size was measured with {RHEL} 7, 8, and 9 repositories synchronized.
 endif::[]
 
 .Storage requirements for a {ProjectServer} installation

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -3,7 +3,7 @@
 
 ifdef::satellite[]
 You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
-Red{nbsp}Hat {ProductName} is supported on the latest version of {RHEL} 8 that is available at the time when {ProductName} is installed.
+Red{nbsp}Hat {ProductName} is supported on the latest versions of {RHEL} 9 and {RHEL} 8 that are available at the time when {ProductName} is installed.
 Previous versions of {RHEL} including EUS or z-stream are not supported.
 endif::[]
 
@@ -13,9 +13,11 @@ The following operating systems are supported by the installer, have packages, a
 |====
 | Operating System | Architecture | Notes
 ifdef::foreman-el,katello,orcharhino[]
+| {PlanningDocURL}varl-Glossary_of_Terms-Enterprise_Linux[{EL}] 9 | x86_64 only | EPEL is not supported.
 | {PlanningDocURL}varl-Glossary_of_Terms-Enterprise_Linux[{EL}] 8 | x86_64 only | EPEL is not supported.
 endif::[]
 ifdef::satellite[]
+| {RHEL} 9 | x86_64 only |
 | {RHEL} 8 | x86_64 only |
 endif::[]
 ifdef::foreman-deb[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -5,7 +5,7 @@ The following requirements apply to the networked base operating system:
 
 * x86_64 architecture
 ifdef::satellite[]
-* The latest version of {RHEL} 8
+* The latest version of {RHEL} 9 or {RHEL} 8
 endif::[]
 * 4-core 2.0 GHz CPU at a minimum
 
@@ -42,7 +42,7 @@ endif::[]
 
 {Project} only supports `UTF-8` encoding.
 If your territory is USA and your language is English, set `en_US.utf-8` as the system-wide locale settings.
-For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring System Locale guide].
+For more information about configuring system locale in {EL}, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring the system locale].
 
 ifdef::satellite[]
 Your {Project} must have the {SatelliteSub} manifest in your Customer Portal.
@@ -114,7 +114,7 @@ ifndef::satellite[]
 {RHEL} clones are not being actively tested in FIPS mode.
 If you require FIPS, consider using {RHEL}.
 endif::[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in _Security hardening_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing the system in FIPS mode] in _{RHEL} 8 guide_.
 
 [NOTE]
 ====

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -5,7 +5,7 @@ The following requirements apply to the networked base operating system:
 
 * x86_64 architecture
 ifdef::satellite[]
-* The latest version of {RHEL} 9 or {RHEL} 8
+* The latest version of {EL} 9 or {EL} 8
 endif::[]
 * 4-core 2.0 GHz CPU at a minimum
 

--- a/guides/common/modules/snip_step-verify-enabled-repolist.adoc
+++ b/guides/common/modules/snip_step-verify-enabled-repolist.adoc
@@ -2,5 +2,5 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} repolist enabled
+# dnf repolist enabled
 ----

--- a/guides/common/modules/snip_step-verify-enabled-repolist.adoc
+++ b/guides/common/modules/snip_step-verify-enabled-repolist.adoc
@@ -1,0 +1,6 @@
+. Verify that the required repositories are enabled:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-manager} repolist enabled
+----

--- a/guides/common/modules/snip_verify-firewall-settings.adoc
+++ b/guides/common/modules/snip_verify-firewall-settings.adoc
@@ -7,5 +7,5 @@
 ----
 
 ifndef::foreman-deb[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_firewalls_and_packet_filters/using-and-configuring-firewalld_firewall-packet-filters[Using and Configuring firewalld] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and Configuring firewalld] in _{RHEL} 8 guide_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_firewalls_and_packet_filters/using-and-configuring-firewalld_firewall-packet-filters[Using and configuring firewalld] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and configuring firewalld] in _{RHEL} 8 guide_.
 endif::[]

--- a/guides/common/modules/snip_verify-firewall-settings.adoc
+++ b/guides/common/modules/snip_verify-firewall-settings.adoc
@@ -7,5 +7,5 @@
 ----
 
 ifndef::foreman-deb[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and Configuring firewalld] in _{RHEL} 8 Securing networks_.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_firewalls_and_packet_filters/using-and-configuring-firewalld_firewall-packet-filters[Using and Configuring firewalld] in _{RHEL} 9 guide_ or https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/securing_networks/using-and-configuring-firewalld_securing-networks[Using and Configuring firewalld] in _{RHEL} 8 guide_.
 endif::[]


### PR DESCRIPTION
Added EL9 support for Project and Proxy both.
NOTE: Versions in Repositories render incorrectly which should not be a problem for upstream. For Downstream, this will not be published without the correct version.

This applies to Foreman 3.10/Katello 4.12. (GA Soon)

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
