### PR TITLE
katello proxies also need repository configuration before installation

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -20,7 +20,7 @@ endif::[]
 ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
-ifdef::foreman-el,foreman-deb[]
+ifdef::foreman-el,foreman-deb,katello[]
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
