### PR TITLE
Replace outdated attribute {ProductName}

### DIFF
--- a/guides/common/assembly_configuring-external-dhcp.adoc
+++ b/guides/common/assembly_configuring-external-dhcp.adoc
@@ -2,10 +2,10 @@ ifdef::context[:parent-context: {context}]
 
 include::modules/con_configuring-project-with-external-dhcp.adoc[]
 
-//Configuring an External DHCP Server to Use with {ProductName}
+//Configuring an External DHCP Server to Use with {ProjectName}
 include::modules/proc_configuring-an-external-dhcp-server.adoc[leveloffset=+1]
 
-//Configuring {ProductName} with an External DHCP Server
+//Configuring {ProjectName} with an External DHCP Server
 include::modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc[leveloffset=+1]
 
 ifdef::parent-context[:context: {parent-context}]

--- a/guides/common/modules/con_configuring-project-with-external-dhcp.adoc
+++ b/guides/common/modules/con_configuring-project-with-external-dhcp.adoc
@@ -1,7 +1,7 @@
 [id="configuring-external-dhcp_{context}"]
-= Configuring {ProductName} with external DHCP
+= Configuring {ProjectName} with external DHCP
 
-To configure {ProductName} with external DHCP, you must complete the following procedures:
+To configure {ProjectName} with external DHCP, you must complete the following procedures:
 
 . xref:configuring-an-external-dhcp-server_{context}[]
 . xref:Configuring_Server_with_an_External_DHCP_Server_{context}[]

--- a/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
+++ b/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
@@ -1,17 +1,17 @@
 [id="configuring-external-idm-dns_{context}"]
-= Configuring {ProductName} with external IdM DNS
+= Configuring {ProjectName} with external IdM DNS
 
 When {ProjectServer} adds a DNS record for a host, it first determines which {SmartProxy} is providing DNS for that domain.
 It then communicates with the {SmartProxy} that is configured to provide DNS service for your deployment and adds the record.
 The hosts are not involved in this process.
 Therefore, you must install and configure the IdM client on the {Project} or {SmartProxy} that is currently configured to provide a DNS service for the domain you want to manage using the IdM server.
 
-{ProductName} can be configured to use a Red{nbsp}Hat Identity Management (IdM) server to provide DNS service.
+{ProjectName} can be configured to use a Red{nbsp}Hat Identity Management (IdM) server to provide DNS service.
 ifdef::satellite[]
 For more information about Red{nbsp}Hat Identity Management, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/linux_domain_identity_authentication_and_policy_guide/[Linux Domain Identity, Authentication, and Policy Guide].
 endif::[]
 
-To configure {ProductName} to use a Red{nbsp}Hat Identity Management (IdM) server to provide DNS service, use one of the following procedures:
+To configure {ProjectName} to use a Red{nbsp}Hat Identity Management (IdM) server to provide DNS service, use one of the following procedures:
 
 * xref:configuring-dynamic-dns-update-with-gss-tsig-authentication_{context}[]
 
@@ -22,9 +22,9 @@ To revert to internal DNS service, use the following procedure:
 * xref:reverting-to-internal-dns-service_{context}[]
 
 [NOTE]
-You are not required to use {ProductName} to manage DNS.
+You are not required to use {ProjectName} to manage DNS.
 When you are using the realm enrollment feature of {Project}, where provisioned hosts are enrolled automatically to IdM, the `ipa-client-install` script creates DNS records for the client.
-Configuring {ProductName} with external IdM DNS and realm enrollment are mutually exclusive.
+Configuring {ProjectName} with external IdM DNS and realm enrollment are mutually exclusive.
 For more information about configuring realm enrollment, see
 ifeval::["{context}" == "{project-context}"]
 ifeval::["{mode}" == "connected"]

--- a/guides/common/modules/con_configuring-project-with-external-services.adoc
+++ b/guides/common/modules/con_configuring-project-with-external-services.adoc
@@ -1,4 +1,4 @@
 [id="configuring-external-services"]
-= Configuring {ProductName} with external services
+= Configuring {ProjectName} with external services
 
