### PR TITLE
Use Katello API for GPG pub keys of custom content

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -64,6 +64,18 @@ If an attacker, located in the network between {Project} and a host, fetches the
 Therefore, if you have chosen to deploy SSH keys during registration, the attacker will be able to access the host using the SSH key.
 * On the *Advanced* tab, in the *Repositories* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
+ifdef::orcharhino[]
+ifdef::debian,ubuntu[]
++
+To verify synchronized {client-content-type} content, you can use the `pulp_deb_signing.key` file on your {SmartProxy} as GPG public key.
+For example, `\https://{foreman-example-com}/pub/pulp_deb_signing.key`.
+endif::[]
+ifndef::debian,ubuntu[]
++
+To verify synchronized {client-content-type} content, you can use {Project} API to get associated GPG public keys of repositories.
+For example, `\https://{foreman-example-com}/katello/api/v2/repositories/_My_Repository_ID_/gpg_key_content`.
+endif::[]
+endif::[]
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated `curl` command works.
 +


### PR DESCRIPTION
#### What changes are you introducing?

If you register a host that requires content from Foreman+Katello and you have that content already synchronized to your Foreman+Katello instance and that content is published unprotected, then you can use the Katello API to get the associated GPG public key for Yum repositories and the Pulp Deb Signing Key for Deb content.

Examples:

* Your host runs Debian 12 and needs "subscription-manager" from oss.atix.de and additional Deb repositories to satisfy all dependencies of "subscription-manager" and "katello-host-tools".
* Your host runs AlmaLinux 9 but has no internet access and no mounted ISO image. You will have to provide BaseOS, AppStream, and the Foreman Client repository through your Smart Proxy to enable offline host registration.

With GPG public keys, package managers can verify that the package has not been tampered with by verifying the signature made by the OS/package vendor. "apt" on Debian/Ubuntu verifies the meta data of repositories.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

improve user experience and security

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
