### PR TITLE
CentOS 7 EoL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ We capitalize the following terms:
 * Enterprise Linux (umbrella term for RHEL-derivatives)
 * Hammer
 * Insights (Red Hat product)
+* Katello
 * Kickstart
 * Library (environment)
 * OpenSCAP

--- a/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
+++ b/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
@@ -16,7 +16,7 @@ ifdef::satellite[]
 include::modules/con_supported-client-architectures-for-configuration-management.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::satellite[]
+ifndef::satellite,orcharhino[]
 include::modules/con_projectserver-operating-system.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/modules/con_client-operating-systems.adoc
+++ b/guides/common/modules/con_client-operating-systems.adoc
@@ -16,7 +16,6 @@ ifndef::satellite[]
 endif::[]
 * Windows Remote Management (WinRM)
 * Operating system installers that can perform unattended installations, such as Anaconda or Debian-installer
-* Other clients where integration is provided by external plugins
 
 ifndef::foreman-deb[]
 The Katello plugin provides functionality for content and subscription management.

--- a/guides/common/modules/con_client-operating-systems.adoc
+++ b/guides/common/modules/con_client-operating-systems.adoc
@@ -1,8 +1,11 @@
 [id="Client-Operating-Systems_{context}"]
 = Client operating systems
 
-Using {Project}, you can manage multiple operating systems that have clients {Project} can integrate with:
-For example:
+Using {Project}, you can manage multiple operating systems that have {Project} clients:
+
+include::snip_supported-client-operating-systems.adoc[]
+
+{Project} can integrate with the following client features:
 
 * Ansible
 * OpenSCAP
@@ -12,21 +15,11 @@ For example:
 * Operating system installers that can perform unattended installations, such as Anaconda or Debian-installer
 * Other clients where integration is provided by external plugins
 
-{Project} is actively tested with the following client operating systems:
-
-* CentOS 7 and 8
-* Debian stable
-ifndef::orcharhino[]
-* {EL} 7, 8, and 9
-endif::[]
-ifdef::orcharhino[]
-* {SLES}
-endif::[]
-* Ubuntu LTS
-
+ifndef::foreman-deb[]
 The Katello plugin provides functionality for content and subscription management.
 The following utilities are provided for supported client operating systems:
 
 * Katello host tools
-* Subscription manager
+* Subscription Manager
 * Tracer utility
+endif::[]

--- a/guides/common/modules/con_client-operating-systems.adoc
+++ b/guides/common/modules/con_client-operating-systems.adoc
@@ -11,6 +11,9 @@ include::snip_supported-client-operating-systems.adoc[]
 * OpenSCAP
 * OpenSSH
 * Puppet
+ifndef::satellite[]
+* Salt
+endif::[]
 * Windows Remote Management (WinRM)
 * Operating system installers that can perform unattended installations, such as Anaconda or Debian-installer
 * Other clients where integration is provided by external plugins

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -21,12 +21,14 @@ ifdef::client-content-dnf[]
 ----
 # {client-package-install-el8} katello-pull-transport-migrate
 ----
+ifdef::orcharhino,satellite[]
 ** On {EL} 7 hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {client-package-install-el7} katello-pull-transport-migrate
 ----
+endif::[]
 endif::[]
 ifdef::client-content-apt[]
 ** On {DL} hosts:

--- a/guides/common/modules/proc_configuring-project-for-performance.adoc
+++ b/guides/common/modules/proc_configuring-project-for-performance.adoc
@@ -3,5 +3,3 @@
 
 {Project} comes with a number of components that communicate with each other.
 You can tune these components independently of each other to achieve the maximum possible performance for your scenario.
-
-You will see no significant performance difference between {Project} installed on {EL} 7 and {EL} 8.

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -8,15 +8,12 @@ Use this procedure to configure a repository in a directory on a remote server.
 To create a file type repository in a directory on the base system where {ProjectServer} is installed, see xref:Creating_a_Local_Source_for_a_Custom_File_Type_Repository_{context}[].
 
 .Prerequisites
