### PR TITLE
Update RHEL 8 C2R links

### DIFF
--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -30,8 +30,8 @@ The utility also subscribes the host to {Team} Subscription Management.
 The duration of the conversion process depends on the number of packages that have to be replaced, network speed, storage speed, and similar factors.
 
 .Prerequisites
-* Review {RHELDocsBaseURL}8/html-single/converting_from_an_rpm-based_linux_distribution_to_rhel/index#con_supported-conversion-paths_converting-from-a-linux-distribution-to-rhel[Supported conversion paths] in _{RHEL}{nbsp}8 Converting from an RPM-based Linux distribution to RHEL_.
-* You must have completed the steps 1.{range}5. of the procedure {RHELDocsBaseURL}8/html-single/converting_from_an_rpm-based_linux_distribution_to_rhel/index#proc_preparing-for-a-rhel-conversion_converting-using-the-command-line[Preparing for a RHEL conversion] in _{RHEL}{nbsp}8 Converting from an RPM-based Linux distribution to RHEL_.
+* Review {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#con_supported-conversion-paths_converting-from-a-linux-distribution-to-rhel[Supported conversion paths] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
+* You must have completed the steps 1.{range}5. of the procedure {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#converting-using-the-command-line_converting-from-a-linux-distribution-to-rhel[Preparing for a RHEL conversion] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
 * Ensure you have a subscription manifest uploaded to your {Project} and that there are sufficient {RHEL} entitlements allocated for the conversions you intend.
 Alternatively, you can use Ansible variables to tell the role to import the manifest from disk.
 The manifest must be imported to the organization to which you will register hosts for conversion.
@@ -79,7 +79,7 @@ endif::[]
 +
 Review pre-conversion analysis reports and resolve all issues that are blocking the conversion.
 Repeat this step until you resolve all blocking issues.
-For more information, see {RHELDocsBaseURL}8/html-single/converting_from_an_rpm-based_linux_distribution_to_rhel/index#reviewing-the-pre-conversion-analysis-report_converting-using-the-command-line[Reviewing the pre-conversion analysis report] in _{RHEL}{nbsp}8 Converting from an RPM-based Linux distribution to RHEL_.
+For more information, see {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#reviewing-the-pre-conversion-analysis-report_converting-using-the-command-line[Reviewing the pre-conversion analysis report] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
 . Run the Convert2RHEL playbook on the host group.
 Execute a remote job with the following settings:
 * **Job category**: `Convert 2 RHEL`


### PR DESCRIPTION
The guide has been retitled and the links aren't passing the linkchecker builds.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
