### PR TITLE
Fix the asciidoc URL syntax in Foreman's headline features

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -15,14 +15,14 @@ Single-host actions - Additionally, you can click the vertical ellipsis in the r
 
 Column selector - You can now click Manage Columns and customize columns displayed in the table. The column options are the same as those on the legacy All Hosts page. Any changes made here will also reflect on the legacy All Hosts page, and vice versa.
 
-For more information, see  #37395[https://projects.theforeman.org/issues/37395], #37551[https://projects.theforeman.org/issues/37551], #37690[https://projects.theforeman.org/issues/37690], #37675[https://projects.theforeman.org/issues/37675], #37478[https://projects.theforeman.org/issues/37478], #37293[https://projects.theforeman.org/issues/37293].
+For more information, see https://projects.theforeman.org/issues/37395[#37395], https://projects.theforeman.org/issues/37551[#37551], https://projects.theforeman.org/issues/37690[#37690], https://projects.theforeman.org/issues/37675[#37675], https://projects.theforeman.org/issues/37478[#37478], https://projects.theforeman.org/issues/37293[#37293].
 
 === Puppet 8 support
 
 Foreman 3.12 now fully supports Puppet 8.
 While Foreman 3.11 unofficially supported Puppet 8, Puppet's official puppetserver RPMs are known to break on Java.
 The installer now handles this for users.
-For more information, see #37686[https://projects.theforeman.org/issues/37686].
+For more information, see https://projects.theforeman.org/issues/37686[#37686].
 Users are encouraged to upgrade since Puppet 7 is expected to go end of life in February 2025.
 
 [id="foreman-upgrade-warnings"]


### PR DESCRIPTION
#### What changes are you introducing?

Fixing asciidoc syntaxa.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The [URL macro](https://docs.asciidoctor.org/asciidoc/latest/macros/url-macro/) was used incorrectly as `label[url]` instead of `url[label]`.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.