### PR TITLE
Drop SmartProxyServerTitle attribute

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -1,7 +1,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="configuring-capsule-custom-server-certificate_{context}"]
-= Configuring {SmartProxyServerTitle} with a custom SSL certificate
+= Configuring {SmartProxyServer} with a custom SSL certificate
 
 If you configure {ProjectServer} to use a custom SSL certificate, you must also configure each of your external {SmartProxyServers} with a distinct custom SSL certificate.
 

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -1,7 +1,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="installing-capsule-server"]
-= Installing {SmartProxyServerTitle}
+= Installing {SmartProxyServer}
 
 Before you install {SmartProxyServer}, you must ensure that your environment meets the requirements for installation.
 For more information, see {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation].
@@ -40,7 +40,7 @@ include::modules/proc_synchronizing-the-system-clock-with-chronyd.adoc[leveloffs
 
 ifdef::katello,satellite[]
 [id="configuring-capsule-server-with-ssl-certificates"]
-== Configuring {SmartProxyServerTitle} with SSL certificates
+== Configuring {SmartProxyServer} with SSL certificates
 endif::[]
 
 ifdef::katello,satellite[]

--- a/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-capsule-server.adoc
@@ -1,7 +1,7 @@
 ifdef::context[:parent-context: {context}]
 
 [id="performing-additional-configuration-on-capsule-server"]
-= Performing additional configuration on {SmartProxyServerTitle}
+= Performing additional configuration on {SmartProxyServer}
 
 Use this chapter to configure additional settings on your {SmartProxyServer}.
 

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -128,9 +128,7 @@
 :smartproxy-example-com: smartproxy.example.com
 :SmartProxy: Smart{nbsp}Proxy
 :SmartProxyServer: {SmartProxy}{nbsp}server
-:SmartProxyServerTitle: {SmartProxy}{nbsp}Server
 :SmartProxyServers: {SmartProxyServer}s
-:SmartProxyServersTitle: {SmartProxyServerTitle}s
 :Team: {Project} community
 :sectanchors:
 :client-content-dnf:

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -19,9 +19,7 @@
 :SmartProxies: orcharhino{nbsp}Proxies
 :SmartProxy: orcharhino{nbsp}Proxy
 :SmartProxyServer: {SmartProxy}
-:SmartProxyServerTitle: {SmartProxyServer}
 :SmartProxyServers: orcharhino{nbsp}Proxies
-:SmartProxyServersTitle: {SmartProxyServers}
 :Team: ATIX{nbsp}AG
 :certs-proxy-context: orcharhino-proxy
 :customcontent: custom content

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -118,9 +118,7 @@
 :smartproxy-example-com: capsule.example.com
 :SmartProxy: Capsule
 :SmartProxyServer: Capsule{nbsp}Server
-:SmartProxyServerTitle: {SmartProxyServer}
 :SmartProxyServers: {SmartProxyServer}s
-:SmartProxyServersTitle: {SmartProxyServers}
 :Team: Red{nbsp}Hat
 
 // Repositories and subscriptions (used in Satellite guides)

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -10,7 +10,7 @@
 :InstallingServerDocTitle: Installing {ProjectServerTitle} {ProjectVersion} on {install-on-os}
 // Installing Disconnected - defined for Satellite only
 :InstallingServerDisconnectedDocTitle: Installing {ProjectServerTitle} in a Disconnected Network Environment
-:InstallingSmartProxyDocTitle: Installing a {SmartProxyServerTitle} {ProjectVersion} on {install-on-os}
+:InstallingSmartProxyDocTitle: Installing a {SmartProxy}{nbsp}Server {ProjectVersion} on {install-on-os}
 :ManagingConfigurationsAnsibleDocTitle: Configuring Hosts Using Ansible
 // Puppet Guide - overridden in Satellite
 :ManagingConfigurationsPuppetDocTitle: Configuring Hosts Using Puppet
@@ -54,6 +54,6 @@ endif::[]
 
 ifdef::orcharhino[]
 :InstallingServerDocTitle: Installing {ProjectServerTitle}
-:InstallingSmartProxyDocTitle: Installing {SmartProxyServerTitle}
+:InstallingSmartProxyDocTitle: Installing {SmartProxyServer}
 :QuickstartDocTitle: Quickstart
 endif::[]

--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -1,5 +1,5 @@
 [id="backing-up-{project-context}-server-and-{smart-proxy-context}_{context}"]
-= Backing up {ProjectServer} and {SmartProxyServerTitle}
+= Backing up {ProjectServer} and {SmartProxyServer}
 
 You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.

--- a/guides/common/modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc
+++ b/guides/common/modules/con_backup-and-restore-smart-proxy-using-a-virtual-machine-snapshot.adoc
@@ -1,5 +1,5 @@
 [id="backup-and-restore-{smart-proxy-context}-using-a-virtual-machine-snapshot_{context}"]
-= Backup and restore {SmartProxyServerTitle} using a virtual machine snapshot
+= Backup and restore {SmartProxyServer} using a virtual machine snapshot
 
 If your {SmartProxyServer} is a virtual machine, you can restore it from a snapshot.
 Creating weekly snapshots to restore from is recommended.

--- a/guides/common/modules/con_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_for_Load_Balancing_with_Puppet_{context}"]
-= Configuring {SmartProxyServerTitle} with custom SSL certificates for load balancing with Puppet
+= Configuring {SmartProxyServer} with custom SSL certificates for load balancing with Puppet
 
 If you use Puppet in your {Project} configuration, then you must complete the following procedures:
 

--- a/guides/common/modules/con_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,4 +1,4 @@
 [id="con_Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}"]
-= Configuring {SmartProxyServerTitle} with custom SSL certificates for load balancing without Puppet
+= Configuring {SmartProxyServer} with custom SSL certificates for load balancing without Puppet
 
 The following section describes how to configure {SmartProxyServers} that use custom SSL certificates for load balancing without Puppet.

--- a/guides/common/modules/con_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_for_Load_Balancing_with_Puppet_{context}"]
-= Configuring {SmartProxyServerTitle} with default SSL certificates for load balancing with Puppet
+= Configuring {SmartProxyServer} with default SSL certificates for load balancing with Puppet
 
 The following section describes how to configure {SmartProxyServers} that use default SSL certificates for load balancing with Puppet.
 

--- a/guides/common/modules/con_configuring-smart-proxy-servers-for-load-balancing.adoc
+++ b/guides/common/modules/con_configuring-smart-proxy-servers-for-load-balancing.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Servers_for_Load_Balancing_{context}"]
-= Configuring {SmartProxyServersTitle} for load balancing
+= Configuring {SmartProxyServers} for load balancing
 
 This chapter outlines how to configure {SmartProxyServers} for load balancing.
 Proceed to one of the following sections depending on your {ProjectServer} configuration:

--- a/guides/common/modules/con_external-authentication-for-provisioned-hosts.adoc
+++ b/guides/common/modules/con_external-authentication-for-provisioned-hosts.adoc
@@ -7,7 +7,7 @@ Use this section to configure {ProjectServer} or {SmartProxyServer} for {FreeIPA
 * {ProjectServer} that is registered to the Content Delivery Network or an external {SmartProxyServer} that is registered to {ProjectServer}.
 * A deployed realm or domain provider such as {FreeIPA}.
 
-.To install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServerTitle}:
+.To install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}:
 
 To use {FreeIPA} for provisioned hosts, complete the following steps to install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}:
 
