### PR TITLE
don't mention foreman-debug, only sos report

### DIFF
--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -20,7 +20,6 @@
 :postgresql-lib-dir: /var/lib/postgresql
 :postgresql-data-dir: {postgresql-lib-dir}/13/main
 :postgresql-log-dir: /var/log/postgresql
-:project-debug: foreman-debug
 
 // Some documents are not ready for stable releases, but can be published on nightly
 ifeval::["{DocState}" != "nightly"]

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -47,7 +47,6 @@
 :smartproxy-example-com: orcharhino-proxy.example.com
 :smartproxy_port: 9090
 :fdi-package-name: orcharhino-fdi
-:project-debug: orcharhino-debug
 // Overwritten in downstream for docs.orcharhino.com
 :client-package-install: dnf install
 :client-package-remove: dnf remove

--- a/guides/common/modules/ref_utilities-for-processing-log-information.adoc
+++ b/guides/common/modules/ref_utilities-for-processing-log-information.adoc
@@ -3,36 +3,22 @@
 
 You can collect information from log files to troubleshoot {Project}.
 
-ifdef::foreman-el,katello,satellite[]
 sosreport::
-The `sosreport` command collects configuration and diagnostic information from a Linux system, such as the running Kernel version, loaded modules, running services, and system and service configuration files.
+The `sos report` command collects configuration and diagnostic information from a Linux system, such as the running kernel version, loaded modules, running services, and system and service configuration files.
+Additionally, it collects information about {ProjectName}, such as its back-end services and tasks.
 This output is stored in a tar file located at `/var/tmp/__sosreport-XXX-20171002230919.tar.xz__`.
 +
-For more information, run `sosreport --help` or see https://access.redhat.com/solutions/3592[_What is a sosreport and how can I create one?_].
+For more information, run `sos report --help` or see
+ifdef::satellite[]
+https://access.redhat.com/solutions/3592[What is a sosreport and how can I create one?] in the _{Team} Knowledgebase_.
 endif::[]
-ifdef::foreman-deb,orcharhino[]
-{project-debug}::
-The `{project-debug}` command collects configuration and log file data for {ProjectName}, its back-end services, and system information.
-This output is stored in a tar file.
-By default, the tar file is located at `/tmp/__{project-debug}-xxx.tar.xz__`.
-+
-Additionally, the `{project-debug}` command exports tasks run during the last 60 days.
-By default, the output tar file is located at `/tmp/__task-export-xxx.tar.xz__`.
-If the file is missing, see the file `/tmp/task-export.log` to learn why task export was unsuccessful.
-There is no timeout when running this command.
-+
-For more information, run `{project-debug} -h`.
+ifndef::satellite[]
+https://github.com/sosreport/sos/wiki#for-users[_SOS user documentation_].
 endif::[]
 +
 [IMPORTANT]
 ====
-ifdef::foreman-el,katello,satellite[]
-The `sosreport` command
-endif::[]
-ifdef::foreman-deb,orcharhino[]
-The `{project-debug}` command
-endif::[]
-removes security information such as passwords, tokens, and keys while collecting information.
+The `sos report` command removes security information such as passwords, tokens, and keys while collecting information.
 However, the tar files can still contain sensitive information about the {ProjectServer}.
 Send the tar files directly to the intended recipient and not to a public target.
 ====


### PR DESCRIPTION
#### What changes are you introducing?

Move all deployment targets to use `sos report`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

`foreman-debug` is unmaintained, partially broken on EL9 (at least the Katello integration is) and not installed by default since Foreman 3.10: https://projects.theforeman.org/issues/37022

I intend to completely remove that tool, but first docs need to be updated not to refer to it :)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
