### PR TITLE
Unify admonition syntax & hide KB article for orcharhino

### DIFF
--- a/guides/common/modules/con_api-overview.adoc
+++ b/guides/common/modules/con_api-overview.adoc
@@ -12,8 +12,11 @@ Using the REST API has the following benefits:
 
 Scripts based on API commands communicate directly with the {Project} API, which makes them faster than scripts based on Hammer commands or Ansible Playbooks relying on modules within {ansible-namespace}.
 
-IMPORTANT: API commands differ between versions of {Project}.
+[IMPORTANT]
+====
+API commands differ between versions of {Project}.
 When you prepare to upgrade {ProjectServer}, update all the scripts that contain {Project} API commands.
+====
 
 ifdef::satellite[]
 .Additional resources

--- a/guides/common/modules/con_browsing-hosts-in-foreman-webui.adoc
+++ b/guides/common/modules/con_browsing-hosts-in-foreman-webui.adoc
@@ -12,5 +12,8 @@ To search for a host, type in the *Search* field, and use an asterisk ({asterisk
 For example, if searching for a content host named `{server-example-com}`, click the *Content Hosts* page and type `server*` in the *Search* field.
 Alternatively, `{asterisk}ver{asterisk}` will also find the content host `{server-example-com}`.
 
-WARNING: {ProjectServer} is listed as a host itself even if it is not self-registered.
+[WARNING]
+====
+{ProjectServer} is listed as a host itself even if it is not self-registered.
 Do not delete {ProjectServer} from the list of hosts.
+====

--- a/guides/common/modules/proc_adding-a-microsoft-azure-connection.adoc
+++ b/guides/common/modules/proc_adding-a-microsoft-azure-connection.adoc
@@ -43,8 +43,11 @@ This tests if your connection to Azure Resource Manager is successful and loads 
 +
 Note that the value for the `--region` option must be in lowercase and must not contain special characters.
 
-IMPORTANT: If you are using Azure Government Cloud then you must pass in the `--cloud` parameter.
+[IMPORTANT]
+====
+If you are using Azure Government Cloud then you must pass in the `--cloud` parameter.
 The values for the `cloud` parameter are:
+====
 
 [%header,cols=2*]
 |===

--- a/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
+++ b/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
@@ -4,8 +4,11 @@
 If errata are available but not installable, you can create an incremental content view version to add the errata to your content hosts.
 For example, if the content view is version 1.0, it becomes content view version 1.1, and when you publish, it becomes content view version 2.0.
 
-IMPORTANT: If your content view version is old, you might encounter incompatibilities when incrementally adding enhancement errata.
+[IMPORTANT]
+====
+If your content view version is old, you might encounter incompatibilities when incrementally adding enhancement errata.
 This is because enhancements are typically designed for the most current software in a repository.
+====
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-errata-to-an-incremental-content-view[].
 

--- a/guides/common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc
+++ b/guides/common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc
@@ -43,7 +43,10 @@ which is referenced from datastream
 # curl -o _security-data-oval-com.redhat.rhsa-RHEL8.xml.bz2_ _https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2_
 ----
 +
-IMPORTANT: Ensure that the name of the downloaded file matches the name the data stream references.
+[IMPORTANT]
+====
+Ensure that the name of the downloaded file matches the name the data stream references.
+====
 . Add the file as new {customfiletype} content into your {ProjectServer}.
 For more information, see {ContentManagementDocURL}Managing_Custom_File_Type_Content_content-management[Managing {customfiletype} content] in _{ContentManagementDocTitle}_.
 +

--- a/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
+++ b/guides/common/modules/proc_configuring-capsule-default-certificate.adoc
@@ -59,5 +59,8 @@ root@_{smartproxy-example-com}_:/root/_{smartproxy-example-com}_-certs.tar
 When network connections or ports to {Project} are not yet open, you can set the `--foreman-proxy-register-in-foreman` option to `false` to prevent {SmartProxy} from attempting to connect to {Project} and reporting errors.
 Run the installer again with this option set to `true` when the network and firewalls are correctly configured.
 +
-IMPORTANT: Do not delete the certificate archive file after you deploy the certificate.
+[IMPORTANT]
+====
+Do not delete the certificate archive file after you deploy the certificate.
 It is required, for example, when upgrading {SmartProxyServer}.
+====

--- a/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
@@ -38,7 +38,7 @@ You can enter trusted proxies as valid IPv4 or IPv6 addresses of {SmartProxies},
 +
 [WARNING]
 ====
-Do not use a network range that is too wide, because that poses a potential security risk.
+Do not use a network range that is too broad because that might cause a security risk.
 ====
 +
 Enter the following command.

--- a/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc
@@ -36,7 +36,10 @@ This is required for {Project} to recognize hosts' IP addresses forwarded over t
 For security reasons, {Project} recognizes this HTTP header only from localhost by default.
 You can enter trusted proxies as valid IPv4 or IPv6 addresses of {SmartProxies}, or network ranges.
 +
-WARNING: Do not use a network range that is too wide, because that poses a potential security risk.
+[WARNING]
+====
+Do not use a network range that is too wide, because that poses a potential security risk.
+====
 +
 Enter the following command.
 Note that the command overwrites the list that is currently stored in {Project}.

--- a/guides/common/modules/ref_oauth-request-format.adoc
+++ b/guides/common/modules/ref_oauth-request-format.adoc
@@ -9,8 +9,11 @@ Every OAuth API request requires the `FOREMAN-USER` header with the login of an 
 --header 'Authorization: OAuth oauth_version="1.0",oauth_consumer_key="_secretkey_",oauth_signature_method="hmac-sha1",oauth_timestamp=_timestamp_,oauth_signature=_signature_'
 ----
 
-IMPORTANT: Use an OAuth client library to construct all OAuth parameters.
+[IMPORTANT]
+====
+Use an OAuth client library to construct all OAuth parameters.
 For an example that uses the *requests_oauthlib* Python module, see https://access.redhat.com/solutions/4240401[How to execute an API call by using the OAuth authentication method via python script in {ProjectNameX}?] in the _Red{nbsp}Hat Knowledgebase_.
+====
 
 .Example
 This example lists architectures by using OAuth for authentication.

--- a/guides/common/modules/ref_oauth-request-format.adoc
+++ b/guides/common/modules/ref_oauth-request-format.adoc
@@ -9,11 +9,13 @@ Every OAuth API request requires the `FOREMAN-USER` header with the login of an 
 --header 'Authorization: OAuth oauth_version="1.0",oauth_consumer_key="_secretkey_",oauth_signature_method="hmac-sha1",oauth_timestamp=_timestamp_,oauth_signature=_signature_'
 ----
 
+ifdef::satellite[]
 [IMPORTANT]
 ====
 Use an OAuth client library to construct all OAuth parameters.
 For an example that uses the *requests_oauthlib* Python module, see https://access.redhat.com/solutions/4240401[How to execute an API call by using the OAuth authentication method via python script in {ProjectNameX}?] in the _Red{nbsp}Hat Knowledgebase_.
 ====
+endif::[]
 
 .Example
 This example lists architectures by using OAuth for authentication.

--- a/guides/common/modules/ref_overview-of-individual-loggers.adoc
+++ b/guides/common/modules/ref_overview-of-individual-loggers.adoc
@@ -26,7 +26,10 @@ Logs information from the background processing component.
 `blob`::
 Logs contents of rendered templates for auditing purposes.
 +
-IMPORTANT: The `blob` logger might contain sensitive data.
+[IMPORTANT]
+====
+The `blob` logger might contain sensitive data.
+====
 
 `dynflow`::
 Logs information from the Dynflow process.


### PR DESCRIPTION
#### What changes are you introducing?

Hide link to RH KB for non-Satellite builds

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

branding.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

First commit unified the usage of admonitions.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
