### PR TITLE
Add information about Distinguished Names

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -66,12 +66,16 @@ Optional: If you want to add Distinguished Name (DN) details to the CSR, add the
 ----
 [req_distinguished_name]
 CN = _{context}.example.com_
-countryName = Country Name (2 letter code)
-stateOrProvinceName = State or Province Name (full name)
-localityName = Locality Name (eg. city)
-organizationName = Name of the Organization or Company
-organizationalUnitName = Organizational Unit Name (eg. section)
+countryName =_My_Country_Name_ <1>
+stateOrProvinceName = _My_State_Or_Province_Name_ <2>
+localityName = _My_Locality_Name_ <3>
+organizationName = _My_Organization_Or_Company_Name_
+organizationalUnitName = _My_Organizational_Unit_Name_ <4>
 ----
+<1> Country Name (2 letter code)
+<2> State or Province Name (full name)
+<3> Locality Name (eg. city)
+<4> Organizational Unit Name (eg. section)
 . Generate CSR:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -72,10 +72,10 @@ localityName = _My_Locality_Name_ <3>
 organizationName = _My_Organization_Or_Company_Name_
 organizationalUnitName = _My_Organizational_Unit_Name_ <4>
 ----
-<1> Country Name (2 letter code)
-<2> State or Province Name (full name)
-<3> Locality Name (example: New York)
-<4> Organizational Unit Name (example: IT)
+<1> Two letter code
+<2> Full name
+<3> Full name (example: New York)
+<4> Division responsible for the certificate (example: IT)
 . Generate CSR:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -74,8 +74,8 @@ organizationalUnitName = _My_Organizational_Unit_Name_ <4>
 ----
 <1> Country Name (2 letter code)
 <2> State or Province Name (full name)
-<3> Locality Name (eg. city)
-<4> Organizational Unit Name (eg. section)
+<3> Locality Name (example: New York)
+<4> Organizational Unit Name (example: IT)
 . Generate CSR:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -75,7 +75,7 @@ organizationalUnitName = _My_Organizational_Unit_Name_ <4>
 <1> Two letter code
 <2> Full name
 <3> Full name (example: New York)
-<4> Division responsible for the certificate (example: IT)
+<4> Division responsible for the certificate (example: IT department)
 . Generate CSR:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -60,6 +60,18 @@ authorityKeyIdentifier=keyid,issuer
 [ alt_names ]
 DNS.1 = _{context}.example.com_
 ----
+Optional: If you want to add Distinguished Name (DN) details to the CSR, add the following information to the `[ req_distinguished_name ]` section:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+[req_distinguished_name]
+CN = _{context}.example.com_
+countryName = Country Name (2 letter code)
+stateOrProvinceName = State or Province Name (full name)
+localityName = Locality Name (eg. city)
+organizationName = Name of the Organization or Company
+organizationalUnitName = Organizational Unit Name (eg. section)
+----
 . Generate CSR:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -85,9 +85,9 @@ organizationalUnitName = _My_Organizational_Unit_Name_ <4>
 -config _/root/{context}_cert/openssl.cnf_ \ <2>
 -out _/root/{context}_cert/{context}_cert_csr.pem_ <3>
 ----
-<1> Path to the private key.
-<2> Path to the configuration file.
-<3> Path to the CSR to generate.
+<1> Path to the private key
+<2> Path to the configuration file
+<3> Path to the CSR to generate
 
 . Send the certificate signing request to the certificate authority (CA).
 The same CA must sign certificates for {ProjectServer} and {SmartProxyServer}.


### PR DESCRIPTION
When generating a certificate signing request, adding DN information increases trust. Although this is optional, users can benefit from this information.

There are two ways of doing this:
- Add the configuration to the openssl.cnf file.
- Provide the details when prompted by the command.

However, in the docs, we specifically ask the user to provide "prompt = no", this will tell the openssl command to not prompt for these details. So, adding this to the `openssl.cnf` file under the `[ req_distinguished_name ]` section.

BZ link:https://bugzilla.redhat.com/show_bug.cgi?id=2256000


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
