### PR TITLE
Correct RHEL version in Enabling Tuned Profiles

### DIFF
--- a/guides/common/modules/proc_enabling-tuned-profiles.adoc
+++ b/guides/common/modules/proc_enabling-tuned-profiles.adoc
@@ -1,7 +1,7 @@
 [id="Enabling_Tuned_Profiles_{context}"]
 = Enabling Tuned Profiles
 
-{RHEL} 7 enables the tuned daemon by default during installation.
+{RHEL} 8 enables the tuned daemon by default during installation.
 On bare-metal, {Team} recommends to run the `throughput-performance` tuned profile on {ProjectServer} and {SmartProxies}.
 On virtual machines, {Team} recommends to run the `virtual-guest` profile.
 


### PR DESCRIPTION
The sentence is not present on higher versions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
