### PR TITLE
add Ubuntu 22.04

### DIFF
--- a/guides/common/modules/con_projectserver-operating-system.adoc
+++ b/guides/common/modules/con_projectserver-operating-system.adoc
@@ -1,7 +1,7 @@
 [id="ProjectServer-Operating-System_{context}"]
 = {ProjectServer} operating system
 
-{Project} has packages for {EL} 8 and 9, Debian 11 and Ubuntu 20.04.
+{Project} has packages for {EL} 8 and 9, Debian 11 and Ubuntu 20.04 and 22.04.
 Katello plug-in packages, which provide content management capabilities, are only available for {EL}.
 
 {Team} only packages {Project} for x86_64.

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -17,6 +17,7 @@ endif::[]
 ifdef::foreman-deb[]
 * xref:#repositories-debian-11[Debian 11 (Bullseye)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
+* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
@@ -121,4 +122,9 @@ include::proc_configuring-repositories-deb.adoc[]
 :distribution-codename: focal
 include::proc_configuring-repositories-deb.adoc[]
 
+[id="repositories-ubuntu-2204"]
+== Ubuntu 22.04 (Jammy)
+
+:distribution-codename: jammy
+include::proc_configuring-repositories-deb.adoc[]
 endif::[]

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -23,6 +23,7 @@ endif::[]
 ifdef::foreman-deb[]
 | Debian 11 (Bullseye) | amd64 |
 | Ubuntu 20.04 (Focal) | amd64 |
+| Ubuntu 22.04 (Jammy) | amd64 |
 endif::[]
 |====
 

--- a/guides/doc-Planning_for_Project/topics/Introduction.adoc
+++ b/guides/doc-Planning_for_Project/topics/Introduction.adoc
@@ -217,7 +217,7 @@ ifndef::satellite[]
 [[Foreman_Server_Operating_System]]
 ==== {ProjectServer} Operating system
 
-{Project} has packages for {EL} 8 and 9, Debian 11 and Ubuntu 20.04.
+{Project} has packages for {EL} 8 and 9, Debian 11 and Ubuntu 20.04 and 22.04.
 Katello plug-in packages, which provide content management capabilities, are only available for {EL}.
 
 The only architecture {Project} has packages for is x86_64.


### PR DESCRIPTION
contains #2894 to avoid merge-conflicts

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
