### PR TITLE
Add guidance for backups to NFS share

### DIFF
--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -43,6 +43,21 @@ You can use the `{foreman-maintain} backup` command to back up remote databases.
 
 You can use both online and offline methods to back up remote databases, but if you use offline method, the `{foreman-maintain} backup` command performs a database dump.
 
+.Backing up to a remote NFS share
+
+You can back up your {ProjectServer} or {SmartProxyServer} in a remote NFS share.
+
+* Make sure you export the share in your NFS server with the `no_root_squash` option to disable root squashing.
+For example:
+
+[options="nowrap", subs="+quotes,attributes"]
+----
+/backup/{project-context}/backup {foreman-example-com}(rw,sync,no_root_squash)
+----
+
+* Make sure the NFS share has the appropriate permissions set on the NFS server.
+Otherwise, {Project} might fail to save the backup to the NFS share.
+
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.
 For more information, see xref:Estimating_the_Size_of_a_Backup_{context}[].

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -45,7 +45,7 @@ You can use both online and offline methods to back up remote databases, but if 
 
 .Backing up to a remote NFS share
 
-To enable {Project} to save the backup to the NFS share, make sure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
+To enable {Project} to save the backup to an NFS share, make sure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
 NFS export options such as `root_squash` and `all_squash` are known to prevent this.
 
 For more information, see link:{RHELDocsBaseURL}9/html/configuring_and_using_network_file_services/deploying-an-nfs-server_configuring-and-using-network-file-services[{RHEL} _Configuring and using network files services_] and link:{RHELDocsBaseURL}9/html/securing_networks/securing-network-services_securing-networks#export-options-for-securing-an-nfs-server_securing-the-nfs-service[{RHEL} _Securing network services_].

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -45,13 +45,10 @@ You can use both online and offline methods to back up remote databases, but if 
 
 .Backing up to a remote NFS share
 
-You can back up your {ProjectServer} or {SmartProxyServer} in a remote NFS share.
-To enable {Project} to save the backup to the NFS share, make sure you meet the following conditions:
-
-* The `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
+To enable {Project} to save the backup to the NFS share, make sure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
 NFS export options such as `root_squash` and `all_squash` are known to prevent this.
+
 For more information, see link:{RHELDocsBaseURL}9/html/configuring_and_using_network_file_services/deploying-an-nfs-server_configuring-and-using-network-file-services[{RHEL} _Configuring and using network files services_] and link:{RHELDocsBaseURL}9/html/securing_networks/securing-network-services_securing-networks#export-options-for-securing-an-nfs-server_securing-the-nfs-service[{RHEL} _Securing network services_].
-* The NFS share has the appropriate permissions set on the NFS server.
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -48,7 +48,9 @@ You can use both online and offline methods to back up remote databases, but if 
 To enable {Project} to save the backup to an NFS share, make sure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
 NFS export options such as `root_squash` and `all_squash` are known to prevent this.
 
+ifndef::orcharhino[]
 For more information, see link:{RHELDocsBaseURL}9/html/configuring_and_using_network_file_services/deploying-an-nfs-server_configuring-and-using-network-file-services[{RHEL} _Configuring and using network files services_] and link:{RHELDocsBaseURL}9/html/securing_networks/securing-network-services_securing-networks#export-options-for-securing-an-nfs-server_securing-the-nfs-service[{RHEL} _Securing network services_].
+endif::[]
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -46,23 +46,12 @@ You can use both online and offline methods to back up remote databases, but if 
 .Backing up to a remote NFS share
 
 You can back up your {ProjectServer} or {SmartProxyServer} in a remote NFS share.
+To enable {Project} to save the backup to the NFS share, make sure you meet the following conditions:
 
-* Make sure you export the share in your NFS server with the `no_root_squash` option to disable root squashing.
-For example:
-
-[options="nowrap", subs="+quotes,attributes"]
-----
-/backup/{project-context}/backup {foreman-example-com}(rw,sync,no_root_squash)
-----
-
-[WARNING]
-====
-With `no_root_squash`, the root user on the NFS client has root privileges on the NFS share.
-Only use `no_root_squash` in a trusted environment.
-====
-
-* Make sure the NFS share has the appropriate permissions set on the NFS server.
-Otherwise, {Project} might fail to save the backup to the NFS share.
+* The `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
+NFS export options such as `root_squash` and `all_squash` are known to prevent this.
+For more information, see link:{RHELDocsBaseURL}9/html/configuring_and_using_network_file_services/deploying-an-nfs-server_configuring-and-using-network-file-services[{RHEL} _Configuring and using network files services_] and link:{RHELDocsBaseURL}9/html/securing_networks/securing-network-services_securing-networks#export-options-for-securing-an-nfs-server_securing-the-nfs-service[{RHEL} _Securing network services_].
+* The NFS share has the appropriate permissions set on the NFS server.
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -44,8 +44,7 @@ You can use the `{foreman-maintain} backup` command to back up remote databases.
 You can use both online and offline methods to back up remote databases, but if you use offline method, the `{foreman-maintain} backup` command performs a database dump.
 
 .Backing up to a remote NFS share
-
-To enable {Project} to save the backup to an NFS share, make sure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
+To enable {Project} to save the backup to an NFS share, ensure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.
 NFS export options such as `root_squash` and `all_squash` are known to prevent this.
 
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -57,7 +57,7 @@ For example:
 
 [WARNING]
 ====
-With `no_root_squash`, the root user on the NFS client has root privileges on the NFS server.
+With `no_root_squash`, the root user on the NFS client has root privileges on the NFS share.
 Only use `no_root_squash` in a trusted environment.
 ====
 

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -55,6 +55,12 @@ For example:
 /backup/{project-context}/backup {foreman-example-com}(rw,sync,no_root_squash)
 ----
 
+[WARNING]
+====
+With `no_root_squash`, the root user on the NFS client has root privileges on the NFS server.
+Only use `no_root_squash` in a trusted environment.
+====
+
 * Make sure the NFS share has the appropriate permissions set on the NFS server.
 Otherwise, {Project} might fail to save the backup to the NFS share.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SAT-21300 requests adding "lightweight guidance" on backing up Project on an NFS share. This PR adds a short section to the procedure module for a full backup that covers the most important points of an NFS share backup.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
