### PR TITLE
Change authentication to SCRAM

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -59,7 +59,7 @@ listen_addresses = '*'
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-  host  all   all   _{Project}_ip_/32   md5
+  host  all   all   _{Project}_ip_/32   scram-sha-256
 ----
 
 . To start, and enable PostgreSQL service, enter the following commands:


### PR DESCRIPTION
Postgres authentication defaults to SCRAM and md5 is no longer supported. Changing the postgres documentation to reflect this.

JIRA link:
https://issues.redhat.com/browse/SAT-24619


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
