### PR TITLE
Fix broken link to "Using manifests"

### DIFF
--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -37,7 +37,7 @@ Alternatively, you can use Ansible variables to tell the role to import the mani
 The manifest must be imported to the organization to which you will register hosts for conversion.
 +
 You can update your allocations and download the updated manifest from the https://access.redhat.com[Red Hat Customer Portal].
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_subscription_management/2022/html/using_red_hat_subscription_management/using_manifests_con[Using manifests] in _Red Hat Subscription Management_.
+For more information, see https://access.redhat.com/documentation/en-us/subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index#proc-exporting-downloading-manifest-satellite-connected[Exporting and downloading a manifest] in _Creating and managing manifests for a connected Satellite Server_.
 * Ensure that you have enabled and synchronized Red Hat repositories in {Project} for the minor {RHEL} version to which you convert your hosts.
 For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 


### PR DESCRIPTION
- It's not clear what the original link pointed to because the subscription product changed its name and unpublished old docs without setting up redirects. This seems to be the most relevant manifest/subscriptions link.
- If the link can be cherrypicked to older versions, that would probably be better than a 404.
- This link should not change for a while. "1-latest" is intended to be a stable permanent version.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
