### PR TITLE
Hide Provisioning sections unsupported in Satellite

### DIFF
--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -28,9 +28,9 @@ include::modules/proc_creating-hardware-models.adoc[leveloffset=+1]
 
 include::modules/proc_using-a-synced-kickstart-repository.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_adding-installation-media.adoc[leveloffset=+1]
 
-ifndef::satellite[]
 include::modules/proc_creating-an-installation-medium-for-debian.adoc[leveloffset=+1]
 
 include::modules/proc_creating-an-installation-medium-for-ubuntu-22-04.adoc[leveloffset=+1]

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -26,7 +26,9 @@ include::common/assembly_using-infoblox-as-dhcp-and-dns-providers.adoc[leveloffs
 
 include::common/assembly_using-pxe-to-provision-hosts.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::common/assembly_using-ipxe-to-reduce-provisioning-times.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_configuring-the-discovery-service.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Hide sections in Provisioning that are not supported in Satellite.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
