### PR TITLE
Fix capitalization in web navigation

### DIFF
--- a/web/releases/3.12.json
+++ b/web/releases/3.12.json
@@ -20,7 +20,7 @@
         },
         {
           "title": "Configuring user authentication",
-          "path": "Configuring_user_authentication"
+          "path": "Configuring_User_Authentication"
         },
         {
           "title": "Configuring hosts by using Ansible",
@@ -50,7 +50,7 @@
         },
         {
           "title": "Configuring user authentication",
-          "path": "Configuring_user_authentication"
+          "path": "Configuring_User_Authentication"
         },
         {
           "title": "Configuring hosts by using Ansible",
@@ -92,7 +92,7 @@
         },
         {
           "title": "Configuring user authentication",
-          "path": "Configuring_user_authentication"
+          "path": "Configuring_User_Authentication"
         },
         {
           "title": "Tuning performance",

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -28,7 +28,7 @@
         },
         {
           "title": "Configuring user authentication",
-          "path": "Configuring_user_authentication"
+          "path": "Configuring_User_Authentication"
         },
         {
           "title": "Deploying Foreman on AWS",
@@ -102,7 +102,7 @@
         },
         {
           "title": "Configuring user authentication",
-          "path": "Configuring_user_authentication"
+          "path": "Configuring_User_Authentication"
         },
         {
           "title": "Deploying Foreman on AWS",
@@ -168,7 +168,7 @@
         },
         {
           "title": "Configuring user authentication",
-          "path": "Configuring_user_authentication"
+          "path": "Configuring_User_Authentication"
         },
         {
           "title": "Tuning performance",


### PR DESCRIPTION
#### What changes are you introducing?

Fixing capitalization in JSON navigation entries for the Configuring user authentication guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3301/files originally introduced the entries but I got the capitalization wrong so the guides don't actually show.

https://docs.theforeman.org/nightly/Configuring_user_authentication/index-katello.html currently gives Page not found

vs

https://docs.theforeman.org/nightly/Configuring_User_Authentication/index-katello.html actually displays the guide

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
