### PR TITLE
Reduce doc bloat in registering a host

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -42,7 +42,7 @@ endif::[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
 . Enter the details for how you want the registered hosts to be configured.
-. Click *Generate*.
+. Click *Generate* to generate a `curl` command.
 . Run the `curl` command as `root` on the host that you want to register.
 After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.
 

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -51,9 +51,9 @@ After registration completes, any Ansible roles assigned to a host group you spe
 
 The registration details that you can specify include the following:
 
-* Optional: On the *General* tab, in the *{SmartProxy}* field, select the {SmartProxy} to register hosts through.
+* On the *General* tab, in the *{SmartProxy}* field, you can select the {SmartProxy} to register hosts through.
 A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
-* Optional: On the *General* tab, select the *Insecure* option to make the first call insecure.
+* On the *General* tab, you can select the *Insecure* option to make the first call insecure.
 During this first call, hosts download the CA file from {Project}.
 Hosts will use this CA file to connect to {Project} with all future calls making them secure.
 +
@@ -87,9 +87,9 @@ The following is an example of the `curl` command with the `--insecure` option:
 ----
 # curl -sS --insecure https://{foreman-example-com}/register ...
 ----
-* Optional: On the *Advanced* tab, in the *Repository* field, list repositories to be added before the registration is performed.
+* On the *Advanced* tab, in the *Repository* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
-* Optional: On the *Advanced* tab, in the *Token lifetime (hours)* field, change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
+* On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated `curl` command works.
 +
 Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of hosts.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -87,7 +87,7 @@ The following is an example of the `curl` command with the `--insecure` option:
 ----
 # curl -sS --insecure https://{foreman-example-com}/register ...
 ----
-* On the *Advanced* tab, in the *Repository* field, you can list repositories to be added before the registration is performed.
+* On the *Advanced* tab, in the *Repositories* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated `curl` command works.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -42,6 +42,9 @@ endif::[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
 . Enter the details for how you want the registered hosts to be configured.
+ifdef::katello,satellite,orcharhino[]
+. On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to hosts.
+endif::[]
 . Click *Generate* to generate a `curl` command.
 . Run the `curl` command as `root` on the host that you want to register.
 After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -41,26 +41,16 @@ endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
-. Optional: Select a different *Organization*.
-. Optional: Select a different *Location*.
-. Optional: From the *Host Group* list, select the host group to associate the hosts with.
-Fields that inherit value from *Host group*: *Operating system*, *Activation Keys* and *Lifecycle environment*.
-+
-If your host group has any Ansible roles assigned, the Ansible roles will run on your host upon the registration.
-. Optional: From the *Operating system* list, select the operating system of hosts that you want to register.
-ifndef::satellite,orcharhino[]
-Specifying an operating system is required when you register machines without `subscription-manager`, such as Debian or Ubuntu.
-endif::[]
-. Optional: From the *{SmartProxy}* list, select the {SmartProxy} to register hosts through.
-+
-[NOTE]
-====
-A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the host's content source.
-====
-ifdef::katello,satellite,orcharhino[]
-. In the *Activation Keys* field, enter one or more activation keys to assign to hosts.
-endif::[]
-. Optional: Select the *Insecure* option, if you want to make the first call insecure.
+. Enter the details for how you want the registered hosts to be configured.
+. Click *Generate*.
+. Run the `curl` command as `root` on the host that you want to register.
+After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.
+
+The registration details that you can specify include the following:
+
+* Optional: On the *General* tab, in the *{SmartProxy}* field, select the {SmartProxy} to register hosts through.
+A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
+* Optional: On the *General* tab, select the *Insecure* option to make the first call insecure.
 During this first call, hosts download the CA file from {Project}.
 Hosts will use this CA file to connect to {Project} with all future calls making them secure.
 +
@@ -94,87 +84,16 @@ The following is an example of the `curl` command with the `--insecure` option:
 ----
 # curl -sS --insecure https://{foreman-example-com}/register ...
 ----
-. Select the *Advanced* tab.
-. Optional: From the *Setup REX* list, select whether you want to deploy {Project} SSH keys to hosts or not.
-+
-If set to `Yes`, public SSH keys will be installed on the registered host.
-The inherited value is based on the `host_registration_remote_execution` parameter.
-It can be inherited, for example from a host group, an operating system, or an organization.
-When overridden, the selected value will be stored on host parameter level.
-ifdef::client-content-dnf[]
-. Optional: From the *Setup Insights* list, select whether you want to install `insights-client` and register the hosts to Insights.
-+
-The Insights tool is available for {RHEL} only.
-It has no effect on other operating systems.
-+
-You must enable the following repositories on a registered machine:
-
-* {RHEL} 6: `rhel-6-server-rpms`
-* {RHEL} 7: `rhel-7-server-rpms`
-* {RHEL} 8: `rhel-8-for-x86_64-appstream-rpms`
-+
-The `insights-client` package is installed by default on {RHEL} 8 except in environments whereby {RHEL} 8 was deployed with "Minimal Install" option.
-endif::[]
-. Optional: In the *Install packages* field, list the packages (separated with spaces) that you want to install on the host upon registration.
-This can be set by the `host_packages` parameter.
-. Optional: Select the *Update packages* option to update all packages on the host upon registration.
-This can be set by the `host_update_packages` parameter.
-. In the *Repositories* field, click *Add repositories for registration*.
-+
-On the *Repository list* window, add content that is required before performing the registration.
-For example, it can be useful to make the `subscription-manager` package available for the purpose of the registration.
-+
-* In the *Repository* field, enter a repository to be added before the registration is performed.
-ifdef::client-content-dnf[]
-For Red Hat family distributions, enter the URL of the repository, for example `\http://rpm.example.com/`.
-endif::[]
-ifdef::client-content-apt[]
-For Debian OS families, enter the whole line of list file content, for example `deb \http://deb.example.com/ bookworm 1.0`.
-endif::[]
-* Optional: In the *Repository GPG key URL* field, specify the public key to verify the signatures of GPG-signed packages.
-It needs to be specified in the ASCII form with the GPG public key header.
-ifdef::katello,orcharhino,satellite[]
-
-+
+* Optional: On the *Advanced* tab, in the *Repository* field, list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
-endif::[]
-. Optional: In the *Token lifetime (hours)* field, change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
+* Optional: On the *Advanced* tab, in the *Token lifetime (hours)* field, change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated `curl` command works.
-You can set the duration to 0{range}999 999 hours or unlimited.
 +
 Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of hosts.
 If the user loses or gains additional permissions, the permissions of the JWT change too.
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
-. Optional: In the *Remote Execution Interface* field, enter the identifier of a network interface that hosts must use for the SSH connection.
-If you keep this field blank, {Project} uses the default network interface.
-. Optional: From the *REX pull mode* list, select whether you want to deploy {Project} remote execution pull client.
-+
-If set to `Yes`, the remote execution pull client is installed on the registered host.
-The inherited value is based on the `host_registration_remote_execution_pull` parameter.
-It can be inherited, for example from a host group, an operating system, or an organization.
-When overridden, the selected value is stored on the host parameter level.
-+
-The registered host must have access to the {project-client-name} repository.
-+
-ifdef::managing-hosts[]
-For more information about the pull mode, see xref:transport-modes-for-remote-execution_{context}[].
-endif::[]
-ifndef::managing-hosts[]
-For more information about the pull mode, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport Modes for Remote Execution] in _{ManagingHostsDocTitle}_.
-endif::[]
-ifdef::katello,satellite,orcharhino[]
-. Optional: Select the *Ignore errors* option if you want to ignore subscription manager errors.
-. Optional: Select the *Force* option if you want to remove any `katello-ca-consumer` packages before registration and run `subscription-manager` with the `--force` argument.
-endif::[]
-ifdef::katello[]
-If you register {EL} hosts, in the *Activation Keys* field, enter one or more activation keys to assign to registered hosts.
-endif::[]
-
-. Click *Generate*.
-. Copy the generated `curl` command.
-. On the host that you want to register, run the `curl` command as `root`.
 
 .CLI procedure
 . Use the `hammer host-registration generate-command` to generate the `curl` command to register the host.


### PR DESCRIPTION
#### What changes are you introducing?

I cross-checked the existing web UI procedure for registering a host with the page in the web UI and identified the parts of the documented procedure that can be dropped because they are actually documented in the web UI. Additionally, I'm making minor changes to the wording in order to make the procedure even shorter.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current procedure is _very_ long (22 steps!). Making sure we don't duplicate the web UI elements (obvious input fields, tooltips, etc.) will go a long way towards making the procedure shorter.

I wanted to do this because in https://github.com/theforeman/foreman-documentation/pull/3329, I'm introducing information on how to perform the action from the CLI, using Ansible, or using API. Without trimming the web UI procedure, the new additions would be lost at the end of a huge web UI procedure.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

In editing the procedure, I followed the template for web UI procedures established in https://github.com/theforeman/foreman-documentation/pull/2865.

I'm requesting cherry-picks down to 3.7 only because that's what https://github.com/theforeman/foreman-documentation/pull/3143, which targets the same procedure, did.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
