### PR TITLE
Reword "a HTTP proxy/server" to "an HTTP proxy/server"

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -26,7 +26,7 @@ Clear this field if the repository does not require authentication.
 Leave this field empty if the repository does not require authentication.
 . From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
 For more information, see xref:Mirroring_Policies_Overview_{context}[].
-. Optional: In the *HTTP Proxy Policy* field, select or deselect using a HTTP proxy.
+. Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.
 By default, it uses the `Global Default` HTTP proxy.
 . Optional: You can clear the *Unprotected* checkbox to require a subscription entitlement certificate for accessing this repository.
 By default, the repository is published through HTTP.

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -2,7 +2,7 @@
 = Using a {LoraxCompose} image for provisioning
 
 In {Project}, you can integrate with {Cockpit} to perform actions and monitor your hosts.
-Using {Cockpit}, you can access {LoraxCompose} and build images that you can then upload to a HTTP server and use this image to provision hosts.
+Using {Cockpit}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
 When you configure {Project} for image provisioning, Anaconda installer partitions disks, downloads and mounts the image and copies files over to a host.
 The preferred image type is TAR.
 

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -77,7 +77,7 @@ For HTTP booting to work, ensure that {Project} has the following configurations
 * The UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
 * Ensure that the TCP port 8000 is open for the client to download the bootloader and Kickstart templates from the {SmartProxy}.
 * The TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} using the HTTPS protocol.
-* The subnet that functions as the host's provisioning interface has a DHCP {SmartProxy}, a HTTP Boot {SmartProxy}, a TFTP {SmartProxy}, and a Templates {SmartProxy}
+* The subnet that functions as the host's provisioning interface has a DHCP {SmartProxy}, an HTTP Boot {SmartProxy}, a TFTP {SmartProxy}, and a Templates {SmartProxy}
 
 ifndef::foreman-deb[]
 * The `grub2-efi` package is updated to the latest version.
@@ -116,8 +116,8 @@ Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {Sm
 * Ensure that both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
 * Ensure that the UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
 * Ensure that the TCP port 8000 is open for the client to download bootloader and Kickstart templates from the {SmartProxy}.
-* Ensure that the TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} via HTTPS protocol.
-* Ensure that the host provisioning interface subnet has a HTTP Boot {SmartProxy} set.
+* Ensure that the TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} through HTTPS.
+* Ensure that the host provisioning interface subnet has an HTTP Boot {SmartProxy} set.
 * Ensure that the host provisioning interface subnet has a TFTP {SmartProxy} set.
 * Ensure that the host provisioning interface subnet has a Templates {SmartProxy} set.
 


### PR DESCRIPTION
* Replace "via" with "through"


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)