### PR TITLE
Add future downstream version to applicable files

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -25,7 +25,8 @@
 :UpdatingDocURL: {BaseURL}updating_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_connected_red_hat_satellite_to_{ProjectVersion}/index#
 :UpgradingDisconnectedDocURL: {BaseURL}upgrading_disconnected_red_hat_satellite_to_{ProjectVersion}/index#
-:UpgradingPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_red_hat_satellite_to_{ProjectVersionPrevious}/index#
+:UpgradingConnectedPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_connected_red_hat_satellite_to_{ProjectVersionPrevious}/index#
+:UpgradingDisconnectedPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_disconnected_red_hat_satellite_to_{ProjectVersionPrevious}/index#
 
 // Not upstreamed
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -25,8 +25,8 @@
 :UpdatingDocURL: {BaseURL}updating_red_hat_satellite/index#
 :UpgradingDocURL: {BaseURL}upgrading_connected_red_hat_satellite_to_{ProjectVersion}/index#
 :UpgradingDisconnectedDocURL: {BaseURL}upgrading_disconnected_red_hat_satellite_to_{ProjectVersion}/index#
-:UpgradingConnectedPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_connected_red_hat_satellite_to_{ProjectVersionPrevious}/index#
-:UpgradingDisconnectedPreviousDocURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_disconnected_red_hat_satellite_to_{ProjectVersionPrevious}/index#
+:UpgradingPreviousDocURL: {RHDocsBaseURL}red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_connected_red_hat_satellite_to_{ProjectVersionPrevious}/index#
+:UpgradingDisconnectedPreviousDocURL: {RHDocsBaseURL}red_hat_satellite/{ProjectVersionPrevious}/html-single/upgrading_disconnected_red_hat_satellite_to_{ProjectVersionPrevious}/index#
 
 // Not upstreamed
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -1,7 +1,7 @@
 // Attributes only for satellite build
 :install-on-os: RHEL
-:ProjectVersion: 6.15
-:ProjectVersionPrevious: 6.14
+:ProjectVersion: 6.16
+:ProjectVersionPrevious: 6.15
 // Add -beta for Beta releases
 :ProjectVersionRepoTitle: {ProjectVersion}
 

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -27,7 +27,8 @@
 :UpdatingDocTitle: Updating {ProjectName}
 :UpgradingDocTitle: Upgrading {ProjectName} to {ProjectVersion}
 :UpgradingDisconnectedDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersion}
-:UpgradingPreviousDocTitle: Upgrading {ProjectName} to {ProjectVersionPrevious}
+:UpgradingConnectedPreviousDocTitle: Upgrading connected {ProjectName} to {ProjectVersionPrevious}
+:UpgradingDisconnectedPreviousDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersionPrevious}
 
 // Not upstreamed
 :APIDocTitle: API guide

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -27,7 +27,7 @@
 :UpdatingDocTitle: Updating {ProjectName}
 :UpgradingDocTitle: Upgrading {ProjectName} to {ProjectVersion}
 :UpgradingDisconnectedDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersion}
-:UpgradingPreviousDocTitle: Upgrading {ProjectName} to {ProjectVersionPrevious}
+:UpgradingPreviousDocTitle: Upgrading connected {ProjectName} to {ProjectVersionPrevious}
 :UpgradingDisconnectedPreviousDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersionPrevious}
 
 // Not upstreamed

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -27,7 +27,7 @@
 :UpdatingDocTitle: Updating {ProjectName}
 :UpgradingDocTitle: Upgrading {ProjectName} to {ProjectVersion}
 :UpgradingDisconnectedDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersion}
-:UpgradingConnectedPreviousDocTitle: Upgrading connected {ProjectName} to {ProjectVersionPrevious}
+:UpgradingPreviousDocTitle: Upgrading {ProjectName} to {ProjectVersionPrevious}
 :UpgradingDisconnectedPreviousDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersionPrevious}
 
 // Not upstreamed

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -18,5 +18,5 @@ ignore=example.com
   rhsso.com
   sources/
   atixservice.zendesk.com
-  # 6.15 docs are not yet published
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.15
+  # 6.16 docs are not yet published
+  access.redhat.com/documentation/en-us/red_hat_satellite/6.16

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -5,7 +5,7 @@ You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVer
 
 ifdef::satellite[]
 {ProjectServer}s and {SmartProxyServers} on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
-For more information, see {UpgradingPreviousDocURL}[_{UpgradingPreviousDocTitle}_].
+For more information, see {UpgradingConnectedPreviousDocURL}[_{UpgradingConnectedPreviousDocTitle}_] or {UpgradingDisconnectedPreviousDocURL}[_{UpgradingDisconnectedPreviousDocTitle}_].
 endif::[]
 
 .High-level upgrade steps

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -5,7 +5,7 @@ You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVer
 
 ifdef::satellite[]
 {ProjectServer}s and {SmartProxyServers} on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
-For more information, see {UpgradingConnectedPreviousDocURL}[_{UpgradingConnectedPreviousDocTitle}_] or {UpgradingDisconnectedPreviousDocURL}[_{UpgradingDisconnectedPreviousDocTitle}_].
+For more information, see {UpgradingPreviousDocURL}[_{UpgradingPreviousDocTitle}_] or {UpgradingDisconnectedPreviousDocURL}[_{UpgradingDisconnectedPreviousDocTitle}_].
 endif::[]
 
 .High-level upgrade steps


### PR DESCRIPTION
Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
