### PR TITLE
Fix attribute substitution in API examples

### DIFF
--- a/guides/common/modules/proc_calling-the-api-in-python.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-python.adoc
@@ -82,12 +82,12 @@ def main():
     """
 
     # Check if our organization already exists
-    org = get_json(f"{project-allcaps}_API/organizations/\{ORG_NAME}")
+    org = get_json(f"{{project-allcaps}_API}/organizations/\{ORG_NAME}")
 
     # If our organization is not found, create it
     if org.get('error', None):
         org_id = post_json(
-            f"{project-allcaps}_API/organizations/",
+            f"\{{project-allcaps}_API}/organizations/",
             json.dumps({"name": ORG_NAME})
         )["id"]
         print("Creating organization:\t" + ORG_NAME)
@@ -98,7 +98,7 @@ def main():
 
     # Now, let's fetch all available life cycle environments for this org...
     envs = get_json(
-        f"{project-allcaps}_API/organizations/\{org_id}/environments/"
+        f"\{{project-allcaps}_API}/organizations/\{org_id}/environments/"
     )
 
     # ...and add them to a dictionary, with respective 'Prior' environment
@@ -116,7 +116,7 @@ def main():
     # Create life cycle environments
     for environment in ENVIRONMENTS:
         new_env_id = post_json(
-            f"{project-allcaps}_API/organizations/\{org_id}/environments/",
+            f"\{{project-allcaps}_API}/organizations/\{org_id}/environments/",
             json.dumps({
                 "name": environment,
                 "organization_id": org_id,

--- a/guides/common/modules/proc_calling-the-api-in-python.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-python.adoc
@@ -19,7 +19,7 @@ If the organization already exists, the script uses that organization.
 If any of the environments already exist in the organization, the script raises an error and quits.
 
 .Python 3 example
-[source, Python]
+[source, Python, subs="attributes"]
 ----
 #!/usr/bin/python3
 
@@ -35,9 +35,9 @@ except ImportError:
 # URL to your {ProjectX} server
 URL = "https://{foreman-example-com}"
 # URL for the API to your deployed {ProjectX} server
-{project_allcaps}_API = f"{URL}/katello/api/v2/"
+{project-allcaps}_API = f"\{URL}/katello/api/v2/"
 # Katello-specific API
-KATELLO_API = f"{URL}/katello/api/"
+KATELLO_API = f"\{URL}/katello/api/"
 POST_HEADERS = {'content-type': 'application/json'}
 # Default credentials to login to {ProjectX}
 USERNAME = "admin"
@@ -82,23 +82,23 @@ def main():
     """
 
     # Check if our organization already exists
-    org = get_json(f"{project_allcaps}_API/organizations/{ORG_NAME}")
+    org = get_json(f"{project-allcaps}_API/organizations/\{ORG_NAME}")
 
     # If our organization is not found, create it
     if org.get('error', None):
         org_id = post_json(
-            f"{project_allcaps}_API/organizations/",
+            f"{project-allcaps}_API/organizations/",
             json.dumps({"name": ORG_NAME})
         )["id"]
         print("Creating organization:\t" + ORG_NAME)
     else:
         # Our organization exists, so let's grab it
         org_id = org['id']
-        print(f"Organization '{ORG_NAME}' exists.")
+        print(f"Organization '\{ORG_NAME}' exists.")
 
     # Now, let's fetch all available life cycle environments for this org...
     envs = get_json(
-        f"{project_allcaps}_API/organizations/{org_id}/environments/"
+        f"{project-allcaps}_API/organizations/\{org_id}/environments/"
     )
 
     # ...and add them to a dictionary, with respective 'Prior' environment
