### PR TITLE
Document high-level steps for upgrading

### DIFF
--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -2,14 +2,49 @@
 == Upgrade paths
 
 You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}.
+The high-level steps in upgrading {Project} to {ProjectVersion} are as follows:
 
 ifdef::satellite[]
-{ProjectServer}s and {SmartProxyServers} on earlier versions must first be upgraded to {Project} {ProjectVersionPrevious}.
+. Ensure that your {ProjectServer}s and {SmartProxyServers} have been upgraded to {Project} {ProjectVersionPrevious}.
 For more information, see {UpgradingPreviousDocURL}[_{UpgradingPreviousDocTitle}_] or {UpgradingDisconnectedPreviousDocURL}[_{UpgradingDisconnectedPreviousDocTitle}_].
 endif::[]
 
-Upgrading {Project} to {ProjectVersion} includes upgrading your {ProjectServer} and all {SmartProxyServers} to {ProjectVersion}.
 ifndef::foreman-deb[]
-After the upgrade, you can also upgrade the operating system of your {ProjectServer} and {SmartProxyServers} to {EL}{nbsp}9.
+. Upgrade your {ProjectServer}:
+.. Upgrade your {ProjectServer} to {ProjectVersion}.
+.. Optional: Upgrade the operating system on your {ProjectServer} to {EL}{nbsp}9.
+ifdef::satellite[]
+.. Synchronize the new {ProjectVersion} repositories.
 endif::[]
-For more information on the steps of the upgrade process, see xref:Upgrading_{project-context}_{context}[].
+. Upgrade your {SmartProxyServers}:
+.. Upgrade all {SmartProxyServers} to {ProjectVersion}.
+.. Optional: Upgrade the operating system on your {SmartProxyServers} to {EL}{nbsp}9.
+endif::[]
+
+ifdef::foreman-deb[]
+. Upgrade your {ProjectServer} to {ProjectVersion}.
+. Upgrade all {SmartProxyServers} to {ProjectVersion}.
+endif::[]
+
+ifndef::foreman-deb[]
+[NOTE]
+====
+Although upgrading the operating system of your {ProjectServer} and {SmartProxyServers} to {EL}{nbsp}9 is an optional part of the upgrade process, you will need to upgrade to {EL}{nbsp}9 before you can upgrade to the next {Project} version after {ProjectVersion}.
+====
+endif::[]
+
+{SmartProxies} at version {ProjectVersionPrevious} will keep working with your upgraded {ProjectServer} {ProjectVersion}.
+After you upgrade {ProjectServer} to {ProjectVersion}, you can upgrade your {SmartProxies} separately over multiple maintenance windows.
+ifdef::foreman-el,katello,satellite[]
+For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
+endif::[]
+
+{Project} services are shut down during the upgrade. Make sure to plan for the required downtime.
+The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
+
+* Upgrading {ProjectServer} takes approximately 1{range}2 hours.
+* Upgrading {SmartProxyServer} takes approximately 10{range}30 minutes.
+
+.Additional resources
+
+* For more information on the steps of the upgrade process, see xref:Upgrading_{project-context}_{context}[].

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -13,24 +13,28 @@ ifndef::foreman-deb[]
 . Upgrade your {ProjectServer}:
 .. Upgrade your {ProjectServer} to {ProjectVersion}.
 .. Optional: Upgrade the operating system on your {ProjectServer} to {EL}{nbsp}9.
++
+[NOTE]
+====
+Although upgrading the operating system of your {ProjectServer} to {EL}{nbsp}9 is optional, you will need to do it before you can upgrade to the next {Project} version after {ProjectVersion}.
+====
++
 ifdef::satellite[]
 .. Synchronize the new {ProjectVersion} repositories.
 endif::[]
 . Upgrade your {SmartProxyServers}:
 .. Upgrade all {SmartProxyServers} to {ProjectVersion}.
 .. Optional: Upgrade the operating system on your {SmartProxyServers} to {EL}{nbsp}9.
++
+[NOTE]
+====
+Although upgrading the operating system of your {SmartProxyServers} to {EL}{nbsp}9 is optional, you will need to do it before you can upgrade to the next {Project} version after {ProjectVersion}.
+====
 endif::[]
 
 ifdef::foreman-deb[]
 . Upgrade your {ProjectServer} to {ProjectVersion}.
 . Upgrade all {SmartProxyServers} to {ProjectVersion}.
-endif::[]
-
-ifndef::foreman-deb[]
-[NOTE]
-====
-Although upgrading the operating system of your {ProjectServer} and {SmartProxyServers} to {EL}{nbsp}9 is an optional part of the upgrade process, you will need to upgrade to {EL}{nbsp}9 before you can upgrade to the next {Project} version after {ProjectVersion}.
-====
 endif::[]
 
 {SmartProxies} at version {ProjectVersionPrevious} will keep working with your upgraded {ProjectServer} {ProjectVersion}.

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -2,6 +2,8 @@
 == Upgrade paths
 
 You can upgrade to {ProjectName} {ProjectVersion} from {ProjectName} {ProjectVersionPrevious}.
