### PR TITLE
Avoid the integrated SmartProxy for non-Katello

### DIFF
--- a/guides/common/modules/snip_glossary-term-smart-proxy.adoc
+++ b/guides/common/modules/snip_glossary-term-smart-proxy.adoc
@@ -1,9 +1,9 @@
 {SmartProxyServer}::
 ifdef::satellite[]
-{SmartProxyServers} provide DHCP, DNS, and TFTP services and act as an Ansible control node or Puppet server in separate networks.
+{SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node or Puppet server in separate networks.
 endif::[]
 ifndef::satellite[]
-{SmartProxyServers} provide DHCP, DNS, and TFTP services and act as an Ansible control node, Puppet server, or Salt Master in separate networks.
+{SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node, Puppet server, or Salt Master in separate networks.
 endif::[]
 They interact with {ProjectServer} in a client-server model.
 {ProjectServer} always comes bundled with an integrated {SmartProxy}.

--- a/guides/common/modules/snip_glossary-term-smart-proxy.adoc
+++ b/guides/common/modules/snip_glossary-term-smart-proxy.adoc
@@ -6,6 +6,8 @@ ifndef::satellite[]
 {SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node, Puppet server, or Salt Master in separate networks.
 endif::[]
 They interact with {ProjectServer} in a client-server model.
+ifdef::katello,orcharhino,satellite[]
 {ProjectServer} always comes bundled with an integrated {SmartProxy}.
+endif::[]
 +
 {SmartProxyServers} are required in {Project} deployments that manage IT infrastructure spanning across multiple networks and useful for {Project} deployments across various geographical locations.


### PR DESCRIPTION
The concept of an "integrated" or "external" Smart Proxy has never been used outside of Katello. In vanilla Foreman all Smart Proxies are equal.  Some just happen to run on the same server as Foreman, but even that's optional. Advanced users can use `--no-enable-foreman-proxy` to the installer to disable this.

Within Katello there is a slight nuance and that's the role of Pulp. Each Smart Proxy Pulp plugin can identify itself as a mirror. Typically this is true for every Smart Proxy that's not on the Foreman server while it's false for the one on the Foreman server. If the number of non-mirrors isn't equal to 1 then Katello has a problem.

On a technical level there is no code difference and it's just a simple configuration flag. It would also be perfectly valid to separate out the non-mirror from Foreman, but the current installer doesn't make that easy and our upgrade tooling also doesn't support this.

In the future this may become supported, so it's best to keep the references to integrated/external to a minimum.

It also makes it obvious that a SmartProxyServer can provide services.  All the components mentioned are optional and not provided by default (except Puppet Server in non-Katello deployments).

I still struggle to properly define these things. For example, I couldn't find how we define Smart Proxy, but here's how I would define it:

Smart Proxy: a service that acts as a facade for various services, providing a unified REST API with a single authentication mechanism. Each Smart Proxy is registered to Foreman, allowing Foreman to delegate functionality for hosts, hostgroups, domains and subnet to specific Smart Proxies.

Foreman Proxy: the default (and currently only) implementation of a Smart Proxy.

Smart Proxy Server: a server running the Smart Proxy, with optionally additional services such as DHCP, DNS, TFTP and Puppet Server.

I debated leaving these comments on https://github.com/theforeman/foreman-documentation/pull/2972 or open a new issue. Feel free to consider this a bug report and take it over.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.