### PR TITLE
Avoid or clarify /etc/foreman-installer/scenarios.d references

### DIFF
--- a/guides/common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc
+++ b/guides/common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc
@@ -11,10 +11,10 @@
 
 .Verification
 ifndef::orcharhino[]
-Ensure the following parameters in `/etc/foreman-installer/scenarios.d/{project-context}-answers.yaml` have no values:
+Verify that the following parameters in `/etc/foreman-installer/scenarios.d/{project-context}-answers.yaml` have no values:
 endif::[]
 ifdef::orcharhino[]
-Ensure the following parameters in `/etc/foreman-installer/scenarios.d/katello-answers.yaml` have no values:
+Verify that the following parameters in `/etc/foreman-installer/scenarios.d/katello-answers.yaml` have no values:
 endif::[]
 
 * server_cert:

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -42,6 +42,7 @@ For more information about automating {Project} using {Project} Ansible collecti
 [[Answer_file]]
 Answer file:: A configuration file that defines settings for an installation scenario.
 Answer files are defined in the YAML format and stored in the `/etc/foreman-installer/scenarios.d/` directory.
+To see the default values for installation scenario parameters, use the `{foreman-installer} --full-help` command on your {ProjectServer}.
 
 [[ARF_report]]
 ARF report::


### PR DESCRIPTION
#### What changes are you introducing?

Removing one reference to `scenarios.d/` and clarifying two others in a way that (hopefully) ensures that users will not update its contents.

EDIT: One of the references to `scenarios.d/` was resolved separately in https://github.com/theforeman/foreman-documentation/pull/3486.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/issues/190

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I couldn't find a way to completely avoid mentioning scenarios.d/ in all of the existing occurrences.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
