### PR TITLE
Fix the DB command in the upgrade guides

### DIFF
--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -41,11 +41,11 @@ ifdef::katello,satellite,orcharhino[]
 ----
 # {package-install} postgresql-contrib
 ----
-.. Connect to the Pulp database:
+.. Connect to the pulpcore database:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# su - postgres -c psql pulpcore
+# su - postgres -c "psql pulpcore"
 ----
 .. Create the `hstore` extension:
 +

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-connected-project-server.adoc
@@ -41,7 +41,7 @@ ifdef::katello,satellite,orcharhino[]
 ----
 # {package-install} postgresql-contrib
 ----
-.. Connect to the pulpcore database:
+.. Connect to the Pulp database:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -69,11 +69,11 @@ endif::[]
 ----
 # {package-install} postgresql-contrib
 ----
-.. Connect to the Pulp database:
+.. Connect to the pulpcore database:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# su - postgres -c psql pulpcore
+# su - postgres -c "psql pulpcore"
 ----
 .. Create the `hstore` extension:
 +

--- a/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/doc-Upgrading_Project/topics/proc_upgrading-a-disconnected-project-server.adoc
@@ -69,7 +69,7 @@ endif::[]
 ----
 # {package-install} postgresql-contrib
 ----
-.. Connect to the pulpcore database:
+.. Connect to the Pulp database:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----


### PR DESCRIPTION
If we run the command provided in the current document, it connects to postgres instead of the pulpcore database. Changing the DB name command so that it connects to pulpcore.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
