### PR TITLE
Fix x.y.z version terminology

### DIFF
--- a/guides/common/modules/con_updating-project-to-next-patch-version.adoc
+++ b/guides/common/modules/con_updating-project-to-next-patch-version.adoc
@@ -7,4 +7,7 @@ The minor releases are non-disruptive to your operating environment and often fa
 You can update the underlying operating system.
 If there are pending {ProjectServer} updates, updating the operating system will update both.
 
-{Team} recommends performing updates regularly, because the minor releases patch security vulnerabilities and minor issues discovered after code is released.
+[IMPORTANT]
+====
+Perform updates regularly to resolve security vulnerabilities and other issues.
+====

--- a/guides/common/modules/con_updating-project-to-next-patch-version.adoc
+++ b/guides/common/modules/con_updating-project-to-next-patch-version.adoc
@@ -1,7 +1,7 @@
-[id="updating-project-to-next-minor-version_{context}"]
-= Updating {Project} to the next minor version
+[id="updating-project-to-next-patch-version_{context}"]
+= Updating {Project} to the next patch version
 
-You can update your {ProjectServer} and {SmartProxyServer} to a new minor release version, such as from {ProjectVersion}.0 to {ProjectVersion}.1, using the {Project} maintain tool.
+You can update your {ProjectServer} and {SmartProxyServer} to a new patch release version, such as from {ProjectVersion}.0 to {ProjectVersion}.1, using the {Project} maintain tool.
 The minor releases are non-disruptive to your operating environment and often fast.
 
 You can update the underlying operating system.

--- a/guides/common/modules/con_updating-project-to-next-patch-version.adoc
+++ b/guides/common/modules/con_updating-project-to-next-patch-version.adoc
@@ -2,7 +2,7 @@
 = Updating {Project} to the next patch version
 
 You can update your {ProjectServer} and {SmartProxyServer} to a new patch release version, such as from {ProjectVersion}.0 to {ProjectVersion}.1, using the {Project} maintain tool.
-The minor releases are non-disruptive to your operating environment and often fast.
+The patch releases are non-disruptive to your operating environment and often fast.
 
 You can update the underlying operating system.
 If there are pending {ProjectServer} updates, updating the operating system will update both.

--- a/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
+++ b/guides/common/modules/proc_managing-packages-on-the-base-operating-system.adoc
@@ -37,4 +37,4 @@ You can manage packages using `{foreman-maintain} packages` command as follows:
 ----
 
 Updating packages individually can lead to package inconsistencies on {ProjectServer} or {SmartProxyServer}.
-For more information about updating packages on {ProjectServer}, see {UpdatingDocURL}updating-project-to-next-minor-version_updating[Updating {ProjectServer} to the Next Minor Version] in _{UpdatingDocTitle}_.
+For more information about updating packages on {ProjectServer}, see {UpdatingDocURL}updating-project-to-next-patch-version_updating[Updating {ProjectServer} to the Next Patch Version] in _{UpdatingDocTitle}_.

--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -1,7 +1,7 @@
 [id="Updating-Disconnected-{project-context}_{context}"]
 = Updating a disconnected {ProjectServer}
 
-Update your air-gapped {Project} setup where the connected {ProjectServer}, which synchronizes content from CDN, is air gapped from a disconnected {ProjectServer}, to the next minor version.
+Update your air-gapped {Project} setup where the connected {ProjectServer}, which synchronizes content from CDN, is air gapped from a disconnected {ProjectServer}, to the next patch version.
 You can follow this process to update the underlying operating system between minor release versions.
 
 .Prerequisites

--- a/guides/common/modules/proc_updating-server.adoc
+++ b/guides/common/modules/proc_updating-server.adoc
@@ -2,12 +2,12 @@
 = Updating {ProjectServer}
 
 ifdef::satellite[]
-Update your connected {ProjectServer} to the next minor version.
+Update your connected {ProjectServer} to the next patch version.
 You can follow this process to update the underlying operating system between minor release versions.
 For information to update a disconnected {Project} setup, see xref:Updating-Disconnected-{project-context}_{context}[].
 endif::[]
 ifndef::satellite[]
-Update your {ProjectServer} to the next minor version.
+Update your {ProjectServer} to the next patch version.
 endif::[]
 
 .Prerequisites

--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -1,7 +1,7 @@
 [id="Updating-Smart-Proxy_{context}"]
 = Updating {SmartProxyServer}
 
-Update {SmartProxyServers} to the next minor version.
+Update {SmartProxyServers} to the next patch version.
 
 .Procedure
 ifdef::satellite[]

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -534,10 +534,10 @@ Requires foreman_statistics plugin on your {ProjectServer}.
 endif::[]
 
 [[Updating]]
-Updating {Project}:: The process of advancing your {ProjectServer} and {SmartProxyServer} installations from a z-stream release to the next, for example {Project} {ProjectVersion}.0 to {Project} {ProjectVersion}.1.
+Updating {Project}:: The process of advancing your {ProjectServer} and {SmartProxyServer} installations from one patch release to the next, for example {Project} {ProjectVersion}.0 to {Project} {ProjectVersion}.1.
 
 [[Upgrading]]
-Upgrading {Project}:: The process of advancing your {ProjectServer} and {SmartProxyServer} installations from a y-stream release to the next, for example {Project} {ProjectVersionPrevious} to {Project} {ProjectVersion}.
+Upgrading {Project}:: The process of advancing your {ProjectServer} and {SmartProxyServer} installations from one minor release to the next, for example {Project} {ProjectVersionPrevious} to {Project} {ProjectVersion}.
 
 [[User_group]]
 User group:: A collection of roles which can be assigned to a collection of users.

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -16,7 +16,7 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/modules/con_updating-project-to-next-minor-version.adoc[leveloffset=+1]
+include::common/modules/con_updating-project-to-next-patch-version.adoc[leveloffset=+1]
 
 include::common/modules/proc_updating-server.adoc[leveloffset=+1]
 


### PR DESCRIPTION
It must be confusing that we call z-stream "minor version" when it should be called "patch version". This has been bugging me for quite some time.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
