### PR TITLE
Update time stamps in example API requests

### DIFF
--- a/guides/common/modules/ref_json-response-format.adoc
+++ b/guides/common/modules/ref_json-response-format.adoc
@@ -26,8 +26,8 @@ Example response:
     "name": "qa.lab.example.com",
     "fullname": "QA",
     "dns_id": 10,
-    "created_at": "2013-08-13T09:02:31Z",
-    "updated_at": "2013-08-13T09:02:31Z"
+    "created_at": "2024-08-13T09:02:31Z",
+    "updated_at": "2024-08-13T09:02:31Z"
 }
 ----
 
@@ -64,24 +64,24 @@ Example response:
             "name": "qa.lab.example.com",
             "fullname": "QA",
             "dns_id": 10,
-            "created_at": "2013-08-13T09:02:31Z",
-            "updated_at": "2013-08-13T09:02:31Z"
+            "created_at": "2024-08-13T09:02:31Z",
+            "updated_at": "2024-08-13T09:02:31Z"
         },
         {
             "id": 25,
             "name": "dev.lab.example.com",
             "fullname": "DEVEL",
             "dns_id": 8,
-            "created_at": "2013-08-13T08:32:48Z",
-            "updated_at": "2013-08-14T07:04:03Z"
+            "created_at": "2024-08-13T08:32:48Z",
+            "updated_at": "2024-08-14T07:04:03Z"
         },
         {
             "id": 32,
             "name": "hr.lab.example.com",
             "fullname": "HR",
             "dns_id": 8,
-            "created_at": "2013-08-16T08:32:48Z",
-            "updated_at": "2013-08-16T07:04:03Z"
+            "created_at": "2024-08-16T08:32:48Z",
+            "updated_at": "2024-08-16T07:04:03Z"
         }
     ]
 }


### PR DESCRIPTION
#### What changes are you introducing?

Replacing "2013" with "2024" in several API request examples.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Using "2013" makes the examples look old.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
