### PR TITLE
Merge the DNS/DHCP/TFTP sections between server/proxy

### DIFF
--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -31,11 +31,10 @@ endif::[]
 * Enter the `{foreman-installer}` command with the options appropriate for your environment.
 The following example shows configuring full provisioning services:
 
-ifeval::["{context}" == "{project-context}"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-proxy-dns true \
 --foreman-proxy-dns-managed true \
 --foreman-proxy-dns-zone _example.com_ \
@@ -52,28 +51,6 @@ ifeval::["{context}" == "{project-context}"]
 
 You can monitor the progress of the `{foreman-installer}` command displayed in your prompt.
 You can view the logs in `{installer-log-file}`.
-You can view the settings used, including the `initial_admin_password` parameter, in the `/etc/foreman-installer/scenarios.d/{project-context}-answers.yaml` file.
-endif::[]
-
-ifeval::["{context}" == "{smart-proxy-context}"]
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {installer-scenario-smartproxy} \
---foreman-proxy-dns true \
---foreman-proxy-dns-managed true \
---foreman-proxy-dns-zone _example.com_ \
---foreman-proxy-dns-reverse _2.0.192.in-addr.arpa_ \
---foreman-proxy-dhcp true \
---foreman-proxy-dhcp-managed true \
---foreman-proxy-dhcp-range "_192.0.2.100_ _192.0.2.150_" \
---foreman-proxy-dhcp-gateway _192.0.2.1_ \
---foreman-proxy-dhcp-nameservers _192.0.2.2_ \
---foreman-proxy-tftp true \
---foreman-proxy-tftp-managed true \
---foreman-proxy-tftp-servername _192.0.2.3_
-----
-endif::[]
 
 .Additional resources
 * For more information about the `{installer-scenario}` command, enter `{installer-scenario} --help`.


### PR DESCRIPTION
On an existing installation the foreman-installer command can be used, without any additional options like the scenario. In fact, it's recommended. Given the position in the guide (under "additional") we can assume it's an existing installation. This also allows us to merge the instructions for servers and proxies.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.