@@ -32,7 +32,7 @@ To use {FreeIPA} for provisioned hosts, complete the following steps to install 
 +
 Note the principal name that returns and your {FreeIPA} server configuration details because you require them for the following procedure.
 
-.To configure {ProjectServer} or {SmartProxyServerTitle} for {FreeIPA} realm support:
+.To configure {ProjectServer} or {SmartProxyServer} for {FreeIPA} realm support:
 
 Complete the following procedure on {Project} and every {SmartProxy} that you want to use:
 

--- a/guides/common/modules/con_load-balancing-considerations.adoc
+++ b/guides/common/modules/con_load-balancing-considerations.adoc
@@ -21,7 +21,7 @@ The following additional steps are required for load balancing:
 * You must upgrade each {SmartProxy} in sequence
 * You must backup each {SmartProxy} that you configure regularly
 
-.Upgrading {SmartProxyServersTitle} in a load balancing configuration
+.Upgrading {SmartProxyServers} in a load balancing configuration
 ifdef::satellite[]
 To upgrade {SmartProxyServers} from {ProjectVersionPrevious} to {ProjectVersion}, complete the {UpgradingDocURL}upgrading_capsule_server[Upgrading {SmartProxyServers}] procedure in _{UpgradingDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_monitoring-smart-proxy-server.adoc
+++ b/guides/common/modules/con_monitoring-smart-proxy-server.adoc
@@ -1,4 +1,4 @@
 [id="monitoring-{smart-proxy-context}-server_{context}"]
-= Monitoring {SmartProxyServerTitle}
+= Monitoring {SmartProxyServer}
 
 The following section shows how to use the {ProjectWebUI} to find {SmartProxy} information valuable for maintenance and troubleshooting.

--- a/guides/common/modules/con_prerequisites-for-configuring-smart-proxy-server-for-load-balancing.adoc
+++ b/guides/common/modules/con_prerequisites-for-configuring-smart-proxy-server-for-load-balancing.adoc
@@ -1,5 +1,5 @@
 [id="Prerequisites_for_Configuring_{smart-proxy-context}_Servers_for_Load_Balancing_{context}"]
-= Prerequisites for configuring {SmartProxyServersTitle} for load balancing
+= Prerequisites for configuring {SmartProxyServers} for load balancing
 
 ifdef::orcharhino[]
 You can find a list of requirements for {SmartProxyServer} in xref:sources/installation_and_maintenance/installing_orcharhino_proxy.adoc[_{InstallingSmartProxyDocTitle}_].

--- a/guides/common/modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -1,5 +1,5 @@
 [id="restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_{context}"]
-= Restoring {ProjectServer} or {SmartProxyServerTitle} from a backup
+= Restoring {ProjectServer} or {SmartProxyServer} from a backup
 
 You can restore {ProjectServer} or {SmartProxyServer} from the backup data that you create as part of xref:backing-up-{project-context}-server-and-{smart-proxy-context}_{context}[].
 This process outlines how to restore the backup on the same server that generated the backup, and all data covered by the backup is deleted on the target system.

--- a/guides/common/modules/proc_adding-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_adding-lifecycle-environments.adoc
@@ -1,5 +1,5 @@
 [id="Adding_Lifecycle_Environments_{context}"]
-= Adding lifecycle environments to {SmartProxyServersTitle}
+= Adding lifecycle environments to {SmartProxyServers}
 
 If your {SmartProxyServer} has the content functionality enabled, you must add an environment so that {SmartProxy} can synchronize content from {ProjectServer} and provide content to host systems.
 

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -1,5 +1,5 @@
 [id="configuring-capsule-default-certificate_{context}"]
-= Configuring {SmartProxyServerTitle} with a default SSL certificate
+= Configuring {SmartProxyServer} with a default SSL certificate
 
 Use this section to configure {SmartProxyServer} with an SSL certificate that is signed by {ProjectServer} default Certificate Authority (CA).
 

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -135,7 +135,7 @@ grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard 
 .. Click *Save* to save the changes.
 
 
-.Configuring the {Project} or {SmartProxyServerTitle} that manages the DNS service for the domain
+.Configuring the {Project} or {SmartProxyServer} that manages the DNS service for the domain
 
 . Use the `{foreman-installer}` command to configure the {Project} or {SmartProxy} that manages the DNS Service for the domain:
 * On {Project}, enter the following command:

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_Remaining_{smart-proxy-context}_Servers_with_Custom_SSL_Certificates_for_Load_Balancing_{context}"]
-= Configuring remaining {SmartProxyServersTitle} with custom SSL certificates for load balancing
+= Configuring remaining {SmartProxyServers} with custom SSL certificates for load balancing
 
 Complete this procedure for each {SmartProxyServer} excluding the system where you configure {SmartProxyServer} to sign Puppet certificates.
 

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_Remaining_{smart-proxy-context}_Servers_with_Default_SSL_Certificates_for_Load_Balancing_{context}"]
-= Configuring remaining {SmartProxyServersTitle} with default SSL certificates for load balancing
+= Configuring remaining {SmartProxyServers} with default SSL certificates for load balancing
 
 Complete this procedure on each {SmartProxyServer} excluding the system where you configure {SmartProxyServer} to sign Puppet certificates.
 

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}"]
-= Configuring {SmartProxyServerTitle} with custom SSL certificates for load balancing without Puppet
+= Configuring {SmartProxyServer} with custom SSL certificates for load balancing without Puppet
 
 The following section describes how to configure {SmartProxyServers} that use custom SSL certificates for load balancing without Puppet.
 Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Custom_SSL_Certificates_to_Generate_and_Sign_Puppet_Certificates_{context}"]
