### PR TITLE
Remove Discovery from iPXE

### DIFF
--- a/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-to-reduce-provisioning-times.adoc
@@ -87,8 +87,3 @@ endif::[]
 ----
 # cp /usr/share/ipxe/undionly.kpxe /var/lib/tftpboot/undionly-ipxe.0
 ----
-
-. Optionally, configure Foreman discovery.
-For more information, see xref:Configuring_the_Discovery_Service_{context}[].
-* In the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
-* Locate the *Default PXE global template entry* row and in the *Value* column, change the value to *discovery*.


### PR DESCRIPTION
This scenario is untested and unsupported.
https://bugzilla.redhat.com/show_bug.cgi?id=2170908

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
