### PR TITLE
Use single quote as apostrophe

### DIFF
--- a/guides/common/modules/proc_cloning_satellite_server.adoc
+++ b/guides/common/modules/proc_cloning_satellite_server.adoc
@@ -23,7 +23,7 @@ Ensure that you understand the following terms:
 . Back up the source server.
 . Clone the source server to the target server.
 . Power off the source server.
-. Update the network configuration on the target server to match the target server’s IP address with its new host name.
+. Update the network configuration on the target server to match the IP address of the target server with its new host name.
 . Test the new target server.
 
 
@@ -193,7 +193,7 @@ Immediately update the admin password to secure credentials.
 . Click *Refresh* and then click *Close* to return to the list of subscriptions.
 . Verify that the available subscriptions are correct.
 . Follow the instructions in the `/usr/share/satellite-clone/logs/reassociate_capsules.txt` file to restore the associations between {SmartProxies} and their lifecycle environments.
-. Update your network configuration, for example, DNS, to match the target server’s IP address with its new host name.
+. Update your network configuration, for example, DNS, to match the IP address of the target server with its new host name.
 The `satellite-clone` tool changes the host name to the source server's host name.
 If you want to change the host name to something different, you can use the `satellite-change-hostname` tool.
 For more information, see {AdministeringDocURL}renaming-{project-context}_admin[Renaming {ProjectServer}] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc
+++ b/guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc
@@ -18,7 +18,7 @@ In the {Keycloak} web UI:
 . In the *X509/Validate Username Form* row, select *ALTERNATIVE*.
 Click *Actions* > *Config*.
 .. In the *Alias* field, enter a name for this configuration.
-.. From the *User Identity Source* list, select *Subject’s Common Name*,
+.. From the *User Identity Source* list, select *Subject's Common Name*,
 .. From the *User mapping method* list, select *Username or Email*.
 .. Click *Save*.
 . Navigate to *Authentication* > *Bindings*.

--- a/guides/common/modules/proc_creating-a-content-view-filter-for-errata.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-filter-for-errata.adoc
@@ -33,7 +33,7 @@ For example, select the *Enhancement* and *Bugfix* checkboxes and clear the *Sec
 +
 * *Issued On* for the issued date of the erratum.
 +
-* *Updated On* for the date of the erratum’s last update.
+* *Updated On* for the date of the last update of the erratum.
 
 . Select the *Start Date* to exclude all errata on or after the selected date.
 . Leave the *End Date* field blank.

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -134,7 +134,7 @@ ifdef::load-balancing[]
 -b /root/{cert-name}_cert/ca_cert_bundle.pem <3>
 ----
 <1> {SmartProxyServer} certificate file, provided by your Certificate Authority
-<2> {SmartProxyServer}’s private key that you used to sign the certificate
+<2> {SmartProxyServer} private key that you used to sign the certificate
 <3> Certificate Authority bundle, provided by your Certificate Authority
 +
 If you set the `commonName=` to a wildcard value `*`, you must add the `-t {certs-proxy-context}` option to the `katello-certs-check` command.

