### PR TITLE
Avoid Red Hat Red Hat in the Satellite client repository name

### DIFF
--- a/guides/common/modules/con_importing-the-project-client-name-repository.adoc
+++ b/guides/common/modules/con_importing-the-project-client-name-repository.adoc
@@ -1,7 +1,7 @@
 [id="importing-the-project-client-name-repository_{context}"]
 = Importing the {project-client-name} repository
 
-The {Team} {project-client-name} repository provides client integration tools, such as `katello-host-tools` or `puppet-agent` packages, for hosts registered to {Project}.
+The {project-client-name} repository provides client integration tools, such as `katello-host-tools` or `puppet-agent` packages, for hosts registered to {Project}.
 You must enable the repository, synchronize the repository to your {ProjectServer}, and enable the repository on your hosts.
 
 ifeval::["{mode}" == "disconnected"]


### PR DESCRIPTION
#### What changes are you introducing?

It changes from `Red Hat Red Hat Satellite Client 6` to `Red Hat Satellite Client 6` when describing the client repository.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Previously it rendered as `Red Hat Red Hat Satellite Client 6` which is confusing.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This change was introduced in 620b1bd28aa3. I can see it wasn't cherry picked in the PR and the commit is only in `master` and `3.12`. I noticed it when @evgeni was sharing his screen and I thought it was 6.15, but now I can't find it there anymore.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.