### PR TITLE
Bump orcharhino version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 Please cherry-pick my commits into:
 
 * [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
-* [ ] Foreman 3.11/Katello 4.13
+* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
 * [ ] Foreman 3.10/Katello 4.12
 * [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
 * [ ] Foreman 3.8/Katello 4.10

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,8 +1,8 @@
 // Overrides for orcharhino build
 :atix_service_portal_clients_url: https://atixservice.zendesk.com/hc/de/articles/9833875714844
 :BaseURL: https://docs.orcharhino.com/
-:ProjectVersion: 6.10
-:ProjectVersionPrevious: 6.9
+:ProjectVersion: 6.11
+:ProjectVersionPrevious: 6.10
 :Project: orcharhino
 :project-allcaps: ORCHARHINO
 :project-context: {Project}


### PR DESCRIPTION
https://orcharhino.com/orcharhino-6-11-0/

#### What changes are you introducing?

ATIX has released orcharhino 6.11 using Foreman 3.11/Katello 4.13.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

mostly to add the release to GH PR template.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
