### PR TITLE
Update Pulp Manifest package name for Sat 6.15

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -29,7 +29,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} python39-pulp_manifest
+# {project-package-install} python3.11-pulp_manifest
 ----
 ifdef::satellite[]
 +

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -55,7 +55,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf install python39-pulp_manifest
+# dnf install python3.11-pulp_manifest
 ----
 ** On {EL} 7:
 +


### PR DESCRIPTION
The package is designated for a newer Python version. (Verified.)

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
