### PR TITLE
Fix repo config for disconnected update

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -29,7 +29,7 @@ For more information, see {AdministeringDocURL}Creating_an_Organization_Debug_Ce
 [{RepoRHEL8BaseOS}]
 name=Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
 baseurl=_https://{foreman-example-com}_/pulp/content/_My_Organization_/Library/content/dist/rhel8/8/x86_64/baseos/os
-enabled=0
+enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
@@ -51,6 +51,7 @@ enabled=1
 sslclientcert = /etc/pki/katello/certs/org-debug-cert.pem
 sslclientkey = /etc/pki/katello/certs/org-debug-cert.pem
 sslcacert = /etc/pki/katello/certs/katello-server-ca.crt
+sslverify = 1
 
 [{RepoRHEL8ServerSatelliteMaintenanceProjectVersion}]
 name={ProjectName} Maintenance {ProjectVersion} for RHEL 8 RPMs x86_64


### PR DESCRIPTION
Fixing two issues with the repo configuration for disconnected updating guide:
- The BaseOS repository should be enabled.
- SSLverify should be enabled for the Project repo.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2278161

* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
