### PR TITLE
Change headings to sentence case for deployment topics

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -35,7 +35,7 @@ include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1
 include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]
 
 [[part-Deployment_Planning]]
-= {Project} Deployment Planning
+= {Project} deployment planning
 include::topics/Deployment_Scenarios.adoc[]
 
 include::topics/Deployment_Considerations.adoc[]

--- a/guides/doc-Planning_for_Project/topics/Configuration_Management_Support.adoc
+++ b/guides/doc-Planning_for_Project/topics/Configuration_Management_Support.adoc
@@ -1,5 +1,5 @@
 [[tabl-Architecture_Guide-Configuration_Management_Support]]
-==== Configuration Management
+==== Configuration management
 Supported combinations of major versions of {RHEL} and hardware architectures for configuration management with {Project}.
 
 .Puppet Agent Support

--- a/guides/doc-Planning_for_Project/topics/Content_Management_Support.adoc
+++ b/guides/doc-Planning_for_Project/topics/Content_Management_Support.adoc
@@ -1,5 +1,5 @@
 [[tabl-Architecture_Guide-Content_Management_Support]]
-==== Content Management
+==== Content management
 Supported combinations of major versions of {RHEL} and hardware architectures for registering and managing hosts with {Project}.
 This includes the {project-client-name} repositories.
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -1,5 +1,5 @@
 [[chap-Architecture_Guide-Deployment_Considerations]]
-== Deployment Considerations
+== Deployment considerations
 
 This section provides an overview of general topics to be considered when planning a {ProjectName} deployment together with recommendations and references to more specific documentation.
 
