### PR TITLE
PR: use attributes to address the missing article in the RHEL web console term

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -51,6 +51,8 @@
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy
 :Cockpit: Cockpit
+:Cockpita: Cockpit
+:CockpitA: Cockpit
 :customcontent: content
 :customfiletype: file type
 :customfiletypeFirstCap: Custom file type

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -51,8 +51,7 @@
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy
 :Cockpit: Cockpit
-:CockpitL: Cockpit
-:CockpitA: Cockpit
+:the-Cockpit: {Cockpit}
 :customcontent: content
 :customfiletype: file type
 :customfiletypeFirstCap: Custom file type

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -51,7 +51,7 @@
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy
 :Cockpit: Cockpit
-:Cockpita: Cockpit
+:CockpitL: Cockpit
 :CockpitA: Cockpit
 :customcontent: content
 :customfiletype: file type

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -50,8 +50,7 @@
 :client-os: {RHEL}
 :client-os-context: red-hat-enterprise-linux
 :Cockpit: RHEL web console
-:CockpitL: the RHEL web console
-:CockpitA: The RHEL web console
+:the-Cockpit: the {Cockpit}
 :customcontent: custom content
 :customfiletype: custom file type
 :customfiletypeFirstCap: Custom file type

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -50,7 +50,7 @@
 :client-os: {RHEL}
 :client-os-context: red-hat-enterprise-linux
 :Cockpit: RHEL web console
-:Cockpita: the RHEL web console
+:CockpitL: the RHEL web console
 :CockpitA: The RHEL web console
 :customcontent: custom content
 :customfiletype: custom file type

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -50,6 +50,8 @@
 :client-os: {RHEL}
 :client-os-context: red-hat-enterprise-linux
 :Cockpit: RHEL web console
+:Cockpita: the RHEL web console
+:CockpitA: The RHEL web console
 :customcontent: custom content
 :customfiletype: custom file type
 :customfiletypeFirstCap: Custom file type

--- a/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
@@ -1,7 +1,7 @@
 [id="Host_Management_and_Monitoring_Using_Cockpit_{context}"]
-= Host management and monitoring using {CockpitL}
+= Host management and monitoring using {the-Cockpit}
 
-{CockpitA} is an interactive web interface that you can use to perform actions and monitor {EL} hosts.
-You can enable a remote-execution feature to integrate {Project} with {CockpitL}.
-When you install {CockpitL} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
-You can also use the features that are integrated with {CockpitL}, for example, {LoraxCompose}.
+You can use the {Cockpit} interactive web interface to perform actions and monitor {EL} hosts.
+You can enable a remote-execution feature to integrate {Project} with {the-Cockpit}.
+When you install {the-Cockpit} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
+You can also use the features that are integrated with {the-Cockpit}, for example, {LoraxCompose}.

--- a/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
@@ -1,7 +1,7 @@
 [id="Host_Management_and_Monitoring_Using_Cockpit_{context}"]
-= Host management and monitoring using {Cockpit}
+= Host management and monitoring using {Cockpita}
 
-{Cockpit} is an interactive web interface that you can use to perform actions and monitor {EL} hosts.
-You can enable a remote-execution feature to integrate {Project} with {Cockpit}.
-When you install {Cockpit} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
-You can also use the features that are integrated with {Cockpit}, for example, {LoraxCompose}.
+{CockpitA} is an interactive web interface that you can use to perform actions and monitor {EL} hosts.
+You can enable a remote-execution feature to integrate {Project} with {Cockpita}.
+When you install {Cockpita} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
+You can also use the features that are integrated with {Cockpita}, for example, {LoraxCompose}.

--- a/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/modules/con_host-management-and-monitoring-using-cockpit.adoc
@@ -1,7 +1,7 @@
 [id="Host_Management_and_Monitoring_Using_Cockpit_{context}"]
-= Host management and monitoring using {Cockpita}
+= Host management and monitoring using {CockpitL}
 
 {CockpitA} is an interactive web interface that you can use to perform actions and monitor {EL} hosts.
