### PR TITLE
Remove deprecated plugin foreman_hooks

### DIFF
--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -27,8 +27,6 @@ endif::[]
 * Review and update your firewall configuration before upgrading your {ProjectServer}.
 For more information, see {InstallingServerDisconnectedDocURL}Port_and_firewall_requirements_satellite[Port and firewall requirements] in _{InstallingServerDisconnectedDocTitle}_.
 * Ensure that you do not delete the manifest from the Customer Portal or in the {ProjectWebUI} because this removes all the entitlements of your content hosts.
-* Back up and remove all Foreman hooks before upgrading.
-Reinstate hooks only after {Project} is known to be working after the upgrade is complete.
 ifdef::satellite[]
 * All {ProjectServer}s must be on the same version.
 endif::[]

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -134,13 +134,6 @@ ifdef::satellite[]
 Foreman is the main upstream counterpart of {ProjectName}.
 endif::[]
 
-[[Foreman_Hook]]
-Foreman hook:: An executable that is automatically triggered when an orchestration event occurs, such as when a host is created or when provisioning of a host has completed.
-ifdef::satellite,orcharhino[]
-+
-Foreman hook functionality is deprecated and will be removed in a future {Project} version.
-endif::[]
-
 [[Full_host_image]]
 Full host image:: A boot disk used for PXE-less provisioning of a specific host.
 The full host image contains an embedded Linux kernel and init RAM disk of the associated operating system installer.


### PR DESCRIPTION
foreman_hooks is deprecated and will be removed with Foreman 3.11. See https://github.com/theforeman/foreman_hooks

This PR is a response to https://github.com/theforeman/foreman-documentation/pull/2950#discussion_r1560682095

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.