### PR TITLE
Add organization to export repo without error

### DIFF
--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -34,14 +34,14 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 * Ensure that you synchronize products that you export to the required date.
 
 .Procedure
-. Export a repository using the product name and repository name:
+. Export a repository using the product, repository, and organization names:
 +
 [options="nowrap" subs="+quotes"]
 ----
 # hammer content-export complete repository \
---name="_My_Repository_" \
---organization="_My_Organization" \
---product="_My_Product_"
+--name="My_Repository" \
+--product="My_Product"  \
+--organization="My_Organization"
 ----
 +
 [NOTE]

--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -39,9 +39,9 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 [options="nowrap" subs="+quotes"]
 ----
 # hammer content-export complete repository \
---name="My_Repository" \
---product="My_Product"  \
---organization="My_Organization"
+--name="_My_Repository_" \
+--product="_My_Product_"  \
+--organization="_My_Organization_"
 ----
 +
 [NOTE]

--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -34,7 +34,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 * Ensure that you synchronize products that you export to the required date.
 
 .Procedure
-. Export a repository using the product, repository, and organization names:
+. Export a repository:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -26,10 +26,6 @@ include::common/modules/proc_configuring-server-to-consume-content-from-a-custom
 
 include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+2]
 
-include::common/assembly_importing-kickstart-repositories.adoc[leveloffset=+2]
-
-include::common/assembly_importing-the-project-client-name-repository.adoc[leveloffset=+2]
-
 include::common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc[leveloffset=+2]
 
 include::common/modules/proc_enabling-power-management-on-hosts.adoc[leveloffset=+2]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -26,6 +26,10 @@ include::common/modules/proc_configuring-server-to-consume-content-from-a-custom
 
 include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+2]
 
+include::common/assembly_importing-kickstart-repositories.adoc[leveloffset=+2]
+
+include::common/assembly_importing-the-project-client-name-repository.adoc[leveloffset=+2]
+
 include::common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc[leveloffset=+2]
 
 include::common/modules/proc_enabling-power-management-on-hosts.adoc[leveloffset=+2]


### PR DESCRIPTION
The command for exporting a repository resulted in 
error until a flag
for organization was added. The organization's name has 
been added to
the command to fix the error. See https://issues.redhat.com/browse/SAT-26583.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
