### PR TITLE
Fix broken links in Installing Proxy

### DIFF
--- a/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
+++ b/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
@@ -31,9 +31,9 @@ ifeval::["{mode}" == "connected"]
 xref:configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{context}[].
 endif::[]
 ifeval::["{mode}" == "disconnected"]
-{InstallingServerDocURL}External_Authentication_for_Provisioned_Hosts_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
+{InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
 endif::[]
 endif::[]
 ifeval::["{context}" == "{smart-proxy-context}"]
-{InstallingServerDocURL}External_Authentication_for_Provisioned_Hosts_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
+{InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
+++ b/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
@@ -31,9 +31,9 @@ ifeval::["{mode}" == "connected"]
 xref:configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{context}[].
 endif::[]
 ifeval::["{mode}" == "disconnected"]
-{InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
+{InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[Configuring {Project} to manage the lifecycle of a host registered to a {FreeIPA} realm] in _{InstallingServerDocTitle}_.
 endif::[]
 endif::[]
 ifeval::["{context}" == "{smart-proxy-context}"]
-{InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[External Authentication for Provisioned Hosts] in _{InstallingServerDocTitle}_.
+{InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[Configuring {Project} to manage the lifecycle of a host registered to a {FreeIPA} realm] in _{InstallingServerDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_managing-dhcp-by-using-smartproxy.adoc
+++ b/guides/common/modules/con_managing-dhcp-by-using-smartproxy.adoc
@@ -9,9 +9,9 @@ Note that your {SmartProxy} cannot manage subnet declarations.
 .Available DHCP providers
 * `dhcp_infoblox` {endash} For more information, see xref:Using_Infoblox_as_DHCP_and_DNS_Providers_{smart-proxy-context}[].
 * `dhcp_isc` {endash} ISC DHCP server over OMAPI.
-For more information, see {InstallingSmartProxyDocURL}configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[Configuring DNS, DHCP, and TFTP on {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see xref:configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[].
 * `dhcp_remote_isc` {endash} ISC DHCP server over OMAPI with leases mounted through networking.
-For more information, see {InstallingSmartProxyDocURL}configuring-external-dhcp_{smart-proxy-context}[Configuring an External DHCP Server to Use with {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see xref:configuring-external-dhcp_{smart-proxy-context}[].
 ifndef::satellite[]
 * `dhcp_libvirt` {endash} dnsmasq DHCP via libvirt API
 endif::[]

--- a/guides/common/modules/con_managing-dhcp-by-using-smartproxy.adoc
+++ b/guides/common/modules/con_managing-dhcp-by-using-smartproxy.adoc
@@ -7,9 +7,9 @@ You can use the DHCP module of {SmartProxy} to query for available IP addresses,
 Note that your {SmartProxy} cannot manage subnet declarations.
 
 .Available DHCP providers
-* `dhcp_infoblox` {endash} For more information, see {ProvisioningDocURL}Using_Infoblox_as_DHCP_and_DNS_Providers_provisioning[Using Infoblox as DHCP and DNS Providers] in _{ProvisioningDocTitle}_.
+* `dhcp_infoblox` {endash} For more information, see xref:Using_Infoblox_as_DHCP_and_DNS_Providers_{smart-proxy-context}[].
 * `dhcp_isc` {endash} ISC DHCP server over OMAPI.
-For more information, see {InstallingSmartProxyDocURL}configuring-dns-dhcp-and-tftp_{smart-proxy-context}[Configuring DNS, DHCP, and TFTP on {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[Configuring DNS, DHCP, and TFTP on {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 * `dhcp_remote_isc` {endash} ISC DHCP server over OMAPI with leases mounted through networking.
 For more information, see {InstallingSmartProxyDocURL}configuring-external-dhcp_{smart-proxy-context}[Configuring an External DHCP Server to Use with {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 ifndef::satellite[]

--- a/guides/common/modules/con_managing-dns-by-using-smartproxy.adoc
+++ b/guides/common/modules/con_managing-dns-by-using-smartproxy.adoc
@@ -12,7 +12,7 @@ Other providers provide more direct integration, such as `dns_infoblox` for http
 ifdef::orcharhino[]
 * `dns_dnscmd` {endash} Static DNS records in Microsoft Active Directory.
 endif::[]
-* `dns_infoblox` {endash} For more information, see {ProvisioningDocURL}Using_Infoblox_as_DHCP_and_DNS_Providers_provisioning[Using Infoblox as DHCP and DNS Providers] in _{ProvisioningDocTitle}_.
+* `dhcp_infoblox` {endash} For more information, see xref:Using_Infoblox_as_DHCP_and_DNS_Providers_{smart-proxy-context}[].
 ifndef::satellite[]
 * `dns_libvirt` {endash} Dnsmasq DNS via libvirt API.
 For more information, see xref:configuring_dns_libvirt_{context}[].

--- a/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
+++ b/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
@@ -1,4 +1,4 @@
-[id="registering_hosts_to_server_{context}"]
+[id="registering-hosts-and-setting-up-host-integration_{context}"]
 = Registering hosts and setting up host integration
 
 You must register hosts that have not been provisioned through {Project} to be able to manage them with {Project}.

--- a/guides/common/modules/con_smartproxy-networking.adoc
+++ b/guides/common/modules/con_smartproxy-networking.adoc
@@ -1,4 +1,4 @@
-[id="{SmartProxy}-Networking_{context}"]
+[id="{smart-proxy-context}-networking_{context}"]
 = {SmartProxy} networking
 
 The communication between {ProjectServer} and hosts registered to a {SmartProxyServer} is routed through that {SmartProxyServer}.

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -7,10 +7,10 @@ Use this section to configure {SmartProxyServer} with an SSL certificate that is
 
 ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
-For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering to {ProjectServer}].
+For more information, see {InstallingSmartProxyDocURL}Registering_Proxy_to_Server_{smart-proxy-context}[Registering to {ProjectServer}].
 endif::[]
 * {SmartProxyServer} packages are installed.
-For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
+For more information, see {InstallingSmartProxyDocURL}Installing_Proxy_Packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure
 

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -7,10 +7,10 @@ Use this section to configure {SmartProxyServer} with an SSL certificate that is
 
 ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
-For more information, see {InstallingSmartProxyDocURL}Registering_Proxy_to_Server_{smart-proxy-context}[Registering to {ProjectServer}].
+For more information, see xref:Registering_Proxy_to_Server_{smart-proxy-context}[].
 endif::[]
 * {SmartProxyServer} packages are installed.
-For more information, see {InstallingSmartProxyDocURL}Installing_Proxy_Packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
+For more information, see xref:Installing_Proxy_Packages_{smart-proxy-context}[].
 
 .Procedure
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -9,9 +9,9 @@ Do not use the same command on more than one {SmartProxyServer}.
 * {ProjectServer} is configured with a custom certificate.
 For more information, see {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
-For more information, see {InstallingSmartProxyDocURL}Registering_Proxy_to_Server_{smart-proxy-context}[Registering to {ProjectServer}].
+For more information, see xref:Registering_Proxy_to_Server_{smart-proxy-context}[].
 * {SmartProxyServer} packages are installed.
-For more information, see {InstallingSmartProxyDocURL}Installing_Proxy_Packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
+For more information, see xref:Installing_Proxy_Packages_{smart-proxy-context}[].
 
 .Procedure
 . On your {ProjectServer}, generate a certificate bundle:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -7,11 +7,11 @@ Do not use the same command on more than one {SmartProxyServer}.
 
 .Prerequisites
 * {ProjectServer} is configured with a custom certificate.
-For more information, see {InstallingServerDocURL}configuring-satellite-custom-server-certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
-For more information, see {InstallingSmartProxyDocURL}registering-to-satellite-server_{smart-proxy-context}[Registering to {ProjectServer}].
+For more information, see {InstallingSmartProxyDocURL}Registering_Proxy_to_Server_{smart-proxy-context}[Registering to {ProjectServer}].
 * {SmartProxyServer} packages are installed.
-For more information, see {InstallingSmartProxyDocURL}installing-capsule-server-packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
+For more information, see {InstallingSmartProxyDocURL}Installing_Proxy_Packages_{smart-proxy-context}[Installing {SmartProxyServer} Packages].
 
 .Procedure
 . On your {ProjectServer}, generate a certificate bundle:

--- a/guides/common/modules/proc_renaming-smart-proxy.adoc
+++ b/guides/common/modules/proc_renaming-smart-proxy.adoc
@@ -60,7 +60,7 @@ ifndef::orcharhino[]
 For more information, see {InstallingSmartProxyDocURL}deploying-a-custom-ssl-certificate-to-{smart-proxy-context}-server_{smart-proxy-context}[Deploying a Custom SSL Certificate to {SmartProxyServer}] in _{InstallingSmartProxyDocTitle}_.
 endif::[]
 . Reregister all hosts that are registered to your {SmartProxyServer}.
-For more information, see {ManagingHostsDocURL}registering_hosts_to_server_managing-hosts[Registering hosts and setting up host integration] in _{ManagingHostsDocTitle}_.
+For more information, see {ManagingHostsDocURL}registering-hosts-and-setting-up-host-integration_managing-hosts[Registering hosts and setting up host integration] in _{ManagingHostsDocTitle}_.
 . Update the {SmartProxy} host name in the {ProjectWebUI}.
 .. In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}*.
 .. Locate {SmartProxyServer} in the list, and click *Edit*.

--- a/guides/common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-smartproxy.adoc
+++ b/guides/common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-smartproxy.adoc
@@ -9,5 +9,5 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_by_Using_Global
 . On the *Overview* tab, click *Refresh features*.
 
 .Additional Resources
-* {InstallingServerDocURL}reset-custom-ssl-certificate-to-default-self-signed-certificate-on-{project-context}_{project-context}[Reset {customssl} certificate to default self-signed certificate on {ProjectServer}] in _{InstallingServerDocTitle}_.
-* {ManagingHostsDocURL}reset-custom-ssl-certificate-to-default-self-signed-certificate-on-hosts_managing-hosts[Reset {customssl} certificate to default self-signed certificate on hosts] in _{ManagingHostsDocTitle}_.
+* {InstallingServerDocURL}resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-{project-context}_{project-context}[Reset {customssl} certificate to default self-signed certificate on {ProjectServer}] in _{InstallingServerDocTitle}_.
+* {ManagingHostsDocURL}resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-hosts_managing-hosts[Reset {customssl} certificate to default self-signed certificate on hosts] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/proc_reverting-to-internal-dns-service.adoc
+++ b/guides/common/modules/proc_reverting-to-internal-dns-service.adoc
@@ -29,7 +29,12 @@ To configure {Project} or {SmartProxy} as DNS server without using an answer fil
 --foreman-proxy-dns=true
 ----
 +
+ifeval::["{context}" == "{smart-proxy-context}"]
+For more information, see xref:configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[].
+endif::[]
+ifeval::["{context}" == "{project-context}"]
 For more information, see {InstallingSmartProxyDocURL}configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[Configuring DNS, DHCP, and TFTP on {SmartProxyServer}].
+endif::[]
 
 After you run the `{foreman-installer}` command to make any changes to your {SmartProxy} configuration, you must update the configuration of each affected {SmartProxy} in the {ProjectWebUI}.
 

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -16,7 +16,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
 ifdef::satellite[]
-For more information on {Project} Topology and an illustration of port connections, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _{PlanningDocTitle}_.
+For more information on {Project} Topology and an illustration of port connections, see {PlanningDocURL}{SmartProxy}-Networking_planning[{SmartProxy} Networking] in _{PlanningDocTitle}_.
 endif::[]
 
 Required ports can change based on your configuration.

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -17,7 +17,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
-For more information on {Project} Topology, see {PlanningDocURL}{SmartProxy}-Networking_planning[{SmartProxy} Networking] in _{PlanningDocTitle}_.
+For more information on {Project} Topology, see {PlanningDocURL}{smart-proxy-context}-networking_planning[{SmartProxy} Networking] in _{PlanningDocTitle}_.
 
 Required ports can change based on your configuration.
 

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -17,7 +17,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
-For more information on {Project} Topology, see {PlanningDocURL}{smart-proxy-context}-networking_planning[{SmartProxy} Networking] in _{PlanningDocTitle}_.
+For more information on {Project} Topology, see {PlanningDocURL}{smart-proxy-context}-networking_planning[{SmartProxy} networking] in _{PlanningDocTitle}_.
 
 Required ports can change based on your configuration.
 

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -17,7 +17,7 @@ This includes the base operating system on which {SmartProxyServer} is running.
 
 .Clients of {SmartProxy}
 Hosts which are clients of {SmartProxies}, other than {Project}'s integrated {SmartProxy}, do not need access to {ProjectServer}.
-For more information on {Project} Topology, see {PlanningDocURL}sect-Documentation-Architecture_Guide-Capsule_Networking[{SmartProxy} Networking] in _{PlanningDocTitle}_.
+For more information on {Project} Topology, see {PlanningDocURL}{SmartProxy}-Networking_planning[{SmartProxy} Networking] in _{PlanningDocTitle}_.
 
 Required ports can change based on your configuration.
 

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -1,5 +1,5 @@
 You can register hosts with {Project} using the host registration feature in the {ProjectWebUI}, Hammer CLI, or the {Project} API.
-For more information, see {ManagingHostsDocURL}registering_hosts_to_server_managing-hosts[Registering hosts and setting up host integration] in _{ManagingHostsDocTitle}_.
+For more information, see {ManagingHostsDocURL}registering-hosts-and-setting-up-host-integration_managing-hosts[Registering hosts and setting up host integration] in _{ManagingHostsDocTitle}_.
 
 ifeval::["{context}" == "load-balancing"]
 .Prerequisites

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -1,5 +1,5 @@
 You can register hosts with {Project} using the host registration feature in the {ProjectWebUI}, Hammer CLI, or the {Project} API.
-For more information, see {ManagingHostsDocURL}registering_hosts_to_server_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+For more information, see {ManagingHostsDocURL}registering_hosts_to_server_managing-hosts[Registering hosts and setting up host integration] in _{ManagingHostsDocTitle}_.
 
 ifeval::["{context}" == "load-balancing"]
 .Prerequisites

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -1,5 +1,5 @@
 You can register hosts with {Project} using the host registration feature in the {ProjectWebUI}, Hammer CLI, or the {Project} API.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+For more information, see {ManagingHostsDocURL}registering_hosts_to_server_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 
 ifeval::["{context}" == "load-balancing"]
 .Prerequisites

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -33,7 +33,7 @@ To provision machines using PXE booting, ensure that you meet the following requ
 .Client requirements
 
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{SmartProxy}-Networking_planning[].
+For more information, see xref:{smart-proxy-context}-networking_{context}[].
 
 * Ensure that your client has access to the DHCP and TFTP servers.
 
@@ -61,7 +61,7 @@ To provision machines through HTTP booting ensure that you meet the following re
 For HTTP booting to work, ensure that your environment has the following client-side configurations:
 
 * All the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{SmartProxy}-Networking_planning[].
+For more information, see xref:{smart-proxy-context}-networking_{context}[].
 * Your client has access to the DHCP and DNS servers.
 * Your client has access to the HTTP UEFI Boot {SmartProxy}.
 
@@ -101,7 +101,7 @@ To provision machines through HTTP booting without managed DHCP ensure that you 
 * Ensure that your client has access to the DHCP and DNS servers.
 * Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{SmartProxy}-Networking_planning[].
+For more information, see xref:{smart-proxy-context}-networking_{context}[].
 
 .Network requirements
 


### PR DESCRIPTION
#### What changes are you introducing?

Fixing several broken links found in Installing Proxy.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We received a list of broken links in https://issues.redhat.com/browse/SAT-27794. About half of these actually needed fixing, the other ~half was just references to guides for a future d/s release.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

EDIT: Apart from just fixing the broken links, I also changed some of them into xrefs in cases when the target was in the same guide.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
