### PR TITLE
Clarify GPG public key extraction process and update keyserver URIs

### DIFF
--- a/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
+++ b/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
@@ -18,13 +18,16 @@ $ wget https://deb.debian.org/debian/dists/bullseye/Release.gpg
 ----
 $ gpg --verify Release.gpg Release
 ----
++
+Note the GPG key fingerprint for any missing public GPG keys above the `Can't check signature: No public key` message.
+These fingerprints will be used in the next step.
 . If you cannot verify the signature, import the missing GPG public keys based on their fingerprint:
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 0146DC6D4A0B2914BDED34DB648ACFD622F3D138
-$ gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys A7236886F3CCCAAD148A27F80E98404D386FA1D9
-$ gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys A4285295FC7B1A81600062A9605C66F00D6C9793
+$ gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys A7236886F3CCCAAD148A27F80E98404D386FA1D9
+$ gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 4CB50190207B4758A3F73A796ED0E7B82643E131
+$ gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys A4285295FC7B1A81600062A9605C66F00D6C9793
 ----
 . Optional: Verify the signature again:
 +
@@ -36,8 +39,10 @@ $ gpg --verify Release.gpg Release
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ gpg --armor --export 0146DC6D4A0B2914BDED34DB648ACFD622F3D138 A7236886F3CCCAAD148A27F80E98404D386FA1D9 A4285295FC7B1A81600062A9605C66F00D6C9793 > debian_11.txt
+$ gpg --armor --export A7236886F3CCCAAD148A27F80E98404D386FA1D9 4CB50190207B4758A3F73A796ED0E7B82643E131 A4285295FC7B1A81600062A9605C66F00D6C9793 > debian_11.txt
 ----
++
+Ensure that `gpg` returns a `Good signature` message for each signature.
 +
 Use this `.txt` file and upload it to {Project} as described below.
 

--- a/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
+++ b/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
@@ -45,4 +45,4 @@ $ gpg --armor --export A7236886F3CCCAAD148A27F80E98404D386FA1D9 4CB50190207B4758
 Ensure that `gpg` returns a `Good signature` message for each signature.
 +
 Upload the .txt file to {Project}.
-For more information, see xref:Importing_a_Custom_GPG_Key_{context}[import the custom GPG public key] into {Project}.
+For more information, see xref:Importing_a_Custom_GPG_Key_{context}[] into {Project}.

--- a/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
+++ b/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
@@ -44,6 +44,5 @@ $ gpg --armor --export A7236886F3CCCAAD148A27F80E98404D386FA1D9 4CB50190207B4758
 +
 Ensure that `gpg` returns a `Good signature` message for each signature.
 +
-Use this `.txt` file and upload it to {Project} as described below.
-
-Continue to xref:Importing_a_Custom_GPG_Key_{context}[import the custom GPG public key] into {Project}.
+Upload the .txt file to {Project}.
+For more information, see xref:Importing_a_Custom_GPG_Key_{context}[import the custom GPG public key] into {Project}.


### PR DESCRIPTION
I already had twice the issue to make the connection between the `gpg --verify Release.gpg Release` commands output and the `gpg --recv-keys`, so this change extends that part.

And recently we noticed, that the receiving from `hkp://keyserver.ubuntu.com` does not work anymore -> switches this to `hkps://`

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.