### PR TITLE
Add running Ansible playbook in Foreman

### DIFF
--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -17,9 +17,9 @@ For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[
 . Click *Next*.
 . Select the hosts on which you want to run the playbook.
 . In the *playbook* field, paste the content of your Ansible playbook.
-. Optional: Customize any advanced settings and schedule.
+. Follow the wizzard to complete setting the remote job.
 For more information, see xref:executing-a-remote-job_{context}[].
-. Click *Run on selected hosts*.
+. Click *Submit* to run the Ansible playbook on your hosts.
 
 .Additional resources
 * Alternatively, you can import Ansible playbooks from {SmartProxyServers}.

--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -5,7 +5,8 @@ You can run an Ansible playbook on a host or host group by executing a remote jo
 
 .Prerequisites
 * Ansible plugin in {Project} is enabled.
-* You have configured xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[remote job execution].
+* Remote job execution is configured.
+For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[].
 * You have an Ansible playbook ready to use.
 
 .Procedure
@@ -21,7 +22,7 @@ For more information, see xref:executing-a-remote-job_{context}[].
 . Click *Run on selected hosts*.
 
 .Additional resources
-* Alternatively, you can import Ansible playbooks from {SmartProxy}.
-For more information, see:
+* Alternatively, you can import Ansible playbooks from {SmartProxyServers}.
+For more information, see the following resources:
 ** xref:importing-an-ansible-playbook-by-name_{context}[]
 ** xref:importing-all-available-ansible-playbooks_{context}[]

--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -1,0 +1,27 @@
+[id="running-an-ansible-playbook-from-{project-context}_{context}"]
+= Running an Ansible playbook from {Project}
+
+You can run an Ansible playbook on a host or host group by executing a remote job in {Project}.
+
+.Prerequisites
+* Ansible plugin in {Project} is enabled.
+* You have configured xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[remote job execution].
+* You have an Ansible playbook ready to use.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Monitor* > *Jobs*.
+. Click *Run Job*.
+. In *Job category*, select `Ansible Playbook`.
+. In *Job template*, select `Ansible - Run playbook`.
+. Click *Next*.
+. Select the hosts on which you want to run the playbook.
+. In the *playbook* field, paste the content of your Ansible playbook.
+. Optional: Customize any advanced settings and schedule.
+For more information, see xref:executing-a-remote-job_{context}[].
+. Click *Run on selected hosts*.
+
+.Additional resources
+* Alternatively, you can import Ansible playbooks from {SmartProxy}.
+For more information, see:
+** xref:importing-an-ansible-playbook-by-name_{context}[]
+** xref:importing-all-available-ansible-playbooks_{context}[]

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -15,6 +15,8 @@ include::common/assembly_getting-started-with-ansible.adoc[leveloffset=+1]
 
 include::common/assembly_using-ansible-roles.adoc[leveloffset=+1]
 
+include::common/modules/proc_running-an-ansible-playbook.adoc[leveloffset=+1]
+
 include::common/assembly_configuring-and-setting-up-remote-jobs.adoc[leveloffset=+1]
 
 include::common/assembly_integrating-awx.adoc[leveloffset=+1]


### PR DESCRIPTION
We have an old customer request for this use case.
The job template *should* be available in all maintained versions.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
