### PR TITLE
Use CentOS Stream 9 as repo discovery example URL

### DIFF
--- a/guides/common/modules/proc_creating-repositories-to-synchronize.adoc
+++ b/guides/common/modules/proc_creating-repositories-to-synchronize.adoc
@@ -7,7 +7,7 @@ Use this procedure to discover available repositories in the CentOS Stream, then
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
 . Click *Repo Discovery*.
 . In the *Repository Type* field, select *Yum Repositories*.
-. In the *URL to Discover* field, enter the CentOS Stream URL `http://mirror.centos.org/centos/8-stream`.
+. In the *URL to Discover* field, enter the CentOS Stream URL `https://mirror.stream.centos.org/9-stream/`.
 . Click *Discover*.
 . Select `/AppStream/x86_64/os/` and `/BaseOS/x86_64/os/` repositories.
 . Click *Create Selected*.


### PR DESCRIPTION
Tested locally; URL works and repo names did not change:

![image](https://github.com/theforeman/foreman-documentation/assets/12595287/f234f86f-596e-418a-9ca5-4cc41de73db3)
