### PR TITLE
Fix heading of Discovery settings

### DIFF
--- a/guides/common/assembly_administer-settings-information.adoc
+++ b/guides/common/assembly_administer-settings-information.adoc
@@ -6,7 +6,7 @@ include::modules/ref_project-task-settings.adoc[leveloffset=+1]
 
 include::modules/ref_template-sync-settings.adoc[leveloffset=+1]
 
-include::modules/ref_discovered-settings.adoc[leveloffset=+1]
+include::modules/ref_discovery-settings.adoc[leveloffset=+1]
 
 include::modules/ref_boot-disk-settings.adoc[leveloffset=+1]
 

--- a/guides/common/modules/ref_discovery-settings.adoc
+++ b/guides/common/modules/ref_discovery-settings.adoc
@@ -1,5 +1,5 @@
-[id="discovered_settings_{context}"]
-= Discovered settings
+[id="discovery-settings"]
+= Discovery settings
 
 [cols="30%,30%,40%",options="header"]
 |====


### PR DESCRIPTION
#### What changes are you introducing?

Fixing the heading of "Discovered settings" reference

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's wrong. IT's supposed to be "Discovery settings"

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
