### PR TITLE
Deleted mention of Content Host from prereqs

### DIFF
--- a/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
+++ b/guides/doc-Upgrading_and_Updating/topics/updating_satellite_server_to_next_minor_version.adoc
@@ -6,7 +6,7 @@
 .Prerequisites
 
 * Ensure that you have synchronized {ProjectServer} repositories for {Project}, {SmartProxy}, and {project-client-name}.
-* Ensure each external {SmartProxy} and Content Host can be updated by promoting the updated repositories to all relevant Content Views.
+* Ensure each external {SmartProxy} can be updated by promoting the updated repositories to all relevant Content Views.
 
 include::../common/modules/snip_using_installer_noop.adoc[]
 


### PR DESCRIPTION
As mentioned in issue #2889 i have deleted mentions of Content Host from prerequisites.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
