### PR TITLE
Added the CLI steps in provisioning guide

### DIFF
--- a/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
@@ -15,7 +15,7 @@ If you have a VPC for provisioning new hosts, use its subnet.
 . Click *Submit* to save the compute profile.
 
 .CLI procedure
-. Set Amazon EC2 details to a compute profile:
+* Set Amazon EC2 details to a compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
@@ -22,5 +22,5 @@ If you have a VPC for provisioning new hosts, use its subnet.
 # hammer compute-profile values create 
 --compute-resource "_My_Laptop_" \
 --compute-profile "_My_Compute_Profile_" \
---compute-atributes "flavor_id=1,availability_zone= _My_Zone_,subnet_id=1,security_group_ids=1,managed_ip=public_ip" 
+--compute-attributes "flavor_id=1,availability_zone= _My_Zone_,subnet_id=1,security_group_ids=1,managed_ip=public_ip" 
 ----

--- a/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
@@ -15,5 +15,12 @@ If you have a VPC for provisioning new hosts, use its subnet.
 . Click *Submit* to save the compute profile.
 
 .CLI procedure
-The compute profile CLI commands are not yet implemented in {ProjectName}.
-As an alternative, you can include the same settings directly during the host creation process.
+. To add Amazon EC2 details to a compute profile, use the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile values create 
+--compute-resorce "_My_Laptop_" \
+--compute-profile "_My_Compute_Profile_" \
+--compute-atributes "flavor_id=1,availability_zone= _My_Zone_,subnet_id=1,security_group_ids=1,managed_ip=public_ip" 
+----

--- a/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
@@ -15,12 +15,12 @@ If you have a VPC for provisioning new hosts, use its subnet.
 . Click *Submit* to save the compute profile.
 
 .CLI procedure
-. To add Amazon EC2 details to a compute profile, use the following command:
+. Set Amazon EC2 details to a compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile values create 
---compute-resorce "_My_Laptop_" \
+--compute-resource "_My_Laptop_" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-atributes "flavor_id=1,availability_zone= _My_Zone_,subnet_id=1,security_group_ids=1,managed_ip=public_ip" 
 ----

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
@@ -29,5 +29,5 @@ If not selected, the instance boots the image directly.
 # hammer compute-profile values create 
 --compute-resource "_My_Laptop_" \
 --compute-profile "_My_Compute_Profile_" \
---compute-atributes "availability_zone=_My_Zone_,image_ref=_My_Image_,flavor_ref=m1.small,tenant_id=openstack,security_groups=default,network=_My_Network_,boot_from_volume=false"
+--compute-attributes "availability_zone=_My_Zone_,image_ref=_My_Image_,flavor_ref=m1.small,tenant_id=openstack,security_groups=default,network=_My_Network_,boot_from_volume=false"
 ----

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
@@ -22,7 +22,7 @@ If not selected, the instance boots the image directly.
 . Click *Submit* to save the compute profile.
 
 .CLI procedure
-. Set {OpenStack} details to a compute profile:
+* Set {OpenStack} details to a compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
@@ -22,12 +22,12 @@ If not selected, the instance boots the image directly.
 . Click *Submit* to save the compute profile.
 
 .CLI procedure
-. To add Openstack details to a compute profile, use the following command:
+. Set {OpenStack} details to a compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile values create 
---compute-resorce "_My_Laptop_" \
+--compute-resource "_My_Laptop_" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-atributes "availability_zone=_My_Zone_,image_ref=_My_Image_,flavor_ref=m1.small,tenant_id=openstack,security_groups=default,network=_My_Network_,boot_from_volume=false"
 ----

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
@@ -22,6 +22,12 @@ If not selected, the instance boots the image directly.
 . Click *Submit* to save the compute profile.
 
 .CLI procedure
-
-The compute profile CLI commands are not yet implemented in {ProjectName}.
-As an alternative, you can include the same settings directly during the host creation process.
+. To add Openstack details to a compute profile, use the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile values create 
+--compute-resorce "_My_Laptop_" \
+--compute-profile "_My_Compute_Profile_" \
+--compute-atributes "availability_zone=_My_Zone_,image_ref=_My_Image_,flavor_ref=m1.small,tenant_id=openstack,security_groups=default,network=_My_Network_,boot_from_volume=false"
+----

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -2,6 +2,7 @@
 = Creating compute profiles
 
 You can use compute profiles to predefine virtual machine hardware details such as CPUs, memory, and storage.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-compute-profiles_{context}[]. +
 A default installation of {ProjectName} contains three predefined profiles:
 
 * `1-Small`
