### PR TITLE
Fix capitalization of "Ansible module"

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -85,7 +85,7 @@ For more information, see the Hammer CLI help with `hammer host-registration gen
 .Ansible procedure
 * Use the `{ansible-namespace}.registration_command` module.
 
-For more information, see the Ansible Module documentation with `ansible-doc {ansible-namespace}.registration_command`.
+For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.registration_command`.
 
 .API procedure
 * Use the `POST /api/registration_commands` resource.


### PR DESCRIPTION
#### What changes are you introducing?

Fixing capitalization.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3428#discussion_r1832107472

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
