### PR TITLE
Require review labels before merging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ We respect each others time and energy spent on Foreman documentation.
 * help less experienced community members with git, Github, PRs, asciidoc, and asciidoctor.
 * expect a basic effort in contributions, including the [pull request template](PULL_REQUEST_TEMPLATE.md) being filled out.
 * only merge PRs if the Github Actions are green.
+* only merge PRs that have the `style review done` and `tech review done` labels set, indicating that a technical author has provided editorial review and a subject matter expert (SME) has provided technical review.
+For an overview of what to expect from editorial review, see [Red Hat peer review guide for technical documentation](https://redhat-documentation.github.io/peer-review/#checklist).
 * read the proposed change and make friendly and helpful comments.
 * ping community members with more experience if they are unsure about specific details.
 * try to review PRs in a timely manner.

--- a/guides/README.md
+++ b/guides/README.md
@@ -152,9 +152,6 @@ In order to implement the same technique for the upstream documentation, there i
 Please read these guidelines before opening a Pull Request.
 For more information, see [Guidelines for Red Hat Documentation](https://redhat-documentation.github.io/).
 
-New contributions are subject to technical review for accuracy and editorial review for consistency.
-For an overview of what to expect from editorial review, see [Red Hat peer review guide for technical documentation](https://redhat-documentation.github.io/peer-review/#checklist).
-
 If you need help to get started, open an issue, ask the docs team on [Matrix](https://matrix.to/#/#theforeman-doc:matrix.org), or ping [`@docs`](https://community.theforeman.org/g/docs) on the [Foreman Community Forum](https://community.theforeman.org/).
 
 If you are unsure into which guide you should place your content, have a look at the `docinfo.xml` files within each `doc-*` directory.


### PR DESCRIPTION
#### What changes are you introducing?

I propose updating the project's contributing guidelines with a bullet point explaining that each PR must have the `style review done` and `tech review done` labels set before anyone can merge it.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The idea came up during Red Hat's docs team retrospective when we met to evaluate the process we followed for the Foreman 3.12 release. The issues we discussed and hope to address with this PR include:

* Uncertainty surrounding whether a PR has been properly reviewed and is ready to be merged.
* Accountability about who is responsible for reviewing what.
* Transparency about who has already reviewed a PR and where feedback was provided.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

@Lennonka suggested it would be a good idea to completely disable the ability to merge PRs that don't have these labels. That would be great if GH supports that feature.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
