### PR TITLE
Fix curl arguments and HTTP proxy examples

### DIFF
--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -25,9 +25,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 +
 [options="nowrap"]
 ----
-# unset http_proxy
-# unset https_proxy
-# unset no_proxy
+# unset http_proxy https_proxy no_proxy
 ----
 . Add an HTTP proxy entry to {Project}:
 +

--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -8,11 +8,10 @@ The following procedure configures a proxy only for downloading content for {Pro
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-http-proxy_{context}[].
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *HTTP Proxies*.
 . Click *New HTTP Proxy*.
 . In the *Name* field, enter the name for the HTTP proxy.
-. In the *Url* field, enter the URL of the HTTP proxy in the following format: `\https://proxy.example.com:8080`.
+. In the *Url* field, enter the URL of the HTTP proxy in the following format: `\https://http-proxy.example.com:8080`.
 . Optional: If authentication is required, in the *Username* field, enter the username to authenticate with.
 . Optional: If authentication is required, in the *Password* field, enter the password to authenticate with.
 . To test connection to the proxy, click *Test Connection*.
@@ -22,8 +21,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 
 [id="cli-adding-a-default-http-proxy_{context}"]
 .CLI procedure
-
-. Verify that the `http_proxy`, `https_proxy`, and `no_proxy` variables are not set.
+. Verify that the `http_proxy`, `https_proxy`, and `no_proxy` variables are not set:
 +
 [options="nowrap"]
 ----
@@ -31,20 +29,21 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 # unset https_proxy
 # unset no_proxy
 ----
-
 . Add an HTTP proxy entry to {Project}:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer http-proxy create --name=_myproxy_ \
---url http://_myproxy.example.com_:8080  \
---username=_proxy_username_ \
---password=_proxy_password_
+# hammer http-proxy create \
+--name=_My_HTTP_Proxy_ \
+--username=_My_HTTP_Proxy_User_Name_ \
+--password=_My_HTTP_Proxy_Password_ \
+--url http://_http-proxy.example.com_:8080
 ----
-
 . Configure {Project} to use this HTTP proxy by default:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer settings set --name=content_default_http_proxy --value=_myproxy_
+# hammer settings set \
+--name=content_default_http_proxy \
+--value=__My_HTTP_Proxy__
 ----

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -13,7 +13,8 @@ If {ProjectServer} uses a proxy to communicate with subscription.rhsm.redhat.com
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-proxy[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *HTTP Proxies* and select *New HTTP Proxy*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *HTTP Proxies*.
+. Select *New HTTP Proxy*.
 . In the *Name* field, enter a name for the HTTP proxy.
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
@@ -29,11 +30,11 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 [options="nowrap" subs="+quotes,verbatim"]
 ----
 # hammer http-proxy create \
---name _proxy-name_ \
---url _proxy-URL:port-number_
+--name _My_HTTP_Proxy_ \
+--url _http-proxy.example.com:8080_
 ----
 +
-If your HTTP proxy requires authentication, add the `--username _name_` and `--password _password_` options.
+If your HTTP proxy requires authentication, add the `--username _My_User_Name_` and `--password _My_Password_` options.
 
 ifndef::orcharhino[]
 For further information, see the Knowledgebase article https://access.redhat.com/solutions/65300[How to access Red Hat Subscription Manager (RHSM) through a firewall or proxy] on the Red{nbsp}Hat Customer Portal.

--- a/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-to-connect-to-cdn.adoc
@@ -19,7 +19,7 @@ To configure the Subscription Manager with the HTTP proxy, follow the procedure 
 [source, none, options="nowrap" subs="+quotes"]
 ----
 # an http proxy server to use (enter server FQDN)
-proxy_hostname = _myproxy.example.com_
+proxy_hostname = _http-proxy.example.com_
 
 # port for http proxy server
 proxy_port = 8080

--- a/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
+++ b/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
@@ -80,7 +80,12 @@ Provisioning callback is configured correctly if the command returns the followi
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# curl -k -s --data curl --insecure --data host_config_key=_my_config_key_ \
+$ curl \
+--data curl \
+--data host_config_key=_My_Host_Config_Key_ \
+--insecure \
+--show-error \
+--silent \
 https://_controller.example.com_/api/v2/job_templates/_8_/callback/
 ----
 +

--- a/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
+++ b/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
@@ -70,9 +70,9 @@ Do not add `https` because this is appended by {Project}.
 +
 Provisioning callback is configured correctly if the command returns the following output:
 +
-[options="nowrap", subs="+quotes,verbatim,attributes"]
+[source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-SAT_host systemd[1]: Started Provisioning callback to {awx}...
+{foreman-example-com} systemd[1]: Started Provisioning callback to {awx}...
 ----
 
 .Manual provisioning callback

--- a/guides/common/modules/proc_configuring-pxe-files-proxy.adoc
+++ b/guides/common/modules/proc_configuring-pxe-files-proxy.adoc
@@ -5,30 +5,24 @@ For Red Hat content served through the Content Delivery Network, {SmartProxy} do
 However, when configuring and installing an operating system using Installation Media, {SmartProxy} connects directly using the `wget` utility.
 
 .Procedure
-
-. On {SmartProxy} with the TFTP feature, to verify the ports that are permitted by SELinux for the HTTP cache, enter the following command:
+. On your TFTP {SmartProxy}, verify the ports that are permitted by SELinux for the HTTP cache by entering the following command:
 +
 [options="nowrap",subs="+quotes"]
 ----
 # systemctl edit foreman-proxy
 ----
+. Configure the HTTP proxy in `/etc/systemd/system/foreman-proxy.service.d/overrides.conf`:
 +
-. Insert the following test into the editor:
-+
-[options="nowrap",subs="+quotes"]
+[source, none, options="nowrap",subs="+quotes"]
 ----
 [Service]
-Environment="http_proxy=http://proxy.example.com:8888"
-Environment="https_proxy=https://proxy.example.com:8888"
+Environment="http_proxy=http://_http-proxy.example.com:8080_"
+Environment="https_proxy=https://_http-proxy.example.com:8443_"
 ----
-+
-. Save the file.
-Verify that the file appears as `/etc/systemd/system/foreman-proxy.service.d/overrides.conf`.
 . Restart the `foreman-proxy` service:
 +
 [options="nowrap",subs="+quotes"]
 ----
 # systemctl restart foreman-proxy
 ----
-+
 . Create a host or enter build mode for an existing host to re-download PXE files to the TFTP {SmartProxy}.

--- a/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
+++ b/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
@@ -16,14 +16,21 @@ If you have a custom collection, place it in `/etc/ansible/collections/ansible_c
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# curl -X GET -H 'Content-Type: application/json' https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/fetch?proxy_id=__My_{smart-proxy-context}_ID__
+$ curl \
+--header 'Content-Type: application/json' \
+--request GET \
+https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/fetch?proxy_id=__My_{smart-proxy-context}_ID__
 ----
 . Select the Ansible Playbook you want to import and note its name.
 . Import the Ansible Playbook by its name:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# curl -X PUT -H 'Content-Type: application/json' -d '{ "playbook_names": ["_My_Playbook_Name_"] }' https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/sync?proxy_id=__My_{smart-proxy-context}_ID__
+$ curl \
+--data '{ "playbook_names": ["_My_Playbook_Name_"] }' \
+--header 'Content-Type: application/json' \
+--request PUT \
+https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/sync?proxy_id=__My_{smart-proxy-context}_ID__
 ----
 +
 You get a notification in the {ProjectWebUI} after the import completes.

--- a/guides/common/modules/proc_passing-arguments-to-shellhook-script-using-curl.adoc
+++ b/guides/common/modules/proc_passing-arguments-to-shellhook-script-using-curl.adoc
@@ -6,7 +6,7 @@ Use this procedure to pass arguments to a shellhook script using curl.
 .Procedure
 * When executing a shellhook script using `curl`, create HTTP headers in the following format:
 +
-[options="nowrap" subs="+quotes,attributes,verbatim"]
+[source, none, options="nowrap" subs="+quotes,attributes,verbatim"]
 ----
 "X-Shellhook-Arg-1: _VALUE_"
 "X-Shellhook-Arg-2: _VALUE_"

--- a/guides/common/modules/proc_passing-arguments-to-shellhook-script-using-curl.adoc
+++ b/guides/common/modules/proc_passing-arguments-to-shellhook-script-using-curl.adoc
@@ -15,8 +15,13 @@ Use this procedure to pass arguments to a shellhook script using curl.
 .Example
 [options="nowrap" subs="+quotes,attributes,verbatim"]
 ----
-# curl -sX POST -H 'Content-Type: text/plain' \
--H "X-Shellhook-Arg-1: Version 1.0" \
--H "X-Shellhook-Arg-2: My content view" \
---data "" https://{smartproxy-example-com}:{smartproxy_port}/shellhook/My_Script
+$ curl \
+--data "" \
+--header "Content-Type: text/plain" \
+--header "X-Shellhook-Arg-1: Version 1.0" \
+--header "X-Shellhook-Arg-2: My content view" \
+--request POST \
+--show-error \
+--silent \
+https://{smartproxy-example-com}:{smartproxy_port}/shellhook/My_Script
 ----


### PR DESCRIPTION
#### What changes are you introducing?

* Fix curl arguments: some were duplicate (both "-k" and "--insecure" which is the same)
* Somewhat unfiy the HTTP proxy example names and URLs; always say "http-proxy", not "proxy" to clearly differentiate betwen Smart Proxies and HTTP proxies.

Please review commit by commit.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Better readability

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I have verified all curl arguments via man page.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
