### PR TITLE
Add Monitoring_Project to upstream_filename_to_satellite_link.json

### DIFF
--- a/guides/upstream_filename_to_satellite_link.json
+++ b/guides/upstream_filename_to_satellite_link.json
@@ -7,6 +7,7 @@
   "build/Installing_Server_Disconnected/index-satellite.html": "installing_satellite_server_in_a_disconnected_network_environment",
   "build/Managing_Configurations_Ansible/index-satellite.html": "managing_configurations_by_using_ansible_integration",
   "build/Managing_Configurations_Puppet/index-satellite.html": "managing_configurations_by_using_puppet_integration",
+  "build/Monitoring_Project/index-satellite.html": "monitoring_satellite_performance",
   "build/Managing_Content/index-satellite.html": "managing_content",
   "build/Managing_Hosts/index-satellite.html": "managing_hosts",
   "build/Provisioning_Hosts/index-satellite.html": "provisioning_hosts",


### PR DESCRIPTION
I manually verified what was linked on https://docs.redhat.com/en/documentation/red_hat_satellite/6.15

I couldn't find a way to determine this automatically. I looked at docinfo.xml but there's no destination there so I'm assuming it's coded somewhere in a conversion script. [foreman_theme_satellite](https://github.com/RedHatSatellite/foreman_theme_satellite) will also use this same info when https://github.com/RedHatSatellite/foreman_theme_satellite/pull/58 is merged so those will need to be kept in sync.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.