### PR TITLE
Fix VMware capitalization

### DIFF
--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -8,7 +8,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_VMware_Det
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Profiles*.
 . Select a compute profile.
-. Select a Vmware compute resource.
+. Select a VMware compute resource.
 . In the *CPUs* field, enter the number of CPUs to allocate to the host.
 . In the *Cores per socket* field, enter the number of cores to allocate to each CPU.
 . In the *Memory* field, enter the amount of memory in MiB to allocate to the host.

--- a/guides/common/modules/proc_adding-vmware-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-vmware-images-to-server.adoc
@@ -9,7 +9,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-vmware-vsp
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
-. Select your Vmware compute resource.
+. Select your VMware compute resource.
 . Click *Create Image*.
 . In the *Name* field, enter a name for the image.
 . From the *Operating System* list, select the base operating system of the image.


### PR DESCRIPTION
#### What changes are you introducing?

Properly capitalizing "VMware" instead of "Vmware" where possible.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

VMware is the proper capitalization of the compute resource.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

There are also 2 occurences in [this CLI procedure](https://docs.theforeman.org/nightly/Provisioning_Hosts/index-katello.html#cli-adding-vmware-vsphere-connection_vmware-provisioning). However, since it is a literal value for the `--provider` argument, I hesitate to change the capitalization because it may go unrecognized. Value verified with the Hammer reference that also capitalizes it as "Vmware". I think we should keep it consistent with Hammer help/reference.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **As far as without conflicts.**

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