-= Configuring {SmartProxyServerTitle} with custom SSL certificates to generate and sign Puppet certificates
+= Configuring {SmartProxyServer} with custom SSL certificates to generate and sign Puppet certificates
 
 Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing.
 

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_for_Load_Balancing_without_Puppet_{context}"]
-= Configuring {SmartProxyServerTitle} with default SSL certificates for load balancing without Puppet
+= Configuring {SmartProxyServer} with default SSL certificates for load balancing without Puppet
 
 The following section describes how to configure {SmartProxyServers} that use default SSL certificates for load balancing without Puppet.
 Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -1,5 +1,5 @@
 [id="Configuring_{smart-proxy-context}_Server_with_Default_SSL_Certificates_to_Generate_and_Sign_Puppet_Certificates_{context}"]
-= Configuring {SmartProxyServerTitle} with default SSL certificates to generate and sign Puppet certificates
+= Configuring {SmartProxyServer} with default SSL certificates to generate and sign Puppet certificates
 
 Complete this procedure only for the system where you want to configure {SmartProxyServer} to generate and sign Puppet certificates for all other {SmartProxyServers} that you configure for load balancing.
 

--- a/guides/common/modules/proc_creating-custom-ssl-certificates-for-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_creating-custom-ssl-certificates-for-smart-proxy-server.adoc
@@ -1,5 +1,5 @@
 [id="Creating_Custom_SSL_Certificates_for_{smart-proxy-context}_{context}"]
