### PR TITLE
Consistently use foreman-installer to reconfigure REX mode

### DIFF
--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc
@@ -19,8 +19,7 @@ To use `pull-mqtt` mode on {ProjectServer}, follow the procedure below:
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
-# {installer-scenario} \
---foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
 ----
 . Configure the firewall to allow MQTT service on port 1883:
 +

--- a/guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc
+++ b/guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc
@@ -22,8 +22,7 @@ If you wish to avoid this scenario, configure all {SmartProxies} to use the same
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
-# {installer-scenario-smartproxy} \
---foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
 ----
 . Configure the firewall to allow MQTT service:
 +


### PR DESCRIPTION
This always uses foreman-installer without additional arguments. That can be used on existing installations and from the context it's clear that this is only applicable in those installations.

It's similar to https://github.com/theforeman/foreman-documentation/pull/2932.

These files are all very similar, but I don't have time to see if we can merge them.

* `guides/common/modules/proc_configuring-remote-execution-for-pull-client-smart-proxy.adoc`
* `guides/common/modules/proc_rex-pull-based-transport.adoc`
* `guides/common/modules/proc_configuring-remote-execution-for-pull-client-on-project-server.adoc`
* `guides/common/modules/proc_increasing-host-limit-for-pull-based-rex-transport.adoc`

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.