### PR TITLE
Update package list for direct AD integration

### DIFF
--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -18,7 +18,7 @@ Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} adcli ipa-python-compat krb5-workstation \
+# {project-package-install} adcli krb5-workstation \
 oddjob oddjob-mkhomedir realmd samba-common-tools sssd
 ----
 . Enroll {ProjectServer} with the AD server.

--- a/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
+++ b/guides/common/modules/proc_enrolling-server-with-the-ad-server.adoc
@@ -18,7 +18,8 @@ Installing GSS-proxy and {nfs-client-package}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} sssd adcli realmd ipa-python-compat krb5-workstation samba-common-tools
+# {project-package-install} adcli ipa-python-compat krb5-workstation \
+oddjob oddjob-mkhomedir realmd samba-common-tools sssd
 ----
 . Enroll {ProjectServer} with the AD server.
 You may need to have administrator permissions to perform the following command:


### PR DESCRIPTION
Both https://issues.redhat.com/browse/SAT-22855 and https://issues.redhat.com/browse/SAT-26355 request adding the packages to the list of packages required for direct integration with AD.

UPDATE: Confirmed in https://github.com/theforeman/foreman-documentation/pull/3149#discussion_r1688125085.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
