### PR TITLE
Change ID to fix a broken UI link

### DIFF
--- a/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
+++ b/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
@@ -1,5 +1,8 @@
-[id="registering-hosts-and-setting-up-host-integration_{context}"]
+[id="registering_hosts_to_server_{context}"]
 = Registering hosts and setting up host integration
+[[registering-hosts-and-setting-up-host-integration_{context}]]
+// The primary ID ([id="..."]) is used in the UI to link to this section.
+// The secondary ID ([[...]]) is used in the docs set and matches the section heading and file name.
 
 You must register hosts that have not been provisioned through {Project} to be able to manage them with {Project}.
 You can register hosts through {ProjectServer} or {SmartProxyServer}.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a secondary ID to the assembly for registering hosts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Another PR recently changed the ID which broke a UI link: https://github.com/theforeman/foreman-documentation/pull/3327#discussion_r1791397965

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
