### PR TITLE
Overwrite SmartProxy port for orcharhino

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -43,6 +43,7 @@
 :smart-proxy-context-titlecase: orcharhino_Proxy
 :smart-proxy-principal: orcharhinoproxy
 :smartproxy-example-com: orcharhino-proxy.example.com
+:smartproxy_port: 9090
 :fdi-package-name: orcharhino-fdi
 :project-debug: orcharhino-debug
 // Overwritten in downstream for docs.orcharhino.com


### PR DESCRIPTION
orcharhino Proxies now follow Katello and Satellite:

````
$ rg smartproxy_port guides/common/attributes*
guides/common/attributes-satellite.adoc
115::smartproxy_port: 9090

guides/common/attributes-orcharhino.adoc
46::smartproxy_port: 9090

guides/common/attributes-katello.adoc
10::smartproxy_port: 9090
````

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15)
