### PR TITLE
Change 4.12 (RC) to 4.13 (RC)

### DIFF
--- a/web/releases/3.11.json
+++ b/web/releases/3.11.json
@@ -1,5 +1,5 @@
 {
-  "katello": "4.12",
+  "katello": "4.13",
   "state": "RC",
   "builds": [
     {


### PR DESCRIPTION
Attempts to fix the following:
![image](https://github.com/theforeman/foreman-documentation/assets/14796566/b1bb6f13-023a-4f70-bfe6-a595c0d21e49)

Foreman 3.11 should pair with Katello 4.13, not 4.12.