### PR TITLE
Update contexts for discovered hosts

### DIFF
--- a/guides/common/modules/ref_automatic-contexts-for-discovered-hosts.adoc
+++ b/guides/common/modules/ref_automatic-contexts-for-discovered-hosts.adoc
@@ -1,17 +1,13 @@
 [id="Automatic_Contexts_for_Discovered_Hosts_{context}"]
 = Automatic contexts for discovered hosts
 
-{ProjectServer} assigns an organization and location to discovered hosts according to the following sequence of rules:
+{ProjectServer} assigns an organization and location to discovered hosts automatically according to the following sequence of rules:
 
 . If a discovered host uses a subnet defined in {Project}, the host uses the first organization and location associated with the subnet.
-. If the `discovery_organization` or `discovery_location` fact values are set, the discovered host uses these fact values as an organization and location.
-To set these fact values, navigate to *Administer* > *Settings* > *Discovered*, and add these facts to the *Default organization* and *Default location* fields.
-Ensure that the discovered host's subnet also belongs to the organization and location set by the fact, otherwise {Project} refuses to set it for security reasons.
-. If none of the previous conditions exists, {Project} assigns the first Organization and Location ordered by name.
+. If the default location and organization is configured in global settings, the discovered hosts are placed in this organization and location.
+To configure these settings, navigate to *Administer* > *Settings* > *Discovery* and select values for the *Discovery organization* and *Discovery location* settings.
+Ensure that the subnet of discovered host also belongs to the selected organization and location, otherwise {Project} refuses to set it for security reasons.
+. If none of the previous conditions is met, {Project} assigns the first organization and location ordered by name.
 
-You can change the organization or location using the bulk actions menu of the *Discovered hosts* page.
-Select the discovered hosts to modify and select *Assign Organization* or *Assign Location* from the *Select Action* menu.
-
-Note that the `foreman_organization` and `foreman_location` facts are no longer valid values for assigning context for discovered hosts.
-You still can use these facts to configure the host for Puppet runs.
-To do this, navigate to *Administer* > *Settings* > *Puppet* section and add the `foreman_organization` and `foreman_location` facts to the *Default organization* and *Default location* fields.
+You can change the organization or location manually by using the bulk actions on the *Discovered Hosts* page.
+Select the discovered hosts to modify and, from the *Select Action* menu, select *Assign Organization* or *Assign Location*.


### PR DESCRIPTION
Old changes in global settings require this update.
Tested on Foreman 3.9 and Foreman 3.3.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
