### PR TITLE
Salt repo update

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -187,7 +187,7 @@
 :client-content-content-view-label: AlmaLinux_9
 :client-content-product-label: {client-content-content-view-label}
 :client-content-repository-label: BaseOS
-:client-salt-minion-repository-url: https://repo.saltproject.io/py3/
+:client-salt-minion-repository-url: https://packages.broadcom.com/ui/repos/tree/General/saltproject-rpm
 // Foreman Server and Smart Proxy Server
 :project-minimum-memory: 4 GB
 :project-package-check-update: dnf check-update

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -187,7 +187,6 @@
 :client-content-content-view-label: AlmaLinux_9
 :client-content-product-label: {client-content-content-view-label}
 :client-content-repository-label: BaseOS
-:client-salt-minion-repository-url: https://packages.broadcom.com/ui/repos/tree/General/saltproject-rpm
 // Foreman Server and Smart Proxy Server
 :project-minimum-memory: 4 GB
 :project-package-check-update: dnf check-update

--- a/guides/common/modules/con_introduction-to-salt.adoc
+++ b/guides/common/modules/con_introduction-to-salt.adoc
@@ -18,4 +18,4 @@ endif::[]
 
 .Additional resources
 * The https://docs.saltproject.io/en/latest/[official Salt documentation] is a good entry point when starting with Salt.
-* You can download the Salt packages from the official Salt package repository at link:https://packages.broadcom.com.
+* You can download the Salt packages from the official Salt package repository at link:https://packages.broadcom.com[].

--- a/guides/common/modules/con_introduction-to-salt.adoc
+++ b/guides/common/modules/con_introduction-to-salt.adoc
@@ -18,4 +18,4 @@ endif::[]
 
 .Additional resources
 * The https://docs.saltproject.io/en/latest/[official Salt documentation] is a good entry point when starting with Salt.
-* You can download the Salt packages from the https://repo.saltproject.io/[official Salt package repository].
+* You can download the Salt packages from the official Salt package repository at link:https://packages.broadcom.com.

--- a/guides/common/modules/con_salt-architecture.adoc
+++ b/guides/common/modules/con_salt-architecture.adoc
@@ -5,7 +5,6 @@ You need a Salt Master that either runs on your {ProjectServer} or {SmartProxySe
 You can also use an existing Salt Master by installing and configuring the relevant {SmartProxy} features on the existing Salt Master host.
 
 For more information on installing a Salt Master, consult the https://docs.saltproject.io/en/latest/[official Salt documentation].
-Alternatively, use the bootstrap instructions found in the https://repo.saltproject.io/[official Salt package repository].
 
 .Terminology
 * Hosts are referred to as _Salt Minions_.

--- a/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
+++ b/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
@@ -8,29 +8,6 @@ ifdef::suse_linux_enterprise_server[]
 * Salt minions are part of the default {client-os} repositories.
 endif::[]
 ifndef::suse_linux_enterprise_server[]
-. Create a product called `Salt`.
-For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a product].
-. Create a repository within the _Salt_ product for each operating system supported by {Project} that you want to install the Salt Minion client software on.
-ifdef::client-content-apt[]
-For more information, see {ContentManagementDocURL}Adding_Custom_Deb_Repositories_content-management[Adding Deb repositories].
-endif::[]
-ifdef::salt,client-content-dnf[]
-For more information, see {ContentManagementDocURL}Adding_Custom_RPM_Repositories_content-management[Adding RPM repositories].
-endif::[]
-+
-Add the operating system to the name of the repository, for example `Salt for {client-os} {client-os-major}`.
-+
-You can find the _upstream URL_ for the Salt packages on the https://repo.saltproject.io/[official Salt package repository].
-The URL depends on both the Salt version and the operating system, for example `{client-salt-minion-repository-url}`.
-. Synchronize the previously created products.
-For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories].
-. Create a content view for each repository.
-For more information, see {ContentManagementDocURL}Creating_a_Content_View_content-management[Creating a content view].
-. Create a composite content view for each major version of each operating system to make the new content available.
-For more information, see {ContentManagementDocURL}Creating_a_Composite_Content_View_content-management[Create a composite content view].
-. Add each of your operating system specific Salt content views to your main composite content view for that operating system and version.
-. Publish a new version of the composite content view from the previous step.
-. Promote the content view from the previous step to your lifecycle environments as appropriate.
-For more information, see {ContentManagementDocURL}Promoting_a_Content_View_content-management[Promoting a content view].
-. Optional: Create activation keys for your composite content view and lifecycle environment combinations.
+* Provide the Salt Minion repository on your host.
+For more information, see https://packages.broadcom.com/ui/repos/tree/General/saltproject-deb[Salt Minion for {DL}] and https://packages.broadcom.com/ui/repos/tree/General/saltproject-rpm[Salt Minion for {EL}].
 endif::[]

--- a/guides/doc-Managing_Configurations_Salt/master.adoc
+++ b/guides/doc-Managing_Configurations_Salt/master.adoc
@@ -33,9 +33,7 @@ include::common/modules/proc_activating-salt.adoc[leveloffset=+2]
 
 include::common/modules/proc_setting-up-salt-minions.adoc[leveloffset=+1]
 
-ifdef::orcharhino,katello[]
 include::common/modules/proc_providing-the-salt-client-to-salt-minions.adoc[leveloffset=+2]
-endif::[]
 
 include::common/modules/proc_creating-a-host-group-with-salt.adoc[leveloffset=+2]
 


### PR DESCRIPTION
#### What changes are you introducing?

Replacing links to repo.saltproject.io with up-to-date links and dropping parts of the obsolete Salt content.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The old URL for Salt package repositories is no longer available, which breaks quite a few things on our side. More details in https://saltproject.io/blog/salt-project-package-repo-migration-and-guidance/.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.) 

@maximiliankolb was kind enough to provide a patch to take my PR further than just updating the broken links.

~~I'm not sure at all whether the new links are the right ones, all I can verify is that they work. Whether they actually take users where they need to go is a different matter.~~

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