-If you do not want to configure the DNS, DHCP, and TFTP services on {ProductName}, use this section to configure your {ProductName} to work with external DNS, DHCP, and TFTP services.
+If you do not want to configure the DNS, DHCP, and TFTP services on {ProjectName}, use this section to configure your {ProjectName} to work with external DNS, DHCP, and TFTP services.

--- a/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
+++ b/guides/common/modules/proc_attaching-satellite-infrastructure-subscription.adoc
@@ -14,7 +14,7 @@ endif::[]
 For more information about SCA, see https://access.redhat.com/articles/simple-content-access[Simple Content Access].
 ====
 
-After you have registered {ProductName}, you must identify your subscription Pool ID and attach an available subscription.
+After you have registered {ProjectName}, you must identify your subscription Pool ID and attach an available subscription.
 The {ProjectName} Infrastructure subscription provides access to the {ProjectName} and {RHEL} content.
 
 {ProjectName} Infrastructure is included with all subscriptions that include {Project}, formerly known as Smart Management.
@@ -72,7 +72,7 @@ Entitlement Type:    Physical
 . Make a note of the subscription Pool ID.
 Your subscription Pool ID is different from the example provided.
 
-. Attach the {Project} Infrastructure subscription to the base operating system that your {ProductName} is running on.
+. Attach the {Project} Infrastructure subscription to the base operating system that your {ProjectName} is running on.
 If SCA is enabled on {ProjectServer}, you can skip this step:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -1,5 +1,5 @@
 [id="configuring-an-external-dhcp-server_{context}"]
-= Configuring an external DHCP server to use with {ProductName}
+= Configuring an external DHCP server to use with {ProjectName}
 
 ifdef::foreman-deb[]
 [NOTE]
@@ -8,8 +8,8 @@ Note that this procedure describes how to run an external DHCP server on {EL} 8.
 ====
 endif::[]
 
-To configure an external DHCP server running {EL} to use with {ProductName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) utilities packages.
-You must also share the DHCP configuration and lease files with {ProductName}.
+To configure an external DHCP server running {EL} to use with {ProjectName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) utilities packages.
+You must also share the DHCP configuration and lease files with {ProjectName}.
 The example in this procedure uses the distributed Network File System (NFS) protocol to share the DHCP configuration and lease files.
 
 [NOTE]

--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -1,7 +1,7 @@
 [id="configuring-dns-dhcp-and-tftp-on-productname_{context}"]
-= Configuring DNS, DHCP, and TFTP on {ProductName}
+= Configuring DNS, DHCP, and TFTP on {ProjectName}
 
-To configure the DNS, DHCP, and TFTP services on {ProductName}, use the `{foreman-installer}` command with the options appropriate for your environment.
+To configure the DNS, DHCP, and TFTP services on {ProjectName}, use the `{foreman-installer}` command with the options appropriate for your environment.
 
 Any changes to the settings require entering the `{foreman-installer}` command again.
 You can enter the command multiple times and each time it updates all configuration files with the changed values.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -2,7 +2,7 @@
 = Configuring dynamic DNS update with GSS-TSIG authentication
 
 You can configure the IdM server to use the generic security service algorithm for secret key transaction (GSS-TSIG) technology defined in https://tools.ietf.org/html/rfc3645[RFC3645].
-To configure the IdM server to use the GSS-TSIG technology, you must install the IdM client on the {ProductName} base operating system.
+To configure the IdM server to use the GSS-TSIG technology, you must install the IdM client on the {ProjectName} base operating system.
 
 .Prerequisites
 
@@ -27,7 +27,7 @@ To configure dynamic DNS update with GSS-TSIG authentication, complete the follo
 # kinit _idm_user_
 ----
 
-. Create a new Kerberos principal for {ProductName} to use to authenticate on the IdM server:
+. Create a new Kerberos principal for {ProjectName} to use to authenticate on the IdM server:
 +
 ifeval::["{context}" == "{smart-proxy-context}"]
 [options="nowrap" subs="+quotes,attributes"]
@@ -167,7 +167,7 @@ grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard 
 After you run the `{foreman-installer}` command to make any changes to your {SmartProxy} configuration, you must update the configuration of each affected {SmartProxy} in the {ProjectWebUI}.
 
 .Updating the configuration in the {ProjectWebUI}
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProductName}, and from the list in the *Actions* column, select *Refresh*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProjectName}, and from the list in the *Actions* column, select *Refresh*.
 . Configure the domain:
 .. In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains* and select the domain name.
 .. In the *Domain* tab, ensure *DNS {SmartProxy}* is set to the {SmartProxy} where the subnet is connected.

