### PR TITLE
Support puppet 8

### DIFF
--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -3,7 +3,7 @@
 
 Puppet uses a server-agent architecture.
 The Puppet server is the central component that stores configuration definitions.
-{ProjectServer} or any {SmartProxies} are typically deployed with the Puppet server and {Project} acts as an https://puppet.com/docs/puppet/7/nodes_external.html[External Node Classifier (ENC)] for such Puppet server.
+{ProjectServer} or any {SmartProxies} are typically deployed with the Puppet server and {Project} acts as an https://puppet.com/docs/puppet/8/nodes_external.html[External Node Classifier (ENC)] for such Puppet server.
 Hosts run the Puppet agent that communicates with the Puppet server.
 
 The Puppet agent collects _facts_ about a host and reports them to the Puppet server on each run.

--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -3,7 +3,7 @@
 
 Puppet uses a server-agent architecture.
 The Puppet server is the central component that stores configuration definitions.
-{ProjectServer} or any {SmartProxies} are typically deployed with the Puppet server and {Project} acts as an https://puppet.com/docs/puppet/8/nodes_external.html[External Node Classifier (ENC)] for such Puppet server.
+{ProjectServer} or {SmartProxyServers} are typically deployed with the Puppet server and {Project} acts as an https://puppet.com/docs/puppet/8/nodes_external.html[External Node Classifier (ENC)] for such Puppet server.
 Hosts run the Puppet agent that communicates with the Puppet server.
 
 The Puppet agent collects _facts_ about a host and reports them to the Puppet server on each run.

--- a/guides/common/modules/proc_configuring-repositories-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-deb.adoc
@@ -1,6 +1,7 @@
 [id="configuring-repositories-deb-{distribution-codename}"]
 
-:PuppetReleaseDeb: puppet7-release-{distribution-codename}.deb
+:Puppet8ReleaseDeb: puppet8-release-{distribution-codename}.deb
+:Puppet7ReleaseDeb: puppet7-release-{distribution-codename}.deb
 
 . Install the `wget` and `ca-certificates` packages:
 +
@@ -9,18 +10,32 @@
 # {project-package-install} wget ca-certificates
 ----
 
-. Change directory to `/tmp` and retrieve the `{PuppetReleaseDeb}` package:
+. Change directory to `/tmp` and retrieve the `puppet-release` package.
+* For Puppet 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# cd /tmp && wget https://apt.puppet.com/{PuppetReleaseDeb}
+# cd /tmp && wget https://apt.puppet.com/{Puppet8ReleaseDeb}
+----
+* For Puppet 7:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# cd /tmp && wget https://apt.puppet.com/{Puppet7ReleaseDeb}
 ----
 
-. Install the `{PuppetReleaseDeb}` package:
+. Install the `puppet-release` package.
+* For Puppet 8:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {project-package-install} /tmp/{PuppetReleaseDeb}
+# {project-package-install} /tmp/{Puppet8ReleaseDeb}
+----
+* For Puppet 7:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {project-package-install} /tmp/{Puppet7ReleaseDeb}
 ----
 
 . Enable the Foreman repository:

--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -23,7 +23,14 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::foreman-el,katello[]
-. Install the `puppet7-release-el-{distribution-major-version}.noarch.rpm` package:
+. Install the `puppet-release` package.
+* For Puppet 8:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {client-package-install-el8} https://yum.puppet.com/puppet8-release-el-{distribution-major-version}.noarch.rpm
+----
+* For Puppet 7:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
@@ -53,12 +53,14 @@ endif::[]
 Note that this snippet is already included in the templates shipped with {Project}, such as `Kickstart default` or `Preseed default`.
 ifdef::katello,orcharhino,satellite[]
 . Enable the Puppet agent using a host parameter in global parameters, a host group, or for a single host.
-Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
+To use Puppet 8, add a host parameter named `enable-puppet8`, select the *boolean* type, and set the value to `true`.
+To use Puppet 7, add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
 endif::[]
 ifndef::katello,orcharhino,satellite[]
 . Enable the Puppet agent from the official Puppet repository using one of the following host parameters in global parameters, a host group, or for a single host:
 
 * Add a host parameter named `enable-puppetlabs-repo` for the latest stable Puppet release in the unversioned repository.
+* Add a host parameter named `enable-official-puppet8-repo` for the Puppet 8 release repository.
 * Add a host parameter named `enable-official-puppet7-repo` for the Puppet 7 release repository.
 
 +

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -47,10 +47,14 @@ endif::[]
 Alternatively, you can navigate to *Configure* > *Host Groups* and edit or create a host group to add host parameters only to a host group.
 . Enable the Puppet agent using a host parameter in global parameters or a host group.
 ifdef::katello,orcharhino,satellite[]
-Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
++
+* To use Puppet 8, add a host parameter named `enable-puppet8`, select the *boolean* type, and set the value to `true`.
+* To use Puppet 7, add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
 endif::[]
 ifndef::katello,orcharhino,satellite[]