-= Creating custom SSL certificates for {SmartProxyServerTitle}
+= Creating custom SSL certificates for {SmartProxyServer}
 
 This procedure outlines how to create a configuration file for the Certificate Signing Request and include the load balancer and {SmartProxyServer} as Subject Alternative Names (SAN).
 Complete this procedure on each {SmartProxyServer} that you want to configure for load balancing.

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -1,5 +1,5 @@
 [id="deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{context}"]
-= Deploying a custom SSL certificate to {SmartProxyServerTitle}
+= Deploying a custom SSL certificate to {SmartProxyServer}
 
 Use this procedure to configure your {SmartProxyServer} with a custom SSL certificate signed by a Certificate Authority.
 The `{foreman-installer}` command, which the `{certs-generate}` command returns, is unique to each {SmartProxyServer}.

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc
@@ -9,7 +9,7 @@ For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
 ifdef::satellite[]
-For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServersTitle}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServers}] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information, see xref:Installing_the_OpenSCAP_Plug-in_{context}[].

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
@@ -9,7 +9,7 @@ For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
 ifdef::satellite[]
-For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServersTitle}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServers}] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information, see xref:Installing_the_OpenSCAP_Plug-in_{context}[].

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
@@ -9,7 +9,7 @@ For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
 ifdef::satellite[]
-For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServersTitle}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServers}] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information, see xref:Installing_the_OpenSCAP_Plug-in_{context}[].

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
@@ -9,7 +9,7 @@ For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
 ifdef::satellite[]
-For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServersTitle}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{smart-proxy-context}[Enabling OpenSCAP on {SmartProxyServers}] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
 ifndef::satellite[]
 For more information, see xref:Installing_the_OpenSCAP_Plug-in_{context}[].

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -1,5 +1,5 @@
 [id="assigning-organization-location-capsule-server_{context}"]
-= Assigning the correct organization and location to {SmartProxyServerTitle} in the {ProjectWebUI}
+= Assigning the correct organization and location to {SmartProxyServer} in the {ProjectWebUI}
 
 After installing {SmartProxyServer} packages, if there is more than one organization or location, you must assign the correct organization and location to {SmartProxy} to make {SmartProxy} visible in the {ProjectWebUI}.
 

