### PR TITLE
Rework procedure to enable BMC on Smart Proxies

### DIFF
--- a/guides/common/modules/con_prerequisites-for-bare-metal-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-bare-metal-provisioning.adoc
@@ -1,16 +1,16 @@
 [id="Prerequisites_for_Bare_Metal_Provisioning_{context}"]
-= Prerequisites for bare metal provisioning
+= Prerequisites for bare-metal provisioning
 
-The requirements for bare metal provisioning include:
+The requirements for bare-metal provisioning include:
 
-* A {SmartProxyServer} managing the network for bare metal hosts.
+* A {SmartProxyServer} managing the network for bare-metal hosts.
 For unattended provisioning and discovery-based provisioning, {ProjectServer} requires PXE server settings.
 +
 For more information about networking requirements, see xref:Configuring_Networking_{context}[].
 +
 For more information about the Discovery service, xref:Configuring_the_Discovery_Service_{context}[].
 +
-* A bare metal host or a blank VM.
+* A bare-metal host or a blank VM.
 include::snip_prerequisites-common-compute-resource.adoc[]
 
 For information about the security token for unattended and PXE-less provisioning, see xref:Configuring_the_Security_Token_Validity_Duration_{context}[].

--- a/guides/common/modules/con_provisioning-methods-in-project.adoc
+++ b/guides/common/modules/con_provisioning-methods-in-project.adoc
@@ -3,9 +3,9 @@
 
 With {ProjectName}, you can provision hosts by using multiple methods.
 
-Bare Metal Provisioning::
-{Project} provisions bare metal hosts primarily by using PXE boot and MAC address identification.
-When provisioning bare metal hosts with {Project}, you can do the following:
+Bare-Metal Provisioning::
+{Project} provisions bare-metal hosts primarily by using PXE boot and MAC address identification.
+When provisioning bare-metal hosts with {Project}, you can do the following:
 +
 * Create host entries and specify the MAC address of the physical host to provision.
 * Boot blank hosts to use the {Project} Discovery service, which creates a pool of hosts that are ready to be provisioned.
@@ -25,7 +25,7 @@ Virtualization Infrastructure::
 When provisioning virtual machines with {Project}, you can do the following:
 +
 * Provision virtual machines from virtual image templates.
-* Use the same PXE-based boot methods as bare metal providers.
+* Use the same PXE-based boot methods as bare-metal providers.
 
 ifdef::orcharhino[]
 For more information, see xref:sources/compute_resources.adoc[compute resources].

--- a/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
+++ b/guides/common/modules/con_unattended-use-customization-and-image-remastering.adoc
@@ -140,6 +140,6 @@ if=/usr/share/foreman-discovery-image/foreman-discovery-image-3.4.4-5.iso \
 of=/dev/sdb
 ----
 
-Insert the Discovery boot media into a bare metal host, start the host, and boot from the media.
+Insert the Discovery boot media into a bare-metal host, start the host, and boot from the media.
 
 For more information about provisioning discovered hosts, see xref:Creating_Hosts_from_Discovered_Hosts_{context}[].

--- a/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
@@ -1,7 +1,7 @@
 [id="Using_PXE_to_Provision_Hosts_{context}"]
 = Using PXE to provision hosts
 
-You can provision bare metal instances with {Project} using one of the following methods:
+You can provision bare-metal instances with {Project} using one of the following methods:
 
 Unattended Provisioning::
 New hosts are identified by a MAC address and {ProjectServer} provisions the host using a PXE boot process.

--- a/guides/common/modules/proc_adding-a-bmc-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bmc-interface.adoc
@@ -1,11 +1,11 @@
 [id="Adding_a_Baseboard_Management_Controller_Interface_{context}"]
 = Adding a baseboard management controller (BMC) interface
 
+You can control the power status of bare-metal hosts from {Project}.
 Use this procedure to configure a baseboard management controller (BMC) interface for a host that supports this feature.
 
 .Prerequisites
