### PR TITLE
Fix install VMware

### DIFF
--- a/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
@@ -5,7 +5,9 @@
 
 include::modules/con_provisioning-virtual-machines-in-vmware.adoc[]
 
+ifndef::satellite[]
 include::modules/proc_installing-vmware-plugin.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/con_prerequisites-for-vmware-provisioning.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_installing-vmware-plugin.adoc
+++ b/guides/common/modules/proc_installing-vmware-plugin.adoc
@@ -1,8 +1,8 @@
 [id="Installing_VMware_plugin_{context}"]
 = Installing VMware plugin
 
-Install the VMware plugin to attach a VMware compute resource provider to {Project}.
-This allows you to manage and deploy hosts to VMware.
+Install the VMware plugin to attach the VMware compute resource provider to {Project}.
+You can use the VMware provider to manage and deploy hosts to VMware.
 
 .Procedure
 . Install the VMware compute resource provider on your {ProjectServer}:
@@ -11,4 +11,7 @@ This allows you to manage and deploy hosts to VMware.
 ----
 # {foreman-installer} --enable-foreman-compute-vmware
 ----
-. Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the _compute resources_ tab to verify the installation of the VMware plugin.
+
+.Verification
+. In the {ProjectWebUI}, navigate to *Administer* > *About*.
+. On the *System Status* card, select the *Available Providers* tab to verify that the VMware provider is installed.


### PR DESCRIPTION
The VMware provider is installed by default in Satellite.
The navigation to verify the CR provider is installed has been fixed too.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
