### PR TITLE
Deprecate running on Debian 11

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -34,4 +34,11 @@ endif::[]
 [id="foreman-deprecations"]
 == Deprecations
 
+ifndef::foreman-deb[]
 There are no deprecations with Foreman {ProjectVersion}.
+endif::[]
+ifdef::foreman-deb[]
+Now that Debian 12 is supported, Foreman 3.14 will drop support for Debian 11.
+Note this is for running Foreman itself.
+Clients will remain supported.
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Add a release note that Foreman 3.14 will drop the support for running on Debian 11.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I still need to open an RFC for this, but this allows RC1 to be announced with it already.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is only for 3.13.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.