### PR TITLE
move verifcation-enabled-repolist after enable repos

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -105,9 +105,9 @@ ifeval::["{context}" != "{project-context}"]
 endif::[]
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Lifecycle].
 ====
-endif::[]
 
 include::snip_verification-enabled-repolist.adoc[]
+endif::[]
 
 ifdef::foreman-deb[]
 [id="repositories-debian-11"]


### PR DESCRIPTION
This was moved in f8cf2c973d15d11104bef4e91fa70355c88b0271 and was
placed where it didn't make any sense AND rendered in Debian docs.

Fixes: f8cf2c973d15d11104bef4e91fa70355c88b0271


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
