### PR TITLE
Fix enable and sync Client repo

### DIFF
--- a/guides/common/assembly_enabling-and-synchronizing-the-project-client-name-repository.adoc
+++ b/guides/common/assembly_enabling-and-synchronizing-the-project-client-name-repository.adoc
@@ -1,9 +1,9 @@
 include::modules/con_enabling-and-synchronizing-the-project-client-name-repository.adoc[]
 
-include::modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc[leveloffset=+1]
-
-include::modules/proc_synchronizing-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc[leveloffset=+1]
-
 include::modules/proc_enabling-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc[leveloffset=+1]
 
 include::modules/proc_enabling-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc[leveloffset=+1]
+
+include::modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc[leveloffset=+1]
+
+include::modules/proc_synchronizing-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc[leveloffset=+1]

--- a/guides/common/modules/con_enabling-and-synchronizing-the-project-client-name-repository.adoc
+++ b/guides/common/modules/con_enabling-and-synchronizing-the-project-client-name-repository.adoc
@@ -1,5 +1,5 @@
 [id="enabling-and-synchronizing-the-project-client-name-repository_{context}"]
 = Enabling and synchronizing the {project-client-name} repository
 
-The {project-client-name} repository provides the `katello-host-tools` and `puppet` packages for hosts registered to {Project}.
-You must periodically synchronize the repository from the Red Hat Content Delivery Network (CDN) to your {ProjectServer} and enable the repository on your hosts.
+The {project-client-name} repository provides client integration tools, such as `katello-host-tools` or `puppet-agent` packages, for hosts registered to {Project}.
+You have to enable the repository and periodically synchronize the repository from the Red Hat Content Delivery Network (CDN) to your {ProjectServer}, and enable the repository on your hosts.

--- a/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc
+++ b/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc
@@ -12,6 +12,10 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 * xref:CLI_Synchronizing_the_Client_Repository_rhel_7_{context}[]
 * xref:CLI_Synchronizing_the_Client_Repository_rhel_6_{context}[]
 
+.Prerequisites
+* You have enabled the repository.
+For more information, see xref:enabling-the-project-client-name-repository-rhel-7-and-rhel-6[].
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 . Click the arrow next to the *{RHEL} Server* or *{RHEL} Server - Extended Lifecycle Support*.

--- a/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
+++ b/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
@@ -6,6 +6,10 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 * xref:CLI_Synchronizing_the_Client_Repository_rhel_9_{context}[]
 * xref:CLI_Synchronizing_the_Client_Repository_rhel_8_{context}[]
 
+.Prerequisites
+* You have enabled the repository.
+For more information, see xref:enabling-the-project-client-name-repository-rhel-9-and-rhel-8[].
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 . Click the arrow next to the *{RHEL} for x86_64* product to view available content.


### PR DESCRIPTION
The user cannot sync a repo that hadn't been enabled first.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
