### PR TITLE
Remove Puppet Forge content source

### DIFF
--- a/guides/common/modules/con_content-flow-in-project.adoc
+++ b/guides/common/modules/con_content-flow-in-project.adoc
@@ -8,7 +8,7 @@ _{SmartProxyServers}_ mirror the content from {ProjectServer} to _hosts_.
 
 External content sources::
 You can configure many content sources with {Project}.
-The supported content sources include the Red{nbsp}Hat Customer Portal, Git repositories, Ansible collections, Docker Hub, Puppet Forge, SCAP repositories, or internal data stores of your organization.
+The supported content sources include the Red{nbsp}Hat Customer Portal, Git repositories, Ansible collections, Docker Hub, SCAP repositories, or internal data stores of your organization.
 *{ProjectServer}*::
 On your {ProjectServer}, you plan and manage the content lifecycle.
 *{SmartProxyServers}*::

--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -38,7 +38,7 @@ There are four stages through which content flows in this architecture:
 [[varl-Architecture_System_Architecture-External_Content_Sources]]
 *External Content Sources*:: The _{ProjectServer}_ can consume diverse types of content from various sources.
 The Red{nbsp}Hat Customer Portal is the primary source of software packages, errata, and container images.
-In addition, you can use other supported content sources (Git repositories, Docker Hub, Puppet Forge, SCAP repositories) as well as your organization's internal data store.
+In addition, you can use other supported content sources (Git repositories, Docker Hub, SCAP repositories) as well as your organization's internal data store.
 
 
 [[varl-Architecture_System_Architecture-RednbspHat_Satellite_Server]]


### PR DESCRIPTION
- Puppet Forge is no longer a supported content source.
- This PR removes it from the planning guide.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
