### PR TITLE
Adding note into Reclaiming space from on demand repositories

### DIFF
--- a/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
+++ b/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
@@ -4,6 +4,13 @@
 If you set the _download policy_ to on demand, {Project} downloads packages only when the clients request them.
 You can clean up these packages to reclaim space.
 
+[NOTE]
+====
+Space reclamation requires an existing repository. For deleted repositories, wait for the next scheduled orphan cleanup or run: 
+----
+# foreman-rake katello:delete_orphaned_content
+----
+====
 .For a single repository
 * In the {ProjectWebUI}, navigate to *Content* > *Products*.
 * Select a product.

--- a/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
+++ b/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
@@ -6,7 +6,8 @@ You can clean up these packages to reclaim space.
 
 [NOTE]
 ====
-Space reclamation requires an existing repository. For deleted repositories, wait for the next scheduled orphan cleanup or run: 
+Space reclamation requires an existing repository.
+For deleted repositories, wait for the next scheduled orphan cleanup or remove orphaned content manually:
 ----
 # foreman-rake katello:delete_orphaned_content
 ----


### PR DESCRIPTION
As described in the linked issue I added a note about deleted repositories.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
