### PR TITLE
Use the correct protocol for template-url option

### DIFF
--- a/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
@@ -12,7 +12,7 @@ ifdef::foreman-deb,foreman-el[]
 # {installer-scenario-smartproxy} \
 --foreman-proxy-registration true \
 --foreman-proxy-templates true \
---foreman-proxy-template-url "https://_{smartproxy-example-com}_:8000"
+--foreman-proxy-template-url "http://_{smartproxy-example-com}_:8000"
 ----
 . On your {SmartProxyServer}, open the corresponding ports:
 +

--- a/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
+++ b/guides/common/modules/proc_setting-the-load-balancer-for-host-registration.adoc
@@ -30,7 +30,7 @@ For more information, see the following sections:
 ----
 # {installer-scenario-smartproxy} \
 --foreman-proxy-registration-url "https://_{loadbalancer-example-com}_:{smartproxy_port}" \
---foreman-proxy-template-url "https://_{loadbalancer-example-com}_:8000"
+--foreman-proxy-template-url "http://_{loadbalancer-example-com}_:8000"
 ----
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
 . For each {SmartProxy}, click the dropdown menu in the *Actions* column and select *Refresh*.


### PR DESCRIPTION
The Smart Proxy on port 8000 listens on HTTP, not HTTPS.

Fixes: ad381579919a ("Register hosts through a load balancer")

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.