--- a/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
+++ b/guides/common/modules/proc_enabling-connections-from-capsule-to-satellite.adoc
@@ -1,5 +1,5 @@
 [id="Enabling_Connections_from_Proxy_to_Server_{context}"]
-= Enabling connections from {SmartProxyServerTitle} to {ProjectServer}
+= Enabling connections from {SmartProxyServer} to {ProjectServer}
 
 On {ProjectServer}, you must enable the incoming connection from {SmartProxyServer} to {ProjectServer} and make this rule persistent across reboots.
 

--- a/guides/common/modules/proc_enabling-connections-to-capsule.adoc
+++ b/guides/common/modules/proc_enabling-connections-to-capsule.adoc
@@ -1,5 +1,5 @@
 [id="enabling-connections-to-capsule_{context}"]
-= Enabling connections from {ProjectServer} and clients to a {SmartProxyServerTitle}
+= Enabling connections from {ProjectServer} and clients to a {SmartProxyServer}
 
 On the base operating system on which you want to install {SmartProxy}, you must enable incoming connections from {ProjectServer} and clients to {SmartProxyServer} and make these rules persistent across reboots.
 

--- a/guides/common/modules/proc_enabling-openscap.adoc
+++ b/guides/common/modules/proc_enabling-openscap.adoc
@@ -1,5 +1,5 @@
 [id="Enabling_OpenSCAP_on_{smart-proxy-context}_Servers_{context}"]
-= Enabling OpenSCAP on {SmartProxyServersTitle}
+= Enabling OpenSCAP on {SmartProxyServers}
 
 On {ProjectServer} and the integrated {SmartProxy} of your {ProjectServer}, OpenSCAP is enabled by default.
 To use the OpenSCAP plug-in and content on external {SmartProxies}, you must enable OpenSCAP on each {SmartProxy}.

--- a/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Installing_ACD_on_Smart_Proxy_{context}"]
-= Installing ACD on {SmartProxyServerTitle}
+= Installing ACD on {SmartProxyServer}
 
 .Prerequisites
 * {ProjectServer} with the Foreman ACD plug-in installed.

--- a/guides/common/modules/proc_installing-capsule-server-packages.adoc
+++ b/guides/common/modules/proc_installing-capsule-server-packages.adoc
@@ -1,5 +1,5 @@
 [id="Installing_Proxy_Packages_{context}"]
-= Installing {SmartProxyServerTitle} packages
+= Installing {SmartProxyServer} packages
 
 Before installing {SmartProxyServer} packages, you must update all packages that are installed on the base operating system.
 

--- a/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-upstream.adoc
@@ -1,5 +1,5 @@
 [id="installing-an-external-smart-proxy-upstream_{context}"]
-= Installing {SmartProxyServerTitle}
+= Installing {SmartProxyServer}
 
 .Procedure
 ifdef::foreman-el,foreman-deb[]

--- a/guides/common/modules/proc_installing-the-infoblox-ca-certificate-on-smartproxy.adoc
+++ b/guides/common/modules/proc_installing-the-infoblox-ca-certificate-on-smartproxy.adoc
@@ -1,5 +1,5 @@
 [id="Installing_the_Infoblox_CA_Certificate_on_Smart_Proxy_{context}"]
-= Installing the Infoblox CA certificate on {SmartProxyServerTitle}
+= Installing the Infoblox CA certificate on {SmartProxyServer}
 
 You must install Infoblox HTTPS CA certificate on the base system for all {SmartProxies} that you want to integrate with Infoblox applications.
 

--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -1,5 +1,5 @@
 [id="Managing_Packages_on_the_Base_Operating_System_{context}"]
-= Managing packages on the base operating system of {ProjectServer} or {SmartProxyServerTitle}
+= Managing packages on the base operating system of {ProjectServer} or {SmartProxyServer}
 
 To install and update packages on the {ProjectServer} or {SmartProxyServer} base operating system, you must enter the `{foreman-maintain} packages` command.
 {Project} prevents users from installing and updating packages with `yum` because `yum` might also update the packages related to {ProjectServer} or {SmartProxyServer} and result in system inconsistency.

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -1,5 +1,5 @@
 [id="Performing_a_Full_Backup_{context}"]
