### PR TITLE
Add missing step for PXE config

### DIFF
--- a/guides/common/modules/proc_configuring-the-discovery-service.adoc
+++ b/guides/common/modules/proc_configuring-the-discovery-service.adoc
@@ -12,6 +12,14 @@ The Discovery service is enabled by default on {ProjectServer}.
 However, the default setting of the global templates is to boot from the local hard drive.
 To change the default setting, in the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.
 Locate the *Default PXE global template entry* row, and in the *Value* column, enter *discovery*.
+Then build the PXE default configuration.
+Navigate to *Hosts* > *Templates* > *Provisioning Templates* and click *Build PXE Default*.
+ifdef::satellite[]
+{Project} distributes the PXE configuration to any TFTP {SmartProxies}.
+endif::[]
+ifndef::satellite[]
+{Project} distributes the PXE configuration to any TFTP Proxies.
+endif::[]
 
 ifdef::satellite[]
 image::common/pxe-mode-satellite.png[PXE mode]


### PR DESCRIPTION
This is a quick fix for current docs requested in a bug report.
https://bugzilla.redhat.com/show_bug.cgi?id=2263570

Note that I'm rewriting Discovery chapter properly in the PR #2890.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
