### PR TITLE
Show link to Hammer CLI guide for all builds

### DIFF
--- a/guides/common/modules/ref_cli-help.adoc
+++ b/guides/common/modules/ref_cli-help.adoc
@@ -16,11 +16,4 @@ For more information, run `{foreman-installer} --full-help` on your {ProjectServ
 
 [[Hammer_CLI]]
 Hammer CLI:: You can manage {Project} on the command line using `hammer`.
-For more information on using Hammer CLI,
-ifdef::orcharhino[]
-see xref:sources/installation_and_maintenance/using_hammer_cli.adoc[Using Hammer CLI] or
-endif::[]
-ifdef::satellite[]
-see {HammerDocURL}[{HammerDocTitle}] or
-endif::[]
-run `hammer --help` on your {ProjectServer} or {SmartProxyServer}.
+For more information on using Hammer CLI, see {HammerDocURL}[_{HammerDocTitle}_] or run `hammer --help` on your {ProjectServer} or {SmartProxyServer}.


### PR DESCRIPTION
#### What changes are you introducing?

Show a link to Hammer CLi guide unconditionally:

* Hammer CLI guide is part of foreman-documentation since d7fbafe289fb37ef94fcd24062fde671fcd64614.
* In downstream orcharhino docs, the file path will be changed.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I am in the process of incorporating Hammer CLI guide in orcharhino downstream docs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
