### PR TITLE
Fix the syntax for the Smart Proxy repo name

### DIFF
--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -5,7 +5,7 @@ Update {SmartProxyServers} to the next minor version.
 
 .Procedure
 ifdef::satellite[]
-. Synchronize the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
+. Synchronize the `{RepoRHEL8ServerSatelliteCapsuleProjectVersion}` repository in the {ProjectServer}.
 . Publish and promote a new version of the content view with which the {SmartProxy} is registered.
 endif::[]
 . Ensure that the {Project} Maintenance repository is enabled:

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -89,7 +89,7 @@ ifdef::satellite[]
 # yum clean metadata
 ----
 +
-. Synchronize the {RepoRHEL8ServerSatelliteCapsuleProjectVersion} repository in the {ProjectServer}.
+. Synchronize the `{RepoRHEL8ServerSatelliteCapsuleProjectVersion}` repository in the {ProjectServer}.
 . Publish and promote a new version of the content view with which the {SmartProxy} is registered.
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +


### PR DESCRIPTION
The Smart Proxy repo name is mentioned in plain text, fixing the syntax,


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
