### PR TITLE
Use RHDocsBaseURL where possible

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -22,7 +22,7 @@
 :UpgradingDisconnectedDocURL: {BaseURL}Upgrading_Project_Disconnected/{BaseFilenameURL}#
 
 // Red Hat specific URLs
-:RHDocsBaseURL: https://access.redhat.com/documentation/en-us/
+:RHDocsBaseURL: https://access.redhat.com/documentation/
 :RHELDocsBaseURL: {RHDocsBaseURL}red_hat_enterprise_linux/
 
 // Repositories and subscriptions (used both upstream and Satellite guides)

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -19,4 +19,4 @@ ignore=example.com
   sources/
   atixservice.zendesk.com
   # 6.16 docs are not yet published
-  access.redhat.com/documentation/en-us/red_hat_satellite/6.16
+  access.redhat.com/documentation/red_hat_satellite/6.16

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -37,7 +37,7 @@ Alternatively, you can use Ansible variables to tell the role to import the mani
 The manifest must be imported to the organization to which you will register hosts for conversion.
 +
 You can update your allocations and download the updated manifest from the https://access.redhat.com[Red Hat Customer Portal].
-For more information, see https://access.redhat.com/documentation/en-us/subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index#proc-exporting-downloading-manifest-satellite-connected[Exporting and downloading a manifest] in _Creating and managing manifests for a connected Satellite Server_.
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index#proc-exporting-downloading-manifest-satellite-connected[Exporting and downloading a manifest] in _Creating and managing manifests for a connected Satellite Server_.
 * Ensure that you have enabled and synchronized Red Hat repositories in {Project} for the minor {RHEL} version to which you convert your hosts.
 For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 

--- a/guides/common/modules/con_managing-container-images.adoc
+++ b/guides/common/modules/con_managing-container-images.adoc
@@ -4,7 +4,7 @@
 With {Project}, you can import container images from various sources and distribute them to external containers using content views.
 
 ifndef::orcharhino[]
-For information about containers for {RHEL} Atomic Host 7, see https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/index[Getting Started with Containers] in _{RHEL} Atomic Host 7_.
+For information about containers for {RHEL} Atomic Host 7, see {RHDocsBaseURL}red_hat_enterprise_linux_atomic_host/7/html/getting_started_with_containers/index[Getting Started with Containers] in _{RHEL} Atomic Host 7_.
 
 For information about containers for {RHEL} 8, see {RHELDocsBaseURL}8/html-single/building_running_and_managing_containers/index[_{RHEL}{nbsp}8 Building, running, and managing containers_].
 

--- a/guides/common/modules/con_monitoring-hosts-using-red-hat-insights.adoc
+++ b/guides/common/modules/con_monitoring-hosts-using-red-hat-insights.adoc
@@ -19,5 +19,5 @@ For more information, see xref:deploying-red-hat-insights-using-the-ansible-role
 Refresh your subscription manifest to update your certificates.
 * You can change the default schedule for running `insights-client` by configuring `insights-client.timer` on a host.
 ifdef::satellite[]
-For more information, see https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see {RHDocsBaseURL}/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
 endif::[]

--- a/guides/common/modules/con_monitoring-hosts-using-red-hat-insights.adoc
+++ b/guides/common/modules/con_monitoring-hosts-using-red-hat-insights.adoc
@@ -19,5 +19,5 @@ For more information, see xref:deploying-red-hat-insights-using-the-ansible-role
 Refresh your subscription manifest to update your certificates.
 * You can change the default schedule for running `insights-client` by configuring `insights-client.timer` on a host.
 ifdef::satellite[]
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
 endif::[]

--- a/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
@@ -11,7 +11,7 @@ include::snip_prerequisites-common-compute-resource.adoc[]
 For more information, see {ProvisioningDocURL}Configuring_Networking_provisioning[Configuring Networking] in _{ProvisioningDocTitle}_.
 * An image added to OpenStack Image Storage (glance) service for image-based provisioning.
 ifndef::orcharhino[]
-For more information, see the https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/instances_and_images_guide/index[{OpenStack} _Instances and Images Guide_].
+For more information, see the {RHDocsBaseURL}red_hat_openstack_platform/16.0/html/instances_and_images_guide/index[{OpenStack} _Instances and Images Guide_].
 endif::[]
 
 .Additional resources

--- a/guides/common/modules/con_provisioning-virtual-machines-on-ovirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-ovirt.adoc
@@ -19,7 +19,7 @@ For more information, see {ProvisioningDocURL}Configuring_Networking_provisionin
 * An existing template, other than the `blank` template, if you want to use image-based provisioning.
 For more information about creating templates for virtual machines, see
 ifdef::satellite[]
-https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates[Templates] in the _Red{nbsp}Hat Virtualization Virtual Machine Management Guide_.
+{RHDocsBaseURL}red_hat_virtualization/4.3/html/virtual_machine_management_guide/chap-templates[Templates] in the _Red{nbsp}Hat Virtualization Virtual Machine Management Guide_.
 endif::[]
 ifndef::satellite[]
 https://www.ovirt.org/documentation/virtual_machine_management_guide/#chap-Templates[Templates] in the {oVirt} documentation.
