### PR TITLE
Support RHEL-convertible OSs in host registration for Satellite

### DIFF
--- a/guides/common/modules/snip_supported-client-operating-systems.adoc
+++ b/guides/common/modules/snip_supported-client-operating-systems.adoc
@@ -7,6 +7,11 @@ ifndef::orcharhino[]
 endif::[]
 ifdef::satellite[]
 * {EL} 7 and 6 with the https://www.redhat.com/en/resources/els-datasheet[ELS Add-On]
+ifdef::managing-hosts[]
+* You can register the following hosts for converting to RHEL:
+** CentOS Linux 7
+** Oracle Linux 7 and 8
+endif::[]
 endif::[]
 ifndef::orcharhino,satellite[]
 * Fedora


### PR DESCRIPTION
Requested by https://issues.redhat.com/browse/SAT-26077

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
