### PR TITLE
Uppercase headings iPXE 3.8

### DIFF
--- a/guides/common/modules/con_prerequisites-for-using-ipxe.adoc
+++ b/guides/common/modules/con_prerequisites-for-using-ipxe.adoc
@@ -1,5 +1,5 @@
 [id="prerequisites-for-using-ipxe_{context}"]
-= Prerequisites for using iPXE
+= Prerequisites for Using iPXE
 
 You can use iPXE to boot virtual machines in the following cases:
 

--- a/guides/common/modules/con_using-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/modules/con_using-ipxe-to-reduce-provisioning-times.adoc
@@ -1,5 +1,5 @@
 [id="using-ipxe-to-reduce-provisioning-times_{context}"]
-= Using iPXE to reduce provisioning times
+= Using iPXE to Reduce Provisioning Times
 
 iPXE is an open-source network-boot firmware.
 It provides a full PXE implementation enhanced with additional features, such as booting from an HTTP server.

--- a/guides/common/modules/proc_configuring-ipxe-environment.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-environment.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_iPXE_Environment_{context}"]
-= Configuring iPXE environment
+= Configuring iPXE Environment
 
 Configure an iPXE environment on all {SmartProxies} that you want to use for iPXE provisioning.
 


### PR DESCRIPTION
Matching the style of headings with older conventions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
