### PR TITLE
Manually set global Git configuration in proc to sync templates with an existing repo

### DIFF
--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -5,6 +5,25 @@ Use this procedure to synchronize templates between your {ProjectServer} and an 
 
 .Procedure
 . If you want to use HTTPS to connect to the repository and you use a self-signed certificate authentication on your Git server:
+.. Create a new directory under the `/usr/share/foreman/` directory to store the Git configuration for the certificate:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# mkdir -p /usr/share/foreman/.config/git
+----
+.. Create a file named `config` in the new directory:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# touch /usr/share/foreman/.config/git/config
+----
+.. Allow the `foreman` user access to the `.config` directory:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# chown -R foreman /usr/share/foreman/.config
+----
++
 .. Validate the certificate:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -23,7 +23,6 @@ Use this procedure to synchronize templates between your {ProjectServer} and an 
 ----
 # chown --recursive foreman /usr/share/foreman/.config
 ----
-+
 .. Update the Git global configuration for the `foreman` user with the path to your self-signed CA certificate:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -9,7 +9,7 @@ Use this procedure to synchronize templates between your {ProjectServer} and an 
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# mkdir -p /usr/share/foreman/.config/git
+# mkdir --parents /usr/share/foreman/.config/git
 ----
 .. Create a file named `config` in the new directory:
 +
@@ -21,28 +21,28 @@ Use this procedure to synchronize templates between your {ProjectServer} and an 
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# chown -R foreman /usr/share/foreman/.config
+# chown --recursive foreman /usr/share/foreman/.config
 ----
 +
 .. Update the Git global configuration for the `foreman` user with the path to your self-signed CA certificate:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# sudo -u foreman git config --global http.sslCAPath _Path_To_CA_Certificate_
+# sudo --user foreman git config --global http.sslCAPath _Path_To_CA_Certificate_
 ----
 . If you want to use SSH to connect to the repository:
 .. Create an SSH key pair if you do not already have it.
 Do not specify a passphrase.
 +
 ----
-# sudo -u foreman ssh-keygen
+# sudo --user foreman ssh-keygen
 ----
 .. Configure your version control server with the public key from your {Project}, which resides in `/usr/share/foreman/.ssh/id_rsa.pub`.
 .. Accept the Git SSH host key as the `foreman` user:
 +
 [subs="+quotes"]
 ----
-# sudo -u foreman ssh _git.example.com_
+# sudo --user foreman ssh _git.example.com_
 ----
 . Configure the TemplateSync plugin settings on a *TemplateSync* tab.
 .. Change the *Branch* setting to match the target branch on a Git server.

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -4,13 +4,14 @@
 Use this procedure to synchronize templates between your {ProjectServer} and an existing repository.
 
 .Procedure
-. If you want to use HTTPS to connect to the repository and you use a self-signed certificate authentication on your Git server, validate the certificate:
+. If you want to use HTTPS to connect to the repository and you use a self-signed certificate authentication on your Git server:
+.. Validate the certificate:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # sudo -u foreman git config --global http.sslCAPath _Path_To_My_Certificate_
 ----
-. If you want to use SSH to connect to the repository, perform the following steps:
+. If you want to use SSH to connect to the repository:
 .. Create an SSH key pair if you do not already have it.
 Do not specify a passphrase.
 +

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -4,7 +4,7 @@
 Use this procedure to synchronize templates between your {ProjectServer} and an existing repository.
 
 .Procedure
-. If you want to use HTTPS to connect to the repository and you use a self-signed certificate authentication on your Git server:
+. If you want to use HTTPS to connect to the repository and you use a self-signed certificate authority (CA) on your Git server:
 .. Create a new directory under the `/usr/share/foreman/` directory to store the Git configuration for the certificate:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
@@ -24,11 +24,11 @@ Use this procedure to synchronize templates between your {ProjectServer} and an 
 # chown -R foreman /usr/share/foreman/.config
 ----
 +
-.. Validate the certificate:
+.. Update the Git global configuration for the `foreman` user with the path to your self-signed CA certificate:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# sudo -u foreman git config --global http.sslCAPath _Path_To_My_Certificate_
+# sudo -u foreman git config --global http.sslCAPath _Path_To_CA_Certificate_
 ----
 . If you want to use SSH to connect to the repository:
 .. Create an SSH key pair if you do not already have it.


### PR DESCRIPTION
#### What changes are you introducing?
Attempting to update the Git global config for the `foreman` user fails due to insufficient permissions. Adding steps to manually create the config file as well as set the appropriate permissions on the file ensures that it gets updated as expected.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-27104

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
The proposed solution might be considered hacky by some but it looks like [SAT-27349](https://issues.redhat.com/browse/SAT-27349) should make the whole section obsolete in a future version.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
