### PR TITLE
Optimize the diff text when there's no change

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -68,8 +68,10 @@ jobs:
       - name: Create diff to old base
         run: |
           diff -Nrwu old/ preview/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > preview/diff.patch
-          pygmentize -o preview/diff.html -l diff -f html -O full preview/diff.patch
-          diffstat -l -p2 preview/diff.patch > diff.txt
+          if [[ -s preview/diff.patch ]] ; then
+            pygmentize -o preview/diff.html -l diff -f html -O full preview/diff.patch
+            diffstat -l -p2 preview/diff.patch > diff.txt
+          fi
 
       - name: Deploy to surge.sh
         run: ./node_modules/.bin/surge ./preview $PREVIEW_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
@@ -78,12 +80,23 @@ jobs:
         run: |
           echo "The PR preview for ${{ fromJSON(env.PR_DATA).head_sha }} is available at [${{ env.PREVIEW_DOMAIN }}](https://${{ env.PREVIEW_DOMAIN }})" >> pr.md
           echo "" >> pr.md
-          echo "The following output files are affected by this PR:" >> pr.md
-          sed -E "s#(.*)#- [\1](https://${{ env.PREVIEW_DOMAIN }}/${{ fromJSON(env.PR_DATA).target_name }}/\1)#" diff.txt >> pr.md
-          echo "" >> pr.md
-          echo '[show diff](https://${{ env.PREVIEW_DOMAIN }}/diff.patch)' >> pr.md
-          echo "" >> pr.md
-          echo '[show diff as HTML](https://${{ env.PREVIEW_DOMAIN }}/diff.html)' >> pr.md
+
+          if [[ -f diff.txt ]] ; then
+            echo "The following output files are affected by this PR:" >> pr.md
+            sed -E "s#(.*)#- [\1](https://${{ env.PREVIEW_DOMAIN }}/${{ fromJSON(env.PR_DATA).target_name }}/\1)#" diff.txt >> pr.md
+          else
+            echo "No diff compared to the current base" >> pr.md
+          fi
+
+          if [[ -f preview/diff.patch ]] ; then
+            echo "" >> pr.md
+            echo '[show diff](https://${{ env.PREVIEW_DOMAIN }}/diff.patch)' >> pr.md
+          fi
+
+          if [[ -f preview/diff.html ]] ; then
+            echo "" >> pr.md
+            echo '[show diff as HTML](https://${{ env.PREVIEW_DOMAIN }}/diff.html)' >> pr.md
+          fi
 
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
If a PR doens't generate a diff (like this change) then the message shouldn't link to any diffs. By making this message explicit it makes reviewing a bit easier.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.