### PR TITLE
Allow tabs for container-based builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,17 @@ RUN dnf install -y \
         make \
         redhat-rpm-config \
         ruby-devel \
-        rubygem-asciidoctor && \
+        rubygem-asciidoctor \
+        rubygem-bundler && \
     dnf groupinstall -y development-tools && \
     gem install \
+        asciidoctor-tabs:1.0.0.beta.6 \
         ffi:1.16.3 \
-        nokogiri \
+        nokogiri:1.16.5 \
+        racc:1.8.0 \
+        rb-fsevent:0.11.2 \
         rb-inotify:0.10.1 \
-        sass
+        sass-listen:4.0.0 \
+        sass:3.7.4
 
 WORKDIR /foreman-documentation/guides


### PR DESCRIPTION
Gem versions follow GHA in foreman-documentation for PR 3104 that introduces tabs which require "asciidoctor-tabs".

#### What changes are you introducing?

add "asciidoctor-tabs" to container image.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

prerequisite to testing #3104 locally

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I have tested removing "rubygem-asciidoctor" as RPM without success. even if it's not perfect, it works as is.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
