### PR TITLE
Make a disconnected upgrade requirement harder to overlook

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -36,8 +36,6 @@ ifeval::["{mode}" == "disconnected"]
 * You require access to {RHEL} and {Project} packages.
 Obtain the ISO files for {RHEL}{nbsp}9 and {Project}{nbsp}{ProjectVersion}.
 For more information, see {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] in _{InstallingServerDisconnectedDocTitle}_. 
-* Leapp completes part of the upgrade in a container that has no access to additional ISO mounts.
-The required repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
 endif::[]
 
 .Procedure
@@ -56,7 +54,13 @@ endif::[]
 ----
 ifdef::satellite[]
 ifeval::["{mode}" == "disconnected"]
-. Set up the following repositories to perform the upgrade in a disconnected environment:
+. Set up the required repositories to perform the upgrade in a disconnected environment.
++
+[IMPORTANT]
+====
+The required repositories cannot be served from a locally mounted ISO but must be delivered over the network from a different machine.
+Leapp completes part of the upgrade in a container that has no access to additional ISO mounts.
+====
 .. Add the following lines to `/etc/yum.repos.d/rhel9.repo`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

Moving an existing prerequisite from the list of prerequisites to the step where the information is relevant. (It's not really a prerequisite anyway.)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27001 notes that in its original place, the information can be easily overlooked.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
