### PR TITLE
Follow-up to PR 2914

### DIFF
--- a/guides/common/modules/con_registering-hosts-by-using-global-registration.adoc
+++ b/guides/common/modules/con_registering-hosts-by-using-global-registration.adoc
@@ -1,7 +1,7 @@
 [id="Registering_Hosts_by_Using_Global_Registration_{context}"]
 = Registering hosts by using global registration
 
-You can register a host to {Project} by generating a `curl` command on {Project} and running this command on hosts.
+You can register a host to {Project} by generating a `curl` or `wget` command on {Project} and running this command on hosts.
 This method uses two provisioning templates: *Global Registration* template and *Linux host_init_config default* template.
 That gives you complete control over the host registration process.
 

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -62,20 +62,6 @@ Copy the CA file to the `/etc/pki/ca-trust/source/anchors/` directory on your ho
 # update-ca-trust enable
 # update-ca-trust
 ----
-+
-Then register your host with a secure `curl` command, such as:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# curl -sS https://{foreman-example-com}/register ...
-----
-+
-The following is an example of the `curl` command with the `--insecure` option:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# curl -sS --insecure https://{foreman-example-com}/register ...
-----
 . Select the *Advanced* tab.
 . Optional: From the *Setup REX* list, select whether you want to deploy {Project} SSH keys to your host or not.
 +

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -141,9 +141,6 @@ ifdef::katello,satellite,orcharhino[]
 . Optional: Select the *Ignore errors* option if you want to ignore subscription manager errors.
 . Optional: Select the *Force* option if you want to remove any `katello-ca-consumer` rpms before registration and run `subscription-manager` with the `--force` argument.
 endif::[]
-ifdef::katello[]
-If you register {EL} hosts, in the *Activation Keys* field, enter one or more activation keys to assign to registered hosts.
-endif::[]
 
 . Click *Generate*.
 . Copy the generated `curl` command.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -6,6 +6,7 @@ You can register a host by using registration templates and set up various integ
 .Prerequisites
 * Your user account has a role assigned that has the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
+* You must either install `curl` or `wget` on the host that you want to register.
 ifdef::satellite,orcharhino[]
 * {ProjectServer}, any {SmartProxyServers}, and your host must be synchronized with the same NTP server, and have a time synchronization tool enabled and running.
 * An activation key must be available for your host.
@@ -42,7 +43,7 @@ A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selec
 ifdef::katello,satellite,orcharhino[]
 . In the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
-. If you want to use `wget` to register your host to {Project}, select the *Use wget* option.
+. If you want to use `wget` to register your host to {Project}, select `wget` in the *Download Utility* dropdown.
 By default, {Project} generates a `curl` command.
 . If your host does not trust the SSL certificate of your {ProjectServer}, select the *Insecure* option.
 During the first call, your host downloads the CA file from {Project}.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -7,13 +7,13 @@ You can register a host by using registration templates and set up various integ
 * Your user account has a role assigned that has the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
 ifdef::satellite,orcharhino[]
-* {ProjectServer}, any {SmartProxyServers}, and all hosts must be synchronized with the same NTP server, and have a time synchronization tool enabled and running.
-* An activation key must be available for the host.
+* {ProjectServer}, any {SmartProxyServers}, and your host must be synchronized with the same NTP server, and have a time synchronization tool enabled and running.
+* An activation key must be available for your host.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::satellite[]
-* Optional: If you want to register hosts to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
-This is required to install the `insights-client` package on hosts.
+* Optional: If you want to register your host to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
+This is required to install the `insights-client` package on your host.
 endif::[]
 include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 ifdef::katello,orcharhino,satellite[]
@@ -27,35 +27,35 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
 . Optional: Select a different *Organization*.
 . Optional: Select a different *Location*.
-. Optional: From the *Host Group* list, select the host group to associate the hosts with.
+. Optional: From the *Host Group* list, select the host group to associate your host with.
 Fields that inherit value from *Host group*: *Operating system*, *Activation Keys* and *Lifecycle environment*.
