### PR TITLE
Debian 12 support for Foreman 3.11 & repository config in tabs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'asciidoctor'
+gem 'asciidoctor-tabs'
 gem 'sass'

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -75,7 +75,7 @@ $(IMAGES_TS): $(IMAGES)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD).css $(IMAGES_TS)
-	bundle exec asciidoctor -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -a attribute-missing=warn -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
+	bundle exec asciidoctor -r asciidoctor-tabs -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -a attribute-missing=warn -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
 	@echo CHECKING FOR ASCIIDOCTOR ERRORS AND WARNINGS
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 	@echo CHECKING FOR ORPHAN XREFS HTML LINKS

--- a/guides/common/assembly_configuring-repositories.adoc
+++ b/guides/common/assembly_configuring-repositories.adoc
@@ -1,0 +1,3 @@
+include::modules/con_configuring-repositories.adoc[]
+
+include::modules/proc_configuring-repositories-{build}.adoc[]

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -16,7 +16,7 @@ ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
 ifndef::satellite[]
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::assembly_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
 // we do not package "fapolicy" for Foreman on Debian/Ubuntu

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 include::modules/proc_registering-to-red-hat-subscription-management.adoc[leveloffset=+1]
 endif::[]
 
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::assembly_configuring-repositories.adoc[leveloffset=+1]
 
 // we do not package "fapolicy" for Foreman on Debian/Ubuntu
 ifndef::foreman-deb[]

--- a/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
+++ b/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
@@ -10,7 +10,7 @@ ifdef::satellite[]
 include::modules/proc_configuring-repositories-proxy.adoc[leveloffset=+1]
 endif::[]
 ifndef::satellite[]
-include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::assembly_configuring-repositories.adoc[leveloffset=+1]
 endif::[]
 
 // Installing {SmartProxyServer} Packages

--- a/guides/common/modules/con_configuring-repositories.adoc
+++ b/guides/common/modules/con_configuring-repositories.adoc
@@ -1,0 +1,2 @@
+[id="configuring-repositories_{context}"]
+= Configuring repositories

--- a/guides/common/modules/con_projectserver-operating-system.adoc
+++ b/guides/common/modules/con_projectserver-operating-system.adoc
@@ -1,7 +1,7 @@
 [id="ProjectServer-Operating-System_{context}"]
 = {ProjectServer} operating system
 
-{Project} has packages for {EL} 8 and 9, Debian 11 and Ubuntu 20.04 and 22.04.
+{Project} has packages for {EL} 8 and 9, Debian 11 and 12, and Ubuntu 20.04 and 22.04.
 Katello plugin packages, which provide content management capabilities, are only available for {EL}.
 
 {Team} only packages {Project} for x86_64.

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -10,6 +10,13 @@ Debian 11 (Bullseye)::
 include::proc_configuring-repositories-deb.adoc[]
 --
 
+Debian 12 (Bookworm)::
++
+--
+:distribution-codename: bookworm
+include::proc_configuring-repositories-deb.adoc[]
+--
+
 Ubuntu 20.04 (Focal)::
 +
 --

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -1,25 +1,29 @@
 .Procedure
-Select the operating system and version you are installing on:
 
 // List of supported OS for foreman-deb has to match "guides/common/modules/proc_upgrading-a-connected-project-server.adoc"
-* xref:#repositories-debian-11[Debian 11 (Bullseye)]
-* xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
-* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
-
 [id="repositories-debian-11"]
 == Debian 11 (Bullseye)
 
+[tabs]
+=====
+Debian 11 (Bullseye)::
++
+--
 :distribution-codename: bullseye
 include::proc_configuring-repositories-deb.adoc[]
+--
 
-[id="repositories-ubuntu-2004"]
-== Ubuntu 20.04 (Focal)
-
+Ubuntu 20.04 (Focal)::
++
+--
 :distribution-codename: focal
 include::proc_configuring-repositories-deb.adoc[]
+--
 
-[id="repositories-ubuntu-2204"]
-== Ubuntu 22.04 (Jammy)
-
+Ubuntu 22.04 (Jammy)::
++
+--
 :distribution-codename: jammy
 include::proc_configuring-repositories-deb.adoc[]
+--
+=====

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -1,0 +1,24 @@
+.Procedure
+Select the operating system and version you are installing on:
+
+* xref:#repositories-debian-11[Debian 11 (Bullseye)]
+* xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
+* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
+
+[id="repositories-debian-11"]
+== Debian 11 (Bullseye)
+
+:distribution-codename: bullseye
+include::proc_configuring-repositories-deb.adoc[]
+
+[id="repositories-ubuntu-2004"]
+== Ubuntu 20.04 (Focal)
+
+:distribution-codename: focal
+include::proc_configuring-repositories-deb.adoc[]
+
+[id="repositories-ubuntu-2204"]
+== Ubuntu 22.04 (Jammy)
+
+:distribution-codename: jammy
+include::proc_configuring-repositories-deb.adoc[]

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -1,6 +1,7 @@
 .Procedure
 Select the operating system and version you are installing on:
 
