### PR TITLE
Ensure RHEL 8 AppStream repo is enabled

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -25,6 +25,14 @@ The required repositories cannot be served from a locally mounted ISO but must b
 endif::[]
 
 .Procedure
+ifdef::satellite[]
+. Ensure that the *{EL} 8 - AppStream (RPMs)* repository is enabled:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms
+----
+endif::[]
 ifndef::satellite[]
 . Enable the https://copr.fedorainfracloud.org/coprs/g/theforeman/leapp/[@theforeman/leapp COPR Repository], which contains Leapp packages with patches to support {Project} or {SmartProxy} upgrades:
 +
@@ -33,8 +41,8 @@ ifndef::satellite[]
 ----
 endif::[]
 . Install required packages:
-[options="nowrap", subs="+quotes,verbatim,attributes"]
 +
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {project-package-install} leapp leapp-upgrade-el8toel9
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Satellite users must ensure that the repo containing Leapp packages is enabled.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27995

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
