### PR TITLE
Add section for RHEL8to9 in-place upgrade using LEAPP

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -67,6 +67,7 @@
 :DL: Debian/Ubuntu
 :DL-ID: Debian-Ubuntu
 :EL: Enterprise Linux
+:EL-abbr: {EL}
 :foreman-example-com: foreman.example.com
 :foreman-installer: foreman-installer
 :foreman-installer-package: foreman-installer

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -67,7 +67,7 @@
 :DL: Debian/Ubuntu
 :DL-ID: Debian-Ubuntu
 :EL: Enterprise Linux
-:EL-abbr: {EL}
+:EL-abbr: EL
 :foreman-example-com: foreman.example.com
 :foreman-installer: foreman-installer
 :foreman-installer-package: foreman-installer

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -63,7 +63,7 @@
 :customssl: custom SSL
 :DocState: satellite
 :EL: {RHEL}
-:EL-abbr: {RHEL}
+:EL-abbr: RHEL
 :fdi-package-name: foreman-discovery-image
 :foreman-example-com: satellite.example.com
 :foreman-installer-package: satellite-installer

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -63,6 +63,7 @@
 :customssl: custom SSL
 :DocState: satellite
 :EL: {RHEL}
+:EL-abbr: {RHEL}
 :fdi-package-name: foreman-discovery-image
 :foreman-example-com: satellite.example.com
 :foreman-installer-package: satellite-installer

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -7,6 +7,7 @@
 :ProjectVersionPrevious: 3.11
 :KatelloVersion: nightly
 :PulpcoreVersion: 3.49
+:CandlepinVersion: 4.4
 
 //
 // WHERE ARE MY ATTRIBUTES?

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -6,6 +6,7 @@
 :ProjectVersion: nightly
 :ProjectVersionPrevious: 3.11
 :KatelloVersion: nightly
