### PR TITLE
Update the label for Administrator privileges when defining roles

### DIFF
--- a/guides/common/modules/proc_assigning-roles-to-a-user.adoc
+++ b/guides/common/modules/proc_assigning-roles-to-a-user.adoc
@@ -18,7 +18,7 @@ To list all the users in {Project}, click *Default Organization* and then *Any O
 . Click the *Roles* tab to display the list of available roles.
 . Select the roles to assign from the *Roles* list.
 +
-To grant all the available permissions, select the *Admin* checkbox.
+To grant all the available permissions, select the *Administrator* checkbox.
 . Click *Submit*.
 
 To view the roles assigned to a user, click the *Roles* tab; the assigned roles are listed under *Selected items*.


### PR DESCRIPTION
#### What changes are you introducing?

I'm updating the checkbox label for setting administrator privileges in user account settings.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

See Administer > Users > _username_ > Roles.

![Screenshot from 2024-09-03 18-58-46](https://github.com/user-attachments/assets/3ffe277c-33dc-463c-97a1-6c0bfe20af20)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I'm requesting cherry-picks down to 3.9 only because I can't currently verify on earlier versions and the issue is not _that_ critical.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
