### PR TITLE
Fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 Please cherry-pick my commits into:
 
-* [ ] Foreman 3.13/Katello 4.15 (Satellite 6.17)
+* [ ] Foreman 3.13/Katello 4.15
 * [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
 * [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
 * [ ] Foreman 3.10/Katello 4.12


### PR DESCRIPTION
#### What changes are you introducing?

Removing Satellite 6.17 from the PR template.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because Satellite 6.17 will be based on Foreman 3.14, not 3.13.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
