### PR TITLE
Add procedure for copying a content view

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -8,6 +8,8 @@ include::modules/ref_best-practices-for-patching-content-hosts.adoc[leveloffset=
 
 include::modules/proc_creating-a-content-view.adoc[leveloffset=+1]
 
+include::modules/proc_copying-a-content-view.adoc[leveloffset=+1]
+
 include::modules/proc_viewing-module-streams.adoc[leveloffset=+1]
 
 include::modules/proc_promoting-a-content-view.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -31,4 +31,8 @@ As a result, you cannot promote an older version of a content view from the copi
 ----
 
 .Verification
-* The Hammer command reports successful completion: `Content view copied.`
+* The Hammer command reports:
+----
+# hammer content-view copy --id=5 --new-name="mixed_copy"
+Content view copied.
+----

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -31,8 +31,4 @@ As a result, you cannot promote an older version of a content view from the copi
 ----
 
 .Verification
-* The copied content view using Hammer is verified:
-----
-# hammer content-view copy --id=5 --new-name="mixed_copy"
-Content view copied.
-----
+* The Hammer command reports successful completion: `Content view copied.`

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -1,0 +1,29 @@
+[id="Copying_a_Content_View_{context}"]
+= Copying a content view
+
+Use this procedure to copy a content view.
+You can copy a content view in the {ProjectWebUI} or you can use the Hammer CLI to copy an existing content view into a new content view.
+
+[NOTE]
+====
+A copied content view does not have the same history as a regular content view.
+Version 1 of the content view is where a copied content view begins.
+As a result, you cannot promote an older version of a content view from the copied content view.
+====
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
+. Select the content view you want to copy.
+. Click the vertical ellipsis icon and click *Copy*.
+. In the *Name* field, enter a name for the content view you want to copy and click *Copy content view*.
+
+The copied content view will appear on the *Content views* page.
+
+.CLI procedure
+* Copy the content view using the Hammer CLI:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# hammer content-view copy --name <CURRENT_CV_NAME> \
+--new-name <NEW_CV_NAME>
+----

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -17,6 +17,9 @@ As a result, you cannot promote an older version of a content view from the copi
 . Click the vertical ellipsis icon and click *Copy*.
 . In the *Name* field, enter a name for the new content view and click *Copy content view*.
 
+.Verification
+* The copied content view appears on the *Content views* page.
+
 [id="cli-copying-a-content-view_{context}"]
 .CLI procedure
 * Copy the content view by using Hammer:
@@ -26,5 +29,10 @@ As a result, you cannot promote an older version of a content view from the copi
 # hammer content-view copy --name _My_original_CV_name_ \
 --new-name _My_new_CV_name_
 ----
+
 .Verification
-* The copied content view appears on the *Content views* page.
+* The copied content view using Hammer is verified:
+----
+# hammer content-view copy --id=5 --new-name="mixed_copy"
+Content view copied.
+----

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -1,13 +1,13 @@
 [id="Copying_a_Content_View_{context}"]
 = Copying a content view
 
-Use this procedure to copy a content view.
 You can copy a content view in the {ProjectWebUI} or you can use the Hammer CLI to copy an existing content view into a new content view.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-copying-a-content-view_{context}[].
 
 [NOTE]
 ====
-A copied content view does not have the same history as a regular content view.
-Version 1 of the content view is where a copied content view begins.
+A copied content view does not have the same history as the original content view.
+Version 1 of the copied content view begins at the last version of the original content view.
 As a result, you cannot promote an older version of a content view from the copied content view.
 ====
 
@@ -15,15 +15,16 @@ As a result, you cannot promote an older version of a content view from the copi
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select the content view you want to copy.
 . Click the vertical ellipsis icon and click *Copy*.
-. In the *Name* field, enter a name for the content view you want to copy and click *Copy content view*.
+. In the *Name* field, enter a name for the new content view and click *Copy content view*.
 
-The copied content view will appear on the *Content views* page.
-
+[id="cli-copying-a-content-view_{context}"]
 .CLI procedure
-* Copy the content view using the Hammer CLI:
+* Copy the content view by using Hammer:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer content-view copy --name <CURRENT_CV_NAME> \
---new-name <NEW_CV_NAME>
+# hammer content-view copy --name _My_original_CV_name_ \
+--new-name _My_new_CV_name_
 ----
+.Verification
+* The copied content view appears on the *Content views* page.


### PR DESCRIPTION
It was requested that we include a procedure for 
copying content views
since there was only a solution article available with 
a short
description for copying a content view. This procedure 
gives a more
detailed set of steps.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
