### PR TITLE
Drop Internet Explorer reference

### DIFF
--- a/guides/common/assembly_configuring-active-directory-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/assembly_configuring-active-directory-as-an-external-identity-provider-for-project.adoc
@@ -1,5 +1,3 @@
 include::modules/con_configuring-active-directory-as-an-external-identity-provider-for-project.adoc[]
 
 include::modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc[leveloffset=+1]
-
-include::modules/con_kerberos-configuration-in-web-browsers.adoc[leveloffset=+1]

--- a/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
+++ b/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
@@ -4,6 +4,3 @@
 ifndef::orcharhino[]
 For information about configuring Firefox, see {RHELDocsBaseURL}9/html/configuring_authentication_and_authorization_in_rhel/configuring_applications_for_sso#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to use Kerberos for single sign-on] in _{RHEL}{nbsp}9 Configuring authentication and authorization in RHEL_.
 endif::[]
-
-If you use the Internet Explorer browser, add {ProjectServer} to the list of Local Intranet or Trusted sites, and turn on the _Enable Integrated Windows Authentication_ setting.
-See the Internet Explorer documentation for details.

--- a/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
+++ b/guides/common/modules/con_kerberos-configuration-in-web-browsers.adoc
@@ -1,6 +1,0 @@
-[id="Kerberos_Configuration_in_Web_Browsers_{context}"]
-= Kerberos configuration in web browsers
-
-ifndef::orcharhino[]
-For information about configuring Firefox, see {RHELDocsBaseURL}9/html/configuring_authentication_and_authorization_in_rhel/configuring_applications_for_sso#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to use Kerberos for single sign-on] in _{RHEL}{nbsp}9 Configuring authentication and authorization in RHEL_.
-endif::[]

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -107,3 +107,4 @@ $ curl -k -u : --negotiate https://{foreman-example-com}/users/extlogin
 
 .Additional resources
 * `sssd-ad(5)` man page on your system
+* For information about configuring Mozilla Firefox for Kerberos, see {RHELDocsBaseURL}9/html/configuring_authentication_and_authorization_in_rhel/configuring_applications_for_sso#Configuring_Firefox_to_use_Kerberos_for_SSO[Configuring Firefox to use Kerberos for single sign-on] in _{RHEL}{nbsp}9 Configuring authentication and authorization in RHEL_.


### PR DESCRIPTION
#### What changes are you introducing?

I'm removing a reference to configuring Internet Explorer for Kerberos SSO. After that, the remaining content in the module can't really stand on its own so I'm merging it with another module.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Internet Explorer is being deprecated for years now. Its latest version is still officially supported, but in a very limited way with Microsoft Edge now being the recommended browser for Windows users.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Initially, I thought about replacing the entry about IE with a similar one about Edge. But then I thought that we probably don't need to (or even shouldn't) document third-party software unless absolutely necessary. Microsoft Edge users should use Microsoft docs for that.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
