### PR TITLE
Drop *.akamaiedge.net from list of CDN prereqs

### DIFF
--- a/guides/common/modules/snip_host-names-for-http-proxy.adoc
+++ b/guides/common/modules/snip_host-names-for-http-proxy.adoc
@@ -5,7 +5,6 @@
 | Host name | Port | Protocol
 | subscription.rhsm.redhat.com | 443 | HTTPS
 | cdn.redhat.com | 443 | HTTPS
-| *.akamaiedge.net | 443 | HTTPS
 ifdef::satellite[]
 | cert.console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS


### PR DESCRIPTION
#### What changes are you introducing?

Removing *.akamaiedge.net from the list of hosts that Foreman must be able to access to reach Red Hat CDN.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

While cdn.redhat.com is hosted by Akamai, *.akamaiedge.net itself doesn't need to be listed as a prerequisite. Because the domain doesn't belong to Red Hat, it can confuse some users, which is why it seems better to remove it. The relationship between CDN and Akamai is explained in the RH KBase article linked elsewhere in the section.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
