### PR TITLE
Replace xref with link for template sync reference

### DIFF
--- a/guides/common/modules/proc_enabling-the-templatesync-plugin.adoc
+++ b/guides/common/modules/proc_enabling-the-templatesync-plugin.adoc
@@ -10,4 +10,4 @@
 ----
 . To verify that the plugin is installed correctly, ensure *Administer* > *Settings* includes the *TemplateSync* menu.
 . Optional: In the {ProjectWebUI}, navigate to *Administer* > *Settings* > *TemplateSync* to configure the plugin.
-For more information, see xref:template_sync_settings_{context}[].
+For more information, see link:{AdministeringDocURL}template_sync_settings_admin[Template sync settings] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -11,7 +11,7 @@ To use the API, see the xref:api_Exporting_Templates_{context}[].
 . Click *Export*.
 . Each field is populated with values configured in *Administer* > *Settings* > *TemplateSync*.
 Change the values as required for the templates you want to export.
-For more information about each field, see xref:template_sync_settings_{context}[].
+For more information about each field, see link:{AdministeringDocURL}template_sync_settings_admin[Template sync settings] in _{AdministeringDocTitle}_.
 . Click *Submit*.
 
 The {ProjectWebUI} displays the status of the export.

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -40,7 +40,7 @@ To use the API, see the xref:api_Importing_Templates_{context}[].
 . Click *Import*.
 . Each field is populated with values configured in *Administer* > *Settings* > *TemplateSync*.
 Change the values as required for the templates you want to import.
-For more information about each field, see xref:template_sync_settings_{context}[].
+For more information about each field, see link:{AdministeringDocURL}template_sync_settings_admin[Template sync settings] in _{AdministeringDocTitle}_.
 . Click *Submit*.
 
 The {ProjectWebUI} displays the status of the import.


### PR DESCRIPTION
#### What changes are you introducing?

I'm replacing an xref to a Template Sync reference module in Managing Hosts with an external link to a Template Sync reference module in Administering Project. The module the xref points to was removed in https://github.com/theforeman/foreman-documentation/pull/3397.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3397 broke things on 3.11, 3.10, and 3.9 because the affected assembly exists in a different guide there so the xref that works on 3.12 and later doesn't work on 3.11 and earlier.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

An alternative is to revert https://github.com/theforeman/foreman-documentation/pull/3397 on the broken branches.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
