### PR TITLE
Mention that target should have same config as source

### DIFF
--- a/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup.adoc
+++ b/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup.adoc
@@ -17,7 +17,7 @@ endif::[]
 . Perform a full backup of your {ProjectServer} or {SmartProxy}.
 This is the source {EL}{nbsp}8 server that you are migrating.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin#Performing_a_Full_Backup_admin[Performing a full backup of {ProjectServer} or {SmartProxyServer}] in _{AdministeringDocTitle}_.
-. Deploy a system with {EL}{nbsp}9.
+. Deploy a {EL}{nbsp}9 system with the same hostname and configuration as the source server.
 This is the target server.
 ifdef::satellite[]
 . Restore the {ProjectServer} backup by following one of these options:

--- a/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup.adoc
+++ b/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup.adoc
@@ -17,7 +17,7 @@ endif::[]
 . Perform a full backup of your {ProjectServer} or {SmartProxy}.
 This is the source {EL}{nbsp}8 server that you are migrating.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin#Performing_a_Full_Backup_admin[Performing a full backup of {ProjectServer} or {SmartProxyServer}] in _{AdministeringDocTitle}_.
-. Deploy a {EL}{nbsp}9 system with the same hostname and configuration as the source server.
+. Deploy a system with {EL}{nbsp}9 and the same hostname and configuration as the source server.
 This is the target server.
 ifdef::satellite[]
 . Restore the {ProjectServer} backup by following one of these options:


### PR DESCRIPTION
In the Migrating using Backup and Restore section, it needs to be specifically pointed out that the target system should have the same config as the source. This is easy to miss in the linked docs and can cause the migration to fail. Hence mentioning it explicitly in the procedure module.

JIRA: https://issues.redhat.com/browse/SAT-27958

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
