### PR TITLE
Add new OSTree properties and add brief usage path

### DIFF
--- a/guides/common/assembly_managing-ostree-content.adoc
+++ b/guides/common/assembly_managing-ostree-content.adoc
@@ -7,3 +7,5 @@ include::modules/proc_uploading-ostree-content-with-hammer-cli.adoc[leveloffset=
 endif::[]
 
 include::modules/proc_managing-ostree-content-with-content-views.adoc[leveloffset=+1]
+
+include::modules/proc_installing-ostree-content-from-server.adoc[leveloffset=+1]

--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -10,7 +10,7 @@ You can create an OSTree image using an image builder and expose it in an OSTree
 Then you can use your {Project} to synchronize and manage OSTree branches from the exposed OSTree repository.
 
 .Prerequisites
-* OSTree content is supported only when running {Project} on {EL} 8.
+* OSTree content is supported only when running {Project} on {EL} 8 or {EL} 9.
 * In {ProjectServer}, OSTree management tools are not enabled by default.
 To enable OSTree, enter the following command:
 +

--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -28,6 +28,10 @@ For example `\http://www.example.com/rpm-ostree/`.
 Clear this field if the repository does not require authentication.
 . In the *Upstream Password* field, enter the corresponding password for the upstream repository.
 . In the *Upstream Authentication Token* field, enter the corresponding token for the upstream repository.
+. Optional: In the *Exclude Refs* field, enter a list of OSTree head refs seperated by commas to exclude from importing to {Project}.
+The exclude will be evaluated after the includes.
+. Optional: In the *Include Refs* field, enter a list of OSTree head refs seperated by commas to include from importing to {Project}.
+For example `fedora/x86_64/coreos/stable`.
 . From the *Mirroring Policy* menu, select one of the following policies to mirror OSTree content for this repository:
 * *Additive* {endash} new content available during sync will be added to the repository, and no content will be removed.
 * *Mirror Content Only* {endash} any new content available during sync will be added to the repository and any content removed from the upstream repository will be removed from the local repository.

--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -28,9 +28,9 @@ For example `\http://www.example.com/rpm-ostree/`.
 Clear this field if the repository does not require authentication.
 . In the *Upstream Password* field, enter the corresponding password for the upstream repository.
 . In the *Upstream Authentication Token* field, enter the corresponding token for the upstream repository.
-. Optional: In the *Exclude Refs* field, enter a list of OSTree head refs seperated by commas to exclude from importing to {Project}.
-The exclude will be evaluated after the includes.
-. Optional: In the *Include Refs* field, enter a list of OSTree head refs seperated by commas to include from importing to {Project}.
+. Optional: In the *Exclude Refs* field, enter a list of OSTree head refs separated with commas to exclude from importing to {Project}.
+The excludes are evaluated after the includes.
+. Optional: In the *Include Refs* field, enter a list of OSTree head refs separated with commas to include in importing to {Project}.
 For example `fedora/x86_64/coreos/stable`.
 . From the *Mirroring Policy* menu, select one of the following policies to mirror OSTree content for this repository:
 * *Additive* {endash} new content available during sync will be added to the repository, and no content will be removed.

--- a/guides/common/modules/proc_installing-ostree-content-from-server.adoc
+++ b/guides/common/modules/proc_installing-ostree-content-from-server.adoc
@@ -1,10 +1,10 @@
 [id="Installing_OSTree_Content_from_{project-context}_Server_{context}"]
-= Installing OSTree content from {ProjectServerTitle}
+= Installing OSTree content from {ProjectServer} on hosts
 
-OSTree content from {Project} on hosts is managed by Subscription manager and can be accessed using `rpm-ostree`.
+OSTree content from {Project} on hosts is managed by Subscription Manager and can be accessed by using `rpm-ostree`.
 
 .Prerequisites
-* You have uploaded or synchronized a OSTree head to {Project}.
+* You have uploaded or synchronized an OSTree head to {Project}.
 
 .Procedure
 * On your hosts, view the available heads:
@@ -15,7 +15,7 @@ My_Organization_OSTree_Content_OSTree
 fedora
 fedora-compose
 ----
-* Rebase to use new remote from {Project}:
+* Rebase to a new remote from {Project}:
 +
 ----
 $ rpm-ostree rebase --remote=My_Organization_OSTree_Content_OSTree

--- a/guides/common/modules/proc_installing-ostree-content-from-server.adoc
+++ b/guides/common/modules/proc_installing-ostree-content-from-server.adoc
@@ -4,7 +4,7 @@
 OSTree content from {Project} on hosts is managed by Subscription Manager and can be accessed by using `rpm-ostree`.
 
 .Prerequisites
-* You have uploaded or synchronized an OSTree head to {Project}.
+* You have synchronized or uploaded an OSTree head to {Project}, see xref:importing-ostree-content_{context}[] and xref:uploading-ostree-content-with-hammer-cli_{context}[].
 
 .Procedure
 * On your hosts, view the available heads:

--- a/guides/common/modules/proc_installing-ostree-content-from-server.adoc
+++ b/guides/common/modules/proc_installing-ostree-content-from-server.adoc
@@ -4,20 +4,19 @@
 OSTree content from {Project} on hosts is managed by Subscription Manager and can be accessed by using `rpm-ostree`.
 
 .Prerequisites
-* You have synchronized or uploaded an OSTree head to {Project}, see xref:importing-ostree-content_{context}[] and xref:uploading-ostree-content-with-hammer-cli_{context}[].
+* You have synchronized or uploaded an OSTree head to {Project}.
+For more information, see xref:importing-ostree-content_{context}[] and xref:uploading-ostree-content-with-hammer-cli_{context}[].
 
 .Procedure
-* On your hosts, view the available heads:
+. On your hosts, view the available heads:
 +
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 $ rpm-ostree remote list
-My_Organization_OSTree_Content_OSTree
-fedora
-fedora-compose
 ----
-* Rebase to a new remote from {Project}:
+. Rebase to a new remote from {Project}:
 +
+[options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-$ rpm-ostree rebase --remote=My_Organization_OSTree_Content_OSTree
-Rebasing to My_Organization_OSTree_Content_OSTree:fedora/x86_64/coreos/stable
+$ rpm-ostree rebase --remote=_My_Organization_OSTree_Content_OSTree_
 ----

--- a/guides/common/modules/proc_installing-ostree-content-from-server.adoc
+++ b/guides/common/modules/proc_installing-ostree-content-from-server.adoc
@@ -1,0 +1,23 @@
+[id="Installing_OSTree_Content_from_{project-context}_Server_{context}"]
+= Installing OSTree content from {ProjectServerTitle}
+
+OSTree content from {Project} on hosts is managed by Subscription manager and can be accessed using `rpm-ostree`.
+
+.Prerequisites
+* You have uploaded or synchronized a OSTree head to {Project}.
+
+.Procedure
+* On your hosts, view the available heads:
++
+----
+$ rpm-ostree remote list
+My_Organization_OSTree_Content_OSTree
+fedora
+fedora-compose
+----
+* Rebase to use new remote from {Project}:
++
+----
+$ rpm-ostree rebase --remote=My_Organization_OSTree_Content_OSTree
+Rebasing to My_Organization_OSTree_Content_OSTree:fedora/x86_64/coreos/stable
+----

--- a/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
+++ b/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
@@ -32,6 +32,6 @@ The value of `--ostree-repository-name` must match the name of the OSTree reposi
 
 .Additional resources
 ifndef::orcharhino[]
-* {RHELDocsBaseURL}8/html-single/composing_installing_and_managing_rhel_for_edge_images/index[_{RHEL}{nbsp}8Composing, installing, and managing RHEL for Edge images using Image Builder_]
+* {RHELDocsBaseURL}8/html-single/composing_installing_and_managing_rhel_for_edge_images/index[_{RHEL}{nbsp}8 Composing, installing, and managing RHEL for Edge images using Image Builder_]
 endif::[]
 * https://osbuild.org/docs/on-premises/commandline/building-ostree-images[Building OSTree images using the OSBuild tool]


### PR DESCRIPTION
The properties will first be available in Katello 4.13.
I also looked if there is already a global attribute for subman, but doesn't look like so.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
