### PR TITLE
Fix spelling of boot loader

### DIFF
--- a/guides/common/modules/con_network-boot-provisioning-workflow.adoc
+++ b/guides/common/modules/con_network-boot-provisioning-workflow.adoc
@@ -32,7 +32,7 @@ endif::[]
 . The host reboots.
 . The new host requests a DHCP reservation from the DHCP server.
 . The DHCP server responds to the reservation request and returns TFTP `next-server` and `filename` options.
-. The host requests the bootloader and menu from the TFTP server according to the PXELoader setting.
+. The host requests the boot loader and menu from the TFTP server according to the PXELoader setting.
 . A boot loader is returned over TFTP.
 . The boot loader fetches the configuration for the host through its provision interface MAC address.
 . The boot loader initiates boot from the local drive.
@@ -50,7 +50,7 @@ The fully provisioned host performs the following workflow:
 * The boot loader returns non-bootable device so BIOS skips to the next device (boot from HDD).
 . For EFI hosts:
 * The boot loader finds Grub2 on a ESP partition and chainboots it.
-. If the host is unknown to {Project}, a default bootloader configuration is provided. When Discovery service is enabled, it boots into discovery, otherwise it boots from HDD.
+. If the host is unknown to {Project}, a default boot loader configuration is provided. When Discovery service is enabled, it boots into discovery, otherwise it boots from HDD.
 
 This workflow differs depending on custom options.
 For example:

