### PR TITLE
Revert "Include links to Hammer and API guides for all builds (#3455)"

### DIFF
--- a/guides/common/modules/con_api-overview.adoc
+++ b/guides/common/modules/con_api-overview.adoc
@@ -18,5 +18,7 @@ API commands differ between versions of {Project}.
 When you prepare to upgrade {ProjectServer}, update all the scripts that contain {Project} API commands.
 ====
 
+ifdef::satellite[]
 .Additional resources
 * See {APIDocURL}[_{APIDocTitle}_] for details on using the {Project} API.
+endif::[]

--- a/guides/common/modules/con_hammer-cli-overview.adoc
+++ b/guides/common/modules/con_hammer-cli-overview.adoc
@@ -22,5 +22,7 @@ In the background, each Hammer command first establishes a binding to the API, t
 This can have performance implications when executing a large number of Hammer commands in sequence.
 In contrast, scripts that use API commands communicate directly with the Satellite API and they establish the binding only once.
 
+ifdef::satellite[]
 .Additional resources
 * See {HammerDocURL}[_{HammerDocTitle}_] for details on using Hammer CLI.
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

This reverts https://github.com/theforeman/foreman-documentation/pull/3455, to be included in branches 3.11, 3.10, and 3.9.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

When cherry-picking https://github.com/theforeman/foreman-documentation/pull/3455, I didn't realize that the Hammer and API guides are not available for all builds on these branches.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Sorry!

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
