### PR TITLE
Add troubleshooting test email delivery (postfix)

### DIFF
--- a/guides/common/modules/proc_testing-email-delivery.adoc
+++ b/guides/common/modules/proc_testing-email-delivery.adoc
@@ -17,8 +17,8 @@ Otherwise, you must perform the following diagnostic steps:
 .. Verify the user's email address.
 .. Verify {ProjectServer}'s email configuration.
 .. Examine firewall and mail server logs.
-.. {Project} uses the Postfix service for email delivery by default.
-Enter the `mailq` command to list the mail queue.
+.. If your {ProjectServer} uses the Postfix service for email delivery, the test email might be held in the queue.
+To verify, enter the `mailq` command to list the current mail queue.
 If the test email is held in the queue, `mailq` displays the following message:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_testing-email-delivery.adoc
+++ b/guides/common/modules/proc_testing-email-delivery.adoc
@@ -17,3 +17,20 @@ Otherwise, you must perform the following diagnostic steps:
 .. Verify the user's email address.
 .. Verify {ProjectServer}'s email configuration.
 .. Examine firewall and mail server logs.
+.. {Project} uses the Postfix service for email delivery by default.
+Enter the `mailq` command to list the mail queue.
+If the test email is held in the queue, `mailq` displays the following message:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+postqueue: warning: Mail system is down -- accessing queue directly
+-Queue ID-  --Size-- ----Arrival Time---- -Sender/Recipient-------
+BE68482A783    1922 Thu Oct  3 05:13:36  {project-context}-noreply@example.com
+----
++
+To fix the problem, start the Postfix service on your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# systemctl start postfix
+----


### PR DESCRIPTION
#### What changes are you introducing?

Adding a troubleshooting bullet point regarding test emails not being delivered.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27822

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
