### PR TITLE
Perform health check before restore

### DIFF
--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -1,7 +1,7 @@
 [id="Restoring_from_a_Full_Backup_{context}"]
 = Restoring from a full backup
 
-Use this procedure to restore {ProjectName} or {SmartProxyServer} from a full backup.
+Use this procedure to restore {ProjectServer} or {SmartProxyServer} from a full backup.
 When the restore process completes, all processes are online, and all databases and system configuration revert to the state at the time of the backup.
 
 .Prerequisites
@@ -15,14 +15,14 @@ To check the space used by a directory, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# du -sh _/var/backup_directory_
+# du -sh _/var/My_Backup_Directory_
 ----
 +
 To check for free space, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# df -h _/var/backup_directory_
+# df -h _/var/My_Backup_Directory_
 ----
 +
 Add the ``--total`` option to get a total of the results from more than one directory.
@@ -38,7 +38,7 @@ Enter the following command to restore the correct SELinux contexts:
 endif::[]
 
 .Procedure
-. Choose the appropriate method to install {Project} or {SmartProxy}:
+. Choose the appropriate method to install {ProjectServer} or {SmartProxyServer}:
 ** To install {ProjectServer} from a connected network, follow the procedures in {InstallingServerDocURL}[{InstallingServerDocTitle}].
 ifdef::satellite[]
 ** To install {ProjectServer} from a disconnected network, follow the procedures in {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
@@ -50,10 +50,10 @@ Use `/var/` or `/var/tmp/`.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-maintain} restore __/var/backup_directory__
+# {foreman-maintain} restore _/var/My_Backup_Directory_
 ----
 +
-Where _backup_directory_ is the time-stamped directory or subdirectory containing the backed-up data.
+Where _My_Backup_Directory_ is the time-stamped directory or subdirectory containing the backed-up data.
 +
 The restore process can take a long time to complete, because of the amount of data to copy.
 

--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -44,6 +44,12 @@ ifdef::satellite[]
 ** To install {ProjectServer} from a disconnected network, follow the procedures in {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
 endif::[]
 ** To install a {SmartProxyServer}, follow the procedures in {InstallingSmartProxyDocURL}[{InstallingSmartProxyDocTitle}].
+. Ensure that all {Project} services are running:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} health check
+----
 . Copy the backup data to {ProjectServer}’s local file system.
 Use `/var/` or `/var/tmp/`.
 . Run the restoration script.


### PR DESCRIPTION
users should not (try to) restore to a Foreman/Katello instance that is not running smoothly. 

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
