### PR TITLE
Add a rebase step to branching instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ When a commit is pushed into `X.Y`:
 
 ## Branching new release
 
-* Create a new `X.Y` branch.
+* On `master`, pull the latest changes and create a new `X.Y` branch.
+* On `X.Y`:
   * Update `guides/common/attributes.adoc`
     * Set `DocState` to `unsupported`
     * Set `ProjectVersion` to `X.Y` and set the matching `KatelloVersion`
   * Push into `X.Y` branch.
   * Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel
-* Update master
+* On `master`:
   * Update `ProjectVersionPrevious` to `X.Y` in `guides/common/attributes.adoc`
   * Create a copy of [/web/releases/nightly.json](https://github.com/theforeman/foreman-documentation/tree/master/web/releases/nightly.json) as `X.Y.json` and edit it accordingly.
     * Set the `state` to `RC`

--- a/README.md
+++ b/README.md
@@ -59,24 +59,24 @@ When a commit is pushed into `X.Y`:
 
 * On `master`, pull the latest changes and create a new `X.Y` branch.
 * On `X.Y`:
-  * Update `guides/common/attributes.adoc`
-    * Set `DocState` to `unsupported`
-    * Set `ProjectVersion` to `X.Y` and set the matching `KatelloVersion`
+  * Update `guides/common/attributes.adoc`.
+    * Set `DocState` to `unsupported`.
+    * Set `ProjectVersion` to `X.Y` and set the matching `KatelloVersion`.
   * Push into `X.Y` branch.
-  * Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel
+  * Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel.
 * On `master`:
-  * Update `ProjectVersionPrevious` to `X.Y` in `guides/common/attributes.adoc`
+  * Update `ProjectVersionPrevious` to `X.Y` in `guides/common/attributes.adoc`.
   * Create a copy of [/web/releases/nightly.json](https://github.com/theforeman/foreman-documentation/tree/master/web/releases/nightly.json) as `X.Y.json` and edit it accordingly.
-    * Set the `state` to `RC`
-    * Change `katello` to the right version
-    * Change `Nightly` in titles to the appropriate version
+    * Set the `state` to `RC`.
+    * Change `katello` to the right version.
+    * Change `Nightly` in titles to the appropriate version.
     * Remove guides which aren't ready for stable branches.
   * Create a copy of [/web/releases/nightly.adoc](https://github.com/theforeman/foreman-documentation/tree/master/web/releases/nightly.adoc) as `X.Y.adoc` and edit it accordingly. Remove guides which aren't ready for stable branches.
   * Test the changes by following the instructions in [/web/README.md](https://github.com/theforeman/foreman-documentation/tree/master/web/README.md) to deploy the website locally.
   * Add the new Foreman version to [/.github/PULL_REQUEST_TEMPLATE.md](https://github.com/theforeman/foreman-documentation/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
   * Update `VERSION_LINKS` in the root `Makefile`.
   * Push the changes into `master`.
-* Check the site if links and landing page appeared correctly. HTML guides should be deployed into `/X.Y`
+* Check the site if links and landing page appeared correctly. HTML guides should be deployed into `/X.Y`.
 
 ## License
 


### PR DESCRIPTION
#### What changes are you introducing?

I'm adding a new step to the branching procedure to include rebasing the new branch on top of master.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

During the latest branching, the new branch initially missed a few commits from master. Adding the step could help prevent that next time.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
