### PR TITLE
Correct installer-scenario-smartproxy attribute for orcharhino

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -35,7 +35,7 @@
 :dnf-module: orcharhino:el8
 :foreman-example-com: orcharhino.example.com
 :installer-log-file: /var/log/foreman-installer/katello.log
-:installer-scenario-smartproxy: orcharhino-installer --no-enable-foreman
+:installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content
 :installer-scenario: foreman-installer --scenario katello
 :project-client-name: {Project}{nbsp}Client
 :project-minimum-memory: 20 GB


### PR DESCRIPTION
This aligns it with Katello. Even if it's unused, it's less confusing.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.