### PR TITLE
Apply sentence case to headings in deployment topics, vol.2

### DIFF
--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -5,7 +5,7 @@ This section provides an overview of general topics to be considered when planni
 
 ifdef::satellite[]
 [[sect-Satellite_Server_Configuration]]
-=== {ProjectServer} Configuration
+=== {ProjectServer} configuration
 
 The first step to a working {Project} infrastructure is installing an instance of {ProjectServer} on a dedicated {RHEL} 8 server.
 
@@ -19,7 +19,7 @@ For more information, see {InstallingServerDocURL}tuning-with-predefined-profile
 On large {Project} deployments, you can improve performance by configuring your {Project} with predefined tuning profiles.
 For more information, see {InstallingServerDisconnectedDocURL}tuning-with-predefined-profiles_{project-context}[Tuning {ProjectServer} with Predefined Profiles] in _{InstallingServerDisconnectedDocTitle}_.
 
-.Adding Red{nbsp}Hat Subscription Manifests to {ProjectServer}
+.Adding Red{nbsp}Hat subscription manifests to {ProjectServer}
 
 A Red{nbsp}Hat Subscription Manifest is a set of encrypted files that contains your subscription information.
 {ProjectServer} uses this information to access the CDN and find what repositories are available for the associated subscription.
@@ -41,8 +41,8 @@ This can be imported into the {Project} as a distinct Organization.
 This allows system administrators the ability to manage Example Corporation 1's systems using {Project} completely independently of Example Corporation 2's organizations (R&D, Operations, and Engineering).
 
 [[satellite_server_with_multiple_manifests_image]]
-.{ProjectServer} with Multiple Manifests
-image::server-multiple-manifests-satellite.png[{ProjectServer} with Multiple Manifests]
+.{ProjectServer} with multiple manifests
+image::server-multiple-manifests-satellite.png[{ProjectServer} with multiple manifests]
 
 When creating a Red{nbsp}Hat Subscription Manifest:
 

--- a/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Scenarios.adoc
@@ -44,7 +44,7 @@ For information about upgrading a disconnected {Project}, see {UpgradingDocURL}u
 
 There are two options for importing content to a disconnected {ProjectServer}:
 
-* *Disconnected {Project} with Content ISO* – in this setup, you download ISO images with content from the Red{nbsp}Hat Customer Portal and extract them to {ProjectServer} or a local web server.
+* *Disconnected {Project} with content ISO* – in this setup, you download ISO images with content from the Red{nbsp}Hat Customer Portal and extract them to {ProjectServer} or a local web server.
 The content on {ProjectServer} is then synchronized locally.
 This allows for complete network isolation of {ProjectServer}, however, the release frequency of content ISO images is around six weeks and not all product content is included.
 To see the products in your subscription for which content ISO images are available, log in to the Red Hat Customer Portal at https://access.redhat.com, navigate to *Downloads* > *{ProjectName}*, and click *Content ISOs*.

--- a/guides/doc-Planning_for_Project/topics/Hosts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Hosts.adoc
@@ -45,33 +45,33 @@ A well planned host group structure can help to simplify the maintenance of host
 This section outlines four approaches to organizing host groups.
 
 [[figu-Life_Cycle_Environment_Based_Structure]]
-.Host Group Structuring Examples
+.Host group structuring examples
 
-image::host-group-structures-satellite.png[Host Group Structuring Examples]
+image::host-group-structures-satellite.png[Host group structuring examples]
 
 
 [[brid-Flat_Structure]]
-*Flat Structure*
+*Flat structure*
 
 The advantage of a flat structure is limited complexity, as inheritance is avoided.
 In a deployment with few host types, this scenario is the best option.
 However, without inheritance there is a risk of high duplication of settings between host groups.
 
 [[brid-Lifecycle_Environment_Based_Structure]]
-*Lifecycle Environment Based Structure*
+*Lifecycle environment based structure*
 
 In this hierarchy, the first host group level is reserved for parameters specific to a lifecycle environment.
 The second level contains operating system related definitions, and the third level contains application specific settings.
 Such structure is useful in scenarios where responsibilities are divided among lifecycle environments (for example, a dedicated owner for the *Development*, *QA*, and *Production* lifecycle stages).
 [[brid-Flat_Host_Group_Structure]]
-*Application Based Structure*
+*Application based structure*
 
 This hierarchy is based on roles of hosts in a specific application.
 For example, it enables defining network settings for groups of back-end and front-end servers.
 The selected characteristics of hosts are segregated, which supports Puppet-focused management of complex configurations.
 However, the content views can only be assigned to host groups at the bottom level of this hierarchy.
 [[brid-Location_Based_Structure]]
-*Location Based Structure*
+*Location based structure*
 
 In this hierarchy, the distribution of locations is aligned with the host group structure.
 In a scenario where the location ({SmartProxyServer}) topology determines many other attributes, this approach is the best option.

--- a/guides/doc-Planning_for_Project/topics/Org_Loc_and_Lifecycle_Environments.adoc
+++ b/guides/doc-Planning_for_Project/topics/Org_Loc_and_Lifecycle_Environments.adoc
@@ -1,5 +1,5 @@
 [[chap-Architecture_Guide-Org_Loc_and_Lifecycle_Environments]]
-== Organizations, Locations, and lifecycle environments
+== Organizations, locations, and lifecycle environments
 
 {ProjectName} takes a consolidated approach to Organization and Location management.
 System administrators define multiple Organizations and multiple Locations in a single {ProjectServer}.
@@ -13,9 +13,9 @@ include::../common/modules/snip_red-hat-images.adoc[]
 endif::[]
 
 [id="figu-Example_Topology_for_Server_{context}"]
-.Example Topology for {ProjectName}
+.Example topology for {ProjectName}
 
-image::system-architecture-satellite.png[Example Topology for {ProjectName}]
+image::system-architecture-satellite.png[Example topology for {ProjectName}]
 
 {ProjectServer} defines all locations and organizations.
 Each respective {Project} {SmartProxyServer} synchronizes content and handles configuration of systems in a different location.
@@ -45,6 +45,6 @@ include::../common/modules/snip_red-hat-images.adoc[]
 endif::[]
 
 [[figu-An_Environment_Path_Containing_Four_Environments]]
-.An Environment Path Containing Four Environments
+.An environment path containing four environments
 
-image::lifecycle-satellite.png[An Environment Path Containing Four Environments]
+image::lifecycle-satellite.png[An environment path containing four environments]

--- a/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
+++ b/guides/doc-Planning_for_Project/topics/Required_Technical_Users.adoc
@@ -19,7 +19,7 @@ Because of potential conflicts with local users that {Project} creates, you cann
 
 [[tabl-Documentation-Architecture_Guide-Technical_Users_Provided_and_Required_by_Satellite]]
 
-.Technical Users Provided and Required by {Project}
+.Technical users provided and required by {Project}
 [options="header"]
 |====
 |User name |UID |Group name |GID |Flexible UID and GID |Home |Shell


### PR DESCRIPTION
A follow-up on https://github.com/theforeman/foreman-documentation/pull/2873 where I apparently missed two section headings (sorry!).

This PR updates the mentioned section-level headings and also several in-section headings (tables, lists, images, etc.) to sentence case.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
