### PR TITLE
Update client repository to satellite-6-client-2

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -117,6 +117,7 @@
 :project-allcaps: FOREMAN
 :project-client-url: https://yum.theforeman.org/client/{ProjectVersion}
 :project-client-name: {project-client-url}[Foreman Client]
+:project-client-2-name: {project-client-name}
 :project-client-RHEL7-url: {project-client-url}/el7/x86_64/foreman-client-release.rpm
 :project-client-RHEL8-url: {project-client-url}/el8/x86_64/foreman-client-release.rpm
 :project-context: foreman

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -40,6 +40,7 @@
 :installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content
 :installer-scenario: foreman-installer --scenario katello
 :project-client-name: {Project}{nbsp}Client
+:project-client-2-name: {project-client-name}
 :project-minimum-memory: 20 GB
 :smart-proxy-context: orcharhino-proxy
 :smart-proxy-context-titlecase: orcharhino_Proxy

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -138,13 +138,13 @@
 
 // For a release
 :RepoSatelliteVersion: {ProjectVersion}
-:project-client-2-name: satellite-6-client-2
+:project-client-name: satellite-6-client-2
 
 // RHEL 9 Satellite repos
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
-:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-9-<arch>-rpms
+:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-name}-for-rhel-9-<arch>-rpms
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
@@ -152,14 +152,14 @@
 :RepoRHEL8ServerSatelliteMaintenanceProjectVersionPrevious: satellite-maintenance-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersionPrevious: satellite-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
-:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-8-<arch>-rpms
+:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-name}-for-rhel-8-<arch>-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
 :RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
-:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-7-<arch>-rpms
+:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-name}-for-rhel-7-<arch>-rpms
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -144,7 +144,8 @@
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
-:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-9-<arch>-rpms
+:RepoRHEL9ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-9-<arch>-rpms
+:RepoRHEL9ServerSatelliteTools2ProjectVersion: rhel-9-server-{project-client-2-name}-rpms
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
@@ -152,14 +153,16 @@
 :RepoRHEL8ServerSatelliteMaintenanceProjectVersionPrevious: satellite-maintenance-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersionPrevious: satellite-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
-:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-8-<arch>-rpms
+:RepoRHEL8ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-8-<arch>-rpms
+:RepoRHEL8ServerSatelliteTools2ProjectVersion: rhel-8-server-{project-client-2-name}-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
 :RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
-:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-7-<arch>-rpms
+:RepoRHEL7ServerSatelliteToolsProjectVersion: rhel-7-server-satellite-client-6-rpms
+:RepoRHEL7ServerSatelliteTools2ProjectVersion: rhel-7-server-{project-client-2-name}-rpms
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -138,12 +138,13 @@
 
 // For a release
 :RepoSatelliteVersion: {ProjectVersion}
+:project-client-2-name: satellite-6-client-2
 
 // RHEL 9 Satellite repos
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
-:RepoRHEL9ServerSatelliteToolsProjectVersion: satellite-6-client-2
+:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-2-name}
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
@@ -151,14 +152,14 @@
 :RepoRHEL8ServerSatelliteMaintenanceProjectVersionPrevious: satellite-maintenance-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersionPrevious: satellite-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
-:RepoRHEL8ServerSatelliteToolsProjectVersion: satellite-6-client-2
+:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-2-name}
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
 :RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
-:RepoRHEL7ServerSatelliteToolsProjectVersion: satellite-6-client-2
+:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-2-name}
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -143,7 +143,7 @@
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
-:RepoRHEL9ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-9-<arch>-rpms
+:RepoRHEL9ServerSatelliteToolsProjectVersion: satellite-6-client-2
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
@@ -151,14 +151,14 @@
 :RepoRHEL8ServerSatelliteMaintenanceProjectVersionPrevious: satellite-maintenance-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersionPrevious: satellite-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
-:RepoRHEL8ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-8-<arch>-rpms
+:RepoRHEL8ServerSatelliteToolsProjectVersion: satellite-6-client-2
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
 :RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
-:RepoRHEL7ServerSatelliteToolsProjectVersion: rhel-7-server-satellite-client-6-rpms
+:RepoRHEL7ServerSatelliteToolsProjectVersion: satellite-6-client-2
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -138,13 +138,13 @@
 
 // For a release
 :RepoSatelliteVersion: {ProjectVersion}
-:project-client-name: satellite-6-client-2
+:project-client-2-name: satellite-6-client-2
 
 // RHEL 9 Satellite repos
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
-:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-name}-for-rhel-9-<arch>-rpms
+:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-9-<arch>-rpms
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
@@ -152,14 +152,14 @@
 :RepoRHEL8ServerSatelliteMaintenanceProjectVersionPrevious: satellite-maintenance-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersionPrevious: satellite-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
-:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-name}-for-rhel-8-<arch>-rpms
+:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-8-<arch>-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
 :RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
-:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-name}-for-rhel-7-<arch>-rpms
+:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-7-<arch>-rpms
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -144,7 +144,7 @@
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
-:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-2-name}
+:RepoRHEL9ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-9-<arch>-rpms
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
@@ -152,14 +152,14 @@
 :RepoRHEL8ServerSatelliteMaintenanceProjectVersionPrevious: satellite-maintenance-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 :RepoRHEL8ServerSatelliteServerProjectVersionPrevious: satellite-{ProjectVersionPrevious}-for-rhel-8-x86_64-rpms
-:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-2-name}
+:RepoRHEL8ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-8-<arch>-rpms
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
 :RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
 :RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
-:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-2-name}
+:RepoRHEL7ServerSatelliteToolsProjectVersion: {project-client-2-name}-for-rhel-7-<arch>-rpms
 :RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
@@ -15,7 +15,7 @@ ifndef::satellite[]
 For more information, see xref:Installing_the_OpenSCAP_plugin_{context}[].
 endif::[]
 include::snip_prerequisite-repositories-with-oscap.adoc[]
-include::snip_prerequisite-project-client-repository-enabled.adoc[]
+include::snip_prerequisite-puppet-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
 * You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Puppet deployment option and assigned the host group.
 

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
@@ -15,7 +15,7 @@ ifndef::satellite[]
 For more information, see xref:Installing_the_OpenSCAP_plugin_{context}[].
 endif::[]
 include::snip_prerequisite-repositories-with-oscap.adoc[]
-include::snip_prerequisite-project-client-repository-enabled.adoc[]
+include::snip_prerequisite-puppet-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
 * You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Puppet deployment option.
 

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -19,7 +19,7 @@ endif::[]
 endif::[]
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-* Synchronize the `satellite-6-client-2` repository on {ProjectServer}, add it to the content view and the lifecycle environment of the host, and enable it for the host.
+* Synchronize the {project-client-2-name} repository on {ProjectServer}, add it to the content view and the lifecycle environment of the host, and enable it for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]
 ifndef::satellite,orcharhino[]

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -19,8 +19,7 @@ endif::[]
 endif::[]
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-* {project-client-name}-2 repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
-For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
+include::snip_prerequisite-project-client-repository-enabled.adoc[]
 endif::[]
 ifndef::satellite,orcharhino[]
 * Ensure a repository containing the Puppet agent is enabled on the host, for example https://apt.puppet.com/[apt.puppet.com] or https://yum.puppet.com/[yum.puppet.com].

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -19,7 +19,8 @@ endif::[]
 endif::[]
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-include::snip_prerequisite-project-client-repository-enabled.adoc[]
+* Synchronize the `satellite-6-client-2` repository on {ProjectServer}, add it to the content view and the lifecycle environment of the host, and enable it for the host.
+For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]
 ifndef::satellite,orcharhino[]
 * Ensure a repository containing the Puppet agent is enabled on the host, for example https://apt.puppet.com/[apt.puppet.com] or https://yum.puppet.com/[yum.puppet.com].

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -19,7 +19,7 @@ endif::[]
 endif::[]
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]
-* Synchronize the {project-client-2-name} repository on {ProjectServer}, add it to the content view and the lifecycle environment of the host, and enable it for the host.
+* {project-client-name}-2 repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]
 ifndef::satellite,orcharhino[]

--- a/guides/common/modules/snip_prerequisite-puppet-project-client-repository-enabled.adoc
+++ b/guides/common/modules/snip_prerequisite-puppet-project-client-repository-enabled.adoc
@@ -1,0 +1,7 @@
+ifdef::foreman-el[]
+* {project-client-name} repository is available on the host.
+endif::[]
+ifndef::foreman-el[]
+* `{project-client-2-name}` repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
+For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
+endif::[]

--- a/guides/common/modules/snip_prerequisite-puppet-project-client-repository-enabled.adoc
+++ b/guides/common/modules/snip_prerequisite-puppet-project-client-repository-enabled.adoc
@@ -2,6 +2,6 @@ ifdef::foreman-el[]
 * {project-client-name} repository is available on the host.
 endif::[]
 ifndef::foreman-el[]
-* `{project-client-2-name}` repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
+* The {project-client-2-name} repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]


### PR DESCRIPTION
- The newer versions support puppet-agent 8.
- The client repo is versionless and older versions use puppet-agent 7.
- To work around this, `satellite-6-client-2` is created for the later versions with puppet-agent 8.
- Removed the snippet linked in `Installing and configuring Puppet agent manually` as this snippet is used in multiple modules.

JIRA: https://issues.redhat.com/browse/SAT-27092

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
