### PR TITLE
Filter repository by Status on Activation Key page

### DIFF
--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -7,7 +7,8 @@ You can enable or disable repositories on an activation key in the {ProjectWebUI
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.
 . Select an activation key.
 . Select the *Repository Sets* tab.
-. From the dropdown, you can filter the *Repository type* column to *Custom* or *Red Hat*, if desired.
+. Optional: Clear the *Limit to Environment* checkbox to view repositories that are available in the lifecycle environment of the activation key.
+. Optional: Use the *Repository type* dropdown menu to filter repositories by type.
 . Optional: Use the *Status* dropdown menu to filter repositories by status.
 . Select the desired repositories or click the *Select All* checkbox to select all repositories.
 . From the *Select Action* list, select *Override to Enabled*, *Override to Disabled*, or *Reset to Default*.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -8,5 +8,6 @@ You can enable or disable repositories on an activation key in the {ProjectWebUI
 . Select an activation key.
 . Select the *Repository Sets* tab.
 . From the dropdown, you can filter the *Repository type* column to *Custom* or *Red Hat*, if desired.
+. Optional: Use the *Status* dropdown menu to filter repositories by status.
 . Select the desired repositories or click the *Select All* checkbox to select all repositories.
 . From the *Select Action* list, select *Override to Enabled*, *Override to Disabled*, or *Reset to Default*.


### PR DESCRIPTION
#### What changes are you introducing?

Document missing filter on AK page.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

follow-up to Katello PR https://github.com/Katello/katello/pull/11114

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Can I consolidate this? What's our preferred way?
````
$ rg "dropdown list" | wc -l
1
$ rg "dropdown menu" | wc -l
12
$ rg "drop-down menu" | wc -l
7
$ rg "drop-down list" | wc -l
5
````

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13