### PR TITLE
Unify URL for pulp content on Foreman/Katello

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -49,4 +49,4 @@
 // Overwritten in downstream for docs.orcharhino.com
 :client-package-install: dnf install
 :client-package-remove: dnf remove
-:client-repo-url: http://_{foreman-example-com}_/pulp/repos/_My_Organization_/Library/custom/{client-os}_Client/{client-os}_Client_{client-os-major}/
+:client-repo-url: http://_{foreman-example-com}_/pulp/content/_My_Organization_/Library/custom/{client-os}_Client/{client-os}_Client_{client-os-major}/


### PR DESCRIPTION
Pulp serves content under "FQDN/pulp/content". Historically, it was (also) "FQDN/pulp/repos". Looking at "git grep", this seems to be the only outlier.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
