### PR TITLE
Add warning to overriding Ansible variables

### DIFF
--- a/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
@@ -13,6 +13,7 @@ To ensure the variable that you override follows the correct order of precedence
 .Prerequisites
 * You must have Ansible variables in {Project}.
 For more information, see xref:Importing_Ansible_Roles_and_Variables_{context}[]
+* To use overridden Ansible variables, a user must have a role that allows them to see those variables.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Ansible* > *Variables*.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2215453


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
