### PR TITLE
Add container push to Katello 4.14 headline features

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -9,6 +9,8 @@
 There are some significant improvements in the experimental new All Hosts index page with this release.
 To use the new page by default, in Settings, set Show new host overview page to Yes.
 
+*Container push* - You can now push container images to Katello via `podman push`.
+
 *Host bulk actions* - You can now select one or more hosts and click the vertical ellipsis menu to perform the following actions:
 
 * Manage content


### PR DESCRIPTION
A headline feature for container push was missed.