### PR TITLE
Fix container push headline feature location

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -4,12 +4,15 @@
 [id="katello-headline-features"]
 == Headline Features
 
+=== Container push
+
+You can now push container images to Katello via `podman push`.
+Please check the documentation for container name requirements since organization and product namespacing is required.
+
 === New All Hosts index page improvements
 
 There are some significant improvements in the experimental new All Hosts index page with this release.
 To use the new page by default, in Settings, set Show new host overview page to Yes.
-
-*Container push* - You can now push container images to Katello via `podman push`.
 
 *Host bulk actions* - You can now select one or more hosts and click the vertical ellipsis menu to perform the following actions:
 


### PR DESCRIPTION
In the previous PR https://github.com/theforeman/foreman-documentation/pull/3319/ , the container push headline feature was put in the wrong spot. This corrects that (and adds a little more text).