### PR TITLE
Run Hammer CLI as non-root user

### DIFF
--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -31,7 +31,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer http-proxy create \
+$ hammer http-proxy create \
 --name=_My_HTTP_Proxy_ \
 --username=_My_HTTP_Proxy_User_Name_ \
 --password=_My_HTTP_Proxy_Password_ \
@@ -41,7 +41,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name=content_default_http_proxy \
 --value=__My_HTTP_Proxy__
 ----

--- a/guides/common/modules/proc_adding-a-domain.adoc
+++ b/guides/common/modules/proc_adding-a-domain.adoc
@@ -41,7 +41,7 @@ For example, user defined Boolean or string parameters to use in templates.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer domain create \
+$ hammer domain create \
 --description "_My_Domain_" \
 --dns-id _My_DNS_ID_ \
 --locations "_My_Location_" \

--- a/guides/common/modules/proc_adding-a-google-gce-connection.adoc
+++ b/guides/common/modules/proc_adding-a-google-gce-connection.adoc
@@ -50,7 +50,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource create \
+$ hammer compute-resource create \
 --key-path "/etc/foreman/_My_GCE_Key_.json" \
 --name "_My_GCE_Compute_Resource_" \
 --provider "gce" \

--- a/guides/common/modules/proc_adding-a-host-to-a-host-collection.adoc
+++ b/guides/common/modules/proc_adding-a-host-to-a-host-collection.adoc
@@ -27,7 +27,7 @@ Note that if you add a host to a host collection, the {Project} auditing system 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host-collection add-host \
+$ hammer host-collection add-host \
 --host-ids _My_Host_ID_1_ \
 --id _My_Host_Collection_ID_
 ----

--- a/guides/common/modules/proc_adding-a-microsoft-azure-connection.adoc
+++ b/guides/common/modules/proc_adding-a-microsoft-azure-connection.adoc
@@ -31,7 +31,7 @@ This tests if your connection to Azure Resource Manager is successful and loads 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource create \
+$ hammer compute-resource create \
 --app-ident _My_Client_ID_ \
 --name _My_Compute_Resource_Name_ \
 --provider azurerm \

--- a/guides/common/modules/proc_adding-a-subnet.adoc
+++ b/guides/common/modules/proc_adding-a-subnet.adoc
@@ -40,7 +40,7 @@ For example, user defined Boolean or string parameters to use in templates.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer subnet create \
+$ hammer subnet create \
 --boot-mode "DHCP" \
 --description "_My_Description_" \
 --dhcp-id _My_DHCP_ID_ \

--- a/guides/common/modules/proc_adding-a-vmware-connection-to-server.adoc
+++ b/guides/common/modules/proc_adding-a-vmware-connection-to-server.adoc
@@ -44,7 +44,7 @@ Select `Vmware` as the `--provider` and set the instance UUID of the data center
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource create \
+$ hammer compute-resource create \
 --datacenter "_My_Datacenter_" \
 --description "vSphere server at _vsphere.example.com_" \
 --locations "_My_Location_" \

--- a/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile.adoc
@@ -19,7 +19,7 @@ If you have a VPC for provisioning new hosts, use its subnet.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create 
+$ hammer compute-profile values create 
 --compute-resource "_My_Laptop_" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-attributes "flavor_id=1,availability_zone= _My_Zone_,subnet_id=1,security_group_ids=1,managed_ip=public_ip" 

--- a/guides/common/modules/proc_adding-amazon-ec2-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-images-to-server.adoc
@@ -31,7 +31,7 @@ Use the `--uuid` field to store the full path of the image location on the Amazo
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --architecture "_My_Architecture_" \
 --compute-resource "_My_EC2_Compute_Resource_" \
 --name "_My_Amazon_EC2_Image_" \

--- a/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
+++ b/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
@@ -42,7 +42,7 @@ Use `--user` and `--password` options to add the access key and secret key respe
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource create \
+$ hammer compute-resource create \
 --description "Amazon EC2 Public Cloud` \
 --locations "_My_Location_" \
 --name "_My_EC2_Compute_Resource_" \

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -29,7 +29,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 +
 [options="nowrap" subs="+quotes,verbatim"]
 ----
-# hammer http-proxy create \
+$ hammer http-proxy create \
 --name _My_HTTP_Proxy_ \
 --url _http-proxy.example.com:8080_
 ----

