### PR TITLE
remove superfluous `--certs-update-server` option

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -23,8 +23,7 @@ For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-
 --certs-tar ~/_{smartproxy-example-com}_-certs.tar \
 --server-cert /root/__{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem__ \ <1>
 --server-key /root/__{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem__ \ <2>
---server-ca-cert /root/__{smart-proxy-context}_cert/ca_cert_bundle.pem__ \ <3>
---certs-update-server
+--server-ca-cert /root/__{smart-proxy-context}_cert/ca_cert_bundle.pem__ <3>
 ----
 +
 <1> Path to {SmartProxyServer} certificate file that is signed by a Certificate Authority.


### PR DESCRIPTION
This option is both unnecessary and causes the command to fail


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.11/Katello 4.13
* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