+// List of supported OS for foreman-deb has to match "guides/common/modules/proc_upgrading-a-connected-project-server.adoc"
 * xref:#repositories-debian-11[Debian 11 (Bullseye)]
 * xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
 * xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -1,9 +1,6 @@
 .Procedure
 
 // List of supported OS for foreman-deb has to match "guides/common/modules/proc_upgrading-a-connected-project-server.adoc"
-[id="repositories-debian-11"]
-== Debian 11 (Bullseye)
-
 [tabs]
 =====
 Debian 11 (Bullseye)::

--- a/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
@@ -1,23 +1,17 @@
 .Procedure
-Select the operating system and version you are installing on:
 
-* xref:#repositories-el-9[{EL} 9]
-* xref:#repositories-el-8[{EL} 8]
-
-[id="repositories-el-9"]
-== {EL} 9
-
+[tabs]
+=====
+{EL} 9::
++
 :distribution: el
 :distribution-major-version: 9
 :package-manager: dnf
 
 include::proc_configuring-repositories-el.adoc[]
 
-include::snip_verification-enabled-repolist.adoc[]
-
-[id="repositories-el-8"]
-== {EL} 8
-
+{EL} 8::
++
 :distribution: el
 :distribution-major-version: 8
 :package-manager: dnf
@@ -42,5 +36,6 @@ ifeval::["{context}" != "{project-context}"]
 endif::[]
 For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Lifecycle].
 ====
+=====
 
 include::snip_verification-enabled-repolist.adoc[]

--- a/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
@@ -1,0 +1,46 @@
+.Procedure
+Select the operating system and version you are installing on:
+
+* xref:#repositories-el-9[{EL} 9]
+* xref:#repositories-el-8[{EL} 8]
+
+[id="repositories-el-9"]
+== {EL} 9
+
+:distribution: el
+:distribution-major-version: 9
+:package-manager: dnf
+
+include::proc_configuring-repositories-el.adoc[]
+
+include::snip_verification-enabled-repolist.adoc[]
+
+[id="repositories-el-8"]
+== {EL} 8
+
+:distribution: el
+:distribution-major-version: 8
+:package-manager: dnf
+
+include::proc_configuring-repositories-el.adoc[]
+
+. Enable the DNF modules:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# dnf module enable {dnf-module}
+----
++
+[NOTE]
+====
+If there is any warning about conflicts with Ruby or PostgreSQL while enabling `{dnf-module}` module, see
+ifeval::["{context}" == "{project-context}"]
+xref:troubleshooting-dnf-modules_{context}[].
+endif::[]
+ifeval::["{context}" != "{project-context}"]
+{InstallingServerDocURL}troubleshooting-dnf-modules_{project-context}[Troubleshooting DNF modules] in _{InstallingServerDocTitle}_.
+endif::[]
+For more information about modules and lifecycle streams on {RHEL} 8, see https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Lifecycle].
+====
+
+include::snip_verification-enabled-repolist.adoc[]

--- a/guides/common/modules/proc_configuring-repositories-katello.adoc
+++ b/guides/common/modules/proc_configuring-repositories-katello.adoc
@@ -1,0 +1,1 @@
+proc_configuring-repositories-foreman-el.adoc

--- a/guides/common/modules/proc_configuring-repositories-orcharhino.adoc
+++ b/guides/common/modules/proc_configuring-repositories-orcharhino.adoc
@@ -1,0 +1,1 @@
+Ensure the repositories required to install {ProductName} are enabled on your {EL} host.

--- a/guides/common/modules/proc_configuring-repositories-satellite.adoc
+++ b/guides/common/modules/proc_configuring-repositories-satellite.adoc
@@ -1,34 +1,12 @@
-[id="configuring-repositories_{context}"]
-= Configuring repositories
-
-ifdef::orcharhino[]
-Ensure the repositories required to install {ProductName} are enabled on your {EL} host.
-endif::[]
-
-ifndef::orcharhino[]
 .Procedure
 Select the operating system and version you are installing on:
-endif::[]
 
-ifdef::foreman-el,katello,satellite[]
 * xref:#repositories-el-9[{EL} 9]
 * xref:#repositories-el-8[{EL} 8]
-endif::[]
-ifdef::foreman-deb[]
-* xref:#repositories-debian-11[Debian 11 (Bullseye)]
-* xref:#repositories-ubuntu-2004[Ubuntu 20.04 (Focal)]
-* xref:#repositories-ubuntu-2204[Ubuntu 22.04 (Jammy)]
-endif::[]
 
-ifdef::foreman-el,katello,satellite[]
 [id="repositories-el-9"]
 == {EL} 9
 
