### PR TITLE
Fix command to reset Keycloak authentication

### DIFF
--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -72,5 +72,5 @@ Use `hammer-openidc` as the application name.
 
 [NOTE]
 ====
-To disable {keycloak} authentication in {Project}, reset {keycloak} support to the default value by using `{foreman-maintain} --reset-foreman-keycloak`.
+To disable {keycloak} authentication in {Project}, reset {keycloak} support to the default value by using `{foreman-installer} --reset-foreman-keycloak`.
 ====


### PR DESCRIPTION
#### What changes are you introducing?

The correct command to use when resetting Keycloak authentication is foreman-installer, not foreman-maintain.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This is a mistake I made in a previous PR.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Thanks to @lhellebr for pointing this out.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
