### PR TITLE
Add diagram of installer-based provisioning with PXE boot

### DIFF
--- a/guides/image-sources/foreman.pstyle
+++ b/guides/image-sources/foreman.pstyle
@@ -1,0 +1,48 @@
+' Foreman style for PlantUML diagrams
+' This style was created for sequence diagrams and may be incomplete.
+
+skinparam RoundCorner 8
+skinparam Shadowing false
+
+' #ffcc32 Foreman yellow
+' #025d8c Foreman blue
+
+skinparam sequence {
+    ArrowColor  #025d8c
+    LifeLineBorderColor #ecf4f8
+    LifeLineBorderThickness 32
+    DividerBorderColor #025d8c
+    DividerFontColor #025d8c
+    group {
+        TitleFontColor #025d8c
+        BorderColor #d2e4ed
+        FontColor #025d8c
+    }
+    groupHeader {
+        BackgroundColor #d2e4ed
+        FontColor #025d8c
+    }
+}
+
+skinparam Actor {
+    BackgroundColor #025d8c
+    BorderColor #025d8c
+    FontColor   #025d8c
+}
+
+skinparam Participant {
+    BackgroundColor #025d8c
+    BorderColor #025d8c
+    FontColor   White
+}
+
+skinparam Note {
+    BackgroundColor #d2e4ed
+    BorderColor #025d8c
+    FontColor   #025d8c
+}
+
+' Puppet enabled=1, disabled=0
+!$puppet = 1
+
+autonumber

--- a/guides/image-sources/prov-create-host-pxe.iuml
+++ b/guides/image-sources/prov-create-host-pxe.iuml
@@ -1,0 +1,17 @@
+User -> Foreman : Create host
+Foreman -> Proxy : Request a free IP address
+Proxy -> DHCP : Search for a free IP address in DHCP
+DHCP -> Proxy : Return the free IP address
+Proxy -> Foreman : Pass the free IP address
+group Templates [*PXE* installer boot]
+    Foreman -> Proxy : Render boot-loader configuration files
+end
+Proxy -> TFTP : Deploy boot-loader configuration files\nto ""/var/lib/tftpboot""
+Foreman -> Proxy : Command to download installer kernel\nand initial RAM disk
+Proxy -> TFTP : Download kernel and initial RAM disk
+Foreman -> Proxy : Request DHCP reservation
+Proxy -> DHCP : Create DHCP reservation
+Foreman -> Proxy : Create DNS records
+Proxy -> DNS : Forward DNS records
+Proxy -> Foreman : Report status of TFTP, DHCP & DNS
+Foreman -> User : Host is created\n(build mode enabled)

--- a/guides/image-sources/prov-first-local-boot-pxe.iuml
+++ b/guides/image-sources/prov-first-local-boot-pxe.iuml
@@ -1,0 +1,4 @@
+Host -> DHCP : Request reserved IP address and DHCP options
+Host -> TFTP : Download boot loader
+TFTP -> Host : Provide MAC-based configuration for boot loader
+Host -> Host : Boot from HDD

--- a/guides/image-sources/prov-initial-configuration.iuml
+++ b/guides/image-sources/prov-initial-configuration.iuml
@@ -1,0 +1,8 @@
+!if ($puppet)
+opt when Puppet enabled
+    Host -> Host : Install Puppet agent
+    Host -> Puppet : Send certificate signing request
+    Puppet -> Host : Send certificate (if allowed to)
+end
+!endif
+Host -> Host : Configure, for example:\n- Subscription Manager\n- Remote execution\n- Run Ansible roles

--- a/guides/image-sources/prov-installation-media.iuml
+++ b/guides/image-sources/prov-installation-media.iuml
@@ -1,0 +1,6 @@
+loop
+   Host -> Foreman : Request installation media
+   Foreman -> Proxy : Request installation media
+   Proxy -> Foreman : Provide installation media
+   Foreman -> Host : Provide installation media
+end

--- a/guides/image-sources/provisioning-installer-pxeboot.plantuml
+++ b/guides/image-sources/provisioning-installer-pxeboot.plantuml
@@ -1,0 +1,60 @@
+@startuml
+
+!include foreman.pstyle
+
+title Installer-based provisioning with PXE boot on bare metal
+
+actor       User
+participant "Provisioned\nHost" as Host
+participant "Foreman" as Foreman
+participant "Foreman\nProxy" as Proxy
+participant TFTP
+participant DHCP
+participant DNS
+!if ($puppet)
+participant "Puppet\nserver" as Puppet
+!endif
+
+note over Host : Powered off
+
+== Create host in Foreman ==
+
+!include prov-create-host-pxe.iuml
+
+== Boot into installer ==
+
+User -> Host : Power on the machine
+Host -> DHCP : Request reserved IP and DHCP options
+Host -> TFTP : Download boot loader
+Host -> Host : Load the boot loader
+Host -> TFTP : Get MAC-based configuration for boot loader
+Host -> TFTP : Download installer kernel and initial RAM disk
+Host ->  Host : Load the installer
+Host -> Proxy : Request installer configuration
+group Template [Provision]
+   Proxy -> Proxy : Render installer configuration
+end
+Proxy -> Host : Provide installer configuration, such as a Kickstart file
+!include prov-installation-media.iuml
+note over Host : Operating system installed
+!include prov-initial-configuration.iuml
+Host -> Foreman : Call home\n(disables build mode)
+group Templates [*PXE* local boot]
+    Foreman -> Proxy : Render boot-loader configuration files
+end
+Proxy -> TFTP : Deploy boot-loader configuration files\nto ""/var/lib/tftpboot""
+Host -> Host : Reboot
+
+== First local boot ==
+
+!include prov-first-local-boot-pxe.iuml
+
+!if ($puppet)
+== First Puppet run ==
+
+!include puppet-run.iuml
+!endif
+
+note over Host : In operation
+
+@enduml

--- a/guides/image-sources/puppet-run.iuml
+++ b/guides/image-sources/puppet-run.iuml
@@ -1,0 +1,10 @@
+opt when Puppet enabled
+   Host -> Puppet : Send facts
+   Host -> Puppet : Request catalog
+   Puppet -> Foreman : Forward facts
+   Puppet -> Foreman : Request external node classification
+   Puppet -> Host : Respond with requested catalog
+   Host -> Host : Run catalog
+   Host -> Puppet : Send report
+   Puppet -> Foreman : Forward report
+end


### PR DESCRIPTION
#### What changes are you introducing?

Adding a sequence diagram of installer-based provisioning with PXE boot. Using PlantUML to build the diagram.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Preparation for improvements of _Provisioning hosts_. The diagram will be used later to explain the workflow of the provisioning method.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Some files (.iuml, .pstyle) are expected to be reused in mutiple diagrams.
* Continuation of https://github.com/theforeman/foreman-documentation/pull/3069

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