-You can enable a remote-execution feature to integrate {Project} with {Cockpita}.
-When you install {Cockpita} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
-You can also use the features that are integrated with {Cockpita}, for example, {LoraxCompose}.
+You can enable a remote-execution feature to integrate {Project} with {CockpitL}.
+When you install {CockpitL} on a host that you manage with {Project}, you can view the {Cockpit} dashboards of that host from within the {ProjectWebUI}.
+You can also use the features that are integrated with {CockpitL}, for example, {LoraxCompose}.

--- a/guides/common/modules/proc_disabling-cockpit-on-project.adoc
+++ b/guides/common/modules/proc_disabling-cockpit-on-project.adoc
@@ -1,10 +1,10 @@
 [id="disabling-cockpit-on-project_{context}"]
-= Disabling {Cockpit} on {Project}
+= Disabling {Cockpita} on {Project}
 
-Perform the following procedure if you want to disable {Cockpit} on {Project}.
+Perform the following procedure if you want to disable {Cockpita} on {Project}.
 
 .Procedure
-* Disable {Cockpit} on your {ProjectServer}:
+* Disable {Cockpita} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -13,8 +13,8 @@ Perform the following procedure if you want to disable {Cockpit} on {Project}.
 
 [IMPORTANT]
 ====
-{Cockpit} integration can be independently enabled or disabled on {SmartProxyServers}.
-To prevent enabling {Cockpit} integration on a {SmartProxyServer}, run the following command after completing the procedure:
+You can enable or disable {Cockpit} integration independently on {SmartProxyServers}.
+To prevent enabling {Cockpit} integration on a {SmartProxyServer}, enter the following command after completing the procedure:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} --foreman-proxy-plugin-remote-execution-script-cockpit-integration false

--- a/guides/common/modules/proc_disabling-cockpit-on-project.adoc
+++ b/guides/common/modules/proc_disabling-cockpit-on-project.adoc
@@ -1,10 +1,10 @@
 [id="disabling-cockpit-on-project_{context}"]
-= Disabling {CockpitL} on {Project}
+= Disabling {the-Cockpit} on {Project}
 
-Perform the following procedure if you want to disable {CockpitL} on {Project}.
+Perform the following procedure if you want to disable {the-Cockpit} on {Project}.
 
 .Procedure
-* Disable {CockpitL} on your {ProjectServer}:
+* Disable {the-Cockpit} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_disabling-cockpit-on-project.adoc
+++ b/guides/common/modules/proc_disabling-cockpit-on-project.adoc
@@ -1,10 +1,10 @@
 [id="disabling-cockpit-on-project_{context}"]
-= Disabling {Cockpita} on {Project}
+= Disabling {CockpitL} on {Project}
 
-Perform the following procedure if you want to disable {Cockpita} on {Project}.
+Perform the following procedure if you want to disable {CockpitL} on {Project}.
 
 .Procedure
-* Disable {Cockpita} on your {ProjectServer}:
+* Disable {CockpitL} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-cockpit-on-server.adoc
+++ b/guides/common/modules/proc_enabling-cockpit-on-server.adoc
@@ -1,11 +1,11 @@
 [id="Enabling_Cockpit_on_Server_{context}"]
-= Enabling {Cockpita} on {Project}
+= Enabling {CockpitL} on {Project}
 
 By default, {Cockpit} integration is disabled in {Project}.
-If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {Cockpita} on {ProjectServer}.
+If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {CockpitL} on {ProjectServer}.
 
 .Procedure
-* Enable {Cockpita} on your {ProjectServer}:
+* Enable {CockpitL} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-cockpit-on-server.adoc
+++ b/guides/common/modules/proc_enabling-cockpit-on-server.adoc
@@ -1,11 +1,11 @@
 [id="Enabling_Cockpit_on_Server_{context}"]
-= Enabling {CockpitL} on {Project}
+= Enabling {the-Cockpit} on {Project}
 
 By default, {Cockpit} integration is disabled in {Project}.
-If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {CockpitL} on {ProjectServer}.
+If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {the-Cockpit} on {ProjectServer}.
 
 .Procedure
