### PR TITLE
Update /web for Foreman 3.10 GA

### DIFF
--- a/web/content/index.adoc
+++ b/web/content/index.adoc
@@ -20,8 +20,8 @@ For contribution, visit the https://github.com/theforeman/foreman-documentation[
 
 The following releases are supported, meaning they receive (security) updates.
 
+* link:/release/3.10/[Foreman 3.10 & Katello 4.12]
 * link:/release/3.9/[Foreman 3.9 & Katello 4.11]
-* link:/release/3.8/[Foreman 3.8 & Katello 4.10]
 
 === Unsupported releases
 
@@ -29,12 +29,11 @@ The future version is built in nightly.
 
 * link:/release/nightly/[Nightly]
 
-There is a release candidate available for testing.
-
-* link:/release/3.10/[Foreman 3.10 & Katello 4.12]
+// There is a release candidate available for testing.
 
 These releases are unsupported and no longer receive updates. Users should update to a supported release.
 
+* link:/release/3.8/[Foreman 3.8 & Katello 4.10]
 * link:/release/3.7/[Foreman 3.7 & Katello 4.9]
 * link:/release/3.6/[Foreman 3.6 & Katello 4.8]
 * link:/release/3.5/[Foreman 3.5 & Katello 4.7]

--- a/web/content/js/versions.js
+++ b/web/content/js/versions.js
@@ -200,7 +200,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.10 - Katello 4.12 (RC)",
+    "title": "Foreman 3.10 - Katello 4.12 (supported)",
     "path": "3.10",
     "builds": [
       {
@@ -464,7 +464,7 @@ const navVersions = [
     ]
   },
   {
-    "title": "Foreman 3.8 - Katello 4.10 (supported)",
+    "title": "Foreman 3.8 - Katello 4.10 (unsupported)",
     "path": "3.8",
     "builds": [
       {


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
