### PR TITLE
Use generic example password

### DIFF
--- a/guides/common/modules/proc_exporting-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_exporting-report-templates-using-the-api.adoc
@@ -13,7 +13,9 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ curl --insecure --user admin:redhat \
+$ curl \
+--insecure \
+--user _My_User_Name_:__My_Password__ \
 --request GET \
 --config https://_{foreman-example-com}_/api/report_templates \
 | json_reformat

--- a/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
+++ b/guides/common/modules/proc_importing-report-templates-using-the-api.adoc
@@ -62,15 +62,22 @@ model: ReportTemplate
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ curl --insecure --user admin:redhat \
---data @_Example_Template_.json --header "Content-Type:application/json" \
---request POST --config https://_{foreman-example-com}_/api/report_templates/import
+$ curl \
+--insecure \
+--user _My_User_Name_:__My_Password__ \
+--data @_Example_Template_.json \
+--header "Content-Type:application/json" \
+--request POST \
+--config https://_{foreman-example-com}_/api/report_templates/import
 ----
 +
 . Use the following request to retrieve a list of report templates and validate that you can view the template in {Project}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ curl --insecure --user admin:redhat \
- --request GET --config https://_{foreman-example-com}_/api/report_templates | json_reformat
+$ curl \
+--insecure \
+--user _My_User_Name_:__My_Password__ \
+--request GET \
+--config https://_{foreman-example-com}_/api/report_templates | json_reformat
 ----


### PR DESCRIPTION
* Use one argument per line

#### What changes are you introducing?

removing the example password "redhat" due to branding issues and consistency.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

consistency.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

we have both "last argument | next command" and "last argument \ \n | next command". Any preference?

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
