### PR TITLE
Review introductions to template sync procedures

### DIFF
--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -4,17 +4,13 @@ ifndef::satellite[]
 include::modules/proc_enabling-the-template-sync-plugin.adoc[leveloffset=+1]
 endif::[]
 
-include::modules/con_using-repository-sources.adoc[leveloffset=+1]
+include::modules/proc_synchronizing-templates-with-an-existing-repository.adoc[leveloffset=+1]
 
-include::modules/proc_synchronizing-templates-with-an-existing-repository.adoc[leveloffset=+2]
+include::modules/proc_synchronizing-templates-with-a-local-directory.adoc[leveloffset=+1]
 
-include::modules/proc_synchronizing-templates-with-a-local-directory.adoc[leveloffset=+2]
+include::modules/proc_importing-templates.adoc[leveloffset=+1]
 
-include::modules/con_importing-and-exporting-templates.adoc[leveloffset=+1]
-
-include::modules/proc_importing-templates.adoc[leveloffset=+2]
-
-include::modules/proc_exporting-templates.adoc[leveloffset=+2]
+include::modules/proc_exporting-templates.adoc[leveloffset=+1]
 
 ifndef::satellite[]
 include::modules/proc_uninstalling-the-foreman-templates-plugin.adoc[leveloffset=+1]

--- a/guides/common/modules/con_importing-and-exporting-templates.adoc
+++ b/guides/common/modules/con_importing-and-exporting-templates.adoc
@@ -1,6 +1,0 @@
-[id="Importing_and_Exporting_Templates_{context}"]
-= Importing and exporting templates
-
-You can import and export templates by using the {ProjectWebUI}, Hammer CLI, or {Project} API.
-{Project} API calls use the role-based access control system, which enables the tasks to be executed as any user.
-You can synchronize templates with a version control system, such as Git, or a local directory.

--- a/guides/common/modules/con_synchronizing-template-repositories.adoc
+++ b/guides/common/modules/con_synchronizing-template-repositories.adoc
@@ -2,6 +2,5 @@
 = Synchronizing template repositories
 
 In {Project}, you can synchronize repositories of job templates, provisioning templates, report templates, and partition table templates between {ProjectServer} and a version control system or local directory.
-In this chapter, a Git repository is used for demonstration purposes.
 
 This section details the workflow for installing and configuring the Template Sync plugin and performing exporting and importing tasks.

--- a/guides/common/modules/con_using-repository-sources.adoc
+++ b/guides/common/modules/con_using-repository-sources.adoc
@@ -1,4 +1,0 @@
-[id="using-repository-sources_{context}"]
-= Using repository sources
-
-You can use existing repositories or local directories to synchronize templates with your {ProjectServer}.

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -38,6 +38,8 @@ You can use the `--branch "_My_Branch_"` option to export the templates to a spe
 [id="api_Exporting_Templates_{context}"]
 .API procedure
 
+{Project} API calls use the role-based access control system, which enables the tasks to be executed as any user.
+
 . Send a `POST` request to `api/v2/templates/export`:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -1,7 +1,8 @@
 [id="Exporting_Templates_{context}"]
 = Exporting templates
 
-Use this procedure to export templates to a git repository.
+You can export templates to an existing repository.
+In this procedure, a Git repository is used for demonstration purposes.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[].
 To use the API, see the xref:api_Exporting_Templates_{context}[].

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -2,7 +2,6 @@
 = Exporting templates
 
 You can export templates to an existing repository.
-In this procedure, a Git repository is used for demonstration purposes.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[].
 To use the API, see the xref:api_Exporting_Templates_{context}[].
@@ -37,8 +36,6 @@ You can use the `--branch "_My_Branch_"` option to export the templates to a spe
 
 [id="api_Exporting_Templates_{context}"]
 .API procedure
-
-{Project} API calls use the role-based access control system, which enables the tasks to be executed as any user.
 
 . Send a `POST` request to `api/v2/templates/export`:
 +

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -68,8 +68,6 @@ For example `--filter '.*Ansible Default$'` imports various Ansible Default temp
 [id="api_Importing_Templates_{context}"]
 .API procedure
 
-{Project} API calls use the role-based access control system, which enables the tasks to be executed as any user.
-
 . Send a `POST` request to `api/v2/templates/import`:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -67,6 +67,8 @@ For example `--filter '.*Ansible Default$'` imports various Ansible Default temp
 [id="api_Importing_Templates_{context}"]
 .API procedure
 
