### PR TITLE
Document dns_nsupdate provider in managing DNS section

### DIFF
--- a/guides/common/assembly_managing-dns-on-smart-proxies.adoc
+++ b/guides/common/assembly_managing-dns-on-smart-proxies.adoc
@@ -1,5 +1,7 @@
 include::modules/con_managing-dns-by-using-smartproxy.adoc[]
 
+include::modules/proc_configuring-dns-nsupdate.adoc[leveloffset=+1]
+
 ifndef::satellite[]
 include::modules/proc_configuring-dns-libvirt.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_managing-dns-by-using-smartproxy.adoc
+++ b/guides/common/modules/con_managing-dns-by-using-smartproxy.adoc
@@ -17,8 +17,8 @@ ifndef::satellite[]
 * `dns_libvirt` {endash} Dnsmasq DNS via libvirt API.
 For more information, see xref:configuring_dns_libvirt_{context}[].
 endif::[]
-* `dns_nsupdate` {endash} Dynamic DNS update by using nsupdate.
-For more information, see {ProvisioningDocURL}Using_Infoblox_as_DHCP_and_DNS_Providers_provisioning[Using Infoblox as DHCP and DNS Providers] in _{ProvisioningDocTitle}_.
+* `dns_nsupdate` {endash} Dynamic DNS update using nsupdate.
+For more information, see xref:configuring_dns_nsupdate_{context}[].
 * `dns_nsupdate_gss` {endash} Dynamic DNS update with GSS-TSIG.
 For more information, see xref:configuring-dynamic-dns-update-with-gss-tsig-authentication_{context}[].
 ifndef::satellite[]

--- a/guides/common/modules/proc_configuring-dns-nsupdate.adoc
+++ b/guides/common/modules/proc_configuring-dns-nsupdate.adoc
@@ -1,0 +1,20 @@
+[id="configuring_dns_nsupdate_{context}"]
+= Configuring dns_nsupdate
+
+The _dns_nsupdate_ DNS provider manages DNS records using the `nsupdate` utility.
+You can use _dns_nsupdate_ with any DNS server compatible with https://www.rfc-editor.org/rfc/rfc2136[RFC2136].
+By default, _dns_nsupdate_ installs the ISC BIND server.
+For installation without ISC BIND, see xref:configuring-external-dns_{context}[].
+
+.Procedure
+* Configure `dns_nsupdate`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} \
+--foreman-proxy-dns true \
+--foreman-proxy-dns-provider nsupdate \
+--foreman-proxy-dns-managed true \
+--foreman-proxy-dns-zone _example.com_ \
+--foreman-proxy-dns-reverse _2.0.192.in-addr.arpa_
+----


### PR DESCRIPTION
This takes the idea that there should be a central place with documentation on all DNS providers. Not spread over multiple guides. It starts with the `dns_nsupdate` provider, but this should be completed with all of the providers.

This is split off from https://github.com/theforeman/foreman-documentation/pull/2933 to keep the scope limited. Infoblox turned out to be much harder than expected.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.