@@ -19,3 +20,67 @@ You can apply compute profiles to all supported compute resources:
 . Click *Submit*.
 A new window opens with the name of the compute profile.
 . In the new window, click the name of each compute resource and edit the attributes you want to set for this compute profile.
+
+[id="cli-creating-compute-profiles_{context}"]
+.CLI procedure
+. To create a compute profile, enter the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile create --name "_My_Compute_Profile_"
+----
++
+. To set atributes for a compute profile, enter the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile values create \
+--compute-atributes "flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default \
+--compute-resorce "_My_Laptop_" \
+--compute-profile "_My_Compute_Profile_" \
+--volume size=40GB
+----
++
+. To update the attributes of a compute profile, specify the atributes you want to change. To change the number of CPUs, memory, and volume size, enter the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile values update \ 
+--compute-resorce "_My_Laptop_" \
+--compute-profile "_My_Compute_Profile_" \
+--attributes "cpus=2,memory=4GB" \
+--interface "type=network,bridge=br1,index=1" \
+--volume "size=40GB,index=2"
+----
++
+. If you want to delete a compute profile, enter the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile delete \ 
+--name "_My_Compute_Profile_" \
+--id "_My_Compute_Profile_Id_"
+----
++
+. To change the name of the compute profile you can use `--new-name` atribute:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile update \
+--name "_My_Compute_Profile_" \
+--new-name "_My_New_Compute_Profile_"
+----
++
+. Optional: To list all compute profiles, enter the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile list
+----
++
+. Optional: To view the details of a compute profile, enter the following command:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile show --name "_My_Compute_Profile_"
+----

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -25,25 +25,25 @@ A new window opens with the name of the compute profile.
 
 [id="cli-creating-compute-profiles_{context}"]
 .CLI procedure
-. Create Compute Profile:
+. Create compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile create --name "_My_Compute_Profile_"
 ----
 +
-. Set atributes for the Compute Profile using:
+. Set attributes for compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile values create \
---compute-atributes "flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default \
+--compute-attributes "flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default \
 --compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
 --volume size=40GB
 ----
 +
-. Optional: To update the attributes of a Compute Profile, specify the atributes you want to change. To change the number of CPUs, memory, volume size use the following command:
+. Optional: To update the attributes of a compute profile, specify the attributes you want to change. To change the number of CPUs, memory, volume size use the following command:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -55,34 +55,11 @@ A new window opens with the name of the compute profile.
 --volume "size=40GB,index=2"
 ----
 +
-. To change the name of the compute profile you can use `--new-name` atribute:
+. Optional: To change the name of the compute profile you can use `--new-name` attribute:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile update \
 --name "_My_Compute_Profile_" \
 --new-name "_My_New_Compute_Profile_"
-----
-+
-. Optional: Delete a Compute Profile:
-+
-[options="nowrap" subs="+quotes"]
-----
-# hammer compute-profile delete \ 
---name "_My_Compute_Profile_" \
---id "_My_Compute_Profile_Id_"
-----
-+
-. Optional: View all Compute Profiles:
-+
-[options="nowrap" subs="+quotes"]
-----
-# hammer compute-profile list
-----
-+
-. Optional: View details of a Compute Profile:
-+
-[options="nowrap" subs="+quotes"]
-----
-# hammer compute-profile show --name "_My_Compute_Profile_"
 ----

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -25,22 +25,22 @@ A new window opens with the name of the compute profile.
 
 [id="cli-creating-compute-profiles_{context}"]
 .CLI procedure
-. Create compute profile:
+. Create a new compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile create --name "_My_Compute_Profile_"
 ----
 +
-. Set attributes for compute profile:
+. Set attributes for the compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile values create \
---compute-attributes "flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default \
+--compute-attributes "_flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default_ \
 --compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
---volume size=40GB
+--volume size=_40GB_
 ----
 +
 . Optional: To update the attributes of a compute profile, specify the attributes you want to change. To change the number of CPUs, memory, volume size use the following command:
@@ -50,12 +50,12 @@ A new window opens with the name of the compute profile.
 # hammer compute-profile values update \ 
 --compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
---attributes "cpus=2,memory=4GB" \
---interface "type=network,bridge=br1,index=1" \
---volume "size=40GB,index=2"
+--attributes "_cpus=2,memory=4GB_" \
+--interface "_type=network,bridge=br1,index=1_" \
+--volume "size=_40GB_"
 ----
 +
