### PR TITLE
Simplify disabling RH Insights

### DIFF
--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -1,25 +1,15 @@
 [id='disabling-red-hat-insights-registration_{context}']
 = Disabling Red Hat Insights registration
 
-After you install or upgrade {Project}, you can choose to unregister or register Red Hat Insights as needed.
-For example, if you need to use {Project} in a disconnected environment, you can unregister `insights-client` from {ProjectServer}.
+If you decide that you will not use Red Hat Insights, you can unregister {ProjectServer} from Insights.
 
 .Prerequisites
-
-. You have registered {Project} to Red Hat Customer Portal.
+* You have registered {Project} to Red Hat Insights.
 
 .Procedure
-
-. Optional: To unregister Red Hat Insights from {ProjectServer}, enter the following command:
+* To unregister {ProjectServer} from Red Hat Insights, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # insights-client --unregister
-----
-
-. Optional: To register {ProjectServer} with Red Hat Insights, enter the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --register-with-insights
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Simplifying the module about disabling RH Insights.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The scenario for this procedure was unclear and contained also a step to enable Insights, which was confusing. I've attempted to clarify the use case and simplify the procedure.

https://issues.redhat.com/browse/SAT-27612

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