+{Project} API calls use the role-based access control system, which enables the tasks to be executed as any user.
+
 . Send a `POST` request to `api/v2/templates/import`:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -85,4 +85,4 @@ If the import is successful, you receive `{"message":"Success"}`.
 .Ansible procedure
 * Use the `{ansible-namespace}.templates_import` module.
 
-For more information, see the Ansible Module documentation with `ansible-doc {ansible-namespace}.templates_import`.
+For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.templates_import`.

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -34,6 +34,7 @@ organizations:
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[].
 To use the API, see the xref:api_Importing_Templates_{context}[].
+To use Ansible, see the xref:ansible_Importing_Templates_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.
@@ -81,3 +82,9 @@ For example `--filter '.*Ansible Default$'` imports various Ansible Default temp
 ----
 +
 If the import is successful, you receive `{"message":"Success"}`.
+
+[id="ansible_Importing_Templates_{context}"]
+.Ansible procedure
+* Use the `{ansible-namespace}.templates_import` module.
+
+For more information, see the Ansible Module documentation with `ansible-doc {ansible-namespace}.templates_import`.

--- a/guides/common/modules/proc_synchronizing-templates-with-a-local-directory.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-a-local-directory.adoc
@@ -1,7 +1,7 @@
 [id="Synchronizing_Templates_with_a_Local_Directory_{context}"]
 = Synchronizing templates with a local directory
 
-If you store templates in a local directory that is tracked under a version control system, you can configure {Project} to synchronize the templates between your {ProjectServer} and the local directory.
+If you store templates in a local directory that is tracked under a version control system, you can synchronize the templates between your {ProjectServer} and the local directory.
 
 .Prerequisites
 * Each template must contain the location and organization that the template belongs to.

--- a/guides/common/modules/proc_synchronizing-templates-with-a-local-directory.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-a-local-directory.adoc
@@ -26,7 +26,7 @@ organizations:
 ----
 
 .Procedure
-. In `/var/lib/foreman`, create a directory for storing templates:
+. On your {ProjectServer}, in `/var/lib/foreman`, create a directory for storing templates:
 +
 [subs="+quotes"]
 ----

--- a/guides/common/modules/proc_synchronizing-templates-with-a-local-directory.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-a-local-directory.adoc
@@ -1,9 +1,7 @@
 [id="Synchronizing_Templates_with_a_Local_Directory_{context}"]
 = Synchronizing templates with a local directory
 
-Synchronizing templates with a local directory is useful if you have configured a version control repository in the local directory.
-That way, you can edit templates and track the history of edits in the directory.
-You can also synchronize changes to {ProjectServer} after editing the templates.
+If you store templates in a local directory that is tracked under a version control system, you can configure {Project} to synchronize the templates between your {ProjectServer} and the local directory.
 
 .Prerequisites
 * Each template must contain the location and organization that the template belongs to.

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -1,7 +1,7 @@
 [id="synchronizing-templates-with-an-existing-repository_{context}"]
 = Synchronizing templates with an existing repository
 
-If you store templates in a repository under a version control system, you can configure {Project} to connect to the repository and to keep the templates between your {ProjectServer} and the repository synchronized.
+If you store templates in a repository under a version control system, you can synchronize the templates between your {ProjectServer} and the repository.
 
 In this procedure, a Git repository is used for demonstration purposes.
 

--- a/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-templates-with-an-existing-repository.adoc
@@ -1,7 +1,9 @@
 [id="synchronizing-templates-with-an-existing-repository_{context}"]
 = Synchronizing templates with an existing repository
 
-Use this procedure to synchronize templates between your {ProjectServer} and an existing repository.
+If you store templates in a repository under a version control system, you can configure {Project} to connect to the repository and to keep the templates between your {ProjectServer} and the repository synchronized.
+
+In this procedure, a Git repository is used for demonstration purposes.
 
 .Procedure
 . If you want to use HTTPS to connect to the repository and you use a self-signed certificate authority (CA) on your Git server:


### PR DESCRIPTION
#### What changes are you introducing?

I propose to drop some of the existing introductions and extend the others with a few more details. Additionally, I noticed that one of the introductions did not include Ansible as one of the tools to import templates so I added a reference to it.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Currently, the template sync assembly uses two "container" assemblies (one for configuring repos, the other for import/export procedures). But I think these just add complexity to the structure without offering a clear benefit. Removing them will certainly make things easier for us to maintain (fewer files, fewer includes).

At the same time, consolidating the explanatory information in the remaining introductions ensures that each of the introductions has something meaningful to say.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
