### PR TITLE
Remove upgrade warning for pre-3.11 branching

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -10,14 +10,7 @@ There are no highlights with Foreman {ProjectVersion}.
 == Upgrade Warnings
 
 // If this section would be empty otherwise, uncomment the following line:
-// There are no upgrade warnings with Foreman {ProjectVersion}.
-
-=== PostgreSQL upgraded to 13 on Enterprise Linux 8
-
-On Enterprise Linux 8 PostgreSQL is upgraded from 12 to 13, to match the version used on Enterprise Linux 9.
-Users are required to change the DNF module, but the actual upgrade, including data migration, happens when the installer is executed for the first time.
-During the upgrade a backup of the data is created in `/var/lib/pgsql/data-old`.
-This backup can be removed once the upgrade is completed.
+There are no upgrade warnings with Foreman {ProjectVersion}.
 
 [id="foreman-deprecations"]
 == Deprecations


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
