### PR TITLE
Revert "Refs #37334 - Add keycloak-httpd-client-install EL9 removal warning (#2970)"

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -19,17 +19,6 @@ Users are required to change the DNF module, but the actual upgrade, including d
 During the upgrade a backup of the data is created in `/var/lib/pgsql/data-old`.
 This backup can be removed once the upgrade is completed.
 
-=== keycloak-httpd-client-install dropped from {EL} 9
-
-Foreman has shipped its own `keycloak-httpd-client-install` package because initially the version shipped in {EL} 7 was too old to support ODIC.
-Recently it was noticed that the version in {EL} 8 contains the required features, but still contains a https://issues.redhat.com/browse/RHEL-31496[packaging bug].
-The version in {EL} 9 contains all the required features, but is older than what Foreman has shipped.
-Foreman 3.10 was the first release on {EL} 9 and it was marked as experimental.
-Because of that it's been decided to drop it from Foreman's {EL} 9 packaging.
-Users who have this package installed should downgrade it using `dnf downgrade keycloak-httpd-client-install`.
-
-For more details, see https://projects.theforeman.org/issues/37334.
-
 [id="foreman-deprecations"]
 == Deprecations
 


### PR DESCRIPTION
This reverts commit 5ca070d0f723f3070e062366dca9d91fb762874e.

According to #37334, this has been fixed for Foreman 3.11. Because we will branch docs for Foreman 3.11 based on "master", we have to revert this.

**I have merged this by mistake to "master".**