-= Performing a full backup of {ProjectServer} or {SmartProxyServerTitle}
+= Performing a full backup of {ProjectServer} or {SmartProxyServer}
 
 {ProjectName} uses the `{foreman-maintain} backup` command to make backups.
 

--- a/guides/common/modules/proc_removing-lifecycle-environments-from-smart-proxy.adoc
+++ b/guides/common/modules/proc_removing-lifecycle-environments-from-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Removing_Lifecycle_Environments_from_{smart-proxy-context-titlecase}_{context}"]
-= Removing lifecycle environments from {SmartProxyServerTitle}
+= Removing lifecycle environments from {SmartProxyServer}
 
 When lifecycle environments are no longer relevant to the host system or environments are added incorrectly to {SmartProxyServer}, you can remove the lifecycle environments from {SmartProxyServer}.
 

--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -1,5 +1,5 @@
 [id="Updating-Smart-Proxy_{context}"]
-= Updating {SmartProxyServerTitle}
+= Updating {SmartProxyServer}
 
 Update {SmartProxyServers} to the next minor version.
 

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -1,5 +1,5 @@
 [id="upgrading_{smart-proxy-context}_server_{context}"]
-= Upgrading {SmartProxyServersTitle}
+= Upgrading {SmartProxyServers}
 
 This section describes how to upgrade {SmartProxyServers} from {ProjectVersionPrevious} to {ProjectVersion}.
 
@@ -32,7 +32,7 @@ If these files have been deleted, they must be restored from a backup in order f
 ====
 endif::[]
 
-.Upgrading {SmartProxyServersTitle}
+.Upgrading {SmartProxyServers}
 
 . Create a backup.
 +
@@ -142,7 +142,7 @@ ifdef::orcharhino,satellite[]
 . Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
 endif::[]
 
-.Upgrading {SmartProxyServersTitle} using remote execution
+.Upgrading {SmartProxyServers} using remote execution
 
 . Create a backup or take a snapshot.
 +

--- a/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
+++ b/guides/common/modules/ref_capsule-server-scalability-considerations.adoc
@@ -1,6 +1,6 @@
 [appendix]
 [id="capsule-server-scalability-considerations_{context}"]
-= {SmartProxyServerTitle} scalability considerations
+= {SmartProxyServer} scalability considerations
 
 The maximum number of {SmartProxyServers} that {ProjectServer} can support has no fixed limit.
 It was tested that a {ProjectServer} can support 17 {SmartProxyServers} with 2 vCPUs.

--- a/guides/common/modules/ref_capsule-storage-requirements.adoc
+++ b/guides/common/modules/ref_capsule-storage-requirements.adoc
@@ -8,7 +8,7 @@ ifdef::katello,satellite[]
 The runtime size was measured with {RHEL} 6, 7, and 8 repositories synchronized.
 endif::[]
 
-.Storage requirements for {SmartProxyServerTitle} installation
+.Storage requirements for {SmartProxyServer} installation
 [cols="1,1,1",options="header"]
 |====
 |Directory |Installation Size |Runtime Size

--- a/guides/doc-Planning_for_Project/topics/Capsule_Server_Overview.adoc
+++ b/guides/doc-Planning_for_Project/topics/Capsule_Server_Overview.adoc
@@ -1,5 +1,5 @@
 [[chap-Documentation-Architecture_Guide-Capsule_Server_Overview]]
-== {SmartProxyServerTitle} Overview
+== {SmartProxyServer} Overview
 
 {SmartProxyServers} provide *content federation* and run *localized services* to discover, provision, control, and configure hosts.
 You can use {SmartProxies} to extend the {Project} deployment to various geographical locations.


### PR DESCRIPTION
With headings changing from Camel Case to sentence case, these attributes are no longer needed.

Manually updated titles in attributes-titles.adoc to not change current guide titles.

```
find . -type f -iname '*.adoc' | xargs sed -i 's/SmartProxyServersTitle/SmartProxyServers/g'
find . -type f -iname '*.adoc' | xargs sed -i 's/SmartProxyServerTitle/SmartProxyServer/g'
```

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
