### PR TITLE
Run a single make command to build all guides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,11 +69,7 @@ jobs:
       - name: Build HTML with real links
         run: |
           make clean
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-el
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb
-          make -j ${{ env.MAKE_J }} html BUILD=katello
-          make -j ${{ env.MAKE_J }} html BUILD=satellite
-          make -j ${{ env.MAKE_J }} html BUILD=orcharhino
+          make -j ${{ env.MAKE_J }} html
 
       - name: Upload HTML
         uses: actions/upload-artifact@v4
@@ -128,11 +124,7 @@ jobs:
       - name: Build HTML base for comparison
         run: |
           make clean
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-el
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb
-          make -j ${{ env.MAKE_J }} html BUILD=katello
-          make -j ${{ env.MAKE_J }} html BUILD=satellite
-          make -j ${{ env.MAKE_J }} html BUILD=orcharhino
+          make -j ${{ env.MAKE_J }} html
 
       - name: Upload HTML base for comparison
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DEST := result
 PORT := 5000
 VERSION_LINKS := 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.5 2.4
 
-.PHONY: all clean html web compile serve prep FORCE
+.PHONY: all clean html html-upstream html-downstream web compile serve prep FORCE
 
 UNAME = $(shell uname)
 ifeq ($(UNAME), Linux)
@@ -24,7 +24,11 @@ clean:
 	$(MAKE) -C guides/ clean
 	rm -rf $(DEST) web/output/
 
-html: build-foreman-el build-foreman-deb build-katello
+html: html-upstream html-downstream
+
+html-upstream: build-foreman-el build-foreman-deb build-katello
+
+html-downstream: build-satellite build-orcharhino
 
 build-%: FORCE prep
 	$(MAKE) -C guides/ html BUILD=$*


### PR DESCRIPTION
Since 4ca7a1ff4bbfefe7f02ba2ffe14671d39c4ad617 it's possible to run `make html` to build all guides in parallel but that only built upstream. Now there are two separate targets. The GitHub Action now uses this to simplify logic and increase parallelization.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.