### PR TITLE
Changing the note in Creating a content view

### DIFF
--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -29,11 +29,6 @@ This can also cause errors when resolving dependencies for errata.
 . Click *Next*.
 . On the *Review* page, you can review the environments you are trying to publish.
 . Click *Finish*.
-+
-[WARNING]
-====
-*Delete* option deletes the entire content view and the versions associated with that lifecycle environment.
-====
 
 You can view the content view on the *Content Views* page.
 To view more information about the content view, click the content view name.

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -30,10 +30,9 @@ This can also cause errors when resolving dependencies for errata.
 . On the *Review* page, you can review the environments you are trying to publish.
 . Click *Finish*.
 +
-[NOTE]
+[WARNING]
 ====
-*Remove* and *Delete* are similar but the *Delete* option deletes an entire content view and the versions associated with that lifecycle environment.
-The *Remove* option allows you to choose which version you want removed from the lifecycle environment.
+*Delete* option deletes the entire content view and the versions associated with that lifecycle environment.
 ====
 
 You can view the content view on the *Content Views* page.


### PR DESCRIPTION
Relevant issue is https://github.com/theforeman/foreman-documentation/issues/1635

I have changed the note into a warning and deleted mentions of the remove option. 
My thought process for removing mentions of Remove is that relevant information about deleting one or multiple versions is [here](https://docs.theforeman.org/nightly/Managing_Content/index-katello.html#Deleting_Multiple_Content_View_Versions_content-management), a few chapters below.
I left the mention of Delete because i could not find it mentioned anywhere else in the documentation and changed the paragraph to a Warning, because it seemed more like a warning to the user.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
