### PR TITLE
Add permission required for email notifications

### DIFF
--- a/guides/common/modules/proc_configuring-email-notification-preferences.adoc
+++ b/guides/common/modules/proc_configuring-email-notification-preferences.adoc
@@ -12,6 +12,9 @@ Configure email notifications for a user from the {ProjectWebUI}.
 If you want to send email notifications to a group email address instead of an individual email address, create a user account with the group email address and minimal {Project} permissions, then subscribe the user account to the desired notification types.
 ====
 
+.Prerequisite
+* The user you are configuring to receive email notifications has a role with this permission: `view_mail_notifications`.
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
 . Click the *Username* of the user you want to edit.

--- a/guides/common/modules/proc_configuring-email-notification-preferences.adoc
+++ b/guides/common/modules/proc_configuring-email-notification-preferences.adoc
@@ -12,7 +12,7 @@ Configure email notifications for a user from the {ProjectWebUI}.
 If you want to send email notifications to a group email address instead of an individual email address, create a user account with the group email address and minimal {Project} permissions, then subscribe the user account to the desired notification types.
 ====
 
-.Prerequisite
+.Prerequisites
 * The user you are configuring to receive email notifications has a role with this permission: `view_mail_notifications`.
 
 .Procedure


### PR DESCRIPTION
### What changes are you introducing?

The procedure to configure email notifications for a user is missing details on which permission is required.

### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27647 and https://issues.redhat.com/browse/SAT-27616

With the exact permission missing, users might instead be tempted to grant a broader set of permissions (admin level) in an effort to troubleshoot the problem. We should try to avoid that.

### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The error message displayed when the user account doesn't have the required permission is not very helpful:

![Screenshot from 2024-09-04 15-27-37](https://github.com/user-attachments/assets/da7efb16-e2dc-41cb-903e-28ae1c69f7ad)

I might look into expanding the error message next if I have the capacity for it.

### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
