### PR TITLE
Show URL repos structure of content on Katello

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -173,6 +173,9 @@
 :client-pkg-arch: noarch
 :client-pkg-ext: rpm
 :client-provisioning-template-type: Kickstart
+:client-content-content-view-label: AlmaLinux_9
+:client-content-product-label: {client-content-content-view-label}
+:client-content-repository-label: BaseOS
 :client-salt-minion-repository-url: https://repo.saltproject.io/py3/
 // Foreman Server and Smart Proxy Server
 :project-minimum-memory: 4 GB

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -23,7 +23,7 @@ ifndef::satellite[]
 You can access unprotected repositories in the _Default Organization View_ content view.
 The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Library/custom/{client-content-product-label}/{client-content-repository-label}/`.
 ifdef::katello,orcharhino[]
-ifeval::["{context}" == "content-management"]
+ifdef::content-management[]
 For more information, see
 ifdef::katello[]
 xref:Adding_Custom_Deb_Repositories_{context}[] or xref:Adding_Custom_RPM_Repositories_{context}[].
@@ -51,7 +51,7 @@ The repositories for _Testing_ and _Production_ contain the `_my-software_-1.0-0
 | | Development | Testing | Production
 
 | Version of the content view | Version 2 | Version 1 | Version 1
-| Contents of the content view | _my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | _my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext} | _my-software_1.0-0.{client-pkg-arch}.{client-pkg-ext}
+| Contents of the content view | _my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | _my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext} | _my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext}
 |===
 
 If you promote Version 2 of the content view from _Development_ to _Testing_, the repository for _Testing_ updates to contain the `_my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext}` package:

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -19,6 +19,27 @@ However, the repositories for the content views still exist and you can keep man
 A _Default Organization View_ is an application-controlled content view for all content that is synchronized to {Project}.
 With the Default Organization View, you can register a host to {Project} and access content without manipulating content views and lifecycle environments.
 
+ifndef::satellite[]
+You can access unprotected repositories in the _Default Organization View_ content view.
+The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Library/custom/{client-content-product-label}/{client-content-repository-label}/`.
+ifdef::katello,orcharhino[]
+ifeval::["{context}" == "content-management"]
+For more information, see
+ifdef::katello[]
+xref:Adding_Custom_Deb_Repositories_{context}[] or xref:Adding_Custom_RPM_Repositories_{context}[].
+endif::[]
+endif::[]
+ifdef::orcharhino[]
+ifdef::debian,ubuntu[]
+xref:Adding_Custom_Deb_Repositories_{context}[].
+endif::[]
+ifdef::almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
+xref:Adding_Custom_RPM_Repositories_{context}[].
+endif::[]
+endif::[]
+endif::[]
+endif::[]
+
 .Promoting a content view across environments
 When you promote a content view from one environment to the next environment in the application lifecycle, {Project} updates the repository and publishes the packages.
 
@@ -44,6 +65,17 @@ If you promote Version 2 of the content view from _Development_ to _Testing_, th
 
 This ensures hosts are designated to a specific environment but receive updates when that environment uses a new version of the content view.
 ====
+
+ifndef::satellite[]
+You can access unprotected repositories in published content view versions.
+The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/content_views/`, your content view, your content view version, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/content_views/{client-content-content-view-label}/2.1/custom/{client-content-product-label}/{client-content-repository-label}/`.
+
+If you want to access the latest published content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, your lifecycle, your content view, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Production/{client-content-content-view-label}/custom/{client-content-product-label}/{client-content-content-view-label}/`.
+endif::[]
+
+ifdef::orcharhino[]
+You can use these URLs to provide versioned {project-client-name}s during host registration.
+endif::[]
 
 ifeval::["{context}" == "planning"]
 [role="_additional-resources"]

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -30,7 +30,7 @@ The repositories for _Testing_ and _Production_ contain the `_<my_software>_-1.0
 | | Development | Testing | Production
 
 | Version of the content view | Version 2 | Version 1 | Version 1
-| Contents of the content view | _<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | _<my_software>_-1.0-0.{client-pkg-arch}.{client-pkg-ext} | _<my_software>_.0-0.{client-pkg-arch}.{client-pkg-ext}
+| Contents of the content view | _<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | _<my_software>_-1.0-0.{client-pkg-arch}.{client-pkg-ext} | _<my_software>_1.0-0.{client-pkg-arch}.{client-pkg-ext}
 |===
 
 If you promote Version 2 of the content view from _Development_ to _Testing_, the repository for _Testing_ updates to contain the `_<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext}` package:

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -67,7 +67,7 @@ This ensures hosts are designated to a specific environment but receive updates 
 ====
 
 ifndef::satellite[]
-You can access unprotected repositories in published content view versions.
+With `Distribute archived content view versions` enabled, you can access unprotected repositories in published content view versions.
 The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/content_views/`, your content view, your content view version, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/content_views/{client-content-content-view-label}/2.1/custom/{client-content-product-label}/{client-content-repository-label}/`.
 
 If you want to access the latest published content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, your lifecycle, your content view, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Production/{client-content-content-view-label}/custom/{client-content-product-label}/{client-content-content-view-label}/`.

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -17,7 +17,7 @@ However, the repositories for the content views still exist and you can keep man
 
 .Default Organization View
 A _Default Organization View_ is an application-controlled content view for all content that is synchronized to {Project}.