+:PulpcoreVersion: 3.49
 
 //
 // WHERE ARE MY ATTRIBUTES?

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,0 +1,254 @@
+[id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
+= Upgrading {Project} or {SmartProxy} to {EL} 9 In-Place Using Leapp
+
+Use this procedure to upgrade your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9.
+
+.Prerequisites
+* {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
+ifdef::satellite[]
+* Review Known Issues before you begin an upgrade.
+For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+endif::[]
+ifndef::satellite[]
+* Access to available repositories or a local mirror of repositories.
+endif::[]
+
+ifeval::["{mode}" == "disconnected"]
+.Prerequisites for Disconnected Environment
+If you run {Project} in a disconnected environment, ensure it also meets the following prerequisites:
+
+* You require access to {RHEL} and {Project} packages.
+Obtain the ISO files for {RHEL} 9 and {Project}.
+For more information, see {UpgradingDisconnectedDocURL}Upgrading_satellite_upgrading-disconnected[Upgrading Red Hat Satellite] in _{UpgradingDisconnectedDocTitle}_.
+* For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+* Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+* For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
+endif::[]
+
+ifdef::satellite[]
+[NOTE]
+====
+* {Project} supports DEFAULT and FIPS crypto-policies.
+The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
+====
+endif::[]
+
+.Procedure
+. Configure the repositories to obtain Leapp.
+ifdef::foreman-el,katello[]
++
+On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
++
+----
+# curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-8/group_theforeman-leapp-epel-8.repo
+----
+endif::[]
+
+. Install required packages:
+[options="nowrap", subs="+quotes,verbatim,attributes"]
++
+----
+# {project-package-install} leapp leapp-upgrade-el8toel9
+----
+ifdef::satellite[]
+
+ifeval::["{mode}" == "disconnected"]
+. Set up the following repositories to perform the upgrade in a disconnected environment:
+.. `/etc/yum.repos.d/rhel9.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[BaseOS]
+name={RepoRHEL9BaseOS}
+baseurl=http://_server.example.com_/rhel9/BaseOS/
+
+[AppStream]
+name={RepoRHEL9AppStream}
+baseurl=http://_server.example.com_/rhel9/AppStream/
+----
+.. `/etc/yum.repos.d/{project-context}.repo:`
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[{RepoRHEL9ServerSatelliteServerProjectVersion}]
+name={RepoRHEL9ServerSatelliteServerProjectVersion}
+baseurl=http://_server.example.com_/sat6/Satellite/
+
+[{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}]
+name={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+baseurl=http://_server.example.com_/sat6/Maintenance/
+----
+endif::[]
+endif::[]
+
+ifdef::foreman-el,katello[]
+. Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
+Note that this is not required for {RHEL} based installations.
++
+----
+# yum install leapp-data-centos
+----
++
+. Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[leapp-foreman]
+name=Foreman {ProjectVersion}
+baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/el8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+ifdef::katello[]
+[leapp-katello]
+name=Katello {KatelloVersion}
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-katello-candlepin]
+name=Candlepin: an open source entitlement management system.
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el8/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+
+[leapp-pulpcore]
+name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
+baseurl=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el8/$basearch/
+gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore
+enabled=1
+gpgcheck=1
+module_hotfixes=1
+endif::[]
+
+[leapp-foreman-plugins]
+name=Foreman plugins {ProjectVersion}
+baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el8/$basearch
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+module_hotfixes=1
+
+[leapp-foreman-client]
+name=Foreman client {ProjectVersion}
+baseurl=https://yum.theforeman.org/client/{ProjectVersion}/el8/$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
+
+[leapp-puppet7]
+name=Puppet 7 Repository el 8 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
+       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1
+----
+
+* You need a Puppet repository for the Puppet agent that the installer is using.
+
+. We do not support {EL} 9 installations with EPEL 9 enabled, so remove `epel-release`:
++
+----
+# yum remove epel-release
+----
+
+. Let Leapp analyze your system:
++
+----
+# leapp preupgrade
+----
+ifdef::satellite[]
++
+ifeval::["{mode}" == "disconnected"]
+Add the `--no-rhsm` and `--enablerepo` parameters:
+endif::[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp preupgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL9ServerSatelliteServerProjectVersion} \
+--enablerepo {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+----
+endif::[]
+
++
+The first run is expected to fail but report issues and inhibit the upgrade.
+Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
++
+
+. Ensure `leapp preupgrade` has no issues.
+
+. Run:
++
+----
+# leapp upgrade
+----
+
+ifdef::satellite[]
++
+If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# leapp upgrade \
+--no-rhsm \
+--enablerepo BaseOS \
+--enablerepo AppStream \
+--enablerepo {RepoRHEL9ServerSatelliteServerProjectVersion} \
+--enablerepo {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+----
+endif::[]
+
+. Reboot the system.
++
+After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 8 system.
+
+. Leapp finishes the upgrade, watch it with:
++
+----
+# journalctl -u leapp_resume -f
+----
+
+ifdef::satellite[]
+. Complete these procedures in  _Upgrading from RHEL 8 to RHEL 9_:  
+.. Unlock packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages unlock
+----
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system]
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks]
+.. Lock packages:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} packages lock
+----
+endif::[]
+ifdef::satellite[]
+. Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/applying-security-policies_upgrading-from-rhel-7-to-rhel-8#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+. Unset the `subscription-manager` release:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# subscription-manager release --unset
+----
+endif::[]
+
+ifndef::satellite[]
+[NOTE]
+====
+If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
+====
+endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -21,7 +21,7 @@ endif::[]
 ifeval::["{mode}" == "disconnected"]
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
-For more information, see xref:Upgrading_satellite_upgrading-disconnected[].
+For more information, see {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_ 
 * Leapp completes part of the upgrade in a container that has no access to additional ISO mounts.
 The required repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -84,12 +84,12 @@ endif::[]
 
 ifndef::satellite[]
 . Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
-Note that this is not required for {RHEL} based installations.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {project-package-install} leapp-data-centos
 ----
+Note that this is not required for {RHEL} based installations.
 +
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
 +
@@ -167,7 +167,7 @@ The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
 +
 . Ensure `leapp preupgrade` has no issues.
-. Run:
+. Let Leapp create the upgrade environment:
 ifeval::["{mode}" != "disconnected"]
 +
 ----
@@ -190,11 +190,11 @@ endif::[]
 endif::[]
 
 
-. Reboot the system.
+. Reboot the system to start the upgrade.
 +
 After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 9 system.
 
-. Leapp finishes the upgrade, watch it with:
+. Wait for Leapp to finish the upgrade, you can monitor the process with:
 +
 ----
 # journalctl -u leapp_resume -f
@@ -216,9 +216,14 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 # {foreman-maintain} packages lock
 ----
 . Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
+ifeval::["{mode}" != "disconnected"]
 . Unset the `subscription-manager` release:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager release --unset
 ----
+ifndef::satellite[]
+Note that this is only required for {RHEL} based installations.
+endif::[]
+endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,7 +1,7 @@
 [id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL} 9 in-place by using Leapp
 
-{Project} and {SmartProxy} are supported on both {EL}8 and {EL}9.
+{Project} and {SmartProxy} are supported on both {EL} 8 and {EL} 9.
 You can upgrade your {Project} and {SmartProxy} operating system from {EL} 8 to {EL} 9. 
 When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to upgrade as well as to help detect and resolve issues that could prevent you from upgrading successfully.
 
@@ -10,30 +10,32 @@ ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
+ifdef::foreman-el,katello[]
+* Review Known Issues before you begin an upgrade.
+For more information, see https://docs.theforeman.org/3.11/Release_Notes/index-katello.html
+.
+endif::[]
 * {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
 ifndef::satellite[]
 * Access to available repositories or a local mirror of repositories.
 endif::[]
-
 ifeval::["{mode}" == "disconnected"]
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
 For more information, see xref:Upgrading_satellite_upgrading-disconnected[].
-* Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+* Leapp completes part of the upgrade in a container that has no access to additional ISO mounts.
+The required repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 endif::[]
 
 .Procedure
 ifndef::satellite[]
-. Configure the repositories to obtain Leapp.
-+
-Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
+. Enable the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
 +
 ----
 # dnf copr enable @theforeman/leapp
 ----
 Note that this is not required for {RHEL} based installations.
 endif::[]
-
 . Install required packages:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 +
@@ -41,7 +43,6 @@ endif::[]
 # {project-package-install} leapp leapp-upgrade-el8toel9
 ----
 ifdef::satellite[]
-
 ifeval::["{mode}" == "disconnected"]
 . Set up the following repositories to perform the upgrade in a disconnected environment:
 .. Add the following lines to `/etc/yum.repos.d/rhel9.repo`:
@@ -70,7 +71,6 @@ baseurl=http://_server.example.com_/sat6/Maintenance/
 ----
 endif::[]
 endif::[]
-
 ifndef::satellite[]
 . Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
 See `ID` in `/etc/os-release` for your OS code.
@@ -128,10 +128,9 @@ enabled=1
 gpgcheck=1
 endif::[]
 ----
-
 endif::[]
 . Let Leapp analyze your system:
-ifeval::["{mode}" != "disconnected"]
+ifeval::["{mode}" == "connected"]
 +
 ----
 # leapp preupgrade
@@ -151,7 +150,6 @@ ifeval::["{mode}" == "disconnected"]
 ----
 endif::[]
 endif::[]
-
 +
 The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve the other reported problems.
@@ -177,14 +175,12 @@ ifeval::["{mode}" == "disconnected"]
 ----
 endif::[]
 endif::[]
-
-
 . Reboot the system to start the upgrade.
 +
 After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels and then reboots into the final {EL} 9 system.
 
 . Wait for Leapp to finish the upgrade.
-. You can monitor the process with `journalctl`:
+You can monitor the process with `journalctl`:
 +
 ----
 # journalctl -u leapp_resume -f
@@ -198,8 +194,10 @@ ifdef::satellite[]
 # {foreman-maintain} packages unlock
 ----
 endif::[]
-. Verify the post-upgrade state. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
-. Perform post-upgrade tasks on the RHEL{nbsp}9 system. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
+. Verify the post-upgrade state.
+For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
+. Perform post-upgrade tasks on the RHEL{nbsp}9 system.
+For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 ifdef::satellite[]
 . Lock packages:
 +
@@ -208,8 +206,9 @@ ifdef::satellite[]
 # {foreman-maintain} packages lock
 ----
 endif::[]
-. Change SELinux to enforcing mode. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
-ifeval::["{mode}" != "connected"]
+. Change SELinux to enforcing mode.
+For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
+ifeval::["{mode}" == "disconnected"]
 ifdef::satellite[]
 . Unset the `subscription-manager` release:
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -201,20 +201,24 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 ----
 
 . Complete these procedures in  _Upgrading from RHEL 8 to RHEL 9_:  
+ifdef::satellite[]
 .. Unlock packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} packages unlock
 ----
+endif::[]
 .. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state]
 .. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL 9 system]
+ifdef::satellite[]
 .. Lock packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} packages lock
 ----
+endif::[]
 . Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
 ifeval::["{mode}" != "disconnected"]
 . Unset the `subscription-manager` release:

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -12,7 +12,7 @@ For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introduc
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.
-For more information, see {ReleaseNotesBaseURL}[Release notes].
+For more information, see {ReleaseNotesDocURL}[Release notes].
 endif::[]
 * {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
 ifndef::satellite[]
@@ -33,7 +33,7 @@ ifndef::satellite[]
 ----
 # dnf copr enable @theforeman/leapp
 ----
-Note that this is not required for {RHEL} based installations.
+Note that this is not required for {RHEL} installations.
 endif::[]
 . Install required packages:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -212,7 +212,7 @@ ifdef::satellite[]
 . Unset the `subscription-manager` release:
 endif::[]
 ifndef::satellite[]
-. For {RHEL}-based installations, unset the `subscription-manager` release:
+. For {EL} installations, unset the `subscription-manager` release:
 endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,36 +1,27 @@
 [id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL} 9 In-Place Using Leapp
 
-Use this procedure to upgrade your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9.
+When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to help detect and resolve issues that could prevent you from upgrading successfully.
 
 .Prerequisites
-* {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
 ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
+* {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
 ifndef::satellite[]
 * Access to available repositories or a local mirror of repositories.
 endif::[]
 
 ifeval::["{mode}" == "disconnected"]
-.Prerequisites for Disconnected Environment
-If you run {Project} in a disconnected environment, ensure it also meets the following prerequisites:
+If you run {Project} in a disconnected environment, ensure you also meet the following prerequisites:
 
 * You require access to {RHEL} and {Project} packages.
-Obtain the ISO files for {RHEL} 9 and {Project}.
+Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
 For more information, see {UpgradingDisconnectedDocURL}Upgrading_satellite_upgrading-disconnected[Upgrading Red Hat Satellite] in _{UpgradingDisconnectedDocTitle}_.
 * For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
 * Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 * For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
-endif::[]
-
-ifdef::satellite[]
-[NOTE]
-====
-* {Project} supports DEFAULT and FIPS crypto-policies.
-The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} installations.
-====
 endif::[]
 
 .Procedure
@@ -55,7 +46,7 @@ ifdef::satellite[]
 
 ifeval::["{mode}" == "disconnected"]
 . Set up the following repositories to perform the upgrade in a disconnected environment:
-.. `/etc/yum.repos.d/rhel9.repo`:
+.. Add the following lines to `/etc/yum.repos.d/rhel9.repo`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -67,7 +58,7 @@ baseurl=http://_server.example.com_/rhel9/BaseOS/
 name={RepoRHEL9AppStream}
 baseurl=http://_server.example.com_/rhel9/AppStream/
 ----
-.. `/etc/yum.repos.d/{project-context}.repo:`
+.. Add the following lines to `/etc/yum.repos.d/{project-context}.repo:`
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -164,9 +155,9 @@ endif::[]
 
 +
 The first run will most likely report issues and inhibit the upgrade.
-Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
+Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve the other reported problems.
 +
-. Ensure `leapp preupgrade` has no issues.
+. Run `leapp preupgrade` again and make sure that it does not report any more issues.
 . Let Leapp create the upgrade environment:
 ifeval::["{mode}" != "disconnected"]
 +
@@ -192,15 +183,15 @@ endif::[]
 
 . Reboot the system to start the upgrade.
 +
-After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 9 system.
+After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels and then reboots into the final {EL} 9 system.
 
-. Wait for Leapp to finish the upgrade, you can monitor the process with:
+. Wait for Leapp to finish the upgrade.
+. You can monitor the process with `journalctl`:
 +
 ----
 # journalctl -u leapp_resume -f
 ----
 
-. Complete these procedures in  _Upgrading from RHEL 8 to RHEL 9_:  
 ifdef::satellite[]
 .. Unlock packages:
 +
@@ -209,8 +200,8 @@ ifdef::satellite[]
 # {foreman-maintain} packages unlock
 ----
 endif::[]
-.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state]
-.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL 9 system]
+. Verify the post-upgrade state. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 toRHEL{nbsp}9_.
+. Perform post-upgrade tasks on the RHEL{nbsp}9 system. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 ifdef::satellite[]
 .. Lock packages:
 +
@@ -219,15 +210,17 @@ ifdef::satellite[]
 # {foreman-maintain} packages lock
 ----
 endif::[]
-. Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
+. Change SELinux to enforcing mode. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 ifeval::["{mode}" != "disconnected"]
+ifdef::satellite[]
 . Unset the `subscription-manager` release:
+endif::[]
+ifndef::satellite[]
+. For {RHEL}-based installations, unset the `subscription-manager` release:
+endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager release --unset
 ----
-ifndef::satellite[]
-Note that this is only required for {RHEL} based installations.
-endif::[]
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,5 +1,5 @@
 [id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
-= Upgrading {Project} or {SmartProxy} to {EL} 9 in-place Using Leapp
+= Upgrading {Project} or {SmartProxy} to {EL} 9 in-place by using Leapp
 
 When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to help detect and resolve issues that could prevent you from upgrading successfully.
 
@@ -192,7 +192,7 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 ----
 
 ifdef::satellite[]
-.. Unlock packages:
+. Unlock packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -202,7 +202,7 @@ endif::[]
 . Verify the post-upgrade state. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 . Perform post-upgrade tasks on the RHEL{nbsp}9 system. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 ifdef::satellite[]
-.. Lock packages:
+. Lock packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -220,8 +220,10 @@ endif::[]
 ----
 endif::[]
 
-ifeval::["{mode}" == "disconnected"]
+ifndef::orcharhino[]
 .Additional resources
 * For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+ifeval::["{mode}" == "disconnected"]
 * For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
+endif::[]
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -75,10 +75,11 @@ endif::[]
 
 ifndef::satellite[]
 . Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
+See `ID` in `/etc/os-release` for your OS code.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} leapp-data-centos
+# {project-package-install} leapp-data-$ID
 ----
 Note that this is not required for {RHEL} based installations.
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -146,7 +146,7 @@ ifeval::["{mode}" != "disconnected"]
 ----
 # leapp preupgrade
 ----
-endif
+endif::[]
 ifdef::satellite[]
 ifeval::["{mode}" == "disconnected"]
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,5 +1,5 @@
 [id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
-= Upgrading {Project} or {SmartProxy} to {EL} 9 in-place by using Leapp
+= Upgrading {Project} or {SmartProxy} to {EL-abbr} 9 in-place by using Leapp
 
 {Project} and {SmartProxy} are supported on both {EL} 8 and {EL} 9.
 You can upgrade your {Project} and {SmartProxy} operating system from {EL} 8 to {EL} 9. 
@@ -154,7 +154,7 @@ The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve other reported problems.
 . Run `leapp preupgrade` again and make sure that it does not report any more issues.
 . Let Leapp create the upgrade environment:
-ifeval::["{mode}" == "disconnected"]
+ifeval::["{mode}" == "connected"]
 +
 ----
 # leapp upgrade

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,4 +1,4 @@
-[id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
+[id="upgrading-{project-context}-or-{smart-proxy-context}-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL-abbr} 9 in-place by using Leapp
 
 {Project} and {SmartProxy} are supported on both {EL} 8 and {EL} 9.
@@ -79,7 +79,6 @@ See `ID` in `/etc/os-release` for your OS code.
 # {project-package-install} leapp-data-$ID
 ----
 Note that this is not required for {RHEL} installations.
-+
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -196,7 +195,7 @@ endif::[]
 . Verify the post-upgrade state.
 For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 . Perform post-upgrade tasks on the RHEL{nbsp}9 system.
-For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
+For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 ifdef::satellite[]
 . Lock packages:
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -72,7 +72,7 @@ endif::[]
 endif::[]
 ifndef::satellite[]
 . Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
-See `ID` in `/etc/os-release` for your OS code.
+See `ID` in `/etc/os-release` for your operating system code.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -12,8 +12,7 @@ For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introduc
 endif::[]
 ifdef::foreman-el,katello[]
 * Review Known Issues before you begin an upgrade.
-For more information, see https://docs.theforeman.org/3.11/Release_Notes/index-katello.html
-.
+For more information, see {BaseURL}Release_Notes/index-katello.html#katello-upgrade-warnings[Upgrade Warnings].
 endif::[]
 * {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
 ifndef::satellite[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,5 +1,5 @@
 [id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
-= Upgrading {Project} or {SmartProxy} to {EL} 9 In-Place Using Leapp
+= Upgrading {Project} or {SmartProxy} to {EL} 9 in-place Using Leapp
 
 When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to help detect and resolve issues that could prevent you from upgrading successfully.
 
@@ -18,7 +18,7 @@ If you run {Project} in a disconnected environment, ensure you also meet the fol
 
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
-For more information, see {UpgradingDisconnectedDocURL}Upgrading_satellite_upgrading-disconnected[Upgrading Red Hat Satellite] in _{UpgradingDisconnectedDocTitle}_.
+For more information, see xref:Upgrading_satellite_upgrading-disconnected[].
 * For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
 * Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 * For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
@@ -156,7 +156,6 @@ endif::[]
 +
 The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve the other reported problems.
-+
 . Run `leapp preupgrade` again and make sure that it does not report any more issues.
 . Let Leapp create the upgrade environment:
 ifeval::["{mode}" != "disconnected"]
@@ -200,7 +199,7 @@ ifdef::satellite[]
 # {foreman-maintain} packages unlock
 ----
 endif::[]
-. Verify the post-upgrade state. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 toRHEL{nbsp}9_.
+. Verify the post-upgrade state. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 . Perform post-upgrade tasks on the RHEL{nbsp}9 system. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL{nbsp}9 system] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
 ifdef::satellite[]
 .. Lock packages:
@@ -211,7 +210,7 @@ ifdef::satellite[]
 ----
 endif::[]
 . Change SELinux to enforcing mode. For more information, see link:{RHELDocsBaseURL}9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in _Upgrading from RHEL{nbsp}8 to RHEL{nbsp}9_.
-ifeval::["{mode}" != "disconnected"]
+ifeval::["{mode}" != "connected"]
 ifdef::satellite[]
 . Unset the `subscription-manager` release:
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -21,7 +21,7 @@ endif::[]
 ifeval::["{mode}" == "disconnected"]
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
-For more information, see {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_. 
+For more information, see {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] in _{InstallingServerDisconnectedDocTitle}_. 
 * Leapp completes part of the upgrade in a container that has no access to additional ISO mounts.
 The required repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -3,7 +3,7 @@
 
 {Project} and {SmartProxy} are supported on both {EL} 8 and {EL} 9.
 You can upgrade your {Project} and {SmartProxy} operating system from {EL} 8 to {EL} 9. 
-When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to upgrade as well as to help detect and resolve issues that could prevent you from upgrading successfully.
+Use the Leapp tool to upgrade as well as to help detect and resolve issues that could prevent you from upgrading successfully.
 
 .Prerequisites
 ifdef::satellite[]
@@ -21,7 +21,7 @@ endif::[]
 ifeval::["{mode}" == "disconnected"]
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
-For more information, see {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_ 
+For more information, see {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_. 
 * Leapp completes part of the upgrade in a container that has no access to additional ISO mounts.
 The required repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,7 +1,9 @@
 [id="upgrading-{project-context}-or-proxy-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL} 9 in-place by using Leapp
 
-When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to help detect and resolve issues that could prevent you from upgrading successfully.
+{Project} and {SmartProxy} are supported on both {EL}8 and {EL}9.
+You can upgrade your {Project} and {SmartProxy} operating system from {EL} 8 to {EL} 9. 
+When upgrading your {Project} or {SmartProxy} installation from {EL} 8 to {EL} 9, use the Leapp tool to upgrade as well as to help detect and resolve issues that could prevent you from upgrading successfully.
 
 .Prerequisites
 ifdef::satellite[]
@@ -14,8 +16,6 @@ ifndef::satellite[]
 endif::[]
 
 ifeval::["{mode}" == "disconnected"]
-If you run {Project} in a disconnected environment, ensure you also meet the following prerequisites:
-
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
 For more information, see xref:Upgrading_satellite_upgrading-disconnected[].

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -10,9 +10,9 @@ ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 endif::[]
-ifdef::foreman-el,katello[]
-* Review Known Issues before you begin an upgrade.
-For more information, see {BaseURL}Release_Notes/index-katello.html#katello-upgrade-warnings[Upgrade Warnings].
+ifdef::foreman-el,foreman-deb,katello[]
+* Review upgrade warnings before you begin an upgrade.
+For more information, see {ReleaseNotesBaseURL}[Release notes].
 endif::[]
 * {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
 ifndef::satellite[]
@@ -78,7 +78,7 @@ See `ID` in `/etc/os-release` for your OS code.
 ----
 # {project-package-install} leapp-data-$ID
 ----
-Note that this is not required for {RHEL} based installations.
+Note that this is not required for {RHEL} installations.
 +
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
 +
@@ -154,7 +154,7 @@ The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve other reported problems.
 . Run `leapp preupgrade` again and make sure that it does not report any more issues.
 . Let Leapp create the upgrade environment:
-ifeval::["{mode}" != "disconnected"]
+ifeval::["{mode}" == "disconnected"]
 +
 ----
 # leapp upgrade

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -152,7 +152,7 @@ endif::[]
 endif::[]
 +
 The first run will most likely report issues and inhibit the upgrade.
-Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve the other reported problems.
+Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions by using `leapp answer`, and manually resolve other reported problems.
 . Run `leapp preupgrade` again and make sure that it does not report any more issues.
 . Let Leapp create the upgrade environment:
 ifeval::["{mode}" != "disconnected"]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -19,9 +19,7 @@ If you run {Project} in a disconnected environment, ensure you also meet the fol
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}.
 For more information, see xref:Upgrading_satellite_upgrading-disconnected[].
-* For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
 * Since Leapp completes part of the upgrade in a container that has no access to additional ISO mounts, the repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
-* For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
 endif::[]
 
 .Procedure
@@ -223,4 +221,10 @@ endif::[]
 ----
 # subscription-manager release --unset
 ----
+endif::[]
+
+ifeval::["{mode}" == "disconnected"]
+.Additional Resources
+* For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
+* For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -221,7 +221,7 @@ endif::[]
 endif::[]
 
 ifeval::["{mode}" == "disconnected"]
-.Additional Resources
+.Additional resources
 * For more information on customizing the Leapp upgrade for your environment, see https://access.redhat.com/articles/4977891[Customizing your {RHEL} in-place upgrade].
 * For more information, see https://access.redhat.com/solutions/7030156[How to in-place upgrade an offline / disconnected RHEL 8 machine to RHEL 9 with Leapp?]
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -34,7 +34,7 @@ The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} install
 endif::[]
 
 .Procedure
-ifdef::foreman-el,katello[]
+ifndef::satellite[]
 . Configure the repositories to obtain Leapp.
 +
 Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
@@ -42,7 +42,6 @@ Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@thefo
 ----
 # dnf copr enable @theforeman/leapp
 ----
-`
 Note that this is not required for {RHEL} based installations.
 endif::[]
 
@@ -83,10 +82,11 @@ baseurl=http://_server.example.com_/sat6/Maintenance/
 endif::[]
 endif::[]
 
-ifdef::foreman-el,katello[]
+ifndef::satellite[]
 . Install additional OS specific packages (`leapp-data-almalinux` for AlmaLinux, `leapp-data-centos` for CentOS Stream, or `leapp-data-rocky` for Rocky Linux).
 Note that this is not required for {RHEL} based installations.
 +
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {project-package-install} leapp-data-centos
 ----
@@ -106,11 +106,11 @@ gpgcheck=1
 name=Foreman plugins {ProjectVersion}
 baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el9/$basearch
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+gpgcheck=0
 
-leapp-puppet7]
+[leapp-puppet7]
 name=Puppet 7 Repository el 9 - $basearch
-baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/9/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
 enabled=1
 gpgcheck=1
@@ -123,10 +123,10 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
 
-[leapp-katello-candlepin]
+[leapp-candlepin]
 name=Candlepin: an open source entitlement management system.
-baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el9/$basearch/
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+baseurl=https://yum.theforeman.org/candlepin/{CandlepinVersion}/el9/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin
 enabled=1
 gpgcheck=1
 
@@ -141,15 +141,14 @@ endif::[]
 
 endif::[]
 . Let Leapp analyze your system:
+ifeval::["{mode}" != "disconnected"]
 +
 ----
 # leapp preupgrade
 ----
+endif
 ifdef::satellite[]
-+
 ifeval::["{mode}" == "disconnected"]
-Add the `--no-rhsm` and `--enablerepo` parameters:
-endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -161,23 +160,22 @@ endif::[]
 --enablerepo {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
 endif::[]
+endif::[]
 
 +
 The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
 +
-
 . Ensure `leapp preupgrade` has no issues.
-
 . Run:
+ifeval::["{mode}" != "disconnected"]
 +
 ----
 # leapp upgrade
 ----
-
+endif::[]
 ifdef::satellite[]
-+
-If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--enablerepo` parameters:
+ifeval::["{mode}" == "disconnected"]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -189,6 +187,8 @@ If you run {Project} in a disconnected environment, add the `--no-rhsm` and `--e
 --enablerepo {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
 endif::[]
+endif::[]
+
 
 . Reboot the system.
 +
@@ -200,7 +200,6 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 # journalctl -u leapp_resume -f
 ----
 
-ifndef::foreman-deb[]
 . Complete these procedures in  _Upgrading from RHEL 8 to RHEL 9_:  
 .. Unlock packages:
 +
@@ -208,16 +207,14 @@ ifndef::foreman-deb[]
 ----
 # {foreman-maintain} packages unlock
 ----
-.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state of the RHEL 9 system]
-.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks]
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state]
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks on the RHEL 9 system]
 .. Lock packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} packages lock
 ----
