### PR TITLE
Avoid RH RH duplicity in Client repo name

### DIFF
--- a/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
@@ -9,7 +9,7 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 . Toggle the *Recommended Repositories* switch to the *On* position.
 . From the list of results, expand the following repositories and click the *Enable* icon to enable the repositories:
 +
-* To upgrade {Project} clients, enable the *Red{nbsp}Hat {project-client-name}* repositories for all {RHEL} versions that clients use.
+* To upgrade {Project} clients, enable the *{project-client-name}* repositories for all {RHEL} versions that clients use.
 +
 * If you have {SmartProxyServers}, to upgrade them, enable the following repositories too:
 +
@@ -31,8 +31,8 @@ In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*, click *Manage Ma
 . In the {ProjectWebUI}, navigate to *Content* > *Sync Status*.
 . Click the arrow next to the product to view the available repositories.
 . Select the repositories for {ProjectVersion}.
-Note that *Red{nbsp}Hat {project-client-name}* does not have a {ProjectVersion} version.
-Choose *Red{nbsp}Hat {project-client-name}* instead.
+Note that *{project-client-name}* does not have a {ProjectVersion} version.
+Choose *{project-client-name}* instead.
 . Click *Synchronize Now*.
 +
 [IMPORTANT]


### PR DESCRIPTION
#### What changes are you introducing?

Removing "Red Hat" occurence

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To avoid duplicit "Red Hat" in repo name

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
