### PR TITLE
Retire branches older than 3.7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,4 @@ Please cherry-pick my commits into:
 * [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
 * [ ] Foreman 3.8/Katello 4.10
 * [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
-* [ ] Foreman 3.6/Katello 4.8
-* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
-* We do not accept PRs for Foreman older than 3.5.
+* We do not accept PRs for Foreman older than 3.7.


### PR DESCRIPTION
#### What changes are you introducing?

Retiring branches older than 3.7

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because [Satellite 6.13 becomes EOL on November 30, 2024](https://access.redhat.com/support/policy/updates/satellite/)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

@maximiliankolb orcharhino okay with that?

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

### Merge after November 30!