### PR TITLE
Add Secure Boot support for Satellite

### DIFF
--- a/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
@@ -36,18 +36,29 @@ endif::[]
 With {ProjectName}, you can perform both BIOS and UEFI based PXE provisioning.
 Both BIOS and UEFI interfaces work as interpreters between the computer's operating system and firmware, initializing the hardware components and starting the operating system at boot time.
 
-ifdef::satellite[]
-For information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
-endif::[]
-
+.PXE loaders
 In {Project} provisioning, the PXE loader option defines the DHCP `filename` option to use during provisioning.
 For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned node to download the `pxelinux.0` file over TFTP.
 For UEFI systems, use the *PXEGrub2 UEFI* option to enable a TFTP client to download `grub2/grubx64.efi` file, or use the *PXEGrub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` from {SmartProxy} with the HTTP Boot feature.
-ifndef::satellite[]
-Use SecureBoot options to enable a client to download the `shim.efi` bootstrap bootloader that then loads the signed `grubx64.efi`.
-Other PXE loaders like PXELinux UEFI, Grub2 ELF or iPXE Chain, require additional configuration. These workflows are not documented at the moment.
-endif::[]
 
+{ProjectName} supports UEFI Secure Boot.
+SecureBoot PXE loaders enable a client to download the `shim.efi` bootstrap bootloader that then loads the signed `grubx64.efi`.
+Use the *Grub2 UEFI SecureBoot* PXE loader for PXE-boot provisioning or *Grub2 UEFI HTTPS SecureBoot* for HTTP-boot provisioning.
+
+[IMPORTANT]
+====
+You can only use Secure Boot if you provision the hosts by using the same operating system version, major and minor, that runs on your TFTP {SmartProxy}.
+====
+
+ifdef::satellite[]
+For more information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
+endif::[]
+ifndef::satellite[]
+Other PXE loaders, such as PXELinux UEFI, Grub2 ELF, or iPXE Chain, require additional configuration.
+These workflows are not documented.
+
+.Template association with operating systems
 For BIOS provisioning, you must associate a PXELinux template with the operating system.
 For UEFI provisioning, you must associate a PXEGrub2 template with the operating system.
 If you associate both PXELinux and PXEGrub2 templates, {Project} can deploy configuration files for both on a TFTP server, so that you can switch between PXE loaders easily.
+endif::[]

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -40,7 +40,10 @@ include::snip_steps-create-a-host-tab-host.adoc[]
 include::snip_steps-create-a-host-tab-interfaces.adoc[]
 . Click the *Operating System* tab, and verify that all fields contain values.
 Confirm each aspect of the operating system.
-. From the *PXE Loader* list, select *Grub2 UEFI HTTP*.
+. From the *PXE Loader* list, select:
+* *Grub2 UEFI HTTP* to provision without Secure Boot.
+* *Grub2 UEFI HTTPS SecureBoot* to provision with Secure Boot.
+For more information, see xref:Using_PXE_to_Provision_Hosts_{context}[].
 . Optional: Click *Resolve* in *Provisioning template* to check the new host can identify the right provisioning templates to use.
 +
 For more information about associating provisioning templates, see xref:creating-provisioning-templates_{context}[].
@@ -97,6 +100,9 @@ endif::[]
 --organization "_My_Organization_" \
 --pxe-loader "Grub2 UEFI HTTP"
 ----
++
+Use the *Grub2 UEFI HTTPS SecureBoot* PXE loader to provision with Secure Boot.
+For more information, see xref:Using_PXE_to_Provision_Hosts_{context}[].
 . Ensure the network interface options are set using the `hammer host interface update` command:
 +
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
Adds support for current SB implementation for Satellite.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