@@ -42,7 +42,7 @@ Instead, create a new {oVirt} user with the following permissions:
 ** *Disk* > *Disk Profile* > *Attach Disk Profile*
 +
 ifdef::satellite[]
-For more information about how to create a user and add permissions in {oVirt}, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.3/html/administration_guide/sect-red_hat_enterprise_virtualization_manager_user_tasks[Administering User Tasks From the Administration Portal] in the _Red Hat Virtualization Administration Guide_.
+For more information about how to create a user and add permissions in {oVirt}, see {RHDocsBaseURL}red_hat_virtualization/4.3/html/administration_guide/sect-red_hat_enterprise_virtualization_manager_user_tasks[Administering User Tasks From the Administration Portal] in the _Red Hat Virtualization Administration Guide_.
 endif::[]
 ifndef::satellite[]
 For more information about how to create a user and add permissions in {oVirt}, see https://www.ovirt.org/documentation/administration_guide/#chap-Users_and_Roles[Users and Roles] in the {oVirt} documentation.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -2,7 +2,7 @@
 = Configuring RHUI alternate content sources
 
 .Prerequisites
-* Generate the client entitlement certificates for the required repos on the RHUA node as described in https://access.redhat.com/documentation/en-us/red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in _Configuring and Managing Red Hat Update Infrastructure_.
+* Generate the client entitlement certificates for the required repos on the RHUA node as described in {RHDocsBaseURL}red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in _Configuring and Managing Red Hat Update Infrastructure_.
 * Import the client entitlement certificates into {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
 * Obtain a list of the subpaths for the required repositories.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -16,7 +16,7 @@ Importing a manifest does not change your organization's Simple Content Access s
 .Prerequisites
 * You must have a Red{nbsp}Hat subscription manifest file exported from the https://access.redhat.com[Red{nbsp}Hat Customer Portal].
 ifndef::orcharhino[]
-For more information, see https://access.redhat.com/documentation/en-us/subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/assembly-creating-managing-manifests-connected-satellite[Creating and Managing Manifests] in _Using Red Hat Subscription Management_.
+For more information, see {RHDocsBaseURL}subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/assembly-creating-managing-manifests-connected-satellite[Creating and Managing Manifests] in _Using Red Hat Subscription Management_.
 endif::[]
 ifeval::["{mode}" == "disconnected"]
 * Ensure that you disable subscription connection on your {ProjectServer}.

--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -49,7 +49,7 @@ endif::[]
 .. To sync {Project} from `console.redhat.com`, enter your token in the *Auth Token* field and enter your SSO URL in the the *Auth URL* field.
 ifdef::satellite[]
 +
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html/getting_started_with_automation_hub/[_Getting started with automation hub_].
+For more information, see {RHDocsBaseURL}red_hat_ansible_automation_platform/2.3/html/getting_started_with_automation_hub/[_Getting started with automation hub_].
 endif::[]
 .. To sync {Project} from {Project}, leave both authentication fields blank.
 . Click *Save*.

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -14,7 +14,7 @@ To maintain your {ProjectServer}, and improve your ability to monitor and diagno
 .Scheduling insights-client
 
 Note that you can change the default schedule for running `insights-client` by configuring `insights-client.timer` on {Project}.
-For more information, see https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
 
 .Procedure
 

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -14,7 +14,7 @@ To maintain your {ProjectServer}, and improve your ability to monitor and diagno
 .Scheduling insights-client
 
 Note that you can change the default schedule for running `insights-client` by configuring `insights-client.timer` on {Project}.
-For more information, see https://access.redhat.com/documentation/en-us/red_hat_insights/2020-10/html/client_configuration_guide_for_red_hat_insights/changing-the-client-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
 
 .Procedure
 

--- a/guides/common/modules/ref_migrating-ansible-content.adoc
+++ b/guides/common/modules/ref_migrating-ansible-content.adoc
@@ -18,7 +18,7 @@ ifdef::satellite[]
 Note that {Team} does not provide support for this content.
 * If you have a subscription for https://www.ansible.com/products/automation-hub[Red Hat Automation Hub], you can configure your `ansible-galaxy` to talk to Automation Hub server and download content from there.
 That content is supported by {Team}.
-For more information on configuring Automation Hub connection for `ansible-galaxy`, see https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html/getting_started_with_automation_hub/proc-configure-automation-hub-server-cli[Configuring Red Hat automation hub as the primary source for content].
+For more information on configuring Automation Hub connection for `ansible-galaxy`, see {RHDocsBaseURL}red_hat_ansible_automation_platform/2.1/html/getting_started_with_automation_hub/proc-configure-automation-hub-server-cli[Configuring Red Hat automation hub as the primary source for content].
 endif::[]
 * You can rewrite your Ansible roles, templates and other affected content.
 ifdef::satellite[]


### PR DESCRIPTION
This is the result of runnning:

```
sed -i 's|https://access.redhat.com/documentation/en-us/|{RHDocsBaseURL}|' $(rg https://access.redhat.com/documentation/ guides/common/modules/ -l)
```

This should make it easier to switch to https://docs.redhat.com/

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.