-* The `ipmitool` package is installed.
-* You know the MAC address, IP address, and other details of the BMC interface on the host, and the appropriate credentials for that interface.
+* You know the MAC address, IP address, and other details of the BMC interface on the host, and authentication credentials for that interface.
 +
 [NOTE]
 ====
@@ -13,18 +13,30 @@ You only need the MAC address for the BMC interface if the BMC interface is mana
 ====
 
 .Procedure
-. Enable BMC on the {SmartProxy} server if it is not already enabled:
-.. Configure BMC power management on {SmartProxyServer} by running the `{foreman-installer}` script with the following options:
+. Install `ipmitool` on your {SmartProxy}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-bmc=true \
---foreman-proxy-bmc-default-provider=ipmitool
+# {project-package-install} ipmitool
 ----
-.. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
-.. From the list in the *Actions* column, click *Refresh*.
-The list in the *Features* column should now include BMC.
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Enable BMC power management on your {SmartProxy}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} \
+--foreman-proxy-bmc-default-provider=ipmitool \
+--foreman-proxy-bmc=true
+----
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
+. Select the subnet of your host.
+ifdef::satellite[]
+. On the *{SmartProxies}* tab, select your {SmartProxy} as *BMC {SmartProxy}*.
+endif::[]
+ifndef::satellite[]
+. On the *Proxies* tab, select your {SmartProxy} as *BMC Proxy*.
+endif::[]
+. Click *Submit*.
+. Navigate to *Hosts* > *All Hosts*.
 . Click *Edit* next to the host you want to edit.
 . On the *Interfaces* tab, click *Add Interface*.
 . Select *BMC* from the *Type* list.

--- a/guides/common/modules/proc_adding-a-bmc-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bmc-interface.adoc
@@ -13,12 +13,6 @@ You only need the MAC address for the BMC interface if the BMC interface is mana
 ====
 
 .Procedure
-. Install `ipmitool` on your {SmartProxy}:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {project-package-install} ipmitool
-----
 . Enable BMC power management on your {SmartProxy}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts.adoc
@@ -11,7 +11,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-fr
 For more information about networking requirements, see xref:Configuring_Networking_{context}[].
 * Configure the discovery service on {Project}.
 For more information, see xref:Installing_the_Discovery_Service_{context}[].
-* A bare metal host or a blank VM.
+* A bare-metal host or a blank VM.
 include::snip_prerequisites-common-compute-resource.adoc[]
 
 For information about the security tokens, see xref:Configuring_the_Security_Token_Validity_Duration_{context}[].

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -56,7 +56,7 @@ For more information about network interfaces, see {ManagingHostsDocURL}Adding_N
 . From the boot menu, select *Kickstart default PXEGrub2*.
 
 This creates the host entry and the relevant provisioning settings.
-This also includes creating the necessary directories and files for UEFI booting the bare metal host.
+This also includes creating the necessary directories and files for UEFI booting the bare-metal host.
 When you start the physical host and set its boot mode to UEFI HTTP, the host detects the defined DHCP service, receives HTTP endpoint of {SmartProxy} with the Kickstart tree and installs the operating system.
 
 ifdef::katello,satellite,orcharhino[]
@@ -112,7 +112,7 @@ endif::[]
 . From the boot menu, select *Kickstart default PXEGrub2*.
 
 This creates the host entry and the relevant provisioning settings.
-This also includes creating the necessary directories and files for UEFI booting the bare metal host.
+This also includes creating the necessary directories and files for UEFI booting the bare-metal host.
 When you start the physical host and set its boot mode to UEFI HTTP, the host detects the defined DHCP service, receives HTTP endpoint of {SmartProxy} with the Kickstart tree and installs the operating system.
 
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
@@ -26,7 +26,7 @@ endif::[]
 For more information about network interfaces, see {ManagingHostsDocURL}Adding_Network_Interfaces_managing-hosts[Adding network interfaces] in _{ManagingHostsDocTitle}_.
 
 This creates the host entry and the relevant provisioning settings.
