### PR TITLE
Move AD account info into its own module

### DIFF
--- a/guides/common/assembly_configuring-external-authentication.adoc
+++ b/guides/common/assembly_configuring-external-authentication.adoc
@@ -38,6 +38,8 @@ include::assembly_configuring-active-directory-as-an-external-identity-provider-
 
 include::assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+1]
 
+include::modules/con_important-user-and-group-account-information-for-active-directory-accounts.adoc[leveloffset=+1]
+
 include::modules/proc_configuring-external-user-groups.adoc[leveloffset=+1]
 
 include::modules/proc_refreshing-external-user-groups-for-ldap.adoc[leveloffset=+1]

--- a/guides/common/modules/con_configuring-external-authentication.adoc
+++ b/guides/common/modules/con_configuring-external-authentication.adoc
@@ -4,15 +4,3 @@
 By using external authentication you can derive user and user group permissions from user group membership in an external identity provider.
 When you use external authentication, you do not have to create these users and maintain their group membership manually on {ProjectServer}.
 In case the external source does not provide email, it will be requested during the first login through {ProjectWebUI}.
-
-.Important user and group account information
-All user and group accounts must be local accounts.
-This is to ensure that there are no authentication conflicts between local accounts on your {ProjectServer} and accounts in your Active Directory domain.
-
-Your system is not affected by this conflict if your user and group accounts exist in both `/etc/passwd` and `/etc/group` files.
-For example, to check if entries for `puppet`, `{apache-user}`, `foreman` and `foreman-proxy` groups exist in both `/etc/passwd` and `/etc/group` files, enter the following commands:
-
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# grep 'puppet\|{apache-user}\|foreman\|foreman-proxy' /etc/passwd /etc/group
-----

--- a/guides/common/modules/con_important-user-and-group-account-information-for-active-directory-accounts.adoc
+++ b/guides/common/modules/con_important-user-and-group-account-information-for-active-directory-accounts.adoc
@@ -1,0 +1,13 @@
+[id="important-user-and-group-account-information-for-active-directory-accounts_{context}"]
+= Important user and group account information for Active Directory accounts
+
+All user and group accounts must be local accounts.
+This is to ensure that there are no authentication conflicts between local accounts on your {ProjectServer} and accounts in your Active Directory domain.
+
+Your system is not affected by this conflict if your user and group accounts exist in both `/etc/passwd` and `/etc/group` files.
+For example, to check if entries for `puppet`, `{apache-user}`, `foreman` and `foreman-proxy` groups exist in both `/etc/passwd` and `/etc/group` files, enter the following commands:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# grep 'puppet\|{apache-user}\|foreman\|foreman-proxy' /etc/passwd /etc/group
+----


### PR DESCRIPTION
#### What changes are you introducing?

I propose to move a few paragraphs about AD user accounts to a separate module. No changes in wording except for a slight adjustment to the heading of the module; other than that, this really is just about the move.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The content I'm moving is currently included in the introduction to an assembly. That is no place for detailed concept or feature explanations.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This PR is just about moving the content out of the introduction to a place further down the assembly. Although the wording could use some improvement, I don't intend to address that gap in this PR.

I want to move the content out of the introduction in preparation for another PR that will introduce changes to the assembly's introduction and heading.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
