### PR TITLE
Fix URL fragment for Configuring user auth

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -15,7 +15,7 @@
 :AdministeringDocURL: {BaseURL}administering_red_hat_satellite/index#
 :APIDocURL: {BaseURL}using_the_satellite_rest_api/index#
 :ConfiguringLoadBalancerDocURL: {BaseURL}configuring_capsules_with_a_load_balancer/index#
-:ConfiguringUserAuthenticationDocURL: {BaseURL}configuring_user_authentication/index#
+:ConfiguringUserAuthenticationDocURL: {BaseURL}configuring_authentication_for_red_hat_satellite_users/index#
 :ContentManagementDocURL: {BaseURL}managing_content/index#
 :InstallingServerDisconnectedDocURL: {BaseURL}installing_satellite_server_in_a_disconnected_network_environment/index#
 :InstallingServerDocURL: {BaseURL}installing_satellite_server_in_a_connected_network_environment/index#

--- a/guides/upstream_filename_to_satellite_link.json
+++ b/guides/upstream_filename_to_satellite_link.json
@@ -1,6 +1,7 @@
 {
   "build/Administering_Project/index-satellite.html": "administering_red_hat_satellite",
   "build/Configuring_Load_Balancer/index-satellite.html": "configuring_capsules_with_a_load_balancer",
+  "build/Configuring_User_Authentication/index-satellite.html": "configuring_authentication_for_red_hat_satellite_users",
   "build/Deploying_Project_on_AWS/index-satellite.html": "deploying_red_hat_satellite_on_amazon_web_services",
   "build/Installing_Proxy/index-satellite.html": "installing_capsule_server",
   "build/Installing_Server/index-satellite.html": "installing_satellite_server_in_a_connected_network_environment",


### PR DESCRIPTION
#### What changes are you introducing?

Adjusting the URL fragment for a new guide to match its title.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Downstream tooling needs the two to match.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
