### PR TITLE
Opt in to RH insights

### DIFF
--- a/guides/common/assembly_monitoring-hosts-by-using-red-hat-insights.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-red-hat-insights.adoc
@@ -6,7 +6,15 @@ endif::[]
 
 include::modules/ref_access-to-information-from-insights-in-project.adoc[leveloffset=+1]
 
+// By default, Satellite sets "host_registration_insights" to true
+// https://github.com/RedHatSatellite/foreman_theme_satellite/blob/develop/db/migrate/20201118090534_insights_param.rb
+ifdef::satellite[]
 include::modules/proc_excluding-hosts-from-rh-cloud-and-insights-client-reports.adoc[leveloffset=+1]
+endif::[]
+
+ifndef::satellite[]
+include::modules/proc_enabling-rh-cloud-and-insights-client-reports-on-hosts.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_deploying-red-hat-insights-by-using-the-ansible-role.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_adding-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_adding-an-ansible-playbook.adoc
@@ -21,7 +21,7 @@ Click *Sync Repository* to fetch the remote git repository.
 
 [NOTE]
 ====
-You can only edit the directory path or git URL as long as it is not used by any application definition.
+You can only edit the directory path or git URL if it is not used by any application definition.
 ====
 
 [TIP]

--- a/guides/common/modules/proc_enabling-rh-cloud-and-insights-client-reports-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-rh-cloud-and-insights-client-reports-on-hosts.adoc
@@ -1,0 +1,20 @@
+[id="enabling-rh-cloud-and-insights-client-reports-on-hosts_{context}"]
+= Enabling RH Cloud and Insights client reports on hosts
+
+You can enable the Red Hat Insights client on hosts and have {Project} upload hosts inventory to the Insights service in the {RHCloud}.
+
+ifdef::katello,foreman-el,foreman-deb[]
+Red Hat Insights is a service by Red Hat for {RHEL} hosts.
+Ensure to set this parameter for {RHEL} hosts only.
+If you set the parameter on any non-{RHEL} operating systems, {Project} automatically uploads new reports to the {RHCloud} when enabled in RH Cloud {Project} settings.
+endif::[]
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Host* > *Provisioning Setup* > *Operating Systems*.
+. Select any {RHEL} operating systems for which you want to change the value.
+. On the *Parameters* tab, add the `host_registration_insights` parameter, select the *boolean* type, and set the value to *True*.
+. Click *Submit* to save the parameter.
+
+.Additional resources
+* You can set this parameter at any level.
+For more information, see {ProvisioningDocURL}Host_Parameter_Hierarchy_provisioning[Host parameter hierarchy] in _{ProvisioningDocTitle}_.

--- a/guides/common/modules/proc_excluding-hosts-from-rh-cloud-and-insights-client-reports.adoc
+++ b/guides/common/modules/proc_excluding-hosts-from-rh-cloud-and-insights-client-reports.adoc
@@ -4,16 +4,15 @@
 You can set the `host_registration_insights` parameter to *False* to omit _rh-cloud_ and _insights-client_ reports.
 {Project} will exclude the hosts from _rh-cloud_ reports and block _insights-client_ from uploading a report to the cloud.
 
-Use the following procedure to change the value of `host_registration_insights` parameter:
-
 .Procedure
 . In the {ProjectWebUI}, navigate to *Host* > *All Hosts*.
 . Select any host for which you want to change the value.
 . On the *Parameters* tab, click on the edit button of `host_registration_insights`.
 . Set the value to *False*.
 
-This parameter can also be set at the organization, hostgroup, subnet, and domain level.
-Also, it automatically prevents new reports from being uploaded as long as they are associated with the entity.
-
 If you set the parameter to false on a host that is already reported on the https://console.redhat.com/[Red Hat Hybrid Cloud Console], it will be still removed automatically from the inventory.
 However, this process can take some time to complete.
+
+.Additional resources
+* You can set this parameter at any level.
+For more information, see {ProvisioningDocURL}Host_Parameter_Hierarchy_provisioning[Host parameter hierarchy] in _{ProvisioningDocTitle}_.

--- a/guides/common/modules/ref_content-settings.adoc
+++ b/guides/common/modules/ref_content-settings.adoc
@@ -44,8 +44,8 @@ Managed resources linked to the host such as virtual machines and DNS records mi
 | *Content View Dependency Solving Default* | No | The default dependency solving value for new content views.
 | *Host Duplicate DMI UUIDs* | [] | If hosts fail to register because of duplicate _Desktop Management Interface_ (DMI) UUIDs, add their comma-separated values here.
 Subsequent registrations generate a unique DMI UUID for the affected hosts.
-| *Host Profile Assume* | Yes | Enable new host registrations to assume registered profiles with matching hostname as long as the registering DMI UUID is not used by another host.
-| *Host Profile Can Change In Build* | No | Enable host registrations to bypass *Host Profile Assume* as long as the host is in build mode.
+| *Host Profile Assume* | Yes | Enable new host registrations to assume registered profiles with matching hostname if the registering DMI UUID is not used by another host.
+| *Host Profile Can Change In Build* | No | Enable host registrations to bypass *Host Profile Assume* if the host is in build mode.
 | *Host Can Re-Register Only In Build* | No | Enable hosts to re-register only when they are in build mode.
 | *Host Tasks Workers Pool Size* | 5 | Number of workers in the pool to handle the execution of host-related tasks.
 When set to 0, the default queue is used.


### PR DESCRIPTION
#### What changes are you introducing?

add procedure to opt-in to uploading reports to RH cloud.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

on orcharhino, users register hosts with RHEL and non-RHEL OS, but they should only set the parameter for RHEL OS.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
