### PR TITLE
Implement ccutil as a make rule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,20 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Compile html-single
-        run: |
-          for DIR in guides/doc-*; do
-            pushd $DIR &>/dev/null
-            [[ -d images/ ]] || (echo "Required images/ directory missing in $DIR"; exit 1)
-            [[ -h images/common ]] || (echo "Required images/common symlink missing in $DIR"; exit 1)
-            if [[ -f docinfo.xml ]]; then
-              echo "Running ccutil in $DIR"
-              sed -i "1 i:build: satellite\n" master.adoc
-              ccutil compile --lang=en-US --format html-single
-            else
-              echo "Skipping ccutil in $DIR (no docinfo.xml)"
-            fi
-            popd &>/dev/null
-          done
+        run: make -C guides ccutil -j ${{ env.MAKE_J }}
 
   build-html:
     runs-on: ubuntu-22.04

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -22,3 +22,5 @@ linkchecker:
 
 linkchecker-tryer:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | ./scripts/linkchecker-tryer
+
+ccutil: $(SUBDIRS)

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -60,6 +60,12 @@ serve: html
 linkchecker: html
 	linkchecker -r1 -f $(COMMON_DIR)/linkchecker.ini --check-extern "file://$(realpath $(ROOTDIR)/$(DEST_HTML))"
 
+ccutil:
+	if [[ -f docinfo.xml ]] ; then \
+		sed -i "1 i:build: satellite\n" master.adoc ; \
+		ccutil compile --lang=en-US --format html-single ; \
+	fi
+
 $(DEST_DIR)/$(BUILD).css: $(CSS_SOURCES)
 	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 


### PR DESCRIPTION
This removes a lot of logic from the GitHub Action and reuses infrastructure we already have in place. It also allows running in parallel.

It does give up the checks for images and images/common, but those are rather uncommon given how uncommon it is to introduce new guides.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.