### PR TITLE
Remove unnecessary ifdef in assembly

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -174,9 +174,7 @@ include::modules/proc_uploading-content-to-custom-rpm-repositories.adoc[leveloff
 
 include::modules/proc_refreshing-content-counts-on-smart-proxy.adoc[leveloffset=+1]
 
-ifdef::katello,satellite,orcharhino[]
 include::modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc[leveloffset=+1]
-endif::[]
 
 include::modules/proc_recovering-a-corrupted-repository.adoc[leveloffset=+1]
 


### PR DESCRIPTION
ifdef is handled in "master.adoc" for the managing content chapter which only provides content for Katello, Satellite, and orcharhino builds.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
