### PR TITLE
Split proc_configuring-repositories.adoc into several files

### DIFF
--- a/guides/common/assembly_configuring-repositories.adoc
+++ b/guides/common/assembly_configuring-repositories.adoc
@@ -1,0 +1,3 @@
+include::modules/con_configuring-repositories.adoc[]
+
+include::modules/proc_configuring-repositories-{build}.adoc[]

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -21,7 +21,7 @@ ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
 ifndef::satellite[]
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::assembly_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
 // we do not package "fapolicy" for Foreman on Debian/Ubuntu

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -12,7 +12,7 @@ include::modules/proc_registering-to-red-hat-subscription-management.adoc[levelo
 include::modules/proc_attaching-satellite-infrastructure-subscription.adoc[leveloffset=+1]
 endif::[]
 
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::assembly_configuring-repositories.adoc[leveloffset=+1]
 
 // we do not package "fapolicy" for Foreman on Debian/Ubuntu
 ifndef::foreman-deb[]

--- a/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
+++ b/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
 ifndef::satellite[]
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::assembly_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
 // Installing {SmartProxyServer} Packages

--- a/guides/common/modules/con_configuring-repositories.adoc
+++ b/guides/common/modules/con_configuring-repositories.adoc
@@ -1,0 +1,2 @@
+[id="configuring-repositories_{context}"]
+= Configuring repositories

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -1,0 +1,24 @@
+.Procedure
+Select the operating system and version you are installing on:
+
+* xref:#repositories-debian-11[Debian 11 (Bullseye)]
+* xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
+* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
+
+[id="repositories-debian-11"]
+== Debian 11 (Bullseye)
+
+:distribution-codename: bullseye
+include::proc_configuring-repositories-deb.adoc[]
+
+[id="repositories-ubuntu-2004"]
+== Ubuntu 20.04 (Focal)
+
+:distribution-codename: focal
+include::proc_configuring-repositories-deb.adoc[]
+
+[id="repositories-ubuntu-2204"]
+== Ubuntu 22.04 (Jammy)
+
+:distribution-codename: jammy
+include::proc_configuring-repositories-deb.adoc[]

--- a/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
@@ -1,0 +1,46 @@
+.Procedure
+Select the operating system and version you are installing on:
+
+* xref:#repositories-el-9[{EL} 9]
+* xref:#repositories-el-8[{EL} 8]
+
+[id="repositories-el-9"]
+== {EL} 9
+
+:distribution: el
+:distribution-major-version: 9
+:package-manager: dnf
+
+include::proc_configuring-repositories-el.adoc[]
+
+include::snip_verification-enabled-repolist.adoc[]
+
+[id="repositories-el-8"]
+== {EL} 8
+
+:distribution: el
+:distribution-major-version: 8
+:package-manager: dnf
+
+include::proc_configuring-repositories-el.adoc[]
+
+. Enable the DNF modules:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# dnf module enable {dnf-module}
+----
++
+[NOTE]
+====
+If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-module}` module, see
+ifeval::["{context}" == "{project-context}"]
+xref:troubleshooting-dnf-modules_{context}[].
+endif::[]
+ifeval::["{context}" != "{project-context}"]
+{InstallingServerDocURL}troubleshooting-dnf-modules_{project-context}[Troubleshooting DNF modules] in _{InstallingServerDocTitle}_.
+endif::[]
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Lifecycle].
+====
+
+include::snip_verification-enabled-repolist.adoc[]

--- a/guides/common/modules/proc_configuring-repositories-katello.adoc
+++ b/guides/common/modules/proc_configuring-repositories-katello.adoc
@@ -1,0 +1,1 @@
+proc_configuring-repositories-foreman-el.adoc

--- a/guides/common/modules/proc_configuring-repositories-orcharhino.adoc
+++ b/guides/common/modules/proc_configuring-repositories-orcharhino.adoc
@@ -1,0 +1,1 @@
+Ensure the repositories required to install {ProductName} are enabled on your {EL} host.

--- a/guides/common/modules/proc_configuring-repositories-satellite.adoc
+++ b/guides/common/modules/proc_configuring-repositories-satellite.adoc
@@ -1,34 +1,12 @@
-[id="configuring-repositories_{context}"]
-= Configuring repositories
-
-ifdef::orcharhino[]
-Ensure the repositories required to install {ProductName} are enabled on your {EL} host.
-endif::[]
-
-ifndef::orcharhino[]
 .Procedure
 Select the operating system and version you are installing on:
-endif::[]
 
-ifdef::foreman-el,katello,satellite[]
 * xref:#repositories-el-9[{EL} 9]
 * xref:#repositories-el-8[{EL} 8]
-endif::[]
-ifdef::foreman-deb[]
-* xref:#repositories-debian-11[Debian 11 (Bullseye)]
-* xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
-* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
-endif::[]
 
-ifdef::foreman-el,katello,satellite[]
 [id="repositories-el-9"]
 == {EL} 9
 
-:distribution: el
-:distribution-major-version: 9
-:package-manager: dnf
-
-ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -46,22 +24,12 @@ ifdef::satellite[]
 --enable={RepoRHEL9ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
-endif::[]
-
-ifdef::foreman-el,katello[]
-include::proc_configuring-repositories-el.adoc[]
-endif::[]
 
 include::snip_verification-enabled-repolist.adoc[]
 
 [id="repositories-el-8"]
 == {EL} 8
 
-:distribution: el
-:distribution-major-version: 8
-:package-manager: dnf
-
-ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -79,20 +47,13 @@ ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
 ----
-endif::[]
 
-ifdef::foreman-el,katello[]
-include::proc_configuring-repositories-el.adoc[]
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
 . Enable the DNF modules:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # dnf module enable {dnf-module}
 ----
-endif::[]
 +
 [NOTE]
 ====
@@ -107,24 +68,3 @@ For more information about modules and lifecycle streams on {RHEL} 8, see https:
 ====
 
 include::snip_verification-enabled-repolist.adoc[]
-endif::[]
-
-ifdef::foreman-deb[]
-[id="repositories-debian-11"]
-== Debian 11 (Bullseye)
-
-:distribution-codename: bullseye
-include::proc_configuring-repositories-deb.adoc[]
-
-[id="repositories-ubuntu-2004"]
-== Ubuntu 20.04 (Focal)
-
-:distribution-codename: focal
-include::proc_configuring-repositories-deb.adoc[]
-
-[id="repositories-ubuntu-2204"]
-== Ubuntu 22.04 (Jammy)
-
-:distribution-codename: jammy
-include::proc_configuring-repositories-deb.adoc[]
-endif::[]

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -21,7 +21,7 @@ For more information, see {InstallingServerDocURL}system-requirements_{project-c
 The Foreman installer uses Puppet to install Foreman.
 This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the Smart Proxy by default.
 
-include::common/modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::common/assembly_configuring-repositories.adoc[leveloffset=+1]
 
 include::common/modules/proc_installing-the-satellite-server-packages.adoc[leveloffset=+1]
 


### PR DESCRIPTION
The procedure to enable repositories is very specific to every build flavor. Trying to squeeze this into a single file makes it very complicated. This makes maintenance easier and doesn't really duplicate that much.

This PR is split off from https://github.com/theforeman/foreman-documentation/pull/3104 to verify it's just an internal refactor and doesn't have any impact on the resulting guides. It may also be easier to review this standalone, but I'll leave that up to others.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.