### PR TITLE
Using Satellite content in RH Image Builder

### DIFF
--- a/guides/common/modules/proc_using-project-as-a-source-of-content-for-imagebuilder.adoc
+++ b/guides/common/modules/proc_using-project-as-a-source-of-content-for-imagebuilder.adoc
@@ -1,0 +1,21 @@
+[id="using-project-as-a-source-of-content-for-imagebuilder"]
+= Using {Project} as a source of content for {LoraxCompose}
+
+In {Project}, you can integrate with {Cockpit}.
+By using {Cockpit}, you can access {LoraxCompose} and build images.
+When you configure {LoraxCompose} for image building, you can use {Project} content to build the images.
+
+.Prerequisites
+* Ensure you have imported content into {ProjectServer}.
+For more information, see xref:Importing_Content_{context}[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Products*, select your Product and click the repository you require.
+Locate the *Published at* field and note the URL.
+. If your repository is published at a secured URL (HTTPS) only, ensure you have configured the Red{nbsp}Hat Subscription Manager on your {LoraxCompose} host machine to use the Katello server CA certificate.
+For more information, see link:https://access.redhat.com/solutions/7004689[Composer Image Builder fails when multiple custom repos are defined on the Satellite] in the _Red Hat Knowledgebase_.
+. link:{RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/managing-repositories_composing-a-customized-rhel-system-image#overriding-a-system-repository_managing-repositories[Override the required system repository in {LoraxCompose} configuration] and use the URL of your {Project} repository as a `baseurl`.
+
+[role="_additional-resources"]
+.Next steps
+* Build the image.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -43,6 +43,10 @@ include::common/assembly_managing-content-views.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
 
+ifdef::satellite[]
+include::common/modules/proc_using-project-as-a-source-of-content-for-imagebuilder.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
 
 ifdef::katello,orcharhino[]


### PR DESCRIPTION
User Story: As a Satellite and Image Builder on-prem user, I want to to configure Image Builder repositories so that I can source content from Satellite

Requested by IB customers.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [x] Foreman 3.4/Katello 4.6 (EL8 only)
* [x] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
