### PR TITLE
Add section for RHEL8to9 in-place upgrade using LEAPP

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,0 +1,321 @@
+[id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
+= Upgrading {Project} or {SmartProxy} to {EL} 9 In-Place Using Leapp
+
+Use this procedure to upgrade your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9.
+
+.Prerequisites
+* {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
+ifdef::foreman-el,katello[]
+* {Project} or {SmartProxy} installations running on CentOS 8 can be upgraded to CentOS Stream 9 or a {RHEL} rebuild.
+* {Project} or {SmartProxy} installations running on {RHEL}8 can be upgraded to {RHEL} 9.
+endif::[]
+ifdef::satellite[]
+* Review Known Issues before you begin an upgrade.
+For more information, see {ReleaseNotesURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+endif::[]
+ifndef::satellite[]
+* Access to available repositories or a local mirror of repositories.
+endif::[]
+
+ifeval::["{mode}" == "disconnected"]
+.Prerequisites for Disconnected Environment
+If you run {Project} in a disconnected environment, ensure it also meets the following prerequisites:
+
+* You require access to {RHEL} and {Project} packages.
+Obtain the ISO files for {RHEL} 9 and {Project}.
+For more information, see xref:upgrading_a_disconnected_satellite[]. <<<<<Change link>>>>>
+* For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+* Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+* For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
+endif::[]
+
+ifdef::satellite[]
+[NOTE]
+====
+* {Project} supports DEFAULT and FIPS crypto-policies.
+The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
+* In-place upgrade of {EL} systems in FIPS mode is not supported by {Team}.
+Turning FIPS off, upgrading from {EL} 8 to {EL} 9, and then turning FIPS on is not supported either.
+Instead, migrate your {Project} {ProductVersion} to a freshly installed {EL} 8 system with FIPS mode enabled.
+For more information, see xref:migrating-{project-context}-to-a-new-el-system_{context}[]. <<<<<check link>>>>>
+====
+endif::[]
+
+.Procedure
+. Configure the repositories to obtain Leapp.
+ifdef::foreman-el,katello[]
++
+On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains newer Leapp packages than those shipped by https://wiki.almalinux.org/elevate/[AlmaLinux/ELevate], and support {Project} or {SmartProxy} upgrades:
++
+----
+# curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-7/group_theforeman-leapp-epel-7.repo
+----
+endif::[]
++
+On {RHEL}, enable the `rhel-9-server-extras-rpms` repository:
++
+----
+# subscription-manager repos --enable=rhel-9-server-extras-rpms
+----
+
+. Install required packages:
+[options="nowrap", subs="+quotes,verbatim,attributes"]
++
+----
+# {package-install-project} leapp leapp-repository
+----
+ifdef::satellite[]
+
+. Set up the following repositories to perform the upgrade in a disconnected environment:
+.. `/etc/yum.repos.d/rhel8.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[BaseOS]
+name={RepoRHEL8BaseOS}
+baseurl=http://_server.example.com_/rhel9/BaseOS/
+
+[AppStream]
+name={RepoRHEL8AppStream}
+baseurl=http://_server.example.com_/rhel9/AppStream/
+----
+.. `/etc/yum.repos.d/{project-context}.repo:`
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[{RepoRHEL8ServerSatelliteServerProductVersion}]
+name={RepoRHEL8ServerSatelliteServerProductVersion}
+baseurl=http://_server.example.com_/sat6/Satellite/
+
+[{RepoRHEL8ServerSatelliteMaintenanceProductVersion}]
+name={RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+baseurl=http://_server.example.com_/sat6/Maintenance/
+----
+endif::[]
+
+ifdef::foreman-el,katello[]
+. Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
+Note that this is not required for {RHEL} based installations.
++
+----
+# yum install leapp-data-centos
+----
++
+. Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[leapp-foreman]
+name=Foreman {ProjectVersion}
+baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/el8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+ifdef::katello[]
+[leapp-katello]
+name=Katello {KatelloVersion}
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-katello-candlepin]
+name=Candlepin: an open source entitlement management system.
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-pulpcore]
+name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
+baseurl=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el8/$basearch/
+gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+endif::[]
+
+[leapp-foreman-plugins]
+name=Foreman plugins {ProjectVersion}
+baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el8/$basearch
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
+
+[leapp-foreman-client]
+name=Foreman client {ProjectVersion}
+baseurl=https://yum.theforeman.org/client/{ProjectVersion}/el8/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
+
+[leapp-puppet7]
+name=Puppet 7 Repository el 8 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1
+----
+
+* You need a Puppet repository for the Puppet agent that the installer is using.
+
+. We do not support {EL} 9 installations with EPEL 9 enabled, so remove `epel-release`:
++
+----
+# yum remove epel-release
+----
+
+. Remove `centos-release-scl` and `centos-release-scl-rh` repositories:
++
+----
+# yum remove centos-release-scl centos-release-scl-rh
+----
+endif::[]
+
+. Configure Leapp to skip updating the Tomcat packages to ensure the upgrade does not fail:
++
+----
+# echo tomcat >> /etc/leapp/transaction/to_remove
+# echo tomcat-lib >> /etc/leapp/transaction/to_remove
+----
+
+. Let Leapp analyze your system:
++
+----
+# leapp preupgrade
+----
+ifdef::satellite[]
++
+If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp preupgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL9ServerSatelliteServerProductVersion} \
+--enablerepo {RepoRHEL9ServerSatelliteMaintenanceProductVersion}
+----
+endif::[]
+
++
+The first run is expected to fail but report issues and inhibit the upgrade.
+Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
++
+The following commands show the most common steps required:
++
+----
+# rmmod pata_acpi
+# echo PermitRootLogin yes | tee -a /etc/ssh/sshd_config
+# leapp answer --section remove_pam_pkcs11_module_check.confirm=True
+----
++
+If `leapp preupgrade` inhibits the upgrade with *Unsupported network configuration* because there are multiple legacy named network interfaces, follow the instructions shown by Leapp to rename the interfaces, followed by an installer run to reconfigure {Project} or {SmartProxy} to use the new interface names:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --help |grep 'interface.*eth'
+    --foreman-proxy-dhcp-interface  DHCP listen interface (current: "eth0")
+    --foreman-proxy-dns-interface  DNS interface (current: "eth0")
+----
++
+If `eth0` was renamed to `em0`, call the installer to use the new interface name with:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-installer} --foreman-proxy-dhcp-interface=em0 --foreman-proxy-dns-interface=em0
+----
+
+. Ensure `leapp preupgrade` has no issues.
+
+. Run:
++
+----
+# leapp upgrade
+----
+
+ifdef::satellite[]
++
+If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp upgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL8ServerSatelliteServerProductVersion} \
+--enablerepo {RepoRHEL8ServerSatelliteMaintenanceProductVersion}
+----
+endif::[]
+
+. Reboot the system.
++
+After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 8 system.
+
+. Leapp finishes the upgrade, watch it with:
++
+----
+# journalctl -u leapp_resume -f
+----
+
+ifndef::satellite[]
+. Reindex the databases:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# runuser -u postgres -- reindexdb -a
+----
+endif::[]
+
+ifdef::satellite[]
+. Complete these procedures in  _Upgrading from RHEL 8 to RHEL 9_:  
+.. Unlock packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages unlock
+----
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system]
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks]
+.. Lock packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages lock
+----
+endif::[]
+. For {Project} only and not {SmartProxy}, if you require SELinux to be in enforcing mode, run the following command before changing SELinux to enforcing mode:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+ifdef::foreman-el[]
+# dnf reinstall foreman-selinux --disableplugin=foreman-protector
+endif::[]
+ifdef::katello,satellite,orcharhino[]
+# dnf reinstall foreman-selinux katello-selinux --disableplugin=foreman-protector
+endif::[]
+----
+ifdef::satellite[]
+. Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/applying-security-policies_upgrading-from-rhel-7-to-rhel-8#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+. Unset the `subscription-manager` release:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager release --unset
+----
+endif::[]
+
+ifndef::satellite[]
+[NOTE]
+====
+If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
+====
+endif::[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -53,4 +53,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 // Upgrading the External database
 include::common/modules/proc_upgrading-the-external-database.adoc[leveloffset=+2]
 endif::[]
+
+// Upgarding Project and Smart Proxy RHEL8to9 Using LEAPP
+include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
Adding information about the process to upgrade the underlying OS from EL8to9. Repurposed the older RHEL7to8 LEAPP module from 3.1 for 8to9 LEAPP upgrade.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
* We do not accept PRs for Foreman older than 3.3.
