### PR TITLE
Add missing supported content types to Planning guide

### DIFF
--- a/guides/common/modules/con_content-flow-in-project.adoc
+++ b/guides/common/modules/con_content-flow-in-project.adoc
@@ -8,7 +8,14 @@ _{SmartProxyServers}_ mirror the content from {ProjectServer} to _hosts_.
 
 External content sources::
 You can configure many content sources with {Project}.
-The supported content sources include the Red{nbsp}Hat Customer Portal, Git repositories, Ansible collections, Docker Hub, SCAP repositories, or internal data stores of your organization.
+The supported content sources include the Red{nbsp}Hat Customer Portal,
+ifdef::satellite[]
+custom Yum repositories,
+endif::[]
+ifndef::satellite[]
+custom Deb and Yum repositories,
+endif::[]
+Git repositories, Ansible collections, Docker Hub, SCAP repositories, or internal data stores of your organization.
 *{ProjectServer}*::
 On your {ProjectServer}, you plan and manage the content lifecycle.
 *{SmartProxyServers}*::

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -143,7 +143,7 @@ Alternatively, grub2 from Ubuntu or {EL} can be copied to perform booting.
 
 Grub2 in {EL} 8.0-8.3 were updated to mitigate https://access.redhat.com/security/vulnerabilities/grub2bootloader[Boot Hole Vulnerability] and keys of existing {EL} kernels were invalidated.
 To boot any of the affected {EL} kernel (or operating system installer), you must enroll keys manually into the EFI firmware for each host:
-+
+
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # pesign -P -h -i /boot/vmlinuz-<version>


### PR DESCRIPTION
#### What changes are you introducing?

Add two missing content types

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/issues/2775

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
