### PR TITLE
Refs #37334 - Add keycloak-httpd-client-install EL9 removal warning

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -19,6 +19,17 @@ Users are required to change the DNF module, but the actual upgrade, including d
 During the upgrade a backup of the data is created in `/var/lib/pgsql/data-old`.
 This backup can be removed once the upgrade is completed.
 
+=== keycloak-httpd-client-install dropped from {EL} 9
+
+Foreman has shipped its own `keycloak-httpd-client-install` package because initially the version shipped in {EL} 7 was too old to support ODIC.
+Recently it was noticed that the version in {EL} 8 contains the required features, but still contains a https://issues.redhat.com/browse/RHEL-31496[packaging bug].
+The version in {EL} 9 contains all the required features, but is older than what Foreman has shipped.
+Foreman 3.10 was the first release on {EL} 9 and it was marked as experimental.
+Because of that it's been decided to drop it from Foreman's {EL} 9 packaging.
+Users who have this package installed should downgrade it using `dnf downgrade keycloak-httpd-client-install`.
+
+For more details, see https://projects.theforeman.org/issues/37334.
+
 [id="foreman-deprecations"]
 == Deprecations
 


### PR DESCRIPTION
This package has been dropped from Foreman's packaging and users need to take manual action.

I think a manual pick to 3.10 is best. There we should mention that it will be dropped with Foreman 3.10.1.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.