### PR TITLE
Drop --now after restarting gssproxy

### DIFF
--- a/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
+++ b/guides/common/modules/proc_configuring-direct-ad-integration-with-gss-proxy.adoc
@@ -70,7 +70,7 @@ euid = __ID_of_Apache_User__
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # systemctl restart gssproxy
-# systemctl enable --now gssproxy
+# systemctl enable gssproxy
 ----
 . To configure the Apache server to use the `gssproxy` service, create a `systemd` drop-in file and add the following content to it:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/SAT-26357 requests clarifying a procedure step to restart and enable gssproxy.service.

Doing a bit of archeology, I found the commit that introduced `--now` to that step: https://github.com/theforeman/foreman-documentation/commit/a4be0ab11f53cc4ff1302b41816c41dd40874daa  It seems that in case of this particular step, asking users to restart && enable (without --now) might help prevent some raised eyebrows.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
