### PR TITLE
Replace installer-scenario attribute with foreman-installer when possible

### DIFF
--- a/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
+++ b/guides/common/modules/proc_configuring-dns-dhcp-and-tftp.adoc
@@ -53,7 +53,7 @@ You can monitor the progress of the `{foreman-installer}` command displayed in y
 You can view the logs in `{installer-log-file}`.
 
 .Additional resources
-* For more information about the `{installer-scenario}` command, enter `{installer-scenario} --help`.
+* For more information about the `{foreman-installer}` command, enter `{foreman-installer} --help`.
 ifeval::["{context}" == "{smart-proxy-context}"]
 ifndef::foreman-deb,orcharhino[]
 * For more information about configuring DNS, DHCP, and TFTP externally, see xref:configuring-external-services[].

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-gss-tsig-authentication.adoc
@@ -137,12 +137,11 @@ grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard 
 
 .Configuring the {Project} or {SmartProxyServer} that manages the DNS service for the domain
 
-. Use the `{foreman-installer}` command to configure the {Project} or {SmartProxy} that manages the DNS Service for the domain:
-* On {Project}, enter the following command:
+. Configure your {ProjectServer} or {SmartProxyServer} to connect to your DNS service:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate_gss \
 --foreman-proxy-dns-server="_idm1.example.com_" \
@@ -150,30 +149,14 @@ grant {smart-proxy-principal}\047__{foreman-example-com}@EXAMPLE.COM__ wildcard 
 --foreman-proxy-dns-tsig-principal="{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_" \
 --foreman-proxy-dns=true
 ----
-
-* On {SmartProxy}, enter the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {installer-scenario-smartproxy} \
---foreman-proxy-dns-managed=false \
---foreman-proxy-dns-provider=nsupdate_gss \
---foreman-proxy-dns-server="_idm1.example.com_" \
---foreman-proxy-dns-tsig-keytab=/etc/foreman-proxy/dns.keytab \
---foreman-proxy-dns-tsig-principal="{smart-proxy-principal}/_{foreman-example-com}@EXAMPLE.COM_" \
---foreman-proxy-dns=true
-----
-
-After you run the `{foreman-installer}` command to make any changes to your {SmartProxy} configuration, you must update the configuration of each affected {SmartProxy} in the {ProjectWebUI}.
-
-.Updating the configuration in the {ProjectWebUI}
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProductName}, and from the list in the *Actions* column, select *Refresh*.
-. Configure the domain:
-.. In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains* and select the domain name.
-.. In the *Domain* tab, ensure *DNS {SmartProxy}* is set to the {SmartProxy} where the subnet is connected.
-. Configure the subnet:
-.. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select the subnet name.
-.. In the *Subnet* tab, set *IPAM* to *None*.
-.. In the *Domains* tab, select the domain that you want to manage using the IdM server.
-.. In the *{SmartProxies}* tab, ensure *Reverse DNS {SmartProxy}* is set to the {SmartProxy} where the subnet is connected.
-.. Click *Submit* to save the changes.
+. For each affected {SmartProxy}, update the configuration of that {SmartProxy} in the {ProjectWebUI}:
+.. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*, locate the {ProductName}, and from the list in the *Actions* column, select *Refresh*.
+.. Configure the domain:
+... In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains* and select the domain name.
+... In the *Domain* tab, ensure *DNS {SmartProxy}* is set to the {SmartProxy} where the subnet is connected.
+.. Configure the subnet:
+... In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select the subnet name.
+... In the *Subnet* tab, set *IPAM* to *None*.
+... In the *Domains* tab, select the domain that you want to manage using the IdM server.
+... In the *{SmartProxies}* tab, ensure *Reverse DNS {SmartProxy}* is set to the {SmartProxy} where the subnet is connected.
+... Click *Submit* to save the changes.

--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -87,7 +87,7 @@ Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to t
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-proxy-dns-managed=false \
 --foreman-proxy-dns-provider=nsupdate \
 --foreman-proxy-dns-server="_IdM_Server_IP_Address_" \

--- a/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
+++ b/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
@@ -14,8 +14,7 @@ You can use Kerberos authentication to establish an SSH connection for remote ex
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {installer-scenario} \
---foreman-proxy-plugin-remote-execution-script-ssh-kerberos-auth true
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-ssh-kerberos-auth true
 ----
 +
 . To edit the default user for remote execution, in the {ProjectWebUI}, navigate to *Administer* > *Settings* and click the *Remote Execution* tab.

--- a/guides/common/modules/proc_configuring-network-services.adoc
+++ b/guides/common/modules/proc_configuring-network-services.adoc
@@ -9,17 +9,10 @@ This requires configuring {SmartProxyServer} to use the main PXE boot services: 
 Use the `{foreman-installer}` command with the options to configure these services on {ProjectServer}.
 
 ifdef::satellite,orcharhino[]
-To configure these services on an external {SmartProxyServer}, run `{installer-scenario-smartproxy}`.
+To configure these services on an external {SmartProxyServer}, run `{foreman-installer}`.
 endif::[]
 ifdef::orcharhino[]
 For more information, see xref:sources/installation_and_maintenance/installing_orcharhino_proxy.adoc[Installing orcharhino Proxy Guide].
