### PR TITLE
Remove ifndef condition

### DIFF
--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -7,11 +7,9 @@ ifdef::satellite[]
 You can then serve the generated content on a local web server and synchronize it on the importing {ProjectServer} or in another {ProjectServer} organization.
 endif::[]
 
-ifndef::satellite[]
 You can use the generated content to create the same repository in another {ProjectServer} or in another {ProjectServer} organization by using content import.
 On import of the exported archive, a regular content view is created or updated on your importing {ProjectServer}.
 For more information, see xref:Importing_a_Content_View_Version_{context}[].
-endif::[]
 
 You can export the following content in the syncable format from {ProjectServer}:
 


### PR DESCRIPTION
After discussion with SME, the ifndef condition for Satellite needed to
be removed because it was determined the most important information was
hidden and needed to be in the Satellite docs.


* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
