### PR TITLE
Fix command to generate Puppetserver CA certs for load balancer

### DIFF
--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -60,13 +60,15 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# puppet cert generate _{smartproxy-example-com}_ \
---dns_alt_names=_{loadbalancer-example-com}_
+# puppetserver ca generate \
+--ca-client \
+--certname _{smartproxy-example-com}_ \
+--subject-alt-names _{loadbalancer-example-com}_
 ----
 +
 This command creates the following files on the Puppet certificate signing {SmartProxyServer} instance:
 +
-* `/etc/puppetlabs/puppet/ssl/certs/ca.pem`
 * `/etc/puppetlabs/puppet/ssl/certs/{smartproxy-example-com}.pem`
 * `/etc/puppetlabs/puppet/ssl/private_keys/{smartproxy-example-com}.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/{smartproxy-example-com}.pem`
+* `/etc/puppetlabs/puppetserver/ca/signed/{smartproxy-example-com}.pem`

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -78,7 +78,7 @@ This command creates the following files:
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
-. Restart the Puppet server:
+. Start the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -56,15 +56,15 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --puppet-server true \
 --puppet-server-ca "true"
 ----
-. On {SmartProxyServer}, stop the Puppet server:
+. On {SmartProxyServer} that is the Puppetserver Certificate Authority, stop the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# puppetserver stop
+# systemctl stop puppetserver
 ----
-. On {SmartProxyServer}, generate Puppet certificates for all other {SmartProxies} that you configure for load balancing, except this first system where you configure Puppet certificates signing:
+. Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the first system where you configure Puppet certificates signing:
 +
-[options="nowrap", subs="+quotes,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # puppetserver ca generate \
 --ca-client \
@@ -72,15 +72,15 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --subject-alt-names _{loadbalancer-example-com}_
 ----
 +
-This command creates the following files on the Puppet certificate signing {SmartProxyServer} instance:
+This command creates the following files on the system where you configure {SmartProxyServer} to sign Puppet certificates:
 +
-* `/etc/puppetlabs/puppet/ssl/certs/{smartproxy-example-com}.pem`
-* `/etc/puppetlabs/puppet/ssl/private_keys/{smartproxy-example-com}.pem`
-* `/etc/puppetlabs/puppet/ssl/public_keys/{smartproxy-example-com}.pem`
-* `/etc/puppetlabs/puppetserver/ca/signed/{smartproxy-example-com}.pem`
+* `/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem`
+* `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
+* `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
+* `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
 . Resume the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# puppetserver start
+# systemctl start puppetserver
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -62,7 +62,7 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 ----
 # systemctl stop puppetserver
 ----
-. Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the first system where you configure Puppet certificates signing:
+. Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the system where you first configured Puppet certificate signing:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -72,13 +72,13 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --subject-alt-names _{loadbalancer-example-com}_
 ----
 +
-This command creates the following files on the system where you configure {SmartProxyServer} to sign Puppet certificates:
+This command creates the following files:
 +
 * `/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
-. Resume the Puppet server:
+. Restart the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -56,6 +56,12 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --puppet-server true \
 --puppet-server-ca "true"
 ----
+. On {SmartProxyServer}, stop the Puppet server:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# puppetserver stop
+----
 . On {SmartProxyServer}, generate Puppet certificates for all other {SmartProxies} that you configure for load balancing, except this first system where you configure Puppet certificates signing:
 +
 [options="nowrap", subs="+quotes,attributes"]
@@ -72,3 +78,9 @@ This command creates the following files on the Puppet certificate signing {Smar
 * `/etc/puppetlabs/puppet/ssl/private_keys/{smartproxy-example-com}.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/{smartproxy-example-com}.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/{smartproxy-example-com}.pem`
+. Resume the Puppet server:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# puppetserver start
+----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -59,7 +59,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 ----
 # systemctl stop puppetserver
 ----
-. Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the first system where you configure Puppet certificates signing:
+. Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the system where you first configured Puppet certificate signing:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -69,13 +69,13 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --subject-alt-names _{loadbalancer-example-com}_
 ----
 +
-This command creates the following files on the system where you configure {SmartProxyServer} to sign Puppet certificates:
+This command creates the following files:
 +
 * `/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
-. Resume the Puppet server:
+. Restart the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -57,7 +57,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# puppet resource service puppetserver ensure=stopped
+# puppetserver stop
 ----
 . Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the first system where you configure Puppet certificates signing:
 +
@@ -79,5 +79,5 @@ This command creates the following files on the system where you configure {Smar
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# puppet resource service puppetserver ensure=running
+# puppetserver start
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -53,11 +53,11 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --puppet-server true \
 --puppet-server-ca "true"
 ----
-. On {SmartProxyServer}, stop the Puppet server:
+. On {SmartProxyServer} that is the Puppetserver Certificate Authority, stop the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# puppetserver stop
+# systemctl stop puppetserver
 ----
 . Generate Puppet certificates for all other {SmartProxyServers} that you configure for load balancing, except the first system where you configure Puppet certificates signing:
 +
@@ -72,12 +72,12 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 This command creates the following files on the system where you configure {SmartProxyServer} to sign Puppet certificates:
 +
 * `/etc/puppetlabs/puppet/ssl/certs/_{smartproxy-example-com}_.pem`
-* `/etc/puppetlabs/puppet/ssl/certs/ca.pem`
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
+* `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
 . Resume the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# puppetserver start
+# systemctl start puppetserver
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -75,7 +75,7 @@ This command creates the following files:
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
-. Restart the Puppet server:
+. Start the Puppet server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Fixing a command to generate certs on Puppet CA SmartProxy

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It was reported as incorrect and suggested another command instead.

https://issues.redhat.com/browse/SAT-28859

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I have verified that the command exists on a Puppet server (Satellite 6.16/Puppet server 8).
- I have tried to run the command. 
    - First, I had to stop Puppet server before it would run.
    - Then got a report of different set of files already existing on my instance. So I used this output to update the list of files that is in the docs.
- The bug was reported for Satellite 6.15, so I assume that the command is also relevant for Puppet server 7, ie. for all maintained relases.
- The suggested command is actually used in [the other procedure with default certs](https://theforeman-foreman-documentation-preview-pr-3398.surge.sh/nightly/Configuring_Load_Balancer/index-satellite.html#Configuring_capsule_Server_with_Default_SSL_Certificates_to_Generate_and_Sign_Puppet_Certificates_load-balancing).

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
