### PR TITLE
Use satellite-maintain to handle package updates (#2582)

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -87,6 +87,7 @@
 :package-clean: dnf clean
 :package-install-project: dnf install
 :package-install: dnf install
+:project-package-check-update: dnf check-update
 :package-remove-project: dnf remove
 :package-remove: dnf remove
 :package-update-project: dnf update

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -83,6 +83,7 @@
 :oVirt: Red{nbsp}Hat{nbsp}Virtualization
 :oVirtEngine: Red{nbsp}Hat Virtualization Manager
 :oVirtShort: RHV
+:project-package-check-update: satellite-maintain packages check-update
 :package-install-project: satellite-maintain packages install
 :package-remove-project: satellite-maintain packages remove
 :package-update-project: satellite-maintain packages update

--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -9,51 +9,32 @@ To install and update packages on the {ProjectServer} or {SmartProxyServer} base
 The `{foreman-maintain} packages` command restarts some services on the operating system where you run it because it runs the `{foreman-installer}` command after installing packages.
 ====
 
-.Procedure
-* To install packages on {ProjectServer} or {SmartProxyServer}, enter the following command:
+You can manage packages using the `{foreman-maintain} packages` command as follows:
+
+* To install packages on {ProjectServer} or {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {package-install-project} _package_1_ _package_2_
 ----
-* To update specific packages on {ProjectServer} or {SmartProxyServer}, enter the following command:
+* To check for available package updates on {ProjectServer} or {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {package-update-project} _package_1_ _package_2_
+# {project-package-check-update}
 ----
-* To update all packages on {ProjectServer} or {SmartProxyServer}, enter the following command:
+* To update all packages on {ProjectServer} or {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {package-update-project}
 ----
-
-.Using yum to Check for Package Updates
-If you want to check for updates using `yum`, enter the command to install and update packages manually and then you can use `yum` to check for updates:
-
-[options="nowrap" subs="+quotes,attributes"]
+* To update specific packages on {ProjectServer} or {SmartProxyServer}:
++
+[options="nowrap", subs="+quotes,attributes"]
 ----
-# {foreman-maintain} packages unlock
-# yum check update
-# {foreman-maintain} packages lock
+# {package-update-project} _package_1_ _package_2_
 ----
 
-Updating packages individually can lead to package inconsistencies in {ProjectServer} or {SmartProxyServer}.
-For more information about updating packages in {ProjectServer}, see {UpgradingDocURL}updating_satellite_server_to_next_minor_version[Updating {ProjectServer}].
-
-.Enabling yum for {ProjectServer} or {SmartProxyServerTitle} Package Management
-If you want to install and update packages on your system using `yum` directly and control the stability of the system yourself, enter the following command:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} packages unlock
-----
-
-.Restoring Package Management to the Default Settings
-If you want to restore the default settings and enable {ProjectServer} or {SmartProxyServer} to prevent users from installing and updating packages with `yum` and ensure the stability of the system, enter the following command:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} packages lock
-----
+Updating packages individually can lead to package inconsistencies on {ProjectServer} or {SmartProxyServer}.
+For more information about updating packages on {ProjectServer}, see {UpdatingDocURL}updating-project-to-next-minor-version_updating[Updating {ProjectServer} to the Next Minor Version] in _{UpdatingDocTitle}_.


### PR DESCRIPTION
Co-authored-by: Maximilian Kolb <mail@maximilian-kolb.de>
(cherry picked from commit 98b323ff5cc7bc19109ef3a1d256ce08bcbb0a5d)

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
