### PR TITLE
Change details to environment

### DIFF
--- a/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
@@ -6,7 +6,7 @@ Use this procedure to change the environment of a host.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Click the vertical ellipsis in the *Content view details* card and select *Edit content view assignment*.
+. Click the vertical ellipsis in the *Content view environment* card and select *Edit content view assignment*.
 . Select the environment.
 . Select the content view.
 . Click *Save*.

--- a/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
@@ -6,7 +6,7 @@ Use this procedure to change the environment of a host.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Click the vertical ellipsis in the *Content view environment* card and select *Edit content view assignment*.
+. Click the icon in the *Content view environment* card and select *Edit content view environments*.
 . Select the environment.
 . Select the content view.
 . Click *Save*.

--- a/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
@@ -6,7 +6,7 @@ Use this procedure to change the environment of a host.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Click the icon in the *Content view environment* card and select *Edit content view environments*.
+. Click the options icon on the *Content view environment* card and select *Edit content view environments*.
 . Select the environment.
 . Select the content view.
 . Click *Save*.

--- a/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-environment-of-a-host.adoc
@@ -6,7 +6,7 @@ Use this procedure to change the environment of a host.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Click the options icon on the *Content view environment* card and select *Edit content view environments*.
+. On the *Content view environment* card, click the options icon and select *Edit content view environments*.
 . Select the environment.
 . Select the content view.
 . Click *Save*.


### PR DESCRIPTION
Content View details card changed to Content View 
environment card
while changing the environment of a host in Satellite 
6.16.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
