### PR TITLE
Remove mentions of OVAL content management support

### DIFF
--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -72,21 +72,6 @@ Possible values:
 |===
 endif::[]
 
-ifdef::satellite,orcharhino[]
-OVAL scan::
-Indicates if there are any vulnerabilities found on the host
-+
-Possible values:
-+
-[options="header"]
-|===
-| Label | Global host status | Number value
-| No vulnerabilities found | OK | 0
-| Vulnerabilities found | Warning | 1
-| Vulnerabilities with available patch found | Error | 2
-|===
-endif::[]
-
 Execution::
 Status of the last completed remote execution job.
 ifdef::foreman-el,foreman-deb[]


### PR DESCRIPTION
OVAL is not supported in sat 6.16.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
