### PR TITLE
Split host boot order (Provisioning)

### DIFF
--- a/guides/common/assembly_introduction-to-provisioning.adoc
+++ b/guides/common/assembly_introduction-to-provisioning.adoc
@@ -7,3 +7,5 @@ include::modules/ref_supported-cloud-providers.adoc[leveloffset=+1]
 include::modules/ref_supported-virtualization-infrastructures.adoc[leveloffset=+1]
 
 include::modules/con_network-boot-provisioning-workflow.adoc[leveloffset=+1]
+
+include::modules/ref_required-boot-order-for-network-boot.adoc[leveloffset=+1]

--- a/guides/common/modules/con_network-boot-provisioning-workflow.adoc
+++ b/guides/common/modules/con_network-boot-provisioning-workflow.adoc
@@ -1,18 +1,6 @@
 [id="Network_Boot_Provisioning_Workflow_{context}"]
 = Network boot provisioning workflow
 
-For physical or virtual BIOS hosts:
-
-. Set the first booting device as boot configuration with network.
-. Set the second booting device as boot from hard drive.
-{Project} manages TFTP boot configuration files so hosts can be easily provisioned just by rebooting.
-
-For physical or virtual EFI hosts:
-
-. Set the first booting device as boot configuration with network.
-. Depending on the EFI firmware type and configuration, the OS installer typically configures the OS boot loader as the first entry.
-. To reboot into installer again, use `efibootmgr` utility to switch back to boot from network.
-
 The provisioning process follows a basic PXE workflow:
 
 . You create a host and select a domain and subnet.

--- a/guides/common/modules/ref_required-boot-order-for-network-boot.adoc
+++ b/guides/common/modules/ref_required-boot-order-for-network-boot.adoc
@@ -1,0 +1,14 @@
+[id="required-boot-order-for-network-boot_{context}"]
+= Required boot order for network boot
+
+For physical or virtual BIOS hosts::
+
+. Set the first booting device as boot configuration with network.
+. Set the second booting device as boot from hard drive.
+{Project} manages TFTP boot configuration files, so hosts can be easily provisioned just by rebooting.
+
+For physical or virtual EFI hosts::
+
+. Set the first booting device as boot configuration with network.
+. Depending on the EFI firmware type and configuration, the OS installer typically configures the OS boot loader as the first entry.
+. To reboot into installer again, use the `efibootmgr` utility to switch back to boot from network.


### PR DESCRIPTION
Incremental improvement of the Provisioning guide.
For now, I'm just trying to make stuff less bad. :)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
