### PR TITLE
Add missing new lines to a note

### DIFF
--- a/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
+++ b/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
@@ -8,10 +8,12 @@ You can clean up these packages to reclaim space.
 ====
 Space reclamation requires an existing repository.
 For deleted repositories, wait for the next scheduled orphan cleanup or remove orphaned content manually:
+
 ----
 # foreman-rake katello:delete_orphaned_content
 ----
 ====
+
 .For a single repository
 * In the {ProjectWebUI}, navigate to *Content* > *Products*.
 * Select a product.


### PR DESCRIPTION
This fixes the Note added in https://github.com/theforeman/foreman-documentation/pull/2991.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
