### PR TITLE
Clarify that AD users in a cross-forest trust env with FreeIPA cannot login with Kerberos

### DIFF
--- a/guides/common/modules/con_configuring-kerberos-single-sign-on-with-freeipa-in-project.adoc
+++ b/guides/common/modules/con_configuring-kerberos-single-sign-on-with-freeipa-in-project.adoc
@@ -6,10 +6,13 @@ With {Project}, you can integrate {ProjectServer} with your existing {FreeIPA} s
 
 With your {FreeIPA} server configured as an external identity provider, users defined in {FreeIPA} can log in to {Project} with their {FreeIPA} credentials.
 If a cross-forest trust is configured between {FreeIPA} and Active{nbsp}Directory, Active{nbsp}Directory users can also log in to {Project}.
-The following login methods are available:
+
+The following login methods are available for {FreeIPA} users:
 
 * Username and password
 * Kerberos single sign-on
+
+When a cross-forest trust is configured between {FreeIPA} and Active{nbsp}Directory, Active{nbsp}Directory users can log in to {Project} with their user principal name (UPN) and password
 
 ifndef::orcharhino[]
 For information about {FreeIPA}, including its cross-forest trust functionality, see link:{RHELDocsBaseURL}8/html/planning_identity_management/index[{RHEL}{nbsp}8 _Planning Identity Management_] and link:{RHELDocsBaseURL}8/html/installing_identity_management/index[{RHEL}{nbsp}8 _Installing Identity Management_].

--- a/guides/common/modules/con_configuring-kerberos-single-sign-on-with-freeipa-in-project.adoc
+++ b/guides/common/modules/con_configuring-kerberos-single-sign-on-with-freeipa-in-project.adoc
@@ -12,7 +12,7 @@ The following login methods are available for {FreeIPA} users:
 * Username and password
 * Kerberos single sign-on
 
-When a cross-forest trust is configured between {FreeIPA} and Active{nbsp}Directory, Active{nbsp}Directory users can log in to {Project} with their user principal name (UPN) and password
+When a cross-forest trust is configured between {FreeIPA} and Active{nbsp}Directory, Active{nbsp}Directory users can log in to {Project} with their user principal name (UPN) and password.
 
 ifndef::orcharhino[]
 For information about {FreeIPA}, including its cross-forest trust functionality, see link:{RHELDocsBaseURL}8/html/planning_identity_management/index[{RHEL}{nbsp}8 _Planning Identity Management_] and link:{RHELDocsBaseURL}8/html/installing_identity_management/index[{RHEL}{nbsp}8 _Installing Identity Management_].


### PR DESCRIPTION
#### What changes are you introducing?

I'm clarifying that in a setup with a cross-forest trust between FreeIPA and AD, different login methods are available to FreeIPA and AD users.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current description might be interpreted in a way that suggests that either FreeIPA or AD users can use any of the listed login methods.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