+For complete instructions on how to upgrade, see xref:Upgrading_{project-context}_{context}[].
+
 The high-level steps in upgrading {Project} to {ProjectVersion} are as follows:
 
 ifdef::satellite[]
@@ -48,7 +50,3 @@ The upgrade process duration might vary depending on your hardware configuration
 
 * Upgrading {ProjectServer} takes approximately 1{range}2 hours.
 * Upgrading {SmartProxyServer} takes approximately 10{range}30 minutes.
-
-.Additional resources
-
-* For more information on the steps of the upgrade process, see xref:Upgrading_{project-context}_{context}[].

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -8,13 +8,8 @@ ifdef::satellite[]
 For more information, see {UpgradingPreviousDocURL}[_{UpgradingPreviousDocTitle}_] or {UpgradingDisconnectedPreviousDocURL}[_{UpgradingDisconnectedPreviousDocTitle}_].
 endif::[]
 
-.High-level upgrade steps
-
-The high-level steps in upgrading {Project} to {ProjectVersion} are as follows:
-
-. Upgrade {ProjectServer} to {ProjectVersion}.
-For more information, see xref:Project_Upgrade_Considerations_{context}[].
-. Upgrade all {SmartProxyServers} to {ProjectVersion}.
+Upgrading {Project} to {ProjectVersion} includes upgrading your {ProjectServer} and all {SmartProxyServers} to {ProjectVersion}.
 ifndef::foreman-deb[]
-For more information, see xref:upgrading_{smart-proxy-context}_server_{context}[].
+After the upgrade, you can also upgrade the operating system of your {ProjectServer} and {SmartProxyServers} to {EL}{nbsp}9.
 endif::[]
+For more information on the steps of the upgrade process, see xref:Upgrading_{project-context}_{context}[].

--- a/guides/common/modules/con_upgrading-overview.adoc
+++ b/guides/common/modules/con_upgrading-overview.adoc
@@ -9,8 +9,3 @@ This application provides you with an exact guide to match your current version 
 You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
 For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the Red{nbsp}Hat Customer Portal.
 endif::[]
