### PR TITLE
Include Hammer and API guides for all builds

### DIFF
--- a/guides/common/modules/con_api-overview.adoc
+++ b/guides/common/modules/con_api-overview.adoc
@@ -18,7 +18,5 @@ API commands differ between versions of {Project}.
 When you prepare to upgrade {ProjectServer}, update all the scripts that contain {Project} API commands.
 ====
 
-ifdef::satellite[]
 .Additional resources
 * See {APIDocURL}[_{APIDocTitle}_] for details on using the {Project} API.
-endif::[]

--- a/guides/common/modules/con_hammer-cli-overview.adoc
+++ b/guides/common/modules/con_hammer-cli-overview.adoc
@@ -22,7 +22,5 @@ In the background, each Hammer command first establishes a binding to the API, t
 This can have performance implications when executing a large number of Hammer commands in sequence.
 In contrast, scripts that use API commands communicate directly with the Satellite API and they establish the binding only once.
 
-ifdef::satellite[]
 .Additional resources
 * See {HammerDocURL}[_{HammerDocTitle}_] for details on using Hammer CLI.
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

I'm removing conditionals that include links to Hammer and API guides for Satellite only.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The ifdefs are there because previously, these guides were available for Satellite only. That changed with https://github.com/theforeman/foreman-documentation/pull/3212 and https://github.com/theforeman/foreman-documentation/pull/3212.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

There might be more links like this in the docs set but I came across these two and thought I'd fix them right away rather than wait till I have time to search for others.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)

No further because the modules don't exist on lower branches.