### PR TITLE
Improve creating permissions table

### DIFF
--- a/guides/common/modules/proc_creating-a-complete-permission-table.adoc
+++ b/guides/common/modules/proc_creating-a-complete-permission-table.adoc
@@ -3,22 +3,24 @@
 
 Use the {Project} CLI to create a permission table.
 
-.Procedure
-. Ensure that the required packages are installed.
-Execute the following command on {ProjectServer}:
+ifndef::satellite[]
+.Prerequisites
+* Ensure that the `foreman-console` package is installed on {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {project-package-install} foreman-console
 ----
+endif::[]
+
+.Procedure
 . Start the {Project} console with the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # foreman-rake console
 ----
-+
-Insert the following code into the console:
+. Insert the following code into the console:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -34,14 +36,13 @@ f.write(result)
 +
 The above syntax creates a table of permissions and saves it to the `/tmp/table.html` file.
 . Press `*Ctrl*` + `*D*` to exit the {Project} console.
-Insert the following text at the first line of `/tmp/table.html`:
+. Insert the following text at the first line of `/tmp/table.html`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 <table border="1"><tr><td>Permission name</td><td>Actions</td><td>Resource type</td></tr>
 ----
-+
-Append the following text at the end of `/tmp/table.html`:
+. Append the following text at the end of `/tmp/table.html`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Moving the package requirement to prerequisites. The package exists only in Foreman, there's no need to install it in Satellite. + Additional beautification.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In Satellite, installing the package is not only unneccessary but also impossible, it doesn't exist.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Not sure about the package in orcharhino.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
