### PR TITLE
Add Puppet 8 as a headline feature

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -4,7 +4,13 @@
 [id="foreman-headline-features"]
 == Headline Features
 
-There are no highlights with Foreman {ProjectVersion}.
+=== Puppet 8 support
+
+Foreman 3.12 now fully supports Puppet 8.
+While Foreman 3.11 unofficially supported Puppet 8, Puppet's official puppetserver RPMs are known to break on Java.
+The installer now handles this for users.
+For more information, see #37686[https://projects.theforeman.org/issues/37686].
+Users are encouraged to upgrade since Puppet 7 is expected to go end of life in February 2025.
 
 [id="foreman-upgrade-warnings"]
 == Upgrade Warnings


### PR DESCRIPTION
#### What changes are you introducing?

Foreman 3.12 supports Puppet 8. While the manual hasn't been updated, this helps to announce RC1.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://projects.theforeman.org/issues/37686 was the last blocker.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.