### PR TITLE
Add link to Admin Guide for SCA

### DIFF
--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -13,6 +13,9 @@ Simple Content Access (SCA) is set on the organization, not the manifest.
 Importing a manifest does not change your organization's Simple Content Access status.
 ====
 
+Simple Content Access simplifies the entitlement experience for administrators.
+For more information, see the link:https://access.redhat.com/subscription_mgmt_guide_for_RHEL[Subscription Management Administration Guide for Red Hat Enterprise Linux] on the Red Hat Customer Portal.
+
 .Prerequisites
 ifeval::["{mode}" == "connected"]
 * Ensure you have a Red{nbsp}Hat subscription manifest exported from the {RHCloud}.

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -13,7 +13,7 @@ Simple Content Access (SCA) is set on the organization, not the manifest.
 Importing a manifest does not change your organization's Simple Content Access status.
 ====
 
-Simple Content Access simplifies the entitlement experience for administrators.
+Simple Content Access simplifies the subscription experience for administrators.
 For more information, see the link:https://access.redhat.com/subscription_mgmt_guide_for_RHEL[Subscription Management Administration Guide for Red Hat Enterprise Linux] on the Red Hat Customer Portal.
 
 .Prerequisites


### PR DESCRIPTION
#### What changes are you introducing?
Adding a link to a KCS article.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Entitlement-based subscription management has been removed. 
You must use Simple Content Access (SCA), which simplifies the entitlement 
experience for administrators. 
https://access.redhat.com/subscription_mgmt_guide_for_RHEL

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
