### PR TITLE
Katello 4.12 Release Notes

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/katello-4.12.0.adoc[leveloffset=+1]
 include::topics/foreman-3.10.0.adoc[leveloffset=+1]
 
 [appendix]

--- a/guides/doc-Release_Notes/topics/katello-4.12.0.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.12.0.adoc
@@ -1,0 +1,115 @@
+= Katello 4.12.0
+
+A full list of changes are available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1760[Redmine]
+
+== Katello
+
+* pass:[Package installation fails with template error] - https://projects.theforeman.org/issues/37155[#37155]
+* pass:[Remove unused downshift dependency] - https://projects.theforeman.org/issues/37113[#37113]
+* pass:[A lot of COUNT() SQL queries on the content view page] - https://projects.theforeman.org/issues/37111[#37111]
+* pass:[Enable eager loading on CV latest_version_object] - https://projects.theforeman.org/issues/37109[#37109]
+* pass:[Upgrade to VCR 6.1+] - https://projects.theforeman.org/issues/37100[#37100]
+* pass:[Use shared GitHub Action for test execution] - https://projects.theforeman.org/issues/37095[#37095]
+* pass:[Drop uglifier development dependency] - https://projects.theforeman.org/issues/37094[#37094]
+* pass:[Invalid single-table inheritance type: ConfigManagementError is not a subclass of RemoveKatelloFromNotificationName::FakeMailNotification] - https://projects.theforeman.org/issues/37075[#37075]
+* pass:[Migration error 'users.disabled' already exists] - https://projects.theforeman.org/issues/37074[#37074]
+* pass:[Migration error 'column settings.category does not exist'] - https://projects.theforeman.org/issues/37073[#37073]
+* pass:[Cleanup orphans task generates inefficient queries consuming resources and taking long time to run] - https://projects.theforeman.org/issues/37058[#37058]
+
+=== API
+
+* pass:[Remove LCE option from host-registration generate-command in Hammer/API similar to WebUI] - https://projects.theforeman.org/issues/37044[#37044]
+* pass:[Remove deprecated field from docker repo authentication tokens] - https://projects.theforeman.org/issues/36888[#36888]
+
+=== Activation Key
+
+* pass:[The Activation Keys page asks user to register hosts using old deprecated method] - https://projects.theforeman.org/issues/37040[#37040]
+
+=== Content Views
+
+* pass:[Module stream filter adds all modules to all repositories] - https://projects.theforeman.org/issues/37050[#37050]
+* pass:[Wrong link to Files in CV Repositories tab] - https://projects.theforeman.org/issues/37030[#37030]
+* pass:[CV version should display Container manifest list count] - https://projects.theforeman.org/issues/36988[#36988]
+* pass:[Race Condition during Incremental Update] - https://projects.theforeman.org/issues/36871[#36871]
+* pass:[Unable to delete repository if it was included to composite CV] - https://projects.theforeman.org/issues/11760[#11760]
+
+=== Errata Management
+
+* pass:[When applying errata on host using "apply via custom remote execution" => "katello via ansible" method shows  errata field blank] - https://projects.theforeman.org/issues/37051[#37051]
+* pass:[New host details page should show debian content] - https://projects.theforeman.org/issues/35713[#35713]
+
+=== Foreman Proxy Content
+
+* pass:[PG::ProgramLimitExceeded error for Update content counts task on a big setup] - https://projects.theforeman.org/issues/37080[#37080]
+* pass:[Set up smart proxy reference to content source proxy] - https://projects.theforeman.org/issues/37028[#37028]
+* pass:[After upgrade checking sync status/content info fails till next sync] - https://projects.theforeman.org/issues/37023[#37023]
+
+=== Hammer
+
+* pass:[Fix ContentViewVersion undefined error in republish repositories test] - https://projects.theforeman.org/issues/37046[#37046]
+* pass:[hammer proxy content info fails when DB has no content counts] - https://projects.theforeman.org/issues/37031[#37031]
+
+=== Hosts
+
+* pass:[Packages Tab on Host Details page depends on operatingsystem description (which can be changed by user)] - https://projects.theforeman.org/issues/37144[#37144]
+* pass:[virt-who host and virtual host guest did not display the correct mapping info on old Legacy Content Host UI->Details] - https://projects.theforeman.org/issues/37123[#37123]
+* pass:[Host facts disappear during registration, causing incorrect RHEL lifecycle status of Unknown] - https://projects.theforeman.org/issues/37107[#37107]
+* pass:[Host owner not set correctly during registration] - https://projects.theforeman.org/issues/37014[#37014]
+* pass:[Configuration rebuild failed for: Content_Host_Status and Refresh_Content_Host_Status.] - https://projects.theforeman.org/issues/36996[#36996]
+* pass:[Katello Ansible Errata job template starts with spaces before — breaking the template] - https://projects.theforeman.org/issues/36994[#36994]
+* pass:[Traces service restart should warn user that host will reboot] - https://projects.theforeman.org/issues/36986[#36986]
+* pass:[all hosts page slow -> improve installed packages queries] - https://projects.theforeman.org/issues/36946[#36946]
+* pass:[all hosts page slow -> reduce the amount of errat queries] - https://projects.theforeman.org/issues/36943[#36943]
+* pass:[all hosts page slow -> reduce the amount of katello host tracer queries] - https://projects.theforeman.org/issues/36941[#36941]
+* pass:[Host content view environment is reset on any host edit when hostgroup assigns a CVE] - https://projects.theforeman.org/issues/36897[#36897]
+* pass:[When installing a new package, the job is labeled with a job ID and not the package.] - https://projects.theforeman.org/issues/36846[#36846]
+* pass:[Host search by installed_package_name invokes OOM killer] - https://projects.theforeman.org/issues/35974[#35974]
+
+=== Inter Server Sync
+
+* pass:[Hammer is not propagating error message from production log when content-export fails] - https://projects.theforeman.org/issues/36977[#36977]
+* pass:[Add ability to export and import APT (deb) content] - https://projects.theforeman.org/issues/36765[#36765]
+
+=== Localization
+
+* pass:[Unused config/locale directory] - https://projects.theforeman.org/issues/36950[#36950]
+* pass:[Bad translation in french in webui] - https://projects.theforeman.org/issues/36829[#36829]
+
+=== Organizations and Locations
+
+* pass:[SCA-Only: Update behavior of organizations & Candlepin owners] - https://projects.theforeman.org/issues/37131[#37131]
+
+=== Repositories
+
+* pass:[Setting pulp_export_destination is unused] - https://projects.theforeman.org/issues/37083[#37083]
+* pass:[Bump recommended repos for 6-15] - https://projects.theforeman.org/issues/36995[#36995]
+* pass:[param :source_url not working with the sync API] - https://projects.theforeman.org/issues/36987[#36987]
+* pass:[A re-sync should always recover from a previous syncs failed publication] - https://projects.theforeman.org/issues/36859[#36859]
+* pass:[Never use dependency-solving for deb content] - https://projects.theforeman.org/issues/36748[#36748]
+* pass:[Red Hat products that were never synced are reporting last synced time] - https://projects.theforeman.org/issues/31318[#31318]
+
+=== Subscriptions
+
+* pass:[Message under "Simple content access" button on organization edit page can be improved and a hyperlink can be provided to reference the document.] - https://projects.theforeman.org/issues/37117[#37117]
+* pass:[New VDC-subscription shows "Requires Virt-Who: false"] - https://projects.theforeman.org/issues/37024[#37024]
+
+=== Tests
+
+* pass:[Drop simplecov integration] - https://projects.theforeman.org/issues/37084[#37084]
+* pass:[Drop katello:rubocop:jenkins rake task] - https://projects.theforeman.org/issues/37033[#37033]
+* pass:[Drop minitest-tags development dependency] - https://projects.theforeman.org/issues/37032[#37032]
+
+=== Tooling
+
+* pass:[Fix tests to match strict keyword matching] - https://projects.theforeman.org/issues/37153[#37153]
+* pass:[Make plugin compatible with Ruby 3] - https://projects.theforeman.org/issues/37145[#37145]
+* pass:[Missing development dependencies for rubocop] - https://projects.theforeman.org/issues/36998[#36998]
+* pass:[transient test failure test_sync_container_gateway – Katello::SmartProxyExtensionsTest] - https://projects.theforeman.org/issues/34044[#34044]
+
+=== Web UI
+
+* pass:[Update web UI for SCA-only] - https://projects.theforeman.org/issues/37140[#37140]
+* pass:[Virtual guests show up on legacy UI for hosts even if they are not hypervisors] - https://projects.theforeman.org/issues/37118[#37118]
+* pass:[update katello to support webpack5] - https://projects.theforeman.org/issues/37104[#37104]
+* pass:[Field 'id' not recognized for searching! when trying to bulk override repository sets] - https://projects.theforeman.org/issues/37018[#37018]
+* pass:[Can't change default template name for change content source] - https://projects.theforeman.org/issues/37005[#37005]

--- a/guides/doc-Release_Notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/katello-contributors.adoc
@@ -1,0 +1,26 @@
+Adam Růžička
+Ashish Humbe
+Bernhard Suttner
+Chris Roberts
+Eric Helms
+Et7f3
+Evgeni Golov
+Ewoud Kohl van Wijngaarden
+Hao Yu
+Ian Ballou
+Jeremy Lenz
+Joniel Pasqualetto
+Lucy Fu
+Manisha Singhal
+Maria Agaphontzev
+Markus Bucher
+Matěj Mudra
+Nadja Heitmann
+Oleh Fedorenko
+Partha Aji
+Pavel Moravec
+Quinn James
+Samir Jha
+Thorben Denzer
+Tobias Grigo
+William Clark

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -4,14 +4,46 @@
 [id="katello-headline-features"]
 == Headline Features
 
-There are no highlights with Katello {KatelloVersion}.
+=== Entitlement Mode Removed in Favor of Simple Content Access
+Simple Content Access (SCA) is now the only content access mode supported.
+When upgrading Katello, all existing organizations that use entitlement mode will migrate automatically to SCA.
+This change is not reversible.
+
+Toggling SCA from the Organization Edit page, the Organization Create page, and the Organization List page is no longer available.
+
+=== Removed System Purpose-Related Host Statuses
+The following host statuses are removed:
+
+* Subscription Status (this column has also been removed from the All Hosts table)
+* System Purpose Status
+* SLA Status
+* Role Status
+* Usage Status
+* Addon Status
+
+=== Debian Content Support Expanded
+Import and export are now supported for repositories containing debian-type content.
+Additionally, the host details page will now display more details for debian packages.
 
 [id="katello-upgrade-warnings"]
 == Upgrade Warnings
 
-There are no upgrade warnings with Katello {KatelloVersion}.
+Simple Content Access (SCA) is now the only supported content access mode.
+Existing organizations will be automatically migrated on Katello upgrade (see more info above).
+Please note that the 'Subscription - Entitlements' report template does not work with SCA organizations and will never have any rows.
+It will be removed in a future release or release candidate.
+Instead, use the 'Host - Installed Products' report.
+Additionally, please note that SCA-related API and Hammer endpoints and parameters have not yet been removed so you will experience errors if you try to use them.
+They will be removed in a future release or release candidate.
+
+Certain host statuses have been removed (see more info above).
+Please note that system purpose _attributes_ are not being removed, only system purpose-related _host statuses_.
+System purpose _attributes_ (role, usage, release version, etc.) are still important for repository enablement and reporting to the Subscriptions service of the Red Hat Hybrid Cloud Console.
 
 [id="katello-deprecations"]
 == Deprecations
 
-There are no deprecations with Katello {KatelloVersion}.
+Deprecated 'Subscription - Entitlements' report template as it does not work with SCA organizations.
+
+Deprecated certain SCA-related API and Hammer endpoints and parameters.
+These are likely non-functional and will be removed in the future.


### PR DESCRIPTION
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.

Added Katello 4.12 release notes and contributors.