### PR TITLE
Properly send in params in the Python API example

### DIFF
--- a/guides/common/modules/proc_calling-the-api-in-python.adoc
+++ b/guides/common/modules/proc_calling-the-api-in-python.adoc
@@ -164,13 +164,13 @@ SSL_VERIFY = False
 #SSL_VERIFY = "./path/to/CA-certificate.crt" # Put the path to your CA certificate here to allow SSL_VERIFY
 
 
-def get_json(url):
+def get_json(url, params=None):
     # Performs a GET by using the passed URL location
-    r = requests.get(url, auth=(USERNAME, PASSWORD), verify=SSL_VERIFY)
+    r = requests.get(url, params=params, auth=(USERNAME, PASSWORD), verify=SSL_VERIFY)
     return r.json()
 
-def get_results(url):
-    jsn = get_json(url)
+def get_results(url, params=None):
+    jsn = get_json(url, params)
     if jsn.get('error'):
         print("Error: " + jsn['error']['message'])
     else:
@@ -187,8 +187,8 @@ def display_all_results(url):
     if results:
         print(json.dumps(results, indent=4, sort_keys=True))
 
-def display_info_for_hosts(url):
-    hosts = get_results(url)
+def display_info_for_hosts(url, params):
+    hosts = get_results(url, params)
     if hosts:
         print(f"{'ID':10}{'Name':40}{'IP':30}{'Operating System':30}")
         for host in hosts:
@@ -211,14 +211,14 @@ def main():
 
     host_pattern = 'example'
     print(f"Displaying basic info for hosts matching pattern '\{host_pattern}'...")
-    display_info_for_hosts(FOREMAN_API + 'hosts?per_page=1&search=name~' + host_pattern)
+    display_info_for_hosts(FOREMAN_API + 'hosts', {'per_page': 1, 'search': 'name~' + host_pattern})
 
     print(f"Displaying basic info for subscriptions")
     display_info_for_subs(KATELLO_API + 'subscriptions')
 
     environment = 'production'
     print(f"Displaying basic info for hosts in environment \{environment}...")
-    display_info_for_hosts(FOREMAN_API + 'hosts?search=environment=' + environment)
+    display_info_for_hosts(FOREMAN_API + 'hosts', {'search': 'environment=' + environment})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### What changes are you introducing?

Python's requests library accepts a dict with params and then properly encodes this to be sent to a server. This avoids the need to manually encode this in our examples.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This fixes a build issue in Red Hat's downstream where Pantheon fails on `&`, but generally is safer and more understandable code.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is an alternative to https://github.com/theforeman/foreman-documentation/pull/3405.

I must admit I haven't tried this on a real system and is solely written based on knowing Python and requests.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.