### PR TITLE
Move assembly on managing the lifecycle of a host enrolled with FreeIPA

### DIFF
--- a/guides/common/assembly_configuring-external-authentication-and-enabling-single-sign-on-and-two-factor-authentication.adoc
+++ b/guides/common/assembly_configuring-external-authentication-and-enabling-single-sign-on-and-two-factor-authentication.adoc
@@ -38,8 +38,6 @@ endif::[]
 
 include::assembly_configuring-active-directory-as-an-external-identity-provider-for-project.adoc[leveloffset=+1]
 
-include::assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+1]
-
 include::modules/con_important-user-and-group-account-information-for-active-directory-accounts.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-external-user-groups.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-external-services.adoc
+++ b/guides/common/assembly_configuring-external-services.adoc
@@ -14,5 +14,7 @@ include::modules/proc_configuring-external-tftp.adoc[leveloffset=+1]
 
 include::assembly_configuring-external-idm-dns.adoc[leveloffset=+1]
 
+include::assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+1]
+
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]


### PR DESCRIPTION
#### What changes are you introducing?

I'm moving an assembly on managing a FreeIPA's host lifecycle out of the assembly on configuring external authentication.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The assembly doesn't describe configuring authentication so it doesn't belong in a chapter on external authentication, even though it mentions FreeIPA. I can't say for sure if I'm moving it to the right place, though.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I'd like to resolve this before I continue with https://github.com/theforeman/foreman-documentation/pull/3294.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
