### PR TITLE
RH has moved its docs to docs.redhat.com

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -22,7 +22,7 @@
 :UpgradingDisconnectedDocURL: {BaseURL}Upgrading_Project_Disconnected/{BaseFilenameURL}#
 
 // Red Hat specific URLs
-:RHDocsBaseURL: https://access.redhat.com/documentation/
+:RHDocsBaseURL: https://docs.redhat.com/en/documentation/
 :RHELDocsBaseURL: {RHDocsBaseURL}red_hat_enterprise_linux/
 
 // Repositories and subscriptions (used both upstream and Satellite guides)

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -19,4 +19,4 @@ ignore=example.com
   sources/
   atixservice.zendesk.com
   # 6.16 docs are not yet published
-  access.redhat.com/documentation/red_hat_satellite/6.16
+  docs.redhat.com/en/documentation/red_hat_satellite/6.16


### PR DESCRIPTION
It is time. (I think.)

UPDATE: All Red Hat documentation traffic should now get redirected to the new docs site at docs.redhat.com. With this PR, I'm changing `:RHDocsBaseURL:` to reflect that and use docs.redhat.com for all RH links rather than rely on redirects from the previous access.redhat.com.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
