### PR TITLE
Clarify the support level for the Quarkus distribution of Keycloak

### DIFF
--- a/guides/common/assembly_configuring-external-authentication.adoc
+++ b/guides/common/assembly_configuring-external-authentication.adoc
@@ -19,6 +19,7 @@ ifdef::satellite[]
 :!keycloak:
 endif::[]
 
+ifndef::satellite[]
 // The following ifdef sets :keycloak: to `Red Hat build of Keycloak` for Satellite builds only. For, non-Satellite builds, :keycloak: stays set to `Keycloak`.
 ifdef::satellite[]
 :keycloak: {keycloak-quarkus}
@@ -32,6 +33,7 @@ ifndef::parent-context[:!context:]
 // The following ifdef unsets :keycloak: because in Satellite builds, it's always either {keycloak-wildfly} or {keycloak-quarkus}.
 ifdef::satellite[]
 :!keycloak:
+endif::[]
 endif::[]
 
 include::assembly_configuring-active-directory-as-an-external-identity-provider-for-project.adoc[leveloffset=+1]

--- a/guides/common/modules/con_configuring-keycloak-quarkus-authentication-for-project.adoc
+++ b/guides/common/modules/con_configuring-keycloak-quarkus-authentication-for-project.adoc
@@ -1,4 +1,4 @@
-[id="configuring-keycloak-authentication-for-project_{context}"]
+[id="configuring-keycloak-quarkus-authentication-for-project_{context}"]
 = Configuring {keycloak-quarkus} authentication for {Project}
 
 {keycloak-quarkus} is an open-source identity and access management solution that provides authentication features, such as single sign-on functionality, user federation, or centralized authentication management.

--- a/guides/common/modules/con_configuring-keycloak-wildfly-authentication-for-project.adoc
+++ b/guides/common/modules/con_configuring-keycloak-wildfly-authentication-for-project.adoc
@@ -1,4 +1,4 @@
-[id="configuring-keycloak-authentication-for-project_{context}"]
+[id="configuring-keycloak-wildfly-authentication-for-project_{context}"]
 = Configuring {keycloak-wildfly} authentication for {Project}
 
 {keycloak} is an open-source identity and access management solution that provides authentication features, such as single sign-on functionality, user federation, or centralized authentication management.

--- a/guides/common/modules/con_configuring-keycloak-wildfly-authentication-for-project.adoc
+++ b/guides/common/modules/con_configuring-keycloak-wildfly-authentication-for-project.adoc
@@ -1,6 +1,18 @@
 [id="configuring-keycloak-wildfly-authentication-for-project_{context}"]
 = Configuring {keycloak-wildfly} authentication for {Project}
 
+ifndef::satellite[]
+[NOTE]
+====
+The default {keycloak} distribution is now based on Quarkus.
+
+{keycloak-quarkus} replaces {keycloak-wildfly} in {Project} deployments.
+For information about configuring {keycloak-quarkus} authentication, see xref:configuring-keycloak-quarkus-authentication-for-project_keycloak-quarkus[].
+
+For information about migrating from {keycloak-wildfly} to {keycloak-quarkus}, see link:https://www.keycloak.org/migration/migrating-to-quarkus[Migrating to Quarkus distribution].
+====
+endif::[]
+
 {keycloak} is an open-source identity and access management solution that provides authentication features, such as single sign-on functionality, user federation, or centralized authentication management.
 With {keycloak-wildfly}, you can integrate {ProjectServer} with your existing {keycloak} server to delegate user authentication and authorization to {keycloak}.
 The following login methods are available:


### PR DESCRIPTION
The default distribution of Keycloak is now based on Quarkus. While we have the procedures for Quarkus-based Keycloak in place, we are still not clear on whether we should label the Wildfly-based Keycloak procedures as deprecated or whether we can actually support the Quarkus-based Keycloak procedures.

This PR introduces a note that describes the support level and provides links to docs about migrating Keycloak.

https://issues.redhat.com/browse/SAT-27194

UPDATE: I've been adding commits as the discussion around the support levels evolved. The latest state doesn't use the term "deprecated" for the procedures to configure the Wildfly distribution of Keycloak (because it's actually Keycloak that was deprecated, not the procedure in Satellite docs) and also excludes the Quarkus-based procedures from Satellite builds.

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
