### PR TITLE
Add a step to synchronize Smart Proxy repo before upgrading

### DIFF
--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -89,6 +89,8 @@ ifdef::satellite[]
 # yum clean metadata
 ----
 +
+. Synchronize the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
+. Publish and promote a new version of the content view with which the {SmartProxy} is registered.
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
 Ensure {SmartProxy} has access to `{RepoRHEL8ServerSatelliteMaintenanceProjectVersion}` and execute:


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/2784, but for upgrading.

The Smart Proxy repo needs to be updated to have the latest updated packages before performing the upgrade. Ading a step at the beginning to sync the repo and publish and promote the CV that the Smart Proxy uses.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2254225


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
