### PR TITLE
Document new UI that allows importing/overriding Ansible variables from YAML files in foreman_ansible.

### DIFF
--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -10,6 +10,8 @@ include::modules/proc_importing-ansible-roles-and-variables.adoc[leveloffset=+1]
 
 include::modules/proc_overriding-ansible-variables-in-project.adoc[leveloffset=+1]
 
+include::modules/proc_importing-ansible-variables-from-yaml-files.adoc[leveloffset=+1]
+
 ifndef::foreman-deb[]
 include::modules/proc_adding-rhel-system-roles.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/proc_importing-ansible-variables-from-yaml-files.adoc
+++ b/guides/common/modules/proc_importing-ansible-variables-from-yaml-files.adoc
@@ -1,0 +1,16 @@
+[id="Importing_Ansible_Variables_From_Yaml_Files_{context}"]
+= Importing Ansible variables from YAML files
+
+You can import Ansible variables from a `.yaml` file to {Project} within the {ProjectWebUI}.
+
+.Prerequisites
+* You must have at least one Ansible role imported.
+For more information, see xref:Importing_Ansible_Roles_and_Variables_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Configure* > *Ansible* > *Variables*.
+. Click *Import from YAML-File* in the toolbar.
++
+A wizard opens to show you the next steps to import and override Ansible variables.
+Ensure that variables are unique per Ansible role.
+. Click *Finish* to import Ansible variables into {Project}.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

This PR adds documentation for theforeman/foreman_ansible#707
