### PR TITLE
Use a direct command to open a database shell

### DIFF
--- a/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-using-ssh.adoc
+++ b/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-using-ssh.adoc
@@ -10,23 +10,11 @@ However, to connect to any Amazon Web Services EC2 instance that you provision t
 ----
 # hammer compute-resource list
 ----
-. Switch user to the `postgres` user:
-+
-[options="nowrap" subs="+quotes"]
-----
-# su - postgres
-----
-. Initiate the `postgres` shell:
-+
-[options="nowrap" subs="+quotes"]
-----
-$ psql
-----
 . Connect to the Foreman database as the user `postgres`:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# postgres=# \c foreman
+# su - postgres -c psql foreman
 ----
 . Select the secret from `key_pairs` where `compute_resource_id = 3`:
 +


### PR DESCRIPTION
Rather than using various small steps, this uses a single command to run psql as the postgres user. You can also pass a database to open.

I'd like to note that this procedure in itself is problematic. This really isn't a normal procedure that any user can (or should) execute. Direct database access is frowned upon. Also, we should be encrypting the data at rest so that this is possible is IMHO a bug in itself.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.