### PR TITLE
Recommendation for connected and disconnected user

### DIFF
--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -17,9 +17,6 @@ Importing a manifest does not change your organization's Simple Content Access s
 ifeval::["{mode}" == "connected"]
 * Ensure you have a Red{nbsp}Hat subscription manifest exported from the {RHCloud}.
 ifndef::orcharhino[]
-<<<<<<< HEAD
-For more information, see {RHDocsBaseURL}subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/assembly-creating-managing-manifests-connected-satellite[Creating and Managing Manifests] in _Using Red Hat Subscription Management_.
-=======
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 endif::[]
@@ -39,7 +36,6 @@ endif::[]
 ifndef::orcharhino[]
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
 endif::[]
->>>>>>> cccab3c416 (Fix attributes and some context)
 endif::[]
 ifeval::["{mode}" == "disconnected"]
 * Ensure that you disable subscription connection on your {ProjectServer}.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -26,11 +26,16 @@ endif::[]
 There are currently separate processes for connected and disconnected {Project}s.
 Connected {Project}s should do the following:
 
-. Create a blank manifest on `console.redhat.com`.
-. Import the manifest into {Project}.
-. Add subscriptions to the manifest in the {ProjectWebUI}.
+* Ensure you have a Red{nbsp}Hat subscription manifest.
+** If your {Project} is connected, use the {RHCloud} to create the manifest.
+ifdef::satellite[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+endif::[]
 
-Disconnected {Project}s should continue to create manifests and add subscriptions to them on the Customer Portal.
+Disconnected {Project}s should continue to create manifests and add subscriptions to them on the Red Hat Customer Portal.
+ifdef::satellite[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -14,27 +14,36 @@ Importing a manifest does not change your organization's Simple Content Access s
 ====
 
 .Prerequisites
-* You must have a Red{nbsp}Hat subscription manifest file exported from the https://access.redhat.com[Red{nbsp}Hat Customer Portal].
+ifeval::["{mode}" == "connected"]
+* Ensure you have a Red{nbsp}Hat subscription manifest exported from the {RHCloud}.
 ifndef::orcharhino[]
+<<<<<<< HEAD
 For more information, see {RHDocsBaseURL}subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/assembly-creating-managing-manifests-connected-satellite[Creating and Managing Manifests] in _Using Red Hat Subscription Management_.
+=======
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+endif::[]
+endif::[]
+ifeval::["{mode}" == "disconnected"]
+* Ensure you have a Red{nbsp}Hat subscription manifest exported from the Red Hat Customer Portal.
+ifndef::orcharhino[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
+endif::[]
+endif::[]
+ifdef::content-management[]
+* Ensure you have a Red{nbsp}Hat subscription manifest.
+** If your {Project} is connected, use the {RHCloud} to create and export the manifest.
+ifndef::orcharhino[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+endif::[]
+** If your {Project} is disconnected, use the Red Hat Customer Portal to create and export the manifest.
+ifndef::orcharhino[]
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
+endif::[]
+>>>>>>> cccab3c416 (Fix attributes and some context)
 endif::[]
 ifeval::["{mode}" == "disconnected"]
 * Ensure that you disable subscription connection on your {ProjectServer}.
 For more information, see xref:disabling-subscription-connection_{context}[].
-endif::[]
-
-There are currently separate processes for connected and disconnected {Project}s.
-Connected {Project}s should do the following:
-
-* Ensure you have a Red{nbsp}Hat subscription manifest.
-** If your {Project} is connected, use the {RHCloud} to create the manifest.
-ifdef::satellite[]
-For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
-endif::[]
-
-Disconnected {Project}s should continue to create manifests and add subscriptions to them on the Red Hat Customer Portal.
-ifdef::satellite[]
-For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-using-rhsm_#using_manifests_con[Using manifests for a disconnected Satellite Server] in _Subscription Central_.
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -23,6 +23,15 @@ ifeval::["{mode}" == "disconnected"]
 For more information, see xref:disabling-subscription-connection_{context}[].
 endif::[]
 
+There are currently separate processes for connected and disconnected customers.
+Connected customers should do the following:
+
+. Create a blank manifest on `console.redhat.com`.
+. Import the manifest into {Project}.
+. Add subscriptions to the manifest in the {ProjectWebUI}.
+
+Disconnected customers should continue to create manifests and add subscriptions to them on the Customer Portal.
+
 .Procedure
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions* and click *Manage Manifest*.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -23,14 +23,14 @@ ifeval::["{mode}" == "disconnected"]
 For more information, see xref:disabling-subscription-connection_{context}[].
 endif::[]
 
-There are currently separate processes for connected and disconnected customers.
-Connected customers should do the following:
+There are currently separate processes for connected and disconnected {Project}s.
+Connected {Project}s should do the following:
 
 . Create a blank manifest on `console.redhat.com`.
 . Import the manifest into {Project}.
 . Add subscriptions to the manifest in the {ProjectWebUI}.
 
-Disconnected customers should continue to create manifests and add subscriptions to them on the Customer Portal.
+Disconnected {Project}s should continue to create manifests and add subscriptions to them on the Customer Portal.
 
 .Procedure
 . In the {ProjectWebUI}, ensure the context is set to the organization you want to use.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -1,6 +1,7 @@
 include::common/attributes.adoc[]
 include::common/header.adoc[]
-:context: :content-management:
+:context: content-management
+:content-management:
 
 = {ContentManagementDocTitle}
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -1,6 +1,6 @@
 include::common/attributes.adoc[]
 include::common/header.adoc[]
-:context: content-management
+:context: :content-management:
 
 = {ContentManagementDocTitle}
 


### PR DESCRIPTION
After the Prerequisistes in the Importing a Red Hat subscription
manifest into Satellite Server section, we need to recommend users to
create a manifest from access.redhat.com or via
console.redhat.com.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
