### PR TITLE
Add [preface] to inclusivity chapter (Sat only)

### DIFF
--- a/guides/common/modules/con_making-open-source-more-inclusive.adoc
+++ b/guides/common/modules/con_making-open-source-more-inclusive.adoc
@@ -1,3 +1,5 @@
+[preface]
+
 [id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive
 


### PR DESCRIPTION
`[preface]` is needed for this kind of chapter to make it unnumbered. Same as in [Providing feedback](https://github.com/theforeman/foreman-documentation/blob/b0e5e1e2e97ae2330a80b07b87e589bcf533238e/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc?plain=1#L1)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
