### PR TITLE
Add SCA migration prerequisite

### DIFF
--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -20,8 +20,8 @@ For more information, see {InstallingServerDocURL}Preparing_your_Environment_for
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 ifdef::satellite[]
-* Migrate all organizations to Simple Content Access.
-For more information, see https://access.redhat.com/articles/simple-content-access[Simple Content Access].
+* Migrate all organizations to Simple Content Access (SCA).
+For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/articles/simple-content-access[Simple Content Access]. 
 
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -19,8 +19,10 @@ For more information, see {InstallingServerDocURL}Preparing_your_Environment_for
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
-
 ifdef::satellite[]
+* Migrate all organizations to Simple Content Access.
+For more information, see https://access.redhat.com/articles/simple-content-access[Simple Content Access].
+
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]
 

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -56,6 +56,13 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
+. Optional: If you haven't migrated all the organizations to Simple Content Access, auto-migrate the organizations while upgrading:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-maintain} upgrade run --whitelist="check-organization-content-access-mode"
+---- 
+
 . Optional: Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -56,13 +56,6 @@ These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
 
-. Optional: If you haven't migrated all the organizations to Simple Content Access, auto-migrate the organizations while upgrading:
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} upgrade run --whitelist="check-organization-content-access-mode"
----- 
-
 . Optional: Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +


### PR DESCRIPTION
As the latest release supports only SCA mode, it is required that all orgs be migrated to SCA before upgrade. Adding this as a prerequisite

JIRA: https://issues.redhat.com/browse/SAT-26365

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [X] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
