### PR TITLE
Add Product, Ansible Playbook to Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ All headings are sentence case.
 We capitalize the following terms:
 
 * Ansible
+* Ansible Playbook
 * Candlepin
 * Chef
 * Deb (content type)
@@ -74,6 +75,7 @@ We capitalize the following terms:
 * Library (environment)
 * OpenSCAP
 * PostgreSQL
+* Product (collection of repositories)
 * Pulp
 * Puppet
 * Python


### PR DESCRIPTION
Add "Product" and "Ansible Playbook" to Capitalization section of Contributing.md


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