-endif::[]
-ifdef::satellite[]
 . Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
 . Unset the `subscription-manager` release:
 +
@@ -225,4 +222,3 @@ ifdef::satellite[]
 ----
 # subscription-manager release --unset
 ----
-endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -34,14 +34,16 @@ The FUTURE crypto-policy is not supported for {Project} and {SmartProxy} install
 endif::[]
 
 .Procedure
-. Configure the repositories to obtain Leapp.
 ifdef::foreman-el,katello[]
+. Configure the repositories to obtain Leapp.
 +
-On CentOS, configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
+Configure the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
 +
 ----
-# curl -o /etc/yum.repos.d/theforeman-leapp.repo https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/repo/epel-8/group_theforeman-leapp-epel-8.repo
+# dnf copr enable @theforeman/leapp
 ----
+`
+Note that this is not required for {RHEL} based installations.
 endif::[]
 
 . Install required packages:
@@ -86,7 +88,7 @@ ifdef::foreman-el,katello[]
 Note that this is not required for {RHEL} based installations.
 +
 ----
-# yum install leapp-data-centos
+# {project-package-install} leapp-data-centos
 ----
 +
 . Add {Project} specific repositories to `/etc/leapp/files/leapp_upgrade_repositories.repo`:
@@ -95,70 +97,49 @@ Note that this is not required for {RHEL} based installations.
 ----
 [leapp-foreman]
 name=Foreman {ProjectVersion}
-baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/el8/$basearch
+baseurl=https://yum.theforeman.org/releases/{ProjectVersion}/el9/$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
-module_hotfixes=1
+
+[leapp-foreman-plugins]
+name=Foreman plugins {ProjectVersion}
+baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el9/$basearch
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
+
+leapp-puppet7]
+name=Puppet 7 Repository el 9 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1
 
 ifdef::katello[]
 [leapp-katello]
 name=Katello {KatelloVersion}
-baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/$basearch/
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/katello/el9/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
-module_hotfixes=1
 
 [leapp-katello-candlepin]
 name=Candlepin: an open source entitlement management system.
-baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el8/$basearch/
+baseurl=https://yum.theforeman.org/katello/{KatelloVersion}/candlepin/el9/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
 enabled=1
 gpgcheck=1
-module_hotfixes=1
 
 [leapp-pulpcore]
 name=pulpcore: Fetch, Upload, Organize, and Distribute Software Packages.
-baseurl=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el8/$basearch/
+baseurl=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el9/$basearch/
 gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore
 enabled=1
 gpgcheck=1
-module_hotfixes=1
 endif::[]
-
-[leapp-foreman-plugins]
-name=Foreman plugins {ProjectVersion}
-baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el8/$basearch
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman
-module_hotfixes=1
-
-[leapp-foreman-client]
-name=Foreman client {ProjectVersion}
-baseurl=https://yum.theforeman.org/client/{ProjectVersion}/el8/$basearch
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-foreman-client
-
-[leapp-puppet7]
-name=Puppet 7 Repository el 8 - $basearch
-baseurl=http://yum.puppetlabs.com/puppet7/el/8/$basearch
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet7-release
-       file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
-enabled=1
-gpgcheck=1
 ----
 
-* You need a Puppet repository for the Puppet agent that the installer is using.
-
-. We do not support {EL} 9 installations with EPEL 9 enabled, so remove `epel-release`:
-+
-----
-# yum remove epel-release
-----
-
+endif::[]
 . Let Leapp analyze your system:
 +
 ----
@@ -182,7 +163,7 @@ endif::[]
 endif::[]
 
 +
-The first run is expected to fail but report issues and inhibit the upgrade.
+The first run will most likely report issues and inhibit the upgrade.
 Examine the report in the `/var/log/leapp/leapp-report.txt` file, answer all questions (using `leapp answer`), and manually resolve the other reported problems.
 +
 
@@ -211,7 +192,7 @@ endif::[]
 
 . Reboot the system.
 +
-After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 8 system.
+After the system reboots, a live system conducts the upgrade, reboots to fix SELinux labels, then reboots into the final {EL} 9 system.
 
 . Leapp finishes the upgrade, watch it with:
 +
@@ -219,7 +200,7 @@ After the system reboots, a live system conducts the upgrade, reboots to fix SEL
 # journalctl -u leapp_resume -f
 ----
 
-ifdef::satellite[]
+ifndef::foreman-deb[]
 . Complete these procedures in  _Upgrading from RHEL 8 to RHEL 9_:  
 .. Unlock packages:
 +
@@ -227,8 +208,8 @@ ifdef::satellite[]
 ----
 # {foreman-maintain} packages unlock
 ----
-.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/verifying-the-post-upgrade-state-of-the-rhel-8-system_upgrading-from-rhel-7-to-rhel-8[Verifying the post-upgrade state of the RHEL 8 system]
-.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/performing-post-upgrade-tasks-rhel-7-to-rhel-8_upgrading-from-rhel-7-to-rhel-8[Performing post-upgrade tasks]
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/verifying-the-post-upgrade-state_upgrading-from-rhel-8-to-rhel-9[Verifying the post-upgrade state of the RHEL 9 system]
+.. https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/performing-post-upgrade-tasks-on-the-rhel-9-system_upgrading-from-rhel-8-to-rhel-9[Performing post-upgrade tasks]
 .. Lock packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -237,18 +218,11 @@ ifdef::satellite[]
 ----
 endif::[]
 ifdef::satellite[]
-. Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/upgrading_from_rhel_7_to_rhel_8/applying-security-policies_upgrading-from-rhel-7-to-rhel-8#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 7 to RHEL 8_ guide.
+. Complete the steps for changing SELinux to enforcing mode described in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/applying-security-policies_upgrading-from-rhel-8-to-rhel-9#changing-selinux-mode-to-enforcing_applying-security-policies[Changing SELinux mode to enforcing] in the _Upgrading from RHEL 8 to RHEL 9_ guide.
 . Unset the `subscription-manager` release:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager release --unset
 ----
-endif::[]
-
-ifndef::satellite[]
-[NOTE]
-====
-If you install the system and need to use `--disable-system-checks`, the last step of the upgrade is going to fail, and you need to call `{foreman-installer} --disable-system-checks` manually once the system reboots.
-====
 endif::[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -59,6 +59,6 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 include::common/modules/proc_upgrading-the-external-database.adoc[leveloffset=+2]
 endif::[]
 
-// Upgarding Project and Smart Proxy RHEL8to9 Using LEAPP
+// Upgrading Project and Smart Proxy RHEL8to9 Using LEAPP
 include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -58,4 +58,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 // Upgrading the External database
 include::common/modules/proc_upgrading-the-external-database.adoc[leveloffset=+2]
 endif::[]
+
+// Upgarding Project and Smart Proxy RHEL8to9 Using LEAPP
+include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -46,4 +46,7 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 // Upgrading the External database
 include::common/modules/proc_upgrading-the-external-database.adoc[leveloffset=+2]
 endif::[]
+
+// Upgarding Project and Smart Proxy RHEL8to9 Using LEAPP
+include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -47,6 +47,6 @@ ifdef::foreman-el,katello,satellite,orcharhino[]
 include::common/modules/proc_upgrading-the-external-database.adoc[leveloffset=+2]
 endif::[]
 
-// Upgarding Project and Smart Proxy RHEL8to9 Using LEAPP
+// Upgrading Project and Smart Proxy RHEL8to9 Using LEAPP
 include::common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
Adding information about the process to upgrade the underlying OS from EL8to9. Repurposed the older RHEL7to8 LEAPP module from 3.1 for 8to9 LEAPP upgrade.


* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
