### PR TITLE
Use RHEL 9 when creating a remote source for custom file type

### DIFF
--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -27,6 +27,8 @@ ifdef::katello[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el9/x86_64/
+# echo "gpgkey=https://yum.theforeman.org/pulpcore/3.63/GPG-RPM-KEY-pulpcore" \
+>> /etc/yum.repos.d/yum.theforeman.org_pulpcore_3.63_el9_x86_64_.repo
 ----
 endif::[]
 ifdef::satellite[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -28,7 +28,7 @@ ifdef::katello[]
 ----
 # dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el9/x86_64/
 # echo "gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore" \
->> /etc/yum.repos.d/yum.theforeman.org_pulpcore_3.63_el9_x86_64_.repo
+>> /etc/yum.repos.d/yum.theforeman.org_pulpcore_{PulpcoreVersion}_el9_x86_64_.repo
 ----
 endif::[]
 ifdef::satellite[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -27,7 +27,7 @@ ifdef::katello[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el9/x86_64/
-# echo "gpgkey=https://yum.theforeman.org/pulpcore/3.63/GPG-RPM-KEY-pulpcore" \
+# echo "gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore" \
 >> /etc/yum.repos.d/yum.theforeman.org_pulpcore_3.63_el9_x86_64_.repo
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -9,10 +9,10 @@ To create a file type repository in a directory on the base system where {Projec
 
 .Prerequisites
 ifdef::katello,orcharhino[]
-* You have a server running {EL} 9 registered to your {Project}.
+* You have a server running {EL} 9 or {EL} 8 registered to your {Project}.
 endif::[]
 ifdef::satellite[]
-* You have a server running {EL} 9 registered to your {Project} or the Red{nbsp}Hat CDN.
+* You have a server running {EL} 9 or {EL} 8 registered to your {Project} or the Red{nbsp}Hat CDN.
 * Your server has an entitlement to the {RHELServer} and {ProjectName} Utils repositories.
 endif::[]
 * You have installed an HTTP server.
@@ -21,6 +21,14 @@ For more information about configuring a web server, see {RHELDocsBaseURL}9/html
 endif::[]
 
 .Procedure
+ifdef::katello[]
+. On your server, enable the required repositories:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/nightly/el9/x86_64/
+----
+endif::[]
 ifdef::satellite[]
 . On your server, enable the required repositories:
 +

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -9,10 +9,10 @@ To create a file type repository in a directory on the base system where {Projec
 
 .Prerequisites
 ifdef::katello,orcharhino[]
-* You have a server running {EL} 9 or {EL} 8 registered to your {Project}.
+* You have a server running {EL} 9 registered to your {Project}.
 endif::[]
 ifdef::satellite[]
-* You have a server running {EL} 9 or {EL} 8 registered to your {Project} or the Red{nbsp}Hat CDN.
+* You have a server running {EL} 9 registered to your {Project} or the Red{nbsp}Hat CDN.
 * Your server has an entitlement to the {RHELServer} and {ProjectName} Utils repositories.
 endif::[]
 * You have installed an HTTP server.
@@ -26,7 +26,7 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/nightly/el9/x86_64/
+# dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el9/x86_64/
 ----
 endif::[]
 ifdef::satellite[]


### PR DESCRIPTION
Satellite Utils repo incorrectly refers to RHEL 8 where 
it should
mention RHEL 9. A new attribute was created for 
Satellite Utils for
RHEL 9. See https://issues.redhat.com/browse/SAT-26200

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
