### PR TITLE
Consistently link to subscription_central/1-latest

### DIFF
--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -40,7 +40,7 @@ For more information about configuring system locale in {EL}, see {RHELDocsBaseU
 ifdef::satellite[]
 Your {Project} must have the {SatelliteSub} manifest in your Customer Portal.
 {Project} must have {project-context}-{smart-proxy-context}-6.x repository enabled and synced.
-To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see {RHDocsBaseURL}subscription_central/2023/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see {RHDocsBaseURL}subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.


### PR DESCRIPTION
In all other places we link to 1-latest instead of 2023.

It makes me wonder if we need an attribute like for RHEL's docs.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.