### PR TITLE
Fix foreman-maintain attribute that is not rendered correctly

### DIFF
--- a/guides/common/modules/ref_configuring-logging-levels-with-hammer-cli.adoc
+++ b/guides/common/modules/ref_configuring-logging-levels-with-hammer-cli.adoc
@@ -29,7 +29,7 @@ The default logging level is `INFO`.
 
 * To set `DEBUG` level logging for a specific component:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer admin logging --components _My_Component_ --level-debug
 # {foreman-maintain} service restart


### PR DESCRIPTION
A code block is missing a substitution step for attribute references. As a result, {foreman-maintain} is not displayed as expected.

To be cherry-picked only up to 3.7, the file doesn't exist for 3.6 and earlier.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
