### PR TITLE
Update feedback module in Satellite

### DIFF
--- a/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
+++ b/guides/common/modules/proc_providing-feedback-on-red-hat-documentation.adoc
@@ -3,13 +3,17 @@
 [id="providing-feedback-on-red-hat-documentation_{context}"]
 = Providing feedback on Red Hat documentation
 
-We appreciate your input on our documentation.
-Please let us know how we could make it better.
+We appreciate your feedback on our documentation.
+Let us know how we can improve it.
 
-You can submit feedback by filing a ticket in Bugzilla:
+Use the *Create Issue* form in Red Hat Jira to provide your feedback.
+The Jira issue is created in the Red Hat Satellite Jira project, where you can track its progress.
 
-. Navigate to the link:https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20Satellite[Bugzilla] website.
-. In the *Component* field, use `Documentation`.
-. In the *Description* field, enter your suggestion for improvement.
-Include a link to the relevant parts of the documentation.
-. Click *Submit Bug*.
+.Procedure
+. Ensure that you are logged in to link:https://issues.redhat.com/[Red Hat Jira].
+If you do not have a Jira account, create an account to submit feedback.
+. Open the link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12324223&summary=Documentation%20feedback:%20%3CAdd%20summary%20here%3E&issuetype=1&components=12347630&priority=10300[*Create Issue*] form.
+. Complete the *Summary* and *Description* fields.
+In the *Description* field, include the documentation URL, chapter or section number, and a detailed description of the issue.
+Do not modify any other fields in the form.
+. Click *Create*.


### PR DESCRIPTION
With migration from Bugzilla to Jira, we need to update the way users can provide feedback.

**This has to be merged on June 5, not sooner!**

Requested in: https://issues.redhat.com/browse/SAT-25170

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
