### PR TITLE
Add message about cloning templates for disconnected upgrade guide

### DIFF
--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -36,6 +36,9 @@ include::common/modules/proc_upgrading-a-disconnected-project-server.adoc[levelo
 // Synchronizing the New Repositories
 include::common/modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+2]
 
+// Performing Post-Upgrade Tasks
+include::common/modules/con_performing-post-upgrade-tasks.adoc[leveloffset=+2]
+
 // Upgrading Smart Proxy Server
 include::common/modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/2780 for Disconected Upgrade guide. Custom templates created from default templates need to be cloned again after upgrade to ensure that any changes in the default templates apply to custom template as well.

BZ link : https://bugzilla.redhat.com/show_bug.cgi?id=2257737


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
