### PR TITLE
Add list of required SUSE content for host registration

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -40,6 +40,11 @@ ifdef::orcharhino[]
 +
 include::snip_creating-os-on-orcharhino.adoc[]
 endif::[]
+ifdef::orcharhino[]
+ifdef::suse_linux_enterprise_server[]
+include::snip_prerequisites-content-for-sles.adoc[]
+endif::[]
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.

--- a/guides/common/modules/snip_prerequisites-content-for-sles.adoc
+++ b/guides/common/modules/snip_prerequisites-content-for-sles.adoc
@@ -1,0 +1,47 @@
+// do not use any attributes in the table to simplify search using "grep"
+* Ensure that you have synchronized the required content to {Project}.
+The following table shows a list of required Yum repositories to register hosts running {SLES}.
++
+[width="100%",cols="20%,40%,40%,options="header"]
+|===
+|Operating system |Products in SCC Manager |Content on {Project}
+
+|SUSE Linux Enterprise Server 12 SP5
+a|* `SUSE Linux Enterprise Server 12 SP5 x86_64`
+a|* `SUSE Linux Enterprise Server 12 SP5 x86_64` > `SLES12-SP5-Pool for sle-12-x86_64`
+
+|SUSE Linux Enterprise Server 15 SP2
+a|* `SUSE Linux Enterprise Server 15 SP2 x86_64` including `Basesystem Module 15 SP2 x86_64` and `Python 2 Module 15 SP2 x86_64`
+a|
+* `Basesystem Module 15 SP2 x86_64` > `SLE-Module-Basesystem15-SP2-Pool for sle-15-x86_64`
+* `Python 2 Module 15 SP2 x86_64` > `SLE-Module-Python2-15-SP2-Pool for sle-15-x86_64`
+* `SUSE Linux Enterprise Server 15 SP2 x86_64` > `SLE-Product-SLES15-SP2-Pool for sle-15-x86_64`
+
+|SUSE Linux Enterprise Server 15 SP3
+a|* `SUSE Linux Enterprise Server 15 SP3 x86_64` including `Basesystem Module 15 SP3 x86_64` and `Python 2 Module 15 SP3 x86_64`
+a|
+* `Basesystem Module 15 SP3 x86_64` > `SLE-Module-Basesystem15-SP3-Pool for sle-15-x86_64`
+* `Python 2 Module 15 SP3 x86_64` > `SLE-Module-Python2-15-SP3-Pool for sle-15-x86_64`
+* `SUSE Linux Enterprise Server 15 SP3 x86_64` > `SLE-Product-SLES15-SP3-Pool for sle-15-x86_64`
+
+|SUSE Linux Enterprise Server 15 SP4
+a|* `SUSE Linux Enterprise Server 15 SP4 x86_64` including `Basesystem Module 15 SP4 x86_64`
+a|
+* `Basesystem Module 15 SP4 x86_64` > `SLE-Module-Basesystem15-SP4-Pool for sle-15-x86_64`
+* `SUSE Linux Enterprise Server 15 SP4 x86_64` > `SLE-Product-SLES15-SP4-Pool for sle-15-x86_64`
+
+|SUSE Linux Enterprise Server 15 SP5
+a|* `SUSE Linux Enterprise Server 15 SP5 x86_64` including `Basesystem Module 15 SP5 x86_64`
+a|
+* `Basesystem Module 15 SP5 x86_64` > `SLE-Module-Basesystem15-SP5-Pool for sle-15-x86_64`
+* `SUSE Linux Enterprise Server 15 SP5 x86_64` > `SLE-Product-SLES15-SP5-Pool for sle-15-x86_64`
+
+|SUSE Linux Enterprise Server 15 SP6
+a|* `SUSE Linux Enterprise Server 15 SP6 x86_64` including `Basesystem Module 15 SP6 x86_64`
+a|
+* `Basesystem Module 15 SP6 x86_64` > `SLE-Module-Basesystem15-SP6-Pool for sle-15-x86_64`
+* `SUSE Linux Enterprise Server 15 SP6 x86_64` > `SLE-Product-SLES15-SP6-Pool for sle-15-x86_64`
+|===
++
+You can use the SCC Manager plugin to import SUSE products and repositories.
+For more information, see {ContentManagementDocURL}Managing_SUSE_Content_content-management[Managing SUSE content] in _{ContentManagementDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

Add table to help users with registering SLES hosts to Foreman+Katello

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

current table in downstream only contains the repositories but not the way to get there content > products > _a product_ > _a repository_.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

table is already part of orcharhino downstream docs; it's only added the products that contain the required repositories

* https://docs.orcharhino.com/or/docs/sources/guides/suse_linux_enterprise_server/managing_hosts/registering_hosts.html#Registering_Hosts_Using_the_Bootstrap_Script
* https://www.suse.com/lifecycle#suse-linux-enterprise-server-15

no diff is to be expected because the snippet is only included for SLES. If you have an idea on how to provide this to upstream Katello users, please let me know.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
