### PR TITLE
Add procedure to install oVirt compute resource

### DIFF
--- a/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-rhv.adoc
@@ -5,6 +5,10 @@
 
 include::modules/con_provisioning-virtual-machines-on-ovirt.adoc[]
 
+ifndef::satellite[]
+include::modules/proc_installing-ovirt-plugin.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_adding-rhv-connection.adoc[leveloffset=+1]
 
 include::modules/proc_preparing-cloud-init-images-in-rhv.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_installing-ovirt-plugin.adoc
+++ b/guides/common/modules/proc_installing-ovirt-plugin.adoc
@@ -1,0 +1,16 @@
+[id="installing-the-oVirt-plug-in_{context}"]
+= Installing the {oVirt} plug-in
+
+Install the {oVirt} plug-in to attach an {oVirt} compute resource provider to {Project}.
+This allows you to manage and deploy hosts to {oVirt}.
+
+.Procedure
+* Install the {oVirt} compute resource provider on your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --enable-foreman-compute-ovirt
+----
+
+.Verification
+* Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the *Compute resources* tab to verify the installation of the {oVirt} plug-in.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)

current assumption: Plug-in for RHV is installed on Satellite by default.

Refs https://community.theforeman.org/t/ovirt-integration-into-foreman-3-8/37376