### PR TITLE
Extend /usr partition size to 10 GB

### DIFF
--- a/guides/common/modules/ref_storage-requirements.adoc
+++ b/guides/common/modules/ref_storage-requirements.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 |{postgresql-lib-dir} |100 MB |20 GB
 
-|/usr | 5 GB | Not Applicable
+|/usr | 10 GB | Not Applicable
 
 |/opt/puppetlabs | 500 MB | Not Applicable
 


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Fix for BZ https://bugzilla.redhat.com/show_bug.cgi?id=2277211

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