-This also includes creating the necessary directories and files for PXE booting the bare metal host.
+This also includes creating the necessary directories and files for PXE booting the bare-metal host.
 If you start the physical host and set its boot mode to PXE, the host detects the DHCP service of {ProjectServer}'s integrated {SmartProxy}, receives HTTP endpoint of the Kickstart tree and installs the operating system.
 
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/proc_implementing-pxe-less-discovery.adoc
+++ b/guides/common/modules/proc_implementing-pxe-less-discovery.adoc
@@ -50,7 +50,7 @@ For example, to copy to a USB stick at `/dev/sdb`:
 if=/usr/share/foreman-discovery-image/foreman-discovery-image-3.4.4-5.iso \
 of=/dev/sdb
 ----
-. Insert the Discovery boot media into a bare metal host, start the host, and boot from the media.
+. Insert the Discovery boot media into a bare-metal host, start the host, and boot from the media.
 The Discovery Image displays an option for either *Manual network setup* or *Discovery with DHCP*:
 +
 If you select *Manual network setup*, the Discovery image requests a set of network options.

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -30,6 +30,6 @@ endif::[]
 . In the *Value* field, enter the absolute path or a relative path in the following format `custom/_product_/_repository_/_image_name_` that points to the exact location where you store the image.
 . Click *Submit* to save your changes.
 
-You can use this image for bare metal provisioning and provisioning using a compute resource.
-For more information about bare metal provisioning, see xref:Using_PXE_to_Provision_Hosts_{context}[].
+You can use this image for bare-metal provisioning and provisioning using a compute resource.
+For more information about bare-metal provisioning, see xref:Using_PXE_to_Provision_Hosts_{context}[].
 For more information about provisioning with different compute resources, see the relevant chapter for the compute resource that you want to use.

--- a/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
+++ b/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
@@ -25,7 +25,7 @@ The following list provides an overview of the permissions a non-admin user requ
 
 .2+|Compute resource
 |view_compute_resources, create_compute_resources, destroy_compute_resources, power_compute_resources
-|Required to provision bare metal hosts.
+|Required to provision bare-metal hosts.
 |view_compute_resources_vms, create_compute_resources_vms, destroy_compute_resources_vms, power_compute_resources_vms
 |Required to provision virtual machines.
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -109,7 +109,7 @@ ifdef::satellite[]
 If you require frequent updates of Red{nbsp}Hat content on a disconnected {Project}, plan an additional {Project} instance for {ISS}.
 endif::[]
 
-* *What compute resources do I need for my hosts?* – Apart from provisioning bare metal hosts, you can use various compute resources supported by {Project}.
+* *What compute resources do I need for my hosts?* – Apart from provisioning bare-metal hosts, you can use various compute resources supported by {Project}.
 To learn about provisioning on different compute resources see {ProvisioningDocURL}[_{ProvisioningDocTitle}_].
 
 [[sect-Defining_Content_Sources]]
@@ -248,7 +248,7 @@ The same guide contains information on configuring external authentication sourc
 
 This section provides a short overview of selected {Project} capabilities that can be used for automating certain tasks or extending the core usage of {Project}:
 
-* *Discovering bare metal hosts* – the {Project} Discovery plug-in enables automatic bare-metal discovery of unknown hosts on the provisioning network.
+* *Discovering bare-metal hosts* – the {Project} Discovery plug-in enables automatic bare-metal discovery of unknown hosts on the provisioning network.
 These new hosts register themselves to {ProjectServer} and the Puppet Agent on the client uploads system facts collected by Facter, such as serial ID, network interface, memory, and disk information.
 After registration you can initialize provisioning of those discovered hosts.
 For more information, see {ProvisioningDocURL}Creating_Hosts_from_Discovered_Hosts_provisioning[Creating Hosts from Discovered Hosts] in _{ProvisioningDocTitle}_.


### PR DESCRIPTION
* Clarifiy enabling BMC Smart Proxy per subnet
* Simplify enabling BMC on Smart Proxies
* Sort options in alphabetical order


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
