### PR TITLE
Prevent asterisk substitution in a code block

### DIFF
--- a/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc
@@ -19,7 +19,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ google-chrome --auth-server-whitelist="*._example.com_" --auth-negotiate-delegate-whitelist="*._example.com_"
+$ google-chrome --auth-server-whitelist="\*._example.com_" --auth-negotiate-delegate-whitelist="*._example.com_"
 ----
 +
 [NOTE]


### PR DESCRIPTION
#### What changes are you introducing?

A minor change to make sure the asterisks in a command included in a code block are preserved.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Right now, the asterisks are interpreted as bold text.

![Screenshot from 2024-09-13 18-59-39](https://github.com/user-attachments/assets/ba8a33fc-a941-4584-b30f-a26c8a818366)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Another PR is coming soon for 3.10 and earlier.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
