### PR TITLE
Add missing step to update RHSM cert

### DIFF
--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-manually.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-manually.adoc
@@ -17,6 +17,12 @@ You can deploy the CA certificate on the host manually by rendering a public pro
 include::snip_replace-fqdn-projectserver.adoc[]
 . Transfer the CA certificate to your host securely, for example by using `scp`.
 . Login to your host by using SSH.
+. Copy the certificate to the Subscription Manager configuration directory:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp -u {project-context}_ca_cert.crt /etc/rhsm/ca/katello-server-ca.pem
+----
 . Copy the certificate to the truststore:
 ifdef::client-content-dnf[]
 ifndef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding missing step to update the CA cert in RHSM config

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-28431

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Follow-up on https://github.com/theforeman/foreman-documentation/pull/3193

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