-Add a host parameter named `enable-official-puppet7-repo`, select the *boolean* type, and set the value to `true`.
++
+To use Puppet 8, add a host parameter named `enable-official-puppet8-repo`, select the *boolean* type, and set the value to `true`.
+To use Puppet 7, add a host parameter named `enable-official-puppet7-repo`, select the *boolean* type, and set the value to `true`.
 endif::[]
 . Specify configuration for the Puppet agent using the following host parameters in global parameters or a host group:
 * Add a host parameter named `puppet_server`, select the *string* type, and set the value to the hostname of your Puppet server, such as `puppet.example.com`.

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -46,12 +46,17 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Configure* > *Global Parameters* to add host parameters globally.
 Alternatively, you can navigate to *Configure* > *Host Groups* and edit or create a host group to add host parameters only to a host group.
 . Enable the Puppet agent using a host parameter in global parameters or a host group.
-ifdef::katello,orcharhino,satellite[]
+// consolidate with line 54 as soon as Satellite client contains Puppet agent 8
+ifdef::satellite[]
++
+Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
+endif::[]
+ifdef::katello,orcharhino[]
 +
 * To use Puppet 8, add a host parameter named `enable-puppet8`, select the *boolean* type, and set the value to `true`.
 * To use Puppet 7, add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
 endif::[]
-ifndef::katello,orcharhino,satellite[]
+ifdef::foreman-el,foreman-deb[]
 +
 To use Puppet 8, add a host parameter named `enable-official-puppet8-repo`, select the *boolean* type, and set the value to `true`.
 To use Puppet 7, add a host parameter named `enable-official-puppet7-repo`, select the *boolean* type, and set the value to `true`.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -93,13 +93,6 @@ baseurl=https://yum.theforeman.org/plugins/{ProjectVersion}/el9/$basearch
 enabled=1
 gpgcheck=0
 
-[leapp-puppet7]
-name=Puppet 7 Repository el 9 - $basearch
-baseurl=http://yum.puppetlabs.com/puppet7/el/9/$basearch
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
-enabled=1
-gpgcheck=1
-
 ifdef::katello[]
 [leapp-katello]
 name=Katello {KatelloVersion}
@@ -122,6 +115,29 @@ gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcor
 enabled=1
 gpgcheck=1
 endif::[]
+----
+. Append Yum repositories for Puppet to `/etc/leapp/files/leapp_upgrade_repositories.repo`.
+* For Puppet 8:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[leapp-puppet8]
+name=Puppet 8 Repository el 9 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet8/el/9/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet8-release
+enabled=1
+gpgcheck=1
+----
+* For Puppet 7:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[leapp-puppet7]
+name=Puppet 7 Repository el 9 - $basearch
+baseurl=http://yum.puppetlabs.com/puppet7/el/9/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-2025-04-06-puppet7-release
+enabled=1
+gpgcheck=1
 ----
 endif::[]
 . Let Leapp analyze your system:

--- a/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
+++ b/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
@@ -4,9 +4,11 @@
 Before you begin with the Puppet integration, review the supported Puppet versions and system requirements.
 
 Supported Puppet Versions::
-{Project} supports Puppet 7.
-Ensure that the Puppet modules used to configure your hosts are compatible with Puppet 7.
+{Project} supports Puppet 8 and 7.
+Ensure that the Puppet modules used to configure your hosts are compatible with your Puppet version.
++
+On hosts, you can use either Puppet agent 8 or Puppet agent 7.
 
 System Requirements::
 Before you begin integrating Puppet with your {Project}, ensure that you meet the system requirements.
-For more information, see https://puppet.com/docs/puppet/7/system_requirements.html[System Requirements for Puppet 7] in the _Open Source Puppet_ documentation.
+For more information, see https://puppet.com/docs/puppet/8/system_requirements.html[System Requirements for Puppet 8] or https://puppet.com/docs/puppet/7/system_requirements.html[System Requirements for Puppet 7] in the _Open Source Puppet_ documentation.

--- a/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
+++ b/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
@@ -4,11 +4,26 @@
 Before you begin with the Puppet integration, review the supported Puppet versions and system requirements.
 
 Supported Puppet Versions::
-{Project} supports Puppet 8 and 7.
+ifdef::satellite[]
+{Project} supports Puppet server 8.
+endif::[]
+ifndef::satellite[]
+{Project} supports Puppet server 8 and 7.
+endif::[]
 Ensure that the Puppet modules used to configure your hosts are compatible with your Puppet version.
 +
+ifdef::satellite[]
+On hosts, you can use Puppet agent 7.
+endif::[]
+ifndef::satellite[]
 On hosts, you can use either Puppet agent 8 or Puppet agent 7.
+endif::[]
 
 System Requirements::
 Before you begin integrating Puppet with your {Project}, ensure that you meet the system requirements.
+ifdef::satellite[]
+For more information, see https://puppet.com/docs/puppet/7/system_requirements.html[System Requirements for Puppet 7] in the _Open Source Puppet_ documentation.
+endif::[]
+ifndef::satellite[]
 For more information, see https://puppet.com/docs/puppet/8/system_requirements.html[System Requirements for Puppet 8] or https://puppet.com/docs/puppet/7/system_requirements.html[System Requirements for Puppet 7] in the _Open Source Puppet_ documentation.
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Declare offical support for Puppet 8 to configure hosts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Foreman 3.12 supports Puppet 8: [source: release notes](https://docs.theforeman.org/3.12/Release_Notes/index-katello.html#_puppet_8_support)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Partially untested; instructions are based on steps for Puppet 7.
* Do we want to make a recommendation to use Puppet 8?

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
