### PR TITLE
Pin Ubuntu to 22.04 in vale.yml to work around a bug

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   vale:
     name: linter
-    runs-on: ubuntu-latest
+    # workaround for https://github.com/errata-ai/vale-action/issues/128
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: errata-ai/vale-action@reviewdog


### PR DESCRIPTION
Workaround for https://github.com/errata-ai/vale-action/issues/128

Does not need style review because it does not affect doc content.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
