### PR TITLE
Cleanup DB after migrating to external DB

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -107,6 +107,7 @@
 :oVirtEngine: {oVirt} Engine
 :oVirtShort: {oVirt}
 :PAT: Personal Access Token
+:postgresql-server-package: postgresql-server
 :postgresql-lib-dir: /var/lib/pgsql
 :postgresql-data-dir: {postgresql-lib-dir}/data
 :postgresql-conf-dir: {postgresql-data-dir}

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -15,6 +15,7 @@
 :package-remove: apt remove
 :project-package-update: apt upgrade
 :package-update: apt upgrade
+:postgresql-server-package: postgresql
 :postgresql-conf-dir: /etc/postgresql/13/main
 :postgresql-lib-dir: /var/lib/postgresql
 :postgresql-data-dir: {postgresql-lib-dir}/13/main

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -10,12 +10,13 @@ include::snip_firewalld.adoc[]
 
 . To install PostgreSQL, enter the following command:
 +
+[options="nowrap" subs="verbatim,quotes,attributes"]
 ----
 ifdef::katello,satellite,orcharhino[]
-# dnf install postgresql-server postgresql-evr postgresql-contrib
+# dnf install {postgresql-server-package} postgresql-evr postgresql-contrib
 endif::[]
 ifndef::katello,satellite,orcharhino[]
-# dnf install postgresql-server
+# dnf install {postgresql-server-package}
 endif::[]
 ----
 

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -52,3 +52,15 @@ PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d
 --foreman-db-username foreman \
 --foreman-db-password _Foreman_Password_
 ----
+. Remove the PostgreSQL package on {ProjectServer}:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {project-package-remove} {postgresql-server-package}
+----
+. Remove the PostgreSQL data directory:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# rm -fr {postgresql-data-dir}
+----


### PR DESCRIPTION
#### What changes are you introducing?

remove DB RPM package and DB itself after migrating to external DB. otherwise, unnecessary data remains on Foreman Server.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes https://github.com/theforeman/foreman-documentation/issues/2131

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
