### PR TITLE
Update procedure to sync Python-type content

### DIFF
--- a/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
+++ b/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
@@ -29,11 +29,11 @@ include::snip_step-downloading-file-from-server.adoc[]
 ----
 . View the repository information:
 +
-[options="nowrap",subs="+quotes"]
+[options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # hammer repository info \
 --name "_My_Python_Repository_" \
 --organization-id _My_Organization_ID_ \
---product "_My_{customproductid}_"
+--product "__My_{customproductFirstCap}__"
 ----
 include::snip_step-downloading-file-from-server.adoc[]

--- a/guides/common/modules/proc_installing-python-packages-from-server.adoc
+++ b/guides/common/modules/proc_installing-python-packages-from-server.adoc
@@ -12,7 +12,7 @@ You can install Python packages from {Project} on hosts using `pip`.
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 $ pip install \
---index-url https://{foreman-example-com}/pulp/content/_My_Organization_Label_/Library/custom/_My_{customproductid}/_My_Python_Repository_/simple/ \
+--index-url https://{foreman-example-com}/pulp/content/_My_Organization_Label_/Library/custom/__My_{customproductFirstCap}__/_My_Python_Repository_/simple/ \
 _My_Python_Package_
 ----
 +

--- a/guides/common/modules/proc_synchronizing-python-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-python-repositories.adoc
@@ -13,17 +13,16 @@ You can view the Python packages in the {ProjectWebUI} at *Content* > *Content T
 +
 The *Label* field is populated automatically based on the name.
 . From the *Type* list, select *python*.
-. In the *Upstream URL* field, enter the URL for the upstream content source, for example `\https://pypi.org`.
+. In the *Upstream URL* field, enter the URL for the upstream content source, for example, `https://pypi.org`.
+. Optional: Clear *Verify SSL* if you do not want {ProjectServer} to verify the SSL certificate of the upstream content source.
 . Optional: In the *Upstream Username* field, enter the user name for the upstream repository if required for authentication.
 Clear this field if the repository does not require authentication.
 . Optional: In the *Upstream Password* field, enter the corresponding password for the upstream repository.
 Clear this field if the repository does not require authentication.
-. Optional: In the *Upstream Authentication Token* field, provide the token of the upstream repository user for authentication.
-Leave this field empty if the repository does not require authentication.
 . Optional: In the *Excludes* field, enter a list of Python packages separated by newlines to exclude from synchronizing to {Project}.
 . Optional: In the *Includes* field, enter a list of Python packages separated by newlines to limit the synchronization only to the included packages.
 . Optional: In the *Package Types* field, enter a list of package types separated by comma.
-You can use this field to only synchronize the source distribution if you enter `.tar.gz` or the built distribution if you enter `.whl`.
+You can enter `sdist` to synchronize the source distribution or `bdist_wheel` to synchronize the built distribution.
 . From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
 For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.


### PR DESCRIPTION
Tested on Foreman 3.11 that "Upstream Authentication Token" is gone; "Verify SSL" is present, and that the values for "Package Types" have changed.

Synchronized from pypi.org:

* "django ~= 5.1" + "bdist_wheel" -> "Django-5.1-py3-none-any.whl"
* "django ~= 5.1" + "sdist" -> "Django-5.1.tar.gz"

#### What changes are you introducing?

Ensure docs match the Foreman Web UI.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Docs were outdated.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I think we should consolidate the wording for "SSL Verify" in a follow-up PR:

````
$ rg "Verify SSL"
guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
20:. Select *Verify SSL* to verify that the SSL certificates of the repository are signed by a trusted CA.

guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
30:. If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.

guides/common/modules/proc_adding-custom-rpm-repositories.adoc
36:. Select the *Verify SSL* checkbox if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.

guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
20:. If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.

guides/common/modules/proc_synchronizing-python-repositories.adoc
17:. Optional: Unselect *Verify SSL* if you do not want {ProjectServer} to verify the SSL certificate of the upstream content source.

guides/common/modules/proc_adding-custom-deb-repositories.adoc
45:. Optional: Select the *Verify SSL* checkbox if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.

guides/common/modules/proc_creating-a-webhook.adoc
22:. Optional: Uncheck *Verify SSL* if you do not want to verify the server certificate against the system certificate store or {Project} CA.

guides/common/modules/proc_importing-ostree-content.adoc
26:. Optional: Select the *Verify SSL* checkbox if you want to verify that the upstream repository's SSL certificates are signed by a trusted CA.
````

I considered dropping content that's obvious from the WebUI too but decided that I'd rather quickly fix the drift docs <-> WebUI for now.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
