### PR TITLE
Unify macro for Ruby code blocks

### DIFF
--- a/guides/common/modules/proc_calling-the-api-in-ruby.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-ruby.adoc
@@ -16,7 +16,7 @@ This script connects to the {ProjectNameX} API and creates an organization, and 
 If the organization already exists, the script uses that organization.
 If any of the lifecycle environments already exist in the organization, the script raises an error and quits.
 
-[source, Ruby, subs="attributes"]
+[source, ruby, subs="attributes"]
 ----
 #!/usr/bin/ruby
 
@@ -106,7 +106,7 @@ end
 Apipie bindings are the Ruby bindings for apipie documented API calls.
 They fetch and cache the API definition from {Project} and then generate API calls as needed.
 
-[source, Ruby, subs="attributes"]
+[source, ruby, subs="attributes"]
 ----
 #!/usr/bin/ruby
 

--- a/guides/common/modules/proc_managing-puppet-modules-with-r10k.adoc
+++ b/guides/common/modules/proc_managing-puppet-modules-with-r10k.adoc
@@ -7,7 +7,7 @@ It does not handle dependencies between Puppet modules.
 
 A _Puppetfile_ looks as follows:
 
-[source,ruby]
+[source, ruby]
 ----
 forge "https://forge.puppet.com"
 

--- a/guides/common/modules/ref_customizing-job-templates.adoc
+++ b/guides/common/modules/ref_customizing-job-templates.adoc
@@ -6,7 +6,7 @@ This way you can combine templates, or create more specific templates from the g
 
 The following template combines default templates to install and start the *nginx* service on clients:
 
-[source, Ruby]
+[source, ruby]
 ----
 <%= render_template 'Package Action - SSH Default', :action => 'install', :package => 'nginx' %>
 <%= render_template 'Service Action - SSH Default', :action => 'start', :service_name => 'nginx' %>
@@ -16,7 +16,7 @@ The above template specifies parameter values for the rendered template directly
 It is also possible to use the *input()* method to allow users to define input for the rendered template on job execution.
 For example, you can use the following syntax:
 
-[source, Ruby]
+[source, ruby]
 ----
 <%= render_template 'Package Action - SSH Default', :action => 'install', :package => input("package") %>
 ----

--- a/guides/common/modules/ref_example-including-power-options-in-a-job-template.adoc
+++ b/guides/common/modules/ref_example-including-power-options-in-a-job-template.adoc
@@ -6,7 +6,7 @@ This procedure prevents {Project} from interpreting the disconnect exception upo
 
 Create a new template as described in {ManagingHostsDocURL}setting-up-job-templates_managing-hosts[Setting up Job Templates], and specify the following string in the template editor:
 
-[source, Ruby]
+[source, ruby]
 ----
 <%= render_template("Power Action - SSH Default", :action => "restart") %>
 ----

--- a/guides/common/modules/ref_example-restorecon-template.adoc
+++ b/guides/common/modules/ref_example-restorecon-template.adoc
@@ -10,7 +10,7 @@ This example shows how to create a template called *Run Command - restorecon* th
 Select *Default* to make the template available to all organizations.
 Add the following text to the template editor:
 +
-[source, Ruby]
+[source, ruby]
 ----
 restorecon -RvF <%= input("directory") %>
 ----

--- a/guides/common/modules/ref_rendering-a-restorecon-template.adoc
+++ b/guides/common/modules/ref_rendering-a-restorecon-template.adoc
@@ -6,7 +6,7 @@ This template does not require user input on job execution, it will restore the 
 
 Create a new template as described in {ManagingHostsDocURL}setting-up-job-templates_managing-hosts[Setting up Job Templates], and specify the following string in the template editor:
 
-[source, Ruby]
+[source, ruby]
 ----
 <%= render_template("Run Command - restorecon", :directory => "/home") %>
 ----


### PR DESCRIPTION
$ rg "source, Ruby"
$ rg "source,Ruby"
$ rg "source,ruby"

#### What changes are you introducing?

unify the way we enforce syntax highlighting for Ruby.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I am currently working on automation around this; fewer variance helps a lot!

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

rendered docs should be identical.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
