### PR TITLE
Migrate PR requirements to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+#### What changes are you introducing?
+
+#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
+
+#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
+
 
 * [x] I am okay with my commits getting squashed when you merge this PR.
 * [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 #### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
 
+#### Checklists
 
 * [x] I am okay with my commits getting squashed when you merge this PR.
 * [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We respect each others time and energy spent on Foreman documentation.
 ## Maintainers
 
 * help less experienced community members with git, Github, PRs, asciidoc, and asciidoctor.
-* expect a basic effort in contributions.
+* expect a basic effort in contributions, including the [pull request template](PULL_REQUEST_TEMPLATE.md) being filled out.
 * only merge PRs if the Github Actions are green.
 * read the proposed change and make friendly and helpful comments.
 * ping community members with more experience if they are unsure about specific details.
@@ -49,8 +49,6 @@ See [Capitalization](#Capitalization).
 
 Please explain why someone else should merge your proposed change:
 
-* What has been changed?
-* Why has it been changed?
 * Are there any alternatives to my PR?
 * Are there any regressions or downsides to my PR?
 * Does my PR make multiple changes and therefore require multiple commits?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,15 +45,6 @@ See [LICENSE](LICENSE).
 * [ ] I am familiar to proper capitalization for project-specific terminology.
 See [Capitalization](#Capitalization).
 
-## Crafting Great Pull Requests
-
-Please explain why someone else should merge your proposed change:
-
-* Are there any alternatives to my PR?
-* Are there any regressions or downsides to my PR?
-* Does my PR make multiple changes and therefore require multiple commits?
-Ideally, each individual change correlates to an individual commit.
-
 ## Capitalization
 
 All headings are sentence case.


### PR DESCRIPTION
What: I'm proposing to move the expected contents of a PR from CONTRIBUTING.md directly to the PR template. This PR only moves two bullet points (the _what_ and the _why_) because I find that the rest is unclear or very difficult to enforce anyway. If you feel we should include the dropped bullet points as well, feel free to suggest more headings.

Why: Any documentation works best when presented at the moment when users need it. And I don't think adding these two points to the PR template makes it too cumbersome.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
