### PR TITLE
Add notify team to branching instructions in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ When a commit is pushed into `X.Y`:
   * Update `VERSION_LINKS` in the root `Makefile`.
   * Push the changes into `master`.
 * Check the site if links and landing page appeared correctly. HTML guides should be deployed into `/X.Y`
+* Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When a commit is pushed into `X.Y`:
     * Set `DocState` to `unsupported`
     * Set `ProjectVersion` to `X.Y` and set the matching `KatelloVersion`
   * Push into `X.Y` branch.
+  * Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel
 * Update master
   * Update `ProjectVersionPrevious` to `X.Y` in `guides/common/attributes.adoc`
   * Create a copy of [/web/content/release-nightly.md](https://github.com/theforeman/foreman-documentation/tree/master/web/content/release-nightly.md) as `release-X.Y.md` and edit it accordingly.
@@ -71,7 +72,6 @@ When a commit is pushed into `X.Y`:
   * Update `VERSION_LINKS` in the root `Makefile`.
   * Push the changes into `master`.
 * Check the site if links and landing page appeared correctly. HTML guides should be deployed into `/X.Y`
-* Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel
 
 ## License
 


### PR DESCRIPTION
We would like to be notified when a new branch is created because of cherry-picking. :)

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
