### PR TITLE
force leapp to keep tomcat instead of removing it

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -189,11 +189,11 @@ gpgcheck=1
 ----
 endif::[]
 
-. Configure Leapp to skip updating the Tomcat packages to ensure the upgrade does not fail:
+. Configure Leapp to keep Tomcat packages to ensure the upgrade does not fail:
 +
 ----
-# echo tomcat >> /etc/leapp/transaction/to_remove
-# echo tomcat-lib >> /etc/leapp/transaction/to_remove
+# echo tomcat >> /etc/leapp/transaction/to_keep
+# echo tomcat-lib >> /etc/leapp/transaction/to_keep
 ----
 
 . Let Leapp analyze your system:


### PR DESCRIPTION
in 8.9 we had to remove it
in 8.10 we need to keep it
pray there won't be a 8.11


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
