### PR TITLE
Replace deprecated use of dnf update

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -172,7 +172,7 @@
 :client-package-remove-sles: zypper remove
 :client-package-update-deb: apt upgrade
 :client-package-update-el7: yum upgrade
-:client-package-update-el8: dnf update
+:client-package-update-el8: dnf upgrade
 :client-package-update-sles: zypper update
 :client-pkg-arch: noarch
 :client-pkg-ext: rpm
@@ -187,4 +187,4 @@
 :project-package-clean: dnf clean
 :project-package-install: dnf install
 :project-package-remove: dnf remove
-:project-package-update: dnf update
+:project-package-update: dnf upgrade

--- a/guides/common/modules/con_resolving-package-dependencies.adoc
+++ b/guides/common/modules/con_resolving-package-dependencies.adoc
@@ -62,7 +62,7 @@ ifeval::["{client-os-family}" == "Red Hat"]
 [id="Excluding_packages_and_dependency_solving_with_DNF_{context}"]
 .Excluding packages sometimes makes dependency solving impossible for DNF
 ====
-If you make a {RHEL}{nbsp}8.3 repository with a few excluded packages, `dnf update` can sometimes fail.
+If you make a {RHEL}{nbsp}8.3 repository with a few excluded packages, `dnf upgrade` can sometimes fail.
 
 Do not enable dependency solving to resolve the problem.
 Instead, investigate the error from `dnf` and adjust the filters to stop excluding the missing dependency.

--- a/guides/common/modules/proc_applying-errata-to-hosts-el.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts-el.adoc
@@ -22,5 +22,5 @@ include::snip_applying-errata.adoc[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# dnf update _Module_Stream_Name_
+# dnf upgrade _Module_Stream_Name_
 ----

--- a/guides/common/modules/proc_installing-proxy-packages.adoc
+++ b/guides/common/modules/proc_installing-proxy-packages.adoc
@@ -5,7 +5,7 @@
 [options="nowrap" subs="+quotes,attributes"]
 ----
 ifdef::satellite[]
-# dnf update
+# dnf upgrade
 endif::[]
 ifndef::satellite[]
 # {project-package-update}

--- a/guides/common/modules/proc_installing-server-packages-el.adoc
+++ b/guides/common/modules/proc_installing-server-packages-el.adoc
@@ -4,7 +4,7 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} update
+# {package-manager} upgrade
 ----
 ifdef::satellite[]
 . Install {ProjectServer} packages:


### PR DESCRIPTION
The dnf upgrade command lists dnf update as a deprecated alias.

I split this off from https://github.com/theforeman/foreman-documentation/pull/2936 to reduce its scope.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.