### PR TITLE
Add CLI procedure for syncing content view

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -10,6 +10,8 @@ include::modules/proc_creating-a-content-view.adoc[leveloffset=+1]
 
 include::modules/proc_copying-a-content-view.adoc[leveloffset=+1]
 
+include::modules/proc_synchronizing-a-content-view-to-a-smartproxy.adoc[leveloffset=+1]
+
 include::modules/proc_viewing-module-streams.adoc[leveloffset=+1]
 
 include::modules/proc_promoting-a-content-view.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_synchronizing-a-content-view-to-a-smartproxy.adoc
+++ b/guides/common/modules/proc_synchronizing-a-content-view-to-a-smartproxy.adoc
@@ -1,0 +1,16 @@
+[id="Synchronizing_a_Content_View_to_a_{smart-proxy-context}_{context}"]
+= Synchronizing a content view to a {SmartProxy}
+
+In the {ProjectWebUI}, you can only synchronize all selected lifecycle environments simultaneously.
+If you need to synchronize smaller items, such as individual lifecycle environments, single content views, and single repositories, use the Hammer CLI.
+
+.CLI procedure
+* Synchronize a content view to your {SmartProxy} by using Hammer:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ {hammer-smart-proxy} content synchronize --content-view "my content view name"
+----
+
+.Additional resources
+* For more information about the command, run `{hammer-smart-proxy} content synchronize --help`.


### PR DESCRIPTION
A CLI procedure for synchronizing a content view has been added to the
Content Management Guide related to
https://issues.redhat.com/browse/SAT-13027.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