--- a/guides/common/modules/proc_building-a-custom-discovery-image.adoc
+++ b/guides/common/modules/proc_building-a-custom-discovery-image.adoc
@@ -84,7 +84,7 @@ $ ls -h ./result/*.iso
 # isohybrid --partok fdi.iso
 ----
 +
-If you have `grub2` packages installed, you can also use the following command to install a `grub2` bootloader:
+If you have `grub2` packages installed, you can also use the following command to install a `grub2` boot loader:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
+++ b/guides/common/modules/proc_configuring-an-external-dhcp-server.adoc
@@ -16,7 +16,7 @@ The example in this procedure uses the distributed Network File System (NFS) pro
 ====
 If you use dnsmasq as an external DHCP server, enable the `dhcp-no-override` setting.
 This is required because {Project} creates configuration files on the TFTP server under the `grub2/` subdirectory.
-If the `dhcp-no-override` setting is disabled, hosts fetch the bootloader and its configuration from the root directory, which might cause an error.
+If the `dhcp-no-override` setting is disabled, hosts fetch the boot loader and its configuration from the root directory, which might cause an error.
 ====
 
 include::snip_firewalld.adoc[]

--- a/guides/common/modules/ref_host-specific-variables.adoc
+++ b/guides/common/modules/ref_host-specific-variables.adoc
@@ -11,7 +11,7 @@ Note that job templates accept only `@host` variables.
 |`@host.architecture` |The architecture of the host.
 |`@host.bond_interfaces` |Returns an array of all bonded interfaces.
 See xref:Parsing_Arrays_{context}[].
-|`@host.capabilities` |The method of system provisioning, can be either build (for example kickstart) or image.
+|`@host.capabilities` |The method of system provisioning, can be either build (for example Kickstart) or image.
 |`@host.certname` |The SSL certificate name of the host.
 |`@host.diskLayout` |The disk layout of the host.
 Can be inherited from the operating system.

--- a/guides/common/modules/ref_host-specific-variables.adoc
+++ b/guides/common/modules/ref_host-specific-variables.adoc
@@ -8,72 +8,72 @@ Note that job templates accept only `@host` variables.
 [options="header"]
 |====
 |Name |Description
-|@host.architecture |The architecture of the host.
-|@host.bond_interfaces |Returns an array of all bonded interfaces.
+|`@host.architecture` |The architecture of the host.
+|`@host.bond_interfaces` |Returns an array of all bonded interfaces.
 See xref:Parsing_Arrays_{context}[].
-|@host.capabilities |The method of system provisioning, can be either build (for example kickstart) or image.
-|@host.certname |The SSL certificate name of the host.
-|@host.diskLayout |The disk layout of the host.
+|`@host.capabilities` |The method of system provisioning, can be either build (for example kickstart) or image.
+|`@host.certname` |The SSL certificate name of the host.
+|`@host.diskLayout` |The disk layout of the host.
 Can be inherited from the operating system.
-|@host.domain |The domain of the host.
-|@host.environment *Deprecated* Use the `host_puppet_environment` variable instead. |The Puppet environment of the host.
-|@host.facts |Returns a Ruby hash of facts from Facter.
+|`@host.domain` |The domain of the host.
+|`@host.environment` *Deprecated* Use the `host_puppet_environment` variable instead. |The Puppet environment of the host.
+|`@host.facts` |Returns a Ruby hash of facts from Facter.
 For example to access the 'ipaddress' fact from the output, specify @host.facts['ipaddress'].
-|@host.grub_pass |Returns the host's boot loader password.
-|@host.hostgroup |The host group of the host.
-|host_enc['parameters'] |Returns a Ruby hash containing information on host parameters.
+|`@host.grub_pass` |Returns the host's boot loader password.
+|`@host.hostgroup` |The host group of the host.
+|`host_enc['parameters']` |Returns a Ruby hash containing information on host parameters.
 For example, use host_enc['parameters']['lifecycle_environment'] to get the lifecycle environment of a host.
-|@host.image_build? |Returns `true` if the host is provisioned using an image.
-|@host.interfaces |Contains an array of all available host interfaces including the primary interface.
+|`@host.image_build?` |Returns `true` if the host is provisioned using an image.
+|`@host.interfaces` |Contains an array of all available host interfaces including the primary interface.
 See xref:Parsing_Arrays_{context}[].
-|@host.interfaces_with_identifier('IDs') |Returns array of interfaces with given identifier.
+|`@host.interfaces_with_identifier('IDs')` |Returns array of interfaces with given identifier.
 You can pass an array of multiple identifiers as an input, for example @host.interfaces_with_identifier(['eth0', 'eth1']).
 See xref:Parsing_Arrays_{context}[].
-|@host.ip |The IP address of the host.
-|@host.location |The location of the host.
-|@host.mac |The MAC address of the host.
-|@host.managed_interfaces |Returns an array of managed interfaces (excluding BMC and bonded interfaces).
+|`@host.ip` |The IP address of the host.
+|`@host.location` |The location of the host.
+|`@host.mac` |The MAC address of the host.
+|`@host.managed_interfaces` |Returns an array of managed interfaces (excluding BMC and bonded interfaces).
 See xref:Parsing_Arrays_{context}[].
-|@host.medium |The assigned operating system installation medium.
-|@host.name |The full name of the host.
-|@host.operatingsystem.family |The operating system family.
-|@host.operatingsystem.major |The major version number of the assigned operating system.
-|@host.operatingsystem.minor |The minor version number of the assigned operating system.
-|@host.operatingsystem.name |The assigned operating system name.
-|@host.operatingsystem.boot_files_uri(medium_provider) |Full path to the kernel and initrd, returns an array.
-|@host.os.medium_uri(@host) |The URI used for provisioning (path configured in installation media).
-|host_param('parameter_name') |Returns the value of the specified host parameter.
-|host_param_false?('parameter_name') |Returns `false` if the specified host parameter evaluates to false.
-|host_param_true?('parameter_name') |Returns `true` if the specified host parameter evaluates to true.
-|@host.primary_interface |Returns the primary interface of the host.
-|@host.provider |The compute resource provider.
-|@host.provision_interface |Returns the provisioning interface of the host.
+|`@host.medium` |The assigned operating system installation medium.
+|`@host.name` |The full name of the host.
+|`@host.operatingsystem.family` |The operating system family.
+|`@host.operatingsystem.major` |The major version number of the assigned operating system.
+|`@host.operatingsystem.minor` |The minor version number of the assigned operating system.
+|`@host.operatingsystem.name` |The assigned operating system name.
+|`@host.operatingsystem.boot_files_uri(medium_provider)` |Full path to the kernel and initrd, returns an array.
+|`@host.os.medium_uri(@host)` |The URI used for provisioning (path configured in installation media).
+|`host_param('parameter_name')` |Returns the value of the specified host parameter.
+|`host_param_false?('parameter_name')` |Returns `false` if the specified host parameter evaluates to false.
+|`host_param_true?('parameter_name')` |Returns `true` if the specified host parameter evaluates to true.
+|`@host.primary_interface` |Returns the primary interface of the host.
+|`@host.provider` |The compute resource provider.
+|`@host.provision_interface` |Returns the provisioning interface of the host.
 Returns an interface object.
-|@host.ptable |The partition table name.
-|@host.puppet_ca_server *Deprecated* Use the `host_puppet_ca_server` variable instead. |The Puppet CA server the host must use.
-|@host.puppetmaster *Deprecated* Use the `host_puppet_server` variable instead. |The Puppet server the host must use.
-|@host.pxe_build? |Returns `true` if the host is provisioned using the network or PXE.
-|@host.shortname |The short name of the host.
-|@host.sp_ip |The IP address of the BMC interface.
-|@host.sp_mac |The MAC address of the BMC interface.
-|@host.sp_name |The name of the BMC interface.
-|@host.sp_subnet |The subnet of the BMC network.
-|@host.subnet.dhcp |Returns `true` if a DHCP proxy is configured for this host.
-|@host.subnet.dns_primary |The primary DNS server of the host.
-|@host.subnet.dns_secondary |The secondary DNS server of the host.
-|@host.subnet.gateway |The gateway of the host.
-|@host.subnet.mask |The subnet mask of the host.
-|@host.url_for_boot(:initrd) |Full path to the initrd image associated with this host.
+|`@host.ptable` |The partition table name.
+|`@host.puppet_ca_server` *Deprecated* Use the `host_puppet_ca_server` variable instead. |The Puppet CA server the host must use.
+|`@host.puppetmaster` *Deprecated* Use the `host_puppet_server` variable instead. |The Puppet server the host must use.
+|`@host.pxe_build?` |Returns `true` if the host is provisioned using the network or PXE.
+|`@host.shortname` |The short name of the host.
+|`@host.sp_ip` |The IP address of the BMC interface.
+|`@host.sp_mac` |The MAC address of the BMC interface.
+|`@host.sp_name` |The name of the BMC interface.
+|`@host.sp_subnet` |The subnet of the BMC network.
+|`@host.subnet.dhcp` |Returns `true` if a DHCP proxy is configured for this host.
+|`@host.subnet.dns_primary` |The primary DNS server of the host.
+|`@host.subnet.dns_secondary` |The secondary DNS server of the host.
+|`@host.subnet.gateway` |The gateway of the host.
+|`@host.subnet.mask` |The subnet mask of the host.
+|`@host.url_for_boot(:initrd)` |Full path to the initrd image associated with this host.
 Not recommended, as it does not interpolate variables.
-|@host.url_for_boot(:kernel) |Full path to the kernel associated with this host.
+|`@host.url_for_boot(:kernel)` |Full path to the kernel associated with this host.
 Not recommended, as it does not interpolate variables, prefer boot_files_uri.
-|@provisioning_type |Equals to 'host' or 'hostgroup' depending on type of provisioning.
-|@static |Returns `true` if the network configuration is static.
-|@template_name |Name of the template being rendered.
-|grub_pass |Returns a boot loader argument to set the encrypted boot loader password, such as *--md5pass=#{@host.grub_pass}*.
-|ks_console |Returns a string assembled using the port and the baud rate of the host which can be added to a kernel line.
+|`@provisioning_type` |Equals to 'host' or 'hostgroup' depending on type of provisioning.
+|`@static` |Returns `true` if the network configuration is static.
+|`@template_name` |Name of the template being rendered.
+|`grub_pass` |Returns a boot loader argument to set the encrypted boot loader password, such as *--md5pass=#{@host.grub_pass}*.
+|`ks_console` |Returns a string assembled using the port and the baud rate of the host which can be added to a kernel line.
 For example *console=ttyS1,9600*.
-|root_pass |Returns the root password configured for the system.
+|`root_pass` |Returns the root password configured for the system.
 |====
 
 The majority of common Ruby methods can be applied on host-specific variables.

--- a/guides/common/modules/ref_host-specific-variables.adoc
+++ b/guides/common/modules/ref_host-specific-variables.adoc
@@ -19,7 +19,7 @@ Can be inherited from the operating system.
 |@host.environment *Deprecated* Use the `host_puppet_environment` variable instead. |The Puppet environment of the host.
 |@host.facts |Returns a Ruby hash of facts from Facter.
 For example to access the 'ipaddress' fact from the output, specify @host.facts['ipaddress'].
-|@host.grub_pass |Returns the host's bootloader password.
+|@host.grub_pass |Returns the host's boot loader password.
 |@host.hostgroup |The host group of the host.
 |host_enc['parameters'] |Returns a Ruby hash containing information on host parameters.
 For example, use host_enc['parameters']['lifecycle_environment'] to get the lifecycle environment of a host.
@@ -70,7 +70,7 @@ Not recommended, as it does not interpolate variables, prefer boot_files_uri.
 |@provisioning_type |Equals to 'host' or 'hostgroup' depending on type of provisioning.
 |@static |Returns `true` if the network configuration is static.
 |@template_name |Name of the template being rendered.
-|grub_pass |Returns a bootloader argument to set the encrypted bootloader password, such as *--md5pass=#{@host.grub_pass}*.
+|grub_pass |Returns a boot loader argument to set the encrypted boot loader password, such as *--md5pass=#{@host.grub_pass}*.
 |ks_console |Returns a string assembled using the port and the baud rate of the host which can be added to a kernel line.
 For example *console=ttyS1,9600*.
 |root_pass |Returns the root password configured for the system.

--- a/guides/common/modules/ref_host-specific-variables.adoc
+++ b/guides/common/modules/ref_host-specific-variables.adoc
@@ -67,7 +67,7 @@ Returns an interface object.
 Not recommended, as it does not interpolate variables.
 |`@host.url_for_boot(:kernel)` |Full path to the kernel associated with this host.
 Not recommended, as it does not interpolate variables, prefer boot_files_uri.
-|`@provisioning_type` |Equals to 'host' or 'hostgroup' depending on type of provisioning.
+|`@provisioning_type` |Equals to `host` or `hostgroup` depending on type of provisioning.
 |`@static` |Returns `true` if the network configuration is static.
 |`@template_name` |Name of the template being rendered.
 |`grub_pass` |Returns a boot loader argument to set the encrypted boot loader password, such as *--md5pass=#{@host.grub_pass}*.

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -69,19 +69,19 @@ For more information, see xref:{SmartProxy}-Networking_planning[].
 * Optional: If the host and the DHCP server are separated by a router, configure the DHCP relay agent and point to the DHCP server.
 
 .{Project} requirements
-Although TFTP protocol is not used for HTTP UEFI Booting, {Project} uses TFTP {SmartProxy} API to deploy bootloader configuration.
+Although TFTP protocol is not used for HTTP UEFI Booting, {Project} uses TFTP {SmartProxy} API to deploy boot loader configuration.
 
 For HTTP booting to work, ensure that {Project} has the following configurations:
 
 * Both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
 * The UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
-* Ensure that the TCP port 8000 is open for the client to download the bootloader and Kickstart templates from the {SmartProxy}.
-* The TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} using the HTTPS protocol.
+* Ensure that the TCP port 8000 is open for the client to download the boot loader and Kickstart templates from the {SmartProxy}.
+* The TCP port {smartproxy_port} is open for the client to download the boot loader from the {SmartProxy} using the HTTPS protocol.
 * The subnet that functions as the host's provisioning interface has a DHCP {SmartProxy}, an HTTP Boot {SmartProxy}, a TFTP {SmartProxy}, and a Templates {SmartProxy}
 
 ifndef::foreman-deb[]
 * The `grub2-efi` package is updated to the latest version.
-To update the `grub2-efi` package to the latest version and execute the installer to copy the recent bootloader from `/boot` into `/var/lib/tftpboot` directory, enter the following commands:
+To update the `grub2-efi` package to the latest version and execute the installer to copy the recent boot loader from `/boot` into `/var/lib/tftpboot` directory, enter the following commands:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -111,18 +111,18 @@ In case DNS is not available, use IP address to configure clients.
 
 .{Project} requirements
 
-Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {SmartProxy} API to deploy bootloader configuration.
+Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {SmartProxy} API to deploy boot loader configuration.
 
 * Ensure that both {ProjectServer} and {SmartProxy} have DNS configured and are able to resolve provisioned host names.
 * Ensure that the UDP ports 67 and 68 are accessible by the client so that the client can send and receive a DHCP request and offer.
-* Ensure that the TCP port 8000 is open for the client to download bootloader and Kickstart templates from the {SmartProxy}.
-* Ensure that the TCP port {smartproxy_port} is open for the client to download the bootloader from the {SmartProxy} through HTTPS.
+* Ensure that the TCP port 8000 is open for the client to download boot loader and Kickstart templates from the {SmartProxy}.
+* Ensure that the TCP port {smartproxy_port} is open for the client to download the boot loader from the {SmartProxy} through HTTPS.
 * Ensure that the host provisioning interface subnet has an HTTP Boot {SmartProxy} set.
 * Ensure that the host provisioning interface subnet has a TFTP {SmartProxy} set.
 * Ensure that the host provisioning interface subnet has a Templates {SmartProxy} set.
 
 ifndef::foreman-deb[]
-* Update the `grub2-efi` package to the latest version and execute the installer to copy the recent bootloader from the `/boot` directory into the `/var/lib/tftpboot` directory:
+* Update the `grub2-efi` package to the latest version and execute the installer to copy the recent boot loader from the `/boot` directory into the `/var/lib/tftpboot` directory:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -134,11 +134,11 @@ endif::[]
 ifdef::foreman-el,katello,orcharhino[]
 === Secure boot
 
-When {Project} is installed on {EL} using `{foreman-installer}`, grub2 and shim bootloaders that are signed by Red Hat are deployed into the TFTP and HTTP UEFI Boot directory.
+When {Project} is installed on {EL} using `{foreman-installer}`, grub2 and shim boot loaders that are signed by Red Hat are deployed into the TFTP and HTTP UEFI Boot directory.
 PXE loader options named "SecureBoot" configure hosts to load `shim.efi`.
 
-On Debian and Ubuntu operating systems, the grub2 bootloader is created using the `grub2-mkimage` unsigned.
-To perform the Secure Boot, the bootloader must be manually signed and key enrolled into the EFI firmware.
+On Debian and Ubuntu operating systems, the grub2 boot loader is created using the `grub2-mkimage` unsigned.
+To perform the Secure Boot, the boot loader must be manually signed and key enrolled into the EFI firmware.
 Alternatively, grub2 from Ubuntu or {EL} can be copied to perform booting.
 
 Grub2 in {EL} 8.0-8.3 were updated to mitigate https://access.redhat.com/security/vulnerabilities/grub2bootloader[Boot Hole Vulnerability] and keys of existing {EL} kernels were invalidated.


### PR DESCRIPTION
$ fd -e adoc | xargs sed -i "s/bootloader/boot loader/g"

Reverted change to URL manually.

#### What changes are you introducing?

Make vale happy: change "bootloader" to "boot loader".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

prerequisite to https://github.com/theforeman/foreman-documentation/pull/3272/files

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
