### PR TITLE
Correct Puppetserver description in glossary

### DIFF
--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -70,7 +70,7 @@ endif::[]
 [[Catalog]]
 Catalog:: A document that describes the desired system state for one specific host managed by Puppet.
 It lists all of the resources that need to be managed, as well as any dependencies between those resources.
-Catalogs are compiled by a Puppet server from Puppet Manifests and data from Puppet Agents.
+Catalogs are compiled by a Puppet server from Puppet Manifests and data from Puppet agents.
 
 ifdef::katello,orcharhino,satellite[]
 [[Candlepin]]
@@ -413,7 +413,7 @@ For more information about using Puppet to configure hosts, see {ManagingConfigu
 Puppet agent:: A service running on a host that applies configuration changes to that host.
 
 [[Puppet_environment]]
-Puppet environment:: An isolated set of Puppet Agent nodes that can be associated with a specific set of Puppet Modules.
+Puppet environment:: An isolated set of Puppet agent nodes that can be associated with a specific set of Puppet Modules.
 
 [[Puppet_manifest]]
 Puppet manifest:: Refers to Puppet scripts, which are files with the *.pp* extension.
@@ -422,7 +422,7 @@ The files contain code to define a set of necessary resources, such as packages,
 Do not confuse with xref:Manifest[Manifest (Red{nbsp}Hat subscription manifest)].
 
 [[Puppet_server]]
-Puppet server:: A {SmartProxyServer} component that provides Puppet Manifests to hosts for execution by the Puppet Agent.
+Puppet server:: A {SmartProxyServer} component that provides Puppet Manifests to hosts for execution by the Puppet agent.
 
 [[Puppet_module]]
 Puppet module:: A self-contained bundle of code (Puppet Manifests) and data (facts) that you can use to manage resources such as users, files, and services.

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -422,7 +422,7 @@ The files contain code to define a set of necessary resources, such as packages,
 Do not confuse with xref:Manifest[Manifest (Red{nbsp}Hat subscription manifest)].
 
 [[Puppet_server]]
-Puppet server:: A {SmartProxyServer} component that provides Puppet Manifests to hosts for execution by the Puppet agent.
+Puppet server:: A {SmartProxyServer} component that provides a Puppet catalog to hosts for execution by the Puppet agent.
 
 [[Puppet_module]]
 Puppet module:: A self-contained bundle of code (Puppet Manifests) and data (facts) that you can use to manage resources such as users, files, and services.

--- a/guides/doc-Planning_for_Project/topics/Configuration_Management_Support.adoc
+++ b/guides/doc-Planning_for_Project/topics/Configuration_Management_Support.adoc
@@ -2,7 +2,7 @@
 ==== Configuration management
 Supported combinations of major versions of {RHEL} and hardware architectures for configuration management with {Project}.
 
-.Puppet Agent Support
+.Puppet agent support
 [options="header",cols="2,1"]
 |====
 |Platform |Architectures

--- a/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
+++ b/guides/doc-Planning_for_Project/topics/Deployment_Considerations.adoc
@@ -249,7 +249,7 @@ The same guide contains information on configuring external authentication sourc
 This section provides a short overview of selected {Project} capabilities that can be used for automating certain tasks or extending the core usage of {Project}:
 
 * *Discovering bare-metal hosts* – the {Project} Discovery plugin enables automatic bare-metal discovery of unknown hosts on the provisioning network.
-These new hosts register themselves to {ProjectServer} and the Puppet Agent on the client uploads system facts collected by Facter, such as serial ID, network interface, memory, and disk information.
+These new hosts register themselves to {ProjectServer} and the Puppet agent on the client uploads system facts collected by Facter, such as serial ID, network interface, memory, and disk information.
 After registration you can initialize provisioning of those discovered hosts.
 For more information, see {ProvisioningDocURL}Creating_Hosts_from_Discovered_Hosts_provisioning[Creating Hosts from Discovered Hosts] in _{ProvisioningDocTitle}_.
 


### PR DESCRIPTION
The Puppetserver service compiles manifests into a catalog. The agent retries this catalog and applies it. Manifests don't leave the Puppetserver process.

Puppetserver does a lot more, so this is still an inaccurate description but less than it used to be. For example, if the Certificate Authority component is enabled it also deals with certificates and it's a fileserver used by the Puppet Agent. The Puppet Agent also sends its facts and reports to Puppetserver.

We could also copy https://www.puppet.com/docs/puppet/8/server/about_server.html

> Puppet is configured in an agent-server architecture, in which a primary server node manages the configuration information for a fleet of agent nodes. Puppet Server acts as the primary server node. Puppet Server is a Ruby and Clojure application that runs on the Java Virtual Machine (JVM). Puppet Server runs Ruby code for compiling Puppet catalogs and for serving files in several JRuby interpreters. It also provides a certificate authority through Clojure.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.