--- a/guides/common/modules/proc_configuring-external-dns.adoc
+++ b/guides/common/modules/proc_configuring-external-dns.adoc
@@ -1,8 +1,8 @@
 [id="configuring-external-dns_{context}"]
-= Configuring {ProductName} with external DNS
+= Configuring {ProjectName} with external DNS
 
-You can configure {ProductName} with external DNS.
-{ProductName} uses the `nsupdate` utility to update DNS records on the remote server.
+You can configure {ProjectName} with external DNS.
+{ProjectName} uses the `nsupdate` utility to update DNS records on the remote server.
 
 To make any changes persistent, you must enter the `{foreman-installer}` command with the options appropriate for your environment.
 
@@ -11,7 +11,7 @@ To make any changes persistent, you must enter the `{foreman-installer}` command
 * This guide assumes you have an existing installation.
 
 .Procedure
-. Copy the `/etc/rndc.key` file from the external DNS server to {ProductName}:
+. Copy the `/etc/rndc.key` file from the external DNS server to {ProjectName}:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -50,5 +50,5 @@ send\n" | nsupdate -k /etc/foreman-proxy/rndc.key
 --foreman-proxy-keyfile=/etc/foreman-proxy/rndc.key
 ----
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
-. Locate the {ProductName} and select *Refresh* from the list in the *Actions* column.
+. Locate the {ProjectName} and select *Refresh* from the list in the *Actions* column.
 . Associate the DNS service with the appropriate subnets and domain.

--- a/guides/common/modules/proc_configuring-external-tftp.adoc
+++ b/guides/common/modules/proc_configuring-external-tftp.adoc
@@ -1,7 +1,7 @@
 [id="configuring-external-tftp_{context}"]
-= Configuring {ProductName} with external TFTP
+= Configuring {ProjectName} with external TFTP
 
-You can configure {ProductName} with external TFTP services.
+You can configure {ProjectName} with external TFTP services.
 
 .Procedure
 . Create the TFTP directory for NFS:
@@ -37,5 +37,5 @@ _TFTP_Server_IP_Address_:/exports/var/lib/tftpboot /mnt/nfs/var/lib/tftpboot nfs
 # {foreman-installer} --foreman-proxy-tftp-servername=_TFTP_Server_FQDN_
 ----
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
-. Locate the {ProductName} and select *Refresh* from the list in the *Actions* column.
+. Locate the {ProjectName} and select *Refresh* from the list in the *Actions* column.
 . Associate the TFTP service with the appropriate subnets and domain.

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -3,7 +3,7 @@
 :dnf-module: satellite-capsule:el8
 :package-manager: dnf
 
-Use this procedure to enable the repositories that are required to install {ProductName}.
+Use this procedure to enable the repositories that are required to install {ProjectName}.
 
 . Disable all repositories:
 +
@@ -40,7 +40,7 @@ For more information about modules and lifecycle streams on {RHEL} 8, see https:
 
 [NOTE]
 ====
