### PR TITLE
Remove CDN SSL version

### DIFF
--- a/guides/common/modules/ref_content-settings.adoc
+++ b/guides/common/modules/ref_content-settings.adoc
@@ -5,7 +5,6 @@
 |====
 | Setting | Default Value | Description
 | *Default HTTP Proxy* | | Default HTTP Proxy for syncing content.
-| *CDN SSL version* | | SSL version used to communicate with the CDN.
 | *Default synced OS provisioning template* | Kickstart default | Default provisioning template for operating systems created from synced content.
 | *Default synced OS finish template* | Kickstart default finish | Default finish template for new operating systems created from synced content.
 | *Default synced OS user-data* | Kickstart default user data |Default user data for new operating systems created from synced content.


### PR DESCRIPTION
The CDN SSL version was determined not to be needed in 
the content
settings reference module. There is no mention of it in 
the
documentation and if it was mentioned, it would have 
been removed.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
