### PR TITLE
Add Configuring user authentication guide to navigation

### DIFF
--- a/web/releases/3.12.json
+++ b/web/releases/3.12.json
@@ -19,6 +19,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Configuring user authentication",
+          "path": "Configuring_user_authentication"
+        },
+        {
           "title": "Configuring hosts by using Ansible",
           "path": "Managing_Configurations_Ansible"
         },
@@ -43,6 +47,10 @@
         {
           "title": "Upgrading Foreman to 3.12",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Configuring user authentication",
+          "path": "Configuring_user_authentication"
         },
         {
           "title": "Configuring hosts by using Ansible",
@@ -81,6 +89,10 @@
         {
           "title": "Upgrading Katello to 4.14",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Configuring user authentication",
+          "path": "Configuring_user_authentication"
         },
         {
           "title": "Tuning performance",

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -27,6 +27,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Configuring user authentication",
+          "path": "Configuring_user_authentication"
+        },
+        {
           "title": "Deploying Foreman on AWS",
           "path": "Deploying_Project_on_AWS"
         },
@@ -97,6 +101,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Configuring user authentication",
+          "path": "Configuring_user_authentication"
+        },
+        {
           "title": "Deploying Foreman on AWS",
           "path": "Deploying_Project_on_AWS"
         },
@@ -157,6 +165,10 @@
         {
           "title": "Upgrading Katello to Nightly",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Configuring user authentication",
+          "path": "Configuring_user_authentication"
         },
         {
           "title": "Tuning performance",


### PR DESCRIPTION
#### What changes are you introducing?

Adding a new guide, Configuring User Authentication (https://github.com/theforeman/foreman-documentation/pull/3294), to docs.theforeman.org navigation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

N/A

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