--- a/guides/common/modules/proc_adding-an-scc-account.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account.adoc
@@ -47,7 +47,7 @@ For more information, see {ContentManagementDocURL}cli-importing-a-gpg-key[Impor
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts create \
+$ hammer scc_manager scc_accounts create \
 --base-url "https://scc.suse.com/" \
 --interval _My_Interval_ \
 --katello-gpg-key-id _My_GPG_Key_ID_ \
@@ -62,7 +62,7 @@ For more information, see {ContentManagementDocURL}cli-importing-a-gpg-key[Impor
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts test_connection \
+$ hammer scc_manager scc_accounts test_connection \
 --id _My_SCC_Account_ID_
 ----
 +
@@ -71,14 +71,14 @@ Ensure the command returns `Testing connection for SCC account succeeded`.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts sync \
+$ hammer scc_manager scc_accounts sync \
 --id _My_SCC_Account_ID_
 ----
 . Check the status of the task:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer task info \
+$ hammer task info \
 --id _My_Task_ID_
 ----
 +

--- a/guides/common/modules/proc_adding-custom-deb-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repositories.adoc
@@ -68,7 +68,7 @@ By default, the repository is published through HTTP.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository create \
+$ hammer repository create \
 --content-type "deb" \
 --deb-architectures "_My_Deb_Architectures" \
 --deb-components "_My_Deb_Components_" \

--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -61,7 +61,7 @@ By default, the repository is published through HTTP.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository create \
+$ hammer repository create \
 --arch "_My_Architecture_" \
 --content-type "yum" \
 --gpg-key-id _My_GPG_Key_ID_ \

--- a/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
+++ b/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
@@ -26,19 +26,19 @@ This creates the incremental update to the content view.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer erratum list
+$ hammer erratum list
 ----
 . List the different content-view versions and the corresponding IDs:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version list
+$ hammer content-view version list
 ----
 . Apply a single erratum to content-view version.
 You can add more IDs in a comma-separated list.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version incremental-update \
+$ hammer content-view version incremental-update \
 --content-view-version-id 319 --errata-ids 34068b
 ----

--- a/guides/common/modules/proc_adding-google-gce-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-google-gce-details-to-a-compute-profile.adoc
@@ -25,13 +25,13 @@ If you need a permanent IP address, reserve a static public IP address on Google
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile create --name _My_GCE_Compute_Profile_
+$ hammer compute-profile create --name _My_GCE_Compute_Profile_
 ----
 . Add GCE details to the compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create \
+$ hammer compute-profile values create \
 --compute-attributes "machine_type=f1-micro,associate_external_ip=true,network=default" \
 --compute-profile "_My_GCE_Compute_Profile_" \
 --compute-resource "_My_GCE_Compute_Resource_" \

--- a/guides/common/modules/proc_adding-hosts-to-a-host-collection-in-bulk.adoc
+++ b/guides/common/modules/proc_adding-hosts-to-a-host-collection-in-bulk.adoc
@@ -26,7 +26,7 @@ Note that if you add a host to a host collection, the {Project} auditing system 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host-collection add-host \
+$ hammer host-collection add-host \
 --host-ids _My_Host_ID_1_,_My_Host_ID_2_ \
 --id _My_Host_Collection_ID_
 ----

--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -57,7 +57,7 @@ Use the `--uuid` field to store the full path of the image location on the KVM s
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --name "_KVM Image_" \
 --compute-resource "_My_KVM_Server_"
 --operatingsystem "RedHat _version_" \
@@ -72,7 +72,7 @@ Use the `--uuid` option to store the template UUID on the {oVirt} server.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --name "__{oVirtShort}_Image__" \
 --compute-resource "__My_{oVirtShort}__"
 --operatingsystem "RedHat _version_" \
@@ -86,7 +86,7 @@ Use the `--uuid` field to store the full path of the image location on the {Open
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --name "OpenStack Image" \
 --compute-resource "_My_OpenStack_Platform_"
 --operatingsystem "RedHat _version_" \
@@ -102,7 +102,7 @@ The username must begin with a letter and consist of lowercase letters and numbe
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --name '_gce_image_name_' \
 --compute-resource '_gce_cr_' \
 --operatingsystem-id 1 \
@@ -118,7 +118,7 @@ You cannot use the `root` user.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --name _Azure_image_name_ \
 --compute-resource _azure_cr_name_ \
 --uuid '_marketplace://RedHat:RHEL:7-RAW:latest_' \

--- a/guides/common/modules/proc_adding-installation-media.adoc
+++ b/guides/common/modules/proc_adding-installation-media.adoc
@@ -93,7 +93,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer medium create \
+$ hammer medium create \
 --locations "_My_Location_" \
 --name "_My_Operating_System_" \
 --organizations "_My_Organization_" \

--- a/guides/common/modules/proc_adding-kvm-connection.adoc
+++ b/guides/common/modules/proc_adding-kvm-connection.adoc
@@ -41,7 +41,7 @@ If you want, add additional contexts to these tabs.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource create --name "_My_KVM_Server_" \
+$ hammer compute-resource create --name "_My_KVM_Server_" \
 --provider "Libvirt" --description "KVM server at _kvm.example.com_" \
 --url "qemu+ssh://root@_kvm.example.com/system_" --locations "New York" \
 --organizations "_My_Organization_"

--- a/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile.adoc
@@ -28,14 +28,14 @@ You can create multiple volumes for the host.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile create --name "Libvirt CP"
+$ hammer compute-profile create --name "Libvirt CP"
 ----
 +
 . To add the values for the compute profile, enter the following command:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create --compute-profile "Libvirt CP" \
+$ hammer compute-profile values create --compute-profile "Libvirt CP" \
 --compute-resource "_My_KVM_Server_" \
 --interface "compute_type=network,compute_model=virtio,compute_network=_examplenetwork_" \
 --volume "pool_name=default,capacity=20G,format_type=qcow2" \

--- a/guides/common/modules/proc_adding-microsoft-azure-resource-manager-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-microsoft-azure-resource-manager-details-to-a-compute-profile.adoc
@@ -48,7 +48,7 @@ For more information, see the Microsoft Azure documentation link above.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile create --name _compute_profile_name_
+$ hammer compute-profile create --name _compute_profile_name_
 ----
 . Add Azure details to the compute profile.
 With the `username` setting, enter the SSH user name for image access.
@@ -56,7 +56,7 @@ Note that the username that you enter for compute profile must be the same that 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create \
+$ hammer compute-profile values create \
 --compute-attributes="resource_group=_resource_group_,vm_size=_Standard_B1s_,username=_azure_user_,password=_azure_password_,platform=Linux,script_command=touch /var/tmp/text.txt" \
 --compute-profile "_compute_profile_name_" \
 --compute-resource _azure_cr_name_ \

--- a/guides/common/modules/proc_adding-openstack-connection.adoc
+++ b/guides/common/modules/proc_adding-openstack-connection.adoc
@@ -30,7 +30,7 @@ Add any additional contexts that you want to these tabs.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource create --name "_My_OpenStack_" \
+$ hammer compute-resource create --name "_My_OpenStack_" \
 --provider "OpenStack" \
 --description "_My OpenStack environment at openstack.example.com_" \
 --url "_http://openstack.example.com_:5000/v3/auth/tokens" \

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile.adoc
@@ -26,7 +26,7 @@ If not selected, the instance boots the image directly.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create 
+$ hammer compute-profile values create 
 --compute-resource "_My_Laptop_" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-attributes "availability_zone=_My_Zone_,image_ref=_My_Image_,flavor_ref=m1.small,tenant_id=openstack,security_groups=default,network=_My_Network_,boot_from_volume=false"

--- a/guides/common/modules/proc_adding-permissions-to-a-role.adoc
+++ b/guides/common/modules/proc_adding-permissions-to-a-role.adoc
@@ -25,13 +25,13 @@ When you enable the *Override* checkbox, you can add additional locations and or
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer filter available-permissions
+$ hammer filter available-permissions
 ----
 . Add permissions to a role:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer filter create \
+$ hammer filter create \
 --permission-ids _My_Permission_ID_1_,_My_Permission_ID_2_ \
 --role _My_Role_Name_
 ----

--- a/guides/common/modules/proc_adding-rhv-connection.adoc
+++ b/guides/common/modules/proc_adding-rhv-connection.adoc
@@ -29,7 +29,7 @@ Alternatively, if you leave the field blank, a self-signed certificate is genera
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-resource create \
+$ hammer compute-resource create \
 --name "__My_{oVirtShort}__" --provider "Ovirt" \
 --description "{oVirtShort} server at _{ovirt-example-com}_" \
 --url "_https://{ovirt-example-com}/ovirt-engine/api/v4_" \

--- a/guides/common/modules/proc_adding-rhv-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-rhv-details-to-a-compute-profile.adoc
@@ -38,14 +38,14 @@ For each volume, enter the following details:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-profile create --name "{oVirt} CP"
+$ hammer compute-profile create --name "{oVirt} CP"
 ----
 +
 . To set the values for the compute profile, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer compute-profile values create --compute-profile "{oVirt} CP" \
+$ hammer compute-profile values create --compute-profile "{oVirt} CP" \
 --compute-resource "__My_{oVirtShort}__" \
 --interface "compute_interface=_Interface_Type_,compute_name=eth0,compute_network=satnetwork" \
 --volume "size_gb=20G,storage_domain=Data,bootable=true" \

--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -39,13 +39,13 @@ At least one interface must point to a {SmartProxy}-managed network.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile create --name "_My_Compute_Profile_"
+$ hammer compute-profile create --name "_My_Compute_Profile_"
 ----
 . Set VMware details to a compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create \
+$ hammer compute-profile values create \
 --compute-attributes "cpus=1,corespersocket=2,memory_mb=1024,cluster=MyCluster,path=MyVMs,start=true" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-resource "_My_VMware_" \

--- a/guides/common/modules/proc_adding-vmware-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-vmware-images-to-server.adoc
@@ -28,7 +28,7 @@ Use the `--uuid` field to store the relative template path on the vSphere enviro
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-resource image create \
+$ hammer compute-resource image create \
 --architecture "_My_Architecture_" \
 --compute-resource "_My_VMware_"
 --name "_My_Image_" \

--- a/guides/common/modules/proc_applying-errata-to-a-host-collection.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host-collection.adoc
@@ -8,7 +8,7 @@ ifndef::rest-api[]
 .CLI procedure
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer job-invocation create \
+$ hammer job-invocation create \
 --feature katello_errata_install \
 --inputs errata=_ERRATUM_ID1_,_ERRATUM_ID2_,... \
 --search-query "host_collection = _HOST_COLLECTION_NAME_"

--- a/guides/common/modules/proc_applying-errata-to-hosts-centos7-debian-sles-ubuntu.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts-centos7-debian-sles-ubuntu.adoc
@@ -9,7 +9,7 @@ include::snip_applying-errata.adoc[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host errata list \
+$ hammer host errata list \
 --host _client.example.com_
 ----
 . Apply the most recent erratum to the host.
@@ -17,7 +17,7 @@ Identify the erratum to apply using the erratum ID:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer job-invocation create \
+$ hammer job-invocation create \
 --feature katello_errata_install \
 --inputs errata=_ERRATUM_ID1_,_ERRATUM_ID2_ \
 --search-query "name = client.example.com"

--- a/guides/common/modules/proc_applying-errata-to-hosts-el.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts-el.adoc
@@ -9,14 +9,14 @@ include::snip_applying-errata.adoc[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host errata list \
+$ hammer host errata list \
 --host _client.example.com_
 ----
 . Find the module stream an erratum belongs to:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer erratum info --id _ERRATUM_ID_
+$ hammer erratum info --id _ERRATUM_ID_
 ----
 . On the host, update the module stream:
 +

--- a/guides/common/modules/proc_applying-errata-to-hosts-el7.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts-el7.adoc
@@ -9,7 +9,7 @@ include::snip_applying-errata.adoc[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer host errata list \
+$ hammer host errata list \
 --host _client.example.com_
 ----
 . Apply the most recent erratum to the host.
@@ -19,7 +19,7 @@ Using `Remote Execution`
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer job-invocation create \
+$ hammer job-invocation create \
 --feature katello_errata_install \
 --inputs errata=_ERRATUM_ID1_,_ERRATUM_ID2_ \
 --search-query "name = client.example.com"

--- a/guides/common/modules/proc_applying-errata-to-multiple-hosts.adoc
+++ b/guides/common/modules/proc_applying-errata-to-multiple-hosts.adoc
@@ -23,7 +23,7 @@ For more information about running remote execution jobs, see {ManagingHostsDocU
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer erratum list \
+$ hammer erratum list \
 --errata-restrict-installable true \
 --organization "_Default Organization_"
 ----
@@ -33,7 +33,7 @@ Using `Remote Execution`
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer job-invocation create \
+$ hammer job-invocation create \
 --feature katello_errata_install \
 --inputs errata=_ERRATUM_ID_ \
 --search-query "applicable_errata = _ERRATUM_ID_"
@@ -54,11 +54,11 @@ This command identifies all hosts with _erratum_IDs_ as an applicable erratum an
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# hammer task list
+$ hammer task list
 ----
 . View the state of a selected task:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer task progress --id _task_ID_
+$ hammer task progress --id _task_ID_
 ----

--- a/guides/common/modules/proc_assigning-a-sync-plan-to-a-product.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-a-product.adoc
@@ -17,7 +17,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-assigning-a-sync-
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product set-sync-plan \
+$ hammer product set-sync-plan \
 --name "_My_Product_Name_" \
 --organization "_My_Organization_" \
 --sync-plan "_My_Sync_Plan_Name_"

--- a/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
@@ -21,5 +21,5 @@ done
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# hammer product list --organization $ORG --sync-plan $SYNC_PLAN
+$ hammer product list --organization $ORG --sync-plan $SYNC_PLAN
 ----

--- a/guides/common/modules/proc_assigning-roles-to-a-user.adoc
+++ b/guides/common/modules/proc_assigning-roles-to-a-user.adoc
@@ -30,5 +30,5 @@ To remove an assigned role, click the role name in *Selected items*.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user add-role --id _user_id_ --role _role_name_
+$ hammer user add-role --id _user_id_ --role _role_name_
 ----

--- a/guides/common/modules/proc_associating-templates-with-operating-systems.adoc
+++ b/guides/common/modules/proc_associating-templates-with-operating-systems.adoc
@@ -15,19 +15,19 @@ The following example adds a provisioning template to an operating system entry.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer template list
+$ hammer template list
 ----
 . Optional: View all operating systems:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer os list
+$ hammer os list
 ----
 . Associate a template with an operating system:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer template add-operatingsystem \
+$ hammer template add-operatingsystem \
 --id _My_Template_ID_ \
 --operatingsystem-id _My_Operating_System_ID_
 ----

--- a/guides/common/modules/proc_authenticating-hammer-using-sessions.adoc
+++ b/guides/common/modules/proc_authenticating-hammer-using-sessions.adoc
@@ -19,7 +19,7 @@ Note that if you enable sessions, credentials stored in the configuration file w
 * To start a session, enter the following command:
 +
 ----
-# hammer auth login
+$ hammer auth login
 ----
 +
 You are prompted for your {Project} credentials, and logged in.
@@ -30,18 +30,18 @@ You can change the time to suit your preference.
 For example, to change it to 30 minutes, enter the following command:
 +
 ----
-# hammer settings set --name idle_timeout --value 30
+$ hammer settings set --name idle_timeout --value 30
 Setting [idle_timeout] updated to [30]
 ----
 +
 * To see the current status of the session, enter the following command:
 +
 ----
-# hammer auth status
+$ hammer auth status
 ----
 +
 * To end the session, enter the following command:
 +
 ----
-# hammer auth logout
+$ hammer auth logout
 ----

--- a/guides/common/modules/proc_changing-the-default-download-policy.adoc
+++ b/guides/common/modules/proc_changing-the-default-download-policy.adoc
@@ -30,7 +30,7 @@ endif::[]
 +
 [subs="+quotes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name default_redhat_download_policy \
 --value _immediate_
 ----
@@ -44,7 +44,7 @@ endif::[]
 +
 [subs="+quotes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name default_download_policy \
 --value _immediate_
 ----

--- a/guides/common/modules/proc_changing-the-download-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-download-policy-for-a-repository.adoc
@@ -14,14 +14,14 @@ You can set the download policy for a repository.
 +
 [subs="+quotes"]
 ----
-# hammer repository list \
+$ hammer repository list \
 --organization-label _My_Organization_Label_
 ----
 . Change the download policy for a repository to `immediate` or `on_demand`:
 +
 [subs="+quotes"]
 ----
-# hammer repository update \
+$ hammer repository update \
 --download-policy immediate \
 --name "_My_Repository_" \
 --organization-label _My_Organization_Label_ \

--- a/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-repository.adoc
@@ -24,7 +24,7 @@ For more information, see xref:Adding_an_HTTP_Proxy_{context}[].
 +
 [subs="+quotes"]
 ----
-# hammer repository update \
+$ hammer repository update \
 --http-proxy-policy _HTTP_Proxy_Policy_ \
 --id _Repository_ID_
 ----

--- a/guides/common/modules/proc_changing-the-mirroring-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-mirroring-policy-for-a-repository.adoc
@@ -17,14 +17,14 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Changing_the_Mirr
 +
 [subs="+quotes"]
 ----
-# hammer repository list \
+$ hammer repository list \
 --organization-label _My_Organization_Label_
 ----
 . Change the mirroring policy for a repository to `additive`, `mirror_complete`, or `mirror_content_only`:
 +
 [subs="+quotes"]
 ----
-# hammer repository update \
+$ hammer repository update \
 --id 1 \
 --mirroring-policy mirror_complete
 ----

--- a/guides/common/modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc
+++ b/guides/common/modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc
@@ -9,13 +9,13 @@ This configuration setting must be applied for each operating system you want to
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer os list
+$ hammer os list
 ----
 . Update each operating system's password hash value.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer os update \
+$ hammer os update \
 --password-hash SHA256
 --title "_My_Operating_System_"
 ----

--- a/guides/common/modules/proc_configuring-a-bonded-interface.adoc
+++ b/guides/common/modules/proc_configuring-a-bonded-interface.adoc
@@ -39,7 +39,7 @@ These can be physical interfaces or VLANs.
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --ask-root-password yes \
 --hostgroup _My_Host_Group_ \
 --ip=_My_IP_Address_ \

--- a/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc
+++ b/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc
@@ -23,13 +23,13 @@ On the {Project} client registered to {keycloak}:
 . Set the login delegation to `true` so that users can authenticate using the Open IDC protocol:
 +
 ----
-# hammer settings set --name authorize_login_delegation --value true
+$ hammer settings set --name authorize_login_delegation --value true
 ----
 . Set the login delegation logout URL:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set --name login_delegation_logout_url \
+$ hammer settings set --name login_delegation_logout_url \
 --value https://_{foreman-example-com}_/users/extlogout
 ----
 . Set the algorithm for encoding:
@@ -37,13 +37,13 @@ For example, to use the `RS256` algorithm:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set --name oidc_algorithm --value 'RS256'
+$ hammer settings set --name oidc_algorithm --value 'RS256'
 ----
 . Add the value for the Hammer client in the Open IDC audience:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set --name oidc_audience \
+$ hammer settings set --name oidc_audience \
 --value "['_{foreman-example-com}_-hammer-openidc']"
 ----
 +
@@ -53,7 +53,7 @@ If you register several {keycloak} clients to {Project}, ensure that you append 
 For example:
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set --name oidc_audience \
+$ hammer settings set --name oidc_audience \
 --value "['_{foreman-example-com}_-foreman-openidc', '_{foreman-example-com}_-hammer-openidc']"
 ----
 ====
@@ -61,26 +61,26 @@ For example:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set --name oidc_issuer \
+$ hammer settings set --name oidc_issuer \
 --value "https://_{keycloak-example-com}_/auth/realms/_{keycloak-realm}_"
 ----
 . Set the value for Open IDC Java Web Token (JWT):
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set --name oidc_jwks_url \
+$ hammer settings set --name oidc_jwks_url \
 --value "https://_{keycloak-example-com}_/auth/realms/_{keycloak-realm}_/protocol/openid-connect/certs"
 ----
 . Retrieve the ID of the {keycloak} authentication source:
 +
 ----
-# hammer auth-source external list
+$ hammer auth-source external list
 ----
 . Set the location and organization:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer auth-source external update \
+$ hammer auth-source external update \
 --id _My_Authentication_Source_ID_ \
 --location-ids _My_Location_ID_ \
 --organization-ids _My_Organization_ID_

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -27,7 +27,7 @@ For example, if your base URL is `https://{server-example-com}` and your subpath
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source create \
+$ hammer alternate-content-source create \
 --alternate-content-source-type custom \
 --base-url "_https://local-repo.example.com:port_" \
 --name "_My_ACS_Name_" \
@@ -37,19 +37,19 @@ For example, if your base URL is `https://{server-example-com}` and your subpath
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source list
+$ hammer alternate-content-source list
 ----
 . Refresh the alternate content source:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
+$ hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
 ----
 . Add the {SmartProxies} to which the alternate content source is to be synced:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source update \
+$ hammer alternate-content-source update \
 --id _My_Alternate_Content_Source_ID_ \
 --smart-proxy-ids __My_{smart-proxy-context-titlecase}_ID__
 ----
@@ -57,5 +57,5 @@ For example, if your base URL is `https://{server-example-com}` and your subpath
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
+$ hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
 ----

--- a/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-by-using-exports.adoc
+++ b/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-by-using-exports.adoc
@@ -16,7 +16,7 @@ If you deployed your downstream {ProjectServer} as air gapped, configure your {P
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer organization configure-cdn --name="_My_Organization_" --type=export_sync
+$ hammer organization configure-cdn --name="_My_Organization_" --type=export_sync
 ----
 
 ifndef::content-management[]

--- a/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network.adoc
@@ -47,7 +47,7 @@ For more information, see {ContentManagementDocURL}Creating_a_Sync_Plan_content-
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-credential show \
+$ hammer content-credential show \
 --name="_My_Upstream_CA_Cert_" \
 --organization="_My_Downstream_Organization_"
 ----
@@ -57,7 +57,7 @@ Note the ID of the CA certificate for the next step.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer organization configure-cdn --name="_My_Downstream_Organization_" \
+$ hammer organization configure-cdn --name="_My_Downstream_Organization_" \
 --type=network_sync \
 --url https://_upstream-{foreman-example-com}_ \
 --username _upstream_username_ --password _upstream_password_ \

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -37,7 +37,7 @@ Ensure that you pass the repo labels of the desired repositories.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source create \
+$ hammer alternate-content-source create \
 --alternate-content-source-type rhui \
 --base-url "_https://rhui-cds-node/pulp/content_" \
 --name "_My_ACS_Name_" \
@@ -51,19 +51,19 @@ Ensure that you pass the repo labels of the desired repositories.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source list
+$ hammer alternate-content-source list
 ----
 . Refresh the alternate content source:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
+$ hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
 ----
 . Add the {SmartProxies} to which the alternate content source is to be synced:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source update \
+$ hammer alternate-content-source update \
 --id _My_Alternate_Content_Source_ID_ \
 --smart-proxy-ids __My_{smart-proxy-context-titlecase}_ID__
 ----
@@ -71,5 +71,5 @@ Ensure that you pass the repo labels of the desired repositories.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
+$ hammer alternate-content-source refresh --id _My_Alternate_Content_Source_ID_
 ----

--- a/guides/common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn.adoc
+++ b/guides/common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn.adoc
@@ -29,7 +29,7 @@ For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certific
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer organization configure-cdn --name="_My_Organization_" \
+$ hammer organization configure-cdn --name="_My_Organization_" \
 --type=custom_cdn \
 --url https://_my-cdn.example.com_ \
 --ssl-ca-credential-id "_My_CDN_CA_Cert_ID_"

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -19,7 +19,7 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source create \
+$ hammer alternate-content-source create \
 --alternate-content-source-type simplified \
 --name _My_ACS_Name_ \
 --product-ids _My_Product_ID_ \
@@ -29,11 +29,11 @@
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source list
+$ hammer alternate-content-source list
 ----
 . Refresh the ACS:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer alternate-content-source refresh --id _My_ACS_ID_
+$ hammer alternate-content-source refresh --id _My_ACS_ID_
 ----

--- a/guides/common/modules/proc_configuring-the-fallback-to-any-smartproxy-remote-execution-setting-in-project.adoc
+++ b/guides/common/modules/proc_configuring-the-fallback-to-any-smartproxy-remote-execution-setting-in-project.adoc
@@ -25,7 +25,7 @@ To set the value to `true`, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name=remote_execution_fallback_proxy \
 --value=true
 ----

--- a/guides/common/modules/proc_configuring-the-global-smartproxy-remote-execution-setting-in-project.adoc
+++ b/guides/common/modules/proc_configuring-the-global-smartproxy-remote-execution-setting-in-project.adoc
@@ -18,7 +18,7 @@ To set the value to `true`, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name=remote_execution_global_proxy \
 --value=true
 ----

--- a/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-using-ssh.adoc
+++ b/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-using-ssh.adoc
@@ -8,7 +8,7 @@ However, to connect to any Amazon Web Services EC2 instance that you provision t
 . To locate the compute resource list, on your {ProjectServer} base system, enter the following command, and note the ID of the compute resource that you want to use:
 +
 ----
-# hammer compute-resource list
+$ hammer compute-resource list
 ----
 . Connect to the Foreman database as the user `postgres`:
 +

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -26,13 +26,13 @@ As a result, you cannot promote an older version of a content view from the copi
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer content-view copy --name _My_original_CV_name_ \
+$ hammer content-view copy --name _My_original_CV_name_ \
 --new-name _My_new_CV_name_
 ----
 
 .Verification
 * The Hammer command reports:
 ----
-# hammer content-view copy --id=5 --new-name="mixed_copy"
+$ hammer content-view copy --id=5 --new-name="mixed_copy"
 Content view copied.
 ----

--- a/guides/common/modules/proc_creating-a-composite-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-composite-content-view.adoc
@@ -27,7 +27,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-compos
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version list \
+$ hammer content-view version list \
 --organization "_My_Organization_"
 ----
 . Create a new composite content view.
@@ -35,7 +35,7 @@ When the `--auto-publish` option is set to `yes`, the composite content view is 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view create \
+$ hammer content-view create \
 --composite \
 --auto-publish yes \
 --name "_Example_Composite_Content_View_" \
@@ -50,7 +50,7 @@ To add multiple content views to the composite content view, repeat this step fo
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view component add \
+$ hammer content-view component add \
 --component-content-view-id _Content_View_ID_ \
 --composite-content-view "_Example_Composite_Content_View_" \
 --latest \
@@ -60,7 +60,7 @@ To add multiple content views to the composite content view, repeat this step fo
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view component add \
+$ hammer content-view component add \
 --component-content-view-id _Content_View_ID_ \
 --composite-content-view "_Example_Composite_Content_View_" \
 --component-content-view-version-id _Content_View_Version_ID_ \
@@ -70,7 +70,7 @@ To add multiple content views to the composite content view, repeat this step fo
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view publish \
+$ hammer content-view publish \
 --name "_Example_Composite_Content_View_" \
 --description "Initial version of composite content view" \
 --organization "_My_Organization_"
@@ -79,17 +79,17 @@ To add multiple content views to the composite content view, repeat this step fo
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Composite_Content_View_" \
 --version 1 \
 --to-lifecycle-environment "Development" \
 --organization "_My_Organization_"
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Composite_Content_View_" \
 --version 1 \
 --to-lifecycle-environment "Testing" \
 --organization "_My_Organization_"
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Composite_Content_View_" \
 --version 1 \
 --to-lifecycle-environment "Production" \

--- a/guides/common/modules/proc_creating-a-content-filter-for-deb-content.adoc
+++ b/guides/common/modules/proc_creating-a-content-filter-for-deb-content.adoc
@@ -32,7 +32,7 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view filter create \
+$ hammer content-view filter create \
 --content-view "_Example_Content_View_" \
 --description "_My_Content_View_Filter_Description_" \
 --inclusion false \
@@ -44,7 +44,7 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view filter rule create \
+$ hammer content-view filter rule create \
 --content-view "_My_Content_View_" \
 --content-view-filter "_My_Errata_Filter_" \
 --date-type updated \
@@ -56,7 +56,7 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view publish \
+$ hammer content-view publish \
 --description "Adding errata filter" \
 --name "_My_Content_View_" \
 --organization "_My_Organization_"
@@ -65,17 +65,17 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Content_View_" \
 --organization "_My_Organization_" \
 --to-lifecycle-environment "Development" \
 --version 1
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Content_View_" \
 --organization "_My_Organization_" \
 --to-lifecycle-environment "Testing" \
 --version 1
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Content_View_" \
 --organization "_My_Organization_" \
 --to-lifecycle-environment "Production" \

--- a/guides/common/modules/proc_creating-a-content-filter-for-yum-content.adoc
+++ b/guides/common/modules/proc_creating-a-content-filter-for-yum-content.adoc
@@ -32,7 +32,7 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view filter create \
+$ hammer content-view filter create \
 --name "_Errata Filter_" \
 --type erratum --content-view "_Example_Content_View_" \
 --description "_My latest filter_" \
@@ -43,7 +43,7 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view filter rule create \
+$ hammer content-view filter rule create \
 --content-view "_Example_Content_View_" \
 --content-view-filter "_Errata Filter_" \
 --start-date "_YYYY-MM-DD_" \
@@ -55,7 +55,7 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view publish \
+$ hammer content-view publish \
 --name "_Example_Content_View_" \
 --description "Adding errata filter" \
 --organization "_My_Organization_"
@@ -64,17 +64,17 @@ Use the `--inclusion false` option to set the filter to an Exclude filter:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Content_View_" \
 --version 1 \
 --to-lifecycle-environment "Development" \
 --organization "_My_Organization_"
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Content_View_" \
 --version 1 \
 --to-lifecycle-environment "Testing" \
 --organization "_My_Organization_"
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_Example_Content_View_" \
 --version 1 \
 --to-lifecycle-environment "Production" \

--- a/guides/common/modules/proc_creating-a-content-view-filter-for-errata.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-filter-for-errata.adoc
@@ -58,7 +58,7 @@ This means the filter successfully excluded the all non-security errata from the
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view filter create \
+$ hammer content-view filter create \
 --content-view "_My_Content_View_" \
 --description "Exclude errata items from the _YYYY-MM-DD_" \
 --name "_My_Filter_Name_" \
@@ -69,7 +69,7 @@ This means the filter successfully excluded the all non-security errata from the
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view filter rule create \
+$ hammer content-view filter rule create \
 --content-view "_My_Content_View_" \
 --content-view-filter="_My_Content_View_Filter_" \
 --organization "_My_Organization_" \
@@ -80,7 +80,7 @@ This means the filter successfully excluded the all non-security errata from the
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view publish \
+$ hammer content-view publish \
 --name "_My_Content_View_" \
 --organization "_My_Organization_"
 ----
@@ -88,7 +88,7 @@ This means the filter successfully excluded the all non-security errata from the
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "_My_Content_View_" \
 --organization "_My_Organization_" \
 --to-lifecycle-environment "_My_Lifecycle_Environment_"

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -40,13 +40,13 @@ To register a host to your content view, see {ManagingHostsDocURL}Registering_Ho
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer repository list --organization "_My_Organization_"
+$ hammer repository list --organization "_My_Organization_"
 ----
 . Create the content view and add repositories:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view create \
+$ hammer content-view create \
 --description "_My_Content_View_" \
 --name "_My_Content_View_" \
 --organization "_My_Organization_" \
@@ -58,7 +58,7 @@ For the `--repository-ids` option, you can find the IDs in the output of the `ha
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view publish \
+$ hammer content-view publish \
 --description "_My_Content_View_" \
 --name "_My_Content_View_" \
 --organization "_My_Organization_"
@@ -67,7 +67,7 @@ For the `--repository-ids` option, you can find the IDs in the output of the `ha
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view add-repository \
+$ hammer content-view add-repository \
 --name "_My_Content_View_" \
 --organization "_My_Organization_" \
 --repository-id _repository_ID_

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -43,7 +43,7 @@ By default, the repository is published through HTTP.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product create \
+$ hammer product create \
 --description "_My_Files_" \
 --name "_My_File_Product_" \
 --organization "_My_Organization_" \
@@ -64,7 +64,7 @@ By default, the repository is published through HTTP.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository create \
+$ hammer repository create \
 --content-type "file" \
 --name "_My_Files_" \
 --organization "_My_Organization_" \

--- a/guides/common/modules/proc_creating-a-custom-product.adoc
+++ b/guides/common/modules/proc_creating-a-custom-product.adoc
@@ -22,7 +22,7 @@ To create the product, enter the following command:
 
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product create \
+$ hammer product create \
 --name "_My_Product_" \
 --sync-plan "_Example Plan_" \
 --description "_Content from My Repositories_" \

--- a/guides/common/modules/proc_creating-a-granular-permission-filter.adoc
+++ b/guides/common/modules/proc_creating-a-granular-permission-filter.adoc
@@ -40,7 +40,7 @@ For many resource types, you can combine queries using logical operators such as
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# hammer filter create \
+$ hammer filter create \
 --permission-ids 91 \
 --search "name ~ ccv*" \
 --role qa-user

--- a/guides/common/modules/proc_creating-a-host-collection.adoc
+++ b/guides/common/modules/proc_creating-a-host-collection.adoc
@@ -16,7 +16,7 @@ The following procedure shows how to create host collections.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer host-collection create \
+$ hammer host-collection create \
 --name "_My_Host_Collection_" \
 --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_creating-a-host-group.adoc
+++ b/guides/common/modules/proc_creating-a-host-group.adoc
@@ -34,7 +34,7 @@ To create a suitable Puppet environment to be associated with a host group, manu
 For example:
 +
 ----
-# hammer hostgroup create --name "Base" \
+$ hammer hostgroup create --name "Base" \
 --architecture "My_Architecture" \
 --content-source-id _My_Content_Source_ID_ \
 --content-view "_My_Content_View_" \

--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -38,7 +38,7 @@ For more information, see {ManagingHostsDocURL}template_writing_reference_managi
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-template create \
+$ hammer job-template create \
 --file "_Path_to_My_Template_File_" \
 --job-category "_My_Category_Name_" \
 --name "_My_Template_Name_" \

--- a/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
+++ b/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
@@ -17,7 +17,7 @@ Then optionally add additional environments to the environment paths.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment create \
+$ hammer lifecycle-environment create \
 --name "_Environment Path Name_" \
 --description "_Environment Path Description_" \
 --prior "Library" \
@@ -27,7 +27,7 @@ Then optionally add additional environments to the environment paths.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment create \
+$ hammer lifecycle-environment create \
 --name "_Environment Name_" \
 --description "_Environment Description_" \
 --prior "_Prior Environment Name_" \
@@ -37,5 +37,5 @@ Then optionally add additional environments to the environment paths.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment paths --organization "_My_Organization_"
+$ hammer lifecycle-environment paths --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_creating-a-location.adoc
+++ b/guides/common/modules/proc_creating-a-location.adoc
@@ -24,7 +24,7 @@ You can return to this page at any time by navigating to *Administer* > *Locatio
 +
 [subs="+quotes"]
 ----
-# hammer location create \
+$ hammer location create \
 --description "_My_Location_Description_" \
 --name "_My_Location_" \
 --parent-id "_My_Location_Parent_ID_"

--- a/guides/common/modules/proc_creating-a-role.adoc
+++ b/guides/common/modules/proc_creating-a-role.adoc
@@ -14,7 +14,7 @@ Use this procedure to create a role.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer role create --name _My_Role_Name_
+$ hammer role create --name _My_Role_Name_
 ----
 
 To serve its purpose, a role must contain permissions.

--- a/guides/common/modules/proc_creating-a-sync-plan.adoc
+++ b/guides/common/modules/proc_creating-a-sync-plan.adoc
@@ -20,7 +20,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-sync-p
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer sync-plan create \
+$ hammer sync-plan create \
 --description "_My_Description_" \
 --enabled true \
 --interval daily \
@@ -32,5 +32,5 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-sync-p
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer sync-plan list --organization "_My_Organization_"
+$ hammer sync-plan list --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_creating-a-user-group.adoc
+++ b/guides/common/modules/proc_creating-a-user-group.adoc
@@ -18,7 +18,7 @@ Alternatively, select the *Admin* checkbox to assign all available permissions.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user-group create \
+$ hammer user-group create \
 --name _My_User_Group_Name_ \
 --role-ids _My_Role_ID_1_,_My_Role_ID_2_ \
 --user-ids _My_User_ID_1_,_My_User_ID_2_

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -31,7 +31,7 @@ If a user is not assigned to an organization, their access is limited.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user create \
+$ hammer user create \
 --auth-source-id _My_Authentication_Source_ \
 --login _My_User_Name_ \
 --mail _My_User_Mail_ \

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -28,7 +28,7 @@ It also helps with reporting in the Subscriptions service of the Red Hat Hybrid 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer activation-key create \
+$ hammer activation-key create \
 --name "_My_Activation_Key_" \
 --unlimited-hosts \
 --description "_Example Stack in the Development Environment_" \
@@ -42,7 +42,7 @@ It also helps with reporting in the Subscriptions service of the Red Hat Hybrid 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer activation-key update \
+$ hammer activation-key update \
 --organization "_My_Organization_" \
 --name "_My_Activation_Key_" \
 --service-level "_Standard_" \
@@ -54,7 +54,7 @@ It also helps with reporting in the Subscriptions service of the Red Hat Hybrid 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer activation-key product-content \
+$ hammer activation-key product-content \
 --content-access-mode-all true \
 --name "_My_Activation_Key_" \
 --organization "_My_Organization_"
@@ -65,7 +65,7 @@ To enable, enter the following command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer activation-key content-override \
+$ hammer activation-key content-override \
 --name "_My_Activation_Key_" \
 --content-label {project-client-RHEL7-url} \
 --value 1 \

--- a/guides/common/modules/proc_creating-an-organization.adoc
+++ b/guides/common/modules/proc_creating-an-organization.adoc
@@ -25,7 +25,7 @@ You can return to this page at any time by navigating to *Administer* > *Organiz
 +
 [subs="+quotes"]
 ----
-# hammer organization create \
+$ hammer organization create \
 --name "_My_Organization_" \
 --label "_My_Organization_Label_" \
 --description "_My_Organization_Description_"
@@ -35,7 +35,7 @@ For example, the following command assigns a compute resource to the organizatio
 +
 [subs="+quotes"]
 ----
-# hammer organization update \
+$ hammer organization update \
 --name "_My_Organization_" \
 --compute-resource-ids 1
 ----

--- a/guides/common/modules/proc_creating-architectures.adoc
+++ b/guides/common/modules/proc_creating-architectures.adoc
@@ -30,7 +30,7 @@ Specify its name and operating systems that include this architecture:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer architecture create \
+$ hammer architecture create \
 --name "_My_Architecture_" \
 --operatingsystems "_My_Operating_System_"
 ----

--- a/guides/common/modules/proc_creating-compute-profiles.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles.adoc
@@ -29,13 +29,13 @@ A new window opens with the name of the compute profile.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile create --name "_My_Compute_Profile_"
+$ hammer compute-profile create --name "_My_Compute_Profile_"
 ----
 . Set attributes for the compute profile:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values create \
+$ hammer compute-profile values create \
 --compute-attributes "_flavor=m1.small,cpus=2,memory=4GB,cpu_mode=default_ \
 --compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
@@ -46,7 +46,7 @@ For example, to change the number of CPUs and memory size:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile values update \ 
+$ hammer compute-profile values update \ 
 --compute-resource "_My_Compute_Resource_" \
 --compute-profile "_My_Compute_Profile_" \
 --attributes "_cpus=2,memory=4GB_" \
@@ -57,7 +57,7 @@ For example, to change the number of CPUs and memory size:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer compute-profile update \
+$ hammer compute-profile update \
 --name "_My_Compute_Profile_" \
 --new-name "_My_New_Compute_Profile_"
 ----

--- a/guides/common/modules/proc_creating-custom-provisioning-snippets.adoc
+++ b/guides/common/modules/proc_creating-custom-provisioning-snippets.adoc
@@ -24,7 +24,7 @@ The name must start with the name of a provisioning template that supports inclu
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer template create \
+$ hammer template create \
 --file "_/path/to/My_Snippet_" \
 --locations "_My_Location_" \
 --name "_My_Template_Name_custom_pre" \

--- a/guides/common/modules/proc_creating-discovery-rules.adoc
+++ b/guides/common/modules/proc_creating-discovery-rules.adoc
@@ -53,7 +53,7 @@ Rules with lower values have a higher priority.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer discovery-rule create \
+$ hammer discovery-rule create \
 --enabled true \
 --hostgroup "_My_Host_Group_" \
 --hostname "hypervisor-<%= rand(99999) %>" \
@@ -65,5 +65,5 @@ Rules with lower values have a higher priority.
 . Automatically provision a host with the `hammer discovery auto-provision` command:
 +
 ----
-# hammer discovery auto-provision --name "macabcdef123456"
+$ hammer discovery auto-provision --name "macabcdef123456"
 ----

--- a/guides/common/modules/proc_creating-hardware-models.adoc
+++ b/guides/common/modules/proc_creating-hardware-models.adoc
@@ -20,7 +20,7 @@ Optionally, enter the hardware model with the `--hardware-model` option, a vendo
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer model create \
+$ hammer model create \
 --hardware-model "_My_Hardware_Model_" \
 --info "_My_Description_" \
 --name "_My_Hardware_Model_Name_" \

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts.adoc
@@ -48,14 +48,14 @@ When the host provisioning is complete, the discovered host moves to *Hosts* > *
 . Identify the discovered host to provision:
 +
 ----
-# hammer discovery list
+$ hammer discovery list
 ----
 . Select the host and provision it by using a host group.
 Set a new host name with the `--new-name` option:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer discovery provision \
+$ hammer discovery provision \
 --build true \
 --enabled true \
 --hostgroup "_My_Host_Group_" \

--- a/guides/common/modules/proc_creating-hosts-on-vmware.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-vmware.adoc
@@ -49,7 +49,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --build true \
 --compute-attributes="cpus=1,corespersocket=2,memory_mb=1024,cluster=MyCluster,path=MyVMs,start=true" \
 --compute-resource "_My_VMware_" \
@@ -67,7 +67,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --compute-attributes="cpus=1,corespersocket=2,memory_mb=1024,cluster=MyCluster,path=MyVMs,start=true" \
 --compute-resource "_My_VMware_" \
 --enabled true \

--- a/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
@@ -100,7 +100,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --build true \
 --enabled true \
 --hostgroup "_My_Host_Group_" \
@@ -114,7 +114,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host interface update \
+$ hammer host interface update \
 --host "_My_Host_Name_" \
 --managed true \
 --primary true \
@@ -127,14 +127,14 @@ ifndef::satellite[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer bootdisk host --host _My_Host_Name_
+$ hammer bootdisk host --host _My_Host_Name_
 ----
 endif::[]
 * For *Full host image*:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer bootdisk host \
+$ hammer bootdisk host \
 --full true \
 --host _My_Host_Name_
 ----
@@ -143,14 +143,14 @@ ifndef::satellite[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer bootdisk generic
+$ hammer bootdisk generic
 ----
 endif::[]
 * For *Subnet image*:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer bootdisk subnet --subnet _My_Subnet_Name_
+$ hammer bootdisk subnet --subnet _My_Subnet_Name_
 ----
 
 +

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -86,7 +86,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --build true \
 --enabled true \
 --hostgroup "_My_Host_Group_" \
@@ -101,7 +101,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host interface update \
+$ hammer host interface update \
 --host "_My_Host_Name_" \
 --managed true \
 --primary true \

--- a/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
@@ -39,7 +39,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --build true \
 --enabled true \
 --hostgroup "_My_Host_Group_" \
@@ -52,7 +52,7 @@ endif::[]
 . Ensure the network interface options are set using the `hammer host interface update` command:
 +
 ----
-# hammer host interface update \
+$ hammer host interface update \
 --host "_My_Host_Name_" \
 --managed true \
 --primary true \

--- a/guides/common/modules/proc_creating-image-based-hosts-on-amazon-ec2.adoc
+++ b/guides/common/modules/proc_creating-image-based-hosts-on-amazon-ec2.adoc
@@ -25,7 +25,7 @@ This new host entry triggers the Amazon EC2 server to create the instance, using
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --compute-attributes="flavor_id=m1.small,image_id=TestImage,availability_zones=us-east-1a,security_group_ids=Default,managed_ip=Public" \
 --compute-resource "_My_EC2_Compute_Resource_" \
 --enabled true \

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -34,7 +34,7 @@ ifeval::["{context}" == "openstack-provisioning"]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --compute-attributes="flavor_ref=m1.small,tenant_id=openstack,security_groups=default,network=mynetwork" \
 --compute-resource "_My_OpenStack_Platform_" \
 --enabled true \
@@ -52,7 +52,7 @@ ifeval::["{context}" == "gce-provisioning"]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --architecture _x86_64_ \
 --compute-profile "_My_Compute_Profile_" \
 --compute-resource "_My_Compute_Resource_" \
@@ -73,7 +73,7 @@ ifeval::["{context}" == "azure-provisioning"]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer host create \
+$ hammer host create \
 --architecture _x86_64_ \
 --compute-profile "_My_Compute_Profile_" \
 --compute-resource "_My_Compute_Resource_" \

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -44,7 +44,7 @@ ifeval::["{context}" == "kvm-provisioning"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --build true \
 --compute-attributes="cpus=1,memory=1073741824" \
 --compute-resource "_My_KVM_Server_" \
@@ -64,7 +64,7 @@ ifeval::["{context}" == "rhv-provisioning"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --build true \
 --compute-attributes="cluster=Default,cores=1,memory=1073741824,start=true" \
 --compute-resource "_My_{oVirtShort}_" \
@@ -86,7 +86,7 @@ ifeval::["{context}" == "kvm-provisioning"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --compute-attributes="cpus=1,memory=1073741824" \
 --compute-resource "_My_KVM_Server_" \
 --enabled true \
@@ -105,7 +105,7 @@ ifeval::["{context}" == "rhv-provisioning"]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host create \
+$ hammer host create \
 --compute-attributes="cluster=Default,cores=1,memory=1073741824,start=true" \
 --compute-resource "_My_{oVirtShort}_" \
 --enabled true \

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -61,7 +61,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer os create \
+$ hammer os create \
 --architectures "x86_64" \
 --description "_My_Operating_System_" \
 --family "{client-os-family-hammer}" \

--- a/guides/common/modules/proc_creating-partition-tables.adoc
+++ b/guides/common/modules/proc_creating-partition-tables.adoc
@@ -41,7 +41,7 @@ include::snip_ptable-format.adoc[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer partition-table create \
+$ hammer partition-table create \
 --file "_~/My_Partition_Table_" \
 --locations "_My_Location_" \
 --name "_My_Partition_Table_" \

--- a/guides/common/modules/proc_creating-provisioning-templates.adoc
+++ b/guides/common/modules/proc_creating-provisioning-templates.adoc
@@ -19,7 +19,7 @@ This example uses the `~/my-template` file.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer template create \
+$ hammer template create \
 --file ~/my-template \
 --locations "_My_Location_" \
 --name "_My_Provisioning_Template_" \

--- a/guides/common/modules/proc_deleting-a-location.adoc
+++ b/guides/common/modules/proc_deleting-a-location.adoc
@@ -16,7 +16,7 @@ There must be at least one location in the environment at any given time.
 +
 [subs="+quotes"]
 ----
-# hammer location list
+$ hammer location list
 ----
 +
 From the output, note the ID of the location that you want to delete.
@@ -24,5 +24,5 @@ From the output, note the ID of the location that you want to delete.
 +
 [subs="+quotes"]
 ----
-# hammer location delete --id _Location ID_
+$ hammer location delete --id _Location ID_
 ----

--- a/guides/common/modules/proc_deleting-an-organization.adoc
+++ b/guides/common/modules/proc_deleting-an-organization.adoc
@@ -21,7 +21,7 @@ There must be at least one organization in the environment at any given time.
 . Enter the following command to retrieve the ID of the organization that you want to delete:
 +
 ----
-# hammer organization list
+$ hammer organization list
 ----
 +
 From the output, note the ID of the organization that you want to delete.
@@ -29,5 +29,5 @@ From the output, note the ID of the organization that you want to delete.
 +
 [subs="+quotes"]
 ----
-# hammer organization delete --id _Organization_ID_
+$ hammer organization delete --id _Organization_ID_
 ----

--- a/guides/common/modules/proc_deleting_a_task_by_id.adoc
+++ b/guides/common/modules/proc_deleting_a_task_by_id.adoc
@@ -14,7 +14,7 @@ You can delete tasks by ID, for example if you have submitted confidential data 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer task info --id _My_Task_ID_
+$ hammer task info --id _My_Task_ID_
 ----
 . Delete the task:
 +
@@ -26,7 +26,7 @@ You can delete tasks by ID, for example if you have submitted confidential data 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer task info --id _My_Task_ID_
+$ hammer task info --id _My_Task_ID_
 ----
 +
 Note that because the task is deleted, this command returns a non-zero exit code.

--- a/guides/common/modules/proc_disabling-subscription-connection.adoc
+++ b/guides/common/modules/proc_disabling-subscription-connection.adoc
@@ -16,5 +16,5 @@ This will also prevent you from refreshing the manifest and updating upstream en
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer settings set --name subscription_connection_enabled --value false
+$ hammer settings set --name subscription_connection_enabled --value false
 ----

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
@@ -31,7 +31,7 @@ include::snip_step-downloading-file-from-server.adoc[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository list --content-type file
+$ hammer repository list --content-type file
 ---|------------|-------------------|--------------|----
 ID | NAME       | PRODUCT           | CONTENT TYPE | URL
 ---|------------|-------------------|--------------|----
@@ -42,7 +42,7 @@ ID | NAME       | PRODUCT           | CONTENT TYPE | URL
 +
 [options="nowrap",subs="+quotes"]
 ----
-# hammer repository info \
+$ hammer repository info \
 --name "_My_Files_" \
 --organization-id _My_Organization_ID_ \
 --product "_My_File_Product_"

--- a/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
+++ b/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
@@ -25,13 +25,13 @@ include::snip_step-downloading-file-from-server.adoc[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository list --content-type python
+$ hammer repository list --content-type python
 ----
 . View the repository information:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# hammer repository info \
+$ hammer repository info \
 --name "_My_Python_Repository_" \
 --organization-id _My_Organization_ID_ \
 --product "__My_{customproductFirstCap}__"

--- a/guides/common/modules/proc_enabling-red-hat-repositories.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories.adoc
@@ -28,13 +28,13 @@ Note that Kickstart repositories only have minor versions.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product list --organization "_My_Organization_"
+$ hammer product list --organization "_My_Organization_"
 ----
 . List the repository set for the product:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository-set list \
+$ hammer repository-set list \
 --product "Red Hat Enterprise Linux Server" \
 --organization "_My_Organization_"
 ----
@@ -43,7 +43,7 @@ Include the release version, such as `7Server`, and base architecture, such as `
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository-set enable \
+$ hammer repository-set enable \
 --name "Red Hat Enterprise Linux 7 Server (RPMs)" \
 --releasever "7Server" \
 --basearch "x86_64" \

--- a/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests.adoc
+++ b/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests.adoc
@@ -15,5 +15,5 @@ If you use an HTTP Proxy for all {Project} HTTP or HTTPS requests, you can preve
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer settings set --name=http_proxy_except_list --value=[_hostname1.hostname2..._]
+$ hammer settings set --name=http_proxy_except_list --value=[_hostname1.hostname2..._]
 ----

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -69,7 +69,7 @@ You have the option to return to any part of the job wizard and edit the informa
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name=remote_execution_global_proxy \
 --value=false
 ----
@@ -77,19 +77,19 @@ You have the option to return to any part of the job wizard and edit the informa
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-template list
+$ hammer job-template list
 ----
 . Show the template details to see parameters required by your template:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-template info --id _My_Template_ID_
+$ hammer job-template info --id _My_Template_ID_
 ----
 . Execute a remote job with custom parameters:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer job-invocation create \
+$ hammer job-invocation create \
 --inputs _My_Key_1_="_My_Value_1_",_My_Key_2_="_My_Value_2_",... \
 --job-template "_My_Template_Name_" \
 --search-query "_My_Search_Query_"

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -23,7 +23,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 +
 [subs="+quotes"]
 ----
-# hammer content-view version list \
+$ hammer content-view version list \
 --content-view="_My_Content_View_" \
 --organization="_My_Organization_"
 ----
@@ -34,7 +34,7 @@ The following example targets version `1.0` for export:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete version \
+$ hammer content-export complete version \
 --content-view="_Content_View_Name_" \
 --version=1.0 \
 --organization="_My_Organization_" \

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -17,7 +17,7 @@ include::snip_content-types-export.adoc[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export incremental version \
+$ hammer content-export incremental version \
 --content-view="_My_Content_View_" \
 --organization="_My_Organization_" \
 --version="_My_Content_View_Version_"

--- a/guides/common/modules/proc_exporting-a-content-view-version.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version.adoc
@@ -31,7 +31,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 [subs="+quotes"]
 ----
 
-# hammer content-view version list \
+$ hammer content-view version list \
 --content-view="_My_Content_View_" \
 --organization="_My_Organization_"
 
@@ -51,7 +51,7 @@ The following example targets version `1.0` for export.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete version \
+$ hammer content-export complete version \
 --content-view="_Content_View_Name_" \
 --version=1.0 \
 --organization="_My_Organization_"
@@ -73,7 +73,7 @@ The following example uses the `--chunk-size-gb=2` to split the archives into `2
 
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete version \
+$ hammer content-export complete version \
 --chunk-size-gb=2 \
 --content-view="_Content_View_Name_" \
 --organization="_My_Organization_" \

--- a/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
@@ -16,7 +16,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete repository \
+$ hammer content-export complete repository \
 --organization="_My_Organization_" \
 --product="_My_Product_" \
 --name="_My_Repository_" \

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -16,7 +16,7 @@ The procedure below shows an incremental export of a repository in the Library l
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export incremental repository \
+$ hammer content-export incremental repository \
 --format=syncable \
 --name="_My_Repository_" \
 --organization="_My_Organization_" \

--- a/guides/common/modules/proc_exporting-a-repository-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally.adoc
@@ -16,7 +16,7 @@ The example below shows incremental export of a repository in the Library lifecy
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export incremental repository \
+$ hammer content-export incremental repository \
 --name="_My_Repository_" \
 --organization="_My_Organization_" \
 --product="_My_Product_"

--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -25,7 +25,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete repository \
+$ hammer content-export complete repository \
 --name="_My_Repository_" \
 --product="_My_Product_" \
 --organization="_My_Organization_"

--- a/guides/common/modules/proc_exporting-report-templates.adoc
+++ b/guides/common/modules/proc_exporting-report-templates.adoc
@@ -15,7 +15,7 @@ An `.erb` file that contains the template downloads.
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer report-template list
+$ hammer report-template list
 ----
 +
 Note the template ID of the template that you want to export in the output of this command.
@@ -23,5 +23,5 @@ Note the template ID of the template that you want to export in the output of th
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer report-template dump --id _My_Template_ID_ > _example_export_.erb
+$ hammer report-template dump --id _My_Template_ID_ > _example_export_.erb
 ----

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -23,7 +23,7 @@ The status is not persistent; if you leave the status page, you cannot return to
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer export-templates \
+$ hammer export-templates \
 --organization "_My_Organization_" \
 --repo "_https://git.example.com/path/to/repository_"
 ----

--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -26,7 +26,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete library \
+$ hammer content-export complete library \
 --organization="_My_Organization_" \
 --format=syncable
 ----

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
@@ -19,7 +19,7 @@ The example below shows incremental export of all repositories in the organizati
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-export incremental library \
+$ hammer content-export incremental library \
 --organization="_My_Organization_"
 ----
 include::snip_syncable-exports.adoc[]

--- a/guides/common/modules/proc_exporting-the-library-environment.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment.adoc
@@ -21,7 +21,7 @@ For more information, see xref:Download_Policies_Overview_{context}[].
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete library --organization="_My_Organization_"
+$ hammer content-export complete library --organization="_My_Organization_"
 ----
 . Verify that the archive containing the exported version of a content view is located in the export directory:
 +
@@ -48,7 +48,7 @@ In the following example, you can see how to specify `--chunk-size-gb=2` to spli
 
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete library \
+$ hammer content-export complete library \
 --chunk-size-gb=2 \
 --organization="_My_Organization_"
 

--- a/guides/common/modules/proc_generating-host-monitoring-reports.adoc
+++ b/guides/common/modules/proc_generating-host-monitoring-reports.adoc
@@ -21,13 +21,13 @@ If you have selected the *Send report via e-mail* checkbox, the host monitoring 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer report-template list
+$ hammer report-template list
 ----
 . Generate a report:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer report-template generate --id _My_Template_ID_
+$ hammer report-template generate --id _My_Template_ID_
 ----
 +
 This command waits until the report fully generates before completing.
@@ -40,7 +40,7 @@ If you want to generate the *Subscription - General* report, you have to use the
 .Show all subscriptions
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----
-# hammer report-template generate \
+$ hammer report-template generate \
 --inputs "Days from Now=no limit" \
 --name "Subscription - General Report"
 ----
@@ -48,7 +48,7 @@ If you want to generate the *Subscription - General* report, you have to use the
 .Show all subscriptions that are going to expire within 60 days
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----
-# hammer report-template generate \
+$ hammer report-template generate \
 --inputs "Days from Now=60" \
 --name "Subscription - General Report"
 ----

--- a/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
@@ -25,7 +25,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-import version \
+$ hammer content-import version \
 --organization=_My_Organization_ \
 --path=http://_{server-example-com}_/pub/exports/2021-02-25T21-15-22-00-00/
 ----

--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -37,7 +37,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-import version \
+$ hammer content-import version \
 --organization=_My_Organization_ \
 --path=/var/lib/pulp/imports/2021-02-25T21-15-22-00-00/
 ----
@@ -48,7 +48,7 @@ Relative paths do not work.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-view version list \
+$ hammer content-view version list \
 --organization-id=_My_Organization_ID_
 ----
 include::snip_extract-directory-imported-project-server.adoc[]

--- a/guides/common/modules/proc_importing-a-custom-gpg-key.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key.adoc
@@ -71,7 +71,7 @@ $ scp ~/etc/pki/rpm-gpg/RPM-GPG-KEY-_EXAMPLE-95_ root@{foreman-example-com}:~/.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-credentials create \
+$ hammer content-credentials create \
 --content-type gpg_key \
 --name "_My_GPG_Key_" \
 --organization "_My_Organization_" \

--- a/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
@@ -18,7 +18,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-import repository \
+$ hammer content-import repository \
 --organization="_My_Organization_" \
 --path=http://_{server-example-com}_/pub/exports/2021-02-25T21-15-22-00-00/
 ----

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -34,7 +34,7 @@ total 68M
 +
 [subs="+quotes"]
 ----
-# hammer content-import repository \
+$ hammer content-import repository \
 --organization="_My_Organization_" \
 --path=/var/lib/pulp/imports/_2021-03-02T03-35-24-00-00_
 ----

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -62,7 +62,7 @@ $ scp ~/_manifest_file_.zip root@_{foreman-example-com}_:~/.
 +
 [subs="+quotes"]
 ----
-# hammer subscription upload \
+$ hammer subscription upload \
 --file ~/_manifest_file_.zip \
 --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -50,7 +50,7 @@ From the list, you can also remove any manifests that you do not require.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer product create \
+$ hammer product create \
 --description "_My_Description_" \
 --name "{client-container-product-name}" \
 --organization "_My_Organization_" \
@@ -60,7 +60,7 @@ From the list, you can also remove any manifests that you do not require.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer repository create \
+$ hammer repository create \
 --content-type "docker" \
 --docker-upstream-name "{client-container-image-name}" \
 --name "{client-container-repository-name}" \
@@ -72,7 +72,7 @@ From the list, you can also remove any manifests that you do not require.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --name "{client-container-repository-name}" \
 --organization "_My_Organization_" \
 --product "{client-container-product-name}"

--- a/guides/common/modules/proc_importing-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_importing-custom-ssl-certificates.adoc
@@ -35,7 +35,7 @@ $ wget -P ~ http://_upstream-{foreman-example-com}_/pub/katello-server-ca.crt
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-credential create \
+$ hammer content-credential create \
 --content-type cert \
 --name "_My_SSL_Certificate_" \
 --organization "_My_Organization_" \

--- a/guides/common/modules/proc_importing-individual-iso-images-and-files.adoc
+++ b/guides/common/modules/proc_importing-individual-iso-images-and-files.adoc
@@ -32,7 +32,7 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product create \
+$ hammer product create \
 --name "_My_ISOs_" \
 --sync-plan "Example Plan" \
 --description "_My_Product_" \
@@ -42,7 +42,7 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository create \
+$ hammer repository create \
 --name "_My_ISOs_" \
 --content-type "file" \
 --product "_My_Product_" \
@@ -52,7 +52,7 @@ Add a corresponding user name and password in the *Upstream Username* and *Upstr
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository upload-content \
+$ hammer repository upload-content \
 --path ~/bootdisk.iso \
 --id _repo_ID_ \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
@@ -18,7 +18,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer content-import library \
+$ hammer content-import library \
 --organization="_My_Organization_" \
 --path=http://_{server-example-com}_/pub/exports/2021-02-25T21-15-22-00-00/
 ----

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -34,7 +34,7 @@ total 68M
 +
 [subs="+quotes"]
 ----
-# hammer content-import library \
+$ hammer content-import library \
 --organization="_My_Organization_" \
 --path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00
 ----

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat.adoc
@@ -24,7 +24,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository-set list \
+$ hammer repository-set list \
 --product "Red Hat Enterprise Linux Server" \
 --organization "_My_Organization_" | grep "file"
 ----
@@ -32,7 +32,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository-set enable \
+$ hammer repository-set enable \
 --product "Red Hat Enterprise Linux Server" \
 --name "Red Hat Enterprise Linux 7 Server (ISOs)" \
 --releasever 7.2 \
@@ -43,7 +43,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository list \
+$ hammer repository list \
 --product "Red Hat Enterprise Linux Server" \
 --organization "_My_Organization_"
 ----
@@ -51,7 +51,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-importing-iso-ima
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --name "Red Hat Enterprise Linux 7 Server ISOs x86_64 7.2" \
 --product "Red Hat Enterprise Linux Server" \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -50,7 +50,7 @@ For example `fedora/x86_64/coreos/stable`.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product create \
+$ hammer product create \
 --name "_OSTree_" \
 --sync-plan "_Example_Plan_" \
 --description "OSTree Content" \
@@ -60,7 +60,7 @@ For example `fedora/x86_64/coreos/stable`.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository create \
+$ hammer repository create \
 --name "_OSTree_" \
 --content-type "ostree" \
 --url "_http://www.example.com/rpm-ostree/_" \
@@ -71,7 +71,7 @@ For example `fedora/x86_64/coreos/stable`.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --name "_OSTree_" \
 --product "OSTree Content" \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_importing-suse-products.adoc
+++ b/guides/common/modules/proc_importing-suse-products.adoc
@@ -30,14 +30,14 @@ Note that the SCC Manager plugin can only add, but not remove products from {Pro
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts scc_products list \
+$ hammer scc_manager scc_accounts scc_products list \
 --scc-account-id _My_SCC_Account_ID_
 ----
 . View information about a SUSE product:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts scc_products info \
+$ hammer scc_manager scc_accounts scc_products info \
 --id _My_SUSE_Product_ID_ \
 --scc-account-id _My_SCC_Account_ID_
 ----
@@ -45,7 +45,7 @@ Note that the SCC Manager plugin can only add, but not remove products from {Pro
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts scc_products subscribe \
+$ hammer scc_manager scc_accounts scc_products subscribe \
 --id _My_SUSE_Product_ID_ \
 --scc-account-id _My_SCC_Account_ID_
 ----
@@ -53,7 +53,7 @@ Note that the SCC Manager plugin can only add, but not remove products from {Pro
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts bulk_subscribe \
+$ hammer scc_manager scc_accounts bulk_subscribe \
 --id _My_SUSE_Account_ID_ \
 --scc-subscribe-product-ids _My_SUSE_Product_ID_1_,_My_SUSE_Product_ID_2_,_My_SUSE_Product_ID_3_
 ----

--- a/guides/common/modules/proc_importing-syncable-exports.adoc
+++ b/guides/common/modules/proc_importing-syncable-exports.adoc
@@ -6,7 +6,7 @@
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-import library
+$ hammer content-import library
 --organization="_My_Organization_"
 --path="_My_Path_To_Syncable_Export_"
 ----

--- a/guides/common/modules/proc_inspecting-available-errata.adoc
+++ b/guides/common/modules/proc_inspecting-available-errata.adoc
@@ -54,20 +54,20 @@ You can also use the new Host page to view to inspect available errata and selec
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# hammer erratum list
+$ hammer erratum list
 ----
 * To view details of a specific erratum, enter the following command:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer erratum info --id _erratum_ID_
+$ hammer erratum info --id _erratum_ID_
 ----
 * You can search errata by entering the query with the `--search` option.
 For example, to view applicable errata for the selected product that contains the specified bugs ordered so that the security errata are displayed on top, enter the following command:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# hammer erratum list \
+$ hammer erratum list \
 --product-id 7 \
 --search "bug = 1213000 or bug = 1207972" \
 --errata-restrict-applicable 1 \

--- a/guides/common/modules/proc_keeping-track-of-your-exports.adoc
+++ b/guides/common/modules/proc_keeping-track-of-your-exports.adoc
@@ -16,7 +16,7 @@ This option is available for all `content-export` operations.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete library \
+$ hammer content-export complete library \
 --destination-server=_My_Downstream_Server_1_ \
 --organization="_My_Organization_" \
 --version=1.0
@@ -27,7 +27,7 @@ This option is available for all `content-export` operations.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-export complete version \
+$ hammer content-export complete version \
 --content-view="_Content_View_Name_" \
 --destination-server=_My_Downstream_Server_1_ \
 --organization="_My_Organization_" \
@@ -39,5 +39,5 @@ This option is available for all `content-export` operations.
 +
 [subs="+quotes"]
 ----
-# hammer content-export list --organization="_My_Organization_"
+$ hammer content-export list --organization="_My_Organization_"
 ----

--- a/guides/common/modules/proc_limiting-synchronization-concurrency.adoc
+++ b/guides/common/modules/proc_limiting-synchronization-concurrency.adoc
@@ -10,7 +10,7 @@ If you are seeing Repository syncs fail due to the upstream servers rejecting re
 .CLI procedure
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# hammer repository update \
+$ hammer repository update \
 --download-concurrency 5 \
 --id _Repository_ID_ \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_listing-available-scap-contents.adoc
+++ b/guides/common/modules/proc_listing-available-scap-contents.adoc
@@ -16,7 +16,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-listing-available
 +
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----
-# hammer scap-content list \
+$ hammer scap-content list \
 --location "_My_Location_" \
 --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_loading-the-default-scap-contents.adoc
+++ b/guides/common/modules/proc_loading-the-default-scap-contents.adoc
@@ -18,5 +18,5 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scap-content bulk-upload --type default
+$ hammer scap-content bulk-upload --type default
 ----

--- a/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
+++ b/guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc
@@ -31,7 +31,7 @@ To authenticate to the {Project} CLI with Hammer:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer auth login oauth \
+$ hammer auth login oauth \
 --oidc-token-endpoint 'https://_{keycloak-example-com}_/auth/realms/_{Project}_realm_/protocol/openid-connect/token' \
 --oidc-authorization-endpoint 'https://_{keycloak-example-com}_/auth' \
 --oidc-client-id '_{foreman-example-com}_-hammer-openidc' \
@@ -51,7 +51,7 @@ To authenticate to the {Project} CLI with Hammer by using {keycloak} TOTP:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer auth login oauth \
+$ hammer auth login oauth \
 --two-factor \
 --oidc-token-endpoint 'https://_{keycloak-example-com}_/auth/realms/_{Project}_realm_/protocol/openid-connect/token' \
 --oidc-authorization-endpoint 'https://_{keycloak-example-com}_/auth' \

--- a/guides/common/modules/proc_managing-ostree-content-with-content-views.adoc
+++ b/guides/common/modules/proc_managing-ostree-content-with-content-views.adoc
@@ -30,13 +30,13 @@ Click *Add Repository* to add the OSTree content from this repository to the con
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository list --organization "_My_Organization_"
+$ hammer repository list --organization "_My_Organization_"
 ----
 . Create the content view and add the repository:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view create \
+$ hammer content-view create \
 --name "_OSTree_" \
 --description "_Example content view for the OSTree_" \
 --repository-ids _My_Repository_IDs_ \
@@ -46,7 +46,7 @@ Click *Add Repository* to add the OSTree content from this repository to the con
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view publish \
+$ hammer content-view publish \
 --name "_OSTree_" \
 --description "_Example content view for the OSTree_" \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_managing-ssh-keys-for-a-user.adoc
+++ b/guides/common/modules/proc_managing-ssh-keys-for-a-user.adoc
@@ -32,7 +32,7 @@ To add an SSH key to a user, you must specify either the path to the public SSH 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user ssh-keys add \
+$ hammer user ssh-keys add \
 --user-id _user_id_ \
 --name _key_name_ \
 --key-file _~/.ssh/id_rsa.pub_
@@ -42,7 +42,7 @@ To add an SSH key to a user, you must specify either the path to the public SSH 
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user ssh-keys add \
+$ hammer user ssh-keys add \
 --user-id _user_id_ \
 --name _key_name_ \
 --key _ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNtYAAABBBHHS2KmNyIYa27Qaa7EHp+2l99ucGStx4P77e03ZvE3yVRJEFikpoP3MJtYYfIe8k 1/46MTIZo9CPTX4CYUHeN8= host@user_
@@ -52,19 +52,19 @@ To delete an SSH key from a user, enter the following command:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user ssh-keys delete --id _key_id_ --user-id _user_id_
+$ hammer user ssh-keys delete --id _key_id_ --user-id _user_id_
 ----
 
 To view an SSH key attached to a user, enter the following command:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user ssh-keys info --id _key_id_ --user-id _user_id_
+$ hammer user ssh-keys info --id _key_id_ --user-id _user_id_
 ----
 
 To list SSH keys attached to a user, enter the following command:
 
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer user ssh-keys list --user-id _user_id_
+$ hammer user ssh-keys list --user-id _user_id_
 ----

--- a/guides/common/modules/proc_promoting-a-content-view.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view.adoc
@@ -34,17 +34,17 @@ Now the repository for the content view appears in all environments.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "Database" \
 --version 1 \
 --to-lifecycle-environment "Development" \
 --organization "_My_Organization_"
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "Database" \
 --version 1 \
 --to-lifecycle-environment "Testing" \
 --organization "_My_Organization_"
-# hammer content-view version promote \
+$ hammer content-view version promote \
 --content-view "Database" \
 --version 1 \
 --to-lifecycle-environment "Production" \
@@ -70,7 +70,7 @@ done
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# hammer content-view version info --id _My_Content_View_Version_ID_
+$ hammer content-view version info --id _My_Content_View_Version_ID_
 ----
 
 .Next steps

--- a/guides/common/modules/proc_providing-an-alternative-fqdn-for-the-host.adoc
+++ b/guides/common/modules/proc_providing-an-alternative-fqdn-for-the-host.adoc
@@ -9,10 +9,10 @@ If you cannot update the host to use an FQDN that is accepted by {Project}, you 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name create_new_host_when_facts_are_uploaded \
 --value false
-# hammer settings set \
+$ hammer settings set \
 --name create_new_host_when_report_is_uploaded \
 --value false
 ----

--- a/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
+++ b/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
@@ -34,7 +34,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository list \
+$ hammer repository list \
 --organization "_My_Organization_"
 ----
 . Synchronize a corrupted repository using the necessary option:
@@ -43,7 +43,7 @@ endif::[]
 +
 [subs="+quotes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --id _My_ID_
 ----
 +
@@ -51,7 +51,7 @@ endif::[]
 +
 [subs="+quotes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --id _My_ID_ \
 --skip-metadata-check true
 ----
@@ -60,7 +60,7 @@ endif::[]
 +
 [subs="+quotes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --id _My_ID_ \
 --validate-contents true
 ----

--- a/guides/common/modules/proc_removing-a-virtual-machine-upon-host-deletion.adoc
+++ b/guides/common/modules/proc_removing-a-virtual-machine-upon-host-deletion.adoc
@@ -25,7 +25,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-removing-a-virtua
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer settings set \
+$ hammer settings set \
 --name destroy_vm_on_host_delete \
 --value true \
 --location "_My_Location_" \

--- a/guides/common/modules/proc_removing-an-scc-account.adoc
+++ b/guides/common/modules/proc_removing-an-scc-account.adoc
@@ -23,6 +23,6 @@ For more information, see xref:Switching_SCC_Accounts_{context}[].
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts delete \
+$ hammer scc_manager scc_accounts delete \
 --id _My_SCC_Account_ID_
 ----

--- a/guides/common/modules/proc_removing-lifecycle-environments-from-foreman.adoc
+++ b/guides/common/modules/proc_removing-lifecycle-environments-from-foreman.adoc
@@ -14,14 +14,14 @@ Use this procedure to remove a lifecycle environment.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment list \
+$ hammer lifecycle-environment list \
 --organization "_My_Organization_"
 ----
 . Use the `hammer lifecycle-environment delete` command to remove an environment:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment delete \
+$ hammer lifecycle-environment delete \
 --name "_My_Environment_" \
 --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_resetting-the-http-proxy.adoc
+++ b/guides/common/modules/proc_resetting-the-http-proxy.adoc
@@ -14,5 +14,5 @@ If you want to reset the current HTTP proxy setting, unset the *Default HTTP Pro
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer settings set --name=content_default_http_proxy --value=""
+$ hammer settings set --name=content_default_http_proxy --value=""
 ----

--- a/guides/common/modules/proc_retrieving-status-of-services.adoc
+++ b/guides/common/modules/proc_retrieving-status-of-services.adoc
@@ -15,7 +15,7 @@ When troubleshooting, you can check the status of {Project} services.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer ping
+$ hammer ping
 ----
 * Check the status of the services running in systemd:
 +

--- a/guides/common/modules/proc_reverting-server-to-download-content-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_reverting-server-to-download-content-from-red-hat-cdn.adoc
@@ -21,5 +21,5 @@ If your environment changes from disconnected to connected, you can reconfigure 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer organization configure-cdn --name="_My_Organization_" --type=redhat_cdn
+$ hammer organization configure-cdn --name="_My_Organization_" --type=redhat_cdn
 ----

--- a/guides/common/modules/proc_running-custom-code-while-applying-errata.adoc
+++ b/guides/common/modules/proc_running-custom-code-while-applying-errata.adoc
@@ -28,7 +28,7 @@ If your template is called `Install Errata - Katello Ansible Default`, name your
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer template create \
+$ hammer template create \
 --file "~/_My_Snippet_" \
 --locations "_My_Location_" \
 --name "_My_Template_Name_custom_pre" \

--- a/guides/common/modules/proc_setting-a-default-organization-and-location-context.adoc
+++ b/guides/common/modules/proc_setting-a-default-organization-and-location-context.adoc
@@ -12,7 +12,7 @@ However, when you switch to a different organization, you must use `hammer` with
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer defaults add --param-name organization \
+$ hammer defaults add --param-name organization \
 --param-value _"Your_Organization"_
 ----
 +
@@ -21,7 +21,7 @@ You can find the name of your organization with the `hammer organization list` c
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# hammer defaults add --param-name location \
+$ hammer defaults add --param-name location \
 --param-value _"Your_Location"_
 ----
 +
@@ -32,5 +32,5 @@ You can find the name of your location with the `hammer location list` command.
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# hammer defaults list
+$ hammer defaults list
 ----

--- a/guides/common/modules/proc_setting-the-fips-enabled-parameter.adoc
+++ b/guides/common/modules/proc_setting-the-fips-enabled-parameter.adoc
@@ -9,7 +9,7 @@ To set this parameter when provisioning a host, append `--parameters fips_enable
 
 [options="nowrap" subs="+quotes"]
 ----
-# hammer hostgroup set-parameter \
+$ hammer hostgroup set-parameter \
 --hostgroup "_My_Host_Group_" \
 --name fips_enabled \
 --value "true"

--- a/guides/common/modules/proc_setting-the-location-context.adoc
+++ b/guides/common/modules/proc_setting-the-location-context.adoc
@@ -16,7 +16,7 @@ For example:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer host list --location "_My_Location_"
+$ hammer host list --location "_My_Location_"
 ----
 
 This command lists hosts associated with the _My_Location_ location.

--- a/guides/common/modules/proc_setting-the-provisioning-context.adoc
+++ b/guides/common/modules/proc_setting-the-provisioning-context.adoc
@@ -19,7 +19,7 @@ For example:
 +
 [subs="+quotes"]
 ----
-# hammer host list --organization "_My_Organization_" --location "_My_Location_"
+$ hammer host list --organization "_My_Organization_" --location "_My_Location_"
 ----
 +
 This command outputs hosts allocated to `My_Organization` and `My_Location`.

--- a/guides/common/modules/proc_setting-the-service-level.adoc
+++ b/guides/common/modules/proc_setting-the-service-level.adoc
@@ -16,7 +16,7 @@ The list only contains service levels available to the activation key.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer activation-key update \
+$ hammer activation-key update \
 --name "_My_Activation_Key_" \
 --organization "_My_Organization_" \
 --service-level premium

--- a/guides/common/modules/proc_synchronizing-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-repositories.adoc
@@ -34,7 +34,7 @@ The following table provides estimates of how long it would take to synchronize 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer product synchronize \
+$ hammer product synchronize \
 --name "_My_Product_" \
 --organization "_My_Organization_"
 ----
@@ -42,7 +42,7 @@ The following table provides estimates of how long it would take to synchronize 
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository synchronize \
+$ hammer repository synchronize \
 --name "_My_Repository_" \
 --organization "_My_Organization_" \
 --product "_My Product_"

--- a/guides/common/modules/proc_updating-an-scc-account.adoc
+++ b/guides/common/modules/proc_updating-an-scc-account.adoc
@@ -17,7 +17,7 @@ For more information, see xref:Adding_an_SCC_Account_to_Server_{context}[].
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer scc_manager scc_accounts update \
+$ hammer scc_manager scc_accounts update \
 --id _My_SCC_Account_ID_ \
 --password "_My_SCC_Account_Password" \
 _My_Options_

--- a/guides/common/modules/proc_updating-disconnected-server-on-EL9.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server-on-EL9.adoc
@@ -59,7 +59,7 @@ sslverify = 1
 . Obtain the organization label:
 +
 ----
-# hammer organization list
+$ hammer organization list
 ----
 . Enter the `reposync` command:
 +

--- a/guides/common/modules/proc_updating-the-details-of-multiple-operating-systems.adoc
+++ b/guides/common/modules/proc_updating-the-details-of-multiple-operating-systems.adoc
@@ -28,5 +28,5 @@ done
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer os info --id _1_
+$ hammer os info --id _1_
 ----

--- a/guides/common/modules/proc_uploading-additional-scap-content.adoc
+++ b/guides/common/modules/proc_uploading-additional-scap-content.adoc
@@ -32,7 +32,7 @@ If the SCAP content file is loaded successfully, a message similar to `Successfu
 +
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----
-# hammer scap-content bulk-upload --type directory \
+$ hammer scap-content bulk-upload --type directory \
 --directory _/usr/share/xml/scap/my_content/_ \
 --location "_My_Location_" \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories.adoc
@@ -19,7 +19,7 @@ To view all RPMs in this repository, click the number next to *Packages* under *
 +
 [options="nowrap" subs="+quotes,verbatim"]
 ----
-# hammer repository upload-content \
+$ hammer repository upload-content \
 --id _My_Repository_ID_ \
 --path __/path/to/example-package.rpm__
 ----
@@ -27,7 +27,7 @@ To view all RPMs in this repository, click the number next to *Packages* under *
 +
 [options="nowrap" subs="+quotes,verbatim"]
 ----
-# hammer repository upload-content \
+$ hammer repository upload-content \
 --content-type srpm \
 --id _My_Repository_ID_ \
 --path __/path/to/example-package.src.rpm__

--- a/guides/common/modules/proc_uploading-files-to-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_uploading-files-to-a-custom-file-repository.adoc
@@ -14,7 +14,7 @@ Use this procedure to upload files to a {customfiletype} repository.
 .CLI procedure
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository upload-content \
+$ hammer repository upload-content \
 --id _repo_ID_ \
 --organization "_My_Organization_" \
 --path _example_file_

--- a/guides/common/modules/proc_uploading-files-to-a-python-repository.adoc
+++ b/guides/common/modules/proc_uploading-files-to-a-python-repository.adoc
@@ -15,7 +15,7 @@ You can upload `.whl` packages and `.tar.gz` archives that contain Python packag
 .CLI procedure
 [options="nowrap" subs="+quotes"]
 ----
-# hammer repository upload-content \
+$ hammer repository upload-content \
 --id _My_Repository_ID_ \
 --organization-id _My_Organization_ID_ \
 --path _Path_To_My_File_

--- a/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
+++ b/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
@@ -22,7 +22,7 @@ You can also create an OSTree image archive by downloading a repository from an 
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer repository upload-content --id _repository_id_ \
+$ hammer repository upload-content --id _repository_id_ \
 --content-type ostree_ref \
 --path _/path/to/image/file.tar_ \
 --ostree-repository-name _example_repo_name_

--- a/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
+++ b/guides/common/modules/proc_using-a-synced-kickstart-repository.adoc
@@ -31,5 +31,5 @@ To view the Kickstart tree, enter the following command:
 
 [subs="+quotes"]
 ----
-# hammer medium list --organization "_My_Organization_"
+$ hammer medium list --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_using-an-http-proxy-for-all-http-requests.adoc
+++ b/guides/common/modules/proc_using-an-http-proxy-for-all-http-requests.adoc
@@ -17,5 +17,5 @@ Note that if you are using compute resources for provisioning, and you want to u
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer settings set --name=http_proxy --value=_Proxy_URL_
+$ hammer settings set --name=http_proxy --value=_Proxy_URL_
 ----

--- a/guides/common/modules/proc_using-the-salt-hammer-cli.adoc
+++ b/guides/common/modules/proc_using-the-salt-hammer-cli.adoc
@@ -12,21 +12,21 @@ Run `hammer --help` for more information.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer salt-state create \
+$ hammer salt-state create \
 --name _My_Salt_State_
 ----
 * Viewing information about a Salt Minion:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer salt-minion info \
+$ hammer salt-minion info \
 --name salt-minion.example.com
 ----
 * Adding Salt States to a Salt Minion:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer salt-minion update \
+$ hammer salt-minion update \
 --name salt-minion.example.com \
 --salt-states _My_Salt_State_
 ----

--- a/guides/common/modules/proc_viewing-module-streams.adoc
+++ b/guides/common/modules/proc_viewing-module-streams.adoc
@@ -16,12 +16,12 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Viewing_Module_St
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer organization list
+$ hammer organization list
 ----
 . View all module streams for your organization:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# hammer module-stream list \
+$ hammer module-stream list \
 --organization-id _My_Organization_ID_
 ----

--- a/guides/common/modules/ref_configuring-logging-levels-with-hammer-cli.adoc
+++ b/guides/common/modules/ref_configuring-logging-levels-with-hammer-cli.adoc
@@ -8,14 +8,14 @@ The default logging level is `INFO`.
 +
 [options="nowrap"]
 ----
-# hammer admin logging --list
+$ hammer admin logging --list
 ----
 
 * To set `DEBUG` level logging for all components:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer admin logging --all --level-debug
+$ hammer admin logging --all --level-debug
 # {foreman-maintain} service restart
 ----
 
@@ -23,7 +23,7 @@ The default logging level is `INFO`.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer admin logging --all --level-production
+$ hammer admin logging --all --level-production
 # {foreman-maintain} service restart
 ----
 
@@ -31,7 +31,7 @@ The default logging level is `INFO`.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer admin logging --components _My_Component_ --level-debug
+$ hammer admin logging --components _My_Component_ --level-debug
 # {foreman-maintain} service restart
 ----
 
@@ -39,7 +39,7 @@ The default logging level is `INFO`.
 +
 [options="nowrap"]
 ----
-# hammer admin logging --help
+$ hammer admin logging --help
 ----
 
 ifdef::satellite[]

--- a/guides/common/modules/ref_using-json-for-complex-parameters.adoc
+++ b/guides/common/modules/ref_using-json-for-complex-parameters.adoc
@@ -7,7 +7,7 @@ An example of JSON formatted content appears below:
 
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# hammer compute-profile values create --compute-profile-id 22 --compute-resource-id 1 --compute-attributes=
+$ hammer compute-profile values create --compute-profile-id 22 --compute-resource-id 1 --compute-attributes=
 '{
 "cpus": 2,
 "corespersocket": 2,

--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -42,21 +42,21 @@ endif::[]
 ifndef::katello,satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host-registration generate-command
+$ hammer host-registration generate-command
 ----
 +
 If your hosts do not trust the SSL certificate of {ProjectServer}, you can disable SSL validation by adding the `--insecure` flag to the registration command.
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host-registration generate-command \
+$ hammer host-registration generate-command \
 --insecure true
 ----
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host-registration generate-command \
+$ hammer host-registration generate-command \
 --activation-keys "_My_Activation_Key_"
 ----
 +
@@ -64,7 +64,7 @@ If your hosts do not trust the SSL certificate of {ProjectServer}, you can disab
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# hammer host-registration generate-command \
+$ hammer host-registration generate-command \
 --activation-keys "_My_Activation_Key_" \
 --insecure true
 ----


### PR DESCRIPTION
#### What changes are you introducing?

The dollar sign indicates that you do not need root priviledges to run Hammer CLI commands.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

the align with our existing convention: `#` for commands that you run as root; `$` for all other commands.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

reproducer:

````
fd -e adoc -t f | xargs sed -i "s/^# hammer /$ hammer /g"
````

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
