### PR TITLE
Update git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,16 +1,41 @@
-Eric D. Helms <ericdhelms@gmail.com> <eric.d.helms@gmail.com>
-Ian Ballou <ianballou67@gmail.com> ianballou <ianballou67@gmail.com>
-Ian Fowler <77341519+ianf77@users.noreply.github.com>
-Justin Sherrill <jlsherrill@gmail.com> <jsherril@redhat.com>
-Lukas Zapletal <lzap@redhat.com> <lzap+git@redhat.com>
-Lukas Zapletal <lzap@redhat.com> <lzap+pub@redhat.com>
-Lukas Zapletal <lzap@redhat.com> <lzap+rpm@redhat.com>
-Lukas Zapletal <lzap@redhat.com> <lzap@seznam.cz>
+Adam Lazik <alazik@redhat.com>
+Adam Lazik <alazik@redhat.com> <108661422+adamlazik1@users.noreply.github.com>
+Adam Růžička <aruzicka@redhat.com>
+Adam Růžička <aruzicka@redhat.com> <a.ruzicka@outlook.com>
+Adam Růžička <aruzicka@redhat.com> <adamruzicka@users.noreply.github.com>
+Adam Růžička <aruzicka@redhat.com> <aruzicka@redhat.com>
+Akshay Gadhave <agadhave@redhat.com> <97217993+AkshayGadhaveRH@users.noreply.github.com>
+Akshay Gadhave <agadhave@redhat.com> <agadhave@agadhave-thinkpadp1gen4i.pnq.csb>
+Amit Upadhye <upadhyeammit@gmail.com> <amitupadhye@foreman.example.com>
+Aneta Šteflová Petrová <aneta@redhat.com> <apetrova@redhat.com>
+Aneta Šteflová Petrová <aneta@redhat.com> <steflova.aneta@gmail.com>
+Brian Angelica <bangelic@redhat.com> <91690569+bangelic@users.noreply.github.com>
+Eric Helms <ericdhelms@gmail.com> <eric.d.helms@gmail.com>
+Eric Helms <ericdhelms@gmail.com> Eric D. Helms <ericdhelms@gmail.com>
+Griffin Sullivan <gsulliva@redhat.com> <48397354+Griffin-Sullivan@users.noreply.github.com>
+Ian Ballou <ianballou67@gmail.com>
+Ian Fowler <ifowler@redhat.com> <77341519+ianf77@users.noreply.github.com>
+Imaanpreet Kaur <ikaur@redhat.com> <32102000+Imaanpreet@users.noreply.github.com>
+Jan Hutař <jhutar@redhat.com>
+Leos Stejskal <lstejska@redhat.com> <github@stejskalleos.cz>
+Levi Leah <isaiah.sai.levi@gmail.com> <61505512+Levi-Leah@users.noreply.github.com>
+Lukáš Zapletal <lzap@redhat.com>
+Lukáš Zapletal <lzap@redhat.com> <lukas@zapletalovi.com>
+Lukáš Zapletal <lzap@redhat.com> <lzap+git@redhat.com>
+Lukáš Zapletal <lzap@redhat.com> <lzap+rpm@redhat.com>
+Malhar Jivrajani <mjivraja@redhat.com> <101559972+mjivraja@users.noreply.github.com>
+Marie Dolezelova <mdolezel@redhat.com> <41426188+mdolezelova@users.noreply.github.com>
+Markus Reisner <reisner@atix.de> <markusreisner@goatway.de>
 Maximilian Kolb <kolb@atix.de>
+Maximilian Kolb <kolb@atix.de> <mail@maximilian-kolb.de>
 Melanie Corr <mcorr@redhat.com> <37373425+melcorr@users.noreply.github.com>
 Partha Aji <paji@redhat.com> <parthaa@gmail.com>
 Rahul Bajaj <rahulrb0509@gmail.com>
-Rahul Bajaj <rahulrb0509@gmail.com> RahulBajaj
-Sergei Petrosian <spetrosi@redhat.com> Sergei <30409084+spetrosi@users.noreply.github.com>
+Sagar Dubewar <sdubewar@redhat.com> <30646108+dubewarsagar@users.noreply.github.com>
+Sagar Dubewar <sdubewar@redhat.com> <dubewar.sagar@gmail.com>
+Sarah Buchanan <sabuchan@redhat.com> <91482741+sabuchan07@users.noreply.github.com>
+Sergei Petrosian <spetrosi@redhat.com> <30409084+spetrosi@users.noreply.github.com>
 Stephen Wadeley <swadeley@redhat.com>
 Suyog Sainkar <ssainkar@redhat.com> <ssainkar@ssainkar.bne.csb>
+Tahlia Richardson <trichard@redhat.com> <3069029+tahliar@users.noreply.github.com>
+Zuzana Lena Ansorgová <zuansorg@redhat.com>


### PR DESCRIPTION
This allows git to map multiple addresses correctly to a single name, which is useful in properly identifying the various authors. Some entries may look redundant, but they assign a proper (single) name where people have used multiple names with the same email address. For example, one with diacritics and one without.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.