### PR TITLE
Add link to Leapp known issues

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -7,6 +7,8 @@ You can use the Leapp tool to upgrade as well as to help detect and resolve issu
 ifdef::satellite[]
 * Review Known Issues before you begin an upgrade.
 For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+* Review Known Issues for Leapp before you begin an upgrade.
+For more information, see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/upgrading_from_rhel_8_to_rhel_9/index#known-issues_troubleshooting[Known issues for the {EL} 8.10 to RHEL 9.4 upgrade]. 
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -6,7 +6,7 @@ You can use the Leapp tool to upgrade as well as to help detect and resolve issu
 .Prerequisites
 ifdef::satellite[]
 * Review known issues before you begin an upgrade.
-For more information, see {ReleaseNotesDocURL}known-issues[Known Issues in {ProjectName} {ProjectVersion}].
+For more information, see {ReleaseNotesDocURL}known-issues[Known issues in {ProjectName} {ProjectVersion}].
 * If you use an HTTP proxy in your environment, configure the Subscription Manager to use the HTTP proxy for connection.
 For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting_upgrading-from-rhel-8-to-rhel-9[Troubleshooting] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -6,8 +6,9 @@ You can use the Leapp tool to upgrade as well as to help detect and resolve issu
 .Prerequisites
 ifdef::satellite[]
 * Review known issues before you begin an upgrade.
-** {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
-** {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#known-issues_troubleshooting[Known issues for the {EL} 8.10 to RHEL 9.4 upgrade]. 
+For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+* If you use an HTTP proxy in your environment, configure the Subscription Manager to use the HTTP proxy for connection.
+For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting-resources_troubleshooting. 
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -6,9 +6,9 @@ You can use the Leapp tool to upgrade as well as to help detect and resolve issu
 .Prerequisites
 ifdef::satellite[]
 * Review known issues before you begin an upgrade.
-For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+For more information, see {ReleaseNotesDocURL}known-issues[Known Issues in {ProjectName} {ProjectVersion}].
 * If you use an HTTP proxy in your environment, configure the Subscription Manager to use the HTTP proxy for connection.
-For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting-resources_troubleshooting[Troubleshooting resources]. 
+For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting_upgrading-from-rhel-8-to-rhel-9[Troubleshooting] in [Troubleshooting] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -8,7 +8,7 @@ ifdef::satellite[]
 * Review known issues before you begin an upgrade.
 For more information, see {ReleaseNotesDocURL}known-issues[Known Issues in {ProjectName} {ProjectVersion}].
 * If you use an HTTP proxy in your environment, configure the Subscription Manager to use the HTTP proxy for connection.
-For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting_upgrading-from-rhel-8-to-rhel-9[Troubleshooting] in [Troubleshooting] in _Upgrading from RHEL 8 to RHEL 9_.
+For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting_upgrading-from-rhel-8-to-rhel-9[Troubleshooting] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -8,7 +8,7 @@ ifdef::satellite[]
 * Review known issues before you begin an upgrade.
 For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
 * If you use an HTTP proxy in your environment, configure the Subscription Manager to use the HTTP proxy for connection.
-For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting-resources_troubleshooting. 
+For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#troubleshooting-resources_troubleshooting[Troubleshooting resources]. 
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -5,10 +5,9 @@ You can use the Leapp tool to upgrade as well as to help detect and resolve issu
 
 .Prerequisites
 ifdef::satellite[]
-* Review Known Issues before you begin an upgrade.
-For more information, see {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
-* Review Known Issues for Leapp before you begin an upgrade.
-For more information, see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/upgrading_from_rhel_8_to_rhel_9/index#known-issues_troubleshooting[Known issues for the {EL} 8.10 to RHEL 9.4 upgrade]. 
+* Review known issues before you begin an upgrade.
+** {ReleaseNotesDocURL}ref_known-issues_assembly_introducing-red-hat-satellite[Known Issues in {ProjectName} {ProjectVersion}].
+** {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#known-issues_troubleshooting[Known issues for the {EL} 8.10 to RHEL 9.4 upgrade]. 
 endif::[]
 ifdef::foreman-el,foreman-deb,katello[]
 * Review upgrade warnings before you begin an upgrade.


### PR DESCRIPTION
Users would like to review the Leapp known issues before beginning the upgrade from EL 8 to 9. Adding a link to the same.

JIRA: https://issues.redhat.com/browse/SAT-17113

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
