### PR TITLE
Add Networking prerequisite as snippet

### DIFF
--- a/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
@@ -8,6 +8,7 @@ You can only use golden images supported by {Team} with {Project} for creating G
 endif::[]
 
 .Prerequisites
+include::snip_prerequisite-networking-for-provisioning.adoc[]
 include::snip_prerequisites-common-compute-resource.adoc[]
 * In your GCE project, configure a service account with the necessary IAM Compute role.
 For more information, see https://cloud.google.com/compute/docs/access/iam[Compute Engine IAM roles] in the GCE documentation.

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts.adoc
@@ -7,8 +7,7 @@ The main difference is that instead of manually entering the host's MAC address,
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-from-discovered-hosts_{context}[].
 
 .Prerequisites
-* Configure a domain and subnet on {Project}.
-For more information about networking requirements, see xref:Configuring_Networking_{context}[].
+include::snip_prerequisite-networking-for-provisioning.adoc[]
 * Configure the discovery service on {Project}.
 For more information, see xref:Installing_the_Discovery_Service_{context}[].
 * A bare metal host or a blank VM.

--- a/guides/common/modules/snip_prerequisite-networking-for-provisioning.adoc
+++ b/guides/common/modules/snip_prerequisite-networking-for-provisioning.adoc
@@ -1,0 +1,2 @@
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:Configuring_Networking_provisioning[].


### PR DESCRIPTION
GCE provisioning was missing a networking prerequisite.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
