### PR TITLE
Add procedure to upgrade Foreman on Deb

### DIFF
--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -15,7 +15,9 @@ The high-level steps in upgrading {Project} to {ProjectVersion} are as follows:
 . Upgrade {ProjectServer} to {ProjectVersion}.
 For more information, see xref:Project_Upgrade_Considerations_{context}[].
 . Upgrade all {SmartProxyServers} to {ProjectVersion}.
+ifndef::foreman-deb[]
 For more information, see xref:upgrading_{smart-proxy-context}_server_{context}[].
+endif::[]
 
 ////
 ifdef::satellite[]

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -18,12 +18,3 @@ For more information, see xref:Project_Upgrade_Considerations_{context}[].
 ifndef::foreman-deb[]
 For more information, see xref:upgrading_{smart-proxy-context}_server_{context}[].
 endif::[]
-
-////
-ifdef::satellite[]
-During an upgrade of {ProjectServer}, you must observe the correct upgrade path depending on your network environment:
-
-.Overview of {ProjectServer} upgrade paths in connected and disconnected network environments
-image::common/upgrade-paths-satellite.png[Overview of {ProjectServer} upgrade paths in connected and disconnected network environments]
-endif::[]
-////

--- a/guides/common/modules/con_upgrading-project.adoc
+++ b/guides/common/modules/con_upgrading-project.adoc
@@ -8,4 +8,6 @@ Use the following procedures to upgrade your existing {ProjectName} to {ProjectN
 ifdef::satellite[]
 . xref:synchronizing_the_new_repositories_{context}[]
 endif::[]
+ifndef::foreman-deb[]
 . xref:upgrading_{smart-proxy-context}_server_{context}[]
+endif::[]

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -1,6 +1,7 @@
 .Procedure
 Select the operating system and version you are installing on:
 
+// List of supported OS for foreman-deb has to match "guides/common/modules/proc_upgrading-a-connected-project-server.adoc"
 * xref:#repositories-debian-11[Debian 11 (Bullseye)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
 * xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -5,9 +5,11 @@
 If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
 For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.
 
+ifdef::katello,orcharhino,satellite[]
 * Pulp is introducing more data about container manifests to the API.
 This information allows Katello to display manifest labels, annotations, and information about the manifest type, such as if it is bootable or represents flatpak content.
 As a result, migrations must be performed to pull this content from manifests into the database.
+endif::[]
 
 ifdef::katello[]
 This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -97,49 +97,9 @@ Replace _My_Distribution_Code_Name_ with the proper distribution code name based
 [options="nowrap" subs="attributes"]
 ----
 # apt-get update
-# apt-get --only-upgrade install ruby\* foreman\*
+# apt-get upgrade
 ----
-. Migrate the database:
-+
-[options="nowrap" subs="attributes"]
-----
-# foreman-rake db:migrate
-# foreman-rake db:seed
-----
-. Clear the cache and existing database sessions:
-+
-[options="nowrap" subs="attributes"]
-----
-# foreman-rake tmp:cache:clear
-# foreman-rake db:sessions:clear
-----
-. Optional: Reclaim space on your PostgreSQL database:
-+
-[options="nowrap" subs="attributes"]
-----
-# su - postgres -c "vacuumdb --full --dbname=foreman"
-----
-. If you have used `{foreman-installer}` to set up your existing {ProjectServer}, {Team} recommends running it again after upgrading.
-However, `{foreman-installer}` can modify config files so this might overwrite your custom changes.
-+
-* You can run the installer in noop mode to see what would be changed:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-installer} --noop --verbose
-----
-+
-You might see errors such as the following:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-/Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[{foreman-example-com}]: Could not evaluate: Connection refused - connect(2)
-----
-+
-These errors mean that the `apache2` service is being stopped.
-You can safely ignore them.
-+
-* After reviewing the changes the installer will make, run it again:
+. Run `{foreman-installer}`:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -30,8 +30,9 @@ include::snip_warning-maintain-config-noop.adoc[]
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-installer} --foreman-proxy-dns-managed=false \
---foreman-proxy-dhcp-managed=false
+# {foreman-installer} \
+--foreman-proxy-dhcp-managed=false \
+--foreman-proxy-dns-managed=false
 ----
 . In the {ProjectWebUI}, navigate to *Hosts* > *Discovered hosts*.
 On the Discovered Hosts page, power off and then delete the discovered hosts.
@@ -74,6 +75,81 @@ ifdef::katello[]
 [options="nowrap" subs="attributes"]
 ----
 # foreman-rake katello:upgrade_check
