### PR TITLE
Remove steps from generating content

### DIFF
--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -4,16 +4,16 @@
 You can export contents of all yum repositories, Kickstart repositories and file repositories in the Library environment of an organization to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
 
 ifdef::satellite[]
-You can then serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization.
+You can then serve the generated content on a local web server and synchronize it on the importing {ProjectServer} or in another {ProjectServer} organization.
 endif::[]
 
 ifndef::satellite[]
-You can use the generated content to create the same repository in another {ProjectServer} or in another {ProjectServer} organization using content import.
-On importing the exported archive, a regular content view is created or updated on your downstream {ProjectServer}.
+You can use the generated content to create the same repository in another {ProjectServer} or in another {ProjectServer} organization by using content import.
+On import of the exported archive, a regular content view is created or updated on your importing {ProjectServer}.
 For more information, see xref:Importing_a_Content_View_Version_{context}[].
 endif::[]
 
-You can export the following content in a syncable format from {ProjectServer}:
+You can export the following content in the syncable format from {ProjectServer}:
 
 * Yum repositories
 * Kickstart repositories

--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -3,7 +3,25 @@
 
 You can export contents of all yum repositories, Kickstart repositories and file repositories in the Library environment of an organization to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
 
-include::snip_generating-content.adoc[]
+ifdef::satellite[]
+You can then serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization.
+endif::[]
+
+ifndef::satellite[]
+You can use the generated content to create the same repository in another {ProjectServer} or in another {ProjectServer} organization using content import.
+On importing the exported archive, a regular content view is created or updated on your downstream {ProjectServer}.
+For more information, see xref:Importing_a_Content_View_Version_{context}[].
+endif::[]
+
+You can export the following content in a syncable format from {ProjectServer}:
+
+* Yum repositories
+* Kickstart repositories
+* File repositories
+
+You cannot export Ansible, Deb, or Docker content.
+
+The export contains directories with the packages, *listing* files, and metadata of the repository in Yum format that can be used to synchronize in the importing {ProjectServer}.
 
 .Prerequisites
 * Ensure that you set the download policy to *Immediate* for all repositories within the Library lifecycle environment you export.

--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -1,5 +1,15 @@
 ifdef::satellite[]
 You can then serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization.
+
+You cannot directly import Syncable Format exports.
+Instead, on the importing {ProjectServer} you must:
+
+* Copy the generated content to an HTTP/HTTPS web server that is accessible to importing {ProjectServer}.
+* Update your CDN configuration to *Custom CDN*.
+* Set the CDN URL to point to the web server.
+* Optional: Set an SSL/TLS CA Credential if the web server requires it.
+* Enable the repository.
+* Synchronize the repository.
 endif::[]
 
 ifndef::satellite[]

--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -1,15 +1,5 @@
 ifdef::satellite[]
 You can then serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization.
-
-You cannot directly import Syncable Format exports.
-Instead, on the importing {ProjectServer} you must:
-
-* Copy the generated content to an HTTP/HTTPS web server that is accessible to importing {ProjectServer}.
-* Update your CDN configuration to *Custom CDN*.
-* Set the CDN URL to point to the web server.
-* Optional: Set an SSL/TLS CA Credential if the web server requires it.
-* Enable the repository.
-* Synchronize the repository.
 endif::[]
 
 ifndef::satellite[]


### PR DESCRIPTION
It was decided that certain steps in generating content are not
necessary due to conflicting statements about
importability of syncable
exports.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
