### PR TITLE
Foreman expects LDAP server to follow RFC2307

### DIFF
--- a/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
+++ b/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
@@ -4,6 +4,7 @@
 Configure an LDAP authentication source to enable users to log in to {Project} with their existing LDAP credentials.
 
 .Prerequisites
+* Your LDAP server is compliant with the link:https://datatracker.ietf.org/doc/html/rfc2307[RFC 2307] schema.
 * Your user account has the following permissions:
 ** `view_authenticators`, `create_authenticators`, `edit_authenticators`
 ** `view_locations`, `assign_locations`


### PR DESCRIPTION
#### What changes are you introducing?

Adding a prerequisite stating that when connecting to an LDAP server as an external authentication source, that LDAP server needs to be RFC2307-compliant.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-25037 and https://bugzilla.redhat.com/show_bug.cgi?id=2127089

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I expect a conflict on 3.10 and lower but the change should go into those versions too.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
