### PR TITLE
Re-add the section to upgrade Smart Proxy using remote execution for …

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -158,3 +158,19 @@ endif::[]
 
 . Optional: If you made manual edits to DNS or DHCP configuration files, check and restore any changes required to the DNS and DHCP configuration files using the backups made earlier.
 . Optional: If you use custom repositories, ensure that you enable these custom repositories after the upgrade completes.
+
+.Upgrading {SmartProxyServers} using remote execution
+
+. Create a backup or take a snapshot.
++
+For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+. In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
+. Click *Run Job*.
+. From the *Job category* list, select *Maintenance Operations*.
+. From the *Job template* list, select *{SmartProxy} Upgrade Playbook*.
+. In the *Search Query* field, enter the host name of the {SmartProxy}.
+. Ensure that *Apply to 1 host* is displayed in the *Resolves to* field.
+. In the *target_version* field, enter the target version of the {SmartProxy}.
+. In the *whitelist_options* field, enter the options.
+. Select the schedule for the job execution in *Schedule*.
+. In the *Type of query* section, click *Static Query*.

--- a/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/upgrading_capsule_server.adoc
@@ -163,7 +163,7 @@ endif::[]
 
 . Create a backup or take a snapshot.
 +
-For more information on backups, see {AdministeringDocURL}backing-up-satellite-server-and-capsule-server[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+For more information on backups, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_{context}[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 . In the {ProjectWebUI} , navigate to *Monitor* > *Jobs*.
 . Click *Run Job*.
 . From the *Job category* list, select *Maintenance Operations*.


### PR DESCRIPTION
…older versions

Same change as https://github.com/theforeman/foreman-documentation/pull/2789, for older versions.

The Upgrading {SmartProxy} Servers Using Remote Execution in the {ProjectWebUI} section has been left out of the post 2.5 versions. However, this is still relevant in the later versions. Adding it back in for 3.1, will push separate PRs for other versions to avoid merge conflicts due to file structure changes.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2248524


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [X] Foreman 3.4/Katello 4.6 (EL8 only)
* [X] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
