### PR TITLE
Fixes #37942 - Updating Job Template Documentation with Ansible Check Mode Option

### DIFF
--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -25,6 +25,7 @@ For examples, see the *Help* tab.
 . Optional: If this template is a snippet to be included in other templates, click the *Type* tab and select *Snippet*.
 . Optional: If you use the Ansible provider, click the *Ansible* tab.
 Select *Enable Ansible Callback* to allow hosts to send facts, which are used to create configuration reports, back to {Project} after a job finishes.
+Select *Enable Ansible Check Mode* to force jobs based off of the template to execute without making changes to hosts.
 . Click the *Location* tab and add the locations where you want to use the template.
 . Click the *Organizations* tab and add the organizations where you want to use the template.
 . Click *Submit* to save your changes.


### PR DESCRIPTION
#### What changes are you introducing?
This PR adds a line of documentation explaining a new Enable Ansible Check Mode option within Ansible Job Templates describing its basic functionality.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
This documentation explains the new functionality introduced in the following PRs:
* https://github.com/theforeman/foreman_ansible

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This PR is dependent on the following PRs being approved/merged first:
* [ ] https://github.com/theforeman/smart_proxy_ansible
* [ ] https://github.com/theforeman/foreman_ansible

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
