### PR TITLE
Document how to populate foreman-contributors.adoc

### DIFF
--- a/guides/doc-Release_Notes/README.md
+++ b/guides/doc-Release_Notes/README.md
@@ -66,3 +66,17 @@ ifdef::katello[]
 include::topics/katello-4.2.0.adoc[leveloffset=+1]
 endif::[]
 ```
+
+## Updating contributors
+
+Use [committers.rb](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/committers.rb) to generate the list of committers. Generically, this is:
+
+```
+theforeman.org/scripts/committers.rb --multi-line FOREMAN_FROM FOREMAN_TO
+```
+
+You need to provide the Foreman tags FROM and TO. For example, `3.10.0-rc1` and `3.11.1`. And store that output to `topics/foreman-contributors.adoc`
+
+```
+theforeman.org/scripts/committers.rb --multi-line 3.10.0-rc1 3.11.1 > topics/foreman-contributors.adoc
+```


### PR DESCRIPTION
The script lives in theforeman.org repo because that's where it has historically lived. That repository also contains the mailmap to ensure multiple identities (different spelling or email) are mapped to a single name.

Something to consider: this doesn't update Katello and the script isn't really suited for that right now. I debated merging the two into one big list of contributors. Simply include Katello contributors as Foreman contributors.

Another note: we need to update the procedures to reuse this:
https://github.com/theforeman/theforeman-rel-eng/blob/ebfe21978af75a30a96d3716ddbd403d7b53aac3/procedures/foreman/release.md.erb#L102
https://github.com/theforeman/theforeman-rel-eng/blob/ebfe21978af75a30a96d3716ddbd403d7b53aac3/procedures/katello/release.md.erb#L35

Fixes #1767 

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.