@@ -69,7 +69,7 @@ If you delete the manifest from the Red Hat Customer Portal or in the {ProjectWe
 endif::[]
 
 [[satellite_server_with_external_database]]
-=== {ProjectServer} with External Database
+=== {ProjectServer} with external database
 
 When you install {Project}, the `{foreman-installer}` command creates databases on the same server that you install {Project}.
 Depending on your requirements, moving to external databases can provide increased working memory for {Project}, which can improve response times for database operating requests.
@@ -87,7 +87,7 @@ This causes {Project} to create a record in PostgreSQL for each job.
 For more information about using an external database, see {InstallingServerDocURL}using-external-databases_{project-context}[Using External Databases with {Project}] in _{InstallingServerDocTitle}_.
 
 [[sect-Mapping_the_Infrastructure_Topology]]
-=== Locations and Topology
+=== Locations and topology
 
 This section outlines general considerations that should help you to specify your {Project} deployment scenario.
 The most common deployment scenarios are listed in xref:chap-Architecture_Guide-Deployment_Scenarios[].
@@ -113,7 +113,7 @@ endif::[]
 To learn about provisioning on different compute resources see {ProvisioningDocURL}[_{ProvisioningDocTitle}_].
 
 [[sect-Defining_Content_Sources]]
-=== Content Sources
+=== Content sources
 
 The Red{nbsp}Hat Subscription Manifest determines what Red{nbsp}Hat repositories are accessible from your {ProjectServer}.
 Once you enable a Red{nbsp}Hat repository, an associated {Project} Product is created automatically.
@@ -127,7 +127,7 @@ For detailed instructions on setting up content sources, see {ContentManagementD
 A custom repository within {ProjectServer} is in most cases populated with content from an external staging server.
 Such servers lie outside of the {Project} infrastructure, however, it is recommended to use a revision control system (such as Git) on these servers to have better control over the custom content.
 [[sect-Defining_the_Content_Lifecycle]]
-=== Content Lifecycle
+=== Content lifecycle
 
 {Project} provides features for precise management of the content lifecycle.
 A *lifecycle environment* represents a stage in the content lifecycle, a *Content View* is a filtered set of content, and can be considered as a defined subset of content.
@@ -190,7 +190,7 @@ Also make sure that when creating a subset of packages for the content view, all
 Note that kickstart repositories should not be added to content views, as they are used for host provisioning only.
 
 [[sect-Defining_Content_Deployment]]
-=== Content Deployment
+=== Content deployment
 
 Content deployment manages errata and packages on content hosts.
 {Project} can be configured to perform remote execution over MQTT/HTTPS (pull-based) or SSH (push-based).
@@ -205,7 +205,7 @@ For a description of the provisioning workflow see {ProvisioningDocURL}provision
 The same guide contains instructions for provisioning on various compute resources.
 
 [[sect-Defining_Role_Based_Authentication]]
-=== Role Based Authentication
+=== Role based authentication
 
 Assigning a role to a user enables controlling access to {Project} components based on a set of permissions.
 You can think of role based authentication as a way of hiding unnecessary objects from users who are not supposed to interact with them.
@@ -244,7 +244,7 @@ For instructions on defining roles and assigning them to users, see {Administeri
 The same guide contains information on configuring external authentication sources.
 
 [[sect-Additional_Tasks]]
-=== Additional Tasks
+=== Additional tasks
 
 This section provides a short overview of selected {Project} capabilities that can be used for automating certain tasks or extending the core usage of {Project}:
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
@@ -1,18 +1,18 @@
 [[chap-Architecture_Guide-Deployment_Scenarios]]
-== Common Deployment Scenarios
+== Common deployment scenarios
 
 This section provides a brief overview of common deployment scenarios for {ProjectName}.
 Note that many variations and combinations of the following layouts are possible.
 
 [[sect-Architecture_Guide-Single_Location]]
-=== Single Location
+=== Single location
 
 An _integrated {SmartProxy}_ is a virtual {SmartProxyServer} that is created by default in {ProjectServer} during the installation process.
 This means {ProjectServer} can be used to provision directly connected hosts for {Project} deployment in a single geographical location, therefore only one physical server is needed.
 The base systems of isolated {SmartProxies} can be directly managed by {ProjectServer}, however it is not recommended to use this layout to manage other hosts in remote locations.
 
 [[sect-Architecture_Guide-Single]]
-=== Single Location with Segregated Subnets
+=== Single location with segregated subnets
 
 Your infrastructure might require multiple isolated subnets even if {ProjectName} is deployed in a single geographic location.
 This can be achieved for example by deploying multiple {SmartProxyServers} with DHCP and DNS services, but the recommended way is to create segregated subnets using a single {SmartProxy}.
@@ -20,7 +20,7 @@ This {SmartProxy} is then used to manage hosts and compute resources in those se
 For more information on configuring subnets see {ManagingHostsDocURL}[_Managing Hosts_].
 
 [[sect-Architecture_Guide-Multiple_Locations]]
-=== Multiple Locations
+=== Multiple locations
 
 It is recommended to create at least one {SmartProxyServer} per geographic location.
 This practice can save bandwidth since hosts obtain content from a local {SmartProxyServer}.
@@ -59,7 +59,7 @@ The above methods for importing content to a disconnected {ProjectServer} can al
 endif::[]
 
 [[sect-Architecture_Guide-Capsule_with_External_Services]]
-=== {SmartProxy} with External Services
+=== {SmartProxy} with external services
 
 You can configure a {SmartProxyServer} (integrated or standalone) to use external DNS, DHCP, or TFTP service.
 If you already have a server that provides these services in your environment, you can integrate it with your {Project} deployment.

--- a/guides/doc-Planning_for_Project/topics/Glossary.adoc
+++ b/guides/doc-Planning_for_Project/topics/Glossary.adoc
@@ -2,7 +2,7 @@
 
 [appendix]
 [[appe-Architecture_Guide-Glossary_of_Terms]]
-== Glossary of Terms
+== Glossary of terms
 
 This glossary documents various terms used in relation to {ProjectName}.
 

--- a/guides/doc-Planning_for_Project/topics/Host_Provisioning_Support.adoc
+++ b/guides/doc-Planning_for_Project/topics/Host_Provisioning_Support.adoc
@@ -1,5 +1,5 @@
 [[tabl-Architecture_Guide-Host_Provisioning_Support]]
-==== Host Provisioning
+==== Host provisioning
 Supported combinations of major versions of {RHEL} and hardware architectures for host provisioning with {Project}.
 
 .Host Provisioning Support

--- a/guides/doc-Planning_for_Project/topics/Hosts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Hosts.adoc
@@ -1,5 +1,5 @@
 [[chap-Architecture_Guide-Host_Grouping_Concepts]]
-== Host Grouping Concepts
+== Host grouping concepts
 
 Apart from the physical topology of {SmartProxyServers}, {ProjectName} provides several logical units for grouping hosts.
 Hosts that are members of those groups inherit the group configuration.
@@ -38,7 +38,7 @@ Organizations, locations, and host groups can be nested.
 endif::[]
 
 [[sect-Architecture_Guide-Host_Group_Hierarchies]]
-=== Host Group Structures
+=== Host group structures
 
 The fact that host groups can be nested to inherit parameters from each other allows for designing host group hierarchies that fit particular workflows.
 A well planned host group structure can help to simplify the maintenance of host settings.

--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -19,7 +19,7 @@ Host systems can pull content and configuration from {SmartProxyServer} in their
 For more information, see xref:chap-Documentation-Architecture_Guide-Capsule_Server_Overview[].
 
 [id="System_Architecture_{context}"]
-=== System Architecture
+=== System architecture
 
 The following diagram represents the high-level architecture of {ProjectName}.
 
@@ -103,7 +103,7 @@ For example, if you need to apply a security erratum to a Content View used in P
 For more information on content management, see {ContentManagementDocURL}[_{ContentManagementDocTitle}_].
 
 [[sect-Architecture_System_Components]]
-=== System Components
+=== System components
 
 ifdef::satellite[]
 {ProjectName} consists of several open source projects which are integrated, verified, delivered and supported as {Project}.
@@ -151,7 +151,7 @@ For explanations of frequently used terms, see xref:appe-Architecture_Guide-Glos
 
 ifdef::satellite[]
 [[sect-Architecture_Supported_Usage]]
-=== Supported Usage
+=== Supported usage
 
 Each {ProjectName} subscription includes one supported instance of {RHELServer}.
 This instance should be reserved solely for the purpose of running  {ProjectName}.
@@ -200,7 +200,7 @@ Third-party usage of any components falls beyond supported usage.
 ====
 
 [[sect-Architecture_Supported_Client_Architectures]]
-=== Supported Client Architectures
+=== Supported client architectures
 
 include::Content_Management_Support.adoc[]
 
@@ -212,10 +212,10 @@ endif::[]
 
 ifndef::satellite[]
 [[Supported_Operating_Systems_and_Architectures]]
-=== Supported Operating Systems and Architectures
+=== Supported operating systems and architectures
 
 [[Foreman_Server_Operating_System]]
-==== {ProjectServer} Operating System
+==== {ProjectServer} Operating system
 
 {Project} has packages for {EL} 8, Debian 11 and Ubuntu 20.04.
 Katello plug-in packages, which provide content management capabilities, are only available for {EL}.
@@ -223,7 +223,7 @@ Katello plug-in packages, which provide content management capabilities, are onl
 The only architecture {Project} has packages for is x86_64.
 
 [[Client_Operating_Systems]]
-==== Client Operating Systems
+==== Client operating systems
 
 {Project} can help to manage any kind of operating systems that have clients {Project} can integrate with.
 For example:

--- a/guides/doc-Planning_for_Project/topics/Org_Loc_and_Lifecycle_Environments.adoc
+++ b/guides/doc-Planning_for_Project/topics/Org_Loc_and_Lifecycle_Environments.adoc
@@ -1,5 +1,5 @@
 [[chap-Architecture_Guide-Org_Loc_and_Lifecycle_Environments]]
-== Organizations, Locations, and Lifecycle Environments
+== Organizations, Locations, and lifecycle environments
 
 {ProjectName} takes a consolidated approach to Organization and Location management.
 System administrators define multiple Organizations and multiple Locations in a single {ProjectServer}.
@@ -33,7 +33,7 @@ This provides a method of managing the content of several individual organizatio
 Locations divide organizations into logical groups based on geographical location.
 Each location is created and used by a single account, although each account can manage multiple locations and organizations.
 
-=== Lifecycle Environments
+=== Lifecycle environments
 
 Application lifecycles are divided into *lifecycle environments* which represent each stage of the application lifecycle.
 Lifecycle environments are linked to form an *environment path*.

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -1,18 +1,18 @@
 [[chap-Architecture_Guide-Provisioning_Concepts]]
 
-== Provisioning Concepts
+== Provisioning concepts
 An important feature of {ProjectName} is unattended provisioning of hosts.
 To achieve this, {ProjectName} uses DNS and DHCP infrastructures, PXE booting, TFTP, and Kickstart.
 Use this chapter to understand the working principle of these concepts.
 
-=== PXE Booting
+=== PXE booting
 Preboot execution environment (PXE) provides the ability to boot a system over a network.
 Instead of using local hard drives or a CD-ROM, PXE uses DHCP to provide host with standard information about the network, to discover a TFTP server, and to download a boot image.
 ifdef::satellite[]
 For more information about setting up a PXE server see the Red{nbsp}Hat Knowledgebase solution https://access.redhat.com/solutions/163253[How to set-up/configure a PXE Server].
 endif::[]
 
-==== PXE Sequence
+==== PXE sequence
 
 . The host boots the PXE image if no other bootable image is found.
 . A NIC of the host sends a broadcast request to the DHCP server.
@@ -23,7 +23,7 @@ endif::[]
 
 For an example of using PXE Booting by {ProjectServer}, see {ProvisioningDocURL}provisioning-workflow_provisioning[Provisioning Workflow] in _{ProvisioningDocTitle}_.
 
-==== PXE Booting Requirements
+==== PXE booting requirements
 To provision machines using PXE booting, ensure that you meet the following requirements:
 
 .Network requirements
@@ -49,11 +49,11 @@ For more information, see xref:{SmartProxy}-Networking_planning[].
 * Enable TFTP using the {Project} installer.
 
 [[http-booting]]
-=== HTTP Booting
+=== HTTP booting
 You can use HTTP booting to boot systems over a network using HTTP.
 
 [[http-booting-requirements]]
-==== HTTP Booting Requirements with managed DHCP
+==== HTTP booting requirements with managed dHCP
 To provision machines through HTTP booting ensure that you meet the following requirements:
 
 .Client requirements
@@ -90,7 +90,7 @@ To update the `grub2-efi` package to the latest version and execute the installe
 ----
 endif::[]
 
-==== HTTP Booting Requirements with unmanaged DHCP
+==== HTTP booting requirements with unmanaged dHCP
 To provision machines through HTTP booting without managed DHCP ensure that you meet the following requirements:
 
 .Client requirements
@@ -132,7 +132,7 @@ ifndef::foreman-deb[]
 endif::[]
 
 ifdef::foreman-el,katello,orcharhino[]
-=== Secure Boot
+=== Secure boot
 
 When {Project} is installed on {EL} using `{foreman-installer}`, grub2 and shim bootloaders that are signed by Red Hat are deployed into the TFTP and HTTP UEFI Boot directory.
 PXE loader options named "SecureBoot" configure hosts to load `shim.efi`.

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -53,7 +53,7 @@ For more information, see xref:{SmartProxy}-Networking_planning[].
 You can use HTTP booting to boot systems over a network using HTTP.
 
 [[http-booting-requirements]]
-==== HTTP booting requirements with managed dHCP
+==== HTTP booting requirements with managed DHCP
 To provision machines through HTTP booting ensure that you meet the following requirements:
 
 .Client requirements
@@ -90,7 +90,7 @@ To update the `grub2-efi` package to the latest version and execute the installe
 ----
 endif::[]
 
-==== HTTP booting requirements with unmanaged dHCP
+==== HTTP booting requirements with unmanaged DHCP
 To provision machines through HTTP booting without managed DHCP ensure that you meet the following requirements:
 
 .Client requirements

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -2,7 +2,7 @@
 
 [appendix]
 [[chap-Documentation-Architecture_Guide-Required_Technical_Users]]
-== Technical Users Provided and Required by {Project}
+== Technical users provided and required by {Project}
 
 During the installation of {Project}, system accounts are created.
 They are used to manage files and process ownership of the components integrated into {Project}.


### PR DESCRIPTION
As a a follow-up on a series of PRs by @apinnick, I'd like to update several more headings in Planning_for_Project to sentence case. I think these were missed before because the content is stored in topics/ in the directory for the guide, not in common/modules/.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
