### PR TITLE
Fix typo in Proxmox procedure

### DIFF
--- a/guides/common/modules/proc_adding-proxmox-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-proxmox-images-to-server.adoc
@@ -17,6 +17,6 @@ By default, this is set to `root`.
 This is only necessary if the image has an inbuilt user account.
 . From the *User data* list, select whether you want the images to support user data input, such as `cloud-init` data.
 . In the *Password* field, enter the SSH password for image access.
-. In the *Image* field, enter the relative path and name of the template on the vSphere environment.
+. In the *Image* field, enter the relative path and name of the template on the Proxmox environment.
 Do not include the data center in the relative path.
 . Click *Submit* to save the image details.


### PR DESCRIPTION
minor copy and paste error :upside_down_face: 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
