### PR TITLE
Update RHEL FIPS mode links

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -107,7 +107,7 @@ ifndef::satellite[]
 {RHEL} clones are not being actively tested in FIPS mode.
 If you require FIPS, consider using {RHEL}.
 endif::[]
-For more information, see {RHELDocsBaseURL}9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode] in _{RHEL}{nbsp}9 Security hardening_ or {RHELDocsBaseURL}8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing the system in FIPS mode] in _{RHEL}{nbsp}8 Security hardening_.
+For more information, see {RHELDocsBaseURL}9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening[Switching RHEL to FIPS mode] in _{RHEL}{nbsp}9 Security hardening_ or {RHELDocsBaseURL}8/html/security_hardening/switching-rhel-to-fips-mode_security-hardening[Switching RHEL to FIPS mode] in _{RHEL}{nbsp}8 Security hardening_.
 
 [NOTE]
 ====


### PR DESCRIPTION
The link targets are missing, links had to be updated.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
