### PR TITLE
Update Quarkus-based Keycloak procedures

### DIFF
--- a/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
+++ b/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
@@ -18,6 +18,8 @@ To authenticate to the {ProjectWebUI} by using {keycloak} TOTP:
 . On your first login attempt, {keycloak} requests you to configure your client by scanning the bar code and entering your PIN.
 Once authenticated, your browser redirects you back to {Project} and logs you in.
 
+To authenticate to the {Project} CLI with Hammer:
+
 . Ensure that Hammer is configured to enforce session usage in `~/.hammer/cli.modules.d/foreman.yml`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -25,7 +27,27 @@ Once authenticated, your browser redirects you back to {Project} and logs you in
 :foreman:
   :use_sessions: true
 ----
-. Initiate an authentication session:
+. Initiate an authentication session with `hammer auth login oauth`:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# hammer auth login oauth \
+--oidc-token-endpoint 'https://_{keycloak-example-com}_/auth/realms/_{Project}_realm_/protocol/openid-connect/token' \
+--oidc-authorization-endpoint 'https://_{keycloak-example-com}_/auth' \
+--oidc-client-id '_{foreman-example-com}_-hammer-openidc' \
+--oidc-redirect-uri urn:ietf:wg:oauth:2.0:oob
+----
+
+To authenticate to the {Project} CLI with Hammer by using {keycloak} TOTP:
+
+. Ensure that Hammer is configured to enforce session usage in `~/.hammer/cli.modules.d/foreman.yml`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+:foreman:
+  :use_sessions: true
+----
+. Initiate an authentication session by using `--two-factor` with `hammer auth login oauth`:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -36,18 +58,9 @@ Once authenticated, your browser redirects you back to {Project} and logs you in
 --oidc-client-id '_{foreman-example-com}_-hammer-openidc' \
 --oidc-redirect-uri urn:ietf:wg:oauth:2.0:oob
 ----
-+
-You will be prompted to enter a success code.
-. To retrieve the success code, navigate to the URL that the command returns.
+. You will be prompted to enter a success code.
+To retrieve the success code, navigate to the URL that the command returns.
 . Enter the success code in CLI.
-
-To authenticate to the {ProjectWebUI} by using {keycloak} TOTP authentication:
-
-. In your browser, log in to {Project}.
-{Project} redirects you to the {keycloak} login screen.
-. Enter your username and password, and click *Log In*.
-. On your first login attempt, {keycloak} requests you to configure your client by scanning the bar code and entering your PIN.
-Once authenticated, your browser redirects you back to {Project} and logs you in.
 
 ifndef::satellite,orcharhino[]
 To log in to the {ProjectWebUI} using the {keycloak} {PIV} cards:

--- a/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
+++ b/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
@@ -27,7 +27,7 @@ To authenticate to the {Project} CLI with Hammer by using the code grant type:
 --two-factor \
 --oidc-token-endpoint 'https://_{keycloak-example-com}_/auth/realms/_{Project}_realm_/protocol/openid-connect/token' \
 --oidc-authorization-endpoint 'https://_{keycloak-example-com}_/auth' \
---oidc-client-id '_{foreman-example-com}_-foreman-openidc' \
+--oidc-client-id '_{foreman-example-com}_-hammer-openidc' \
 --oidc-redirect-uri urn:ietf:wg:oauth:2.0:oob
 ----
 +

--- a/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
+++ b/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
@@ -10,7 +10,13 @@ To authenticate to the {ProjectWebUI}:
 
 * In your browser, go to `https://_{foreman-example-com}_` and enter your credentials.
 
-To authenticate to the {Project} CLI with Hammer by using the code grant type:
+To authenticate to the {ProjectWebUI} by using {keycloak} TOTP:
+
+. In your browser, log in to {Project}.
+{Project} redirects you to the {keycloak} login screen.
+. Enter your username and password, and click *Log In*.
+. On your first login attempt, {keycloak} requests you to configure your client by scanning the bar code and entering your PIN.
+Once authenticated, your browser redirects you back to {Project} and logs you in.
 
 . Ensure that Hammer is configured to enforce session usage in `~/.hammer/cli.modules.d/foreman.yml`:
 +

