### PR TITLE
Use assemblies

### DIFF
--- a/guides/common/assembly_configuring-inter-server-synchronization.adoc
+++ b/guides/common/assembly_configuring-inter-server-synchronization.adoc
@@ -1,0 +1,7 @@
+include::modules/con_configuring-inter-server-synchronization.adoc[]
+
+include::modules/con_how-to-configure-inter-server-sync.adoc[leveloffset=+1]
+
+include::modules/proc_configuring-server-to-sync-content-using-exports.adoc[leveloffset=+1]
+
+include::modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-managing-content.adoc
+++ b/guides/common/assembly_introduction-to-managing-content.adoc
@@ -1,0 +1,3 @@
+include::modules/con_introduction-to-content-management.adoc[]
+
+include::modules/con_content-types-in-project.adoc[]

--- a/guides/common/assembly_introduction-to-managing-content.adoc
+++ b/guides/common/assembly_introduction-to-managing-content.adoc
@@ -1,3 +1,3 @@
 include::modules/con_introduction-to-content-management.adoc[]
 
-include::modules/con_content-types-in-project.adoc[]
+include::modules/con_content-types-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-hosts.adoc
+++ b/guides/common/assembly_overview-of-hosts.adoc
@@ -1,0 +1,3 @@
+include::modules/con_overview-of-hosts-in-project.adoc[]
+
+include::modules/con_browsing-hosts-in-foreman-webui.adoc[]

--- a/guides/common/assembly_overview-of-hosts.adoc
+++ b/guides/common/assembly_overview-of-hosts.adoc
@@ -1,3 +1,3 @@
 include::modules/con_overview-of-hosts-in-project.adoc[]
 
-include::modules/con_browsing-hosts-in-foreman-webui.adoc[]
+include::modules/con_browsing-hosts-in-foreman-webui.adoc[leveloffset=+1]

--- a/guides/common/modules/con_configuring-inter-server-synchronization.adoc
+++ b/guides/common/modules/con_configuring-inter-server-synchronization.adoc
@@ -1,0 +1,2 @@
+[id="Configuring-ISS-in-{project-context}_{context}"]
+= Configuring {ISS} (ISS) in {Project}

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -74,11 +74,5 @@ endif::[]
 
 ifdef::katello,orcharhino[]
 [appendix]
-== Configuring {ISS} (ISS) in {Project}
-
-include::common/modules/con_how-to-configure-inter-server-sync.adoc[leveloffset=+2]
-
-include::common/modules/proc_configuring-server-to-sync-content-using-exports.adoc[leveloffset=+2]
-
-include::common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc[leveloffset=+2]
+include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -21,9 +21,7 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]
-include::common/modules/con_introduction-to-content-management.adoc[leveloffset=+1]
-
-include::common/modules/con_content-types-in-project.adoc[leveloffset=+1]
+include::common/assembly_introduction-to-managing-content.adoc[leveloffset=+1]
 
 ifdef::katello[]
 include::common/assembly_basic-content-management-workflow.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -17,9 +17,7 @@ include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/modules/con_overview-of-hosts-in-project.adoc[leveloffset=+1]
-
-include::common/modules/con_browsing-hosts-in-foreman-webui.adoc[leveloffset=+1]
+include::common/assembly_overview-of-hosts.adoc[leveloffset=+1]
 
 include::common/assembly_administering-hosts.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Would it be OK if we add a "+1" leveloffset to [Content types in Foreman](https://docs.theforeman.org/nightly/Managing_Content/index-katello.html#Content_Types_in_Foreman_content-management) and [Browsing Hosts in Foreman web UI](https://docs.theforeman.org/nightly/Managing_Hosts/index-katello.html#Browsing-Hosts-in-foreman_web_UI_managing-hosts)?

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