-endif::[]
-
-ifdef::foreman-el,katello[]
-[NOTE]
-====
-While performing a Katello deployment, to configure these services on an external {SmartProxyServer}, run `{foreman-installer} --scenario foreman-proxy-content`.
-====
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -11,7 +11,7 @@ Use the `{foreman-installer}` command to configure {Project} to connect to an ex
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-db-database foreman \
 --foreman-db-host _postgres.example.com_ \
 --foreman-db-manage false \

--- a/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
@@ -9,7 +9,7 @@ ifdef::foreman-deb,foreman-el[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario-smartproxy} \
+# {foreman-installer} \
 --foreman-proxy-registration true \
 --foreman-proxy-templates true \
 --foreman-proxy-template-url "https://_{smartproxy-example-com}_:8000"

--- a/guides/common/modules/proc_configuring-your-project-to-run-ansible-roles.adoc
+++ b/guides/common/modules/proc_configuring-your-project-to-run-ansible-roles.adoc
@@ -37,8 +37,7 @@ If you want to use custom or third party Ansible roles, ensure to configure an e
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario-smartproxy} \
---enable-foreman-proxy-plugin-ansible
+# {foreman-installer} --enable-foreman-proxy-plugin-ansible
 ----
 . Distribute SSH keys to enable {SmartProxies} to connect to hosts using SSH.
 For more information, see {ManagingHostsDocURL}ssh-keys-for-remote-execution-overview_managing-hosts[Distributing SSH Keys for Remote Execution] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -25,7 +25,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-proxy-http true \
 --foreman-proxy-httpboot true \
 --foreman-proxy-tftp true
@@ -77,7 +77,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-proxy-http true \
 --foreman-proxy-httpboot true \
 --foreman-proxy-tftp true

--- a/guides/common/modules/proc_enabling-openscap.adoc
+++ b/guides/common/modules/proc_enabling-openscap.adoc
@@ -9,7 +9,7 @@ To use the OpenSCAP plugin and content on external {SmartProxies}, you must enab
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
-# {installer-scenario-smartproxy} \
+# {foreman-installer} \
 --enable-foreman-proxy-plugin-openscap \
 --foreman-proxy-plugin-openscap-ansible-module true \
 --foreman-proxy-plugin-openscap-puppet-module true

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -11,19 +11,9 @@ For more information, see {ManagingHostsDocURL}Adding_a_Baseboard_Management_Con
 .Procedure
 * To enable BMC, enter the following command:
 +
-ifeval::["{context}" == "{project-context}"]
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {foreman-installer} \
 --foreman-proxy-bmc "true" \
 --foreman-proxy-bmc-default-provider "freeipmi"
 ----
-endif::[]
-ifeval::["{context}" == "{smart-proxy-context}"]
-[options="nowrap", subs="+quotes,attributes"]
-----
-# {installer-scenario-smartproxy} \
---foreman-proxy-bmc "true" \
---foreman-proxy-bmc-default-provider "freeipmi"
-----
-endif::[]

--- a/guides/common/modules/proc_installing-acd-on-server.adoc
+++ b/guides/common/modules/proc_installing-acd-on-server.adoc
@@ -12,5 +12,5 @@ endif::[]
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# {installer-scenario} --enable-foreman-plugin-acd --enable-foreman-proxy-plugin-acd
+# {foreman-installer} --enable-foreman-plugin-acd --enable-foreman-proxy-plugin-acd
 ----

--- a/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_installing-acd-on-smart-proxy.adoc
@@ -10,5 +10,5 @@ For more information, see xref:Installing_ACD_on_Server_{context}[].
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# {installer-scenario-smartproxy} --enable-foreman-proxy-plugin-acd
+# {foreman-installer} --enable-foreman-proxy-plugin-acd
 ----

--- a/guides/common/modules/proc_installing-google-gce-plugin.adoc
+++ b/guides/common/modules/proc_installing-google-gce-plugin.adoc
@@ -9,7 +9,7 @@ This allows you to manage and deploy hosts to GCE.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --enable-foreman-cli-google \
 --enable-foreman-plugin-google
 ----

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -40,7 +40,7 @@ PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {installer-scenario} \
+# {foreman-installer} \
 --foreman-db-database foreman \
 --foreman-db-host _postgres.example.com_ \
 --foreman-db-manage false \

--- a/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
+++ b/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
@@ -14,7 +14,7 @@ For more information, see xref:Configuring_{smart-proxy-context}_Servers_for_Loa
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {installer-scenario-smartproxy} \
+# {foreman-installer} \
 --foreman-proxy-registration true \
 --foreman-proxy-templates true
 ----
@@ -24,7 +24,7 @@ For more information, see xref:Configuring_{smart-proxy-context}_Servers_for_Loa
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {installer-scenario-smartproxy} \
+# {foreman-installer} \
 --foreman-proxy-registration-url "https://_{loadbalancer-example-com}_:{smartproxy_port}" \
 --foreman-proxy-template-url "https://_{loadbalancer-example-com}_:8000"
 ----


### PR DESCRIPTION
On existing installations it's preferable to simply use foreman-installer with the options you wish to change. This replaces it where possible.

Includes https://github.com/theforeman/foreman-documentation/pull/2942.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.