### PR TITLE
Apply '.Verification' to a verification step

### DIFF
--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -15,7 +15,7 @@ For more information, see {InstallingSmartProxyDocURL}configuring-remote-executi
 .Procedure
 * Install the `katello-pull-transport-migrate` package on your host:
 ifdef::client-content-dnf[]
-** On {EL} 8 and {EL} 9 hosts:
+** On {EL} 9 and {EL} 8 hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -48,7 +48,9 @@ endif::[]
 +
 The package installs `foreman_ygg_worker` and `yggdrasil` as dependencies and enables the pull mode on the host.
 The host's `subscription-manager` configuration and consumer certificates are used to configure the `yggdrasil` client on the host, and the pull mode client worker is started.
-. Optional: To verify that the pull client is running and configured properly, check the status of the `yggdrasild` service:
+
+.Verification
+* Check the status of the `yggdrasild` service:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -13,15 +13,15 @@ For more information, see {InstallingSmartProxyDocURL}configuring-remote-executi
 * The host is able to communicate with its {SmartProxy} over HTTPS.
 
 .Procedure
-. Install the `katello-pull-transport-migrate` package on your host:
+* Install the `katello-pull-transport-migrate` package on your host:
 ifdef::client-content-dnf[]
-* On {EL} 8 and {EL} 9 hosts:
+** On {EL} 8 and {EL} 9 hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {client-package-install-el8} katello-pull-transport-migrate
 ----
-* On {EL} 7 hosts:
+** On {EL} 7 hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -29,7 +29,7 @@ ifdef::client-content-dnf[]
 ----
 endif::[]
 ifdef::client-content-apt[]
-* On {DL} hosts:
+** On {DL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -37,7 +37,7 @@ ifdef::client-content-apt[]
 ----
 endif::[]
 ifdef::client-content-zypper[]
-* On {SLES} hosts:
+** On {SLES} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
I noticed a procedure module that includes a verification step as an `Optional` last step of the procedure itself. The [template for procedure modules](https://redhat-documentation.github.io/modular-docs/#con-creating-procedure-modules_writing-mod-docs) recommends to use a `.Verification` heading for this purpose. I find it quite useful for scannability, especially when applied consistently. See for example [RHEL Security Hardening](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#proc_installing-the-system-with-fips-mode-enabled_assembly_installing-the-system-in-fips-mode) and search for various instances of `Verification`.

In this PR, I propose a minor edit to introduce `.Verification` into the procedure for configuring a host to use the pull client.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