-If you are installing {ProductName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository and then install {oVirt} guest agents and drivers.
+If you are installing {ProjectName} as a virtual machine hosted on {oVirt}, you must also enable the *Red{nbsp}Hat Common* repository and then install {oVirt} guest agents and drivers.
 For more information, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/virtual_machine_management_guide/installing_guest_agents_and_drivers_linux_linux_vm#Installing_the_Guest_Agents_and_Drivers_on_Red_Hat_Enterprise_Linux[Installing the Guest Agents and Drivers on {RHEL}] in the _Virtual Machine Management Guide_.
 ====
 

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -1,7 +1,7 @@
 [id="configuring-repositories_{context}"]
 = Configuring repositories
 
-Use these procedures to enable the repositories required to install {ProductName}.
+Use these procedures to enable the repositories required to install {ProjectName}.
 
 ifdef::foreman-el,katello,foreman-deb[]
 Choose from the following list which operating system and version you are installing on:

--- a/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-satellite-deployment-with-an-external-dhcp-server.adoc
@@ -1,10 +1,10 @@
 [id="Configuring_Server_with_an_External_DHCP_Server_{context}"]
 = Configuring {ProjectServer} with an external DHCP server
 
-You can configure {ProductName} with an external DHCP server.
+You can configure {ProjectName} with an external DHCP server.
 
 .Prerequisites
-* Ensure that you have configured an external DHCP server and that you have shared the DHCP configuration and lease files with {ProductName}.
+* Ensure that you have configured an external DHCP server and that you have shared the DHCP configuration and lease files with {ProjectName}.
 For more information, see xref:configuring-an-external-dhcp-server_{context}[].
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -1,14 +1,14 @@
 [id="creating-a-custom-ssl-certificate_{context}"]
-= Creating a custom SSL certificate for {ProductName}
+= Creating a custom SSL certificate for {ProjectName}
 
 ifeval::["{context}" == "{project-context}"]
-Use this procedure to create a custom SSL certificate for {ProductName}.
-If you already have a custom SSL certificate for {ProductName}, skip this procedure.
+Use this procedure to create a custom SSL certificate for {ProjectName}.
+If you already have a custom SSL certificate for {ProjectName}, skip this procedure.
 endif::[]
 
 ifeval::["{context}" == "{smart-proxy-context}"]
-On {ProjectServer}, create a custom certificate for your {ProductName}.
-If you already have a custom SSL certificate for {ProductName}, skip this procedure.
+On {ProjectServer}, create a custom certificate for your {ProjectName}.
+If you already have a custom SSL certificate for {ProjectName}, skip this procedure.
 endif::[]
 
 .Procedure
@@ -23,7 +23,7 @@ endif::[]
 Note that the private key must be unencrypted.
 If you use a password-protected private key, remove the private key password.
 +
-If you already have a private key for this {ProductName}, skip this step.
+If you already have a private key for this {ProjectName}, skip this step.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -1,11 +1,11 @@
 [id="enabling-power-management-on-hosts_{context}"]
 = Enabling power management on hosts
 
-To perform power management tasks on hosts using the intelligent platform management interface (IPMI) or a similar protocol, you must enable the baseboard management controller (BMC) module on {ProductName}.
+To perform power management tasks on hosts using the intelligent platform management interface (IPMI) or a similar protocol, you must enable the baseboard management controller (BMC) module on {ProjectName}.
 
 .Prerequisites
 * All hosts must have a network interface of BMC type.
-{ProductName} uses this NIC to pass the appropriate credentials to the host.
+{ProjectName} uses this NIC to pass the appropriate credentials to the host.
 For more information, see {ManagingHostsDocURL}Adding_a_Baseboard_Management_Controller_Interface_managing-hosts[Adding a Baseboard Management Controller (BMC) Interface] in _{ManagingHostsDocTitle}_.
 
 .Procedure

--- a/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
+++ b/guides/common/modules/proc_synchronizing-the-system-clock-with-chronyd.adoc
@@ -1,7 +1,7 @@
 [id="synchronizing-the-system-clock-with-chronyd_{context}"]
 = Synchronizing the system clock with chronyd
 
-To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProductName} with Network Time Protocol (NTP) servers.
+To minimize the effects of time drift, you must synchronize the system clock on the base operating system on which you want to install {ProjectName} with Network Time Protocol (NTP) servers.
 If the base operating system clock is configured incorrectly, certificate verification might fail.
 
 For more information about the `chrony` suite, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings#using-chrony-to-configure-ntp_configuring-basic-system-settings[Using the Chrony suite to configure NTP] in _{RHEL} 8 Configuring basic system settings_.

--- a/guides/common/modules/ref_storage-guidelines.adoc
+++ b/guides/common/modules/ref_storage-guidelines.adoc
@@ -1,13 +1,13 @@
 [id="storage-guidelines_{context}"]
 = Storage guidelines
 
-Consider the following guidelines when installing {ProductName} to increase efficiency.
+Consider the following guidelines when installing {ProjectName} to increase efficiency.
 
 * If you mount the `/tmp` directory as a separate file system, you must use the `exec` mount option in the `/etc/fstab` file.
 If `/tmp` is already mounted with the `noexec` option, you must change the option to `exec` and re-mount the file system.
 This is a requirement for the `puppetserver` service to work.
 
