### PR TITLE
Update translated languages

### DIFF
--- a/guides/common/modules/ref_supported-browsers.adoc
+++ b/guides/common/modules/ref_supported-browsers.adoc
@@ -19,4 +19,9 @@ The recommended requirements are as follows for major browsers:
 Other browsers may work unpredictably.
 endif::[]
 
-The {ProjectWebUI} and command-line interface support English, Portuguese, Simplified Chinese Traditional Chinese, Korean, Japanese, Italian, Spanish, Russian, French, and German.
+ifdef::satellite[]
+The {ProjectWebUI} and command-line interface support English, Simplified Chinese, Japanese, French.
+endif::[]
+ifndef::satellite[]
+The {ProjectWebUI} and command-line interface is translated into various languages.
+endif::[]


### PR DESCRIPTION
Satellite officially only supports a few languages. Others are available, but incomplete. For upstream we don't list all languages because the list is even more inconsistent.

It should be noted that with the next release we'll add Korean to the list, but for now Red Hat's translators haven't worked on that for a long time so it's incomplete.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.