### PR TITLE
Add EL9 to "register host without Puppet"

### DIFF
--- a/guides/common/modules/proc_registering-a-host-without-puppet.adoc
+++ b/guides/common/modules/proc_registering-a-host-without-puppet.adoc
@@ -5,7 +5,7 @@ By default, the bootstrap script configures the host for content management and 
 If you have an existing configuration management system and do not want to install Puppet on the host, use `--skip-puppet`.
 
 .Procedure
-* On {EL} 8, enter the following command:
+* On {EL} 9 or 8, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_registering-a-host-without-puppet.adoc
+++ b/guides/common/modules/proc_registering-a-host-without-puppet.adoc
@@ -18,7 +18,7 @@ If you have an existing configuration management system and do not want to insta
 --activationkey="_My_Activation_Key_" \
 --skip-puppet
 ----
-* On {EL} 6 or 7, enter the following command:
+* On {EL} 7 or 6, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Add EL 9

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

EL 9 was missing

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

local test that command is available:

````
$ podman run --rm -it almalinux:8.10
# /usr/libexec/platform-python --version
Python 3.6.8

$ podman run --rm -it almalinux:9.4
# /usr/libexec/platform-python --version
Python 3.9.18
````

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
