### PR TITLE
Hide fapolicyd sections on all Debian guides

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -24,9 +24,12 @@ ifdef::foreman-el,foreman-deb[]
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
+// we do not package "fapolicy" for Foreman on Debian/Ubuntu
+ifndef::foreman-deb[]
 include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
 
 include::modules/proc_installing-fapolicyd-on-server.adoc[leveloffset=+2]
+endif::[]
 
 // Installing {SmartProxyServer} Packages
 include::modules/proc_installing-capsule-server-packages.adoc[leveloffset=+1]

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -22,9 +22,12 @@ include::modules/proc_downloading-the-binary-dvd-images.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc[leveloffset=+1]
 
+// we do not package "fapolicy" for Foreman on Debian/Ubuntu
+ifndef::foreman-deb[]
 include::modules/con_using-fapolicyd-on-server.adoc[leveloffset=+1]
 
 include::modules/proc_installing-fapolicyd-on-server.adoc[leveloffset=+2]
+endif::[]
 
 include::modules/proc_installing-from-the-offline-repositories.adoc[leveloffset=+1]
 


### PR DESCRIPTION
In f187b7dfa0bb399ffd6d59c644b0dd48f769eb80 it was already hidden for the installing server guide, but this also hides it for other guides where it's included.

This came up while reviewing the Installing Foreman Proxy on Debian/Ubuntu with @apinnick.

I think it raises the question if this is the best way of hiding things. Would it make sense to have something like an assembly for this?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.