### PR TITLE
Fix issues in the cloning process

### DIFF
--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -44,7 +44,7 @@ Before you begin cloning, ensure the following conditions exist:
 
 * The target server is on an isolated network.
 This avoids unwanted communication with {SmartProxyServers} and hosts.
-* The target server has the capacity to store all your backup files from the source server.
+* The target server has at least the same storage capacity as the source server.
 
 .Customized configuration files
 
@@ -90,7 +90,7 @@ Follow the steps in the procedure in xref:sec_Cloning_Satellite_Server[] and rep
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # rsync --archive --partial --progress --compress \
-/var/lib/pulp _target_server.example.com:/var/lib/pulp_
+/var/lib/pulp/ _target_server.example.com:/var/lib/pulp/_
 ----
 
 Proceed to xref:sec-Cloning_to_Target[].


### PR DESCRIPTION
There are some issues in the cloning process that cause it to fail viz.:
- The `rsync` command copies Pulp data to /var/lib/pulp/pulp which is wrong.
- The Prerequisites should expressly mention that the storage on the target should be at least as much as the source.

BZ link:
https://bugzilla.redhat.com/show_bug.cgi?id=2169707

(cherry picked from commit 798e6e5a304f1f1ab62f63e7e7c5dfa7d24362ef)


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (planned Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
