### PR TITLE
Drop references to API requests via Proxy

### DIFF
--- a/guides/common/modules/con_api-cheat-sheet.adoc
+++ b/guides/common/modules/con_api-cheat-sheet.adoc
@@ -2,35 +2,19 @@
 = API cheat sheet
 
 You can review the following examples of how to use the {ProjectName} API to perform various tasks.
-You can use the API on {ProjectServer} via HTTPS on port 443 or on {SmartProxyServer} via HTTPS on port 8443.
+You can use the API on {ProjectServer} via HTTPS on port 443.
 
-[IMPORTANT]
-====
-ifdef::foreman,katello[]
-Calling the API through {SmartProxyServer} has been deprecated since {Project} 3.12.
-endif::[]
-ifdef::satellite[]
-Calling the API through {SmartProxyServer} has been deprecated since {Project} 6.16.
-endif::[]
-ifdef::orcharhino[]
-Calling the API through {SmartProxyServer} has been deprecated since {Project} XXX.
-endif::[]
-Migrate your integrations to call the API through {ProjectServer}.
-====
-
-You can address these different port requirements within the script itself.
-For example, in Ruby, you can specify the {ProjectServer} and {SmartProxyServer} URLs as follows:
+For example, in Ruby, you can specify the {ProjectServer} URL as follows:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 url = 'https://_{foreman-example-com}_/api/v2/'
-{smart-proxy-context}_url = 'https://_{smartproxy-example-com}_:8443/api/v2/'
 ifdef::katello,orcharhino,satellite[]
 katello_url = 'https://_{foreman-example-com}_/katello/api/v2/'
 endif::[]
 ----
 
-For the host that is registered to {ProjectServer} or {SmartProxyServer}, you can determine the correct port required to access the API from the `/etc/rhsm/rhsm.conf` file, in the port entry of the `[server]` section.
+For the host that is registered to {ProjectServer}, you can determine the correct port required to access the API from the `/etc/rhsm/rhsm.conf` file, in the port entry of the `[server]` section.
 You can use these values to fully automate your scripts, removing any need to verify which ports to use.
 
 The following examples use `curl` for sending API requests.

--- a/guides/common/modules/con_api-cheat-sheet.adoc
+++ b/guides/common/modules/con_api-cheat-sheet.adoc
@@ -14,7 +14,6 @@ katello_url = 'https://_{foreman-example-com}_/katello/api/v2/'
 endif::[]
 ----
 
-For the host that is registered to {ProjectServer}, you can determine the correct port required to access the API from the `/etc/rhsm/rhsm.conf` file, in the port entry of the `[server]` section.
 You can use these values to fully automate your scripts, removing any need to verify which ports to use.
 
 The following examples use `curl` for sending API requests.


### PR DESCRIPTION
#### What changes are you introducing?

I'm trying to sanitize the API cheat sheet to remove all references of the possibility to run API requests via Proxies.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The section currently includes an Important box notifying the users about the deprecated functionality. However, why not just drop the references altogether if we don't want users to do this? This was originally proposed in https://issues.redhat.com/browse/SAT-28361.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
