### PR TITLE
Refs #36688 - Option to use wget for host registration

### DIFF
--- a/guides/common/modules/con_registering-hosts-by-using-global-registration.adoc
+++ b/guides/common/modules/con_registering-hosts-by-using-global-registration.adoc
@@ -1,7 +1,7 @@
 [id="Registering_Hosts_by_Using_Global_Registration_{context}"]
 = Registering hosts by using global registration
 
-You can register a host to {Project} by generating a `curl` command on {Project} and running this command on hosts.
+You can register a host to {Project} by generating a `curl` or `wget` command on {Project} and running this command on hosts.
 This method uses two provisioning templates: *Global Registration* template and *Linux host_init_config default* template.
 That gives you complete control over the host registration process.
 

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -6,6 +6,7 @@ You can register a host by using registration templates and set up various integ
 .Prerequisites
 * Your user account has a role assigned that grants the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
+* You must have installed either `curl` or `wget` on the host that you want to register.
 * You have configured your host for registration.
 For more information, see xref:Configuring_a_Host_for_Registration_{context}[].
 ifdef::satellite,orcharhino,katello[]
@@ -54,6 +55,8 @@ The registration details that you can specify include the following:
 
 * On the *General* tab, in the *{SmartProxy}* field, you can select the {SmartProxy} to register your host through.
 A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
+* On the *General* tab, in the *Download utility* field, you can select `wget` if you want to register your host by using a `wget` command.
+By default, {Project} generates a `curl` command.
 * On the *General* tab, you can select the *Insecure* option to make the first call insecure.
 During this first call, your host downloads the CA file from {Project}.
 Your host will use this CA file to connect to {Project} with all future calls making them secure.
@@ -65,17 +68,17 @@ Therefore, if you have chosen to deploy SSH keys during registration, the attack
 * On the *Advanced* tab, in the *Repositories* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
-The duration of this token defines how long the generated `curl` command works.
+The duration of this token defines how long the generated registration command works.
 +
-Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of your host.
+Note that {Project} applies the permissions of the user who generates the registration command to authorization of your host.
 If the user loses or gains additional permissions, the permissions of the JWT change too.
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
 
 .CLI procedure
-. Use the `hammer host-registration generate-command` to generate the `curl` command to register your host.
-. On your host that you want to register, run the `curl` command as `root`.
+. Use the `hammer host-registration generate-command` to generate the registration command to register your host.
+. On your host that you want to register, run the registration command as `root`.
 
 For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.
 

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -6,15 +6,15 @@ You can register a host by using registration templates and set up various integ
 .Prerequisites
 * Your user account has a role assigned that grants the `create_hosts` permission.
 * You must have root privileges on the host that you want to register.
-* You have configured the host for registration.
+* You have configured your host for registration.
 For more information, see xref:Configuring_a_Host_for_Registration_{context}[].
 ifdef::satellite,orcharhino,katello[]
-* An activation key must be available for the host.
+* An activation key must be available for your host.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::satellite[]
-* Optional: If you want to register hosts to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
-This is required to install the `insights-client` package on hosts.
+* Optional: If you want to register your host to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
+This is required to install the `insights-client` package on your host.
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 include::snip_prerequisite-project-client-repository-ak.adoc[]
@@ -42,9 +42,9 @@ endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
-. Enter the details for how you want the registered hosts to be configured.
+. Enter the details for how you want the registered host to be configured.
 ifdef::katello,satellite,orcharhino[]
-. On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to hosts.
+. On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
 . Click *Generate* to generate a `curl` command.
 . Run the `curl` command as `root` on the host that you want to register.
@@ -52,30 +52,30 @@ After registration completes, any Ansible roles assigned to a host group you spe
 
 The registration details that you can specify include the following:
 
-* On the *General* tab, in the *{SmartProxy}* field, you can select the {SmartProxy} to register hosts through.
+* On the *General* tab, in the *{SmartProxy}* field, you can select the {SmartProxy} to register your host through.
 A {SmartProxy} behind a load balancer takes precedence over a {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
 * On the *General* tab, you can select the *Insecure* option to make the first call insecure.
-During this first call, the host downloads the CA file from {Project}.
-The host will use this CA file to connect to {Project} with all future calls making them secure.
+During this first call, your host downloads the CA file from {Project}.
+Your host will use this CA file to connect to {Project} with all future calls making them secure.
 +
 {Team} recommends that you avoid insecure calls.
 +
-If an attacker, located in the network between {Project} and a host, fetches the CA file from the first insecure call, the attacker will be able to access the content of the API calls to and from the registered host and the JSON Web Tokens (JWT).
-Therefore, if you have chosen to deploy SSH keys during registration, the attacker will be able to access the host using the SSH key.
+If an attacker, located in the network between {Project} and your host, fetches the CA file from the first insecure call, the attacker will be able to access the content of the API calls to and from your host and the JSON Web Tokens (JWT).
+Therefore, if you have chosen to deploy SSH keys during registration, the attacker will be able to access your host using the SSH key.
 * On the *Advanced* tab, in the *Repositories* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated `curl` command works.
 +
-Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of hosts.
+Note that {Project} applies the permissions of the user who generates the `curl` command to authorization of your host.
 If the user loses or gains additional permissions, the permissions of the JWT change too.
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
 
 .CLI procedure
-. Use the `hammer host-registration generate-command` to generate the `curl` command to register the host.
-. On the host that you want to register, run the `curl` command as `root`.
+. Use the `hammer host-registration generate-command` to generate the `curl` command to register your host.
+. On your host that you want to register, run the `curl` command as `root`.
 
 For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.
 

--- a/guides/common/modules/ref_registration-methods.adoc
+++ b/guides/common/modules/ref_registration-methods.adoc
@@ -4,7 +4,7 @@
 You can use the following methods to register hosts to {Project}:
 
 Global registration::
-You generate a `curl` command from {Project} and run this command from an unlimited number of hosts to register them using provisioning templates over the {Project} API.
+You generate a registration command from {Project} and run this command on an unlimited number of hosts to register them by using provisioning templates over the {Project} API.
 For more information, see xref:Registering_Hosts_by_Using_Global_Registration_{context}[].
 +
 By using this method, you can also deploy {Project} SSH keys to hosts during registration to {Project} to enable hosts for remote execution jobs.


### PR DESCRIPTION
Documents https://github.com/theforeman/foreman/pull/9808

As documentation for https://github.com/theforeman/foreman/pull/9808 was prematurely merged in https://github.com/theforeman/foreman-documentation/pull/2376 and reverted in https://github.com/theforeman/foreman-documentation/pull/2793, @Lennonka kindly created https://github.com/theforeman/foreman-documentation/pull/2914 to re-add documentation for https://github.com/theforeman/foreman/pull/9808 once it is merged. Additionally I created https://github.com/theforeman/foreman-documentation/pull/3163 as follow-up PR to https://github.com/theforeman/foreman-documentation/pull/2914.

Due to heavy rewriting of the module, we decided to close https://github.com/theforeman/foreman-documentation/pull/2914 as well as https://github.com/theforeman/foreman-documentation/pull/3163 and to open this new PR for documenting https://github.com/theforeman/foreman/pull/9808 instead.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
