### PR TITLE
Consistently cover all build flavors

### DIFF
--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -20,7 +20,7 @@ endif::[]
 ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
-ifdef::foreman-el,foreman-deb[]
+ifndef::satellite[]
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
+++ b/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
@@ -9,7 +9,7 @@ endif::[]
 ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
-ifdef::foreman-el,foreman-deb[]
+ifndef::satellite[]
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
Satellite has different instructions for the proxy repositories while all the rest has the same basic instructions. This matches the ifdef with an ifndef, effectively creating an else condition.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.