### PR TITLE
Fix certificate name in procedure for custom cert

### DIFF
--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -27,7 +27,7 @@ You can use this command to deploy the renewed CA certificates to {ProjectServer
 ----
 # {installer-scenario} \
 --certs-server-cert "/root/_{project-context}_cert/{project-context}_cert.pem_" \
---certs-server-key "/root/_{project-context}_cert/{project-context}_key.pem_" \
+--certs-server-key "/root/_{project-context}_cert/{project-context}_cert_key.pem_" \
 --certs-server-ca-cert "/root/_{project-context}_cert/ca_cert_bundle.pem_" \
 --certs-update-server \
 --certs-update-server-ca


### PR DESCRIPTION
The custom certificate in the command to renew the certificate is `/root/project_cert/project_key.pem`, however, this should be `/root/project_cert/project_cert_key.pem`.

JIRA: https://issues.redhat.com/browse/SAT-24132


* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.11/Katello 4.13
* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
