### PR TITLE
Change "product" to "Product"

### DIFF
--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -21,7 +21,7 @@ You can register a host to the _Library_ environment on {Project} to consume the
 
 ifndef::satellite[]
 You can access unprotected repositories in the _Default Organization View_ content view.
-The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Library/custom/{client-content-product-label}/{client-content-repository-label}/`.
+The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your Product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Library/custom/{client-content-product-label}/{client-content-repository-label}/`.
 ifdef::katello,orcharhino[]
 ifdef::content-management[]
 For more information, see
@@ -68,9 +68,9 @@ This ensures hosts are designated to a specific environment but receive updates 
 
 ifndef::satellite[]
 With `Distribute archived content view versions` enabled, you can access unprotected repositories in published content view versions.
-The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/content_views/`, your content view, your content view version, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/content_views/{client-content-content-view-label}/2.1/custom/{client-content-product-label}/{client-content-repository-label}/`.
+The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/content_views/`, your content view, your content view version, `/custom/`, your Product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/content_views/{client-content-content-view-label}/2.1/custom/{client-content-product-label}/{client-content-repository-label}/`.
 
-If you want to access the latest published content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, your lifecycle, your content view, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Production/{client-content-content-view-label}/custom/{client-content-product-label}/{client-content-content-view-label}/`.
+If you want to access the latest published content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, your lifecycle, your content view, `/custom/`, your Product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Production/{client-content-content-view-label}/custom/{client-content-product-label}/{client-content-content-view-label}/`.
 endif::[]
 
 ifdef::orcharhino[]

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -5,7 +5,7 @@ You can convert {RHEL} derivative distributions into a supportable {RHEL} on a h
 {Project} provides *Convert2RHEL* utilities to simplify the conversion process.
 
 The *Convert2RHEL* utilities in {Project} contain an Ansible role and Ansible Playbook.
-You use the Ansible role to generate conversion data on {ProjectServer}, which includes enabling required repositories and creating products, activation keys, and host groups.
+You use the Ansible role to generate conversion data on {ProjectServer}, which includes enabling required repositories and creating Products, activation keys, and host groups.
 Then you perform the actual conversion on the host using the Ansible Playbook, which installs the Convert2RHEL CLI tool on the host and runs it.
 
 You can use the Ansible role to generate conversion data for the following conversions:

