### PR TITLE
Revert "drop documentation for snapshot backups, we don't support the…

### DIFF
--- a/guides/common/assembly_backing-up-server-and-proxy.adoc
+++ b/guides/common/assembly_backing-up-server-and-proxy.adoc
@@ -12,4 +12,6 @@ include::modules/ref_example-of-a-weekly-full-backup-followed-by-daily-increment
 
 include::modules/proc_performing-an-online-backup.adoc[leveloffset=+1]
 
+include::modules/proc_performing-a-snapshot-backup.adoc[leveloffset=+1]
+
 include::modules/ref_skipping-steps-when-performing-backups.adoc[leveloffset=+1]

--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -14,7 +14,7 @@ Therefore, you must ensure that no other tasks are scheduled by other administra
 You can schedule a backup using `cron`.
 For more information, see the xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
 
-During offline backups, the services are inactive and {Project} is in a maintenance mode.
+During offline or snapshot backups, the services are inactive and {Project} is in a maintenance mode.
 All the traffic from outside on port 443 is rejected by a firewall to ensure there are no modifications triggered.
 
 ifndef::foreman-el,foreman-deb[]

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -3,10 +3,11 @@
 
 {ProjectName} uses the `{foreman-maintain} backup` command to make backups.
 
-There are two main methods of backing up {ProjectServer}:
+There are three main methods of backing up {ProjectServer}:
 
 * Offline backup
 * Online backup
+* Snapshot backups
 +
 For more information about each of these methods, you can view the usage statements for each backup method.
 
@@ -20,6 +21,12 @@ For more information about each of these methods, you can view the usage stateme
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} backup online --help
+----
+
+.Snapshots backups
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} backup snapshot --help
 ----
 
 .Directory creation
@@ -41,7 +48,7 @@ Note that if you use a local PostgreSQL database, the `postgres` user requires w
 .Remote databases
 You can use the `{foreman-maintain} backup` command to back up remote databases.
 
-You can use both online and offline methods to back up remote databases, but if you use offline method, the `{foreman-maintain} backup` command performs a database dump.
+You can use both online and offline methods to back up remote databases, but if you use offline methods, such as snapshot, the `{foreman-maintain} backup` command performs a database dump.
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.

--- a/guides/common/modules/proc_performing-a-snapshot-backup.adoc
+++ b/guides/common/modules/proc_performing-a-snapshot-backup.adoc
@@ -1,0 +1,39 @@
+[id="Performing_a_Snapshot_Backup_{context}"]
+= Performing a snapshot backup
+
+You can perform a snapshot backup that uses Logical Volume Manager (LVM) snapshots of the Pulp, and PostgreSQL directories.
+Creating a backup from LVM snapshots mitigates the risk of an inconsistent backup.
+
+The snapshot backup method is faster than a full offline backup and therefore reduces {Project} downtime.
+
+To view the usage statement, enter the following command:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} backup snapshot -h
+----
+
+[WARNING]
+====
+Request other {ProjectServer} or {SmartProxyServer} users to save any changes and warn them that {Project} services are unavailable for the duration of the backup.
+Ensure no other tasks are scheduled for the same time as the backup.
+====
+
+.Prerequisites
+* The system uses LVM for the directories that you snapshot: `/var/lib/pulp/` and `{postgresql-lib-dir}`.
+* The free disk space in the relevant volume group (VG) is three times the size of the snapshot.
+More precisely, the VG must have enough space unreserved by the member logical volumes (LVs) to accommodate new snapshots.
+In addition, one of the LVs must have enough free space for the backup directory.
+* The target backup directory is on a different LV than the directories that you snapshot.
+
+.Procedure
+* To perform a snapshot backup, enter the `{foreman-maintain} backup snapshot` command:
+[options="nowrap", subs="+quotes,verbatim,attributes"]
++
+----
+# {foreman-maintain} backup snapshot _/var/backup_directory_
+----
+
+The `{foreman-maintain} backup snapshot` command creates snapshots when the services are active, and stops all services which can impact the backup.
+This makes the maintenance window shorter.
+After the successful snapshot, all services are restarted and LVM snapshots are removed.

--- a/guides/common/modules/proc_performing-an-online-backup.adoc
+++ b/guides/common/modules/proc_performing-an-online-backup.adoc
@@ -7,8 +7,8 @@ Perform an online backup only for debugging purposes.
 When performing an online backup, if there are procedures affecting the Pulp database, the Pulp part of the backup procedure repeats until it is no longer being altered.
 Because the backup of the Pulp database is the most time consuming part of backing up {Project}, if you make a change that alters the Pulp database during this time, the backup procedure keeps restarting.
 
-For production environments, use the offline method.
-For more information, see xref:Performing_a_Full_Backup_{context}[].
+For production environments, use the snapshot method.
+For more information, see xref:Performing_a_Snapshot_Backup_{context}[].
 If you want to use the online backup method in production, proceed with caution and ensure that no modifications occur during the backup.
 
 [WARNING]


### PR DESCRIPTION
…se anymore"

This reverts commit ec159f9c1e517fcee4f73386bded0e1587eec86c.

I remembered it too late but this was only supposed to be on master.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
