### PR TITLE
Remove CLP module from documentation

### DIFF
--- a/guides/common/modules/con_making-open-source-more-inclusive.adoc
+++ b/guides/common/modules/con_making-open-source-more-inclusive.adoc
@@ -1,8 +1,0 @@
-[preface]
-
-[id="making-open-source-more-inclusive_{context}"]
-= Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties.
-Because of the enormity of this endeavor, these changes are being updated gradually and where possible.
-For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -11,8 +11,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Administering_with_Ansible/master.adoc
+++ b/guides/doc-Administering_with_Ansible/master.adoc
@@ -12,8 +12,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -13,8 +13,6 @@ endif::[]
 ifndef::foreman-deb,foreman-el[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -12,8 +12,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -15,8 +15,6 @@ endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -14,8 +14,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -6,8 +6,6 @@ include::common/header.adoc[]
 = {ManagingConfigurationsAnsibleDocTitle}
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -12,8 +12,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -16,8 +16,6 @@ For more information, see {BaseURL}Installing_Server/index-katello.html[Installi
 endif::[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -12,8 +12,6 @@ endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -18,8 +18,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Monitoring_Project/master.adoc
+++ b/guides/doc-Monitoring_Project/master.adoc
@@ -5,8 +5,6 @@ include::common/header.adoc[]
 :context: monitoring
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -11,8 +11,6 @@ endif::[]
 ifndef::foreman-el,foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -11,8 +11,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -11,8 +11,6 @@ endif::[]
 ifndef::HideDocumentOnStable[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -13,8 +13,6 @@ endif::[]
 ifndef::foreman-el,foreman-deb,katello[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -14,8 +14,6 @@ endif::[]
 ifndef::foreman-deb[]
 
 ifdef::satellite[]
-include::common/modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
With the launch of docs.redhat.com, the conscious language module is no longer required as the inclusivity statement is a part of the footnotes. E.g.: https://docs.redhat.com/en/documentation/red_hat_satellite/6.15/html/installing_satellite_server_in_a_connected_network_environment/index Removing the CLP module for all releases and from all guides.


* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.11/Katello 4.13
* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [X] Foreman 3.6/Katello 4.8
* [X] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
