### PR TITLE
Fix permissions required to register a host

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -4,7 +4,7 @@
 You can register a host by using registration templates and set up various integration features and host tools during the registration process.
 
 .Prerequisites
-* Your user account has a role assigned that grants the `create_hosts` permission.
+* Your {Project} account has the *Register hosts* role assigned or a role with equivalent permissions.
 * You must have root privileges on the host that you want to register.
 * You must have installed either `curl` or `wget` on the host that you want to register.
 * You have configured your host for registration.


### PR DESCRIPTION
#### What changes are you introducing?

Fixing permissions required to register a host

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The `create_hosts` permission is insufficient. The user must have the role *Register hosts* or equivalent.

Requested in https://issues.redhat.com/browse/SAT-29409

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- The *Register hosts* role lists 19 permissions and it's a default role provided by Foreman. Instead of listing all permissions, I'm just mentioning the role or its equivalent. I believe that a user admin would be able figure out the rest based on this info.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [x] Foreman 3.6/Katello 4.8
* [x] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
