### PR TITLE
Add EL 9 to EL 10 Leapp host upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
@@ -6,6 +6,7 @@ Below upgrade paths are possible:
 
 * {EL} 7 to {EL} 8
 * {EL} 8 to {EL} 9
+* {EL} 9 to {EL} 10
 
 .Prerequisites
 * Ensure that your {EL} hosts meet the requirements for the upgrade.


### PR DESCRIPTION
#### What changes are you introducing?

Leapp upgrade of hosts to EL 10

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because EL 10 hosts will be supported in Foreman 3.14 / Satellite 6.17

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

* [ ] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
