### PR TITLE
Remove argument from zerombr

### DIFF
--- a/guides/common/modules/ref_dynamic_partition_example.adoc
+++ b/guides/common/modules/ref_dynamic_partition_example.adoc
@@ -30,7 +30,7 @@ else
 fi
 
 cat <<EOF > /tmp/diskpart.cfg
-zerombr yes
+zerombr
 clearpart --all --initlabel
 part /boot --fstype ext4 --size 200 --asprimary
 part swap --size "$SWAP_MEMORY"


### PR DESCRIPTION
This command does not take any arguments. [zerombr ref](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/automatically_installing_rhel/index#zerombr_kickstart-commands-for-handling-storage)

Requested in Jira: [SAT-26926](https://issues.redhat.com/browse/SAT-26926)

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
