### PR TITLE
Introduce substeps for rex pull mode based on yggdrasil version

### DIFF
--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -9,6 +9,13 @@ Hosts do not require an SSH connection from their {SmartProxyServer}.
 * The {SmartProxy} through which the host is registered is configured to use `pull-mqtt` mode.
 For more information, see {InstallingSmartProxyDocURL}configuring-remote-execution-for-pull-client_{smart-proxy-context}[Configuring pull-based transport for remote execution] in _{InstallingSmartProxyDocTitle}_.
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
+ifdef::foreman-el[]
+* The AppStream repository is available for the host.
+endif::[]
+ifndef::foreman-el[]
+* The AppStream repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
+For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
+endif::[]
 * The host can communicate with its {SmartProxy} over MQTT using port `1883`.
 * The host can communicate with its {SmartProxy} over HTTPS.
 
@@ -47,13 +54,43 @@ ifdef::client-content-zypper[]
 ----
 endif::[]
 
-+
-The package installs `foreman_ygg_worker` and `yggdrasil` as dependencies, configures the `yggdrasil` client, and starts the pull client worker on the host.
-
 .Verification
-* Check the status of the `yggdrasild` service:
+. Determine which version of the `yggdrasil` package is installed on the host:
++
+ifdef::satellite[]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+endif::[]
+ifndef::satellite[]
+* On {EL} and {SLES} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+endif::[]
+ifdef::client-content-apt[]
+* On {DL} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ dpkg-query --show yggdrasil-mqtt
+----
+endif::[]
+. Check the status of the Yggdrasil services:
+* If your host has `yggdrasil` version 0.4.z or later installed:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl status yggdrasil com.redhat.Yggdrasil1.Worker1.foreman
+----
+* If your host has `yggdrasil` version 0.2.z or earlier installed:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # systemctl status yggdrasild
 ----
+
+If the services are running, you have successfully configured the host to use the pull client.

--- a/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-pull-mode.adoc
+++ b/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-pull-mode.adoc
@@ -3,10 +3,35 @@
 
 By default, {Project} uses the `/run` directory on hosts for remote execution jobs in pull mode.
 If the `/run` directory on your host is mounted with the `noexec` flag, {Project} cannot execute remote execution job scripts in this directory.
-You can use the `yggdrasild` service to set an alternative directory for executing remote execution jobs in pull mode.
+You can use the Yggdrasil service to set an alternative directory for executing remote execution jobs in pull mode.
+
+.Prerequisite
+* Determine which version of the `yggdrasil` package is installed on the host:
+ifdef::satellite[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+endif::[]
+ifndef::satellite[]
+** On {EL} and {SLES} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+endif::[]
+ifdef::client-content-apt[]
+** On {DL} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ dpkg-query --show yggdrasil-mqtt
+----
+endif::[]
 
 .Procedure
-On your host, perform these steps:
 
 . Create a new directory:
 +
@@ -14,7 +39,14 @@ On your host, perform these steps:
 ----
 # mkdir _/My_Remote_Working_Directory_
 ----
-. Access the `yggdrasild` service configuration:
+. Access the Yggdrasil service configuration:
+* If your host has `yggdrasil` version 0.4.z or later installed:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl edit com.redhat.Yggdrasil1.Worker1.foreman
+----
+* If your host has `yggdrasil` version 0.2.z or earlier installed:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -26,7 +58,14 @@ On your host, perform these steps:
 ----
 Environment=FOREMAN_YGG_WORKER_WORKDIR=_/My_Remote_Working_Directory_
 ----
-. Restart the `yggdrasild` service:
+. Restart the Yggdrasil services:
+* If your host has `yggdrasil` version 0.4.z or later installed:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl restart yggdrasil com.redhat.Yggdrasil1.Worker1.foreman
+----
+* If your host has `yggdrasil` version 0.2.z or earlier installed:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Updating documentation on configuring Rex in pull mode, introducing substeps based on which version of yggdrasil is available on the host.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-packaging/pull/11317

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

~~Draft because I still need to cover:~~

~~* https://github.com/theforeman/foreman-packaging/pull/11317#discussion_r1822445063~~
~~* Add a new prerequisite to enable Appstream to the procedure for registering hosts/rex pull client.~~

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
