### PR TITLE
Clarify naming scheme of bonded interfaces

### DIFF
--- a/guides/common/modules/proc_adding-a-bonded-interface.adoc
+++ b/guides/common/modules/proc_adding-a-bonded-interface.adoc
@@ -50,9 +50,11 @@ endif::[]
 --managed true \
 --interface="identifier=_My_NIC_1, mac=_My_MAC_Address_1_, managed=true, type=Nic::Managed, domain_id=_My_Domain_ID_, subnet_id=_My_Subnet_ID_" \
 --interface="identifier=_My_NIC_2_, mac=_My_MAC_Address_2_, managed=true, type=Nic::Managed, domain_id=_My_Domain_ID_, subnet_id=_My_Subnet_ID_" \
---interface="identifier=_bond0_, ip=_My_IP_Address_2_, type=Nic::Bond, mode=active-backup, attached_devices=[_My_NIC_1_,_My_NIC_2_], managed=true, domain_id=_My_Domain_ID_, subnet_id=_My_Subnet_ID_" \
+--interface="identifier=_bondN_, ip=_My_IP_Address_2_, type=Nic::Bond, mode=active-backup, attached_devices=[_My_NIC_1_,_My_NIC_2_], managed=true, domain_id=_My_Domain_ID_, subnet_id=_My_Subnet_ID_" \
 --location "_My_Location_" \
 --name "_My_Host_Name_" \
 --organization "_My_Organization_" \
 --subnet-id=_My_Subnet_ID_
 ----
++
+Ensure to replace `bondN` with `bond` and the ID of your device identifier, for example, `bond0`.


### PR DESCRIPTION
Fixes #73

#### What changes are you introducing?

explanation for naming scheme

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

old GH issue

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
