### PR TITLE
Move the external DB installer parameters around

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
+++ b/guides/common/modules/proc_configuring-satellite-to-use-external-databases.adoc
@@ -12,19 +12,21 @@ Use the `{foreman-installer}` command to configure {Project} to connect to an ex
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} \
---foreman-db-database foreman \
---foreman-db-host _postgres.example.com_ \
---foreman-db-manage false \
---foreman-db-password _Foreman_Password_ \
---foreman-proxy-content-pulpcore-manage-postgresql false \
---foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
---foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
---foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
---foreman-proxy-content-pulpcore-postgresql-user pulp \
+--katello-candlepin-manage-db false \
 --katello-candlepin-db-host _postgres.example.com_ \
 --katello-candlepin-db-name candlepin \
+--katello-candlepin-db-user candlepin \
 --katello-candlepin-db-password _Candlepin_Password_ \
---katello-candlepin-manage-db false
+--foreman-proxy-content-pulpcore-manage-postgresql false \
+--foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
+--foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
+--foreman-proxy-content-pulpcore-postgresql-user pulp \
+--foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
+--foreman-db-manage false \
+--foreman-db-host _postgres.example.com_ \
+--foreman-db-database foreman \
+--foreman-db-username foreman \
+--foreman-db-password _Foreman_Password_
 ----
 +
 

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -36,19 +36,19 @@ PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {foreman-installer} \
---foreman-db-database foreman \
---foreman-db-host _postgres.example.com_ \
---foreman-db-manage false \
---foreman-db-password _Foreman_Password_ \
---foreman-db-username foreman \
---foreman-proxy-content-pulpcore-manage-postgresql false \
---foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
---foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
---foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
---foreman-proxy-content-pulpcore-postgresql-user pulp \
+--katello-candlepin-manage-db false \
 --katello-candlepin-db-host _postgres.example.com_ \
 --katello-candlepin-db-name candlepin \
---katello-candlepin-db-password _Candlepin_Password_ \
 --katello-candlepin-db-user candlepin \
---katello-candlepin-manage-db false
+--katello-candlepin-db-password _Candlepin_Password_ \
+--foreman-proxy-content-pulpcore-manage-postgresql false \
+--foreman-proxy-content-pulpcore-postgresql-host _postgres.example.com_ \
+--foreman-proxy-content-pulpcore-postgresql-db-name pulpcore \
+--foreman-proxy-content-pulpcore-postgresql-user pulp \
+--foreman-proxy-content-pulpcore-postgresql-password _Pulpcore_Password_ \
+--foreman-db-manage false \
+--foreman-db-host _postgres.example.com_ \
+--foreman-db-database foreman \
+--foreman-db-username foreman \
+--foreman-db-password _Foreman_Password_
 ----


### PR DESCRIPTION
This way they are all consistent with eachother. They follow:

* manage
* host
* name
* user
* password

Missing parameters were added for consistency.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.