### PR TITLE
Add procedure to add passphrase to SSH key used for REX

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -30,6 +30,8 @@ include::modules/proc_distributing-ssh-keys-for-remote-execution.adoc[leveloffse
 
 include::modules/proc_distributing-ssh-keys-for-remote-execution-manually.adoc[leveloffset=+1]
 
+include::modules/proc_adding-a-passphrase-to-ssh-key-used-for-remote-execution.adoc[leveloffset=+1]
+
 include::modules/proc_using-the-api-to-obtain-ssh-keys-for-remote-execution.adoc[leveloffset=+1]
 
 ifndef::satellite[]

--- a/guides/common/modules/proc_adding-a-passphrase-to-ssh-key-used-for-remote-execution.adoc
+++ b/guides/common/modules/proc_adding-a-passphrase-to-ssh-key-used-for-remote-execution.adoc
@@ -1,0 +1,16 @@
+[id="adding-a-passphrase-to-ssh-key-used-for-remote-execution_{context}"]
+= Adding a passphrase to SSH key used for remote execution
+
+By default, {SmartProxy} uses a non-passphrase protected SSH key to execute remote jobs on hosts.
+You can protect the SSH key with a passphrase by following this procedure.
+
+.Procedure
+* On your {ProjectServer} or {SmartProxyServer}, use `ssh-keygen` to add a passphrase to your SSH key:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# ssh-keygen -p -f ~foreman-proxy/.ssh/id_rsa_foreman_proxy
+----
+
+.Next steps
+* Users now must use a passphrase when running remote execution jobs on hosts.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2170031


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
