### PR TITLE
Document Container Push Workflow

### DIFF
--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -29,35 +29,35 @@ If a user uses the label-based schema, they pull using labels.
 If a user uses the ID-based schema, they pull using IDs.
 
 .Procedure
-. Log in to the container registry:
+* Logging in to the container registry:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman login {foreman-example-com}
 ----
 
-. List container images:
+* Listing container images:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman search {foreman-example-com}/
 ----
 
-. Pull container images:
+* Pulling container images:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman pull {foreman-example-com}/my-image:<optional_tag>
 ----
 
-. Push container images to the {Project} container registry:
-* To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container repository name.
-* Push accepts the following formats:
+* Pushing container images to the {Project} container registry:
+- To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container repository name.
+- Push accepts the following formats:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman push _image_hash_ _{foreman-example-com}_/_organization_label_/_product_label_/_repository_name_[:_tag_]
-# podman push _image_ _{foreman-example-com}_/id/_organization_id_/_product_id_/_repository_name_[:_tag_]
+# podman push _image_hash_ _{foreman-example-com}_/id/_organization_id_/_product_id_/_repository_name_[:_tag_]
 ----
 * An example of a complete push:
 +

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 .Considerations for pushing content to the {Project} container registry
 * You can only push content to the {ProjectServer} itself.
-If you need pushed content on {SmartProxies} as well, use {SmartProxy} syncing.
+If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
 * The pushed container name must contain only lowercase characters.
 * Unless pushed repositories are published in a content view version, they do not follow the Registry Name Pattern.
 This is to ensure that users can push and pull from the same path.
@@ -56,17 +56,7 @@ If a user uses the ID-based schema, they pull using IDs.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# podman push _image_hash_ _{foreman-example-com}_/_organization_label_/_product_label_/_repository_name_[:_tag_]
-# podman push _image_hash_ _{foreman-example-com}_/id/_organization_id_/_product_id_/_repository_name_[:_tag_]
-----
-* An example of a complete push:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# podman push _d2c94e258dcb_ _{foreman-example-com}_/default_organization/test_product/hello-world:latest
-Getting image source signatures
-Copying blob ac28800ec8bb done   |
-Copying config d2c94e258d done   |
-Writing manifest to image destination
+$ podman push _My_Container_Image_Hash_ _{foreman-example-com}_/_My_Organization_Label_/_My_Product_Label_/_My_Repository_Name_[:_My_Tag_]
+$ podman push _My_Container_Image_Hash_ _{foreman-example-com}_/id/_My_Organization_ID_/_My_Product_ID_/_My_Repository_Name_[:_My_Tag_]
 ----
 * After the content push has completed, a repository is created in {Project}.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -1,8 +1,7 @@
 [id="Using_Container_Registries_{context}"]
 = Using container registries
 
-Podman and Docker can be used to fetch content from container registries.
-Containers are pushed to the {Project} container registry.
+You can use Podman and Docker to fetch content from container registries and push containers to the {Project} container registry.
 The {Project} registry follows the Open Containers Initiative (OCI) specification, so you can push content to {Project} by using the same methods that apply to other registries.
 For more information about OCI, see link:https://opencontainers.org/[Open Container Initiative Distribution Specification].
 
@@ -57,10 +56,9 @@ If a user uses the ID-based schema, they pull using IDs.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# podman push _image_ _{foreman-example-com}_/_organization_label_/_product_label_/_repository_name_[:_tag_]
-# podman push _image_ _{foreman-example-com}_/id/<organization_id>/<product_id>/<repository_name>[:_tag_]
+# podman push _image_hash_ _{foreman-example-com}_/_organization_label_/_product_label_/_repository_name_[:_tag_]
+# podman push _image_ _{foreman-example-com}_/id/_organization_id_/_product_id_/_repository_name_[:_tag_]
 ----
-
 * An example of a complete push:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -6,8 +6,8 @@ The {Project} registry follows the Open Containers Initiative (OCI) specificatio
 For more information about OCI, see link:https://opencontainers.org/[Open Container Initiative Distribution Specification].
 
 .Prerequisites
-* To push content to an organization or product, ensure your {Project} account has the `edit_products` permission.
-* To pull content, ensure that your {Project} account has the `view_lifecycle_environments`, `view_products`, and `view_content_views` permissions, unless the lifecycle environment allows unauthenticated pull.
+* To push content to {Project}, ensure your {Project} account has the `edit_products` permission.
+* To pull content from {Project}, ensure that your {Project} account has the `view_lifecycle_environments`, `view_products`, and `view_content_views` permissions, unless the lifecycle environment allows unauthenticated pull.
 
 ifndef::orcharhino[]
 .Container registries on {SmartProxies}

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -2,31 +2,73 @@
 = Using container registries
 
 Podman and Docker can be used to fetch content from container registries.
+Containers are pushed to the {Project} container registry.
+The {Project} registry follows the Open Containers Initiative (OCI) specification, so you can push content to {Project} by using the same methods that apply to other registries.
+For more information about OCI, see link:https://opencontainers.org/[Open Container Initiative Distribution Specification].
+
+.Prerequisites
+* To push content to an organization or product, a user must have permissions to create repositories.
+The push permission is `edit_products`.
+* To pull content, a user must have permissions as long as *unauthenticated pull* is set to off by default in the lifecycle environment.
+The pull permissions are `view_lifecycle_environments`, `view_products`, `view_content_views`.
 
 ifndef::orcharhino[]
 .Container registries on {SmartProxies}
-
 On {SmartProxies} with content, the https://github.com/Katello/smart_proxy_container_gateway[Container Gateway] {SmartProxy} plugin acts as the container registry.
 It caches authentication information from Katello and proxies incoming requests to Pulp.
 The Container Gateway is available by default on {SmartProxies} with content.
 endif::[]
 
