### PR TITLE
Update proc_configuring-server-to-synchronize-content-over-a-network.…

### DIFF
--- a/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
@@ -11,7 +11,7 @@ For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories
 * The upstream user is an admin or has the following permissions:
 ** `view_organizations`
 ** `view_products`
-** `edit_organizations` (to download the CA certificate)
+** `export_content`
 ** `view_lifecycle_environments`
 ** `view_content_views`
 * On the downstream {ProjectServer}, you have imported the SSL certificate of the upstream {ProjectServer} using the contents of `http://_upstream-{foreman-example-com}_/pub/katello-server-ca.crt`.


### PR DESCRIPTION
…adoc

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=2275343  as of 6.14, edit_organizations is no longer needed to set up inter-satellite sync. Instead there is an export_content role that should be used instead. This was fixed in bz 2143051


* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