-. Optional: From the *Operating system* list, select the operating system of hosts that you want to register.
+. Optional: From the *Operating system* list, select the operating system of the host that you want to register.
 ifndef::satellite,orcharhino[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.
 endif::[]
-. Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
+. Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register your host through.
 +
 [NOTE]
 ====
 A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the host's content source.
 ====
 ifdef::katello,satellite,orcharhino[]
-. In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
+. In the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
-. Optional: Select the *Insecure* option, if you want to make the first call insecure.
-During this first call, hosts download the CA file from {Project}.
-Hosts will use this CA file to connect to {Project} with all future calls making them secure.
+. If your host does not trust the SSL certificate of your {ProjectServer}, select the *Insecure* option.
+During the first call, your host downloads the CA file from {Project}.
+Your host will use this CA file to connect to {ProjectServer} with all future calls.
 +
 {Team} recommends that you avoid insecure calls.
 +
-If an attacker, located in the network between {Project} and a host, fetches the CA file from the first insecure call, the attacker will be able to access the content of the API calls to and from the registered host and the JSON Web Tokens (JWT).
-Therefore, if you have chosen to deploy SSH keys during registration, the attacker will be able to access the host using the SSH key.
+If an attacker, located in the network between {Project} and your host, fetches the CA file from the first insecure call, the attacker will be able to access the content of the API calls to and from your host and the JSON Web Tokens (JWT).
+Therefore, if you have chosen to deploy SSH keys during registration, the attacker will be able to access your host using the SSH key.
 +
-Instead, you can manually copy and install the CA file on each host before registering the host.
+Instead, you can manually copy and install the CA file on each host before registration.
 +
 To do this, find where {Project} stores the CA file by navigating to *Administer* > *Settings* > *Authentication* and locating the value of the *SSL CA file* setting.
 +
-Copy the CA file to the `/etc/pki/ca-trust/source/anchors/` directory on hosts and enter the following commands:
+Copy the CA file to the `/etc/pki/ca-trust/source/anchors/` directory on your host and enter the following commands:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -63,7 +63,7 @@ Copy the CA file to the `/etc/pki/ca-trust/source/anchors/` directory on hosts a
 # update-ca-trust
 ----
 +
-Then register the hosts with a secure `curl` command, such as:
+Then register your host with a secure `curl` command, such as:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -77,14 +77,14 @@ The following is an example of the `curl` command with the `--insecure` option:
 # curl -sS --insecure https://{foreman-example-com}/register ...
 ----
 . Select the *Advanced* tab.
-. Optional: From the *Setup REX* list, select whether you want to deploy {Project} SSH keys to hosts or not.
+. Optional: From the *Setup REX* list, select whether you want to deploy {Project} SSH keys to your host or not.
 +
 If set to `Yes`, public SSH keys will be installed on the registered host.
 The inherited value is based on the `host_registration_remote_execution` parameter.
 It can be inherited, for example from a host group, an operating system, or an organization.
 When overridden, the selected value will be stored on host parameter level.
 ifdef::client-content-dnf[]
-. Optional: From the *Setup Insights* list, select whether you want to install `insights-client` and register the hosts to Insights.
+. Optional: From the *Setup Insights* list, select whether you want to install `insights-client` and register your host to Insights.
 +
 The Insights tool is available for {RHEL} only.
 It has no effect on other operating systems.
@@ -97,9 +97,9 @@ You must enable the following repositories on a registered machine:
 +
 The `insights-client` package is installed by default on {RHEL} 8 except in environments whereby {RHEL} 8 was deployed with "Minimal Install" option.
 endif::[]
-. Optional: In the *Install packages* field, list the packages (separated with spaces) that you want to install on the host upon registration.
+. Optional: In the *Install packages* field, list the packages (separated with spaces) that you want to install on your host upon registration.
 This can be set by the `host_packages` parameter.
-. Optional: Select the *Update packages* option to update all packages on the host upon registration.
+. Optional: Select the *Update packages* option to update all packages on your host upon registration.
 This can be set by the `host_update_packages` parameter.
 . Optional: In the *Repository* field, enter a repository to be added before the registration is performed.
 For example, it can be useful to make the `subscription-manager` package available for the purpose of the registration.
@@ -115,16 +115,16 @@ It needs to be specified in the ASCII form with the GPG public key header.
 The duration of this token defines how long the generated `curl` command works.
 You can set the duration to 0{range}999 999 hours or unlimited.
 +
-Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of hosts.
+Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of your host.
 If the user loses or gains additional permissions, the permissions of the JWT change too.
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
-. Optional: In the *Remote Execution Interface* field, enter the identifier of a network interface that hosts must use for the SSH connection.
+. Optional: In the *Remote Execution Interface* field, enter the identifier of a network interface that your host must use for the SSH connection.
 If you keep this field blank, {Project} uses the default network interface.
 . Optional: From the *REX pull mode* list, select whether you want to deploy {Project} remote execution pull client.
 +
-If set to `Yes`, the remote execution pull client is installed on the registered host.
+If set to `Yes`, the remote execution pull client is installed on your host.
 The inherited value is based on the `host_registration_remote_execution_pull` parameter.
 It can be inherited, for example from a host group, an operating system, or an organization.
 When overridden, the selected value is stored on the host parameter level.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -42,6 +42,8 @@ A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selec
 ifdef::katello,satellite,orcharhino[]
 . In the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
+. If you want to use `wget` to register your host to {Project}, select the *Use wget* option.
+By default, {Project} generates a `curl` command.
 . If your host does not trust the SSL certificate of your {ProjectServer}, select the *Insecure* option.
 During the first call, your host downloads the CA file from {Project}.
 Your host will use this CA file to connect to {ProjectServer} with all future calls.
@@ -98,10 +100,10 @@ endif::[]
 . Optional: In the *Repository GPG key URL* field, specify the public key to verify the signatures of GPG-signed packages.
 It needs to be specified in the ASCII form with the GPG public key header.
 . Optional: In the *Token lifetime (hours)* field, change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
-The duration of this token defines how long the generated `curl` command works.
+The duration of this token defines how long the generated registration command works.
 You can set the duration to 0{range}999 999 hours or unlimited.
 +
-Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of your host.
+Note that {Project} applies the permissions of the user who generates the registration command to authorization of your host.
 If the user loses or gains additional permissions, the permissions of the JWT change too.
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
@@ -129,5 +131,5 @@ ifdef::katello,satellite,orcharhino[]
 endif::[]
 
 . Click *Generate*.
-. Copy the generated `curl` command.
-. On the host that you want to register, run the `curl` command as `root`.
+. Copy the generated registration command.
+. On the host that you want to register, run the copied command as `root`.

--- a/guides/common/modules/ref_registration-methods.adoc
+++ b/guides/common/modules/ref_registration-methods.adoc
@@ -4,7 +4,7 @@
 You can use the following methods to register hosts to {Project}:
 
 Global registration::
-You generate a `curl` command from {Project} and run this command from an unlimited number of hosts to register them using provisioning templates over the {Project} API.
+You generate a `curl` or `wget` command from {Project} and run this command from an unlimited number of hosts to register them using provisioning templates over the {Project} API.
 For more information, see xref:Registering_Hosts_by_Using_Global_Registration_{context}[].
 +
 By using this method, you can also deploy {Project} SSH keys to hosts during registration to {Project} to enable hosts for remote execution jobs.


### PR DESCRIPTION
I found some additional places in the documentation that we should also reword to reflect the usage of `wget` during host registration. Therefore I created this follow-up PR that should be (rebased and) merged as soon as https://github.com/theforeman/foreman-documentation/pull/2914 is merged.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
