### PR TITLE
use literal .z, not italic (to replace) in target-version option

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server.adoc
@@ -144,7 +144,7 @@ On first use of this command, `{foreman-maintain}` prompts you to enter the hamm
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} upgrade check \
---target-version {ProjectVersion}._z_ \
+--target-version {ProjectVersion}.z \
 --whitelist="check-upstream-repository,repositories-validate"
 ----
 +
@@ -158,7 +158,7 @@ If you lose connection to the command shell where the upgrade command is running
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} upgrade run \
---target-version {ProjectVersion}._z_ \
+--target-version {ProjectVersion}.z \
 --whitelist="check-upstream-repository,repositories-setup,repositories-validate"
 ----
 

--- a/guides/common/modules/proc_updating-server.adoc
+++ b/guides/common/modules/proc_updating-server.adoc
@@ -36,7 +36,7 @@ On first use of this command, `{foreman-maintain}` prompts you to enter the hamm
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {ProjectVersion}.__z__
+# {foreman-maintain} upgrade check --target-version {ProjectVersion}.z
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -48,7 +48,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {ProjectVersion}.__z__
+# {foreman-maintain} upgrade run --target-version {ProjectVersion}.z
 ----
 
 include::snip_steps-needs-reboot.adoc[]

--- a/guides/common/modules/proc_updating-smart-proxy.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy.adoc
@@ -27,7 +27,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade check --target-version {ProjectVersion}.__z__
+# {foreman-maintain} upgrade check --target-version {ProjectVersion}.z
 ----
 +
 Review the results and address any highlighted error conditions before performing the upgrade.
@@ -41,7 +41,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-maintain} upgrade run --target-version {ProjectVersion}.__z__
+# {foreman-maintain} upgrade run --target-version {ProjectVersion}.z
 ----
 
 include::snip_steps-needs-reboot.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?

making `--target-version` use 6.15.z, not 6.15._z_, as the command expects a literal z not the Z-stream version

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because they are correct

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

3.11+ doesn't need this, as there the command doesn't take any target version anymore

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
