### PR TITLE
Fix hidden headings behind navigation bar [upstream only]

### DIFF
--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -837,6 +837,20 @@ body.toc2 #header>h1:nth-last-child(2) {
   line-height: 1.44
 }
 
+h1:before,
+h2:before,
+h3:before,
+h4:before,
+h5:before,
+h6:before,
+div.title:before {
+  display: block;
+  content: " ";
+  height: 90px;      /* Height of nav bar */
+  margin-top: -90px; /* Negative margin of nav bar */
+  visibility: hidden;
+}
+
 .sect1 {
   padding-bottom: .625em
 }


### PR DESCRIPTION
#### What changes are you introducing?

Fixing problem with misplaced headings when clicking an item in the TOC

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

UX improvement for Foreman Docs.

Previously, when you clicked an item in the table of contents, the browser scrolled to the top of the page and the actual heading was hidden behind the navigation bar.
With this fix, the heading is visible.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
