### PR TITLE
List Windows Server versions supported for AD integration

### DIFF
--- a/guides/common/modules/con_configuring-active-directory-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/modules/con_configuring-active-directory-as-an-external-identity-provider-for-project.adoc
@@ -18,7 +18,10 @@ The recommended setup consists of two steps:
 * Enrolling {ProjectServer} with the Active Directory server as described in xref:Enrolling_Server_with_the_AD_Server_{context}[].
 * Configuring direct Active Directory integration with GSS-proxy as described in xref:Configuring_Direct_AD_Integration_with_GSS_Proxy_{context}[].
 
-{Team} tests {Project} integration with AD instances that run on Windows Server 2019.
+{Team} supports {Project} integration with AD instances that run on the following Windows Server versions:
+
+* Windows Server 2022
+* Windows Server 2019
 
 ifndef::orcharhino[]
 For information about integrating {RHEL} systems with Active{nbsp}Directory, see link:{RHELDocsBaseURL}8/html/integrating_rhel_systems_directly_with_windows_active_directory/index[{RHEL}{nbsp}8 _Integrating RHEL systems directly with Windows Active Directory_].

--- a/guides/common/modules/con_configuring-active-directory-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/modules/con_configuring-active-directory-as-an-external-identity-provider-for-project.adoc
@@ -18,6 +18,8 @@ The recommended setup consists of two steps:
 * Enrolling {ProjectServer} with the Active Directory server as described in xref:Enrolling_Server_with_the_AD_Server_{context}[].
 * Configuring direct Active Directory integration with GSS-proxy as described in xref:Configuring_Direct_AD_Integration_with_GSS_Proxy_{context}[].
 
+{Team} tests {Project} integration with AD instances that run on Windows Server 2019.
+
 ifndef::orcharhino[]
 For information about integrating {RHEL} systems with Active{nbsp}Directory, see link:{RHELDocsBaseURL}8/html/integrating_rhel_systems_directly_with_windows_active_directory/index[{RHEL}{nbsp}8 _Integrating RHEL systems directly with Windows Active Directory_].
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Let's list the tested and/or supported versions of Windows Server for integration with Active Directory.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We currently don't offer any guidance on which WS versions users can use for integration with Foreman.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
