### PR TITLE
Remove mentions of Content Hosts from updating

### DIFF
--- a/guides/doc-Upgrading_and_Updating/master.adoc
+++ b/guides/doc-Upgrading_and_Updating/master.adoc
@@ -66,7 +66,7 @@ endif::[]
 
 ifdef::satellite[]
 [#updating_{project-context}]
-== Updating {ProjectServer}, {SmartProxyServerTitle}, and Content Hosts
+== Updating {ProjectServer} and {SmartProxyServerTitle}
 
 // Updating Red Hat Satellite Introduction
 include::topics/introduction_updating_satellite.adoc[leveloffset=+2]

--- a/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/introduction_updating_satellite.adoc
@@ -1,6 +1,6 @@
 [[introduction_updating_satellite]]
 
-Use this chapter to update your existing {ProjectServer}, {SmartProxyServer}, and Content Hosts to a new patch version, for example, from {ProjectVersion}.0 to {ProjectVersion}.1.
+Use this chapter to update your existing {ProjectServer} and {SmartProxyServer} to a new patch version, for example, from {ProjectVersion}.0 to {ProjectVersion}.1.
 
 Updates patch security vulnerabilities and minor issues discovered after code is released, and are often fast and non-disruptive to your operating environment.
 


### PR DESCRIPTION
A follow-up on https://github.com/theforeman/foreman-documentation/pull/2569 where cherry-picking into 3.5 was not possible due to a merge conflict.

This PR removes the mention of content hosts from the procedure heading and introduction. It should be the last thing required to close [BZ#2209380](https://bugzilla.redhat.com/show_bug.cgi?id=2209380).

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