-With the Default Organization View, you can register a host to {Project} and access content without manipulating content views and lifecycle environments.
+You can register a host to the _Library_ environment on {Project} to consume the _Default Organization View_ without configuring content views and lifecycle environments.
 
 ifndef::satellite[]
 You can access unprotected repositories in the _Default Organization View_ content view.

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -38,7 +38,7 @@ If you promote Version 2 of the content view from _Development_ to _Testing_, th
 |===
 | | Development | Testing | Production
 
-| Version of the content view | Version 2  | *Version 2* | Version 1
+| Version of the content view | Version 2 | *Version 2* | Version 1
 | Contents of the content view | _my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | *_my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext}* | _my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext}
 |===
 

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -24,22 +24,22 @@ When you promote a content view from one environment to the next environment in 
 
 .Promoting a package from _Development_ to _Testing_
 ====
-The repositories for _Testing_ and _Production_ contain the `_<my_software>_-1.0-0.{client-pkg-arch}.{client-pkg-ext}` package:
+The repositories for _Testing_ and _Production_ contain the `_my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext}` package:
 
 |===
 | | Development | Testing | Production
 
 | Version of the content view | Version 2 | Version 1 | Version 1
-| Contents of the content view | _<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | _<my_software>_-1.0-0.{client-pkg-arch}.{client-pkg-ext} | _<my_software>_1.0-0.{client-pkg-arch}.{client-pkg-ext}
+| Contents of the content view | _my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | _my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext} | _my-software_1.0-0.{client-pkg-arch}.{client-pkg-ext}
 |===
 
-If you promote Version 2 of the content view from _Development_ to _Testing_, the repository for _Testing_ updates to contain the `_<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext}` package:
+If you promote Version 2 of the content view from _Development_ to _Testing_, the repository for _Testing_ updates to contain the `_my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext}` package:
 
 |===
 | | Development | Testing | Production
 
 | Version of the content view | Version 2  | *Version 2* | Version 1
-| Contents of the content view | _<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | *_<my_software>_-1.1-0.{client-pkg-arch}.{client-pkg-ext}* | _<my_software>_-1.0-0.{client-pkg-arch}.{client-pkg-ext}
+| Contents of the content view | _my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext} | *_my-software_-1.1-0.{client-pkg-arch}.{client-pkg-ext}* | _my-software_-1.0-0.{client-pkg-arch}.{client-pkg-ext}
 |===
 
 This ensures hosts are designated to a specific environment but receive updates when that environment uses a new version of the content view.


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)

I would like some guidance/suggestions on the wording.

Example URLs for you to check on your local instance:
* https://katello.example.com/pulp/content/Example/content_views/RHEL_9/12.0/content/dist/rhel9/9.3/x86_64/
* https://katello.example.com/pulp/content/Example/Production/Composite_AlmaLinux_8/custom/AlmaLinux_8/BaseOS/

The content is hidden for Satellite because I assume that you don't want to document how to consume content with subscription-manager. To change this, I'd need to make sure that the repo URLs work for both "custom" and "RH" content by using attributes.