### PR TITLE
Document compliance remediation wizard

### DIFF
--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -1,8 +1,8 @@
 [id="remediating-compliance-failures_{context}"]
 = Remediating compliance failures
 
-You can examine compliance reports and, in some cases, remediate cases of non-compliance.
-With {Project}, you can remediate cases of non-compliance by using a remediation wizard or by creating remote jobs to apply remediation scripts and snippets.
+With {Project}, you can examine compliance reports and, in some cases, remediate cases of non-compliance.
+You can remediate compliance failures by using a remediation wizard or by applying remediation snippets manually.
 
 [WARNING]
 ====
@@ -25,7 +25,7 @@ Follow the wizard to remediate the compliance failure.
 +
 The remediation wizard might not available for all compliance failures.
 
-To examine a full compliance policy report and remediate compliance failures manually:
+To examine a full compliance policy report:
 
 . In the {ProjectWebUI}, navigate to *Hosts* > *Compliance* > *Reports* to list all compliance reports.
 . In the *Actions* column, click *Full Report*.
@@ -33,8 +33,8 @@ To examine a full compliance policy report and remediate compliance failures man
 . In the *Rule Overview* section, click the title of a rule in the *Title* column to inspect further result details.
 . Click *Remediation Shell script*, *Remediation Ansible snippet*, *Remediation Puppet snippet*, or *Remediation Anaconda snippet* to display remediation advice.
 +
-Remediation scripts and snippets might not available for all compliance failures.
+Remediation snippets might not available for all compliance failures.
 
 .Additional resources
-* You can apply the remediation script or snippet by using a remote job.
+* You can apply the remediation snippet by manually configuring a remote job.
 For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and setting up remote jobs] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -2,6 +2,7 @@
 = Remediating compliance failures
 
 You can examine compliance reports and, in some cases, remediate cases of non-compliance.
+With {Project}, you can remediate cases of non-compliance by using a remediation wizard or by creating remote jobs to apply remediation scripts and snippets.
 
 [WARNING]
 ====
@@ -13,11 +14,16 @@ Remediation might render the system non-functional.
 * Your user account has a role assigned that has the `view_arf_reports` and `view_hosts` permissions.
 
 .Procedure
-To examine a simplified compliance policy report:
+To examine a simplified compliance policy report and run the compliance failure remediation wizard:
 
 . In the {ProjectWebUI}, navigate to *Hosts* > *Compliance* > *Reports*.
 . In the *Reported At* column, click the time link of the report you want to examine.
-{Project} displays a simplified list of policy rules with the results of the scan.
+{Project} displays a list of log messages describing the results of the scan.
+. Locate a log message that describes a failed compliance check.
+In the *Actions* column, select *Remediation* to open the compliance remediation wizard.
+Follow the wizard to remediate the compliance failure.
++
+The remediation wizard might not available for all compliance failures.
 
 To examine a full compliance policy report and remediate compliance failures manually:
 
@@ -26,7 +32,8 @@ To examine a full compliance policy report and remediate compliance failures man
 {Project} displays the complete details of an evaluation report.
 . In the *Rule Overview* section, click the title of a rule in the *Title* column to inspect further result details.
 . Click *Remediation Shell script*, *Remediation Ansible snippet*, *Remediation Puppet snippet*, or *Remediation Anaconda snippet* to display remediation advice.
-Remediation scripts and snippets are not available for all compliance rules.
++
+Remediation scripts and snippets might not available for all compliance failures.
 
 .Additional resources
 * You can apply the remediation script or snippet by using a remote job.

--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -11,7 +11,7 @@ Remediation might render the system non-functional.
 ====
 
 .Prerequisites
-* Your user account has a role assigned that has the `view_arf_reports` and `view_hosts` permissions.
+* Your user account has a role assigned that has the following permissions: `view_arf_reports`, `view_hosts`, `create_job_invocations`
 
 .Procedure
 To examine a simplified compliance policy report and run the compliance failure remediation wizard:

--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -14,8 +14,6 @@ Remediation might render the system non-functional.
 * Your user account has a role assigned that has the following permissions: `view_arf_reports`, `view_hosts`, `create_job_invocations`
 
 .Procedure
-To examine a simplified compliance policy report and run the compliance failure remediation wizard:
-
 . In the {ProjectWebUI}, navigate to *Hosts* > *Compliance* > *Reports*.
 . In the *Reported At* column, click the time link of the report you want to examine.
 {Project} displays a list of log messages describing the results of the scan.

--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -23,7 +23,10 @@ To examine a simplified compliance policy report and run the compliance failure 
 In the *Actions* column, select *Remediation* to open the compliance remediation wizard.
 Follow the wizard to remediate the compliance failure.
 +
+[NOTE]
+====
 The remediation wizard might not be available for all compliance failures.
+====
 
 To examine a full compliance policy report:
 
@@ -33,7 +36,10 @@ To examine a full compliance policy report:
 . In the *Rule Overview* section, click the title of a rule in the *Title* column to inspect further result details.
 . Click *Remediation Shell script*, *Remediation Ansible snippet*, *Remediation Puppet snippet*, or *Remediation Anaconda snippet* to display remediation advice.
 +
+[NOTE]
+====
 Remediation snippets might not be available for all compliance failures.
+====
 
 .Additional resources
 * You can apply the remediation snippet by manually configuring a remote job.

--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -23,7 +23,7 @@ To examine a simplified compliance policy report and run the compliance failure 
 In the *Actions* column, select *Remediation* to open the compliance remediation wizard.
 Follow the wizard to remediate the compliance failure.
 +
-The remediation wizard might not available for all compliance failures.
+The remediation wizard might not be available for all compliance failures.
 
 To examine a full compliance policy report:
 
@@ -33,7 +33,7 @@ To examine a full compliance policy report:
 . In the *Rule Overview* section, click the title of a rule in the *Title* column to inspect further result details.
 . Click *Remediation Shell script*, *Remediation Ansible snippet*, *Remediation Puppet snippet*, or *Remediation Anaconda snippet* to display remediation advice.
 +
-Remediation snippets might not available for all compliance failures.
+Remediation snippets might not be available for all compliance failures.
 
 .Additional resources
 * You can apply the remediation snippet by manually configuring a remote job.

--- a/guides/common/modules/proc_remediating-compliance-failures.adoc
+++ b/guides/common/modules/proc_remediating-compliance-failures.adoc
@@ -28,19 +28,6 @@ Follow the wizard to remediate the compliance failure.
 The remediation wizard might not be available for all compliance failures.
 ====
 
-To examine a full compliance policy report:
-
-. In the {ProjectWebUI}, navigate to *Hosts* > *Compliance* > *Reports* to list all compliance reports.
-. In the *Actions* column, click *Full Report*.
-{Project} displays the complete details of an evaluation report.
-. In the *Rule Overview* section, click the title of a rule in the *Title* column to inspect further result details.
-. Click *Remediation Shell script*, *Remediation Ansible snippet*, *Remediation Puppet snippet*, or *Remediation Anaconda snippet* to display remediation advice.
-+
-[NOTE]
-====
-Remediation snippets might not be available for all compliance failures.
-====
-
 .Additional resources
 * You can apply the remediation snippet by manually configuring a remote job.
 For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and setting up remote jobs] in _{ManagingHostsDocTitle}_.


### PR DESCRIPTION
https://github.com/theforeman/foreman_openscap/pull/546 adds a compliance remediation wizard. This PR updates the procedure on remediating compliance failures to reference the wizard.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (planned Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
