### PR TITLE
Add a bullet point for migration using cloning

### DIFF
--- a/guides/common/modules/con_upgrading-el-on-project-or-proxy.adoc
+++ b/guides/common/modules/con_upgrading-el-on-project-or-proxy.adoc
@@ -8,6 +8,7 @@ There are two methods to upgrade your {Project} or {SmartProxy} from {EL} 8 to {
 
 * Leapp in-place upgrade
 * Migration by using backup and restore
+* Migration using cloning
 
 With Leapp, you can upgrade your {Project} or {SmartProxy} in place therefore it is faster but imposes a downtime on the services.
 With migration, you can move your {Project} or {SmartProxy} to a fresh {EL} 9 system.


### PR DESCRIPTION
Migration using cloning is one of the possible methods for EL 8 to 9 upgrade. Since this is not mentioned in the bulleted list, it could be missed. Adding a new bullet point to mention this method.

JIRA: https://issues.redhat.com/browse/SAT-28269

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
