### PR TITLE
Refs #35528 - Reflect that i386 isn't provisioned by default

### DIFF
--- a/guides/common/modules/proc_creating-architectures.adoc
+++ b/guides/common/modules/proc_creating-architectures.adoc
@@ -3,7 +3,7 @@
 
 An architecture in {Project} represents a logical grouping of hosts and operating systems.
 Architectures are created by {Project} automatically when hosts check in with Puppet.
-Basic i386 and x86_64 architectures are already preset in {Project}.
+The x86_64 architecture is already preset in {Project}.
 
 Use this procedure to create an architecture in {Project}.
 


### PR DESCRIPTION
Since Foreman 3.5 the i386 architecture is no longer seeded by default, only x86_64 is ensured.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.