### PR TITLE
Implement repository configuration with asciidoctor-tabs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'asciidoctor'
+gem 'asciidoctor-tabs'
 gem 'sass'
 
 # For TOC generation

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -75,7 +75,7 @@ $(IMAGES_TS): $(IMAGES)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD).css $(IMAGES_TS)
-	bundle exec asciidoctor -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -a attribute-missing=warn -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
+	bundle exec asciidoctor -r asciidoctor-tabs -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -a attribute-missing=warn -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
 	@echo CHECKING FOR ASCIIDOCTOR ERRORS AND WARNINGS
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 	@echo CHECKING FOR ORPHAN XREFS HTML LINKS

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -7,23 +7,13 @@ endif::[]
 
 ifndef::orcharhino[]
 .Procedure
-Select the operating system and version you are installing on:
 endif::[]
 
 ifdef::foreman-el,katello,satellite[]
-* xref:#repositories-el-9[{EL} 9]
-* xref:#repositories-el-8[{EL} 8]
-endif::[]
-ifdef::foreman-deb[]
-* xref:#repositories-debian-11[Debian 11 (Bullseye)]
-* xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
-* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
-[id="repositories-el-9"]
-== {EL} 9
-
+[tabs]
+=====
+{EL} 9::
++
 ifdef::satellite[]
 . Disable all repositories:
 +
@@ -51,11 +41,8 @@ ifdef::foreman-el,katello[]
 include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
-include::snip_verification-enabled-repolist.adoc[]
-
-[id="repositories-el-8"]
-== {EL} 8
-
+{EL} 8::
++
 ifdef::satellite[]
 . Disable all repositories:
 +
@@ -103,26 +90,33 @@ ifeval::["{context}" != "{project-context}"]
 endif::[]
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Lifecycle].
 ====
+=====
 
 include::snip_verification-enabled-repolist.adoc[]
 endif::[]
 
 ifdef::foreman-deb[]
-[id="repositories-debian-11"]
-== Debian 11 (Bullseye)
-
+[tabs]
+=====
+Debian 11 (Bullseye)::
++
+--
 :distribution-codename: bullseye
 include::proc_configuring-repositories-deb.adoc[]
+--
 
-[id="repositories-ubuntu-2004"]
-== Ubuntu 20.04 (Focal)
-
+Ubuntu 20.04 (Focal)::
++
+--
 :distribution-codename: focal
 include::proc_configuring-repositories-deb.adoc[]
+--
 
-[id="repositories-ubuntu-2204"]
-== Ubuntu 22.04 (Jammy)
-
+Ubuntu 22.04 (Jammy)::
++
+--
 :distribution-codename: jammy
 include::proc_configuring-repositories-deb.adoc[]
+--
+=====
 endif::[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -24,10 +24,6 @@ ifdef::foreman-el,katello,satellite[]
 [id="repositories-el-9"]
 == {EL} 9
 
-:distribution: el
-:distribution-major-version: 9
-:package-manager: dnf
-
 ifdef::satellite[]
 . Disable all repositories:
 +
@@ -49,6 +45,9 @@ ifdef::satellite[]
 endif::[]
 
 ifdef::foreman-el,katello[]
+:distribution: el
+:distribution-major-version: 9
+:package-manager: dnf
 include::proc_configuring-repositories-el.adoc[]
 endif::[]
 
@@ -56,10 +55,6 @@ include::snip_verification-enabled-repolist.adoc[]
 
 [id="repositories-el-8"]
 == {EL} 8
-
-:distribution: el
-:distribution-major-version: 8
-:package-manager: dnf
 
 ifdef::satellite[]
 . Disable all repositories:
@@ -82,6 +77,9 @@ ifdef::satellite[]
 endif::[]
 
 ifdef::foreman-el,katello[]
+:distribution: el
+:distribution-major-version: 8
+:package-manager: dnf
 include::proc_configuring-repositories-el.adoc[]
 endif::[]
 


### PR DESCRIPTION
Rather than two procedures below eachother, this implements tabs. That makes the overall page shorter while still obvious.

Currently very much a proof of concept. It's only implemented in the server installation guide and it probably breaks downstream. Please consider this as more of a discussion starter.


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.