-.Procedure
+.Considerations for pushing content to the {Project} container registry
+* You can only push content to the {ProjectServer} itself.
+If you need pushed content on {SmartProxies} as well, use {SmartProxy} syncing.
+* The pushed container name must contain only lowercase characters.
+* Unless pushed repositories are published in a content view version, they do not follow the Registry Name Pattern.
+This is to ensure that users can push and pull from the same path.
+* Users are required to push and pull from the same path.
+If a user uses the label-based schema, they pull using labels.
+If a user uses the ID-based schema, they pull using IDs.
 
-Logging in to the container registry:
+.Procedure
+. Log in to the container registry:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman login {foreman-example-com}
 ----
 
-Listing container images:
+. List container images:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman search {foreman-example-com}/
 ----
 
-Pulling container images:
+. Pull container images:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # podman pull {foreman-example-com}/my-image:<optional_tag>
 ----
+
+. Push container images to the {Project} container registry:
+* To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container repository name.
+* Push accepts the following formats:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# podman push _image_ _{foreman-example-com}_/_organization_label_/_product_label_/_repository_name_[:_tag_]
+# podman push _image_ _{foreman-example-com}_/id/<organization_id>/<product_id>/<repository_name>[:_tag_]
+----
+
+* An example of a complete push:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# podman push _d2c94e258dcb_ _{foreman-example-com}_/default_organization/test_product/hello-world:latest
+Getting image source signatures
+Copying blob ac28800ec8bb done   |
+Copying config d2c94e258d done   |
+Writing manifest to image destination
+----
+* After the content push has completed, a repository is created in {Project}.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -1,15 +1,13 @@
 [id="Using_Container_Registries_{context}"]
 = Using container registries
 
-You can use Podman and Docker to fetch content from container registries and push containers to the {Project} container registry.
+You can use Podman and Docker to fetch content from container registries and push the content to the {Project} container registry.
 The {Project} registry follows the Open Containers Initiative (OCI) specification, so you can push content to {Project} by using the same methods that apply to other registries.
 For more information about OCI, see link:https://opencontainers.org/[Open Container Initiative Distribution Specification].
 
 .Prerequisites
-* To push content to an organization or product, a user must have permissions to create repositories.
-The push permission is `edit_products`.
-* To pull content, a user must have permissions as long as *unauthenticated pull* is set to off by default in the lifecycle environment.
-The pull permissions are `view_lifecycle_environments`, `view_products`, `view_content_views`.
+* To push content to an organization or product, ensure your {Project} account has the `edit_products` permission.
+* To pull content, ensure that your {Project} account has the `view_lifecycle_environments`, `view_products`, and `view_content_views` permissions, unless the lifecycle environment allows unauthenticated pull.
 
 ifndef::orcharhino[]
 .Container registries on {SmartProxies}
@@ -21,12 +19,13 @@ endif::[]
 .Considerations for pushing content to the {Project} container registry
 * You can only push content to the {ProjectServer} itself.
 If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
-* The pushed container name must contain only lowercase characters.
-* Unless pushed repositories are published in a content view version, they do not follow the Registry Name Pattern.
+* The pushed container registry name must contain only lowercase characters.
+* Unless pushed repositories are published in a content view version, they do not follow the registry name pattern.
+For more information about managing registry name patterns, see xref:Managing_Container_Name_Patterns_{context}[].
 This is to ensure that users can push and pull from the same path.
 * Users are required to push and pull from the same path.
-If a user uses the label-based schema, they pull using labels.
-If a user uses the ID-based schema, they pull using IDs.
+If you use the label-based schema, pull using labels.
+If you use the ID-based schema, pull using IDs.
 
 .Procedure
 * Logging in to the container registry:
@@ -52,11 +51,11 @@ If a user uses the ID-based schema, they pull using IDs.
 
 * Pushing container images to the {Project} container registry:
 - To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container repository name.
-- Push accepts the following formats:
+- You can address the container destination in the following ways:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ podman push _My_Container_Image_Hash_ _{foreman-example-com}_/_My_Organization_Label_/_My_Product_Label_/_My_Repository_Name_[:_My_Tag_]
 $ podman push _My_Container_Image_Hash_ _{foreman-example-com}_/id/_My_Organization_ID_/_My_Product_ID_/_My_Repository_Name_[:_My_Tag_]
 ----
-* After the content push has completed, a repository is created in {Project}.
+- After the content push has completed, a repository is created in {Project}.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -21,7 +21,7 @@ endif::[]
 If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
 * The pushed container registry name must contain only lowercase characters.
 * Unless pushed repositories are published in a content view version, they do not follow the registry name pattern.
-For more information about managing registry name patterns, see xref:Managing_Container_Name_Patterns_{context}[].
+For more information, see xref:Managing_Container_Name_Patterns_{context}[].
 This is to ensure that users can push and pull from the same path.
 * Users are required to push and pull from the same path.
 If you use the label-based schema, pull using labels.
@@ -50,8 +50,8 @@ If you use the ID-based schema, pull using IDs.
 ----
 
 * Pushing container images to the {Project} container registry:
-- To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container repository name.
-- You can address the container destination in the following ways:
+- To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container registry name.
+- You can address the container destination by using one of the following schemas:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
Containers are able to be pushed to Satellite's
container registry.
This command for pushing containers was needed to show the user how to
do so.
The Update Using Container Registries .adoc file is updated to reflect this.
Related to PR #3023 and this [Jira ticket](https://issues.redhat.com/browse/SAT-18579).

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
