### PR TITLE
Remove links to a chronyd section in Installing

### DIFF
--- a/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
+++ b/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server.adoc
@@ -14,8 +14,6 @@ Ensure that {ProjectServer}'s time is correctly synchronized.
 Ensure that an NTP service, such as `ntpd` or `chronyd`, is running properly on {ProjectServer}.
 Failure to provide the correct time to Amazon Web Services can lead to authentication failures.
 
-For more information about synchronizing time in {Project}, see {InstallingServerDocURL}synchronizing-the-system-clock-with-chronyd_{project-context}[Synchronizing Time] in _{InstallingServerDocTitle}_.
-
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources* and in the Compute Resources window, click *Create Compute Resource*.
 . In the *Name* field, enter a name to identify the Amazon EC2 compute resource.

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -8,13 +8,11 @@ You can use a configuration management tool to configure multiple hosts at once.
 * The host must be using a supported operating system.
 For more information, see xref:supported-clients-in-registration_{context}[].
 ifdef::satellite,orcharhino,katello[]
-* {ProjectServer} and any {SmartProxyServers} must have a time-synchronization tool enabled and running and be synchronized with the same NTP server.
-For more information, see the following resources:
-** link:{InstallingServerDocURL}synchronizing-the-system-clock-with-chronyd_{project-context}[Synchronizing the system clock with chronyd] in _{InstallingServerDocTitle}_
+* The system clock on your {ProjectServer} and any {SmartProxyServers} must be synchronized across the network.
+If the system clock is not synchronized, SSL certificate verification might fail.
 ifdef::satellite[]
-** link:{InstallingServerDisconnectedDocURL}synchronizing-the-system-clock-with-chronyd_{project-context}[Synchronizing the system clock with chronyd] in _{InstallingServerDisconnectedDocTitle}_
+For example, you can use the Chrony suite for timekeeping.
 endif::[]
-** link:{InstallingSmartProxyDocURL}synchronizing-the-system-clock-with-chronyd_{smart-proxy-context}[Synchronizing the system clock with chronyd] in _{InstallingSmartProxyDocTitle}_
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -10,9 +10,7 @@ For more information, see xref:supported-clients-in-registration_{context}[].
 ifdef::satellite,orcharhino,katello[]
 * The system clock on your {ProjectServer} and any {SmartProxyServers} must be synchronized across the network.
 If the system clock is not synchronized, SSL certificate verification might fail.
-ifdef::satellite[]
 For example, you can use the Chrony suite for timekeeping.
-endif::[]
 endif::[]
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

I'm removing (external) links to a chronyd section in the installation guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The section doesn't exist anymore, it was removed in https://github.com/theforeman/foreman-documentation/pull/3345 and https://github.com/theforeman/foreman-documentation/pull/3413.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The reference in Managing Hosts doesn't exist on 3.8 and below. The one in Provisioning Hosts is in all branches.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
