### PR TITLE
Add option to switch back to SSH REX mode

### DIFF
--- a/guides/common/modules/con_transport-modes-for-remote-execution.adoc
+++ b/guides/common/modules/con_transport-modes-for-remote-execution.adoc
@@ -9,6 +9,16 @@ The SSH service must be enabled and active on the target hosts.
 The remote execution {SmartProxy} must have access to the SSH port on the target hosts.
 Unless you have a different setting, the standard SSH port is 22.
 
+[NOTE]
+====
+If your {SmartProxy} already uses the `pull-mqtt` mode and you want to switch back to the `ssh` mode, run this `{foreman-installer}` command:
+
+[options="nowrap",subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode=ssh
+----
+====
+
 On {SmartProxies} in `pull-mqtt` mode, remote execution uses Message Queueing Telemetry Transport (MQTT) to publish jobs it receives from {ProjectServer}.
 The host subscribes to the MQTT broker on {SmartProxy} for job notifications using the `yggdrasil` pull client.
 After the host receives a notification, it pulls job details from {SmartProxy} over HTTPS, runs the job, and reports results back to {SmartProxy}.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2269398


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
