### PR TITLE
Add limitation of host params in Ansible playbook jobs

### DIFF
--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -6,7 +6,9 @@ You can run an Ansible playbook on a host or host group by executing a remote jo
 .Limitation of host parameters in Ansible playbook job templates
 When you execute an Ansible playbook on multiple hosts and the playbook job template includes a host parameter, {Project} renders the playbook for all hosts in the batch, but only uses the playbook of the first host to execute it on all hosts in the batch.
 Therefore, you cannot use a host parameter to modify the behavior of the playbook per host.
+ifndef::orcharhino[]
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2282275[BZ#2282275].
+endif::[]
 
 .Prerequisites
 * Ansible plugin in {Project} is enabled.

--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -4,8 +4,9 @@
 You can run an Ansible playbook on a host or host group by executing a remote job in {Project}.
 
 .Limitation of host parameters in Ansible playbook job templates
-When you execute an Ansible playbook on multiple hosts and the playbook job template includes a host parameter, {Project} renders the playbook for all hosts in the batch, but only uses the playbook of the first host to execute it on all hosts in the batch.
-Therefore, you cannot use a host parameter to modify the behavior of the playbook per host.
+When you execute an Ansible playbook on multiple hosts and the playbook job template includes a host parameter, {Project} renders the playbook for all hosts in the batch, but only uses the rendered playbook of the first host to execute it on all hosts in the batch.
+Therefore, you cannot modify the behavior of the playbook per host by using the host parameter in the template control flow constructs.
+Host parameters are translated into Ansible variables, so you can use them to control the behavior in native Ansible constructs.
 ifndef::orcharhino[]
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2282275[BZ#2282275].
 endif::[]

--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -4,8 +4,8 @@
 You can run an Ansible playbook on a host or host group by executing a remote job in {Project}.
 
 .Limitation of host parameters in Ansible playbook job templates
-When you execute an Ansible playbook on multiple hosts and the playbook job template includes a host parameter, {Project} renders the playbook for all hosts in the batch, but only uses the rendered playbook of the first host to execute it on all hosts in the batch.
-Therefore, you cannot modify the behavior of the playbook per host by using the host parameter in the template control flow constructs.
+When you execute an Ansible playbook on multiple hosts, {Project} renders the playbook for all hosts in the batch, but only uses the rendered playbook of the first host to execute it on all hosts in the batch.
+Therefore, you cannot modify the behavior of the playbook per host by using a host parameter in the template control flow constructs.
 Host parameters are translated into Ansible variables, so you can use them to control the behavior in native Ansible constructs.
 ifndef::orcharhino[]
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2282275[BZ#2282275].

--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -3,6 +3,11 @@
 
 You can run an Ansible playbook on a host or host group by executing a remote job in {Project}.
 
+.Limitation of host parameters in Ansible playbook job templates
+When you execute an Ansible playbook on multiple hosts and the playbook job template includes a host parameter, {Project} renders the playbook for all hosts in the batch, but only uses the playbook of the first host to execute it on all hosts in the batch.
+Therefore, you cannot use a host parameter to modify the behavior of the playbook per host.
+For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2282275[BZ#2282275].
+
 .Prerequisites
 * Ansible plugin in {Project} is enabled.
 * Remote job execution is configured.


### PR DESCRIPTION
Requested by https://issues.redhat.com/browse/SAT-25285

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
