### PR TITLE
Add step for SCRAM auth

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -49,6 +49,7 @@ listen_addresses = '*'
 ----
 +
 . Add the following line to the end of the file:
++
 [options="nowrap" subs="verbatim,quotes"]
 ----
 password_encryption=scram-sha-256

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -48,6 +48,12 @@ The base recommended external database configuration adjustments are as follows:
 listen_addresses = '*'
 ----
 +
+. Add the following line to the end of the file:
+[options="nowrap" subs="verbatim,quotes"]
+----
+password_encryption=scram-sha-256
+----
++
 . Edit the `{postgresql-conf-dir}/pg_hba.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -48,7 +48,7 @@ The base recommended external database configuration adjustments are as follows:
 listen_addresses = '*'
 ----
 +
-. Add the following line to the end of the file:
+. Add the following line to the end of the file to use SCRAM for authentication:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -54,7 +54,6 @@ listen_addresses = '*'
 ----
 password_encryption=scram-sha-256
 ----
-+
 . Edit the `{postgresql-conf-dir}/pg_hba.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
Postgres authentication defaults to SCRAM and md5 is no longer supported. The changes done in https://github.com/theforeman/foreman-documentation/pull/3107 require an additional step. Adding in the missing step.

JIRA link:
https://issues.redhat.com/browse/SAT-24619


* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
