### PR TITLE
Introduce RH*DocsBaseURL attributes to 3.10-3.5

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -21,6 +21,10 @@
 :UpgradingDocURL: {BaseURL}Upgrading_Project/{BaseFilenameURL}#
 :UpgradingDisconnectedDocURL: {BaseURL}Upgrading_Project_Disconnected/{BaseFilenameURL}#
 
+// Red Hat specific URLs
+:RHDocsBaseURL: https://access.redhat.com/documentation/en-us/
+:RHELDocsBaseURL: {RHDocsBaseURL}red_hat_enterprise_linux/
+
 // Repositories and subscriptions (used both upstream and Satellite guides)
 // The rest of repo IDs moved to attributes-satellite.adoc
 :RepoRHEL7Server: rhel-7-server-rpms

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -5,7 +5,7 @@
 // Add -beta for Beta releases
 :ProjectVersionRepoTitle: {ProjectVersion}
 
-:BaseURL: https://access.redhat.com/documentation/en-us/red_hat_satellite/{ProjectVersion}/html-single/
+:BaseURL: {RHDocsBaseURL}red_hat_satellite/{ProjectVersion}/html-single/
 
 // URLs (published on Red Hat Portal)
 :AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#


### PR DESCRIPTION
Follow up to #2966.
Absence of the attributes is complicating further cherry picks, eg. #3021, #3082
The attributes don't replace any URLs, they are only defined in this PR.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
