### PR TITLE
Hide plug-in uninstallation procedures for Satellite

### DIFF
--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -19,7 +19,9 @@ include::modules/proc_creating-image-only-hosts.adoc[leveloffset=+1]
 
 include::modules/proc_deleting-a-vm-on-microsoft-azure.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_uninstalling-microsoft-azure-plugin.adoc[leveloffset=+1]
+endif::[]
 
 :!azure-provisioning:
 :!CRname:

--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -29,7 +29,9 @@ include::modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc[leveloff
 
 include::modules/proc_deleting-a-virtual-machine-on-amazon-ec2.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_uninstalling-amazon-ec2-plugin.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/con_more-information-about-amazon-web-services.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -16,4 +16,6 @@ include::modules/proc_importing-templates.adoc[leveloffset=+2]
 
 include::modules/proc_exporting-templates.adoc[leveloffset=+2]
 
+ifndef::satellite[]
 include::modules/proc_uninstalling-the-foreman-templates-plugin.adoc[leveloffset=+1]
+endif::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/SAT-25665 This PR hides a few procedures for uninstalling Foreman plug-ins for Satellite builds.  Satellite depends on these plug-ins and they cannot be uninstalled. 

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
