### PR TITLE
Improve intro for PXE provisioning concept

### DIFF
--- a/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
@@ -39,7 +39,7 @@ Both BIOS and UEFI interfaces work as interpreters between the operating system 
 .PXE loaders
 In {Project} provisioning, the PXE loader option defines the DHCP `filename` option to use during provisioning.
 
-* For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned node to download the `pxelinux.0` file over TFTP.
+* For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned host to download the `pxelinux.0` file over TFTP.
 * For UEFI systems, use the *PXEGrub2 UEFI* option to enable a TFTP client to download `grub2/grubx64.efi` file, or use the *PXEGrub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` from {SmartProxy} with the HTTP Boot feature.
 
 ifndef::satellite[]

--- a/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
@@ -34,20 +34,34 @@ endif::[]
 
 .BIOS and UEFI support
 With {ProjectName}, you can perform both BIOS and UEFI based PXE provisioning.
-Both BIOS and UEFI interfaces work as interpreters between the computer's operating system and firmware, initializing the hardware components and starting the operating system at boot time.
+Both BIOS and UEFI interfaces work as interpreters between the operating system and firmware of a computer, initializing hardware components and starting the operating system at boot time.
+
+.PXE loaders
+In {Project} provisioning, the PXE loader option defines the DHCP `filename` option to use during provisioning.
+
+* For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned node to download the `pxelinux.0` file over TFTP.
+* For UEFI systems, use the *PXEGrub2 UEFI* option to enable a TFTP client to download `grub2/grubx64.efi` file, or use the *PXEGrub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` from {SmartProxy} with the HTTP Boot feature.
+
+ifndef::satellite[]
+{ProjectName} supports UEFI Secure Boot.
+SecureBoot PXE loaders enable a client to download the `shim.efi` bootstrap boot loader that then loads the signed `grubx64.efi`.
+Use the *Grub2 UEFI SecureBoot* PXE loader for PXE-boot provisioning or *Grub2 UEFI HTTPS SecureBoot* for HTTP-boot provisioning.
+
+[IMPORTANT]
+====
+You can only use Secure Boot to provision hosts with the same operating system version, major and minor, that runs on your TFTP {SmartProxy}.
+====
+endif::[]
 
 ifdef::satellite[]
-For information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
+For more information about supported workflows, see https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios].
 endif::[]
-
-In {Project} provisioning, the PXE loader option defines the DHCP `filename` option to use during provisioning.
-For BIOS systems, use the *PXELinux BIOS* option to enable a provisioned node to download the `pxelinux.0` file over TFTP.
-For UEFI systems, use the *PXEGrub2 UEFI* option to enable a TFTP client to download `grub2/grubx64.efi` file, or use the *PXEGrub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` from {SmartProxy} with the HTTP Boot feature.
 ifndef::satellite[]
-Use SecureBoot options to enable a client to download the `shim.efi` bootstrap bootloader that then loads the signed `grubx64.efi`.
-Other PXE loaders like PXELinux UEFI, Grub2 ELF or iPXE Chain, require additional configuration. These workflows are not documented at the moment.
-endif::[]
+Other PXE loaders, such as PXELinux UEFI, Grub2 ELF, or iPXE Chain, require additional configuration.
+These workflows are not documented.
 
+.Template association with operating systems
 For BIOS provisioning, you must associate a PXELinux template with the operating system.
 For UEFI provisioning, you must associate a PXEGrub2 template with the operating system.
 If you associate both PXELinux and PXEGrub2 templates, {Project} can deploy configuration files for both on a TFTP server, so that you can switch between PXE loaders easily.
+endif::[]


### PR DESCRIPTION
Changes split from #3161
The SB feature isn't ready for Sat, so it's better to merge these improvements separately.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