-. Optional: To change the name of the compute profile you can use `--new-name` attribute:
+. Optional: To change the name of the compute profile, use the `--new-name` attribute:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -63,3 +63,7 @@ A new window opens with the name of the compute profile.
 --name "_My_Compute_Profile_" \
 --new-name "_My_New_Compute_Profile_"
 ----
+
+.Additional resources
+
+* For more information about creating compute-profile by using Hammer, enter `hammer compute-profile --help`.

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -2,7 +2,9 @@
 = Creating compute profiles
 
 You can use compute profiles to predefine virtual machine hardware details such as CPUs, memory, and storage.
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-compute-profiles_{context}[]. +
+
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-compute-profiles_{context}[].
+
 A default installation of {ProjectName} contains three predefined profiles:
 
 * `1-Small`
@@ -23,43 +25,34 @@ A new window opens with the name of the compute profile.
 
 [id="cli-creating-compute-profiles_{context}"]
 .CLI procedure
-. To create a compute profile, enter the following command:
+. Create Compute Profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile create --name "_My_Compute_Profile_"
 ----
 +
-. To set atributes for a compute profile, enter the following command:
+. Set atributes for the Compute Profile using:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile values create \
 --compute-atributes "flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default \
---compute-resorce "_My_Laptop_" \
+--compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
 --volume size=40GB
 ----
 +
-. To update the attributes of a compute profile, specify the atributes you want to change. To change the number of CPUs, memory, and volume size, enter the following command:
+. Optional: To update the attributes of a Compute Profile, specify the atributes you want to change. To change the number of CPUs, memory, volume size use the following command:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile values update \ 
---compute-resorce "_My_Laptop_" \
+--compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
 --attributes "cpus=2,memory=4GB" \
 --interface "type=network,bridge=br1,index=1" \
 --volume "size=40GB,index=2"
-----
-+
-. If you want to delete a compute profile, enter the following command:
-+
-[options="nowrap" subs="+quotes"]
-----
-# hammer compute-profile delete \ 
---name "_My_Compute_Profile_" \
---id "_My_Compute_Profile_Id_"
 ----
 +
 . To change the name of the compute profile you can use `--new-name` atribute:
@@ -71,14 +64,23 @@ A new window opens with the name of the compute profile.
 --new-name "_My_New_Compute_Profile_"
 ----
 +
-. Optional: To list all compute profiles, enter the following command:
+. Optional: Delete a Compute Profile:
++
+[options="nowrap" subs="+quotes"]
+----
+# hammer compute-profile delete \ 
+--name "_My_Compute_Profile_" \
+--id "_My_Compute_Profile_Id_"
+----
++
+. Optional: View all Compute Profiles:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer compute-profile list
 ----
 +
-. Optional: To view the details of a compute profile, enter the following command:
+. Optional: View details of a Compute Profile:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -31,7 +31,6 @@ A new window opens with the name of the compute profile.
 ----
 # hammer compute-profile create --name "_My_Compute_Profile_"
 ----
-+
 . Set attributes for the compute profile:
 +
 [options="nowrap" subs="+quotes"]
@@ -42,8 +41,8 @@ A new window opens with the name of the compute profile.
 --compute-profile "_My_Compute_Profile_" \
 --volume size=_40GB_
 ----
-+
-. Optional: To update the attributes of a compute profile, specify the attributes you want to change. To change the number of CPUs, memory, volume size use the following command:
+. Optional: To update the attributes of a compute profile, specify the attributes you want to change.
+For example, to change the number of CPUs and memory size:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -54,7 +53,6 @@ A new window opens with the name of the compute profile.
 --interface "_type=network,bridge=br1,index=1_" \
 --volume "size=_40GB_"
 ----
-+
 . Optional: To change the name of the compute profile, use the `--new-name` attribute:
 +
 [options="nowrap" subs="+quotes"]
@@ -66,4 +64,4 @@ A new window opens with the name of the compute profile.
 
 .Additional resources
 
-* For more information about creating compute-profile by using Hammer, enter `hammer compute-profile --help`.
+* For more information about creating compute profiles by using Hammer, enter `hammer compute-profile --help`.


### PR DESCRIPTION
Added CLI steps for these guides: 
creating compute profiles
adding amazon ec2 details to a compute profile 
adding openstack details to a compute profile


* [yes] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:
(Im not sure what this means)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
