### PR TITLE
Add new note snippet

### DIFF
--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -51,3 +51,5 @@ Relative paths do not work.
 # hammer content-view version list \
 --organization-id=_My_Organization_ID_
 ----
+
+include::snip_note-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -51,5 +51,4 @@ Relative paths do not work.
 # hammer content-view version list \
 --organization-id=_My_Organization_ID_
 ----
-
-include::snip_note-imported-project-server.adoc[]
+include::snip_extract-directory-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -42,5 +42,4 @@ total 68M
 Note that you must enter the full path `/var/lib/pulp/imports/_My_Exported_Repo_Dir_`.
 Relative paths do not work.
 . To verify that you imported the repository, check the contents of the product and repository.
-
-include::snip_note-imported-project-server.adoc[]
+include::snip_extract-directory-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -20,6 +20,7 @@ endif::[]
 # chown -R pulp:pulp /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
 ----
 . Verify that the ownership is set correctly:
++
 [options="nowrap" subs="+quotes"]
 ----
 # ls -lh /var/lib/pulp/imports/2021-03-02T03-35-24-00-00

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -41,3 +41,5 @@ total 68M
 Note that you must enter the full path `/var/lib/pulp/imports/_My_Exported_Repo_Dir_`.
 Relative paths do not work.
 . To verify that you imported the repository, check the contents of the product and repository.
+
+include::snip_note-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -47,3 +47,5 @@ This content view is used to facilitate the Library content import.
 By default, this content view is not shown in the {ProjectWebUI}.
 `Import-Library` is not meant to be assigned directly to hosts.
 Instead, assign your hosts to `Default Organization View` or another content view as you would normally.
+
+include::snip_note-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -48,5 +48,4 @@ This content view is used to facilitate the Library content import.
 By default, this content view is not shown in the {ProjectWebUI}.
 `Import-Library` is not meant to be assigned directly to hosts.
 Instead, assign your hosts to `Default Organization View` or another content view as you would normally.
-
-include::snip_note-imported-project-server.adoc[]
+include::snip_extract-directory-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -20,6 +20,7 @@ endif::[]
 # chown -R pulp:pulp /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
 ----
 . Verify that the ownership is set correctly:
++
 [options="nowrap" subs="+quotes"]
 ----
 # ls -lh /var/lib/pulp/imports/2021-03-02T03-35-24-00-00

--- a/guides/common/modules/snip_extract-directory-imported-project-server.adoc
+++ b/guides/common/modules/snip_extract-directory-imported-project-server.adoc
@@ -1,0 +1,1 @@
+. On the importing {ProjectServer}, extract the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`. You can empty the `/var/lib/pulp/imports` directory after a successful import.

--- a/guides/common/modules/snip_extract-directory-imported-project-server.adoc
+++ b/guides/common/modules/snip_extract-directory-imported-project-server.adoc
@@ -1,1 +1,2 @@
-. On the importing {ProjectServer}, extract the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`. You can empty the `/var/lib/pulp/imports` directory after a successful import.
+. The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`.
+You can empty the `/var/lib/pulp/imports` directory after a successful import.

--- a/guides/common/modules/snip_note-imported-project-server.adoc
+++ b/guides/common/modules/snip_note-imported-project-server.adoc
@@ -1,0 +1,4 @@
+[NOTE]
+====
+On the imported {ProjectServer}, the `/var/lib/pulp/imports` directory will get extracted to `/var/lib/pulp/` and the `/var/lib/pulp/imports` directory can be cleared out after the successful import.
+====

--- a/guides/common/modules/snip_note-imported-project-server.adoc
+++ b/guides/common/modules/snip_note-imported-project-server.adoc
@@ -1,4 +1,0 @@
-[NOTE]
-====
-On the imported {ProjectServer}, the `/var/lib/pulp/imports` directory will get extracted to `/var/lib/pulp/` and the `/var/lib/pulp/imports` directory can be cleared out after the successful import.
-====


### PR DESCRIPTION
A new note was needed for 3 sections to tell the user 
that they can
clear the imports directory. A snippet was created.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
