### PR TITLE
Update release notes for Foreman 3.9.2

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/foreman-3.9.2.adoc[leveloffset=+1]
 include::topics/foreman-3.9.1.adoc[leveloffset=+1]
 include::topics/foreman-3.9.0.adoc[leveloffset=+1]
 include::topics/katello-4.11.1.adoc[leveloffset=+1]

--- a/guides/doc-Release_Notes/topics/foreman-3.9.2.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.9.2.adoc
@@ -1,0 +1,24 @@
+= Foreman 3.9.2
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1799[Redmine]
+
+== Foreman
+
+=== JavaScript stack
+
+* pass:[EditorView snapshots change because of classnames update] - https://projects.theforeman.org/issues/37026[#37026]
+
+=== Reporting
+
+* pass:[Getting "undefined method '#name' for NilClass::Jail (NilClass) (Safemode::NoMethodError)" error generating subscription report ] - https://projects.theforeman.org/issues/37016[#37016]
+
+=== Web Interface
+
+* pass:[Closing parent nav should also close child nav] - https://projects.theforeman.org/issues/37067[#37067]
+* pass:[Expanding a section should collapse other expanded sections] - https://projects.theforeman.org/issues/37025[#37025]
+
+== Packaging
+
+=== RPMs
+
+* pass:[rubygem-ipmitool is missing ipmitool dependency] - https://projects.theforeman.org/issues/37246[#37246]


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