--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -44,7 +44,7 @@ ifdef::satellite[]
 ** To install {ProjectServer} from a disconnected network, follow the procedures in {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
 endif::[]
 ** To install a {SmartProxyServer}, follow the procedures in {InstallingSmartProxyDocURL}[{InstallingSmartProxyDocTitle}].
-. Copy the backup data to {ProjectServer}’s local file system.
+. Copy the backup data to the local file system on {ProjectServer}.
 Use `/var/` or `/var/tmp/`.
 . Run the restoration script.
 +

--- a/guides/common/modules/proc_restoring-from-incremental-backups.adoc
+++ b/guides/common/modules/proc_restoring-from-incremental-backups.adoc
@@ -8,8 +8,8 @@ When the restore process completes, all processes are online, and all databases 
 
 .Procedure
 . Restore the last full backup using the instructions in xref:Restoring_from_a_Full_Backup_{context}[].
-. Remove the full backup data from {ProjectServer}’s local file system, for example, `/var/` or `/var/tmp/`.
-. Copy the incremental backup data to {ProjectServer}’s local file system, for example, `/var/` or `/var/tmp/`.
+. Remove the full backup data from the local file system on {ProjectServer}, for example, `/var/` or `/var/tmp/`.
+. Copy the incremental backup data to the local file system on {ProjectServer}, for example, `/var/` or `/var/tmp/`.
 . Restore the incremental backups in the same sequence that they are made:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
@@ -10,7 +10,7 @@ You can use simplified alternate content sources to configure your {SmartProxy} 
 . In the *Name* field, enter a name for the alternate content source.
 . Optional: In the *Description* field, provide a description for the alternate content source.
 . Select {SmartProxies} that you want to sync directly from Red Hat CDN.
-. Optional: Select *Use HTTP proxies* if you want the ACS to use the {SmartProxyServer}’s HTTP proxy.
+. Optional: Select *Use HTTP proxies* if you want the ACS to use the HTTP proxy on {SmartProxyServer}.
 . Select the Red Hat products that should be synced to the {SmartProxy} from Red Hat CDN.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.

--- a/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
@@ -10,7 +10,7 @@ You can use simplified alternate content sources to configure your {SmartProxy} 
 . In the *Name* field, enter a name for the alternate content source.
 . Optional: In the *Description* field, provide a description for the alternate content source.
 . Select {SmartProxies} that you want to sync directly from Red Hat CDN.
-. Optional: Select *Use HTTP proxies* if you want the ACS to use the HTTP proxy on {SmartProxyServer}.
+. Optional: Select *Use HTTP proxies* if you want the ACS to use the HTTP proxy on {SmartProxy}.
 . Select the Red Hat products that should be synced to the {SmartProxy} from Red Hat CDN.
 . Review details and click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -211,7 +211,7 @@ The full host image contains an embedded Linux kernel and init RAM disk of the a
 
 [[Generic_image]]
 Generic image:: A boot disk for PXE-less provisioning that is not tied to a specific host.
-The generic image sends the host’s MAC address to {ProjectServer}, which matches it against the host entry.
+The generic image sends the MAC address of your host to {ProjectServer}, which matches it against the host entry.
 
 [[Hammer]]
 Hammer::

--- a/guides/common/modules/ref_template-macros.adoc
+++ b/guides/common/modules/ref_template-macros.adoc
@@ -34,7 +34,7 @@ Using the `load_hosts` macro, you can generate a complete list of hosts.
 +
 Use the `load_hosts` macro with the `each_record` macro to load records in batches of 1000 to reduce memory consumption.
 +
-If you want to filter the list of hosts for the report, you can add the option `search: input(‘_Example_Host_’)`:
+If you want to filter the list of hosts for the report, you can add the option `search: input('_Example_Host_')`:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -16,7 +16,7 @@ If you use the export method, restore your changes by comparing the exported tem
 .{SmartProxy} considerations
 
 ifdef::katello,orcharhino,satellite[]
-* If you use content views to control updates to a {SmartProxyServer}’s base operating system, or for {SmartProxyServer} repository, you must publish updated versions of those content views.
+* If you use content views to control updates to the base operating system of {SmartProxyServer}, or for {SmartProxyServer} repository, you must publish updated versions of those content views.
 endif::[]
 * Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServers} still at {ProjectVersionPrevious}.
 

--- a/guides/doc-Deploying_Project_on_AWS/topics/AWS_Use_Case_Considerations.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/topics/AWS_Use_Case_Considerations.adoc
@@ -64,7 +64,7 @@ endif::[]
 == Use Cases that Do Not Work
 
 In AWS, you cannot manage the DHCP.
-Because of this, most of {ProjectServer}’s Kickstart and PXE provisioning models are unusable.
+Because of this, most of Kickstart and PXE provisioning models of {ProjectServer} are unusable.
 This includes:
 
 * PXE Provisioning


### PR DESCRIPTION
#### What changes are you introducing?

* Replace ’ with '
* Fix attribute usage
* Reword thing's attribute to attribute of thing

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Found issues in downstream doc builds.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I believe I found this due to a combination of locales and aspell. Example that I found in downstream docs: "XING’s privacy" vs "XING's privacy" with "XING" as spelling exception. Note that this is just a theory though.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
