### PR TITLE
Fix issues in the cloning process

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -49,7 +49,7 @@ Before you begin cloning, ensure the following conditions exist:
 
 * The target server is on an isolated network.
 This avoids unwanted communication with {SmartProxyServers} and hosts.
-* The target server has the same storage as the source server.
+* The target server has at least the same storage capacity as the source server.
 
 .Customized configuration files
 

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -49,7 +49,7 @@ Before you begin cloning, ensure the following conditions exist:
 
 * The target server is on an isolated network.
 This avoids unwanted communication with {SmartProxyServers} and hosts.
-* The target server has the capacity to store all your backup files from the source server.
+* The target server has the same storage as the source server.
 
 .Customized configuration files
 
@@ -95,7 +95,7 @@ Follow the steps in the procedure in xref:sec_Cloning_Satellite_Server[] and rep
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # rsync --archive --partial --progress --compress \
-/var/lib/pulp _target_server.example.com:/var/lib/pulp_
+/var/lib/pulp/ _target_server.example.com:/var/lib/pulp/_
 ----
 
 Proceed to xref:sec-Cloning_to_Target[].
@@ -175,7 +175,8 @@ You can either mount the shared storage or copy the backup files to the `/backup
 # subscription-manager repos --disable=*
 # subscription-manager repos --enable={RepoRHEL8AppStream} \
 --enable={RepoRHEL8ServerSatelliteServerProductVersionPrevious} \
---enable={RepoRHEL8ServerSatelliteMaintenanceProductVersionPrevious}
+--enable={RepoRHEL8ServerSatelliteMaintenanceProductVersionPrevious} \
+--enable={RepoRHEL8BaseOS}
 ----
 +
 . Install the `satellite-clone` package:
@@ -204,7 +205,7 @@ For more information, see {InstallingServerDocURL}configuring-external-services[
 ----
 # {installer-scenario} \
 --enable-foreman-plugin-remote-execution \
---enable-foreman-proxy-plugin-remote-execution-script
+--enable-foreman-proxy-plugin-remote-execution-ssh
 ----
 +
 . Log in to the {ProjectWebUI}, with the username `admin` and the password `changeme`.

--- a/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/cloning_satellite_server.adoc
@@ -174,9 +174,9 @@ You can either mount the shared storage or copy the backup files to the `/backup
 # subscription-manager attach --pool=__pool_ID__
 # subscription-manager repos --disable=*
 # subscription-manager repos --enable={RepoRHEL8AppStream} \
+--enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteServerProductVersionPrevious} \
---enable={RepoRHEL8ServerSatelliteMaintenanceProductVersionPrevious} \
---enable={RepoRHEL8BaseOS}
+--enable={RepoRHEL8ServerSatelliteMaintenanceProductVersionPrevious}
 ----
 +
 . Install the `satellite-clone` package:


### PR DESCRIPTION
There are some issues in the cloning process that cause it to fail viz.:
- The `rsync` command copies Pulp data to /var/lib/pulp/pulp which is wrong.
- The RHEL8 BaseOS repo too should be enabled on the target server.
- The Prerequisites should expressly mention that the storage on the target should be at least as much as the source.
- The command to enable the remote execution plugin is incorrect as at this point the upgrade hasn't taken place.

BZ link:
https://bugzilla.redhat.com/show_bug.cgi?id=2169707


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