-* Because most {ProductName} data is stored in the `/var` directory, mounting `/var` on LVM storage can help the system to scale.
+* Because most {ProjectName} data is stored in the `/var` directory, mounting `/var` on LVM storage can help the system to scale.
 
 * Use high-bandwidth, low-latency storage for the `/var/lib/pulp/` directories.
 As {ProjectName} has many operations that are I/O intensive, using high latency, low-bandwidth storage causes performance degradation.

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -3,7 +3,7 @@
 
 ifdef::satellite[]
 You can install the operating system from a disc, local ISO image, kickstart, or any other method that Red{nbsp}Hat supports.
-Red{nbsp}Hat {ProductName} is supported on the latest version of {RHEL} 8 that is available at the time when {ProductName} is installed.
+Red{nbsp}Hat {ProjectName} is supported on the latest version of {RHEL} 8 that is available at the time when {ProjectName} is installed.
 Previous versions of {RHEL} including EUS or z-stream are not supported.
 endif::[]
 
@@ -26,13 +26,13 @@ endif::[]
 
 {Team} advises against using an existing system because the {Project} installer will affect the configuration of several components.
 ifdef::satellite[]
-Red{nbsp}Hat {ProductName} requires a {RHEL} installation with the `@Base` package group with no other package-set modifications, and without third-party configurations or software not directly necessary for the direct operation of the server.
+Red{nbsp}Hat {ProjectName} requires a {RHEL} installation with the `@Base` package group with no other package-set modifications, and without third-party configurations or software not directly necessary for the direct operation of the server.
 This restriction includes hardening and other non-Red{nbsp}Hat security software.
-If you require such software in your infrastructure, install and verify a complete working {ProductName} first, then create a backup of the system before adding any non-Red{nbsp}Hat software.
+If you require such software in your infrastructure, install and verify a complete working {ProjectName} first, then create a backup of the system before adding any non-Red{nbsp}Hat software.
 
 ifeval::["{context}" == "{smart-proxy-context}"]
 Do not register {SmartProxyServer} to the Red{nbsp}Hat Content Delivery Network (CDN).
 endif::[]
 
-Red{nbsp}Hat does not support using the system for anything other than running {ProductName}.
+Red{nbsp}Hat does not support using the system for anything other than running {ProjectName}.
 endif::[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -54,7 +54,7 @@ endif::[]
 When using custom certificates, the Common Name (CN) of the custom certificate must be a fully qualified domain name (FQDN) instead of a shortname.
 This does not apply to the clients of a {Project}.
 
-Before you install {ProductName}, ensure that your environment meets the requirements for installation.
+Before you install {ProjectName}, ensure that your environment meets the requirements for installation.
 ifeval::["{context}" == "{smart-proxy-context}"]
 [WARNING]
 ====
@@ -64,8 +64,8 @@ For example, the {SmartProxy} version {ProjectVersion} cannot be registered with
 ====
 endif::[]
 
-{ProductName} must be installed on a freshly provisioned system that serves no other function except to run {ProductName}.
-The freshly provisioned system must not have the following users provided by external identity providers to avoid conflicts with the local users that {ProductName} creates:
+{ProjectName} must be installed on a freshly provisioned system that serves no other function except to run {ProjectName}.
+The freshly provisioned system must not have the following users provided by external identity providers to avoid conflicts with the local users that {ProjectName} creates:
 
 * {apache-user}
 ifeval::["{context}" == "{project-context}"]
@@ -92,7 +92,7 @@ endif::[]
 
 ifdef::satellite[]
 .Certified hypervisors
-{ProductName} is fully supported on both physical systems and virtual machines that run on hypervisors that are supported to run {RHEL}.
+{ProjectName} is fully supported on both physical systems and virtual machines that run on hypervisors that are supported to run {RHEL}.
 For more information about certified hypervisors, see https://access.redhat.com/articles/973163[Certified Guest Operating Systems in {OpenStack}, {oVirt}, Red Hat {KubeVirt} and {RHEL} with KVM].
 endif::[]
 


### PR DESCRIPTION
This attribute was removed from `attributes-*.adoc` earlier

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
