### PR TITLE
Use ERB variables for easier branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ When a commit is pushed into `X.Y`:
     * Change `katello` to the right version
     * Change `Nightly` in titles to the appropriate version
     * Remove guides which aren't ready for stable branches.
-  * Create a copy of [/web/releases/nightly.adoc](https://github.com/theforeman/foreman-documentation/tree/master/web/releases/nightly.adoc) as `X.Y.adoc` and edit it accordingly.
-    * Change `FOREMAN_VER` and `KATELLO_VER` to their respective versions
-    * Remove guides which aren't ready for stable branches.
+  * Create a copy of [/web/releases/nightly.adoc](https://github.com/theforeman/foreman-documentation/tree/master/web/releases/nightly.adoc) as `X.Y.adoc` and edit it accordingly. Remove guides which aren't ready for stable branches.
   * Test the changes by following the instructions in [/web/README.md](https://github.com/theforeman/foreman-documentation/tree/master/web/README.md) to deploy the website locally.
   * Add the new Foreman version to [/.github/PULL_REQUEST_TEMPLATE.md](https://github.com/theforeman/foreman-documentation/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
   * Update `VERSION_LINKS` in the root `Makefile`.

--- a/web/releases/2.4.adoc
+++ b/web/releases/2.4.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 2.4
-:KATELLO_VER: 4.0
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/2.5.adoc
+++ b/web/releases/2.5.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 2.5
-:KATELLO_VER: 4.1
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.0.adoc
+++ b/web/releases/3.0.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.0
-:KATELLO_VER: 4.2
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.1.adoc
+++ b/web/releases/3.1.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.1
-:KATELLO_VER: 4.3
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.10.adoc
+++ b/web/releases/3.10.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.10
-:KATELLO_VER: 4.12
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.11.adoc
+++ b/web/releases/3.11.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.11
-:KATELLO_VER: 4.13
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.2.adoc
+++ b/web/releases/3.2.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.2
-:KATELLO_VER: 4.4
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.3.adoc
+++ b/web/releases/3.3.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.3
-:KATELLO_VER: 4.5
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.4.adoc
+++ b/web/releases/3.4.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.4
-:KATELLO_VER: 4.6
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.5.adoc
+++ b/web/releases/3.5.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.5
-:KATELLO_VER: 4.7
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.6.adoc
+++ b/web/releases/3.6.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.6
-:KATELLO_VER: 4.8
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.7.adoc
+++ b/web/releases/3.7.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.7
-:KATELLO_VER: 4.9
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.8.adoc
+++ b/web/releases/3.8.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.8
-:KATELLO_VER: 4.10
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/3.9.adoc
+++ b/web/releases/3.9.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: 3.9
-:KATELLO_VER: 4.11
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 

--- a/web/releases/nightly.adoc
+++ b/web/releases/nightly.adoc
@@ -1,5 +1,5 @@
-:FOREMAN_VER: nightly
-:KATELLO_VER: nightly
+:FOREMAN_VER: <%= @item[:version] %>
+:KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
 


### PR DESCRIPTION
While I tried to somehow find a way to set asciidoctor attributes, I couldn't find a way. The data source already rendered it as .adoc.erb which means it first applies ERB and then asciidoctor. This allows us to use the item's data source and removes duplication, making branching easier.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.