### PR TITLE
Updates for Quick start guide

### DIFF
--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -21,7 +21,7 @@
 :MonitoringDocTitle: Monitoring {Project} performance
 :PlanningDocTitle: Planning for {ProjectName}
 :ProvisioningDocTitle: Provisioning hosts
-:QuickstartDocTitle: Quickstart guide for {Project} on {install-on-os}
+:QuickstartDocTitle: Quick start guide for {Project} on {install-on-os}
 :ReleaseNotesDocTitle: Release notes
 :TuningDocTitle: Tuning performance of {ProjectName}
 :UpdatingDocTitle: Updating {ProjectName}

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -21,7 +21,7 @@
 :MonitoringDocTitle: Monitoring {Project} performance
 :PlanningDocTitle: Planning for {ProjectName}
 :ProvisioningDocTitle: Provisioning hosts
-:QuickstartDocTitle: Quick start guide for {Project} on {install-on-os}
+:QuickStartDocTitle: Quick start guide for {Project} on {install-on-os}
 :ReleaseNotesDocTitle: Release notes
 :TuningDocTitle: Tuning performance of {ProjectName}
 :UpdatingDocTitle: Updating {ProjectName}

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -1,8 +1,8 @@
-[id="running-installer_{context}"]
+[id="proc_running-installer_{context}"]
 = Running the {Project} installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `{foreman-installer} --help`, or by running `{foreman-installer} -i` for interactive mode.
-More examples are given in the Installation Options section.
+More examples are described in the `Installation Options` section.
 The `-v` option disables the progress bar and displays all changes.
 
 .Procedure
@@ -13,4 +13,4 @@ The `-v` option disables the progress bar and displays all changes.
 # {installer-scenario}
 ----
 
-When the installer has completed, details are printed about where to find {ProjectServer} and {SmartProxy}.
+The script displays its progress and writes logs to `{installer-log-file}`.

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -1,0 +1,17 @@
+[id="running-installer_{context}"]
+= Running the Installer
+
+The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.
+More examples are given in the Installation Options section.
+The `-v` option disables the progress bar and displays all changes.
+
+.Procedure
+
+* Run the following command:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {installer-scenario}
+----
+
+When the installer has completed, details are printed about where to find Foreman and the Smart Proxy.

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -1,5 +1,5 @@
 [id="running-installer_{context}"]
-= Running the Installer
+= Running the {Project} installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `{foreman-installer} --help`, or by running `{foreman-installer} -i` for interactive mode.
 More examples are given in the Installation Options section.

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -1,7 +1,7 @@
 [id="running-installer_{context}"]
 = Running the Installer
 
-The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.
+The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `{foreman-installer} --help`, or by running `{foreman-installer} -i` for interactive mode.
 More examples are given in the Installation Options section.
 The `-v` option disables the progress bar and displays all changes.
 

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -1,4 +1,4 @@
-[id="proc_running-installer_{context}"]
+[id="running-the-{project-context}-installer_{context}"]
 = Running the {Project} installer
 
 The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `{foreman-installer} --help`, or by running `{foreman-installer} -i` for interactive mode.

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -6,7 +6,6 @@ More examples are given in the Installation Options section.
 The `-v` option disables the progress bar and displays all changes.
 
 .Procedure
-
 * Run the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_running-installer.adoc
+++ b/guides/common/modules/proc_running-installer.adoc
@@ -13,4 +13,4 @@ The `-v` option disables the progress bar and displays all changes.
 # {installer-scenario}
 ----
 
-When the installer has completed, details are printed about where to find Foreman and the Smart Proxy.
+When the installer has completed, details are printed about where to find {ProjectServer} and {SmartProxy}.

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -13,7 +13,7 @@ It uses native OS packaging (`.rpm` or `.deb` packages) and adds necessary confi
 Components include the Foreman web UI, Smart Proxy, a Puppet server, TFTP, DNS and DHCP servers.
 It is configurable and the Puppet modules can be read or run in "no-op" mode to see what changes it will make.
 
-include::common/modules/ref_supported-operating-systems.adoc[]
+include::common/modules/ref_supported-operating-systems.adoc[leveloffset=+1]
 
 The installation requires {project-minimum-memory} of memory.
 For more information, see {InstallingServerDocURL}system-requirements_{project-context}[System Requirements].
@@ -25,17 +25,5 @@ include::common/modules/proc_configuring-repositories.adoc[leveloffset=+1]
 
 include::common/modules/proc_installing-the-satellite-server-packages.adoc[leveloffset=+1]
 
-== Running the Installer
+include::common/modules/proc_running-installer.adoc[leveloffset=+1]
 
-The installation run is non-interactive, but the configuration can be customized by supplying any of the options listed in `foreman-installer --help`, or by running `foreman-installer -i` for interactive mode.
-More examples are given in the Installation Options section.
-Adding `-v` will disable the progress bar and display all changes.
-
-To run the installer, execute:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {installer-scenario}
-----
-
-When the installer has completed, details will be printed about where to find Foreman and the Smart Proxy.


### PR DESCRIPTION
- Fixed title (quickstart > quick start)
- Moved installer procedure to a module


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
