### PR TITLE
Update URL for Debian cloud images

### DIFF
--- a/guides/common/modules/proc_creating-an-image-for-amazon-ec2.adoc
+++ b/guides/common/modules/proc_creating-an-image-for-amazon-ec2.adoc
@@ -14,7 +14,7 @@ You can create images for Amazon EC2 from within {Project}.
 * In the *Username* field, enter the username needed to SSH into the machine.
 * In the *Image ID* field, enter the image ID provided by Amazon or an operating system vendor.
 ifndef::satellite[]
-This ID can be found within Amazon AWS or on operating system specific pages like https://wiki.debian.org/Cloud/AmazonEC2Image/Buster[debian.org] or https://cloud-images.ubuntu.com/locator/ec2/[ubuntu.com].
+You can find the ID within Amazon AWS or on operating system specific pages such as https://cloud.debian.org/images/cloud/[debian.org] or https://cloud-images.ubuntu.com/locator/ec2/[ubuntu.com].
 endif::[]
 * Optional: Select the *User Data* check box to enable support for user data input.
 * Optional: Set an *Iam Role* for _Fog_ to use when creating this image.


### PR DESCRIPTION
Debian 10 "Buster" is EoL but the Debian project offers multiple cloud images for multiple cloud providers similar to Canonical.


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13