### PR TITLE
Change checksum number

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -74,7 +74,7 @@ By default, the repository is published through HTTP.
 |====
 | *Option* | *Description*
 
-| `--checksum-type` _sha_version_                 | Repository checksum (either `sha1` or `sha256`)
+| `--checksum-type` _sha_version_                 | Repository checksum (either `sha256`, `sha384`, or `sha512`)
 | `--download-policy` _policy_name_       | Download policy for repositories (either `immediate` or `on_demand`)
 | `--gpg-key-id` _gpg_key_id_                 | GPG key numeric identifier
 | `--gpg-key` _gpg_key_name_                  | Key name to search by


### PR DESCRIPTION
The checksum number `sha1` is no longer secure and modern systems support file checksums greater than `sha1`. It has been replaced with the correct checksum values.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