-
-Note that you can upgrade {SmartProxies} separately from {Project}.
-ifdef::foreman-el,katello,satellite[]
-For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
-endif::[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -5,8 +5,6 @@ Upgrading to {Project} {ProjectVersion} affects your entire {Project} infrastruc
 Before proceeding, complete the following:
 
 * Read the {ProjectName} {ProjectVersion} {ReleaseNotesDocURL}[Release Notes].
-* Plan your upgrade path.
-For more information, see xref:upgrade_paths_{context}[].
 * Plan for the required downtime. {Project} services are shut down during the upgrade.
 The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
 +

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -5,13 +5,6 @@ Upgrading to {Project} {ProjectVersion} affects your entire {Project} infrastruc
 Before proceeding, complete the following:
 
 * Read the {ProjectName} {ProjectVersion} {ReleaseNotesDocURL}[Release Notes].
-* Plan for the required downtime. {Project} services are shut down during the upgrade.
-The upgrade process duration might vary depending on your hardware configuration, network speed, and the amount of data that is stored on the server.
-+
-Upgrading {Project} takes approximately 1{range}2 hours.
-+
-Upgrading {SmartProxy} takes approximately 10{range}30 minutes.
-
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
 ifndef::foreman-deb[]

--- a/guides/common/modules/con_upgrading-project.adoc
+++ b/guides/common/modules/con_upgrading-project.adoc
@@ -1,13 +1,4 @@
 [id="Upgrading_{project-context}_{context}"]
 = Upgrading {ProjectName}
 
-Use the following procedures to upgrade your existing {ProjectName} to {ProjectName} {ProjectVersion}:
-
-. Review xref:upgrading_prerequisites_{context}[].
-. xref:Project_Upgrade_Considerations_{context}[]
-ifdef::satellite[]
-. xref:synchronizing_the_new_repositories_{context}[]
-endif::[]
-ifndef::foreman-deb[]
-. xref:upgrading_{smart-proxy-context}_server_{context}[]
-endif::[]
+Use the following procedures to upgrade your existing {ProjectName} to {ProjectName} {ProjectVersion}.

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -187,3 +187,10 @@ endif::[]
 ----
 endif::[]
 include::snip_steps-needs-reboot.adoc[]
+
+ifndef::foreman-deb[]
+.Next steps
+
+* Optional: Upgrade the operating system to {EL}{nbsp}9 on the upgraded {ProjectServer}.
+For more information, see xref:upgrading_EL_on_{project-context}_or_proxy_{context}[].
+endif::[]

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -191,3 +191,10 @@ include::snip_steps-needs-reboot.adoc[]
 
 . In the {ProjectWebUI}, navigate to *Configure* > *Discovery Rules*.
  Associate selected organizations and locations with discovery rules.
+
+ifndef::foreman-deb[]
+.Next steps
+
+* Optional: Upgrade the operating system to {EL}{nbsp}9 on the upgraded {ProjectServer}.
+For more information, see xref:upgrading_EL_on_{project-context}_or_proxy_{context}[].
+endif::[]

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -5,6 +5,7 @@ This section describes how to upgrade {SmartProxyServers} from {ProjectVersionPr
 
 .Before you begin
 
+* Review xref:upgrading_prerequisites_{context}[].
 * You must upgrade {ProjectServer} before you can upgrade any {SmartProxyServers}.
 Note that you can upgrade {SmartProxies} separately from {Project}.
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
@@ -170,3 +171,10 @@ For more information on backups, see {AdministeringDocURL}backing-up-satellite-s
 . In the *whitelist_options* field, enter the options.
 . Select the schedule for the job execution in *Schedule*.
 . In the *Type of query* section, click *Static Query*.
+
+ifndef::foreman-deb[]
+.Next steps
+
+* Optional: Upgrade the operating system to {EL}{nbsp}9 on the upgraded {ProjectServer}.
+For more information, see xref:upgrading_EL_on_{project-context}_or_proxy_{context}[].
+endif::[]

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -3,7 +3,7 @@
 * Review xref:upgrading_prerequisites_{context}[].
 * Note that you can upgrade {SmartProxies} separately from {Project}.
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
-* Review and update your firewall configuration prior to upgrading your {ProjectServer}.
+* Review and update your firewall configuration.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your environment for installation] in _{InstallingServerDocTitle}_.
 ifdef::katello,orcharhino,satellite[]
 * Ensure that you do not delete the manifest from the Customer Portal or in the {ProjectWebUI} because this removes all the entitlements of your content hosts.

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -15,6 +15,7 @@ In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the templ
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
 ifdef::satellite[]
 * Optional: Clone your {ProjectServer} to test the upgrade.
+After you successfully test the upgrade on the clone, you can repeat the upgrade on your primary {ProjectServer} and discard the clone, or you can promote the clone to your primary {ProjectServer} and discard the previous primary {ProjectServer}.
 For more information, see {AdministeringDocURL}cloning_satellite_server[Cloning {ProjectServer}] in _{AdministeringDocTitle}_.
 endif::[]
 

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -13,6 +13,10 @@ Cloning is the recommended method because that prevents them being overwritten i
 To confirm if a template has been edited, you can view its *History* before you upgrade or view the changes in the audit log after an upgrade.
 In the {ProjectWebUI}, navigate to *Monitor* > *Audits* and search for the template to see a record of changes made.
 If you use the export method, restore your changes by comparing the exported template and the default template, manually applying your changes.
+ifdef::satellite[]
+* Optional: Clone your {ProjectServer} to test the upgrade.
+For more information, see {AdministeringDocURL}cloning_satellite_server[Cloning {ProjectServer}] in _{AdministeringDocTitle}_.
+endif::[]
 
 .{SmartProxy} considerations
 

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -1,5 +1,6 @@
 .Before you begin
 
+* Review xref:upgrading_prerequisites_{context}[].
 * Note that you can upgrade {SmartProxies} separately from {Project}.
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].
 * Review and update your firewall configuration prior to upgrading your {ProjectServer}.

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -20,9 +20,9 @@ endif::[]
 // Upgrading Project Server overview
 include::common/modules/con_upgrading-overview.adoc[leveloffset=+1]
 
-include::common/modules/con_upgrading-prerequisites.adoc[leveloffset=+1]
-
 include::common/modules/con_upgrade-paths.adoc[leveloffset=+1]
+
+include::common/modules/con_upgrading-prerequisites.adoc[leveloffset=+1]
 
 include::common/modules/con_upgrading-smartproxies-separately-from-project.adoc[leveloffset=+2]
 

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -17,9 +17,9 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 // Upgrading Project Server overview
 include::common/modules/con_upgrading-overview.adoc[leveloffset=+1]
 
-include::common/modules/con_upgrading-prerequisites.adoc[leveloffset=+1]
-
 include::common/modules/con_upgrade-paths.adoc[leveloffset=+1]
+
+include::common/modules/con_upgrading-prerequisites.adoc[leveloffset=+1]
 
 include::common/modules/con_upgrading-smartproxies-separately-from-project.adoc[leveloffset=+2]
 


### PR DESCRIPTION
#### What changes are you introducing?

* Adding a high-level summary of the upgrade process loosely based on [Upgrade paths](https://docs.theforeman.org/3.3/Upgrading_and_Updating/index-katello.html#upgrade_paths) in version 3.3. ~~("Loosely" because rather than re-create the original list of steps, I rather propose to add a very general summary in its place and include the other, more detailed steps as part of the assembly that actually describes upgrading.)~~
* Removing the introduction for the upgrade assembly (`guides/common/modules/con_upgrading-project.adoc`) because it's out-of-date.
* Enhancing the upgrade procedures with a few bits of information based on the old Upgrade paths section and the removed assembly introduction, to make sure we still keep the important parts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-29113 points out that the high-level upgrade steps are missing in the latest version and requests adding it.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

~~If I get an ack for this, I'd like to open another PR for 3.11 and below, but without the part about upgrading to EL 9.~~

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
