### PR TITLE
Drop mentions of --foreman-proxy-register-in-foreman

### DIFF
--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -38,7 +38,6 @@ Retain a copy of the `{foreman-installer}` command that the `{certs-generate}` c
 _output omitted_
 {installer-scenario-smartproxy} \
 --certs-tar-file "/root/{smart-proxy-context}_cert/_{smartproxy-example-com}_-certs.tar" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
@@ -56,8 +55,8 @@ root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 
 . On {SmartProxyServer}, to deploy the certificate, enter the `{foreman-installer}` command that the `{certs-generate}` command returns.
 +
-When network connections or ports to {Project} are not yet open, you can set the `--foreman-proxy-register-in-foreman` option to `false` to prevent {SmartProxy} from attempting to connect to {Project} and reporting errors.
-Run the installer again with this option set to `true` when the network and firewalls are correctly configured.
+When network connections or ports to {Project} are not yet open, registration of the {SmartProxy} will fail.
+Correctly configure the network and firewalls before rerunning the installer.
 +
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -11,6 +11,8 @@ For more information, see xref:Registering_Proxy_to_Server_{smart-proxy-context}
 endif::[]
 * {SmartProxyServer} packages are installed.
 For more information, see xref:Installing_Proxy_Packages_{smart-proxy-context}[].
+* The required ports are open.
+For more information, see xref:{smart-proxy-context}-port-and-firewall-requirements_{context}[].
 
 .Procedure
 
@@ -54,9 +56,6 @@ root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 ----
 
 . On {SmartProxyServer}, to deploy the certificate, enter the `{foreman-installer}` command that the `{certs-generate}` command returns.
-+
-When network connections or ports to {Project} are not yet open, registration of the {SmartProxy} will fail.
-Correctly configure the network and firewalls before rerunning the installer.
 +
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
@@ -82,7 +82,6 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
 --foreman-proxy-puppetca "false" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \

--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-default-ssl-certificates-for-load-balancing.adoc
@@ -79,7 +79,6 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
 --foreman-proxy-puppetca "false" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -42,7 +42,6 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --foreman-proxy-foreman-base-url "_https://{foreman-example-com}_" \
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_"
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -42,7 +42,6 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --foreman-proxy-oauth-consumer-key "oauth key" \
 --foreman-proxy-oauth-consumer-secret "oauth secret" \
 --foreman-proxy-puppetca "true" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smart-proxy-context}-ca.example.com_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -39,7 +39,6 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --foreman-proxy-foreman-base-url "_https://{foreman-example-com}_" \
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_"
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -45,7 +45,6 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --foreman-proxy-oauth-consumer-key "_oauth key_" \
 --foreman-proxy-oauth-consumer-secret "_oauth secret_" \
 --foreman-proxy-puppetca "true" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smart-proxy-context}-ca.example.com_" \
 --puppet-ca-server "_{smart-proxy-context}-ca.example.com_" \

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -38,7 +38,6 @@ For more information, see xref:Installing_Proxy_Packages_{smart-proxy-context}[]
 _output omitted_
 {installer-scenario-smartproxy} \
 --certs-tar-file "/root/_{smartproxy-example-com}_-certs.tar" \
---foreman-proxy-register-in-foreman "true" \
 --foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{foreman-example-com}_" \
 --foreman-proxy-trusted-hosts "_{smartproxy-example-com}_" \
@@ -54,8 +53,8 @@ root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 ----
 . On your {SmartProxyServer}, to deploy the certificate, enter the `{foreman-installer}` command that the `{certs-generate}` command returns.
 +
-If network connections or ports to {Project} are not yet open, you can set the `--foreman-proxy-register-in-foreman` option to `false` to prevent {SmartProxy} from attempting to connect to {Project} and reporting errors.
-Run the installer again with this option set to `true` when the network and firewalls are correctly configured.
+When network connections or ports to {Project} are not yet open, registration of the {SmartProxy} will fail.
+Correctly configure the network and firewalls before rerunning the installer.
 +
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -12,6 +12,8 @@ For more information, see {InstallingServerDocURL}configuring-{project-context}-
 For more information, see xref:Registering_Proxy_to_Server_{smart-proxy-context}[].
 * {SmartProxyServer} packages are installed.
 For more information, see xref:Installing_Proxy_Packages_{smart-proxy-context}[].
+* The required ports are open.
+For more information, see xref:{smart-proxy-context}-port-and-firewall-requirements_{context}[].
 
 .Procedure
 . On your {ProjectServer}, generate a certificate bundle:
@@ -52,9 +54,6 @@ _output omitted_
 root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 ----
 . On your {SmartProxyServer}, to deploy the certificate, enter the `{foreman-installer}` command that the `{certs-generate}` command returns.
-+
-When network connections or ports to {Project} are not yet open, registration of the {SmartProxy} will fail.
-Correctly configure the network and firewalls before rerunning the installer.
 +
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -39,8 +39,7 @@ You can move the copied file to the applicable path if required.
 # {installer-scenario-smartproxy} \
 --certs-tar-file "_/root/My_Certificates/{smartproxy-example-com}-certs.tar_" \
 --certs-update-server \
---foreman-proxy-foreman-base-url "https://_{foreman-example-com}_" \
---foreman-proxy-register-in-foreman "true"
+--foreman-proxy-foreman-base-url "https://_{foreman-example-com}_"
 ----
 
 [IMPORTANT]


### PR DESCRIPTION
By removing mentions of this, it becomes an unsupported feature. This is good because various parts of the documentation assume it's turned on.  Users can easily get into unexpected errors way further down the line if they disable this feature.

Where there were explicit instructions to disable it, the text is changed into troubleshooting.

I'd appreciate some feedback on the phrasing of the changed lines.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.