### PR TITLE
Updating guide doesn't exist in this version

### DIFF
--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -37,4 +37,4 @@ You can manage packages using the `{foreman-maintain} packages` command as follo
 ----
 
 Updating packages individually can lead to package inconsistencies on {ProjectServer} or {SmartProxyServer}.
-For more information about updating packages on {ProjectServer}, see {UpgradingDocURL}updating-project-to-next-minor-version_updating[Updating {ProjectServer} to the Next Minor Version] in _{UpgradingDocTitle}_.
+For more information about updating packages on {ProjectServer}, see {UpgradingDocURL}updating_{project-context}_server_to_next_minor_version[Updating {ProjectServer} to the Next Minor Version] in _{UpgradingDocTitle}_.

--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -37,4 +37,4 @@ You can manage packages using the `{foreman-maintain} packages` command as follo
 ----
 
 Updating packages individually can lead to package inconsistencies on {ProjectServer} or {SmartProxyServer}.
-For more information about updating packages on {ProjectServer}, see {UpdatingDocURL}updating-project-to-next-minor-version_updating[Updating {ProjectServer} to the Next Minor Version] in _{UpdatingDocTitle}_.
+For more information about updating packages on {ProjectServer}, see {UpgradingDocURL}updating-project-to-next-minor-version_updating[Updating {ProjectServer} to the Next Minor Version] in _{UpgradingDocTitle}_.


### PR DESCRIPTION
We're getting build errors on the Admin guide because of attributes for a guide that doesn't exist for versions 3.6 and below. This PR aims to fix those errors by re-introducing attributes appropriate for these versions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