--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -64,7 +64,7 @@ Use `hammer-openidc` as the application name.
 --keycloak-auth-role root-admin \
 -t openidc -l /users/extlogin --force
 ----
-.. Configure {Project} to use {keycloak} as an authentication source for CLI:
+.. Configure {Project} to use {keycloak} as an authentication source for Hammer CLI:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----

--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -27,12 +27,6 @@ On your {ProjectServer}:
 # {project-package-install} mod_auth_openidc keycloak-httpd-client-install python3-lxml
 ----
 // python3-lxml is only needed on EL8 because of https://issues.redhat.com/browse/RHEL-31496
-. If you have previously used `{foreman-installer}` to enable {keycloak} authentication, reset it to clear the previous configuration:
-+
-[options="nowrap", subs="verbatim,quotes,attributes"]
-----
-# {foreman-installer} --reset-foreman-keycloak
-----
 . Choose the authentication method you want {keycloak} users to use when authenticating to {Project}:
 * If you want users to authenticate by using the {ProjectWebUI}:
 .. Create a client for {Project}.
@@ -77,6 +71,12 @@ Use `hammer-openidc` as the application name.
 # {foreman-installer} --foreman-keycloak true \
 --foreman-keycloak-app-name "hammer-openidc" \
 --foreman-keycloak-realm "_{Project}_Realm_"
+----
+.. Reset {keycloak} support to the default value to ensure that users are not authenticated also in {ProjectWebUI}:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# {foreman-installer} --reset-foreman-keycloak
 ----
 . Restart the `httpd` service:
 +

--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -27,6 +27,12 @@ On your {ProjectServer}:
 # {project-package-install} mod_auth_openidc keycloak-httpd-client-install python3-lxml
 ----
 // python3-lxml is only needed on EL8 because of https://issues.redhat.com/browse/RHEL-31496
+. If you have previously used `{foreman-installer}` to enable {keycloak} authentication, reset it to clear the previous configuration:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# {foreman-installer} --reset-foreman-keycloak
+----
 . Choose the authentication method you want {keycloak} users to use when authenticating to {Project}:
 * If you want users to authenticate by using the {ProjectWebUI}:
 .. Create a client for {Project}.

--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -42,7 +42,7 @@ Use `foreman-openidc` as the application name.
 --keycloak-auth-role root-admin \
 -t openidc -l /users/extlogin --force
 ----
-.. Configure {Project} to use {keycloak} as an authentication source:
+.. Configure {Project} to use {keycloak} as an authentication source for {ProjectWebUI}:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
@@ -50,7 +50,8 @@ Use `foreman-openidc` as the application name.
 --foreman-keycloak-app-name "foreman-openidc" \
 --foreman-keycloak-realm "_{Project}_Realm_"
 ----
-* If you want users to authenticate by using the Hammer CLI, create a client for {Project}.
+* If you want users to authenticate by using the Hammer CLI:
+.. Create a client for {Project}.
 Use `hammer-openidc` as the application name.
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
@@ -62,6 +63,14 @@ Use `hammer-openidc` as the application name.
 --keycloak-admin-realm master \
 --keycloak-auth-role root-admin \
 -t openidc -l /users/extlogin --force
+----
+.. Configure {Project} to use {keycloak} as an authentication source for CLI:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# {foreman-installer} --foreman-keycloak true \
+--foreman-keycloak-app-name "hammer-openidc" \
+--foreman-keycloak-realm "_{Project}_Realm_"
 ----
 . Restart the `httpd` service:
 +


### PR DESCRIPTION
#### What changes are you introducing?

This PR adds a couple of more commands and clarification bits to the procedure for configuring Keycloak.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

QE is testing the procedures to configure the Quarkus distribution of Keycloak as an external authentication source.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