+----
+endif::[]
+ifdef::foreman-deb[]
+. Update repositories in `/etc/apt/sources.list.d/foreman.list` to consume content for {Project} {ProjectVersion}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+deb http://deb.theforeman.org/ _My_Distribution_Code_Name_ {ProjectVersion}
+deb http://deb.theforeman.org/ plugins {ProjectVersion}
+----
++
+// List of supported OS for foreman-deb has to match "guides/common/modules/proc_configuring-repositories-foreman-deb.adoc"
+Replace _My_Distribution_Code_Name_ with the proper distribution code name based on the operating system of your {ProjectServer}:
++
+* `bullseye` for Debian 11
+* `jammy` for Ubuntu 22.04
+* `focal` for Ubuntu 20.04
+. Update to {Project} {ProjectVersion}:
++
+[options="nowrap" subs="attributes"]
+----
+# apt-get update
+# apt-get --only-upgrade install ruby\* foreman\*
+----
+. Migrate the database:
++
+[options="nowrap" subs="attributes"]
+----
+# foreman-rake db:migrate
+# foreman-rake db:seed
+----
+. Clear the cache and existing database sessions:
++
+[options="nowrap" subs="attributes"]
+----
+# foreman-rake tmp:cache:clear
+# foreman-rake db:sessions:clear
+----
+. Optional: Reclaim space on your PostgreSQL database:
++
+[options="nowrap" subs="attributes"]
+----
+# su - postgres -c "vacuumdb --full --dbname=foreman"
+----
+. If you have used `{foreman-installer}` to set up your existing {ProjectServer}, {Team} recommends running it again after upgrading.
+However, `{foreman-installer}` can modify config files so this might overwrite your custom changes.
++
+* You can run the installer in noop mode to see what would be changed:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --noop --verbose
+----
++
+You might see errors such as the following:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+/Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[{foreman-example-com}]: Could not evaluate: Connection refused - connect(2)
+----
++
+These errors mean that the `apache2` service is being stopped.
+You can safely ignore them.
++
+* After reviewing the changes the installer will make, run it again:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer}
+----
+. Restart all {Project} services:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service restart
 ----
 endif::[]
 ifdef::foreman-el,katello[]

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -78,6 +78,12 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::foreman-deb[]
+. Stop all {Project} services:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service stop
+----
 . Update repositories in `/etc/apt/sources.list.d/foreman.list` to consume content for {Project} {ProjectVersion}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
@@ -92,12 +98,6 @@ Replace _My_Distribution_Code_Name_ with the proper distribution code name based
 * `bullseye` for Debian 11
 * `jammy` for Ubuntu 22.04
 * `focal` for Ubuntu 20.04
-. Stop all {Project} services:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service stop
-----
 . Update to {Project} {ProjectVersion}:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -92,6 +92,12 @@ Replace _My_Distribution_Code_Name_ with the proper distribution code name based
 * `bullseye` for Debian 11
 * `jammy` for Ubuntu 22.04
 * `focal` for Ubuntu 20.04
+. Stop all {Project} services:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service stop
+----
 . Update to {Project} {ProjectVersion}:
 +
 [options="nowrap" subs="attributes"]
@@ -104,12 +110,6 @@ Replace _My_Distribution_Code_Name_ with the proper distribution code name based
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer}
-----
-. Restart all {Project} services:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service restart
 ----
 endif::[]
 ifdef::foreman-el,katello[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -6,13 +6,6 @@ include::common/header.adoc[]
 
 = {UpgradingDocTitle}
 
-// This guide is not ready for Debian
-ifdef::foreman-deb[]
-include::common/modules/snip_guide-not-ready.adoc[]
-endif::[]
-
-ifndef::foreman-deb[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -51,8 +44,10 @@ endif::[]
 // Performing Post-Upgrade Tasks
 include::common/modules/proc_performing-post-upgrade-tasks.adoc[leveloffset=+2]
 
+ifdef::foreman-el,katello,satellite,orcharhino[]
 // Upgrading Smart Proxy Server
 include::common/modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+2]
+endif::[]
 
 ifdef::foreman-el,katello,satellite,orcharhino[]
 // Upgrading the External database
@@ -61,5 +56,4 @@ endif::[]
 
 ifndef::foreman-deb[]
 include::common/assembly_upgrading-to-rhel9.adoc[leveloffset=+1]
-endif::[]
 endif::[]


### PR DESCRIPTION
Content is based on Foreman Manual for 3.11:
https://theforeman.org/manuals/3.11/index.html#3.6Upgradeto3.11

#### What changes are you introducing?

Make "Upgrade Server" available for "Foreman on Debian/Ubuntu".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Before, it was only available in the Foreman Manual. Before we can make docs.theforeman.org official, we need to provide basic upgrade instructions for the Community.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Downsides: we now have two places where we define the set of operating systems for `foreman-deb` -> I have added comments to both files.

Follow up task: Add instructions to upgrade Smart Proxy Servers on Debian/Ubuntu

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12