--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -43,7 +43,7 @@ ifdef::satellite[]
 by {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[enabling Red Hat Repositories]
 endif::[]
 ifndef::satellite[]
-by syncing repositories in custom products
+by syncing repositories in custom Products
 endif::[]
 and by using {ContentManagementDocURL}Managing_Activation_Keys_content-management[activation keys] and {ContentManagementDocURL}Managing_Content_Views_content-management[content views].
 endif::[]

--- a/guides/common/modules/con_managing-activation-keys.adoc
+++ b/guides/common/modules/con_managing-activation-keys.adoc
@@ -12,7 +12,7 @@ The changes are not made to existing hosts.
 
 Activation keys can define the following properties for content hosts:
 
-* Available products and repositories
+* Available Products and repositories
 * A lifecycle environment and a content view
 * Host collection membership
 * System purpose

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -16,10 +16,10 @@ Custom::
 Custom alternate content sources download the content from any upstream repository on the network or filesystem.
 
 Simplified::
-Simplified alternate content sources copy the upstream repository information from your {ProjectServer} for the selected products.
+Simplified alternate content sources copy the upstream repository information from your {ProjectServer} for the selected Products.
 Simplified alternate content sources are ideal for situations where the connection from your {SmartProxy} to the upstream repo is faster than from your {ProjectServer}.
 ifdef::satellite[]
-Selecting the Red Hat products when creating a simplified alternate content source will download the content to the {SmartProxies} from the {Team} CDN.
+Selecting the Red Hat Products when creating a simplified alternate content source will download the content to the {SmartProxies} from the {Team} CDN.
 endif::[]
 
 RHUI::

--- a/guides/common/modules/con_managing-custom-file-type-content.adoc
+++ b/guides/common/modules/con_managing-custom-file-type-content.adoc
@@ -3,7 +3,7 @@
 
 In {Project}, you might require methods of managing and distributing SSH keys and source code files or larger files such as virtual machine images and ISO files.
 To achieve this, {customproduct}s in {ProjectName} include repositories for {customfiletype}s.
-This provides a generic method to incorporate arbitrary files in a product.
+This provides a generic method to incorporate arbitrary files in a Product.
 
 You can upload files to the repository and synchronize files from an upstream {ProjectServer}.
 When you add files to a {customfiletype} repository, you can use the normal {Project} management functions such as adding a specific version to a content view to provide version control and making the repository of files available on various {SmartProxyServers}.

--- a/guides/common/modules/con_managing-python-type-content.adoc
+++ b/guides/common/modules/con_managing-python-type-content.adoc
@@ -3,7 +3,7 @@
 
 You can use {Project} to manage Python type repositories.
 To achieve this, {customproduct}s in {ProjectName} include repositories for Python type content.
-This provides a generic method to incorporate Python packages in a product.
+This provides a generic method to incorporate Python packages in a Product.
 
 You can upload Python packages to Python type repositories and synchronize files from an upstream {ProjectServer}.
 When you add Python packages to a Python type repository, you can use the normal {Project} management functions such as adding a specific version to a content view to provide version control and making the repository available on various {SmartProxyServers}.

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -16,14 +16,14 @@ Content overrides::
 By default, content hosted by {Project} can be either enabled or disabled.
 ifdef::orcharhino[]
 ifdef::red_hat_enterprise_linux[]
-In custom products, repositories are always disabled by default, while Red{nbsp}Hat products can be either enabled or disabled by default depending on the specific repository.
+In custom Products, repositories are always disabled by default, while Red{nbsp}Hat Products can be either enabled or disabled by default depending on the specific repository.
 endif::[]
 ifndef::red_hat_enterprise_linux[]
-In custom products, repositories are always disabled by default.
+In custom Products, repositories are always disabled by default.
 endif::[]
 endif::[]
 ifndef::orcharhino[]
-In custom products, repositories are always disabled by default, while Red{nbsp}Hat products can be either enabled or disabled by default depending on the specific repository.
+In custom Products, repositories are always disabled by default, while Red{nbsp}Hat Products can be either enabled or disabled by default depending on the specific repository.
 endif::[]
 Enabling a repository gives the host access to the repository packages or other content, allowing hosts to download and install the available content.
 +
@@ -40,7 +40,7 @@ You can use composite content views to combine and give hosts access to the cont
 For more information about composite content views, see xref:Creating_a_Composite_Content_View_{context}[].
 
 Architecture and OS version restrictions::
-In custom products, you can set restrictions on the architecture and OS versions for `{client-content-type}` repositories on which the product will be available.
+In custom Products, you can set restrictions on the architecture and OS versions for `{client-content-type}` repositories on which the Product will be available.
 For example, if you restrict a custom repository to *{client-os} {client-os-major}*, it is only available on hosts running {client-os} {client-os-major}.
 Architecture and OS version restrictions hold the highest priority among all other strategies.
 They cannot be overridden or invalidated by content overrides, changes to content views, or changes to lifecycle environments.

--- a/guides/common/modules/proc_adding-an-scc-account.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account.adoc
@@ -20,23 +20,23 @@ Add the GPG public key for SLES 15 SP3 from https://www.suse.com/support/securit
 By default, it is set to `\https://scc.suse.com`.
 . Optional: Set a *Sync interval* to periodically update the SCC authentication tokens.
 Note that this does not refer to synchronizing content to {Project}.
-. Optional: In the *Use GPG key for SUSE products* field, you can select the previously created content credential to automatically add a GPG public key to your SUSE products.
+. Optional: In the *Use GPG key for SUSE products* field, you can select the previously created content credential to automatically add a GPG public key to your SUSE Products.
 `zypper` automatically verifies the signatures of each software package to ensure their authenticity.
 +
 [NOTE]
 ====
 You can also set the GPG public key for repositories from SUSE at a later stage.
-However, changing it does not affect already synchronized products.
-If you already have synchronized products in {Project}, navigate to *Content > Products* and replace the GPG key in each respective product.
+However, changing it does not affect already synchronized Products.
+If you already have synchronized Products in {Project}, navigate to *Content > Products* and replace the GPG key in each respective Product.
 ====
-. Optional: From the *Download Policy* list, select a download policy for your SUSE products.
+. Optional: From the *Download Policy* list, select a download policy for your SUSE Products.
 For more information, see xref:Download_Policies_Overview_{context}[].
-. Optional: From the *Mirroring Policy* list, select a mirroring policy for your SUSE products.
+. Optional: From the *Mirroring Policy* list, select a mirroring policy for your SUSE Products.
 For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Click *Test connection* to verify your account information.
 Note that you have to re-enter your password if you have already saved your SCC account to {Project}.
 . Click *Submit* to save your SCC account to {Project}.
-. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*, select your SCC account, and click *Sync* to fetch a list of products associated to your SCC account.
+. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*, select your SCC account, and click *Sync* to fetch a list of Products associated to your SCC account.
 
 [id="cli-Adding_an_SCC_Account_to_Server_{context}"]
 .CLI procedure
@@ -67,7 +67,7 @@ For more information, see {ContentManagementDocURL}cli-importing-a-gpg-key[Impor
 ----
 +
 Ensure the command returns `Testing connection for SCC account succeeded`.
-. Synchronize the list of available SUSE products to {Project}:
+. Synchronize the list of available SUSE Products to {Project}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_adding-custom-deb-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repositories.adoc
@@ -5,7 +5,7 @@ Use this procedure to add Deb repositories in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-custom-deb-repositories[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Products* and select the product that you want to use, and then click *New Repository*.
+. In the {ProjectWebUI}, navigate to *Content* > *Products* and select the Product that you want to use, and then click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 {Project} automatically completes the *Label* field based on what you have entered for *Name*.
 . Optional: In the *Description* field, enter a description for the repository.

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-el.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-el.adoc
@@ -1,7 +1,7 @@
 [id="Adding_Custom_RPM_Repositories_for_{os_name_anchor}_{os_major}_{context}"]
 = Adding {customrpm} repositories for {os_name} {os_major}
 
-This example creates a product and repositories for {os_name} {os_major}.
+This example creates a Product and repositories for {os_name} {os_major}.
 
 .Prerequisites
 * Download and import the {gpg_url}[GPG public key] for yum repositories for {os_name} {os_major} into {Project}.
@@ -9,7 +9,7 @@ For more information, see xref:Importing_a_Custom_GPG_Key_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > Products*.
-. Click *Create Product* to create a product named `{os_name} {os_major}`.
+. Click *Create Product* to create a Product named `{os_name} {os_major}`.
 For more information, see xref:Creating_a_Custom_Product_{context}[].
 . On the *Repositories* tab, click *New Repository* to create three repositories of type `yum` as follows:
 +
@@ -22,7 +22,7 @@ For more information, see xref:Creating_a_Custom_Product_{context}[].
 
 +
 For more information, see xref:Adding_Custom_RPM_Repositories_{context}[].
-. Click *Create Product* to create a product named `{os_name} {os_major} client`.
+. Click *Create Product* to create a Product named `{os_name} {os_major} client`.
 . On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
 +
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -16,7 +16,7 @@ For any issues with these RPMs, contact the third-party developers.
 endif::[]
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Products* and select the product that you want to use, and then click *New Repository*.
+. In the {ProjectWebUI}, navigate to *Content* > *Products* and select the Product that you want to use, and then click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 {Project} automatically completes the *Label* field based on what you have entered for *Name*.
 . Optional: In the *Description* field, enter a description for the repository.
@@ -49,7 +49,7 @@ For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . From the *Checksum* list, select the checksum type for the repository.
 . Optional: You can clear the *Unprotected* checkbox to require a subscription entitlement certificate for accessing this repository.
 By default, the repository is published through HTTP.
-. Optional: From the *GPG Key* list, select the GPG key for the product.
+. Optional: From the *GPG Key* list, select the GPG key for the Product.
 . Optional: In the *SSL CA Cert* field, select the SSL CA Certificate for the repository.
 . Optional: In the *SSL Client cert* field, select the SSL Client Certificate for the repository.
 . Optional: In the *SSL Client Key* field, select the SSL Client Key for the repository.

--- a/guides/common/modules/proc_adding-upstream-repositories-for-deb.adoc
+++ b/guides/common/modules/proc_adding-upstream-repositories-for-deb.adoc
@@ -1,7 +1,7 @@
 [id="adding-upstream-repositories-for-{DL}-{DL-major-context}_{context}"]
 = Adding upstream repositories for {DL} {DL-major}
 
-This example creates a product and repositories for {DL} {DL-major}.
+This example creates a Product and repositories for {DL} {DL-major}.
 
 .Prerequisites
 * xref:Extracting_GPG_Public_Key_Fingerprints_from_Release_Files_{context}[Extract the GPG public keys] from the `Release` file.
@@ -9,7 +9,7 @@ This example creates a product and repositories for {DL} {DL-major}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click *Create Product* to create a product named `{DL} {DL-major}`.
+. Click *Create Product* to create a Product named `{DL} {DL-major}`.
 . On the *Repositories* tab, click *New Repository* to create three `deb` repositories with the following parameter values:
 +
 * *{DL} {DL-major} main*
@@ -27,7 +27,7 @@ This example creates a product and repositories for {DL} {DL-major}.
 ** *Releases/Distributions*: `{DL-codename}-security`
 ** *Component*: `main`
 ** *Architecture*: `amd64`
-. Click *Create Product* to create a product named `{DL} {DL-major} client`.
+. Click *Create Product* to create a Product named `{DL} {DL-major} client`.
 . On the *Repositories* tab, click *New Repository* to create a `deb` repository with the following parameter values:
 +
 * **{DL} {DL-major} client**

--- a/guides/common/modules/proc_assigning-a-puppet-class-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-a-puppet-class-to-a-host-group.adoc
@@ -8,7 +8,7 @@ Every host you deploy based on this host group has this Puppet class installed.
 . In the {ProjectWebUI}, navigate to *Configure > Host Groups* to create a host group or edit an existing one.
 . On the *Host Group* tab, set the following parameters:
 .. The *Lifecycle Environment* describes the stage in which certain versions of content are available to hosts.
-.. The *Content View* is comprised of products and allows for version control of content repositories.
+.. The *Content View* is comprised of Products and allows for version control of content repositories.
 .. The *Environment* allows you to supply a group of hosts with their own dedicated configuration.
 . Navigate to the *Puppet ENC* tab.
 . Add the Puppet class to the _Included Classes_ or to the _Included Config Groups_ if a Puppet config group is configured.

--- a/guides/common/modules/proc_assigning-a-sync-plan-to-a-product.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-a-product.adoc
@@ -1,19 +1,19 @@
 [id="Assigning_a_Sync_Plan_to_a_Product_{context}"]
-= Assigning a sync plan to a product
+= Assigning a sync plan to a Product
 
 A sync plan checks and updates the content at a scheduled date and time.
-In {Project}, you can assign a sync plan to products to update content regularly.
+In {Project}, you can assign a sync plan to Products to update content regularly.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-assigning-a-sync-plan-to-a-product[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > Products*.
-. Select a product.
+. Select a Product.
 . On the *Details* tab, select a *Sync Plan* from the drop down menu.
 
 [id="cli-assigning-a-sync-plan-to-a-product"]
 .CLI procedure
-. Assign a sync plan to a product:
+. Assign a sync plan to a Product:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
@@ -1,7 +1,7 @@
 [id="Assigning_a_Sync_Plan_to_Multiple_Products_{context}"]
-= Assigning a sync plan to multiple products
+= Assigning a sync plan to multiple Products
 
-Use this procedure to assign a sync plan to the products in an organization that have been synchronized at least once and contain at least one repository.
+Use this procedure to assign a sync plan to the Products in an organization that have been synchronized at least once and contain at least one repository.
 
 .Procedure
 . Run the following Bash script:
@@ -17,7 +17,7 @@ do
   hammer product set-sync-plan --sync-plan $SYNC_PLAN --organization $ORG --id $i
 done
 ----
-. After executing the script, view the products assigned to the sync plan:
+. After executing the script, view the Products assigned to the sync plan:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/common/modules/proc_changing-the-download-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-download-policy-for-a-repository.adoc
@@ -5,7 +5,7 @@ You can set the download policy for a repository.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the required product name.
+. Select the required Product name.
 . On the *Repositories* tab, click the required repository name, locate the *Download Policy* field, and click the edit icon.
 . From the list, select the required download policy and then click *Save*.
 

--- a/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-product.adoc
+++ b/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-product.adoc
@@ -1,5 +1,5 @@
 [id="Changing_the_HTTP_Proxy_Policy_for_a_Product_{context}"]
-= Changing the HTTP proxy policy for a product
+= Changing the HTTP proxy policy for a Product
 
 For granular control over network traffic, you can set an HTTP proxy policy for each Product.
 A Product's HTTP proxy policy applies to all repositories in the Product, unless you set a different policy for individual repositories.

--- a/guides/common/modules/proc_changing-the-mirroring-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-mirroring-policy-for-a-repository.adoc
@@ -7,7 +7,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Changing_the_Mirr
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the product name.
+. Select the Product name.
 . On the *Repositories* tab, click the repository name, locate the *Mirroring Policy* field, and click the edit icon.
 . From the list, select a mirroring policy and click *Save*.
 

--- a/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-server-to-synchronize-content-over-a-network.adoc
@@ -16,7 +16,7 @@ For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories
 ** `view_content_views`
 * On the downstream {ProjectServer}, you have imported the SSL certificate of the upstream {ProjectServer} using the contents of `http://_upstream-{foreman-example-com}_/pub/katello-server-ca.crt`.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing SSL Certificates] in _{ContentManagementDocTitle}_.
-* The downstream user is an admin or has the permissions to create product repositories and organizations.
+* The downstream user is an admin or has the permissions to create Product repositories and organizations.
 
 
 .Procedure
@@ -35,8 +35,8 @@ Default is `Default_Organization_View`.
 . From the *SSL CA Content Credential* menu, select a CA certificate used by the upstream {ProjectServer}.
 . Click *Update*.
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the product that contains the repositories that you want to synchronize.
-. From the *Select Action* menu, select *Sync Now* to synchronize all repositories within the product.
+. Select the Product that contains the repositories that you want to synchronize.
+. From the *Select Action* menu, select *Sync Now* to synchronize all repositories within the Product.
 +
 You can also create a synchronization plan to ensure updates on a regular basis.
 For more information, see {ContentManagementDocURL}Creating_a_Sync_Plan_content-management[Creating a Synchronization Plan] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -9,7 +9,7 @@
 . Optional: In the *Description* field, provide a description for the ACS.
 . Select {SmartProxies} to which the alternate content source is to be synced.
 . Optional: Select *Use HTTP proxies* if you want the ACS to use the {SmartProxyServer}'s HTTP proxy.
-. Select the products that should use the alternate content source.
+. Select the Products that should use the alternate content source.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.
 

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -2,13 +2,13 @@
 = Creating a {customfiletype} repository
 
 The procedure for creating a {customfiletype} repository is the same as the procedure for creating any {customcontent}, except that when you create the repository, you select the *file* type.
-You must create a product and then add a {customrepo}.
+You must create a Product and then add a {customrepo}.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-custom-file-type-repository_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > Products*.
-. Select a product that you want to create a repository for.
+. Select a Product that you want to create a repository for.
 . On the *Repositories* tab, click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 {Project} automatically completes the *Label* field based on the name.

--- a/guides/common/modules/proc_creating-a-custom-product.adoc
+++ b/guides/common/modules/proc_creating-a-custom-product.adoc
@@ -6,19 +6,19 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-custom
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*, click *Create Product*.
-. In the *Name* field, enter a name for the product.
+. In the *Name* field, enter a name for the Product.
 {Project} automatically completes the *Label* field based on what you have entered for *Name*.
-. Optional: From the *GPG Key* list, select the GPG key for the product.
-. Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the product.
-. Optional: From the *SSL Client Cert* list, select the SSL client certificate for the product.
-. Optional: From the *SSL Client Key* list, select the SSL client key for the product.
-. Optional: From the *Sync Plan* list, select an existing sync plan or click *Create Sync Plan* and create a sync plan for your product requirements.
-. In the *Description* field, enter a description of the product.
+. Optional: From the *GPG Key* list, select the GPG key for the Product.
+. Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the Product.
+. Optional: From the *SSL Client Cert* list, select the SSL client certificate for the Product.
+. Optional: From the *SSL Client Key* list, select the SSL client key for the Product.
+. Optional: From the *Sync Plan* list, select an existing sync plan or click *Create Sync Plan* and create a sync plan for your Product requirements.
+. In the *Description* field, enter a description of the Product.
 . Click *Save*.
 
 [id="cli-creating-a-custom-product"]
 .CLI procedure
-To create the product, enter the following command:
+To create the Product, enter the following command:
 
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_creating-a-sync-plan.adoc
+++ b/guides/common/modules/proc_creating-a-sync-plan.adoc
@@ -2,7 +2,7 @@
 = Creating a sync plan
 
 A sync plan checks and updates the content at a scheduled date and time.
-In {Project}, you can create a sync plan and assign products to the plan.
+In {Project}, you can create a sync plan and assign Products to the plan.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-sync-plan[].
 

--- a/guides/common/modules/proc_creating-an-activation-key-short.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-short.adoc
@@ -12,5 +12,5 @@ Use the following procedure to create an activation key that you can use to subs
 . Click *Save*.
 . Click on the *Subscriptions* tab on the Activation Key's details page.
 . Click on the *Add* tab.
-. Select all the product subscriptions in the table.
+. Select all the Product subscriptions in the table.
 . Click *Add Selected* to save.

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -50,7 +50,7 @@ It also helps with reporting in the Subscriptions service of the Red Hat Hybrid 
 --purpose-role "_{RHELServer}_" \
 --purpose-addons "_addons_"
 ----
-. List the product content associated with the activation key:
+. List the Product content associated with the activation key:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_creating-kernelcare-repositories-el.adoc
+++ b/guides/common/modules/proc_creating-kernelcare-repositories-el.adoc
@@ -5,7 +5,7 @@ You need to provide the KernelCare client on your hosts to live-patch their Linu
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click *Create Product* to create a product named `KernelCare {EL}`.
+. Click *Create Product* to create a Product named `KernelCare {EL}`.
 For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a Product] in _{ContentManagementDocTitle}_.
 . On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
 +

--- a/guides/common/modules/proc_creating-repositories-to-synchronize.adoc
+++ b/guides/common/modules/proc_creating-repositories-to-synchronize.adoc
@@ -12,7 +12,7 @@ Use this procedure to discover available repositories in the CentOS Stream, then
 . Select `/AppStream/x86_64/os/` and `/BaseOS/x86_64/os/` repositories.
 . Click *Create Selected*.
 . In the *Product* field select *New Product*.
-. In the *Name* field enter *CentOS Stream* or desired product name.
+. In the *Name* field enter *CentOS Stream* or desired Product name.
 . Click *Run Repository Creation*.
 
-To view your newly created product, navigate to *Content* > *Products*, and select the name of the new product.
+To view your newly created Product, navigate to *Content* > *Products*, and select the name of the new Product.

--- a/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
+++ b/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
@@ -11,20 +11,20 @@ Use this procedure to download the ISO images for {RHEL} and {ProjectName}.
 
 . Select *{RHEL}*.
 
-. Ensure that you have the correct product and version for your environment.
+. Ensure that you have the correct Product and version for your environment.
 +
 * *Product Variant* is set to *{RHEL} for x86_64*.
-* *Version*  is set to the latest minor version of the product you plan to use as the base operating system.
+* *Version*  is set to the latest minor version of the Product you plan to use as the base operating system.
 * *Architecture* is set to the 64 bit version.
 
 . On the *Product Software* tab, download the Binary DVD image for the latest *{RHEL} for x86_64* version.
 
 . Click *DOWNLOADS* and select *{ProjectName}*.
 
-. Ensure that you have the correct product and version for your environment.
+. Ensure that you have the correct Product and version for your environment.
 +
 * *Product Variant* is set to *{ProjectName}*.
-* *Version*  is set to the latest minor version of the product you plan to use.
+* *Version*  is set to the latest minor version of the Product you plan to use.
 
 . On the *Product Software* tab, download the Binary DVD image for the latest {ProjectName} version.
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -13,7 +13,7 @@ include::snip_generating-content.adoc[]
 .Prerequisites
 * Ensure that you set the download policy to *Immediate* for all repositories within the content view you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
-* Ensure that you synchronize products you export to the required date.
+* Ensure that you synchronize Products you export to the required date.
 * Ensure that the user exporting the content has the `Content Exporter` role.
 
 .To export a content view version

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -3,7 +3,7 @@
 
 Exporting complete content view versions can be a very expensive operation in terms of system resources.
 ifdef::orcharhino[]
-The size of the exported content view versions depends on the number of products.
+The size of the exported content view versions depends on the number of Products.
 endif::[]
 Content view versions that have multiple {RHEL} trees can occupy several gigabytes of space on {ProjectServer}.
 

--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -31,10 +31,10 @@ You need all the files, `tar.gz`, `toc.json` and `metadata.json`, to be able to 
 * Ensure that the `/var/lib/pulp/exports` directory has enough free storage space equivalent to the size of all repositories that you want to export.
 * Ensure that you set download policy to *Immediate* for the repository within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
-* Ensure that you synchronize products that you export to the required date.
+* Ensure that you synchronize Products that you export to the required date.
 
 .Procedure
-. Export a repository using the product name and repository name:
+. Export a repository using the Product name and repository name:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -24,7 +24,7 @@ The export contains directories with the packages, *listing* files, and metadata
 .Prerequisites
 * Ensure that you set the download policy to *Immediate* for all repositories within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
-* Ensure that you synchronize products you export to the required date.
+* Ensure that you synchronize Products you export to the required date.
 * Ensure that the user exporting the content has the `Content Exporter` role.
 
 .Procedure

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
@@ -3,7 +3,7 @@
 
 Exporting Library content can be a very expensive operation in terms of system resources.
 ifdef::orcharhino[]
-The size of the exported Library depends on the number of products.
+The size of the exported Library depends on the number of Products.
 endif::[]
 Organizations that have multiple {RHEL} trees can occupy several gigabytes of space on {ProjectServer}.
 

--- a/guides/common/modules/proc_generating-host-monitoring-reports.adoc
+++ b/guides/common/modules/proc_generating-host-monitoring-reports.adoc
@@ -6,7 +6,7 @@ To schedule reports, configure a cron job or use the {ProjectWebUI}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Reports* > *Report Templates*.
-For example, the *Host {endash} Installed Products* template generates a report with installed product information along with other metrics, including system purpose attributes.
+For example, the *Host {endash} Installed Products* template generates a report with installed Product information along with other metrics, including system purpose attributes.
 . To the right of the report template that you want to use, click *Generate*.
 . Optional: To schedule a report, to the right of the *Generate at* field, click the icon to select the date and time you want to generate the report at.
 . Optional: To send a report to an e-mail address, select the *Send report via e-mail* checkbox, and in the *Deliver to e-mail addresses* field, enter the required e-mail address.

--- a/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
@@ -10,13 +10,13 @@ endif::[]
 ifndef::debian,ubuntu[]
 When you import a content view version, it has the same major and minor version numbers and contains the same repositories with the same packages and errata.
 endif::[]
-Custom repositories, products, and content views are automatically created if they do not exist in the importing organization.
+Custom repositories, Products, and content views are automatically created if they do not exist in the importing organization.
 
 .Prerequisites
 * The exported files must be in a syncable format.
 * The exported files must be accessible through HTTP/HTTPS.
 ifdef::client-content-dnf[]
-* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
+* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the Products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ role.
 

--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -10,12 +10,12 @@ endif::[]
 ifndef::debian,ubuntu[]
 When you import a content view version, it has the same major and minor version numbers and contains the same repositories with the same packages and errata.
 endif::[]
-Custom repositories, products and content views are automatically created if they do not exist in the importing organization.
+Custom repositories, Products and content views are automatically created if they do not exist in the importing organization.
 
 .Prerequisites
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
 ifdef::client-content-dnf[]
-* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
+* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the Products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ Role.
 

--- a/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
@@ -8,7 +8,7 @@ For more information about exporting the content of a repository, see xref:Expor
 * The exported files must be in a syncable format.
 * The exported files must be accessible through HTTP/HTTPS.
 ifdef::client-content-dnf[]
-* If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the products contained within the export.
+* If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the Products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ Role.
 

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -7,7 +7,7 @@ For more information about exporting content of a repository, see xref:Exporting
 .Prerequisites
 * The export files must be in a directory under `/var/lib/pulp/imports`.
 ifdef::client-content-dnf[]
-* If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the products contained within the export.
+* If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the Products contained within the export.
 endif::[]
 * The user importing the content must have the _Content Importer_ Role.
 

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -20,19 +20,19 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-contain
 . Optional: To further refine the *Discovered Repository* list, in the *Filter* field, enter any additional search criteria that you want to use.
 . From the *Discovered Repository* list, select any repositories that you want to import, and then click *Create Selected*.
 . Optional: To change the download policy for this container repository to _on demand_, see xref:changing_the_download_policy_for_a_repository_{context}[].
-. Optional: If you want to create a product, from the *Product* list, select *New Product*.
-. In the *Name* field, enter a product name.
+. Optional: If you want to create a Product, from the *Product* list, select *New Product*.
+. In the *Name* field, enter a Product name.
 . Optional: In the *Repository Name* and *Repository Label* columns, you can edit the repository names and labels.
 . Click *Run Repository Creation*.
 . When repository creation is complete, you can click each new repository to view more information.
 . Optional: To filter the content you import to a repository, click a repository, and then navigate to *Limit Sync Tags*.
 Click to edit, and add any tags that you want to limit the content that synchronizes to {Project}.
-. In the {ProjectWebUI}, navigate to *Content* > *Products* and select the name of your product.
+. In the {ProjectWebUI}, navigate to *Content* > *Products* and select the name of your Product.
 . Select the new repositories and then click *Sync Now* to start the synchronization process.
 
 .Procedure with creating a repository manually
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-Click the name of the required product.
+Click the name of the required Product.
 . Click *New repository*.
 . From the *Type* list, select *docker*.
 Enter the details for the repository, and click *Save*.
@@ -46,7 +46,7 @@ From the list, you can also remove any manifests that you do not require.
 
 [id="cli-importing-container-images"]
 .CLI procedure
-. Create the custom `{client-container-product-name}` product:
+. Create the custom `{client-container-product-name}` Product:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -80,4 +80,4 @@ From the list, you can also remove any manifests that you do not require.
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about creating a product and repository manually, see xref:Importing_Content_{context}[].
+* For more information about creating a Product and repository manually, see xref:Importing_Content_{context}[].

--- a/guides/common/modules/proc_importing-individual-iso-images-and-files.adoc
+++ b/guides/common/modules/proc_importing-individual-iso-images-and-files.adoc
@@ -9,13 +9,13 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-individ
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*, and in the Products window, click *Create Product*.
-. In the *Name* field, enter a name to identify the product.
+. In the *Name* field, enter a name to identify the Product.
 This name populates the *Label* field.
-. Optional: In the *GPG Key* field, enter a GPG Key for the product.
-. Optional: From the *Sync Plan* list, select a synchronization plan for the product.
-. Optional: In the *Description* field, enter a description of the product.
+. Optional: In the *GPG Key* field, enter a GPG Key for the Product.
+. Optional: From the *Sync Plan* list, select a synchronization plan for the Product.
+. Optional: In the *Description* field, enter a description of the Product.
 . Click *Save*.
-. In the Products window, click the new product and then click *Create Repository*.
+. In the Products window, click the new Product and then click *Create Repository*.
 . In the *Name* field, enter a name for the repository.
 This automatically populates the *Label* field.
 . From the *Type* list, select *file*.

--- a/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
@@ -8,7 +8,7 @@ For more information about exporting contents from the Library environment, see 
 * The exported files must be in a syncable format.
 * The exported files must be accessible through HTTP/HTTPS.
 ifdef::client-content-dnf[]
-* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
+* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the Products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ role.
 

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -7,7 +7,7 @@ For more information about exporting contents from the Library environment, see 
 .Prerequisites
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
 ifdef::client-content-dnf[]
-* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
+* If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the Products contained within the export.
 endif::[]
 * The user importing the content must have the _Content Importer_ Role.
 

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat.adoc
@@ -1,7 +1,7 @@
 [id="Importing_ISO_Images_from_Red_Hat_{context}"]
 = Importing ISO images from Red Hat
 
-The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
+The Red{nbsp}Hat Content Delivery Network provides ISO images for certain Products.
 The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-images-from-red-hat[].
@@ -20,7 +20,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 
 [id="cli-importing-iso-images-from-red-hat"]
 .CLI procedure
-. Locate the {RHELServer} product for `file` repositories:
+. Locate the {RHELServer} Product for `file` repositories:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -39,7 +39,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 --basearch x86_64 \
 --organization "_My_Organization_"
 ----
-. Locate the repository in the product:
+. Locate the repository in the Product:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -47,7 +47,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 --product "Red Hat Enterprise Linux Server" \
 --organization "_My_Organization_"
 ----
-. Synchronize the repository in the product:
+. Synchronize the repository in the Product:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_importing-kickstart-repositories.adoc
+++ b/guides/common/modules/proc_importing-kickstart-repositories.adoc
@@ -10,8 +10,8 @@ ifndef::orcharhino[]
 ifeval::["{el-major-version}" == "7"]
 . Click *Switch to version 7 and below* above the *Product Variant* list.
 endif::[]
-. Select a product variant and a product version from the list.
-For example, product variant *{RHEL} for x86_64* and product version *{el-major-version}.{el-minor-version}*.
+. Select a Product variant and a Product version from the list.
+For example, Product variant *{RHEL} for x86_64* and Product version *{el-major-version}.{el-minor-version}*.
 . Locate the full installation image, for example, *{RHEL} {el-major-version}.{el-minor-version} Binary DVD*, and click *Download Now*.
 ifeval::["{el-major-version}" >= "9"]
 Note that you cannot provision hosts using the minimal ISO.

--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -10,14 +10,14 @@ You can import and synchronize OSTree content from custom online sources over HT
 . In the {ProjectWebUI}, navigate to *Content* > *Products* and click *Create Product*.
 . In the *Name* field, enter a name for your OSTree content.
 This automatically populates the *Label* field.
-. Optional: From the *GPG Key* list, select the GPG key for the product.
-. Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the product.
-. Optional: From the *SSL Client Cert* list, select the SSL client certificate for the product.
-. Optional: From the *SSL Client Key* list, select the SSL client key for the product.
-. Optional: From the *Sync Plan* list, select an existing sync plan or click *Create Sync Plan* and create a sync plan for your product requirements.
-. Optional: In the *Description* field, enter a description of the product.
+. Optional: From the *GPG Key* list, select the GPG key for the Product.
+. Optional: From the *SSL CA Cert* list, select the SSL CA certificate for the Product.
+. Optional: From the *SSL Client Cert* list, select the SSL client certificate for the Product.
+. Optional: From the *SSL Client Key* list, select the SSL client key for the Product.
+. Optional: From the *Sync Plan* list, select an existing sync plan or click *Create Sync Plan* and create a sync plan for your Product requirements.
+. Optional: In the *Description* field, enter a description of the Product.
 . Click *Save*.
-. When the product creation completes, click *New Repository*.
+. When the Product creation completes, click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 This automatically populates the *Label* field.
 . From the *Type* list, select `ostree`.
@@ -45,7 +45,7 @@ For example `fedora/x86_64/coreos/stable`.
 . To view the synchronization status, navigate to *Content* > *Sync Status* and expand the entry that you want to view.
 
 .CLI procedure
-. Create a product for your OSTree content:
+. Create a Product for your OSTree content:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_importing-suse-products.adoc
+++ b/guides/common/modules/proc_importing-suse-products.adoc
@@ -1,7 +1,7 @@
 [id="Importing_SUSE_Products_{context}"]
-= Importing SUSE products
+= Importing SUSE Products
 
-Use this procedure to import products from SUSE into {Project}.
+Use this procedure to import Products from SUSE into {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Importing_SUSE_Products_{context}[].
 
 .Prerequisites
@@ -11,29 +11,29 @@ For more information, see xref:Adding_an_SCC_Account_to_Server_{context}[].
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*.
 . Click *Select products* on your previously synchronized SCC account.
-. Use the *Select Product*, *Select Version*, and *Select Architecture* lists to filter all available SUSE products.
+. Use the *Select Product*, *Select Version*, and *Select Architecture* lists to filter all available SUSE Products.
 +
 Note that each filter depends on the previous selection.
 . Click *Search* to apply the filter.
-. Select all SUSE products you want to synchronize to {Project}.
+. Select all SUSE Products you want to synchronize to {Project}.
 +
 You can select individual repositories from the *Filter repositories* list.
 By default, _debug_ and _source_ repositories are excluded.
-. Click *Add product(s)* to create the selected SUSE products in {Project}.
+. Click *Add product(s)* to create the selected SUSE Products in {Project}.
 +
-Note that the SCC Manager plugin can only add, but not remove products from {Project}.
-. Optional: Click on the task ID to follow the creation of the selected products in {Project}.
+Note that the SCC Manager plugin can only add, but not remove Products from {Project}.
+. Optional: Click on the task ID to follow the creation of the selected Products in {Project}.
 
 [id="cli-Importing_SUSE_Products_{context}"]
 .CLI procedure
-. List all available SUSE products:
+. List all available SUSE Products:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # hammer scc_manager scc_accounts scc_products list \
 --scc-account-id _My_SCC_Account_ID_
 ----
-. View information about a SUSE product:
+. View information about a SUSE Product:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -41,7 +41,7 @@ Note that the SCC Manager plugin can only add, but not remove products from {Pro
 --id _My_SUSE_Product_ID_ \
 --scc-account-id _My_SCC_Account_ID_
 ----
-. Subscribe to a SUSE product:
+. Subscribe to a SUSE Product:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -49,7 +49,7 @@ Note that the SCC Manager plugin can only add, but not remove products from {Pro
 --id _My_SUSE_Product_ID_ \
 --scc-account-id _My_SCC_Account_ID_
 ----
-. Optional: Subscribe to multiple SUSE products:
+. Optional: Subscribe to multiple SUSE Products:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_inspecting-available-errata.adoc
+++ b/guides/common/modules/proc_inspecting-available-errata.adoc
@@ -63,7 +63,7 @@ You can also use the new Host page to view to inspect available errata and selec
 # hammer erratum info --id _erratum_ID_
 ----
 * You can search errata by entering the query with the `--search` option.
-For example, to view applicable errata for the selected product that contains the specified bugs ordered so that the security errata are displayed on top, enter the following command:
+For example, to view applicable errata for the selected Product that contains the specified bugs ordered so that the security errata are displayed on top, enter the following command:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
@@ -15,7 +15,7 @@ For more information, see {ContentManagementDocURL}Managing_Activation_Keys_cont
 endif::[]
 ifdef::katello[]
 .Prerequisites
-* You created a product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
+* You created a Product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
@@ -24,7 +24,7 @@ ifdef::orcharhino[]
 .Prerequisites
 * Puppet must be enabled in your {Project}.
 For more information, see xref:Enabling_Puppet_Integration_{context}[].
-* You created a product and repository containing the Puppet agent and synchronized the repository to {Project}.
+* You created a Product and repository containing the Puppet agent and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing activation keys] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -23,7 +23,7 @@ For more information, see {ContentManagementDocURL}Managing_Activation_Keys_cont
 endif::[]
 ifdef::katello[]
 .Prerequisites
-* You created a product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
+* You created a Product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
@@ -37,7 +37,7 @@ endif::[]
 ifndef::managing-configurations-puppet[]
 For more information, see {ManagingConfigurationsPuppetDocURL}Enabling_Puppet_Integration_managing-configurations-puppet[Enabling Puppet integration with {Project}] in _{ManagingConfigurationsPuppetDocTitle}_.
 endif::[]
-* You created a product and repository containing the Puppet agent and synchronized the repository to {Project}.
+* You created a Product and repository containing the Puppet agent and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing activation keys] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_managing-container-name-patterns.adoc
+++ b/guides/common/modules/proc_managing-container-name-patterns.adoc
@@ -2,7 +2,7 @@
 = Managing container name patterns
 
 When you use {Project} to create and manage your containers, as the container moves through content view versions and different stages of the {Project} lifecycle environment, the container name changes at each stage.
-For example, if you synchronize a container image with the name `ssh` from an upstream repository, when you add it to a {Project} product and organization and then publish as part of a content view, the container image can have the following name: `my_organization_production-custom_spin-my_product-custom_ssh`.
+For example, if you synchronize a container image with the name `ssh` from an upstream repository, when you add it to a {Project} Product and organization and then publish as part of a content view, the container image can have the following name: `my_organization_production-custom_spin-my_product-custom_ssh`.
 This can create problems when you want to pull a container image because container registries can contain only one instance of a container name.
 To avoid problems with {Project} naming conventions, you can set a registry name pattern to override the default name to ensure that your container name is clear for future use.
 

--- a/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
+++ b/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
@@ -8,9 +8,9 @@ ifdef::suse_linux_enterprise_server[]
 * Salt minions are part of the default {client-os} repositories.
 endif::[]
 ifndef::suse_linux_enterprise_server[]
-. Create a product called `Salt`.
-For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a product].
-. Create a repository within the _Salt_ product for each operating system supported by {Project} that you want to install the Salt Minion client software on.
+. Create a Product called `Salt`.
+For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a Product].
+. Create a repository within the _Salt_ Product for each operating system supported by {Project} that you want to install the Salt Minion client software on.
 ifdef::client-content-apt[]
 For more information, see {ContentManagementDocURL}Adding_Custom_Deb_Repositories_content-management[Adding Deb repositories].
 endif::[]
@@ -22,7 +22,7 @@ Add the operating system to the name of the repository, for example `Salt for {c
 +
 You can find the _upstream URL_ for the Salt packages on the https://repo.saltproject.io/[official Salt package repository].
 The URL depends on both the Salt version and the operating system, for example `{client-salt-minion-repository-url}`.
-. Synchronize the previously created products.
+. Synchronize the previously created Products.
 For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories].
 . Create a content view for each repository.
 For more information, see {ContentManagementDocURL}Creating_a_Content_View_content-management[Creating a content view].

--- a/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
+++ b/guides/common/modules/proc_reclaiming-space-from-on-demand-repositories.adoc
@@ -16,13 +16,13 @@ For deleted repositories, wait for the next scheduled orphan cleanup or remove o
 
 .For a single repository
 * In the {ProjectWebUI}, navigate to *Content* > *Products*.
-* Select a product.
+* Select a Product.
 * On the *Repositories* tab, click the repository name.
 * From the *Select Actions* list, select *Reclaim Space*.
 
 .For multiple repositories
 * In the {ProjectWebUI}, navigate to *Content* > *Products*.
-* Select the product name.
+* Select the Product name.
 * On the *Repositories* tab, select the checkbox of the repositories.
 * Click *Reclaim Space* at the top right corner.
 

--- a/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
+++ b/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
@@ -23,7 +23,7 @@ endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the product containing the corrupted repository.
+. Select the Product containing the corrupted repository.
 . Select the name of a repository you want to synchronize.
 . To perform optimized sync or complete sync, select *Advanced Sync* from the *Select Action* menu.
 . Select the required option and click *Sync*.

--- a/guides/common/modules/proc_removing-an-scc-account.adoc
+++ b/guides/common/modules/proc_removing-an-scc-account.adoc
@@ -8,7 +8,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Removing_an_SCC_A
 ====
 If you want to switch SCC accounts and retain your synchronized content, do not delete your old SCC account, even if it is expired.
 Instead, change the login and password of your SCC account.
-If you delete your old SCC account, you cannot reuse existing repositories, products, content views, and composite content views.
+If you delete your old SCC account, you cannot reuse existing repositories, Products, content views, and composite content views.
 For more information, see xref:Switching_SCC_Accounts_{context}[].
 ====
 

--- a/guides/common/modules/proc_republishing-repository-metadata.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata.adoc
@@ -8,7 +8,7 @@ Use this procedure with caution.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the product that includes the repository for which you want to republish metadata.
+. Select the Product that includes the repository for which you want to republish metadata.
 . On the *Repositories* tab, select a repository.
 . To republish metadata for the repository, click *Republish Repository Metadata* from the *Select Action* menu.
 +

--- a/guides/common/modules/proc_restricting-customrepoid-to-a-specific-os-version-or-architecture-in-project.adoc
+++ b/guides/common/modules/proc_restricting-customrepoid-to-a-specific-os-version-or-architecture-in-project.adoc
@@ -9,14 +9,14 @@ endif::[]
 ifdef::satellite[]
 [NOTE]
 ====
-Only restrict architecture and operating system version for custom products.
+Only restrict architecture and operating system version for custom Products.
 {Project} applies these restrictions automatically for Red{nbsp}Hat repositories.
 ====
 endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click the product that contains the repository sets you want to restrict.
+. Click the Product that contains the repository sets you want to restrict.
 . In the *Repositories* tab, click the repository you want to restrict.
 . In the *Publishing Settings* section, set the following options:
 +

--- a/guides/common/modules/proc_switching-scc-accounts.adoc
+++ b/guides/common/modules/proc_switching-scc-accounts.adoc
@@ -8,7 +8,7 @@ You can switch your SCC account by changing the SCC credentials saved on {Projec
 The SCC Manager plugin does not support multiple SCC accounts.
 
 If you want to switch your SCC account and retain the synchronized content, do not immediately delete your old SCC account, even if it is expired.
-If you delete your old SCC account, you cannot reuse existing repositories, products, content views, and composite content views.
+If you delete your old SCC account, you cannot reuse existing repositories, Products, content views, and composite content views.
 ====
 
 .Prerequisites
@@ -21,5 +21,5 @@ For more information, see xref:Adding_an_SCC_Account_to_Server_{context}[].
 . Enter a new *Login* and *Password*.
 . Click *Submit* to change your SCC account.
 
-Your new SCC account reuses existing products and repositories from SUSE.
+Your new SCC account reuses existing Products and repositories from SUSE.
 Content that is no longer available for your new SCC account cannot be synchronized anymore.

--- a/guides/common/modules/proc_synchronizing-a-custom-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-a-custom-repository.adoc
@@ -8,7 +8,7 @@ Follow the procedure for the connected {ProjectServer} before completing the pro
 
 .Connected {ProjectServer}
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click on the custom product.
+. Click on the custom Product.
 . Click on the custom repository.
 . Copy the *Published At:* URL.
 . Continue with the procedure on disconnected {ProjectServer}.
@@ -23,11 +23,11 @@ Follow the procedure for the connected {ProjectServer} before completing the pro
 . Create an SSL Content Credential with the contents of `katello-server-ca.crt`.
 For more information on creating an SSL Content Credential, see xref:Importing_Custom_SSL_Certificates_{context}[].
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Create your custom product with the following:
+. Create your custom Product with the following:
 * *Upstream URL*: Paste the link that you copied earlier.
 * *SSL CA Cert*: Select the SSL certificate that was transferred from your connected {ProjectServer}.
 
 +
-For more information on creating a custom product, see xref:Creating_a_Custom_Product_{context}[].
+For more information on creating a custom Product, see xref:Creating_a_Custom_Product_{context}[].
 
 After completing these steps, the custom repository is properly configured on the disconnected {ProjectServer}.

--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -11,8 +11,8 @@ Ansible Collections will appear on {Project} as a new repository type in the {Pr
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select the required product name.
-. In the *Products* window, select the name of a product that you want to create a repository for.
+. Select the required Product name.
+. In the *Products* window, select the name of a Product that you want to create a repository for.
 . Click the *Repositories* tab, and then click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 +

--- a/guides/common/modules/proc_synchronizing-content-from-an-upstream-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-content-from-an-upstream-repository.adoc
@@ -5,7 +5,7 @@ Use the following procedure to mirror the contents of the upstream CentOS reposi
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*
-. Select your new *CentOS Stream* product from the previous procedure.
+. Select your new *CentOS Stream* Product from the previous procedure.
 . Locate the *AppStream x86_64 os* and *BaseOS x86_64 os* repositories.
 . Select both repositories
 . Click *Sync Now*

--- a/guides/common/modules/proc_synchronizing-python-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-python-repositories.adoc
@@ -7,7 +7,7 @@ You can view the Python packages in the {ProjectWebUI} at *Content* > *Content T
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
 . Select a {customproduct} by name.
-. In the *Products* window, select the name of a product that you want to create a repository for.
+. In the *Products* window, select the name of a Product that you want to create a repository for.
 . Click the *Repositories* tab, and then click *New Repository*.
 . In the *Name* field, enter a name for the repository.
 +

--- a/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
@@ -11,7 +11,7 @@ You can use simplified alternate content sources to configure your {SmartProxy} 
 . Optional: In the *Description* field, provide a description for the alternate content source.
 . Select {SmartProxies} that you want to sync directly from Red Hat CDN.
 . Optional: Select *Use HTTP proxies* if you want the ACS to use the {SmartProxyServer}’s HTTP proxy.
-. Select the Red Hat products that should be synced to the {SmartProxy} from Red Hat CDN.
+. Select the Red Hat Products that should be synced to the {SmartProxy} from Red Hat CDN.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.
 

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -4,14 +4,14 @@
 Use this procedure to synchronize SUSE content to your {Project} to deploy, register, and serve content to hosts.
 
 .Prerequisites
-* You have imported SUSE products into {Project}.
+* You have imported SUSE Products into {Project}.
 For more information, see xref:Importing_SUSE_Products_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > Products*.
-. Select the `SUSE Linux Enterprise Server 15 SP3 x86_64` product and click *Sync Now* to synchronize the SUSE repositories for SLES 15 SP3 to {Project}.
+. Select the `SUSE Linux Enterprise Server 15 SP3 x86_64` Product and click *Sync Now* to synchronize the SUSE repositories for SLES 15 SP3 to {Project}.
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
-. Create a content view called `SLES 15 SP3` comprising the SLES repositories created in the `SLES 15 SP3` product and a content view called `SLES 15 SP3 {Project} client` comprising the {Project} client repository created in the `SLES 15 SP3 {Project} client` product.
+. Create a content view called `SLES 15 SP3` comprising the SLES repositories created in the `SLES 15 SP3` Product and a content view called `SLES 15 SP3 {Project} client` comprising the {Project} client repository created in the `SLES 15 SP3 {Project} client` Product.
 +
 For more information, see xref:Creating_a_Content_View_{context}[].
 . Publish a new version of both content views.

--- a/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
@@ -29,7 +29,7 @@ In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*, click *Manage Ma
 ====
 +
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
-. Click the arrow next to the product to view the available repositories.
+. Click the arrow next to the Product to view the available repositories.
 . Select the repositories for {ProjectVersion}.
 Note that *Red{nbsp}Hat {project-client-name}* does not have a {ProjectVersion} version.
 Choose *Red{nbsp}Hat {project-client-name}* instead.

--- a/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
+++ b/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
@@ -8,7 +8,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
-. Click the arrow next to the *{RHEL} for x86_64* product to view available content.
+. Click the arrow next to the *{RHEL} for x86_64* Product to view available content.
 . Select *{Team} {project-client-name} for RHEL 9 x86_64 RPMs* or *{Team} {project-client-name} for RHEL 8 x86_64 RPMs*.
 . Click *Synchronize Now*.
 

--- a/guides/common/modules/proc_synchronizing-ubuntu-expanded-security-maintenance-content.adoc
+++ b/guides/common/modules/proc_synchronizing-ubuntu-expanded-security-maintenance-content.adoc
@@ -53,13 +53,13 @@ Convert the key if necessary:
 # gpg --export --armor 4067E40313CB4B13
 ----
 .. Click *Save* to save your content credential to {Project}.
-. Create a product and repository:
+. Create a Product and repository:
 .. Navigate to *Content* > *Products*.
 .. Click *Create Product*.
 ... Enter a *Name*, select the previously imported GPG public key, and, optionally, add a sync plan and description.
-... Click *Save* to save the product to {Project}.
+... Click *Save* to save the Product to {Project}.
 .. Navigate to *Content* > *Products*.
-.. Select the previously created product.
+.. Select the previously created Product.
 .. Click *New Repository*.
 ... Enter a *Name* and select type `deb`.
 ... Enter the *Upstream URL*, *Releases*, *Components*, and *Architectures* as extracted from your host from `/etc/apt/sources.list.d/ubuntu-esm-infra.list`.
@@ -68,9 +68,9 @@ ifdef::orcharhino[]
 ... Enter *Errata URL*: `\https://dep.atix.de/dep/api/v1/ubuntu-esm`.
 endif::[]
 ... Click *Save* to save your repository to {Project}.
-. Synchronize your product.
+. Synchronize your Product.
 .. Navigate to *Content* > *Products*.
-.. Select the previously created product.
+.. Select the previously created Product.
 .. In the *Actions* menu, select *Sync Now*.
 
 .Next steps

--- a/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-an-imagebuilder-image-for-provisioning.adoc
@@ -17,7 +17,7 @@ endif::[]
 
 .Procedure
 ifdef::katello,satellite,orcharhino[]
-. On {Project}, create a custom product, add a custom file repository to this product, and upload the image to the repository.
+. On {Project}, create a custom Product, add a custom file repository to this Product, and upload the image to the repository.
 For more information, see {ContentManagementDocURL}Importing_Individual_ISO_Images_and_Files_content-management[Importing Individual ISO Images and Files] in _{ContentManagementDocTitle}_.
 endif::[]
 ifndef::katello,satellite,orcharhino[]

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -50,7 +50,7 @@ If you use the ID-based schema, pull using IDs.
 ----
 
 * Pushing container images to the {Project} container registry:
-- To indicate which organization, product, and repository the container image belongs to, include the organization and product in the container registry name.
+- To indicate which organization, Product, and repository the container image belongs to, include the organization and Product in the container registry name.
 - You can address the container destination by using one of the following schemas:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_using-the-project-content-dashboard.adoc
+++ b/guides/common/modules/proc_using-the-project-content-dashboard.adoc
@@ -28,7 +28,7 @@ Click the particular configuration status to view hosts associated with it.
 
 *Host Configuration Chart*:: A pie chart shows the proportion of the configuration status and the percentage of all hosts associated with it.
 
-*Latest Events*:: A list of messages produced by hosts including administration information, product changes, and any errors.
+*Latest Events*:: A list of messages produced by hosts including administration information, Product changes, and any errors.
 +
 Monitor this section for global notifications sent to all users and to detect any unusual activity or errors.
 
@@ -50,8 +50,8 @@ Click a task to see more details.
 
 *Content Views*:: A list of all content views in {Project} and their publish status.
 
-*Sync Overview*:: An overview of all products or repositories enabled in {Project} and their synchronization status.
-All products that are in the queue for synchronization, are unsynchronized or have been previously synchronized are listed in this section.
+*Sync Overview*:: An overview of all Products or repositories enabled in {Project} and their synchronization status.
+All Products that are in the queue for synchronization, are unsynchronized or have been previously synchronized are listed in this section.
 +
 
 *Host Collections*:: A list of all host collections in {Project} and their status, including the number of content hosts in each host collection.

--- a/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
+++ b/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
@@ -1,7 +1,7 @@
 [id="best-practices-for-products-and-repositories_{context}"]
-= Best practices for products and repositories
+= Best practices for Products and repositories
 
-* Use one content type per product and content view, for example, {client-content-type} content only.
+* Use one content type per Product and content view, for example, {client-content-type} content only.
 ifdef::orcharhino[]
 * Use file repositories for installation media.
 File repositories require a `PULP_MANIFEST` file that you can create using `pulp-manifest /path/to/files`.
@@ -14,7 +14,7 @@ For more information, see xref:Managing_Custom_File_Type_Content_{context}[].
 endif::[]
 * Make file repositories available over HTTP.
 If you set *Protected* to true, you can only download content using a global debugging certificate.
-* Automate the creation of multiple products and repositories by using a Hammer script or an {ansible-docs-url}[Ansible Playbook].
+* Automate the creation of multiple Products and repositories by using a Hammer script or an {ansible-docs-url}[Ansible Playbook].
 ifdef::katello,satellite,red_hat_enterprise_linux[]
 * For Red Hat content, import your Red Hat manifest into {Project}.
 For more information, see xref:Managing_Red_Hat_Subscriptions_{context}[].

--- a/guides/common/modules/ref_best-practices-for-sync-plans.adoc
+++ b/guides/common/modules/ref_best-practices-for-sync-plans.adoc
@@ -1,7 +1,7 @@
 [id="best-practices-for-sync-plans_{context}"]
 = Best practices for sync plans
 
-* Add sync plans to products and regularly synchronize content to keep the load on {Project} low during synchronization.
+* Add sync plans to Products and regularly synchronize content to keep the load on {Project} low during synchronization.
 Synchronize content rather more often than less often.
 For example, setup a sync plan to synchronize content every day rather than only once a month.
 * Automate the creation and update of sync plans by using a Hammer script or an {ansible-docs-url}[Ansible Playbook].

--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -13,7 +13,7 @@ When set to `Yes`, {Project} recreates this cache on the next restart.
 | *DB pending seed* | No | Should the `foreman-rake db:seed` be executed on the next run of the installer modules?
 | *{SmartProxy} request timeout* | 60 | Open and read timeout for HTTP requests from {Project} to {SmartProxy} (in seconds).
 | *Login page footer text* | | Text to be shown in the login-page footer.
-| *HTTP(S) proxy* | | Set a proxy for outgoing HTTP(S) connections from the {Project} product.
+| *HTTP(S) proxy* | | Set a proxy for outgoing HTTP(S) connections from the {Project} Product.
 System-wide proxies must be configured at the operating system level.
 | *HTTP(S) proxy except hosts* | [] | Set hostnames to which requests are not to be proxied.
 Requests to the local host are excluded by default.

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -363,9 +363,9 @@ endif::[]
 ifndef::satellite[]
 If you manage Red{nbsp}Hat content and
 endif::[]
-upload a Red Hat manifest, {Project} automatically groups Red{nbsp}Hat content within products.
+upload a Red Hat manifest, {Project} automatically groups Red{nbsp}Hat content within Products.
 ifndef::satellite[]
-If you manage SUSE content using SCC Manager plugin, {Project} automatically groups SUSE content within products.
+If you manage SUSE content using SCC Manager plugin, {Project} automatically groups SUSE content within Products.
 For more information, see {ContentManagementDocURL}Managing_SUSE_Content_content-management[Managing SUSE content] in _{ContentManagementDocTitle}_.
 endif::[]
 
@@ -455,7 +455,7 @@ A repository is a single source and the smallest unit of content in {Project}.
 You can either synchronize a repository with a URL or manually upload content to {Project}.
 {Project} supports multiple content types.
 For more information, see {ContentManagementDocURL}Content_Types_in_{ProjectNameID}_content-management[Content types in {Project}] in _{ContentManagementDocTitle}_.
-One or more repositories form a xref:Product[product].
+One or more repositories form a xref:Product[Product].
 endif::[]
 
 [[Resource_type]]


### PR DESCRIPTION
Changed "product" to "Product" to align with RHSSG. Not sure whether we do the same for SUSE.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
