### PR TITLE
Remove Team from refs to Client repo name 3.11-3.7

### DIFF
--- a/guides/common/modules/proc_enabling-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc
+++ b/guides/common/modules/proc_enabling-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc
@@ -36,7 +36,7 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 ----
 # hammer repository-set enable \
 --basearch="x86_64" \
---name "{Team} {project-client-name} (for RHEL 7 Server) (RPMs)" \
+--name "{project-client-name} (for RHEL 7 Server) (RPMs)" \
 --organization "_My_Organization_" \
 --product "{RHEL} Server"
 ----
@@ -49,7 +49,7 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 ----
 # hammer repository-set enable \
 --basearch="x86_64" \
---name "{Team} {project-client-name} (for RHEL 6 Server - ELS) (RPMs)" \
+--name "{project-client-name} (for RHEL 6 Server - ELS) (RPMs)" \
 --organization "_My_Organization_" \
 --product "{RHEL} Server - Extended Lifecycle Support"
 ----

--- a/guides/common/modules/proc_enabling-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
+++ b/guides/common/modules/proc_enabling-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
@@ -14,7 +14,7 @@ endif::[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
 . In the Available Repositories pane, enable the *Recommended Repositories* to get the list of repositories.
-. Click *{Team} {project-client-name} for RHEL 9 x86_64 (RPMs)* or *{Team} {project-client-name} for RHEL 8 x86_64 (RPMs)* to expand the repository set.
+. Click *{project-client-name} for RHEL 9 x86_64 (RPMs)* or *{project-client-name} for RHEL 8 x86_64 (RPMs)* to expand the repository set.
 . For the *x86_64* architecture, click the *+* icon to enable the repository.
 +
 If the *{project-client-name}* items are not visible, it may be because they are not included in the Red{nbsp}Hat subscription manifest obtained from the Customer Portal.
@@ -32,7 +32,7 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 ----
 # hammer repository-set enable \
 --basearch="x86_64" \
---name "{Team} {project-client-name} for RHEL 9 x86_64 (RPMs)" \
+--name "{project-client-name} for RHEL 9 x86_64 (RPMs)" \
 --organization "_My_Organization_" \
 --product "{RHEL} for x86_64"
 ----
@@ -45,7 +45,7 @@ After enabling a Red Hat repository, a Product for this repository is automatica
 ----
 # hammer repository-set enable \
 --basearch="x86_64" \
---name "{Team} {project-client-name} for RHEL 8 x86_64 (RPMs)" \
+--name "{project-client-name} for RHEL 8 x86_64 (RPMs)" \
 --organization "_My_Organization_" \
 --product "{RHEL} for x86_64"
 ----

--- a/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc
+++ b/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-7-and-rhel-6.adoc
@@ -15,7 +15,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 . Click the arrow next to the *{RHEL} Server* or *{RHEL} Server - Extended Lifecycle Support*.
-. Select *{Team} {project-client-name} (for RHEL 7 Server) RPMs x86_64* or *{Team} {project-client-name} for RHEL 6 Server - ELS RPMs x86_64* based on your operating system version.
+. Select *{project-client-name} (for RHEL 7 Server) RPMs x86_64* or *{project-client-name} for RHEL 6 Server - ELS RPMs x86_64* based on your operating system version.
 . Click *Synchronize Now*.
 
 [id="CLI_Synchronizing_the_Client_Repository_rhel_7_{context}"]
@@ -26,7 +26,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 ----
 # hammer repository synchronize \
 --async \
---name "{Team} {project-client-name} for RHEL 7 Server RPMs x86_64" \
+--name "{project-client-name} for RHEL 7 Server RPMs x86_64" \
 --organization "_My_Organization_" \
 --product "{RHEL} Server"
 ----
@@ -39,7 +39,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 ----
 # hammer repository synchronize \
 --async \
---name "{Team} {project-client-name} for RHEL 6 Server - ELS RPMs x86_64" \
+--name "{project-client-name} for RHEL 6 Server - ELS RPMs x86_64" \
 --organization "_My_Organization_" \
 --product "{RHEL} Server - Extended Lifecycle Support"
 ----

--- a/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
+++ b/guides/common/modules/proc_synchronizing-the-project-client-name-repository-for-rhel-9-and-rhel-8.adoc
@@ -9,7 +9,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 . Click the arrow next to the *{RHEL} for x86_64* product to view available content.
-. Select *{Team} {project-client-name} for RHEL 9 x86_64 RPMs* or *{Team} {project-client-name} for RHEL 8 x86_64 RPMs*.
+. Select *{project-client-name} for RHEL 9 x86_64 RPMs* or *{project-client-name} for RHEL 8 x86_64 RPMs*.
 . Click *Synchronize Now*.
 
 [id="CLI_Synchronizing_the_Client_Repository_rhel_9_{context}"]
@@ -19,7 +19,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository synchronize \
---name "{Team} {project-client-name} for RHEL 9 x86_64 RPMs" \
+--name "{project-client-name} for RHEL 9 x86_64 RPMs" \
 --organization "_My_Organization_" \
 --product "{RHEL} for x86_64"
 ----
@@ -31,7 +31,7 @@ To use the CLI instead of the {ProjectWebUI}, see the procedure relevant for you
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # hammer repository synchronize \
---name "{Team} {project-client-name} for RHEL 8 x86_64 RPMs" \
+--name "{project-client-name} for RHEL 8 x86_64 RPMs" \
 --organization "_My_Organization_" \
 --product "{RHEL} for x86_64"
 ----


### PR DESCRIPTION
A necessary follow-up on #3143 otherwise we would have "Red Hat Red Hat" in these places.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
