### PR TITLE
Remove unnecessary attribute parent-context

### DIFF
--- a/guides/common/assembly_job-template-examples-and-extensions.adoc
+++ b/guides/common/assembly_job-template-examples-and-extensions.adoc
@@ -1,5 +1,3 @@
-ifdef::context[:parent-context: {context}]
-
 include::modules/con_job-template-examples-and-extensions.adoc[]
 
 include::modules/ref_customizing-job-templates.adoc[leveloffset=+1]
@@ -13,6 +11,3 @@ include::modules/ref_rendering-a-restorecon-template.adoc[leveloffset=+1]
 include::modules/proc_executing-a-restorecon-template-on-multiple-hosts.adoc[leveloffset=+1]
 
 include::modules/ref_example-including-power-options-in-a-job-template.adoc[leveloffset=+1]
-
-ifdef::parent-context[:context: {parent-context}]
-ifndef::parent-context[:!context:]


### PR DESCRIPTION
No module in the "assembly_job-template-examples-and-extensions.adoc" assembly overwrites the "context" attribute. Therefore, it is not required to store the original value as "parent-context".


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
