### PR TITLE
Mark quickstart guide as ready

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -163,6 +163,7 @@
 :client-pkg-ext: rpm
 :client-provisioning-template-type: Kickstart
 // Foreman Server and Smart Proxy Server
+:project-minimum-memory: 4 GB
 :project-package-check-update: dnf check-update
 :project-package-clean: dnf clean
 :project-package-install: dnf install

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -6,4 +6,5 @@
 :installer-log-file: /var/log/foreman-installer/katello.log
 :installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content
 :installer-scenario: foreman-installer --scenario katello
+:project-minimum-memory: 20 GB
 :smartproxy_port: 9090

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -38,6 +38,7 @@
 :installer-scenario-smartproxy: orcharhino-installer --no-enable-foreman
 :installer-scenario: foreman-installer --scenario katello
 :project-client-name: {Project}{nbsp}Client
+:project-minimum-memory: 20 GB
 :smart-proxy-context: orcharhino-proxy
 :smart-proxy-context-titlecase: orcharhino_Proxy
 :smart-proxy-principal: orcharhinoproxy

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -93,6 +93,7 @@
 :PIV: CAC
 :project-context: satellite
 :project-change-hostname: satellite-change-hostname
+:project-minimum-memory: 20 GB
 :Project: Satellite
 :ProjectFeed: https://www.redhat.com/en/rss/blog/channel/red-hat-satellite
 :ProjectName: Red{nbsp}Hat Satellite

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -9,17 +9,11 @@ ifdef::satellite[]
 endif::[]
 * 4-core 2.0 GHz CPU at a minimum
 
-ifdef::foreman-el,foreman-deb[]
 ifeval::["{context}" == "{project-context}"]
-* A minimum of 4 GB RAM is required for {ProjectServer} to function.
-{Project} running with less RAM than the minimum value might not operate correctly.
-endif::[]
-endif::[]
-
+* A minimum of {project-minimum-memory} RAM is required for {ProjectServer} to function.
 ifdef::katello,satellite[]
-ifeval::["{context}" == "{project-context}"]
-* A minimum of 20 GB RAM is required for {ProjectServer} to function.
 In addition, a minimum of 4 GB RAM of swap space is also recommended.
+endif::[]
 {Project} running with less RAM than the minimum value might not operate correctly.
 endif::[]
 
@@ -27,7 +21,6 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 * A minimum of 12 GB RAM is required for {SmartProxyServer} to function.
 In addition, a minimum of 4 GB RAM of swap space is also recommended.
 {SmartProxy} running with less RAM than the minimum value might not operate correctly.
-endif::[]
 endif::[]
 
 ifdef::katello,satellite[]

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -7,12 +7,6 @@ include::common/header.adoc[]
 
 = {QuickstartDocTitle}
 
-// This guide is not ready for stable releases
-ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
-endif::[]
-ifndef::HideDocumentOnStable[]
-
 The Foreman installer is a collection of Puppet modules that installs everything required for a full working Foreman setup.
 It uses native OS packaging (`.rpm` or `.deb` packages) and adds necessary configuration for the complete installation.
 
@@ -45,4 +39,3 @@ To run the installer, execute:
 ----
 
 When the installer has completed, details will be printed about where to find Foreman and the Smart Proxy.
-endif::[]

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -21,7 +21,7 @@ It is configurable and the Puppet modules can be read or run in "no-op" mode to 
 
 include::common/modules/ref_supported-operating-systems.adoc[]
 
-The installation will require 4GB of memory.
+The installation requires {project-minimum-memory} of memory.
 For more information, see {InstallingServerDocURL}system-requirements_{project-context}[System Requirements].
 
 The Foreman installer uses Puppet to install Foreman.


### PR DESCRIPTION
After reviewing the quickstart guide it looks ready to be consumed. It only had one small error for the memory requirement.

I didn't look at the navigation yet.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.