### PR TITLE
Remove entitlement-mode subscription steps from cloning

### DIFF
--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -106,25 +106,6 @@ Use the following procedures to clone {ProjectServer}. Note that because of the 
 
 On the source server, complete the following steps:
 
-. Verify the Pool ID of your {Project} subscription:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# subscription-manager list --consumed \
---matches '{ProjectName}'|grep "_Pool ID_:"|awk '{print $3}'
-----
-+
-Note the _Pool ID_ for later use.
-+
-. Remove the {ProjectName} subscription:
-+
-[options="nowrap" subs="attributes"]
-----
-# subscription-manager remove --serial=$(subscription-manager list \
---consumed \
---matches '{ProjectName}'|grep "Serial:"|awk '{print $2}')
-----
-+
 . Determine the size of the Pulp data:
 +
 [options="nowrap"]
@@ -161,12 +142,11 @@ If you copy to a different folder, update the `backup_dir` variable in the `/etc
 . Place the backup files from the source {Project} in the `/backup/` folder on the target server.
 You can either mount the shared storage or copy the backup files to the `/backup/` folder on the target server.
 . Power off the source server.
-. Enter the following commands to register to the Customer Portal, attach subscriptions, and enable only the required subscriptions:
+. Register your instance to the Red Hat Customer Portal and enable only the required repositories:
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
 # subscription-manager register _your_customer_portal_credentials_
-# subscription-manager attach --pool=__pool_ID__
 # subscription-manager repos --disable=*
 # subscription-manager repos --enable={RepoRHEL8AppStream} \
 --enable={RepoRHEL8BaseOS} \


### PR DESCRIPTION
#### What changes are you introducing?

Removing entitlement-mode subscription steps from cloning, esp. pool attachment

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27778

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Not sure how far this needs to be cherry picked. cc @jeremylenz 

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
