### PR TITLE
hide "dnf needs-restarting" on Satellite, foreman-maintain does hint

### DIFF
--- a/guides/common/modules/snip_steps-needs-reboot.adoc
+++ b/guides/common/modules/snip_steps-needs-reboot.adoc
@@ -1,3 +1,4 @@
+ifndef::satellite[]
 . Determine if the system needs a reboot:
 ifdef::foreman-deb[]
 +
@@ -13,6 +14,10 @@ ifndef::foreman-deb[]
 ----
 # dnf needs-restarting --reboothint
 ----
+. If the previous command told you to reboot, then reboot the system:
+endif::[]
+endif::[]
+ifdef::satellite[]
 . If the previous command told you to reboot, then reboot the system:
 endif::[]
 +


### PR DESCRIPTION
#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
