### PR TITLE
Move ifdef to hide non-katello content to module

### DIFF
--- a/guides/common/assembly_accessing-server.adoc
+++ b/guides/common/assembly_accessing-server.adoc
@@ -2,9 +2,7 @@ include::modules/con_accessing-server.adoc[]
 
 include::modules/con_web-ui-overview.adoc[leveloffset=+1]
 
-ifdef::katello,orcharhino,satellite[]
 include::modules/proc_importing-the-katello-root-ca-certificate.adoc[leveloffset=+1]
-endif::[]
 
 include::modules/proc_logging-in.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_importing-the-katello-root-ca-certificate.adoc
+++ b/guides/common/modules/proc_importing-the-katello-root-ca-certificate.adoc
@@ -1,3 +1,4 @@
+ifdef::katello,orcharhino,satellite[]
 [id="Importing_the_Katello_Root_CA_Certificate_{context}"]
 = Importing the Katello root CA certificate
 
@@ -38,3 +39,4 @@ Ensure that the {Project} URL is valid before you accept the security exception.
 # scp /var/www/html/pub/katello-server-ca.crt _username@hostname:remotefile_
 ----
 . In the browser, import the `katello-server-ca.crt` certificate as a certificate authority and trust it to identify websites.
+endif::[]


### PR DESCRIPTION
This came up in [another PR](https://github.com/theforeman/foreman-documentation/pull/2866#discussion_r1535410858). When an ifdef is included in the assembly file, we need to duplicate the ifdef every time the module in question gets reused. But if the ifdef was included in the module file itself, we would not need to duplicate it.

Any objections? With this PR, I propose to change the location of one particular ifdef that I need for another PR. If anyone feels like we should do it for the whole repo, that would need to be handled in a separate PR.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
