### PR TITLE
Move TemplateSync and hide enablement

### DIFF
--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -1,6 +1,8 @@
 include::modules/con_synchronizing-template-repositories.adoc[]
 
+ifndef::satellite[]
 include::modules/proc_enabling-the-templatesync-plugin.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_configuring-the-templatesync-plugin.adoc[leveloffset=+1]
 

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -58,6 +58,8 @@ ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renewing-custom-ssl-certificate.adoc[leveloffset=+1]
 endif::[]
 
+include::common/assembly_synchronizing-template-repositories.adoc[leveloffset=+1]
+
 include::common/assembly_logging-and-reporting-problems.adoc[leveloffset=+1]
 
 include::common/assembly_monitoring-resources.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -51,8 +51,6 @@ include::common/assembly_configuring-and-setting-up-remote-jobs.adoc[leveloffset
 
 include::common/assembly_host-status.adoc[leveloffset=+1]
 
-include::common/assembly_synchronizing-template-repositories.adoc[leveloffset=+1]
-
 include::common/assembly_managing-packages.adoc[leveloffset=+1]
 
 :numbered!:


### PR DESCRIPTION
The chapter doesn't belong into _Managing hosts_, but into _Administering Project_.
And we can hide plug-in enablement for Sat, because it's enabled by default.

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
