### PR TITLE
Restore info on relevant optional fields in Register Host interface

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -48,8 +48,14 @@ endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
-. Enter the details for how you want the registered host to be configured.
+. Enter the details for how you want the registered host to be configured. Note:
+* If you select a host group from the *Host Group* list, the *Operating system*
 ifdef::katello,satellite,orcharhino[]
+, *Activation Keys*
+endif::[]
+and *Lifecycle environment* fields inherit their values from the host group.
+ifdef::katello,satellite,orcharhino[]
+* A Capsule behind a load balancer takes precedence over the Capsule selected in this UI as the host’s content source.
 . On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
 . Click *Generate* to generate a `curl` command.
@@ -84,6 +90,7 @@ To verify synchronized {client-content-type} content, you can use {Project} API 
 For example, `\https://{foreman-example-com}/katello/api/v2/repositories/_My_Repository_ID_/gpg_key_content`.
 endif::[]
 endif::[]
+* On the *Advanced* tab, you can configure remote execution, Red{nbsp}Hat Insights, and packages to be installed.
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated registration command works.
 +

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -55,7 +55,7 @@ ifdef::katello,satellite,orcharhino[]
 endif::[]
 and *Lifecycle environment* fields inherit their values from the host group.
 ifdef::katello,satellite,orcharhino[]
-* A Capsule behind a load balancer takes precedence over the Capsule selected in this UI as the host’s content source.
+* A {SmartProxy} behind a load balancer takes precedence over the {SmartProxy} selected in the {ProjectWebUI} as the content source of the host."
 . On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
 . Click *Generate* to generate a `curl` command.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -51,11 +51,11 @@ endif::[]
 . Enter the details for how you want the registered host to be configured.
 * If you select a host group from the *Host Group* list, the following fields inherit their values from the host group:
 +
-* *Operating system*
+** *Operating system*
 ifdef::katello,satellite,orcharhino[]
-* *Activation Keys*
+** *Activation Keys*
 endif::[]
-* *Lifecycle environment*
+** *Lifecycle environment*
 ifdef::katello,satellite,orcharhino[]
 * A {SmartProxy} behind a load balancer takes precedence over the {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
 . On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to your host.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -55,7 +55,7 @@ ifdef::katello,satellite,orcharhino[]
 endif::[]
 and *Lifecycle environment* fields inherit their values from the host group.
 ifdef::katello,satellite,orcharhino[]
-* A {SmartProxy} behind a load balancer takes precedence over the {SmartProxy} selected in the {ProjectWebUI} as the content source of the host."
+* A {SmartProxy} behind a load balancer takes precedence over the {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
 . On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to your host.
 endif::[]
 . Click *Generate* to generate a `curl` command.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -49,11 +49,13 @@ endif::[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
 . Enter the details for how you want the registered host to be configured.
-* If you select a host group from the *Host Group* list, the *Operating system*
+* If you select a host group from the *Host Group* list, the following fields inherit their values from the host group:
++
+* *Operating system*
 ifdef::katello,satellite,orcharhino[]
-, *Activation Keys*
+* *Activation Keys*
 endif::[]
-and *Lifecycle environment* fields inherit their values from the host group.
+* *Lifecycle environment*
 ifdef::katello,satellite,orcharhino[]
 * A {SmartProxy} behind a load balancer takes precedence over the {SmartProxy} selected in the {ProjectWebUI} as the content source of the host.
 . On the *General* tab, in the *Activation Keys* field, enter one or more activation keys to assign to your host.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -48,7 +48,7 @@ endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
-. Enter the details for how you want the registered host to be configured. Note:
+. Enter the details for how you want the registered host to be configured.
 * If you select a host group from the *Host Group* list, the *Operating system*
 ifdef::katello,satellite,orcharhino[]
 , *Activation Keys*


### PR DESCRIPTION
#### What changes are you introducing?

Returning selected info about optional fields in the Register Host interface of the Satellite UI.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-28703

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