@@ -116,7 +116,7 @@ def main():
     # Create life cycle environments
     for environment in ENVIRONMENTS:
         new_env_id = post_json(
-            f"{project_allcaps}_API/organizations/{org_id}/environments/",
+            f"{project-allcaps}_API/organizations/\{org_id}/environments/",
             json.dumps({
                 "name": environment,
                 "organization_id": org_id,
@@ -139,7 +139,7 @@ if __name__ == "__main__":
 This is an example script that uses Python for various API requests.
 
 .Python 3 example
-[source, Python]
+[source, Python, subs="attributes"]
 ----
 #!/usr/bin/env python3
 
@@ -154,8 +154,8 @@ except ImportError:
 
 SAT = "{foreman-example-com}"
 # URL for the API to your deployed {ProjectX} server
-{project-allcaps}_API = f"https://{SAT}/api/"
-KATELLO_API = f"https://{SAT}/katello/api/v2/"
+{project-allcaps}_API = f"https://\{SAT}/api/"
+KATELLO_API = f"https://\{SAT}/katello/api/v2/"
 
 POST_HEADERS = {'content-type': 'application/json'}
 # Default credentials to login to {ProjectX}
@@ -205,21 +205,21 @@ def display_info_for_subs(url):
 
 def main():
     host = SAT
-    print(f"Displaying all info for host {host} ...")
+    print(f"Displaying all info for host \{host} ...")
     display_all_results({project-allcaps}_API + 'hosts/' + host)
 
-    print(f"Displaying all facts for host {host} ...")
-    display_all_results({project-allcaps}_API + f'hosts/{host}/facts')
+    print(f"Displaying all facts for host \{host} ...")
+    display_all_results({project-allcaps}_API + f'hosts/\{host}/facts')
 
     host_pattern = 'example'
-    print(f"Displaying basic info for hosts matching pattern '{host_pattern}'...")
+    print(f"Displaying basic info for hosts matching pattern '\{host_pattern}'...")
     display_info_for_hosts({project-allcaps}_API + 'hosts?per_page=1&search=name~' + host_pattern)
 
     print(f"Displaying basic info for subscriptions")
     display_info_for_subs(KATELLO_API + 'subscriptions')
 
     environment = 'production'
-    print(f"Displaying basic info for hosts in environment {environment}...")
+    print(f"Displaying basic info for hosts in environment \{environment}...")
     display_info_for_hosts({project-allcaps}_API + 'hosts?search=environment=' + environment)
 
 

--- a/guides/common/modules/proc_calling-the-api-in-python.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-python.adoc
@@ -87,7 +87,7 @@ def main():
     # If our organization is not found, create it
     if org.get('error', None):
         org_id = post_json(
-            f"\{{project-allcaps}_API}/organizations/",
+            f"{{project-allcaps}_API}/organizations/",
             json.dumps({"name": ORG_NAME})
         )["id"]
         print("Creating organization:\t" + ORG_NAME)
@@ -98,7 +98,7 @@ def main():
 
     # Now, let's fetch all available life cycle environments for this org...
     envs = get_json(
-        f"\{{project-allcaps}_API}/organizations/\{org_id}/environments/"
+        f"{{project-allcaps}_API}/organizations/\{org_id}/environments/"
     )
 
     # ...and add them to a dictionary, with respective 'Prior' environment
@@ -116,7 +116,7 @@ def main():
     # Create life cycle environments
     for environment in ENVIRONMENTS:
         new_env_id = post_json(
-            f"\{{project-allcaps}_API}/organizations/\{org_id}/environments/",
+            f"{{project-allcaps}_API}/organizations/\{org_id}/environments/",
             json.dumps({
                 "name": environment,
                 "organization_id": org_id,

--- a/guides/common/modules/proc_calling-the-api-in-ruby.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-ruby.adoc
@@ -104,7 +104,7 @@ end
 == Using apipie bindings with Ruby
 
 Apipie bindings are the Ruby bindings for apipie documented API calls.
-They fetch and cache the API definition from {Project} and then generate API calls on demand.
+They fetch and cache the API definition from {Project} and then generate API calls as needed.
 
 [source, Ruby, subs="attributes"]
 ----

--- a/guides/common/modules/proc_calling-the-api-in-ruby.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-ruby.adoc
@@ -16,7 +16,7 @@ This script connects to the {ProjectNameX} API and creates an organization, and 
 If the organization already exists, the script uses that organization.
 If any of the lifecycle environments already exist in the organization, the script raises an error and quits.
 
-[source, Ruby]
+[source, Ruby, subs="attributes"]
 ----
 #!/usr/bin/ruby
 
@@ -24,7 +24,7 @@ require 'rest-client'
 require 'json'
 
 url = 'https://{foreman-example-com}/api/v2/'
-katello_url = "#{url}/katello/api/v2/"
+katello_url = "#\{url}/katello/api/v2/"
 
 $username = 'admin'
 $password = 'changeme'
@@ -67,21 +67,21 @@ def id_name_map(records)
 end
 
 # Get list of existing organizations
-orgs = get_json("#{katello_url}/organizations")
+orgs = get_json("#\{katello_url}/organizations")
 org_list = id_name_map(orgs['results'])
 
 if !org_list.has_value?(org_name)
   # If our organization is not found, create it
-  puts "Creating organization: \t#{org_name}"
-  org_id = post_json("#{katello_url}/organizations", JSON.generate({"name"=> org_name}))["id"]
+  puts "Creating organization: \t#\{org_name}"
+  org_id = post_json("#\{katello_url}/organizations", JSON.generate({"name"=> org_name}))["id"]
 else
   # Our organization exists, so let's grab it
   org_id = org_list.key(org_name)
-  puts "Organization \"#{org_name}\" exists"
+  puts "Organization \"#\{org_name}\" exists"
 end
 
 # Get list of organization's lifecycle environments
-envs = get_json("#{katello_url}/organizations/#{org_id}/environments")
+envs = get_json("#\{katello_url}/organizations/#\{org_id}/environments")
 env_list = id_name_map(envs['results'])
 prior_env_id = env_list.key("Library")
 
@@ -95,8 +95,8 @@ end
 
  # Create life cycle environments
 environments.each do |environment|
-  puts "Creating environment: \t#{environment}"
-  prior_env_id = post_json("#{katello_url}/organizations/#{org_id}/environments", JSON.generate({"name" => environment, "organization_id" => org_id, "prior_id" => prior_env_id}))["id"]
+  puts "Creating environment: \t#\{environment}"
+  prior_env_id = post_json("#\{katello_url}/organizations/#\{org_id}/environments", JSON.generate({"name" => environment, "organization_id" => org_id, "prior_id" => prior_env_id}))["id"]
 end
 ----
 
@@ -106,7 +106,7 @@ end
 Apipie bindings are the Ruby bindings for apipie documented API calls.
 They fetch and cache the API definition from {Project} and then generate API calls on demand.
 
-[source, Ruby]
+[source, Ruby, subs="attributes"]
 ----
 #!/usr/bin/ruby
 
@@ -143,12 +143,12 @@ org_list = id_name_map(orgs['results'])
 
 if !org_list.has_value?(org_name)
   # If our organization is not found, create it
-  puts "Creating organization: \t#{org_name}"
+  puts "Creating organization: \t#\{org_name}"
   org_id = call_api(:organizations, :create, {'organization' => { :name => org_name }})['id']
 else
   # Our organization exists, so let's grab it
   org_id = org_list.key(org_name)
-  puts "Organization \"#{org_name}\" exists"
+  puts "Organization \"#\{org_name}\" exists"
 end
 
 # Get list of organization's life cycle environments
@@ -166,7 +166,7 @@ end
 
  # Create life cycle environments
 environments.each do |environment|
-  puts "Creating environment: \t#{environment}"
+  puts "Creating environment: \t#\{environment}"
   prior_env_id = call_api(:lifecycle_environments, :create, {"name" => environment, "organization_id" => org_id, "prior_id" => prior_env_id })['id']
 end
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Introducing attribute substitution into a few API examples. This also involves excluding a few `{`s that are supposed to be rendered verbatim.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The API examples are rendered incorrectly, see also https://github.com/theforeman/foreman-documentation/pull/3328#issuecomment-2382588825.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
