### PR TITLE
Use RPM capability in favor of package name

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -29,7 +29,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} python3.11-pulp_manifest
+# {project-package-install} pulp-manifest
 ----
 ifdef::satellite[]
 +
@@ -39,7 +39,7 @@ Alternatively, to prevent downtime caused by stopping the service, you can use t
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} packages unlock
-# {project-package-install} python39-pulp_manifest
+# {project-package-install} pulp-manifest
 # {foreman-maintain} packages lock
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -42,7 +42,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf install python3.11-pulp_manifest
+# dnf install pulp-manifest
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:
 +


### PR DESCRIPTION
"pulp-manifest" is packaged in pulpcore_packaging. The RPM package name depends on the Python version. Using the RPM capability, you can install "pulp-manifest" independent of the package name.

This is part of Pulpcore 3.49 -> Katello 4.13 -> Foreman 3.11.

Refs PR-1070 in pulpcore-packaging

````
# cat /etc/yum.repos.d/pulpcore.repo
[pulpcore]
name=pulpcore
baseurl=https://yum.theforeman.org/pulpcore/3.49/el8/x86_64/
enabled=1
gpgcheck=0
sslverify=0

# dnf install pulp-manifest
...
Installing:
 python3.11-pulp_manifest                                      noarch                                   3.0.0-5.el8                                         pulpcore                                       21 k
Installing dependencies:
...
````


* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
