### PR TITLE
De-specify the number of available content filter types

### DIFF
--- a/guides/common/modules/con_content-filter-overview.adoc
+++ b/guides/common/modules/con_content-filter-overview.adoc
@@ -29,7 +29,7 @@ In this situation, select which content to include, then which content to exclud
 
 .Content types
 
-There are also five types of content to filter:
+You can filter content based on the following content types:
 
 .Content types
 [cols="2,3"]


### PR DESCRIPTION
_"There are also five types of content to filter:"_ No, there are not! :)

I propose a minor change in wording to eliminate the need to specify the exact number of content types because that's very difficult to maintain.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
