### PR TITLE
Remove RHEL 7 option from file type remote source

### DIFF
--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -9,10 +9,10 @@ To create a file type repository in a directory on the base system where {Projec
 
 .Prerequisites
 ifdef::katello[]
-* You have a server running {EL} 7 or 8 registered to your {Project}.
+* You have a server running {EL} 8 registered to your {Project}.
 endif::[]
 ifdef::satellite[]
-* You have a server running {EL} 7 or 8 registered to your {Project} or the Red{nbsp}Hat CDN.
+* You have a server running {EL} 8 registered to your {Project} or the Red{nbsp}Hat CDN.
 * Your server has an entitlement to the {RHELServer} and {ProjectName} Utils repositories.
 endif::[]
 ifdef::orcharhino[]
@@ -20,13 +20,12 @@ ifdef::orcharhino[]
 endif::[]
 * You have installed an HTTP server.
 ifndef::orcharhino[]
-For more information about configuring a web server, see {RHELDocsBaseURL}8/html/deploying_different_types_of_servers/setting-apache-http-server_deploying-different-types-of-servers[Setting up the Apache HTTP web server] in {RHEL}{nbsp}8 _Deploying different types of servers_ or {RHELDocsBaseURL}7/html/system_administrators_guide/ch-web_servers#s1-The_Apache_HTTP_Server[The Apache HTTP Server] in the _{RHEL}{nbsp}7 System Administrator's Guide_.
+For more information about configuring a web server, see {RHELDocsBaseURL}8/html/deploying_different_types_of_servers/setting-apache-http-server_deploying-different-types-of-servers[Setting up the Apache HTTP web server] in {RHEL}{nbsp}8 _Deploying different types of servers_.
 endif::[]
 
 .Procedure
 ifdef::satellite[]
 . On your server, ensure that the right repositories are enabled.
-** On {EL} 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -34,14 +33,6 @@ ifdef::satellite[]
 --enable={RepoRHEL8AppStream} \
 --enable={RepoRHEL8BaseOS} \
 --enable={RepoRHEL8ServerSatelliteUtils}
-----
-** On {EL} 7:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# subscription-manager repos \
---enable={RepoRHEL7ServerSatelliteUtils} \
---enable={RepoRHEL7Server}
 ----
 . Enable the satellite-utils module:
 +
@@ -51,17 +42,10 @@ ifdef::satellite[]
 ----
 endif::[]
 . Install the Pulp Manifest package:
-** On {EL} 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # dnf install python39-pulp_manifest
-----
-** On {EL} 7:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# yum install tfm-pulpcore-python3-pulp_manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -25,7 +25,7 @@ endif::[]
 
 .Procedure
 ifdef::satellite[]
-. On your server, ensure that the right repositories are enabled.
+. On your server, enable the required repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
RHEL 7 isn't advisable to use because the Satellite Utils repository is designated only for RHEL 8.

To be merged before #3086.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
