### PR TITLE
Remove sync references from Disconnected guide

### DIFF
--- a/guides/common/modules/con_upgrading-project.adoc
+++ b/guides/common/modules/con_upgrading-project.adoc
@@ -6,7 +6,9 @@ Use the following procedures to upgrade your existing {ProjectName} to {ProjectN
 . Review xref:upgrading_prerequisites_{context}[].
 . xref:Project_Upgrade_Considerations_{context}[]
 ifdef::satellite[]
+ifeval:["{mode}" == "connected"]
 . xref:synchronizing_the_new_repositories_{context}[]
+endif::[]
 endif::[]
 ifndef::foreman-deb[]
 . xref:upgrading_{smart-proxy-context}_server_{context}[]

--- a/guides/common/modules/con_upgrading-project.adoc
+++ b/guides/common/modules/con_upgrading-project.adoc
@@ -6,7 +6,7 @@ Use the following procedures to upgrade your existing {ProjectName} to {ProjectN
 . Review xref:upgrading_prerequisites_{context}[].
 . xref:Project_Upgrade_Considerations_{context}[]
 ifdef::satellite[]
-ifeval:["{mode}" == "connected"]
+ifeval::["{mode}" == "connected"]
 . xref:synchronizing_the_new_repositories_{context}[]
 endif::[]
 endif::[]

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -11,7 +11,9 @@ For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context
 ifdef::satellite[]
 * Ensure the {ProjectName} {SmartProxy} {ProjectVersion} repository is enabled in {ProjectServer} and synchronized.
 * Ensure that you synchronize the required repositories on {ProjectServer}.
+ifeval::["{mode}" == "connected"]
 For more information, see xref:synchronizing_the_new_repositories_{context}[].
+endif::[]
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 * If you use content views to control updates to the base operating system of {SmartProxyServer}, update those content views with new repositories, publish, and promote their updated versions.

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -9,10 +9,12 @@ This section describes how to upgrade {SmartProxyServers} from {ProjectVersionPr
 Note that you can upgrade {SmartProxies} separately from {Project}.
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
 ifdef::satellite[]
+ifeval::["{mode}" == "connected"]
 * Ensure the {ProjectName} {SmartProxy} {ProjectVersion} repository is enabled in {ProjectServer} and synchronized.
 * Ensure that you synchronize the required repositories on {ProjectServer}.
 ifeval::["{mode}" == "connected"]
 For more information, see xref:synchronizing_the_new_repositories_{context}[].
+endif::[]
 endif::[]
 endif::[]
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -12,9 +12,7 @@ ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
 * Ensure the {ProjectName} {SmartProxy} {ProjectVersion} repository is enabled in {ProjectServer} and synchronized.
 * Ensure that you synchronize the required repositories on {ProjectServer}.
-ifeval::["{mode}" == "connected"]
 For more information, see xref:synchronizing_the_new_repositories_{context}[].
-endif::[]
 endif::[]
 endif::[]
 ifdef::katello,orcharhino,satellite[]

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -33,9 +33,6 @@ include::common/modules/con_project-server-upgrade-considerations.adoc[leveloffs
 // Upgrading a Disconnected Project
 include::common/modules/proc_upgrading-a-disconnected-project-server.adoc[leveloffset=+2]
 
-// Synchronizing the New Repositories
-include::common/modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+2]
-
 // Performing Post-Upgrade Tasks
 include::common/modules/proc_performing-post-upgrade-tasks.adoc[leveloffset=+2]
 


### PR DESCRIPTION
The Disconnected Upgrade guide contains some references to syncing the repos, which is incorrect. Removing the "Syncing Repos" chapter as well as the reference to it in the procedure.

JIRA:
https://issues.redhat.com/browse/SAT-27265

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [X] Foreman 3.11/Katello 4.13
* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