-:distribution: el
-:distribution-major-version: 9
-:package-manager: dnf
-
-ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -46,22 +24,12 @@ ifdef::satellite[]
 --enable={RepoRHEL9ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
-endif::[]
-
-ifdef::foreman-el,katello[]
-include::proc_configuring-repositories-el.adoc[]
-endif::[]
 
 include::snip_verification-enabled-repolist.adoc[]
 
 [id="repositories-el-8"]
 == {EL} 8
 
-:distribution: el
-:distribution-major-version: 8
-:package-manager: dnf
-
-ifdef::satellite[]
 . Disable all repositories:
 +
 [options="nowrap"]
@@ -79,20 +47,13 @@ ifdef::satellite[]
 --enable={RepoRHEL8ServerSatelliteServerProjectVersion} \
 --enable={RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
 ----
-endif::[]
 
-ifdef::foreman-el,katello[]
-include::proc_configuring-repositories-el.adoc[]
-endif::[]
-
-ifdef::foreman-el,katello,satellite[]
 . Enable the DNF modules:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # dnf module enable {dnf-module}
 ----
-endif::[]
 +
 [NOTE]
 ====
@@ -107,24 +68,3 @@ For more information about modules and lifecycle streams on {RHEL} 8, see https:
 ====
 
 include::snip_verification-enabled-repolist.adoc[]
-endif::[]
-
-ifdef::foreman-deb[]
-[id="repositories-debian-11"]
-== Debian 11 (Bullseye)
-
-:distribution-codename: bullseye
-include::proc_configuring-repositories-deb.adoc[]
-
-[id="repositories-ubuntu-2004"]
-== Ubuntu 20.04 (Focal)
-
-:distribution-codename: focal
-include::proc_configuring-repositories-deb.adoc[]
-
-[id="repositories-ubuntu-2204"]
-== Ubuntu 22.04 (Jammy)
-
-:distribution-codename: jammy
-include::proc_configuring-repositories-deb.adoc[]
-endif::[]

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -96,6 +96,7 @@ deb http://deb.theforeman.org/ plugins {ProjectVersion}
 Replace _My_Distribution_Code_Name_ with the proper distribution code name based on the operating system of your {ProjectServer}:
 +
 * `bullseye` for Debian 11
+* `bookworm` for Debian 12
 * `jammy` for Ubuntu 22.04
 * `focal` for Ubuntu 20.04
 . Update to {Project} {ProjectVersion}:

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -22,6 +22,7 @@ ifdef::satellite[]
 endif::[]
 ifdef::foreman-deb[]
 | Debian 11 (Bullseye) | amd64 |
+| Debian 12 (Bookworm) | amd64 |
 | Ubuntu 20.04 (Focal) | amd64 |
 | Ubuntu 22.04 (Jammy) | amd64 |
 endif::[]

--- a/guides/doc-Quickstart/master.adoc
+++ b/guides/doc-Quickstart/master.adoc
@@ -21,7 +21,7 @@ For more information, see {InstallingServerDocURL}system-requirements_{project-c
 The Foreman installer uses Puppet to install Foreman.
 This guide assumes that you have a newly installed operating system, on which the installer will setup Foreman, a Puppet server, and the Smart Proxy by default.
 
-include::common/modules/proc_configuring-repositories.adoc[leveloffset=+1]
+include::common/assembly_configuring-repositories.adoc[leveloffset=+1]
 
 include::common/modules/proc_installing-the-satellite-server-packages.adoc[leveloffset=+1]
 

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -18,6 +18,11 @@ For more details, see https://projects.theforeman.org/issues/37252 and https://p
 
 Foreman 3.10 only supported {EL} 9 as experimental, but with this release it is fully supported.
 
+=== Running Foreman on Debian 12 is supported
+
+Packages for Debian 12 were built with 3.11.0, but our automated pipelines rely on Puppetserver.
+Now that Puppetserver packages for Debian 12 are available, with Foreman 3.11.4 Debian 12 is considered a supported platform.
+
 [id="foreman-upgrade-warnings"]
 == Upgrade Warnings
 
@@ -44,3 +49,10 @@ Note this is for running Foreman itself.
 Clients will remain supported.
 
 For more details and discussion, see https://community.theforeman.org/t/drop-support-for-running-on-el8-with-foreman-3-13/38083.
+
+=== Running Foreman on Debian 11 removal in Foreman 3.14
+
+Users are encouraged to upgrade to Debian 12.
+
+Note this is for running Foreman itself.
+Clients will remain supported.


### PR DESCRIPTION
With Foreman 3.11.4 we can consider Debian 12 supported. This cherry picks the patches from master and adds a release note. Because in master it's written for asciidoctor-tabs, those commits are included here.

I intend to submit a similar PR for the 3.12 branch.

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.