### PR TITLE
Fix rpm repo url for client

### DIFF
--- a/guides/common/modules/proc_adding-custom-rpm-repositories-el.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-el.adoc
@@ -27,7 +27,7 @@ For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
 +
 ifndef::orcharhino[]
 * **{Project} EL{os_major} Client**
-** *Upstream URL*: `{project-client-name}el{os_major}/`
+** *Upstream URL*: `{project-client-name}el{os_major}/x86_64/`
 endif::[]
 ifdef::orcharhino[]
 * **{os_name} {os_major} client**


### PR DESCRIPTION
Fix https://community.theforeman.org/t/sync-yum-puppet-com-repository-fails-invalid-remote-url/37365
> Error: An invalid remote URL was provided: https://yum.theforeman.org/client/nightly/el9/


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
