### PR TITLE
Reduce doc bloat in procedure for creating a user

### DIFF
--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -11,9 +11,9 @@ The next time the user logs on to {Project}, the user's account has the correct 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
 . Click *Create User*.
-. In the *Login* field, enter a username for the user.
-. In the *Firstname* and *Lastname* fields, enter the real first name and last name of the user.
-. In the *Mail* field, enter the user’s email address.
+. In the *Username* field, enter a username for the user.
+. In the *First Name* and *Surname* fields, enter the real first name and last name of the user.
+. In the *Email Address* field, enter the user’s email address.
 . In the *Description* field, add a description of the new user.
 . Select a specific language for the user from the *Language* list.
 . Select a timezone for the user from the *Timezone* list.

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -10,25 +10,23 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-user_{
 . Enter the account details for the new user.
 . Click *Submit* to create the user.
 
-For example, you can specify the following user account details:
+The user account details that you can specify include the following:
 
-* On the *User* tab, you must set a password for the user.
-Select the source by which the user is authenticated from the *Authorized by* list:
-** Select *INTERNAL* to manage the user inside {ProjectServer}.
-** Select *EXTERNAL* to manage the user with external authentication as described in {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
-* On the *Organizations* tab, ensure an organization is selected for the user.
-You can also use the *Default on login* drop-down list to select which organization is selected for the user after they log in.
+* On the *User* tab, select an authentication source from the *Authorized by* list:
+** *INTERNAL*: to manage the user inside {ProjectServer}.
+** *EXTERNAL*: to manage the user with external authentication.
+For more information, see {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
+* On the *Organizations* tab, select an organization for the user.
+Specify the default organization {Project} selects for the user after login from the *Default on login* list.
 +
 [IMPORTANT]
 ====
-Ensure every user is assigned to an organization.
 If a user is not assigned to an organization, their access is limited.
 ====
 
 [id="cli-creating-a-user_{context}"]
 .CLI procedure
-* To create a user, enter the `hammer user create` command.
-For example:
+* Create a user:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -42,8 +40,10 @@ For example:
 +
 The `--auth-source-id 1` setting means that the user is authenticated internally, you can specify an external authentication source as an alternative.
 Add the `--admin` option to grant administrator privileges to the user.
-Specifying organization IDs is not required, you can modify the user details later using the `update` subcommand.
+Specifying organization IDs is not required.
++
+You can modify the user details later by using the `hammer user update` command.
 
 .Additional resources
 
-* For more information about subcommands related to user accounts, enter `hammer user --help`.
+* For more information about creating user accounts by using Hammer, enter `hammer user create --help`.

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -7,14 +7,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-user_{
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
 . Click *Create User*.
-. In the *Username* field, enter a username for the user.
-. In the *First Name* and *Surname* fields, enter the real first name and last name of the user.
-. In the *Email Address* field, enter the user’s email address.
-. In the *Description* field, add a description of the new user.
-. Select a specific language for the user from the *Language* list.
-. Select a timezone for the user from the *Timezone* list.
-+
-By default, {ProjectServer} uses the language and timezone settings of the user’s browser.
+. Enter the account details for the new user.
 . Set a password for the user:
 .. From the *Authorized by* list, select the source by which the user is authenticated.
 ** *INTERNAL*: to enable the user to be managed inside {ProjectServer}.

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -4,10 +4,6 @@
 Use this procedure to create a user.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-user_{context}[].
 
-If a new user is not assigned to an organization, their access is limited.
-To grant systems rights to users, assign them to an organization.
-The next time the user logs on to {Project}, the user's account has the correct system rights.
-
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
 . Click *Create User*.
@@ -24,6 +20,9 @@ By default, {ProjectServer} uses the language and timezone settings of the userâ
 ** *INTERNAL*: to enable the user to be managed inside {ProjectServer}.
 ** *EXTERNAL*: to configure external authentication as described in {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
 .. Enter an initial password for the user in the *Password* field and the *Verify* field.
+. Click the *Organizations* tab, and make sure an organization is selected for the user.
++
+If a new user is not assigned to an organization, their access is limited.
 . Click *Submit* to create the user.
 
 [id="cli-creating-a-user_{context}"]

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -32,7 +32,8 @@ If a user is not assigned to an organization, their access is limited.
 
 [id="cli-creating-a-user_{context}"]
 .CLI procedure
-* To create a user, enter the following command:
+* To create a user, enter the `hammer user create` command.
+For example:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -5,18 +5,30 @@ Use this procedure to create a user.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-user_{context}[].
 
 .Procedure
+// This is the core procedure -- for users who have trouble finding the right button.
+// But I'm keeping it super short so that following it doesn't become a nuisance due to describing steps that users can just see in the web UI.
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
 . Click *Create User*.
 . Enter the account details for the new user.
-. Set a password for the user:
-.. From the *Authorized by* list, select the source by which the user is authenticated.
-** *INTERNAL*: to enable the user to be managed inside {ProjectServer}.
-** *EXTERNAL*: to configure external authentication as described in {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
-.. Enter an initial password for the user in the *Password* field and the *Verify* field.
-. Click the *Organizations* tab, and make sure an organization is selected for the user.
-+
-If a new user is not assigned to an organization, their access is limited.
 . Click *Submit* to create the user.
+
+// After the procedure, this is the place where users can find more details about the fields that are not that obvious from the web UI.
+// Splitting this from the core procedure supports scannability -- because you can see where the clicking ends and where the explanation begins.
+// Introducing this with "for example" supports maintainability -- because we don't commit ourselves to maintaining a complete list.
+For example, you can specify the following account details:
+
+* On the *User* tab, you must set a password for the user.
+Select the source by which the user is authenticated from the *Authorized by* list:
+** Select *INTERNAL* to manage the user inside {ProjectServer}.
+** Select *EXTERNAL* to manage the user with external authentication as described in {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
+* On the *Organizations* tab, ensure an organization is selected for the user.
+You can also use the *Default on login* drop-down list to select which organization is selected for the user after they log in.
++
+[IMPORTANT]
+====
+Ensure every user is assigned to an organization.
+If a user is not assigned to an organization, their access is limited.
+====
 
 [id="cli-creating-a-user_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -5,17 +5,12 @@ Use this procedure to create a user.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-user_{context}[].
 
 .Procedure
-// This is the core procedure -- for users who have trouble finding the right button.
-// But I'm keeping it super short so that following it doesn't become a nuisance due to describing steps that users can just see in the web UI.
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
 . Click *Create User*.
 . Enter the account details for the new user.
 . Click *Submit* to create the user.
 
-// After the procedure, this is the place where users can find more details about the fields that are not that obvious from the web UI.
-// Splitting this from the core procedure supports scannability -- because you can see where the clicking ends and where the explanation begins.
-// Introducing this with "for example" supports maintainability -- because we don't commit ourselves to maintaining a complete list.
-For example, you can specify the following account details:
+For example, you can specify the following user account details:
 
 * On the *User* tab, you must set a password for the user.
 Select the source by which the user is authenticated from the *Authorized by* list:

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -49,4 +49,6 @@ The `--auth-source-id 1` setting means that the user is authenticated internally
 Add the `--admin` option to grant administrator privileges to the user.
 Specifying organization IDs is not required, you can modify the user details later using the `update` subcommand.
 
-For more information about user related subcommands, enter `hammer user --help`.
+.Additional resources
+
+* For more information about subcommands related to user accounts, enter `hammer user --help`.


### PR DESCRIPTION
During peer review for https://github.com/theforeman/foreman-documentation/pull/2861, there was a suggestion to include a piece of information in the procedure module for creating a user. It's a good idea, but more work needs to be done within that procedure modules to make it happen.

EDIT: In this PR, I propose the following changes to the procedure to create a user.

* Update UI labels (it looks like they changed in the web UI, but not in the docs)
* Delete steps that are clear from the web UI (like "use enter First Name and Surname to enter first name and surname")
* Split the procedure into two parts: one that shows how to find the page to create a user; another that highlights notable account details to enter
* Minor edits to the CLI part of the procedure

This is an effort to reduce maintenance burden (the fewer UI labels are documented, the less chance there is of the docs becoming outdated), usability (users don't need UI instructions that are this detailed), and scannability (being able to identify the really important parts of the procedure).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
