### PR TITLE
Remove local TOC

### DIFF
--- a/guides/common/modules/con_importing-kickstart-repositories.adoc
+++ b/guides/common/modules/con_importing-kickstart-repositories.adoc
@@ -4,12 +4,6 @@
 Kickstart repositories are not provided by the Content ISO image.
 To use Kickstart repositories in your disconnected {Project}, you must download a binary DVD ISO file for the version of {RHEL} that you want to use and copy the Kickstart files to {Project}.
 
-To import Kickstart repositories for {RHEL} 9, complete xref:Importing_Kickstart_Repositories_rhel-9[].
-
-To import Kickstart repositories for {RHEL} 8, complete xref:Importing_Kickstart_Repositories_rhel-8[].
-
-To import Kickstart repositories for {RHEL} 7, complete xref:Importing_Kickstart_Repositories_rhel-7[].
-
 ifndef::satellite[]
 You can follow these procedures for {RHEL} derivatives such as AlmaLinux, CentOS, Oracle Linux, and Rocky Linux, too.
 endif::[]


### PR DESCRIPTION
For two reasons:
- local TOCs aren't well maintainable
- the user can see them in the global TOC (at least in Satellite and I hope for a 3-level TOC in Foreman in future)


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
