### PR TITLE
Add depth option for OSTree repositories

### DIFF
--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -32,6 +32,7 @@ Clear this field if the repository does not require authentication.
 The excludes are evaluated after the includes.
 . Optional: In the *Include Refs* field, enter a list of OSTree head refs separated with commas to include in importing to {Project}.
 For example `fedora/x86_64/coreos/stable`.
+. Optional: In the *Depth* field, enter the number of commits to traverse.
 . From the *Mirroring Policy* menu, select one of the following policies to mirror OSTree content for this repository:
 * *Additive* {endash} new content available during sync will be added to the repository, and no content will be removed.
 * *Mirror Content Only* {endash} any new content available during sync will be added to the repository and any content removed from the upstream repository will be removed from the local repository.


### PR DESCRIPTION
#### What changes are you introducing?

This adds depth OSTree property.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

There was another property for the OSTree repositories added ([#37853](https://projects.theforeman.org/issues/37853)).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The current target is Katello 4.15, so it shouldn't need any backporting, if it surprisingly still gets into 4.14 I will make sure to mention it 👍🏻 

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.

Thank you 🙂 
