### PR TITLE
Retire branches 3.3 and 3.4 in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,4 @@ Please cherry-pick my commits into:
 * [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
 * [ ] Foreman 3.6/Katello 4.8
 * [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
-* [ ] Foreman 3.4/Katello 4.6 (EL8 only)
-* [ ] Foreman 3.3/Katello 4.5 on EL7 & EL8 (Satellite 6.12 on EL8 only; orcharhino 6.4/6.5 on EL8 only)
-* We do not accept PRs for Foreman older than 3.3.
+* We do not accept PRs for Foreman older than 3.5.


### PR DESCRIPTION
Satellite 6.12 [reached EOL on May 31, 2024](https://access.redhat.com/support/policy/updates/satellite/), so we're proposing retirement of the unsupported branches 3.3 and 3.4 for cherry picks.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

TODO: Notify Matrix after merge