### PR TITLE
Show URL to newly rendered upgrade guide for Foreman on Debian/Ubuntu in navigation

### DIFF
--- a/web/releases/3.11.adoc
+++ b/web/releases/3.11.adoc
@@ -27,7 +27,6 @@ Use the top menu bar for navigation for all guides.
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
 
-// Upgrading guides are not ready for non-Katello
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]

--- a/web/releases/3.11.json
+++ b/web/releases/3.11.json
@@ -33,6 +33,10 @@
           "path": "Release_Notes"
         },
         {
+          "title": "Upgrading Foreman to 3.11",
+          "path": "Upgrading_Project"
+        },
+        {
           "title": "Configuring hosts by using Ansible",
           "path": "Managing_Configurations_Ansible"
         },

--- a/web/releases/3.12.adoc
+++ b/web/releases/3.12.adoc
@@ -21,7 +21,6 @@ Use the top menu bar for navigation for all guides.
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
 
-// Upgrading guides are not ready for non-Katello
 * link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]

--- a/web/releases/3.12.json
+++ b/web/releases/3.12.json
@@ -41,6 +41,10 @@
           "path": "Quickstart"
         },
         {
+          "title": "Upgrading Foreman to 3.12",
+          "path": "Upgrading_Project"
+        },
+        {
           "title": "Configuring hosts by using Ansible",
           "path": "Managing_Configurations_Ansible"
         },

--- a/web/releases/nightly.adoc
+++ b/web/releases/nightly.adoc
@@ -7,26 +7,26 @@ Use the top menu bar for navigation for all guides.
 
 === Quickstart
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on RHEL/CentOS quickstart guide]
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on Enterprise Linux quickstart guide]
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS quickstart guide]
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on Enterprise Linux quickstart guide]
 
 === Installation
 
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on Enterprise Linux]
 * link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on Enterprise Linux]
 
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on Enterprise Linux]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on Enterprise Linux]
 
 === Upgrading
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on Enterprise Linux]
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on Enterprise Linux]
 
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on Enterprise Linux]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian/Ubuntu]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on Enterprise Linux]

--- a/web/releases/nightly.adoc
+++ b/web/releases/nightly.adoc
@@ -27,7 +27,6 @@ Use the top menu bar for navigation for all guides.
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
 * link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
 
-// Upgrading guides are not ready for non-Katello
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -85,6 +85,10 @@
           "path": "Installing_Server"
         },
         {
+          "title": "Upgrading Foreman to Nightly",
+          "path": "Upgrading_Project"
+        },
+        {
           "title": "Deploying Foreman on AWS",
           "path": "Deploying_Project_on_AWS"
         },


### PR DESCRIPTION
#### What changes are you introducing?

Show URLs in navigation & minor renaming of links on the overview page in a second commit.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because I forgot it in https://github.com/theforeman/foreman-documentation/pull/3225

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
