### PR TITLE
Refs #37604 - Fix foreman-proxy-dns-forwarders option

### DIFF
--- a/guides/common/modules/proc_configuring-network-services.adoc
+++ b/guides/common/modules/proc_configuring-network-services.adoc
@@ -27,7 +27,8 @@ endif::[]
 --foreman-proxy-dhcp-range "_192.168.140.10_ _192.168.140.110_" \
 --foreman-proxy-dhcp-server "_192.168.140.2_" \
 --foreman-proxy-dns true \
---foreman-proxy-dns-forwarders "_8.8.8.8_; _8.8.4.4_" \
+--foreman-proxy-dns-forwarders "_8.8.8.8_" \
+--foreman-proxy-dns-forwarders "_8.8.4.4_" \
 --foreman-proxy-dns-managed true \
 --foreman-proxy-dns-reverse "_140.168.192.in-addr.arpa_" \
 --foreman-proxy-dns-server "_127.0.0.1_" \


### PR DESCRIPTION
The dns-forwarders option is an array of values. Previously it was just a string but now it's validated to be an IP or `$ip port $port`. This prevents users from specifying an invalid value which could cause BIND to refuse to start up.

The `ip;ip` value was abusing an internal implementation detail. It was never intended to work, but prior to the stricter validation it happened to work. The correct way is to repeat the parameter with the various values.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.