### PR TITLE
Do not set minor OS version for Debian and Ubuntu

### DIFF
--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -13,34 +13,29 @@ ifndef::satellite[]
 :DL-codename: bookworm
 :DL-major: 12
 :DL-major-context: {DL-major}
-:DL-minor: 5
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :DL: Debian
 :DL-codename: bullseye
 :DL-major: 11
 :DL-major-context: {DL-major}
-:DL-minor: 9
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :DL: Ubuntu
 :DL-codename: noble
 :DL-major: 24.04
 :DL-major-context: 24-04
-:DL-minor: 0
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :DL: Ubuntu
 :DL-codename: jammy
 :DL-major: 22.04
 :DL-major-context: 22-04
-:DL-minor: 4
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :!DL-codename:
 :!DL-major:
 :!DL-major-context:
-:!DL-minor:
 :DL: {parent-DL}
 :!parent-DL:
 endif::[]

--- a/guides/common/modules/proc_creating-an-operating-system-for-debian.adoc
+++ b/guides/common/modules/proc_creating-an-operating-system-for-debian.adoc
@@ -2,7 +2,7 @@
 = Creating an operating system for {DL} {DL-major}
 
 Create an operating system in {Project} to provision hosts running {DL} {DL-major}.
-This example creates an operating system entry for {DL} {DL-major}.{DL-minor}.
+This example creates an operating system entry for {DL} {DL-major}.
 
 ifdef::orcharhino[]
 include::snip_creating-os-on-orcharhino.adoc[]
@@ -14,18 +14,7 @@ endif::[]
 . Enter `{DL} {DL-major}` as *Name* for the operating system.
 Choose a name as reported by Ansible, Puppet, or Salt as fact.
 . Set the *Major Version* to `{DL-major}`.
-. Set the *Minor Version* to `{DL-minor}`.
-ifdef::katello,orcharhino[]
-+
-[CAUTION]
-====
-{Project} searches for the boot files in the installation medium depending on the major and minor version of the operating system.
-Ensure to enter both the major and minor version correctly.
-
-For example, for {DL} {DL-major}, set the major field to `{DL-major}` and leave the minor field empty.
-For example, for {DL} {DL-major}.{DL-minor}, set the major field to `{DL-major}` and the minor field to `{DL-minor}`.
-====
-endif::[]
+. Leave the *Minor Version* field empty.
 . Set the *Release Name* to `{DL-codename}` for {DL} {DL-major}.
 . On the *Partition Table* tab, select the `Preseed` partition table.
 +

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -29,7 +29,13 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts* > *Operating systems* and click *New Operating* system.
 . In the *Name* field, enter a name to represent the operating system entry.
 . In the *Major* field, enter the number that corresponds to the major version of the operating system.
+ifdef::debian,ubuntu[]
++
+Ensure to leave the *Minor* field empty.
+endif::[]
+ifndef::debian,ubuntu[]
 . In the *Minor* field, enter the number that corresponds to the minor version of the operating system.
+endif::[]
 . In the *Description* field, enter a description of the operating system.
 . From the *Family* list, select the operating system's family.
 . From the *Root Password Hash* list, select the encoding method for the root password.
@@ -62,7 +68,9 @@ endif::[]
 --family "{client-os-family-hammer}" \
 --major {client-os-major} \
 --media "{client-os-family}" \
+ifndef::debian,ubuntu[]
 --minor {client-os-minor} \
+endif::[]
 --name "{client-os}" \
 --partition-tables "_My_Partition_Table_" \
 --provisioning-templates "_My_Provisioning_Template_"

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -71,6 +71,9 @@ endif::[]
 ifndef::debian,ubuntu[]
 --minor {client-os-minor} \
 endif::[]
+ifdef::debian,ubuntu[]
+--release-name "{client-os-codename}" \
+endif::[]
 --name "{client-os}" \
 --partition-tables "_My_Partition_Table_" \
 --provisioning-templates "_My_Provisioning_Template_"

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -57,7 +57,6 @@ endif::[]
 
 [id="cli-creating-operating-systems_{context}"]
 .CLI procedure
-
 * Create the operating system using the `hammer os create` command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -68,11 +67,11 @@ endif::[]
 --family "{client-os-family-hammer}" \
 --major {client-os-major} \
 --media "{client-os-family}" \
-ifndef::debian,ubuntu[]
---minor {client-os-minor} \
-endif::[]
 ifdef::debian,ubuntu[]
 --release-name "{client-os-codename}" \
+endif::[]
+ifndef::debian,ubuntu[]
+--minor {client-os-minor} \
 endif::[]
 --name "{client-os}" \
 --partition-tables "_My_Partition_Table_" \


### PR DESCRIPTION
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