-ifdef::katello[]
+ifdef::katello,orcharhino[]
 * You have a server running {EL} 8 registered to your {Project}.
 endif::[]
 ifdef::satellite[]
 * You have a server running {EL} 8 registered to your {Project} or the Red{nbsp}Hat CDN.
 * Your server has an entitlement to the {RHELServer} and {ProjectName} Utils repositories.
-endif::[]
-ifdef::orcharhino[]
-* You have a server running {EL} registered to your {Project}.
 endif::[]
 * You have installed an HTTP server.
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -27,12 +27,6 @@ ifndef::satellite,orcharhino[]
 ----
 # {client-package-install-el8} http://_{common-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
 ----
-** On {EL} 7:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {client-package-install-el7} http://_{common-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
-----
 ** On OpenSUSE and {SLES}:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -35,12 +35,14 @@ endif::[]
 ----
 # {client-package-install-el8} puppet-agent
 ----
+ifdef::orcharhino,satellite[]
 * On hosts running {EL} 7 and below:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {client-package-install-el7} puppet-agent
 ----
+endif::[]
 ifndef::satellite[]
 * On hosts running Debian:
 +

--- a/guides/common/modules/proc_preparing-cloud-init-images-in-rhv.adoc
+++ b/guides/common/modules/proc_preparing-cloud-init-images-in-rhv.adoc
@@ -26,12 +26,6 @@ ifndef::orcharhino,satellite[]
 ----
 # {client-package-install-el8} cloud-init
 ----
-** On {EL} 7:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {client-package-install-el7} cloud-init
-----
 ** On OpenSUSE and {SLES}:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/ref_supported-clients-in-registration.adoc
+++ b/guides/common/modules/ref_supported-clients-in-registration.adoc
@@ -17,33 +17,7 @@ endif::[]
 Supported Host Operating Systems::
 The hosts can use the following operating systems:
 
-ifndef::orcharhino,satellite[]
-* Amazon Linux
-* Debian
-endif::[]
-ifndef::orcharhino[]
-* {EL} 9, 8, 7
-endif::[]
-ifdef::satellite[]
-* {EL} 6 with the https://www.redhat.com/en/resources/els-datasheet[ELS Add-On]
-endif::[]
-ifndef::orcharhino,satellite[]
-* Fedora
-* OpenSUSE
-* {SLES}
-* Ubuntu
-endif::[]
-ifdef::orcharhino[]
-* AlmaLinux
-* Amazon Linux
-* CentOS
-* Debian
-* Oracle Linux
-* Red Hat Enterprise Linux
-* Rocky Linux
-* SUSE Linux Enterprise Server
-* Ubuntu
-endif::[]
+include::snip_supported-client-operating-systems.adoc[]
 
 Supported Host Architectures::
 The hosts can use the following architectures:

--- a/guides/common/modules/snip_supported-client-operating-systems.adoc
+++ b/guides/common/modules/snip_supported-client-operating-systems.adoc
@@ -1,0 +1,27 @@
+ifndef::orcharhino,satellite[]
+* Amazon Linux
+* Debian
+endif::[]
+ifndef::orcharhino[]
+* {EL} 9 and 8
+endif::[]
+ifdef::satellite[]
+* {EL} 7 and 6 with the https://www.redhat.com/en/resources/els-datasheet[ELS Add-On]
+endif::[]
+ifndef::orcharhino,satellite[]
+* Fedora
+* OpenSUSE
+* {SLES}
+* Ubuntu
+endif::[]
+ifdef::orcharhino[]
+* AlmaLinux
+* Amazon Linux
+* CentOS
+* Debian
+* Oracle Linux
+* Red Hat Enterprise Linux
+* Rocky Linux
+* SUSE Linux Enterprise Server
+* Ubuntu
+endif::[]


### PR DESCRIPTION
current assumption for other build targets:
* Satellite continues to support RHEL 7 as OS for clients with "ELS" until 2028
RHEL 7 is still supported: it's the extended life support (ELS) phase. The support will last for the next 4 years. :heavy_check_mark: 
* orcharhino continues to support RHEL 7 and Oracle Linux 7 until June 2028 as OS for clients. :heavy_check_mark: 

There are some instances that mention EL6, so I've kept EL7 if it was next to them.

* I am unsure how to best find all instances that relate to CentOS 7.
* We will not cherry-pick this change.