-* Enable {CockpitL} on your {ProjectServer}:
+* Enable {the-Cockpit} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-cockpit-on-server.adoc
+++ b/guides/common/modules/proc_enabling-cockpit-on-server.adoc
@@ -1,11 +1,11 @@
 [id="Enabling_Cockpit_on_Server_{context}"]
-= Enabling {Cockpit} on {Project}
+= Enabling {Cockpita} on {Project}
 
 By default, {Cockpit} integration is disabled in {Project}.
-If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {Cockpit} integration on {ProjectServer}.
+If you want to access {Cockpit} features for your hosts from within {Project}, you must first enable {Cockpita} on {ProjectServer}.
 
 .Procedure
-* Enable {Cockpit} on your {ProjectServer}:
+* Enable {Cockpita} on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -4,8 +4,8 @@
 You can access the {Cockpit} UI through the {ProjectWebUI} and use the functionality to manage and monitor hosts in {Project}.
 
 .Prerequisites
-* {CockpitA} is enabled in {Project}.
-* {CockpitA} is installed on the host that you want to view:
+* You have enabled {the-Cockpit} in {Project}.
+* You have installed {the-Cockpit} on the host that you want to view:
 ifndef::satellite,orcharhino[]
 ** For more information, see https://cockpit-project.org/running.html[Running Cockpit].
 endif::[]
