### PR TITLE
Force a rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This git repository contains the following documentation:
 
 * Official documentation for the Katello project
-* PoC of improving documentation for the Foreman project. See [this milestone](https://github.com/theforeman/foreman-documentation/milestone/3) to check the progress.
+* Work in progress of improving documentation for the Foreman project. See [this milestone](https://github.com/theforeman/foreman-documentation/milestone/3) to check the progress.
 
 For official Foreman documentation, see [Foreman Manual](https://theforeman.org/manuals/latest/index.html).
 


### PR DESCRIPTION
In https://github.com/theforeman/foreman-documentation/pull/3393 I saw it fail on something that I think was unrelated to my change:
```
For more information, see <a href="#template_sync_settings_managing-hosts">[template_sync_settings_managing-hosts]</a>.</p>
For more information about each field, see <a href="#template_sync_settings_managing-hosts">[template_sync_settings_managing-hosts]</a>.</p>
For more information about each field, see <a href="#template_sync_settings_managing-hosts">[template_sync_settings_managing-hosts]</a>.</p>
make[1]: *** [../common/Makefile:82: ../build/Managing_Hosts/index-katello.html] Error 1
make[1]: Leaving directory '/home/runner/work/foreman-documentation/foreman-documentation/guides/doc-Managing_Hosts'
```

I think this may be a regression from c7b091c61735a5e4eb4295cd52e137d9555461e8 so this only touches a README to force a rebuild.