### PR TITLE
Update TLS LDAP procedure

### DIFF
--- a/guides/common/modules/con_using-ldap.adoc
+++ b/guides/common/modules/con_using-ldap.adoc
@@ -4,8 +4,6 @@
 {Project} supports LDAP authentication using one or multiple LDAP directories.
 Your LDAP server must comply with the link:https://datatracker.ietf.org/doc/html/rfc2307[RFC 2307] schema.
 
-If you require {ProjectName} to use `TLS` to establish a secure LDAP connection (LDAPS), first obtain certificates used by the LDAP server you are connecting to and mark them as trusted on the base operating system of your {ProjectServer} as described below.
-If your LDAP server uses a certificate chain with intermediate certificate authorities, all of the root and intermediate certificates in the chain must be trusted, so ensure all certificates are obtained.
 If you do not require secure LDAP at this time, proceed to xref:Configuring_Project_to_Use_LDAP_{context}[].
 
 [IMPORTANT]

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -1,39 +1,31 @@
 [id="Configuring_TLS_for_Secure_LDAP_{context}"]
 = Configuring TLS for secure LDAP
 
-Use the {Project} CLI to configure TLS for secure LDAP (LDAPS).
+If {Project} uses TLS to establish a secure LDAP connection (LDAPS), you must obtain the CA certificates of your LDAP server and add them to the trusted CA list on the base operating system of your {ProjectServer}.
+
+If your LDAP server uses a certificate chain with intermediate certificate authorities, you must obtain all root and intermediate certificates and add them to the trusted CA list.
 
 .Procedure
-. Obtain the Certificate from the LDAP Server.
-.. If you use Active Directory Certificate Services, export the Enterprise PKI CA Certificate using the Base-64 encoded X.509 format.
+. Obtain the CA certificate from the LDAP Server:
+.. If you use Active Directory Certificate Services, export the Enterprise PKI CA Certificate using the Base64 encoded X.509 format.
 ifndef::orcharhino[]
 See https://access.redhat.com/solutions/1498773[How to configure Active Directory authentication with `TLS` on {Project}] for information on creating and exporting a CA certificate from an Active Directory server.
 endif::[]
-.. Download the LDAP server certificate to a temporary location onto {ProjectServer} and remove it when finished.
+.. Download the LDAP server certificate to a temporary location on the {ProjectServer}, such as `/tmp/_example.crt_`.
+You will remove the certificate when finished.
 +
-For example, `/tmp/example.crt`.
 The filename extensions `.cer` and `.crt` are only conventions and can refer to DER binary or PEM ASCII format certificates.
-. Trust the Certificate from the LDAP Server.
-+
-{ProjectServer} requires the CA certificates for LDAP authentication to be individual files in `/etc/pki/tls/certs/` directory.
-
-.. Use the `install` command to install the imported certificate into the `/etc/pki/tls/certs/` directory with the correct permissions:
+. Add the LDAP server certificate to the system truststore:
+.. Import the certificate:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# install /tmp/_example.crt_ /etc/pki/tls/certs/
+# cp /tmp/_example.crt_ /etc/pki/tls/source/anchors
 ----
-.. Enter the following command as `root` to trust the _example.crt_ certificate obtained from the LDAP server:
+.. Update the certificate authority truststore:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ln -s _example.crt_ /etc/pki/tls/certs/$(openssl \
-x509 -noout -hash -in \
-/etc/pki/tls/certs/_example.crt_).0
+# update-ca-trust extract
 ----
-.. Restart the `httpd` service:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# systemctl restart httpd
-----
+. Delete the downloaded LDAP certificate from the temporary location on your {ProjectServer}.


### PR DESCRIPTION
#### What changes are you introducing?

I'm updating the procedure to configure TLS for LDAP external authentication on branches 3.10 and lower to (more or less) match the equivalent procedure on newer branches.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3499 couldn't be cherry-picked but contains important updates.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

https://github.com/theforeman/foreman-documentation/pull/3499 also added a link to RHEL docs for details on adding certs to the system-wide truststore. I'm not adding the link in this PR because for 3.10, I would need to add links to RHEL8 and RHEL9 and for 3.9 and earlier RHEL8 only. I think the section will work fine without the link.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
