### PR TITLE
Drop plugin installation instructions on Satellite

### DIFF
--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -4,7 +4,9 @@ include::modules/con_supported-ansible-versions.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-your-project-to-run-ansible-roles.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_enabling-ansible-integration-with-project.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_importing-ansible-roles-and-variables.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -5,7 +5,7 @@
 
 include::modules/con_provisioning-cloud-instances-on-microsoft-azure-resource-manager.adoc[]
 
-ifdef::foreman-el,katello,orcharhino[]
+ifndef::satellite[]
 include::modules/proc_installing-microsoft-azure-plugin.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/assembly_using-foreman-webhooks.adoc
+++ b/guides/common/assembly_using-foreman-webhooks.adoc
@@ -4,7 +4,9 @@ include::modules/con_using-webhooks.adoc[]
 
 include::modules/con_migrating-to-foreman-webhooks.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::modules/proc_installing-webhooks-plugin.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_creating-a-webhook-template.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_creating-a-shellhook-to-print-arguments.adoc
+++ b/guides/common/modules/proc_creating-a-shellhook-to-print-arguments.adoc
@@ -7,7 +7,9 @@ Create a simple shellhook script that prints `Hello World!` when you run a remot
 * You have the webhooks and shellhooks plugins installed.
 For more information, see:
 
+ifndef::satellite[]
 ** xref:installing-webhooks-plugin_{context}[]
+endif::[]
 ** xref:installing-shellhooks-plugin_{context}[]
 
 .Procedure

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
@@ -26,12 +26,14 @@ endif::[]
 For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{context}[].
 
 .Procedure
+ifndef::satellite[]
 . On {Project}, enable the Leapp plugin:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --enable-foreman-plugin-leapp
 ----
+endif::[]
 . If you are using a custom job template for the Leapp pre-upgrade check, configure the *leapp_preupgrade* remote execution feature to point to your template:
 .. In the {ProjectWebUI}, navigate to *Administer* > *Remote Execution Features*.
 .. Click *leapp_preupgrade*.


### PR DESCRIPTION
Satellite has a set of mandatory plugins and the satellite meta-package ensures these are installed. Previously some were ensured by the installer but starting Satellite 6.16 this list is complete. The next step is to remove them from the installer, but some documentation procedures still told users to use these redundant options.

While this should be safe to cherry pick to Satellite 6.15, I'm a bit hesitant. Technically you'd rely on defaults in the installer to be correct while in 6.16 the packaging guarantees it. On the other hand, for ansible we we only `foreman-proxy-plugin-ansible` being enabled by default.

For now I've only selected the upstream supported versions to reduce potential cherry pick issues. There's also a small change that provides the instructions for azure on foreman-deb, but we probably don't publish that guide anyway.

Link: https://issues.redhat.com/browse/SAT-26276

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.