### PR TITLE
Add steps to configure standalone Hammer on EL 9

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -171,6 +171,7 @@
 :client-package-install-deb: apt install
 :client-package-install-el7: yum install
 :client-package-install-el8: dnf install
+:client-package-install-el9: dnf install
 :client-package-install-sles: zypper install
 :client-package-remove-deb: apt remove
 :client-package-remove-el7: yum remove

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -144,6 +144,7 @@
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-9-<arch>-rpms
+:RepoRHEL9ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 
 // RHEL 8 Satellite repos
 :RepoRHEL8ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -9,7 +9,6 @@ ifndef::katello,orcharhino,satellite[]
 endif::[]
 ifdef::satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 * If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
 ** {RepoRHEL9BaseOS}
 ** {RepoRHEL9AppStream}
@@ -18,26 +17,18 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[
 ** {RepoRHEL8BaseOS}
 ** {RepoRHEL8AppStream}
 ** {RepoRHEL8ServerSatelliteUtils}
-
-+
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::orcharhino[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 * If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
 ** {EL} 9 BaseOS
 ** {EL} 9 AppStream
 * If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
 ** {EL} 8 BaseOS
 ** {EL} 8 AppStream
-
-+
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::katello[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
 * If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
 ** {EL} 9 BaseOS
 ** {EL} 9 AppStream
@@ -46,9 +37,6 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[
 ** {EL} 8 BaseOS
 ** {EL} 8 AppStream
 ** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
-
-+
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 endif::[]
 
 .Procedure
@@ -111,7 +99,6 @@ ifdef::foreman-el[]
 endif::[]
 ifdef::katello[]
 . Enable the required repositories on the host.
-For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
 . If you are installing on {EL}{nbsp}8, enable the following module:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
@@ -133,7 +120,6 @@ For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_C
 endif::[]
 ifdef::orcharhino[]
 . Enable the required repositories on the host.
-For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
 . If you are installing on {EL}{nbsp}8, enable the following module:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
@@ -155,7 +141,6 @@ For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_C
 endif::[]
 ifdef::satellite[]
 . Enable the required repositories on the host.
-For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
 . If you are installing on {EL}{nbsp}8, enable the following module:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
@@ -174,4 +159,11 @@ For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_C
 ----
 :host: 'https://_{foreman-example-com}_'
 ----
+endif::[]
+
+ifdef::katello,orcharhino,satellite[]
+.Additional resources
+* {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_
+* {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_
+* {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_
 endif::[]

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -104,7 +104,7 @@ ifdef::katello,orcharhino,satellite[]
 ----
 # dnf module enable {dnf-module-utils}
 ----
-. Install Hammer CLI.
+. Install Hammer CLI:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -3,6 +3,80 @@
 
 You can install Hammer on a host running {install-on-os} that has no {ProjectServer} installed, and use it to connect from the host to a remote {Project}.
 
+Select the operating system and version you are installing standalone Hammer on:
+
+* xref:#installing-standalone-hammer-el-9[{EL} 9]
+* xref:#installing-standalone-hammer-el-8[{EL} 8]
+
+[id="installing-standalone-hammer-el-9"]
+== {EL}{nbsp}9
+.Prerequisites
+ifdef::katello,orcharhino,satellite[]
+* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+* Ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+ifdef::satellite[]
+** {RepoRHEL9BaseOS}
+** {RepoRHEL9AppStream}
+** {RepoRHEL9ServerSatelliteUtils}
+endif::[]
+ifdef::katello,orcharhino[]
+** {EL} 8 BaseOS
+** {EL} 8 AppStream
+endif::[]
+ifdef::katello[]
+** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
+endif::[]
+
++
+For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
+endif::katello,orcharhino,satellite[]
+ifndef::katello,orcharhino,satellite[]
+* Ensure that the CA certificate of {ProjectServer} is deployed to the truststore on the host.
+endif::[]
+
+.Procedure
+. Enable the required repositories on the host.
+ifdef::katello,orcharhino,satellite[]
+For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
+endif::[]
+ifdef::foreman-el[]
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# {client-package-install-el9} https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm
+----
+endif::[]
+ifdef::foreman-deb[]
++
+:distribution-codename: My_Distribution_Codename
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+# echo "deb http://deb.theforeman.org/ _{distribution-codename}_ {ProjectVersion}" | sudo tee /etc/apt/sources.list.d/foreman.list
+# echo "deb http://deb.theforeman.org/ plugins {ProjectVersion}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
+----
+endif::[]
+. Install Hammer CLI:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+ifdef::foreman-deb[]
+# {client-package-install-deb} {project-context}-cli
+endif::[]
+ifndef::foreman-deb[]
+# {client-package-install-el8} {project-context}-cli
+endif::[]
+----
+. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+:host: 'https://_{foreman-example-com}_'
+----
+
+[id="installing-standalone-hammer-el-8"]
+== {EL}{nbsp}8
 .Prerequisites
 ifdef::katello,orcharhino,satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -25,7 +25,7 @@ ifdef::katello[]
 endif::[]
 
 +
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
+For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories] in _{ContentManagementDocTitle}_.
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -21,7 +21,7 @@ ifdef::katello,orcharhino[]
 ** {EL} 9 AppStream
 endif::[]
 ifdef::katello[]
-** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
+** https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm[{Project} release RPM]
 endif::[]
 
 +

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -3,22 +3,38 @@
 
 You can install Hammer on a host running {install-on-os} that has no {ProjectServer} installed, and use it to connect from the host to a remote {Project}.
 
-Select the operating system and version you are installing standalone Hammer on:
-
-* xref:#installing-standalone-hammer-el-9[{EL} 9]
-* xref:#installing-standalone-hammer-el-8[{EL} 8]
-
-[id="installing-standalone-hammer-el-9"]
-== {EL}{nbsp}9
+.Prerequisites
 .Prerequisites
 ifdef::katello,orcharhino,satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
-* Ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+endif::[]
+
+ifdef::katello,orcharhino,satellite[]
+* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
 ifdef::satellite[]
 ** {RepoRHEL9BaseOS}
 ** {RepoRHEL9AppStream}
 ** {RepoRHEL9ServerSatelliteUtils}
+endif::[]
+ifdef::katello,orcharhino[]
+** {EL} 9 BaseOS
+** {EL} 9 AppStream
+endif::[]
+ifdef::katello[]
+** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
+endif::[]
+
++
+For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
+endif::[]
+
+ifdef::katello,orcharhino,satellite[]
+* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+ifdef::satellite[]
+** {RepoRHEL8BaseOS}
+** {RepoRHEL8AppStream}
+** {RepoRHEL8ServerSatelliteUtils}
 endif::[]
 ifdef::katello,orcharhino[]
 ** {EL} 8 BaseOS
@@ -30,11 +46,20 @@ endif::[]
 
 +
 For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
-endif::katello,orcharhino,satellite[]
+endif::[]
 ifndef::katello,orcharhino,satellite[]
 * Ensure that the CA certificate of {ProjectServer} is deployed to the truststore on the host.
 endif::[]
 
+
+.Procedure
+Select the operating system and version you are installing standalone Hammer on:
+
+* xref:#installing-standalone-hammer-el-9[{EL} 9]
+* xref:#installing-standalone-hammer-el-8[{EL} 8]
+
+[id="installing-standalone-hammer-el-9"]
+== {EL}{nbsp}9
 .Procedure
 . Enable the required repositories on the host.
 ifdef::katello,orcharhino,satellite[]
@@ -77,31 +102,6 @@ endif::[]
 
 [id="installing-standalone-hammer-el-8"]
 == {EL}{nbsp}8
-.Prerequisites
-ifdef::katello,orcharhino,satellite[]
-* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
-* Ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-ifdef::satellite[]
-** {RepoRHEL8BaseOS}
-** {RepoRHEL8AppStream}
-** {RepoRHEL8ServerSatelliteUtils}
-endif::[]
-ifdef::katello,orcharhino[]
-** {EL} 8 BaseOS
-** {EL} 8 AppStream
-endif::[]
-ifdef::katello[]
-** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
-endif::[]
-
-+
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
-endif::katello,orcharhino,satellite[]
-ifndef::katello,orcharhino,satellite[]
-* Ensure that the CA certificate of {ProjectServer} is deployed to the truststore on the host.
-endif::[]
-
 .Procedure
 . Enable the required repositories on the host.
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -43,11 +43,10 @@ endif::[]
 ifdef::foreman-deb[]
 . Enable the required repositories on the host.
 +
-:distribution-codename: My_Distribution_Codename
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
 # wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
-# echo "deb http://deb.theforeman.org/ _{distribution-codename}_ {ProjectVersion}" | sudo tee /etc/apt/sources.list.d/foreman.list
+# echo "deb http://deb.theforeman.org/ _My_Distribution_Codename_ {ProjectVersion}" | sudo tee /etc/apt/sources.list.d/foreman.list
 # echo "deb http://deb.theforeman.org/ plugins {ProjectVersion}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
 ----
 . Install Hammer CLI:

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -4,7 +4,6 @@
 You can install Hammer on a host running {install-on-os} that has no {ProjectServer} installed, and use it to connect from the host to a remote {Project}.
 
 .Prerequisites
-.Prerequisites
 ifdef::katello,orcharhino,satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -4,143 +4,103 @@
 You can install Hammer on a host running {install-on-os} that has no {ProjectServer} installed, and use it to connect from the host to a remote {Project}.
 
 .Prerequisites
-ifdef::katello,orcharhino,satellite[]
+ifndef::katello,orcharhino,satellite[]
+* Ensure that the CA certificate of {ProjectServer} is deployed to the truststore on the host.
+endif::[]
+ifdef::satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
-endif::[]
-
-ifdef::katello,orcharhino,satellite[]
 * If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-ifdef::satellite[]
 ** {RepoRHEL9BaseOS}
 ** {RepoRHEL9AppStream}
 ** {RepoRHEL9ServerSatelliteUtils}
-endif::[]
-ifdef::katello,orcharhino[]
-** {EL} 9 BaseOS
-** {EL} 9 AppStream
-endif::[]
-ifdef::katello[]
-** https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm[{Project} release RPM]
-endif::[]
-
-+
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories] in _{ContentManagementDocTitle}_.
-endif::[]
-
-ifdef::katello,orcharhino,satellite[]
 * If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-ifdef::satellite[]
 ** {RepoRHEL8BaseOS}
 ** {RepoRHEL8AppStream}
 ** {RepoRHEL8ServerSatelliteUtils}
-endif::[]
-ifdef::katello,orcharhino[]
-** {EL} 8 BaseOS
-** {EL} 8 AppStream
-endif::[]
-ifdef::katello[]
-** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
-endif::[]
 
 +
 For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 endif::[]
-ifndef::katello,orcharhino,satellite[]
-* Ensure that the CA certificate of {ProjectServer} is deployed to the truststore on the host.
+ifdef::orcharhino[]
+* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 9 BaseOS
+** {EL} 9 AppStream
+* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 8 BaseOS
+** {EL} 8 AppStream
+
++
+For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
+endif::[]
+ifdef::katello[]
+* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
+For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in _{ManagingHostsDocTitle}_.
+* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 9 BaseOS
+** {EL} 9 AppStream
+** https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm[{Project} release RPM]
+* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 8 BaseOS
+** {EL} 8 AppStream
+** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
+
++
+For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 endif::[]
 
-
 .Procedure
-Select the operating system and version you are installing standalone Hammer on:
-
-* xref:#installing-standalone-hammer-el-9[{EL} 9]
-* xref:#installing-standalone-hammer-el-8[{EL} 8]
-
-[id="installing-standalone-hammer-el-9"]
-== {EL}{nbsp}9
-.Procedure
+ifdef::foreman-deb[]
 . Enable the required repositories on the host.
-ifdef::katello,orcharhino,satellite[]
-For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
++
+:distribution-codename: My_Distribution_Codename
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
+# echo "deb http://deb.theforeman.org/ _{distribution-codename}_ {ProjectVersion}" | sudo tee /etc/apt/sources.list.d/foreman.list
+# echo "deb http://deb.theforeman.org/ plugins {ProjectVersion}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
+----
+. Install Hammer CLI:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# {client-package-install-deb} {project-context}-cli
+----
+. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+:host: 'https://_{foreman-example-com}_'
+----
 endif::[]
 ifdef::foreman-el[]
+. Enable the required repositories on the host.
+* If you are installing on {EL}{nbsp}9, enable the following repository:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
 # {client-package-install-el9} https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm
 ----
-endif::[]
-ifdef::foreman-deb[]
 +
-:distribution-codename: My_Distribution_Codename
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-# wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
-# echo "deb http://deb.theforeman.org/ _{distribution-codename}_ {ProjectVersion}" | sudo tee /etc/apt/sources.list.d/foreman.list
-# echo "deb http://deb.theforeman.org/ plugins {ProjectVersion}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
-----
-endif::[]
-. Install Hammer CLI:
-+
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-ifdef::foreman-deb[]
-# {client-package-install-deb} {project-context}-cli
-endif::[]
-ifndef::foreman-deb[]
-# {client-package-install-el8} {project-context}-cli
-endif::[]
-----
-. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-:host: 'https://_{foreman-example-com}_'
-----
-
-[id="installing-standalone-hammer-el-8"]
-== {EL}{nbsp}8
-.Procedure
-. Enable the required repositories on the host.
-ifdef::katello,orcharhino,satellite[]
-For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
-endif::[]
-ifdef::foreman-el[]
+* If you are installing on {EL}{nbsp}8, enable the following repository:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
 # {client-package-install-el8} https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm
 ----
-endif::[]
-ifdef::foreman-deb[]
-+
-:distribution-codename: My_Distribution_Codename
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-# wget https://deb.theforeman.org/foreman.asc -O /etc/apt/trusted.gpg.d/foreman.asc
-# echo "deb http://deb.theforeman.org/ _{distribution-codename}_ {ProjectVersion}" | sudo tee /etc/apt/sources.list.d/foreman.list
-# echo "deb http://deb.theforeman.org/ plugins {ProjectVersion}" | sudo tee -a /etc/apt/sources.list.d/foreman.list
-----
-endif::[]
-ifndef::foreman-deb[]
-. Enable the following module:
+. If you are installing on {EL}{nbsp}8, enable the following module:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
 # dnf module enable {dnf-module-utils}
 ----
-endif::[]
 . Install Hammer CLI:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
-ifdef::foreman-deb[]
-# {client-package-install-deb} {project-context}-cli
-endif::[]
-ifndef::foreman-deb[]
 # {client-package-install-el8} {project-context}-cli
-endif::[]
 ----
 . Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
 +
@@ -148,3 +108,70 @@ endif::[]
 ----
 :host: 'https://_{foreman-example-com}_'
 ----
+endif::[]
+ifdef::katello[]
+. Enable the required repositories on the host.
+For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
+. If you are installing on {EL}{nbsp}8, enable the following module:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# dnf module enable {dnf-module-utils}
+----
+. Install Hammer CLI.
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# {client-package-install-el8} {project-context}-cli
+----
+. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+:host: 'https://_{foreman-example-com}_'
+----
+endif::[]
+ifdef::orcharhino[]
+. Enable the required repositories on the host.
+For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
+. If you are installing on {EL}{nbsp}8, enable the following module:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# dnf module enable {dnf-module-utils}
+----
+. Install Hammer CLI:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# {client-package-install-el8} {project-context}-cli
+----
+. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+:host: 'https://_{foreman-example-com}_'
+----
+endif::[]
+ifdef::satellite[]
+. Enable the required repositories on the host.
+For more information, see {ManagingHostsDocURL}Enabling_Custom_Repositories_on_Content_Hosts_managing-hosts[Enabling repositories on hosts] in _{ManagingHostsDocTitle}_.
+. If you are installing on {EL}{nbsp}8, enable the following module:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# dnf module enable {dnf-module-utils}
+----
+. Install Hammer CLI:
++
+[options="nowrap" subs="verbatim,quotes,attributes"]
+----
+# {client-package-install-el8} {project-context}-cli
+----
+. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+:host: 'https://_{foreman-example-com}_'
+----
+endif::[]

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -97,7 +97,7 @@ ifdef::foreman-el[]
 :host: 'https://_{foreman-example-com}_'
 ----
 endif::[]
-ifdef::katello[]
+ifdef::katello,orcharhino,satellite[]
 . Enable the required repositories on the host.
 . If you are installing on {EL}{nbsp}8, enable the following module:
 +
@@ -106,48 +106,6 @@ ifdef::katello[]
 # dnf module enable {dnf-module-utils}
 ----
 . Install Hammer CLI.
-+
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-# {client-package-install-el8} {project-context}-cli
-----
-. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-:host: 'https://_{foreman-example-com}_'
-----
-endif::[]
-ifdef::orcharhino[]
-. Enable the required repositories on the host.
-. If you are installing on {EL}{nbsp}8, enable the following module:
-+
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-# dnf module enable {dnf-module-utils}
-----
-. Install Hammer CLI:
-+
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-# {client-package-install-el8} {project-context}-cli
-----
-. Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-:host: 'https://_{foreman-example-com}_'
-----
-endif::[]
-ifdef::satellite[]
-. Enable the required repositories on the host.
-. If you are installing on {EL}{nbsp}8, enable the following module:
-+
-[options="nowrap" subs="verbatim,quotes,attributes"]
-----
-# dnf module enable {dnf-module-utils}
-----
-. Install Hammer CLI:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -7,26 +7,6 @@ You can install Hammer on a host running {install-on-os} that has no {ProjectSer
 ifndef::katello,orcharhino,satellite[]
 * Ensure that the CA certificate of {ProjectServer} is deployed to the truststore on the host.
 endif::[]
-ifdef::satellite[]
-* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {RepoRHEL9BaseOS}
-** {RepoRHEL9AppStream}
-** {RepoRHEL9ServerSatelliteUtils}
-* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {RepoRHEL8BaseOS}
-** {RepoRHEL8AppStream}
-** {RepoRHEL8ServerSatelliteUtils}
-endif::[]
-ifdef::orcharhino[]
-* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {EL} 9 BaseOS
-** {EL} 9 AppStream
-* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {EL} 8 BaseOS
-** {EL} 8 AppStream
-endif::[]
 ifdef::katello[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
 * If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
@@ -37,6 +17,26 @@ ifdef::katello[]
 ** {EL} 8 BaseOS
 ** {EL} 8 AppStream
 ** https://yum.theforeman.org/releases/{ProjectVersion}/el8/x86_64/foreman-release.rpm[{Project} release RPM]
+endif::[]
+ifdef::orcharhino[]
+* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
+* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 9 BaseOS
+** {EL} 9 AppStream
+* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 8 BaseOS
+** {EL} 8 AppStream
+endif::[]
+ifdef::satellite[]
+* Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
+* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {RepoRHEL9BaseOS}
+** {RepoRHEL9AppStream}
+** {RepoRHEL9ServerSatelliteUtils}
+* If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {RepoRHEL8BaseOS}
+** {RepoRHEL8AppStream}
+** {RepoRHEL8ServerSatelliteUtils}
 endif::[]
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

Adding a procedure to configure standalone Hammer on EL 9.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27900

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I used https://github.com/theforeman/foreman-documentation/blob/master/guides/common/modules/proc_preparing-a-host-for-external-databases.adoc as a template for how to structure a procedure for EL8 /EL 9.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
