### PR TITLE
Fix building docs using container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
-FROM fedora:38
+FROM fedora:40
 
-RUN dnf upgrade -y && \
-    dnf install -y findutils \
-                   gcc \
-                   gcc-c++ \
-                   linkchecker \
-                   make \
-                   redhat-rpm-config \
-                   ruby-devel \
-                   rubygem-asciidoctor \
-                   rubygem-nokogiri && \
+RUN dnf install -y \
+        findutils \
+        gcc \
+        gcc-c++ \
+        linkchecker \
+        make \
+        redhat-rpm-config \
+        ruby-devel \
+        rubygem-asciidoctor && \
     dnf groupinstall -y development-tools && \
-    gem install sass
+    gem install \
+        ffi:1.16.3 \
+        nokogiri \
+        rb-inotify:0.10.1 \
+        sass
 
 WORKDIR /foreman-documentation/guides


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

I assume building the docs locally by using the container image broke with a change to the Gemfile, but this is only a guess.

tested locally:

````
$ podman build --tag tmp:2 --file Dockerfile .
$ rm -fr guides/build && podman run --rm -v $(pwd):/foreman-documentation:Z tmp:2 make html BUILD=katello
````