### PR TITLE
Fix FIPS content for SmartProxy Guide

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -112,11 +112,18 @@ ifdef::foreman-el,katello,satellite[]
 SELinux must be enabled, either in enforcing or permissive mode.
 Installation with disabled SELinux is not supported.
 
-.FIPS Mode
-You can install {Project} on a {RHEL} system that is operating in FIPS mode.
+.FIPS mode
+ifeval::["{context}" == "{project-context}"]
+You can install {Project} on a {EL} system that is operating in FIPS mode.
 You cannot enable FIPS mode after the installation of {Project}.
+endif::[]
+ifeval::["{context}" == "{smart-proxy-context}"]
+You can install {SmartProxy} on a {EL} system that is operating in FIPS mode.
+You cannot enable FIPS mode after the installation of {SmartProxy}.
+endif::[]
 ifndef::satellite[]
-{RHEL} clones are not being actively tested in FIPS mode. If you require FIPS, consider using {RHEL}.
+{RHEL} clones are not being actively tested in FIPS mode.
+If you require FIPS, consider using {RHEL}.
 endif::[]
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in _Security hardening_.
 
@@ -125,7 +132,7 @@ For more information, see https://access.redhat.com/documentation/en-us/red_hat_
 {Project} supports DEFAULT and FIPS crypto-policies.
 The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
 The FUTURE policy is a stricter forward-looking security level intended for testing a possible future policy.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening[Using system-wide cryptographic policies] in {EL} guide.
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening[Using system-wide cryptographic policies] in the {RHEL} guide.
 ====
 endif::[]
 


### PR DESCRIPTION
Earlier in the SmartProxy Guide, the FIPS point rendered Project and not the SmartProxy. I have tried to fix that.

(cherry picked from commit f490c0982281a03757c643d17680d33df77ec28c)