### PR TITLE
Correct Smart Proxy upgrade instructions on foreman-el

### DIFF
--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -44,30 +44,31 @@ For information on backups, see {AdministeringDocURL}backing-up-{project-context
 ifdef::foreman-el,katello[]
 . Update repositories:
 +
+ifdef::katello[]
 [options="nowrap" subs="attributes"]
 ----
-ifdef::katello[]
 # {project-package-update} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm \
 https://yum.theforeman.org/katello/{KatelloVersion}/katello/el8/x86_64/katello-repos-latest.rpm
-endif::[]
-ifdef::foreman-el[]
-# {project-package-update} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
-endif::[]
 ----
-ifdef::katello[]
 . Disable the pulpcore module if it is enabled:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # dnf module disable pulpcore
 ----
-endif::[]
 . Switch to the PostgreSQL 13 module:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # dnf -y module switch-to postgresql:13
 ----
+endif::[]
+ifdef::foreman-el[]
+[options="nowrap" subs="attributes"]
+----
+# {project-package-update} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
+----
+endif::[]
 . Ensure the module streams are enabled:
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

On foreman-el there is no PostgreSQL present so there is no DNF module switching.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Eventually users should be able to follow the upgrade guide and actually get an upgraded system.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Note there are no upgrade instructions for EL9 and the setting up repository step for foreman-deb is completely missing.

It's also interesting that it upgrades the OS packages first and then the Foreman packages. That feels redundant to me.

@evgeni any thoughts on recommending foreman-maintain like we do in Satellite? That would help abstract away many of the differences and align on process.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.