@@ -25,5 +25,5 @@ You can now access the full range of features available for host monitoring and 
 ifdef::satellite[]
 For more information about getting started with Red Hat web console, see {RHELDocsBaseURL}8/html/managing_systems_using_the_rhel_8_web_console/index[_Managing systems using the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/managing_systems_using_the_rhel_7_web_console/getting-started-with-the-rhel-web-console_system-management-using-the-rhel-7-web-console#installing-the-web-console_getting-started-with-the-web-console[_Managing systems using the RHEL 7 web console_].
 
-For more information about using {LoraxCompose} through {CockpitL}, see {RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-web-console-interface_composing-a-customized-rhel-system-image#accessing-composer-gui-in-the-rhel-8-web-console_creating-system-images-with-composer-web-console-interface[_Accessing Image Builder GUI in the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/image_builder_guide/chap-documentation-image_builder-test_chapter_4#sect-Documentation-Image_Builder-Chapter4[_Accessing Image Builder GUI in the RHEL{nbsp}7 web console_].
+For more information about using {LoraxCompose} through {the-Cockpit}, see {RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-web-console-interface_composing-a-customized-rhel-system-image#accessing-composer-gui-in-the-rhel-8-web-console_creating-system-images-with-composer-web-console-interface[_Accessing Image Builder GUI in the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/image_builder_guide/chap-documentation-image_builder-test_chapter_4#sect-Documentation-Image_Builder-Chapter4[_Accessing Image Builder GUI in the RHEL{nbsp}7 web console_].
 endif::[]

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -1,5 +1,5 @@
 [id="Managing_and_Monitoring_Hosts_Using_Cockpit_{context}"]
-= Managing and monitoring hosts using {Cockpita}
+= Managing and monitoring hosts using {CockpitL}
 
 You can access the {Cockpit} UI through the {ProjectWebUI} and use the functionality to manage and monitor hosts in {Project}.
 
@@ -17,13 +17,13 @@ endif::[]
 For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpita}.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {CockpitL}.
 . In the upper right of the host window, click the vertical ellipsis and select *Web Console*.
 
-You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {Cockpita}.
+You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {CockpitL}.
 
 ifdef::satellite[]
 For more information about getting started with Red Hat web console, see {RHELDocsBaseURL}8/html/managing_systems_using_the_rhel_8_web_console/index[_Managing systems using the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/managing_systems_using_the_rhel_7_web_console/getting-started-with-the-rhel-web-console_system-management-using-the-rhel-7-web-console#installing-the-web-console_getting-started-with-the-web-console[_Managing systems using the RHEL 7 web console_].
 
-For more information about using {LoraxCompose} through {Cockpita}, see {RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-web-console-interface_composing-a-customized-rhel-system-image#accessing-composer-gui-in-the-rhel-8-web-console_creating-system-images-with-composer-web-console-interface[_Accessing Image Builder GUI in the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/image_builder_guide/chap-documentation-image_builder-test_chapter_4#sect-Documentation-Image_Builder-Chapter4[_Accessing Image Builder GUI in the RHEL{nbsp}7 web console_].
+For more information about using {LoraxCompose} through {CockpitL}, see {RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-web-console-interface_composing-a-customized-rhel-system-image#accessing-composer-gui-in-the-rhel-8-web-console_creating-system-images-with-composer-web-console-interface[_Accessing Image Builder GUI in the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/image_builder_guide/chap-documentation-image_builder-test_chapter_4#sect-Documentation-Image_Builder-Chapter4[_Accessing Image Builder GUI in the RHEL{nbsp}7 web console_].
 endif::[]

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -1,5 +1,5 @@
 [id="Managing_and_Monitoring_Hosts_Using_Cockpit_{context}"]
-= Managing and monitoring hosts using {CockpitL}
+= Managing and monitoring hosts using {the-Cockpit}
 
 You can access the {Cockpit} UI through the {ProjectWebUI} and use the functionality to manage and monitor hosts in {Project}.
 
@@ -17,10 +17,10 @@ endif::[]
 For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {CockpitL}.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {the-Cockpit}.
 . In the upper right of the host window, click the vertical ellipsis and select *Web Console*.
 
-You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {CockpitL}.
+You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {the-Cockpit}.
 
 ifdef::satellite[]
 For more information about getting started with Red Hat web console, see {RHELDocsBaseURL}8/html/managing_systems_using_the_rhel_8_web_console/index[_Managing systems using the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/managing_systems_using_the_rhel_7_web_console/getting-started-with-the-rhel-web-console_system-management-using-the-rhel-7-web-console#installing-the-web-console_getting-started-with-the-web-console[_Managing systems using the RHEL 7 web console_].

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -1,11 +1,11 @@
 [id="Managing_and_Monitoring_Hosts_Using_Cockpit_{context}"]
-= Managing and monitoring hosts using {Cockpit}
+= Managing and monitoring hosts using {Cockpita}
 
-You can access the {Cockpit} web UI through the {ProjectWebUI} and use the functionality to manage and monitor hosts in {Project}.
+You can access the {Cockpit} UI through the {ProjectWebUI} and use the functionality to manage and monitor hosts in {Project}.
 
 .Prerequisites
-* {Cockpit} is enabled in {Project}.
-* {Cockpit} is installed on the host that you want to view:
+* {CockpitA} is enabled in {Project}.
+* {CockpitA} is installed on the host that you want to view:
 ifndef::satellite,orcharhino[]
 ** For more information, see https://cockpit-project.org/running.html[Running Cockpit].
 endif::[]
@@ -17,13 +17,13 @@ endif::[]
 For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpit}.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {Cockpita}.
 . In the upper right of the host window, click the vertical ellipsis and select *Web Console*.
 
-You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through the {Cockpit}.
+You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {Cockpita}.
 
 ifdef::satellite[]
 For more information about getting started with Red Hat web console, see {RHELDocsBaseURL}8/html/managing_systems_using_the_rhel_8_web_console/index[_Managing systems using the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/managing_systems_using_the_rhel_7_web_console/getting-started-with-the-rhel-web-console_system-management-using-the-rhel-7-web-console#installing-the-web-console_getting-started-with-the-web-console[_Managing systems using the RHEL 7 web console_].
 
-For more information about using {LoraxCompose} through {Cockpit}, see {RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-web-console-interface_composing-a-customized-rhel-system-image#accessing-composer-gui-in-the-rhel-8-web-console_creating-system-images-with-composer-web-console-interface[_Accessing Image Builder GUI in the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/image_builder_guide/chap-documentation-image_builder-test_chapter_4#sect-Documentation-Image_Builder-Chapter4[_Accessing Image Builder GUI in the RHEL{nbsp}7 web console_].
+For more information about using {LoraxCompose} through {Cockpita}, see {RHELDocsBaseURL}8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-web-console-interface_composing-a-customized-rhel-system-image#accessing-composer-gui-in-the-rhel-8-web-console_creating-system-images-with-composer-web-console-interface[_Accessing Image Builder GUI in the RHEL{nbsp}8 web console_] or {RHELDocsBaseURL}7/html/image_builder_guide/chap-documentation-image_builder-test_chapter_4#sect-Documentation-Image_Builder-Chapter4[_Accessing Image Builder GUI in the RHEL{nbsp}7 web console_].
 endif::[]

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -1,15 +1,15 @@
 [id="Using_an_Image_Builder_Image_for_Provisioning_{context}"]
 = Using a {LoraxCompose} image for provisioning
 
-In {Project}, you can enable integration with {Cockpita} to perform actions and monitor your hosts.
-Using {Cockpita}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
+In {Project}, you can enable integration with {CockpitL} to perform actions and monitor your hosts.
+Using {CockpitL}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
 When you configure {Project} for image provisioning, Anaconda installer partitions disks, downloads and mounts the image and copies files over to a host.
 The preferred image type is TAR.
 
 Ensure that your blueprint to build the TAR image includes a kernel package.
 
 ifndef::foreman-deb[]
-For more information about integrating {Cockpita} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host Management and Monitoring Using {CockpitA}] in _{ManagingHostsDocTitle}_.
+For more information about integrating {CockpitL} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host Management and Monitoring Using {CockpitA}] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 .Prerequisites

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -1,15 +1,15 @@
 [id="Using_an_Image_Builder_Image_for_Provisioning_{context}"]
 = Using a {LoraxCompose} image for provisioning
 
-In {Project}, you can enable integration with {CockpitL} to perform actions and monitor your hosts.
-Using {CockpitL}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
+In {Project}, you can enable integration with {the-Cockpit} to perform actions and monitor your hosts.
+Using {the-Cockpit}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
 When you configure {Project} for image provisioning, Anaconda installer partitions disks, downloads and mounts the image and copies files over to a host.
 The preferred image type is TAR.
 
 Ensure that your blueprint to build the TAR image includes a kernel package.
 
 ifndef::foreman-deb[]
-For more information about integrating {CockpitL} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host Management and Monitoring Using {CockpitA}] in _{ManagingHostsDocTitle}_.
+For more information about integrating {the-Cockpit} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host management and monitoring using {the-Cockpit}] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 .Prerequisites

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -1,15 +1,15 @@
 [id="Using_an_Image_Builder_Image_for_Provisioning_{context}"]
 = Using a {LoraxCompose} image for provisioning
 
-In {Project}, you can integrate with {Cockpit} to perform actions and monitor your hosts.
-Using {Cockpit}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
+In {Project}, you can enable integration with {Cockpita} to perform actions and monitor your hosts.
+Using {Cockpita}, you can access {LoraxCompose} and build images that you can then upload to an HTTP server and use this image to provision hosts.
 When you configure {Project} for image provisioning, Anaconda installer partitions disks, downloads and mounts the image and copies files over to a host.
 The preferred image type is TAR.
 
 Ensure that your blueprint to build the TAR image includes a kernel package.
 
 ifndef::foreman-deb[]
-For more information about integrating {Cockpit} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host Management and Monitoring Using {Cockpit}] in _{ManagingHostsDocTitle}_.
+For more information about integrating {Cockpita} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host Management and Monitoring Using {CockpitA}] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 .Prerequisites


### PR DESCRIPTION
The name of the product (Cockpit in upstream) in Red Hat Enteprise Linux is the RHEL web console. See the title:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_systems_using_the_rhel_9_web_console/index (I'm maintaining nowadays).

In some cases, the article was missing, in some cases was even redundant in the upstream version of the docs ("the Cockpit"). Because of the differentiation, we need three attributes:

{Cockpit} -> RHEL web console (for the adj. role and the cases where the article already is)
{CockpitL} -> the RHEL web console (lowercased article)
{CockpitA} -> The RHEL web console (uppercased article when starting a sentence)

For non-Satellite docs, all three attributes are replaced just by the Cockpit value.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
