### PR TITLE
New procedure for Ansible job templates

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -75,4 +75,6 @@ include::modules/proc_scheduling-a-recurring-ansible-job-for-a-host-group.adoc[l
 
 include::modules/proc_monitoring-remote-jobs.adoc[leveloffset=+1]
 
+include::modules/proc_using-ansible-job-templates-for-package-and-errata-actions.adoc[leveloffset=+1]
+
 include::modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -75,6 +75,6 @@ include::modules/proc_scheduling-a-recurring-ansible-job-for-a-host-group.adoc[l
 
 include::modules/proc_monitoring-remote-jobs.adoc[leveloffset=+1]
 
-include::modules/proc_using-ansible-job-templates-for-package-and-errata-actions.adoc[leveloffset=+1]
+include::modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc[leveloffset=+1]
 
 include::modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_using-ansible-job-templates-for-package-and-errata-actions.adoc
+++ b/guides/common/modules/proc_using-ansible-job-templates-for-package-and-errata-actions.adoc
@@ -1,0 +1,17 @@
+[id="Using_Ansible_Job_Templates_for_Package_and_Errata_Actions{context}"]
+= Using Ansible job templates for package and errata actions
+
+By default, {Project} is configured to use the Script provider templates for remote execution jobs.
+If you prefer using the Ansible provider templates for your remote jobs, you can configure {Project} to use the Ansible provider templates for remote execution features that take a search query input.
+
+.Prerequisites
+Use remote execution in `ssh` mode.
+Pull mode does not work with Ansible.
+
+.Procedure
+. Navigate to *Administer > Remote Execution Features*.
+. Find each feature whose name contains `by_search`.
+. Change the job template for these features from `Katello Script Default` to `Katello Ansible Default`.
+. Click *Submit*.
+
+Ansible job templates are now used for remote execution when using the web UI to perform package and errata actions, and when using hammer job-invocation created with remote execution features that take a search query input.

--- a/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
+++ b/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
@@ -4,8 +4,10 @@
 By default, {Project} is configured to use the Script provider templates for remote execution jobs.
 If you prefer using Ansible job templates for your remote jobs, you can configure {Project} to use them by default for remote execution features associated with them.
 
-.Prerequisites
-* Use remote execution in `ssh` mode.
+[NOTE]
+====
+Remember that Ansible job templates only work when remote execution is configured for `ssh` mode.
+====
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Remote Execution Features*.
@@ -13,5 +15,5 @@ If you prefer using Ansible job templates for your remote jobs, you can configur
 . Change the job template for these features from `Katello Script Default` to `Katello Ansible Default`.
 . Click *Submit*.
 
-Ansible job templates are now used for remote execution when using the {ProjectWebUI} to perform package and errata actions.
-They are also used when using `hammer job-invocation create` with the same remote execution features used in the procedure above.
+{Project} now uses Ansible provider templates for remote execution jobs by which you can perform package and errata actions.
+This applies to job invocations from the {ProjectWebUI} as well as by using `hammer job-invocation create` with the same remote execution features that you have changed.

--- a/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
+++ b/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
@@ -1,15 +1,14 @@
-[id="Using_Ansible_Job_Templates_for_Package_and_Errata_Actions{context}"]
-= Using Ansible job templates for package and errata actions
+[id="Using_Ansible_Provider_for_Package_and_Errata_Actions_{context}"]
+= Using Ansible provider for package and errata actions
 
 By default, {Project} is configured to use the Script provider templates for remote execution jobs.
 If you prefer using the Ansible provider templates for your remote jobs, you can configure {Project} to use the Ansible provider templates for remote execution features that take a search query input.
 
 .Prerequisites
 Use remote execution in `ssh` mode.
-Pull mode does not work with Ansible.
 
 .Procedure
-. Navigate to *Administer > Remote Execution Features*.
+. In the {ProjectWebUI}, navigate to *Administer* > *Remote Execution Features*.
 . Find each feature whose name contains `by_search`.
 . Change the job template for these features from `Katello Script Default` to `Katello Ansible Default`.
 . Click *Submit*.

--- a/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
+++ b/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
@@ -13,5 +13,5 @@ If you prefer using Ansible job templates for your remote jobs, you can configur
 . Change the job template for these features from `Katello Script Default` to `Katello Ansible Default`.
 . Click *Submit*.
 
-Ansible job templates are now used for remote execution when using the web UI to perform package and errata actions.
+Ansible job templates are now used for remote execution when using the {ProjectWebUI} to perform package and errata actions.
 They are also used when using `hammer job-invocation create` with the same remote execution features used in the procedure above.

--- a/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
+++ b/guides/common/modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc
@@ -2,10 +2,10 @@
 = Using Ansible provider for package and errata actions
 
 By default, {Project} is configured to use the Script provider templates for remote execution jobs.
-If you prefer using the Ansible provider templates for your remote jobs, you can configure {Project} to use the Ansible provider templates for remote execution features that take a search query input.
+If you prefer using Ansible job templates for your remote jobs, you can configure {Project} to use them by default for remote execution features associated with them.
 
 .Prerequisites
-Use remote execution in `ssh` mode.
+* Use remote execution in `ssh` mode.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Remote Execution Features*.
@@ -13,4 +13,5 @@ Use remote execution in `ssh` mode.
 . Change the job template for these features from `Katello Script Default` to `Katello Ansible Default`.
 . Click *Submit*.
 
-Ansible job templates are now used for remote execution when using the web UI to perform package and errata actions, and when using hammer job-invocation created with remote execution features that take a search query input.
+Ansible job templates are now used for remote execution when using the web UI to perform package and errata actions.
+They are also used when using `hammer job-invocation create` with the same remote execution features used in the procedure above.


### PR DESCRIPTION
A new procedure was created for using Ansible job
templates for package
and errata actions.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
