### PR TITLE
Hammer CLI procedure for corrupted content

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -182,6 +182,8 @@ include::modules/proc_configuring-selinux-to-permit-content-synchronization-on-c
 
 include::modules/proc_recovering-a-corrupted-repository.adoc[leveloffset=+1]
 
+include::modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc[leveloffset=+1]
+
 include::modules/proc_republishing-repository-metadata.adoc[leveloffset=+1]
 
 include::modules/proc_republishing-content-view-metadata.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
@@ -1,0 +1,34 @@
+[id="Recovering_Corrupted_Content_on-a-Smart-Proxy_{context}"]
+= Recovering corrupted content on a {SmartProxy}
+
+In case of content corruption on a {SmartProxy}, you can recover it by using the `verify-checksum` command in Hammer CLI.
+The `verify-checksum` command works for optional parameters associated with the {SmartProxy} such as `content-view id`, `environment-id`, or `repository-id` to limit the repair.
+You can run the `verify-checksum` command without any filters so it runs on all content on the {SmartProxy}.
+
+.CLI procedure
+* To run a `verify-checksum` command in Hammer CLI for `content-view id`:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+hammer capsule content verify-checksum --id 2 --organization-id 1 --content-view-id 3
+----
+* To run a `verify-checksum` command in Hammer CLI for `environment-id`:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+hammer capsule content verify-checksum --id 2 --organization-id 1 --lifecycle-environment-id 1
+----
+* To run a `verify-checksum` command in Hammer CLI for `repository-id`:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+hammer capsule content verify-checksum --id 2 --organization-id 1 --repository-id 1
+----
+After running a `verify-checksum` command, it will appear on the *Tasks* page as the action *Verify checksum for content on smart proxy*.
+
+* For global repair of all content, run the following command:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+hammer capsule content verify-checksum --__My_{smart-proxy-context-titlecase}_ID__
+----

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
@@ -1,8 +1,9 @@
 [id="Recovering_Corrupted_Content_on_{smart-proxy-context}_{context}"]
 = Recovering corrupted content on {SmartProxy}
 
+If the client is unable to consume content from a published repository to which it has a subscription, the content has been corrupted and needs to be repaired.
 In case of content corruption on a {SmartProxy}, you can recover it by using the `verify-checksum` command in Hammer CLI.
-The `verify-checksum` command repairs content filtered for content views, lifecycle environments, repositories or all content without any filters on the {SmartProxy}.
+The `verify-checksum` command can repair content in a content view, lifecycle environment, repository, or all content on {SmartProxy}.
 After running a `verify-checksum` command, it will appear on the *Tasks* page as the action *Verify checksum for content on smart proxy*.
 
 .CLI procedure
@@ -24,9 +25,10 @@ $ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --life
 ----
 $ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --repository-id 1
 ----
-* For global repair of all content, run the following command:
+* To repair all content on {SmartProxy}, run the following command:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content verify-checksum --__My_{smart-proxy-context-titlecase}_ID__
+$ {hammer-smart-proxy} content verify-checksum --id __My_{smart-proxy-context-titlecase}_ID__
 ----
+The ID of the {SmartProxy} is required to run the `verify-checksum` command.

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
@@ -20,14 +20,16 @@ $ {hammer-smart-proxy} content verify-checksum \
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ {hammer-smart-proxy} content verify-checksum \
---id 2 --organization-id 1 --lifecycle-environment-id 1
+--id __My_{smart-proxy-context-titlecase}_ID__ \
+--organization-id 1 --lifecycle-environment-id 1
 ----
 * To repair content in a repository, run Hammer on your {SmartProxy}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ {hammer-smart-proxy} content verify-checksum \
---id 2 --organization-id 1 --repository-id 1
+--id __My_{smart-proxy-context-titlecase}_ID__ \
+--organization-id 1 --repository-id 1
 ----
 * To repair all content on {SmartProxy}, run the following command:
 +
@@ -36,4 +38,3 @@ $ {hammer-smart-proxy} content verify-checksum \
 $ {hammer-smart-proxy} content verify-checksum \
 --id __My_{smart-proxy-context-titlecase}_ID__
 ----
