### PR TITLE
Add reproducer for Hammer CLI reference

### DIFF
--- a/hammer_cli_reference/README.adoc
+++ b/hammer_cli_reference/README.adoc
@@ -1,0 +1,31 @@
+= Hammer CLI reference
+
+foreman-documentation contains a Hammer CLI guide for all build flavours.
+The guide contains a list of reference files that are based on Hammer CLI help output for a specific Foreman+Katello version and, optionally, Foreman+Katello plugins.
+
+In *downstream* docs, each team maintains its own set of downstream-only commits that overwrite the assembly and add necessary reference files.
+In *upstream* docs, the community can update the reference files based on a Foreman+Katello instance.
+
+== Updating Hammer CLI reference files
+
+.Prerequisites
+* You have root SSH access to a Foreman+Katello instance.
+* You run Ansible on your local machine.
+
+.Limitations
+* Tested with Foreman 3.11/Katello 4.13 on EL8 only
+
+.Procedure
+. Ensure that there are no uncommitted changes in `foreman-documentation`.
+. Set the FQDN of your Foreman+Katello instance in `hammer_cli_reference/inventory.yaml`.
+. Optional: Lint the Ansible playbook:
++
+----
+$ ansible-lint hammer_cli_reference/playbook.yaml
+----
+. Run the Ansible playbook to update the Hammer CLI reference files:
++
+----
+$ ANSIBLE_CONFIG="hammer_cli_reference/ansible.cfg" ansible-playbook --verbose --inventory hammer_cli_reference/inventory.yaml --extra-vars="repo_path=/home/user/path/to/foreman-documentation" hammer_cli_reference/playbook.yaml
+----
+. In `foreman-documentation`, commit and open a pull request for the relevant Foreman version.

--- a/hammer_cli_reference/inventory.yaml
+++ b/hammer_cli_reference/inventory.yaml
@@ -1,0 +1,17 @@
+---
+localhost:
+  hosts:
+    developer-system:
+      ansible_python_interpreter: "/usr/bin/python3"
+foreman-katello:
+  hosts:
+    foreman-katello.example.com:
+      ansible_user: "root"
+      # If you use Forklift instead of a remote Foreman+Katello instance,
+      # you have to drop "ansible_user" and use the following variables:
+      # ansible_connection: "ssh"
+      # ansible_host: 127.0.0.1
+      # ansible_port: 2222
+      # ansible_ssh_private_key_file: "/path/to/forklift/.vagrant/machines/_My_Instance_/virtualbox/private_key"
+      # ansible_user: "vagrant"
+...

