### PR TITLE
Add PostgreSQL space requirement in prerequisites

### DIFF
--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -17,7 +17,7 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 ifndef::foreman-deb[]
-* Ensure that you have at least the same amount of free space as that consumed by `{postgresql-lib-dir}/data`.
+* Ensure that you have at least the same amount of free space on `{postgresql-lib-dir}` as that consumed by `{postgresql-data-dir}`.
 Upgrading to {Project} {ProjectVersion} involves a PostgreSQL 12 to PostgreSQL 13 upgrade.
 The contents of `{postgresql-lib-dir}` are backed up during the PostgreSQL upgrade. 
 endif::[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -16,9 +16,11 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
-* Ensure that you have at least the same amount of free space as that consumed by `/var/lib/pgsql/data` for PostgreSQL upgrade.
-The upgrade involves PostgreSQL 12 to PostgreSQL 13 upgrade.
-The existing postgreSQL data is backed up during the PostgreSQL upgrade. 
+ifndef::foreman-deb[]
+* Ensure that you have at least the same amount of free space as that consumed by `/var/lib/pgsql/data`.
+Upgrading to {Project} {ProjectVersion} involves a PostgreSQL 12 to PostgreSQL 13 upgrade.
+The contents of `{postgresql-lib-dir}` are backed up during the PostgreSQL upgrade. 
+endif::[]
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -17,6 +17,8 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 * Ensure that you have at least the same amount of free space as that consumed by `/var/lib/pgsql/data` for PostgreSQL upgrade.
+The upgrade involves PostgreSQL 12 to PostgreSQL 13 upgrade.
+The existing postgreSQL data is backed up during the PostgreSQL upgrade. 
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -19,7 +19,7 @@ For more information, see {InstallingServerDocURL}Preparing_your_Environment_for
 ifndef::foreman-deb[]
 * Ensure that you have at least the same amount of free space on `{postgresql-lib-dir}` as that consumed by `{postgresql-data-dir}`.
 Upgrading to {Project} {ProjectVersion} involves a PostgreSQL 12 to PostgreSQL 13 upgrade.
-The contents of `{postgresql-lib-dir}` are backed up during the PostgreSQL upgrade. 
+The contents of `{postgresql-data-dir}` are backed up during the PostgreSQL upgrade. 
 endif::[]
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -17,7 +17,7 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 ifndef::foreman-deb[]
-* Ensure that you have at least the same amount of free space as that consumed by `/var/lib/pgsql/data`.
+* Ensure that you have at least the same amount of free space as that consumed by `{postgresql-lib-dir}/data`.
 Upgrading to {Project} {ProjectVersion} involves a PostgreSQL 12 to PostgreSQL 13 upgrade.
 The contents of `{postgresql-lib-dir}` are backed up during the PostgreSQL upgrade. 
 endif::[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -16,6 +16,7 @@ Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
 
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
+* Ensure that you have at least the same amount of free space as that consumed by `/var/lib/pgsql/data` for PostgreSQL upgrade.
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.


### PR DESCRIPTION
As PostgreSQL is upgraded from 12 to 13 during the upgrade process, it is necessary to maintain enough space for this. Adding this as a prerequisite to the upgrade.

Ref: https://github.com/theforeman/foreman_maintain/blob/master/definitions/checks/disk/available_space_postgresql13.rb

JIRA: https://issues.redhat.com/browse/SAT-28667

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
