### PR TITLE
Add option to log to JSON file

### DIFF
--- a/guides/common/modules/proc_configuring-logging-to-journal-or-file-based-logging.adoc
+++ b/guides/common/modules/proc_configuring-logging-to-journal-or-file-based-logging.adoc
@@ -32,6 +32,22 @@ For example:
 +
 * `/var/log/foreman/production.log`
 * `/var/log/foreman-proxy.log`
+
+.Procedure for configuring logging to JSON output
+. On your {ProjectServer}, enable logging to JSON output for `{foreman-installer}`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} \
+--foreman-logging-layout json \
+--foreman-logging-type file
+----
+. Optional: Inspect the log messages using `jq`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# cat /var/log/foreman/production.log | jq
+----
 ifdef::satellite[]
 
 .Additional resources


### PR DESCRIPTION
If you change the format to JSON, it's easier to retrieve and aggregate logging information using third party software such as ELK stack or splunk.

See puppet-foreman: $ rg "logging_type|logging_layout" manifests/init.pp

As a follow-up PR, I'd like to rework and shorten this file. Any suggestions or objections?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