--- a/hammer_cli_reference/playbook.yaml
+++ b/hammer_cli_reference/playbook.yaml
@@ -1,0 +1,163 @@
+---
+- name: "Check prerequisites on developer-system"
+  connection: local
+  hosts: developer-system
+  vars:
+    repo_path: "/home/user"
+    repo_remote: "git@github.com:theforeman/foreman-documentation.git"
+
+  tasks:
+    - name: "Verify that user input is set"
+      ansible.builtin.assert:
+        that: repo_path != "/home/user"
+        fail_msg: "Supply a variable repo_path pointing to the root of your local clone of foreman-documentation."
+
+    - name: "Verify that foreman-documentation is present"
+      ansible.builtin.git:
+        clone: false
+        dest: "{{ repo_path }}"
+        repo: "{{ repo_remote }}"
+        update: false  # noqa: latest
+        version: "HEAD"
+
+    - name: "Verify that shellscript is present"
+      ansible.builtin.stat:
+        path: "{{ repo_path }}/guides/scripts/generate-hammer-reference.sh"
+      register: result
+
+    - name: "End playbook if shellscript is not present"
+      ansible.builtin.fail:
+        msg: "Shellscript to convert markdown to asciidoc is not present or executable"
+      when:
+        - not result.stat.executable
+        - not result.stat.exists
+
+    - name: "Delete markdown file if present"
+      ansible.builtin.file:
+        path: "{{ repo_path }}/guides/hammer_full_help.md"
+        state: absent
+
+- name: "Generate Hammer CLI help"
+  hosts: foreman-katello
+  vars:
+    foreman_plugins:
+      - foreman-tasks
+      - foreman_acd
+      - foreman_ansible
+      - foreman_azure_rm
+      - foreman_bootdisk
+      - foreman_discovery
+      - foreman_fog_proxmox
+      - foreman_git_templates
+      - foreman_google
+      - foreman_kernel_care
+      - foreman_kubevirt
+      - foreman_leapp
+      - foreman_maintain
+      - foreman_openscap
+      - foreman_puppet
+      - foreman_remote_execution
+      - foreman_remote_execution-cockpit
+      - foreman_resource_quota
+      - foreman_rh_cloud
+      - foreman_salt
+      - foreman_scap_client
+      - foreman_scc_manager
+      - foreman_snapshot_management
+      - foreman_templates
+      - foreman_virt_who_configure
+      - foreman_webhooks
+      # - foreman_concrete
+      # - foreman_datacenter
+      # - foreman_default_hostgroup
+      # - foreman_dhcp_browser
+      # - foreman_dlm
+      # - foreman_expire_hosts
+      # - foreman_graphite
+      # - foreman_hdm
+      # - foreman_host_extra_validator
+      # - foreman_monitoring
+      # - foreman_netbox
+      # - foreman_omaha
+      # - foreman_probing
+      # - foreman_rescue
+      # - foreman_statistics
+      # - foreman_supervisory_authority
+      # - foreman_vault
+      # - foreman_vmwareannotations
+      # - foreman_wreckingball
+
+  tasks:
+    - name: "Update DNF cache"
+      ansible.builtin.dnf:
+        update_cache: true
+
+    - name: "Install Foreman plugins"
+      ansible.builtin.package:
+        name: "rubygem-{{ item }}"
+        state: latest  # noqa: package-latest
+      become: true
+      with_items: "{{ foreman_plugins }}"
+
+    - name: "Install Hammer CLI plugins"
+      ansible.builtin.package:
+        name: "rubygem-hammer_cli_{{ item }}"
+        state: latest  # noqa: package-latest
+      become: true
+      with_items: "{{ foreman_plugins }}"
+      # TODO: find a better solution than ignoring errors:
+      #       * list all available Hammer CLI plugins?
+      #       * create RFE to get Hammer CLI plugins for all Foreman+Katello plugins?
+      #       * query the RPM database?
+      failed_when: false
+
+    - name: "Generate full Hammer CLI help"
+      ansible.builtin.command:
+        cmd: "hammer full-help --md"
+      changed_when: true
+      register: hammer_cli_help_in_markdown
+
+    - name: "Write Hammer CLI help to file"
+      ansible.builtin.copy:
+        content: "{{ hammer_cli_help_in_markdown.stdout }}"
+        dest: "/tmp/hammer_full_help.md"
+        mode: "0644"
+
+    # do not use "ansible.posix.synchronize" to avoid dependency to "rsync"
+    - name: "Copy markdown from Foreman+Katello to local host"
+      ansible.builtin.fetch:
+        dest: "{{ repo_path }}/guides/hammer_full_help.md"
+        flat: true
+        src: "/tmp/hammer_full_help.md"
+
+- name: "Convert markdown to asciidoc"
+  connection: local
+  hosts: developer-system
+
+  tasks:
+    - name: "Verify that markdown file is present"
+      ansible.builtin.stat:
+        path: "{{ repo_path }}/guides/hammer_full_help.md"
+      register: result
+
+    - name: "End playbook if markdown file is not present"
+      ansible.builtin.fail:
+        msg: "Hammer CLI help in markdown is not present"
+      when: not result.stat.exists
+
+    - name: "Convert markdown to asciidoc"
+      ansible.builtin.command:
+        chdir: "{{ repo_path }}/guides/"
+        cmd: "/bin/bash ./scripts/generate-hammer-reference.sh ./hammer_full_help.md"  # overrules hashbang and mitigates failures on ZSH
+      changed_when: true  # TODO: evaluate if we can use the edited assembly
+      register: result
+
+    - name: "Show stdout from converting md to adoc"
+      ansible.builtin.debug:
+        msg: "{{ result.stdout_lines }}"
+
+    - name: "Delete markdown file if present"
+      ansible.builtin.file:
+        path: "{{ repo_path }}/guides/hammer_full_help.md"
+        state: absent
+...


### PR DESCRIPTION
#### What changes are you introducing?

docs on how to create/update/review Hammer CLI reference files for katello.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

as a preparation to another PR to add a Hammer CLI reference for latest greatest Katello.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The first and only goal is to create a reproducer for Hammer CLI reference files for Foreman+Katello "develop" with all possible Hammer CLI plugins.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
