### PR TITLE
Update procedure to configure TLS for LDAP

### DIFF
--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -26,7 +26,6 @@ The filename extensions `.cer` and `.crt` are only conventions and can refer to 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# update-ca-trust enable
-# update-ca-trust
+# update-ca-trust extract
 ----
 . Delete the downloaded LDAP certificate from the temporary location on your {ProjectServer}.

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -29,3 +29,8 @@ The filename extensions `.cer` and `.crt` are only conventions and can refer to 
 # update-ca-trust extract
 ----
 . Delete the downloaded LDAP certificate from the temporary location on your {ProjectServer}.
+
+ifndef::orcharhino[]
+.Additional resources
+* For more information about adding certificates to the system truststore, see link:{RHELDocsBaseURL}9/html/securing_networks/using-shared-system-certificates_securing-networks[Using shared system certificates] in _{RHEL}{nbsp}9 Securing networks_.
+endif::[]

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -15,27 +15,18 @@ endif::[]
 You will remove the certificate when finished.
 +
 The filename extensions `.cer` and `.crt` are only conventions and can refer to DER binary or PEM ASCII format certificates.
-. Add the LDAP certificate to your CA trust list:
-.. Install the LDAP certificate in the `/etc/pki/tls/certs/` directory with the correct permissions:
+. Add the LDAP server certificate to the system trust store:
+.. Import the certificate:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# install /tmp/_example.crt_ /etc/pki/tls/certs/
+# cp /tmp/_example.crt_ /etc/pki/tls/source/anchors
 ----
-+
-LDAP certificates must be individual files.
-.. Create a symbolic link to the LDAP certificate:
+.. Update the certificate authority trust store:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ln -s _example.crt_ /etc/pki/tls/certs/$(openssl \
-x509 -noout -hash -in \
-/etc/pki/tls/certs/_example.crt_).0
-----
-.. Restart the `httpd` service:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# systemctl restart httpd
+# update-ca-trust enable
+# update-ca-trust
 ----
 . Delete the downloaded LDAP certificate from the temporary location on your {ProjectServer}.

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -15,14 +15,14 @@ endif::[]
 You will remove the certificate when finished.
 +
 The filename extensions `.cer` and `.crt` are only conventions and can refer to DER binary or PEM ASCII format certificates.
-. Add the LDAP server certificate to the system trust store:
+. Add the LDAP server certificate to the system truststore:
 .. Import the certificate:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # cp /tmp/_example.crt_ /etc/pki/tls/source/anchors
 ----
-.. Update the certificate authority trust store:
+.. Update the certificate authority truststore:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

I'm updating the procedure to configure TLS for LDAP authentication:
* Restarting httpd is not needed
* We can also simplify the instructions for uploading the LDAP certificate

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I noticed https://issues.redhat.com/browse/SAT-19821 and https://github.com/theforeman/foreman-documentation/pull/2409/ and thought "why not?"

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

A separate PR will probably be needed for some of the older branches due to conflicts but https://github.com/theforeman/foreman-documentation/pull/2409/ suggests that we should get the fixes there too.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
