### PR TITLE
Update Foreman 3.10 release notes for GA

### DIFF
--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,6 +1,6 @@
 // Document state: "nightly" for master, "stable" for last two releases,
 // "unsupported" for the rest and "satellite" for satellite build
-:DocState: unsupported
+:DocState: stable
 
 // Version numbers
 :ProjectVersion: 3.10

--- a/guides/doc-Release_Notes/topics/foreman-3.10.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.10.0.adoc
@@ -4,6 +4,11 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 == Foreman
 
+* pass:[Some APIs / params are not marked as deprecated] - https://projects.theforeman.org/issues/37274[#37274]
+* pass:[OS bootfiles API not working because of misspelled class] - https://projects.theforeman.org/issues/37270[#37270]
+* pass:[Pull provider installation template crash] - https://projects.theforeman.org/issues/37193[#37193]
+* pass:[Race condition in smart proxy test] - https://projects.theforeman.org/issues/37150[#37150]
+* pass:[Alphabetical sorting in test broken] - https://projects.theforeman.org/issues/37132[#37132]
 * pass:[Unpin adobe/css-tools] - https://projects.theforeman.org/issues/37128[#37128]
 * pass:[Clean up old storybook dependencies] - https://projects.theforeman.org/issues/37127[#37127]
 * pass:[Replace `node-sass` with `sass`] - https://projects.theforeman.org/issues/37126[#37126]
@@ -19,10 +24,15 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 * pass:[Run Foreman tests on Ruby 3.0] - https://projects.theforeman.org/issues/36849[#36849]
 * pass:[VM tab (legacy UI) shows error in case host is not associated to VM] - https://projects.theforeman.org/issues/36744[#36744]
 * pass:[Ubuntu version "nil" is interpreted as "0"] - https://projects.theforeman.org/issues/36741[#36741]
+* pass:[iPXE Discovery Only Works On net0] - https://projects.theforeman.org/issues/36502[#36502]
 
 === API
 
 * pass:[Create API for getting permissions of current user] - https://projects.theforeman.org/issues/36917[#36917]
+
+=== Authentication
+
+* pass:[After Foreman installation login page respond with  "Invalid Timezone: Etc/Unknown"] - https://projects.theforeman.org/issues/37069[#37069]
 
 === Compute resources
 
@@ -31,6 +41,10 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 === Compute resources - VMware
 
 * pass:[VmWare - API doesn't show same info about VM as in UI] - https://projects.theforeman.org/issues/35248[#35248]
+
+=== Database
+
+* pass:[Invalid kwargs handling in FindCommon] - https://projects.theforeman.org/issues/37273[#37273]
 
 === Host creation
 
@@ -43,6 +57,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === JavaScript stack
 
+* pass:[Fix javascript method for webpack_asset_paths ] - https://projects.theforeman.org/issues/37199[#37199]
 * pass:[Duplicate ids from webpack style] - https://projects.theforeman.org/issues/37173[#37173]
 * pass:[Load plugin public folder for webpack] - https://projects.theforeman.org/issues/37161[#37161]
 * pass:["Component name already taken" warnings fix] - https://projects.theforeman.org/issues/37154[#37154]
@@ -63,6 +78,8 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === Reporting
 
+* pass:[Satellite "Registered Content Hosts" report generates incorrect hosts' kernel version ] - https://projects.theforeman.org/issues/37184[#37184]
+* pass:[Host - Statuses report failing "unknown keywords: :Name, :Global"] - https://projects.theforeman.org/issues/37065[#37065]
 * pass:[Getting "undefined method '#name' for NilClass::Jail (NilClass) (Safemode::NoMethodError)" error generating subscription report ] - https://projects.theforeman.org/issues/37016[#37016]
 * pass:[Hammer Report-Template Complains about 'Input Days from Now' Being Blank] - https://projects.theforeman.org/issues/32359[#32359]
 
@@ -118,4 +135,5 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === RPMs
 
+* pass:[rubygem-ipmitool is missing ipmitool dependency] - https://projects.theforeman.org/issues/37246[#37246]
 * pass:[Add python-setuptools as an installation dependency for EL6 katello-host-tools] - https://projects.theforeman.org/issues/37106[#37106]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
