### PR TITLE
Document CLI, Ansible, and API for registering a host

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -186,3 +186,9 @@ For more information, see the Hammer CLI help with `hammer host-registration gen
 * Use the `{ansible-namespace}.registration_command` module.
 
 For more information, see the Ansible Module documentation with `ansible-doc {ansible-namespace}.registration_command`.
+
+.API procedure
+
+* Use the `POST /api/registration_commands` resource.
+
+For more information, see the full API reference at `\https://{foreman-example-com}/apidoc/v2.html`.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -180,3 +180,9 @@ endif::[]
 . On the host that you want to register, run the `curl` command as `root`.
 
 For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.
+
+.Ansible procedure
+
+* Use the `{ansible-namespace}.registration_command` module.
+
+For more information, see the Ansible Module documentation with `ansible-doc {ansible-namespace}.registration_command`.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -175,20 +175,17 @@ endif::[]
 . On the host that you want to register, run the `curl` command as `root`.
 
 .CLI procedure
-
 . Use the `hammer host-registration generate-command` to generate the `curl` command to register the host.
 . On the host that you want to register, run the `curl` command as `root`.
 
 For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.
 
 .Ansible procedure
-
 * Use the `{ansible-namespace}.registration_command` module.
 
 For more information, see the Ansible Module documentation with `ansible-doc {ansible-namespace}.registration_command`.
 
 .API procedure
-
 * Use the `POST /api/registration_commands` resource.
 
 For more information, see the full API reference at `\https://{foreman-example-com}/apidoc/v2.html`.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -173,3 +173,10 @@ endif::[]
 . Click *Generate*.
 . Copy the generated `curl` command.
 . On the host that you want to register, run the `curl` command as `root`.
+
+.CLI procedure
+
+. Use the `hammer host-registration generate-command` to generate the `curl` command to register the host.
+. On the host that you want to register, run the `curl` command as `root`.
+
+For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.


### PR DESCRIPTION
#### What changes are you introducing?

I'm describing alternative ways of registering a host: CLI, Ansible, API.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-28377 requested adding the Hammer command and API resource that correspond to the existing web UI procedure as users weren't aware of their existence and were unable to look them up. Then on top of that, prompted by a conversation with @evgeni, I thought it might be a good idea to add a reference to the corresponding Ansible module too.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The CLI, Ansible, and API "procedures" are very minimal by design. Users have very good reference documentation available to them (`--help`, `ansible-doc`, and built-in API reference) and I don't want to duplicate it in the guides.

I'm requesting cherry-picks down to 3.7 only because that's what https://github.com/theforeman/foreman-documentation/pull/3143, which targets the same procedure, did.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
