### PR TITLE
stop enabling rex after cloning

### DIFF
--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -194,15 +194,6 @@ After you install the `satellite-clone` tool, you can adjust any configuration t
 The cloning process disables these services on the target {ProjectServer} to avoid conflict with the source {ProjectServer}.
 . Reconfigure and enable DHCP, DNS, and TFTP in the {ProjectWebUI}.
 For more information, see {InstallingServerDocURL}configuring-external-services[Configuring External Services on {ProjectServer}] in _{InstallingServerDocTitle}_.
-. Enable remote execution:
-+
-[options="nowrap" subs="attributes"]
-----
-# {installer-scenario} \
---enable-foreman-plugin-remote-execution \
---enable-foreman-proxy-plugin-remote-execution-script
-----
-+
 . Log in to the {ProjectWebUI}, with the username `admin` and the password `changeme`.
 Immediately update the admin password to secure credentials.
 . Ensure that the correct organization is selected.


### PR DESCRIPTION
if it was enabled, it remains enabled, so no need to enable it again


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
