### PR TITLE
Require standard VGA for VNC to hosts on Proxmox

### DIFF
--- a/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
+++ b/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
@@ -7,6 +7,9 @@ Use this procedure to add a remote console connection using VNC for a host on Pr
 * This procedure only works for hosts based on `qemu`.
 It does not work for LXC container on Proxmox.
 
+.Prerequisites
+* Ensure that your host has `Standard VGA` selected from the *VGA* list.
+
 .Procedure
 . On your Proxmox, open the required port for VNC:
 +


### PR DESCRIPTION
You can only access hosts running on Proxmox through remote console if they use a specific VGA option.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
