### PR TITLE
Update output of hammer ping

### DIFF
--- a/guides/common/modules/ref_troubleshooting-project-by-using-hammer.adoc
+++ b/guides/common/modules/ref_troubleshooting-project-by-using-hammer.adoc
@@ -8,19 +8,34 @@ If all services are running as expected, the output looks as follows:
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 $ hammer ping
+database:
+    Status:          ok
+    Server Response: Duration: 0ms
+cache:
+    servers:
+     1) Status:          ok
+        Server Response: Duration: 1ms
 candlepin:
     Status:          ok
-    Server Response: Duration: 22ms
+    Server Response: Duration: 17ms
 candlepin_auth:
     Status:          ok
-    Server Response: Duration: 17ms
-pulp:
+    Server Response: Duration: 14ms
+candlepin_events:
     Status:          ok
-    Server Response: Duration: 41ms
-pulp_auth:
+    message:         4 Processed, 0 Failed
+    Server Response: Duration: 0ms
+katello_events:
     Status:          ok
-    Server Response: Duration: 23ms
+    message:         5 Processed, 0 Failed
+    Server Response: Duration: 0ms
+pulp3:
+    Status:          ok
+    Server Response: Duration: 5083ms
+pulp3_content:
+    Status:          ok
+    Server Response: Duration: 5051ms
 foreman_tasks:
     Status:          ok
-    Server Response: Duration: 33ms
+    Server Response: Duration: 2ms
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Updating the example output of `hammer ping`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

As reported in https://issues.redhat.com/browse/SAT-28362, the output of hammer ping in the most recent versions differs significantly from what we currently document.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

~~I'm requesting cherry-picks down to 3.9 only because I currently don't have any test environments for the earlier versions. Considering that we're only talking about example CLI output, I think these cherry picks are enough, but if anyone disagrees, I can check all the other supported versions too.~~

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
