### PR TITLE
Install Hammer CLI on separate hosts (orcharhino only)

### DIFF
--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -20,12 +20,10 @@ ifdef::katello[]
 endif::[]
 ifdef::orcharhino[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {EL} 9 BaseOS
-** {EL} 9 AppStream
 * If you are installing on {EL}{nbsp}8, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
 ** {EL} 8 BaseOS
 ** {EL} 8 AppStream
+** {SmartProxy} repository
 endif::[]
 ifdef::satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.

--- a/guides/doc-Hammer_CLI/master.adoc
+++ b/guides/doc-Hammer_CLI/master.adoc
@@ -17,7 +17,16 @@ include::common/modules/con_hammer-compared-to-project-api.adoc[leveloffset=+2]
 
 include::common/modules/proc_getting-help.adoc[leveloffset=+2]
 
+ifdef::orcharhino[]
+// works for orcharhino with Foreman 3.11 on EL8
+:parent-dnf-module-utils: {dnf-module-utils}
+:dnf-module-utils: ruby:2.7
+endif::[]
 include::common/modules/proc_installing-standalone-hammer.adoc[leveloffset=+1]
+ifdef::orcharhino[]
+:dnf-module-utils: {parent-dnf-module-utils}
+:!parent-dnf-module-utils:
+endif::[]
 
 include::common/modules/con_hammer-authentication.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

Installing Hammer CLI on an EL 8 hosts that is not orcharhino Server or orcharhino Proxy Server does requires the ruby:2.7 DNF module and access to orcharhino content from orcharhino Server or orcharhino Proxy Servers.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

working on Hammer CLI guide for orcharhino downstream.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tested downstream.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
