### PR TITLE
Clarify support content types for exports

### DIFF
--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -10,6 +10,8 @@ Note that this requires both the Export and Import servers to run {Project} {Pro
 
 include::snip_generating-content.adoc[]
 
+include::snip_content-types-syncable-export.adoc[]
+
 .Prerequisites
 * Ensure that you set the download policy to *Immediate* for all repositories within the content view you export.
 For more information, see xref:Download_Policies_Overview_{context}[].

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -10,6 +10,8 @@ Content view versions that have multiple {RHEL} trees can occupy several gigabyt
 In such cases, you can create an incremental export which contains only pieces of content that have changed since the last export.
 Incremental exports typically result in smaller archive files than the full exports.
 
+include::snip_content-types-export.adoc[]
+
 .Procedure
 . Create an incremental export:
 +

--- a/guides/common/modules/proc_exporting-a-content-view-version.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version.adoc
@@ -10,15 +10,9 @@ The exported archive file contains the following data:
 * A JSON file containing content view version metadata
 * An archive file containing all the repositories included into the content view version
 
-ifdef::client-content-dnf[]
-You can only export Yum repositories, Kickstart files, and Docker content added to a version of a content view.
-endif::[]
-ifndef::client-content-dnf[]
-You can only export Deb and Yum repositories, Kickstart files, and Docker content added to a version of a content view.
-endif::[]
-{Project} does not export the following content:
+include::snip_content-types-export.adoc[]
 
-* Content view definitions and metadata, such as package filters.
+{Project} does not export content view definitions and metadata such as package filters.
 
 .Prerequisites
 

--- a/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
@@ -5,6 +5,8 @@ You can export the content of a repository in the Library environment of an orga
 
 include::snip_generating-content.adoc[]
 
+include::snip_content-types-syncable-export.adoc[]
+
 .Prerequisites
 * Ensure that you set the download policy to *Immediate* for the repository within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -7,6 +7,8 @@ A typical {RHEL} tree may occupy several gigabytes of space on {ProjectServer}.
 In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
 Incremental exports typically result in smaller archive files than full exports.
 
+include::snip_content-types-syncable-export.adoc[]
+
 The procedure below shows an incremental export of a repository in the Library lifecycle environment.
 
 .Procedure

--- a/guides/common/modules/proc_exporting-a-repository-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally.adoc
@@ -7,6 +7,8 @@ A typical {RHEL} tree may occupy several gigabytes of space on {ProjectServer}.
 In such cases, you can use *Incremental Export* to export only pieces of content that changed since the previous export.
 Incremental exports typically result in smaller archive files than the full exports.
 
+include::snip_content-types-export.adoc[]
+
 The example below shows incremental export of a repository in the Library lifecycle environment.
 
 .Procedure

--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -4,20 +4,7 @@
 You can export the content of a repository in the Library environment of an organization from {ProjectServer}.
 You can use this archive file to create the same repository in another {ProjectServer} or in another {ProjectServer} organization.
 
-You can export the following content from {ProjectServer}:
-
-* Ansible repositories
-* Kickstart repositories
-* Yum repositories
-* File repositories
-* Docker content
-ifdef::orcharhino[]
-* Deb repositories
-endif::[]
-
-ifndef::satellite,orcharhino[]
-You cannot export Deb repositories from {ProjectServer}.
-endif::[]
+include::snip_content-types-export.adoc[]
 
 The export contains the following data:
 

--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -1,7 +1,7 @@
 [id="Exporting_the_Library_Environment_in_a_Syncable_Format_{context}"]
 = Exporting the library environment in a syncable format
 
-You can export contents of all yum repositories, Kickstart repositories and file repositories in the Library environment of an organization to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
+You can export content in the Library environment of an organization to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
 
 ifdef::satellite[]
 You can then serve the generated content on a local web server and synchronize it on the importing {ProjectServer} or in another {ProjectServer} organization.
@@ -11,13 +11,7 @@ You can use the generated content to create the same repository in another {Proj
 On import of the exported archive, a regular content view is created or updated on your importing {ProjectServer}.
 For more information, see xref:Importing_a_Content_View_Version_{context}[].
 
-You can export the following content in the syncable format from {ProjectServer}:
-
-* Yum repositories
-* Kickstart repositories
-* File repositories
-
-You cannot export Ansible, Deb, or Docker content.
+include::snip_content-types-syncable-export.adoc[]
 
 The export contains directories with the packages, *listing* files, and metadata of the repository in Yum format that can be used to synchronize in the importing {ProjectServer}.
 

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
@@ -10,6 +10,8 @@ Organizations that have multiple {RHEL} trees can occupy several gigabytes of sp
 In such cases, you can create an incremental export which contains only pieces of content that have changed since the last export.
 Incremental exports typically result in smaller archive files than the full exports.
 
+include::snip_content-types-export.adoc[]
+
 The example below shows incremental export of all repositories in the organization's Library.
 
 .Procedure

--- a/guides/common/modules/proc_exporting-the-library-environment.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment.adoc
@@ -1,13 +1,13 @@
 [id="Exporting_the_Library_Environment_{context}"]
 = Exporting the Library environment
 
-You can export contents of all Yum repositories in the Library environment of an organization to an archive file from {ProjectServer} and use this archive file to create the same repositories in another {ProjectServer} or in another {ProjectServer} organization.
+You can export content in the Library environment of an organization to an archive file from {ProjectServer} and use this archive file to create the same repositories in another {ProjectServer} or in another {ProjectServer} organization.
 The exported archive file contains the following data:
 
 * A JSON file containing content view version metadata.
 * An archive file containing all the repositories from the Library environment of the organization.
 
-{ProjectServer} exports only RPM, Kickstart files, and Docker content included in the Library environment.
+include::snip_content-types-export.adoc[]
 
 .Prerequisites
 * Ensure that the export directory has free storage space to accommodate the export.

--- a/guides/common/modules/snip_content-types-export.adoc
+++ b/guides/common/modules/snip_content-types-export.adoc
@@ -1,0 +1,10 @@
+You can export the following content from {ProjectServer}:
+
+* Ansible collections
+ifdef::katello,orcharhino[]
+* Deb content
+endif::[]
+* Docker content
+* {customfiletypeFirstCap} content
+* Kickstart repositories
+* Yum content

--- a/guides/common/modules/snip_content-types-syncable-export.adoc
+++ b/guides/common/modules/snip_content-types-syncable-export.adoc
@@ -1,0 +1,14 @@
+You can export the following content types in the syncable format from {ProjectServer}:
+
+* {customfiletypeFirstCap} content
+* Kickstart repositories
+* Yum content
+
+You cannot export
+ifdef::satellite[]
+Ansible collections or Docker content
+endif::[]
+ifndef::satellite[]
+Ansible collections, Deb content, or Docker content
+endif::[]
+in the syncable format.

--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -20,12 +20,4 @@ For more information, see xref:Importing_a_Content_View_Version_{context}[].
 endif::[]
 endif::[]
 
-You can export the following content in a syncable format from {ProjectServer}:
-
-* Yum repositories
-* Kickstart repositories
-* File repositories
-
-You cannot export Ansible, Deb, or Docker content.
-
 The export contains directories with the packages, *listing* files, and metadata of the repository in Yum format that can be used to synchronize in the importing {ProjectServer}.

--- a/guides/common/modules/snip_syncable-exports.adoc
+++ b/guides/common/modules/snip_syncable-exports.adoc
@@ -1,7 +1,3 @@
 +
 If you want to create a syncable export, add `--format=syncable`.
 By default, {Project} creates an importable export.
-+
-ifndef::satellite[]
-You can only export in syncable format for Yum and file-type content.
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

You can export all supported content types in "importable" format which is the default. You cannot export Ansible, Deb, or Docker content in "syncable" format.

* Add snippet for supported content to export content
* Add snippet for supported content to export content in syncable format
* Hide Deb content for Satellite
* List content types in alphabetical order
* Support exporting Deb content

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It was not clear that Foreman+Katello supports exporting/importing Deb content but not Deb content in syncable format.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

**alternative implementation idea**: add a small concept file that lists supported content types for export in importable format and exports in syncable formats. That would have the benefit of us not including the snippets a dozen times. Downside: users would have to read more than just the procedure.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (Satellite 6.17)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* [ ] Foreman 3.6/Katello 4.8
* [ ] Foreman 3.5/Katello 4.7 (Satellite 6.13; orcharhino 6.6/6.7)
* We do not accept PRs for Foreman older than 3.5.
