### PR TITLE
Align Hammer example to UI procedure

### DIFF
--- a/guides/common/modules/proc_adding-rhv-connection.adoc
+++ b/guides/common/modules/proc_adding-rhv-connection.adoc
@@ -32,7 +32,7 @@ Alternatively, if you leave the field blank, a self-signed certificate is genera
 # hammer compute-resource create \
 --name "__My_{oVirtShort}__" --provider "Ovirt" \
 --description "{oVirtShort} server at _{ovirt-example-com}_" \
---url "_https://{ovirt-example-com}/ovirt-engine/api_" \
+--url "_https://{ovirt-example-com}/ovirt-engine/api/v4_" \
 --user "_{Project}_User_" --password "_My_Password_" \
 --locations "New York" --organizations "_My_Organization_" \
 --datacenter "_My_Datacenter_"


### PR DESCRIPTION
In 8f00ce9b19769cea4931834ec299a83856c8b66a the CLI procedure was added with just `/ovirt-engine/api` as the path while the UI used `/ovirt-engine/api/v3`. It was later updated to v4 in 5adc278351b14a24497e4dcdd2267023808cf02e but the Hammer CLI still doesn't use this.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.