### PR TITLE
Add running Ansible roles upon host registration

### DIFF
--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -47,11 +47,11 @@ endif::[]
 // Host tools
 include::modules/proc_installing-tracer.adoc[leveloffset=+1]
 
-include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+1]
-
 include::modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc[leveloffset=+1]
 
 include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]
+
+include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+1]
 
 include::modules/con_using-custom-ssl-certificate-for-hosts.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -47,6 +47,8 @@ endif::[]
 // Host tools
 include::modules/proc_installing-tracer.adoc[leveloffset=+1]
 
+include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+1]
+
 include::modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc[leveloffset=+1]
 
 include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -45,6 +45,8 @@ endif::[]
 . Optional: Select a different *Location*.
 . Optional: From the *Host Group* list, select the host group to associate the hosts with.
 Fields that inherit value from *Host group*: *Operating system*, *Activation Keys* and *Lifecycle environment*.
++
+If your host group has any Ansible roles assigned, the Ansible roles will run on your host upon the registration.
 . Optional: From the *Operating system* list, select the operating system of hosts that you want to register.
 ifndef::satellite,orcharhino[]
 Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.

--- a/guides/common/modules/proc_running-ansible-roles-during-host-registration.adoc
+++ b/guides/common/modules/proc_running-ansible-roles-during-host-registration.adoc
@@ -8,7 +8,7 @@ ifndef::satellite[]
 * Ansible integration is enabled on {Project}.
 For more information, see {ManagingConfigurationsAnsibleDocURL}Enabling_Ansible_Integration_with_{project-context}_ansible[Enabling Ansible integration with {Project}] in _{ManagingConfigurationsAnsibleDocTitle}_.
 endif::[]
-* The required Ansible roles have been imported to {ProjectServer}.
+* The required Ansible roles have been imported from your {SmartProxy} to {Project}.
 For more information, see {ManagingConfigurationsAnsibleDocURL}Importing_Ansible_Roles_and_Variables_ansible[Importing Ansible roles and variables] in _{ManagingConfigurationsAnsibleDocTitle}_.
 
 .Procedure

--- a/guides/common/modules/proc_running-ansible-roles-during-host-registration.adoc
+++ b/guides/common/modules/proc_running-ansible-roles-during-host-registration.adoc
@@ -1,0 +1,18 @@
+[id="running-ansible-roles-during-host-registration"]
+= Running Ansible roles during host registration
+
+You can run Ansible roles when you are registering a host to {Project}.
+
+.Prerequisites
+ifndef::satellite[]
+* Ansible integration is enabled on {Project}.
+For more information, see {ManagingConfigurationsAnsibleDocURL}Enabling_Ansible_Integration_with_{project-context}_ansible[Enabling Ansible integration with {Project}] in _{ManagingConfigurationsAnsibleDocTitle}_.
+endif::[]
+* The required Ansible roles have been imported to {ProjectServer}.
+For more information, see {ManagingConfigurationsAnsibleDocURL}Importing_Ansible_Roles_and_Variables_ansible[Importing Ansible roles and variables] in _{ManagingConfigurationsAnsibleDocTitle}_.
+
+.Procedure
+. Create a host group with Ansible roles.
+For more information, see xref:Creating_a_Host_Group_{context}[].
+. Register the host by using the host group with assigned Ansible roles.
+For more information, see xref:registering-a-host_{context}[].


### PR DESCRIPTION
#### What changes are you introducing?

Adding a procedure how to run Ansible roles upon host registration and a note in _Registering a host_.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We got a request from our support team that users weren't aware of this option and it should be documented.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