-The ID of the {SmartProxy} is required to run the `verify-checksum` command.

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
@@ -4,31 +4,36 @@
 If the client is unable to consume content from a published repository to which it has a subscription, the content has been corrupted and needs to be repaired.
 In case of content corruption on a {SmartProxy}, you can recover it by using the `verify-checksum` command in Hammer CLI.
 The `verify-checksum` command can repair content in a content view, lifecycle environment, repository, or all content on {SmartProxy}.
-After running a `verify-checksum` command, it will appear on the *Tasks* page as the action *Verify checksum for content on smart proxy*.
+You can track the progress of a command by navigating to *Monitor* > *{Project} Tasks* > *Tasks* and searching for the action *Verify checksum for content on smart proxy*.
 
 .CLI procedure
 * To repair content in a content view, run Hammer on your {SmartProxy}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --content-view-id 3
+$ {hammer-smart-proxy} content verify-checksum \
+--id __My_{smart-proxy-context-titlecase}_ID__ \
+--organization-id 1 --content-view-id 3
 ----
 * To repair content in a lifecycle environment, run Hammer on your {SmartProxy}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --lifecycle-environment-id 1
+$ {hammer-smart-proxy} content verify-checksum \
+--id 2 --organization-id 1 --lifecycle-environment-id 1
 ----
 * To repair content in a repository, run Hammer on your {SmartProxy}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --repository-id 1
+$ {hammer-smart-proxy} content verify-checksum \
+--id 2 --organization-id 1 --repository-id 1
 ----
 * To repair all content on {SmartProxy}, run the following command:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content verify-checksum --id __My_{smart-proxy-context-titlecase}_ID__
+$ {hammer-smart-proxy} content verify-checksum \
+--id __My_{smart-proxy-context-titlecase}_ID__
 ----
 The ID of the {SmartProxy} is required to run the `verify-checksum` command.

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
@@ -1,34 +1,32 @@
-[id="Recovering_Corrupted_Content_on-a-Smart-Proxy_{context}"]
-= Recovering corrupted content on a {SmartProxy}
+[id="Recovering_Corrupted_Content_on_{smart-proxy-context}_{context}"]
+= Recovering corrupted content on {SmartProxy}
 
 In case of content corruption on a {SmartProxy}, you can recover it by using the `verify-checksum` command in Hammer CLI.
-The `verify-checksum` command works for optional parameters associated with the {SmartProxy} such as `content-view id`, `environment-id`, or `repository-id` to limit the repair.
-You can run the `verify-checksum` command without any filters so it runs on all content on the {SmartProxy}.
-
-.CLI procedure
-* To run a `verify-checksum` command in Hammer CLI for `content-view id`:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-hammer capsule content verify-checksum --id 2 --organization-id 1 --content-view-id 3
-----
-* To run a `verify-checksum` command in Hammer CLI for `environment-id`:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-hammer capsule content verify-checksum --id 2 --organization-id 1 --lifecycle-environment-id 1
-----
-* To run a `verify-checksum` command in Hammer CLI for `repository-id`:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-hammer capsule content verify-checksum --id 2 --organization-id 1 --repository-id 1
-----
+The `verify-checksum` command repairs content filtered for content views, lifecycle environments, repositories or all content without any filters on the {SmartProxy}.
 After running a `verify-checksum` command, it will appear on the *Tasks* page as the action *Verify checksum for content on smart proxy*.
 
+.CLI procedure
+* To repair content in a content view, run Hammer on your {SmartProxy}:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --content-view-id 3
+----
+* To repair content in a lifecycle environment, run Hammer on your {SmartProxy}:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --lifecycle-environment-id 1
+----
+* To repair content in a repository, run Hammer on your {SmartProxy}:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ {hammer-smart-proxy} content verify-checksum --id 2 --organization-id 1 --repository-id 1
+----
 * For global repair of all content, run the following command:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-hammer capsule content verify-checksum --__My_{smart-proxy-context-titlecase}_ID__
+$ {hammer-smart-proxy} content verify-checksum --__My_{smart-proxy-context-titlecase}_ID__
 ----


### PR DESCRIPTION
A CLI procedure was needed for repairing corrupted content on a
SmartProxy. There are 3 optional parameters for
repairing corrupted
content as well as a global fix.


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
