### PR TITLE
Remove Appendix B from the Content Management guide

### DIFF
--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -26,10 +26,6 @@ include::common/modules/proc_configuring-server-to-consume-content-from-a-custom
 
 include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+2]
 
-include::common/assembly_importing-kickstart-repositories.adoc[leveloffset=+2]
-
-include::common/assembly_importing-the-project-client-name-repository.adoc[leveloffset=+2]
-
 include::common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc[leveloffset=+2]
 
 include::common/modules/proc_enabling-power-management-on-hosts.adoc[leveloffset=+2]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -67,10 +67,6 @@ endif::[]
 [appendix]
 include::common/modules/proc_using-an-nfs-share-for-content-storage.adoc[leveloffset=+1]
 
-[appendix]
-include::common/assembly_importing-kickstart-repositories.adoc[leveloffset=+1]
-endif::[]
-
 ifdef::katello,orcharhino[]
 [appendix]
 include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -66,6 +66,7 @@ endif::[]
 
 [appendix]
 include::common/modules/proc_using-an-nfs-share-for-content-storage.adoc[leveloffset=+1]
+endif::[]
 
 ifdef::katello,orcharhino[]
 [appendix]


### PR DESCRIPTION
It was determined that Appendix B for Importing 
Kickstart Repositories
was not necessary for the Content Management Guide so 
it was removed. 

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
