### PR TITLE
Document download policy for file-type content

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -24,6 +24,8 @@ Clear this field if the repository does not require authentication.
 Clear this field if the repository does not require authentication.
 . Optional: In the *Upstream Authentication Token* field, provide the token of the upstream repository user for authentication.
 Leave this field empty if the repository does not require authentication.
+. From the *Download Policy* list, select the type of synchronization {ProjectServer} performs.
+For more information, see xref:Download_Policies_Overview_{context}[].
 . From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
 For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.


### PR DESCRIPTION
Refs Redmine issue 37929
Refs katello PR 11184 on GitHub

#### What changes are you introducing?

docs for "Download Policy" list

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

it was added to katello recently: https://github.com/Katello/katello/pull/11184

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

wording is identical to custom rpm/deb repositories

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks