### PR TITLE
Add link for creating manifests

### DIFF
--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -7,8 +7,11 @@ You must have a Red{nbsp}Hat subscription manifest containing a subscription all
 All subscription information is available in your Red Hat Customer Portal account.
 
 Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat subscription manifest in the Customer Portal.
-Manifests can only be created on the Customer Portal by {Project} users on a disconnected network. Manifests are created by {Project} users on a connected network using the {Team} Hybrid Cloud Console.
+Manifests can only be created on the Customer Portal by {Project} users on a disconnected network.
+Manifests are created by {Project} users on a connected network using the {Team} Hybrid Cloud Console.
+ifdef::satellite[]
 For more information on creating manifests on a connected network, see https://access.redhat.com/documentation/en-us/subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+endif::[]
 
 ifdef::satellite[]
 To create, manage, and export a Red{nbsp}Hat subscription manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -10,7 +10,7 @@ Before you can complete the tasks in this chapter, you must create a Red{nbsp}Ha
 Manifests can only be created on the Customer Portal by {Project} users on a disconnected network.
 Manifests are created by {Project} users on a connected network using the Red{nbsp}Hat Hybrid Cloud Console.
 ifdef::satellite[]
-For more information on creating manifests on a connected network, see https://access.redhat.com/documentation/en-us/subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+For more information on creating manifests on a connected network, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 
 ifdef::satellite[]

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -20,7 +20,7 @@ You can use future-dated subscriptions in a subscription manifest.
 When you add future-dated subscriptions to your manifest before the expiry date of the existing subscriptions, you can have uninterrupted access to repositories.
 
 .Prerequisites
-* Create a Red{nbsp}Hat subscription manifest.
+* Ensure you have a Red{nbsp}Hat subscription manifest.
 ** If your {Project} is connected, use the {RHCloud} to create the manifest.
 ifdef::satellite[]
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -7,8 +7,8 @@ You must have a Red{nbsp}Hat subscription manifest containing a subscription all
 All subscription information is available in your Red Hat Customer Portal account.
 
 Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat subscription manifest in the Customer Portal.
-Manifests can only be created on the Customer Portal by {Project} users on a disconnected network.
-Manifests are created by {Project} users on a connected network using the Red{nbsp}Hat Hybrid Cloud Console.
+Only {Project} users on a disconnected network can create manifests on the Customer Portal.
+Only {Project} users on a connected network can create manifests using the Red{nbsp}Hat Hybrid Cloud Console.
 ifdef::satellite[]
 For more information on creating manifests on a connected network, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -8,7 +8,7 @@ All subscription information is available in your Red Hat Customer Portal accoun
 
 Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat subscription manifest in the Customer Portal.
 Manifests can only be created on the Customer Portal by {Project} users on a disconnected network.
-Manifests are created by {Project} users on a connected network using the {Team} Hybrid Cloud Console.
+Manifests are created by {Project} users on a connected network using the Red{nbsp}Hat Hybrid Cloud Console.
 ifdef::satellite[]
 For more information on creating manifests on a connected network, see https://access.redhat.com/documentation/en-us/subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -7,6 +7,8 @@ You must have a Red{nbsp}Hat subscription manifest containing a subscription all
 All subscription information is available in your Red Hat Customer Portal account.
 
 Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat subscription manifest in the Customer Portal.
+Manifests can only be created on the Customer Portal by {Project} users on a disconnected network. Manifests are created by {Project} users on a connected network using the {Team} Hybrid Cloud Console.
+For more information on creating manifests on a connected network, see https://access.redhat.com/documentation/en-us/subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 
 ifdef::satellite[]
 To create, manage, and export a Red{nbsp}Hat subscription manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -6,15 +6,15 @@
 You must have a Red{nbsp}Hat subscription manifest containing a subscription allocation for each organization on {ProjectServer}.
 All subscription information is available in your Red Hat Customer Portal account.
 
-Before you can complete the tasks in this chapter, you must create a Red{nbsp}Hat subscription manifest in the Customer Portal.
-Only {Project} users on a disconnected network can create manifests on the Customer Portal.
-Only {Project} users on a connected network can create manifests using the Red{nbsp}Hat Hybrid Cloud Console.
+.Prerequisites
+* Create a Red{nbsp}Hat subscription manifest.
+** If your {Project} is connected, use the {RHCloud} to create the manifest.
 ifdef::satellite[]
-For more information on creating manifests on a connected network, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
-
+** If your {Project} is disconnected, use the Red Hat Customer Portal to create the manifest.
 ifdef::satellite[]
-To create, manage, and export a Red{nbsp}Hat subscription manifest in the Customer Portal, see https://access.redhat.com/documentation/en-us/subscription_central/2021/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
 endif::[]
 
 Use this chapter to import a Red{nbsp}Hat subscription manifest and manage the manifest within the {ProjectWebUI}.

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -6,17 +6,6 @@
 You must have a Red{nbsp}Hat subscription manifest containing a subscription allocation for each organization on {ProjectServer}.
 All subscription information is available in your Red Hat Customer Portal account.
 
-.Prerequisites
-* Create a Red{nbsp}Hat subscription manifest.
-** If your {Project} is connected, use the {RHCloud} to create the manifest.
-ifdef::satellite[]
-For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
-endif::[]
-** If your {Project} is disconnected, use the Red Hat Customer Portal to create the manifest.
-ifdef::satellite[]
-For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
-endif::[]
-
 Use this chapter to import a Red{nbsp}Hat subscription manifest and manage the manifest within the {ProjectWebUI}.
 
 .Subscription allocations and organizations
@@ -29,6 +18,17 @@ The advantage of this is that each organization maintains separate subscriptions
 
 You can use future-dated subscriptions in a subscription manifest.
 When you add future-dated subscriptions to your manifest before the expiry date of the existing subscriptions, you can have uninterrupted access to repositories.
+
+.Prerequisites
+* Create a Red{nbsp}Hat subscription manifest.
+** If your {Project} is connected, use the {RHCloud} to create the manifest.
+ifdef::satellite[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+endif::[]
+** If your {Project} is disconnected, use the Red Hat Customer Portal to create the manifest.
+ifdef::satellite[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
+endif::[]
 
 .Additional resources
 ifndef::satellite[]


### PR DESCRIPTION
Users need to know that Satellite users on a
disconnected network
create manifests on the Customer Portal. Connected users create
manifests on the Hybrid Cloud Console, following the recent migration.
A link for creating manifests on a connected network has been added to
the second paragraph of Managing Red Hat subscriptions in Managing
Content.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
