### PR TITLE
Configure host for global registration

### DIFF
--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -11,6 +11,8 @@ include::modules/con_registering-hosts-by-using-global-registration.adoc[levelof
 
 include::modules/ref_global-parameters-for-registration.adoc[leveloffset=+2]
 
+include::modules/proc_configuring-a-host-for-registration.adoc[leveloffset=+2]
+
 include::modules/proc_registering-a-host.adoc[leveloffset=+2]
 
 include::modules/proc_customizing-host-registration-by-using-snippets.adoc[leveloffset=+2]

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -2,24 +2,79 @@
 = Configuring a host for registration
 
 Configure your host for registration to {ProjectServer} or {SmartProxyServer}.
+You can use a configuration management tool to configure multiple hosts at once.
 
 .Prerequisites
 * The host must be using a supported operating system.
 For more information, see xref:supported-clients-in-registration_{context}[].
+ifdef::satellite,orcharhino,katello[]
+* {ProjectServer} and any {SmartProxyServers} must have a time-synchronization tool enabled and running and be synchronized with the same NTP server.
+For more information, see the following resources:
+** link:{InstallingServerDocURL}synchronizing-the-system-clock-with-chronyd_{project-context}[Synchronizing the system clock with chronyd] in _{InstallingServerDocTitle}_
+ifdef::satellite[]
+** link:{InstallingServerDisconnectedDocURL}synchronizing-the-system-clock-with-chronyd_{project-context}[Synchronizing the system clock with chronyd] in _{InstallingServerDisconnectedDocTitle}_
+endif::[]
+** link:{InstallingSmartProxyDocURL}synchronizing-the-system-clock-with-chronyd_{smart-proxy-context}[Synchronizing the system clock with chronyd] in _{InstallingSmartProxyDocTitle}_
+endif::[]
 
 .Procedure
-* Ensure that a time-synchronization tool is enabled and running on the host.
+ifdef::satellite,orcharhino,katello[]
+. Enable and start a time-synchronization tool on your host.
+The host must be synchronized with the same NTP server as {ProjectServer} and any {SmartProxyServers}.
 ifdef::client-content-dnf[]
-** For {EL} 7 and newer:
+** On {EL} 7 and later:
 +
 ----
 # systemctl enable --now chronyd
 ----
-** For {EL} 6:
+** On {EL} 6:
 +
 ----
 # chkconfig --add ntpd
 # chkconfig ntpd on
 # service ntpd start
+----
+endif::[]
+endif::[]
+. Deploy the SSL CA file on your host so that the host can make a secured registration call.
+.. Find where {Project} stores the SSL CA file by navigating to *Administer* > *Settings* > *Authentication* and locating the value of the *SSL CA file* setting.
+.. Transfer the SSL CA file to your host securely, for example by using `scp`.
+.. Login to your host by using SSH.
+.. Copy the certificate to the truststore:
+ifdef::client-content-dnf[]
+ifndef::satellite[]
+* On {EL}:
+endif::[]
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp _My_SSL_CA_file_.pem /etc/pki/ca-trust/source/anchors
+----
+endif::[]
+ifdef::client-content-apt[]
+* On {DL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp _My_SSL_CA_file_.pem /usr/local/share/ca-certificates/
+----
+endif::[]
+.. Update the truststore:
+ifdef::client-content-dnf[]
+ifndef::satellite[]
+* On {EL}:
+endif::[]
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# update-ca-trust
+----
+endif::[]
+ifdef::client-content-apt[]
+* On {DL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# update-ca-certificates
 ----
 endif::[]

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -4,10 +4,11 @@
 You can register a host by using registration templates and set up various integration features and host tools during the registration process.
 
 .Prerequisites
-* Your user account has a role assigned that has the `create_hosts` permission.
+* Your user account has a role assigned that grants the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
+* You have configured the host for registration.
+For more information, see xref:Configuring_a_Host_for_Registration_{context}[].
 ifdef::satellite,orcharhino,katello[]
-* {ProjectServer}, any {SmartProxyServers}, and all hosts must be synchronized with the same NTP server, and have a time synchronization tool enabled and running.
 * An activation key must be available for the host.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
@@ -54,39 +55,13 @@ The registration details that you can specify include the following:
 * On the *General* tab, in the *{SmartProxy}* field, you can select the {SmartProxy} to register hosts through.
 A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
 * On the *General* tab, you can select the *Insecure* option to make the first call insecure.
-During this first call, hosts download the CA file from {Project}.
-Hosts will use this CA file to connect to {Project} with all future calls making them secure.
+During this first call, the host downloads the CA file from {Project}.
+The host will use this CA file to connect to {Project} with all future calls making them secure.
 +
 {Team} recommends that you avoid insecure calls.
 +
 If an attacker, located in the network between {Project} and a host, fetches the CA file from the first insecure call, the attacker will be able to access the content of the API calls to and from the registered host and the JSON Web Tokens (JWT).
 Therefore, if you have chosen to deploy SSH keys during registration, the attacker will be able to access the host using the SSH key.
-+
-Instead, you can manually copy and install the CA file on each host before registering the host.
-+
-To do this, find where {Project} stores the CA file by navigating to *Administer* > *Settings* > *Authentication* and locating the value of the *SSL CA file* setting.
-+
-Copy the CA file to the `/etc/pki/ca-trust/source/anchors/` directory on hosts and enter the following commands:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# update-ca-trust enable
-# update-ca-trust
-----
-+
-Then register the hosts with a secure `curl` command, such as:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# curl -sS https://{foreman-example-com}/register ...
-----
-+
-The following is an example of the `curl` command with the `--insecure` option:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# curl -sS --insecure https://{foreman-example-com}/register ...
-----
 * On the *Advanced* tab, in the *Repositories* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.


### PR DESCRIPTION
#### What changes are you introducing?

A host needs to be configured a certain way before it can be registered by using Global Registration and that isn't properly documented at the present time.

We have a _Configure a host for registration_ module, but we don't use it in the _Managing Hosts_ guide currently, which we should. Originally, it covered only the NTP synchronization.

Also, we should provide a prerequisite so that the user can make a secured curl call right away. The CA certificate config is now also included in the pre-registration configuration.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because it's better to tell the user how the host must be configured for registration beforehand instead of explaining it when it's "too late".

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Depends on #3193

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
