### PR TITLE
Add missing steps for disabling TFTP and DNS

### DIFF
--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -15,9 +15,25 @@ However, {Project} does not remove the back-end services on the operating system
 --foreman-proxy-tftp false
 ----
 
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select a subnet.
+. Stop and mask the TFTP and DNS services (FIXME Please confirm that DNS needs to be stopped and masked too):
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# systemctl mask --now tftp.service tftp.socket systemd-resolved.service
+----
 
-. Click the *{SmartProxies}* tab and clear the *DHCP {SmartProxy}*, *TFTP {SmartProxy}*, and *Reverse DNS {SmartProxy}* fields.
+. Optional: On RHEL7 hosts, disable the eXtended Internet Services Daemon (xinetd) and delete the `xinetd` package:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# systemctl mask --now xinetd && yum remove xinetd
+----
+
+. For every subnet where the Capsule is set as a TFTP proxy, disable the proxies:
+
+.. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select a subnet.
+
+.. Click the *{SmartProxies}* tab and clear the *DHCP {SmartProxy}*, *TFTP {SmartProxy}*, and *Reverse DNS {SmartProxy}* fields.
 
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains* and select a domain.
 

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -2,7 +2,6 @@
 = Disabling DNS, DHCP, and TFTP for unmanaged networks
 
 If you want to manage TFTP, DHCP, and DNS services manually, you must prevent {Project} from maintaining these services on the operating system and disable orchestration to avoid DHCP and DNS validation errors.
-However, {Project} does not remove the back-end services on the operating system.
 +
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -4,7 +4,7 @@
 If you want to manage TFTP, DHCP, and DNS services manually, you must prevent {Project} from maintaining these services on the operating system and disable orchestration to avoid DHCP and DNS validation errors.
 [IMPORTANT]
 ====
-Disabling these proxy features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does not stop or remove the corresponding services.
+Disabling these {SmartProxy} features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does not stop or remove the corresponding services.
 ====
 
 .Procedure

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -2,6 +2,7 @@
 = Disabling DNS, DHCP, and TFTP for unmanaged networks
 
 If you want to manage TFTP, DHCP, and DNS services manually, you must prevent {Project} from maintaining these services on the operating system and disable orchestration to avoid DHCP and DNS validation errors.
+
 [IMPORTANT]
 ====
 Disabling these {SmartProxy} features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does not stop or remove the corresponding services.

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -2,7 +2,6 @@
 = Disabling DNS, DHCP, and TFTP for unmanaged networks
 
 If you want to manage TFTP, DHCP, and DNS services manually, you must prevent {Project} from maintaining these services on the operating system and disable orchestration to avoid DHCP and DNS validation errors.
-+
 [IMPORTANT]
 ====
 Disabling these proxy features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does not stop or remove the corresponding services.
@@ -10,7 +9,7 @@ Disabling these proxy features means {Project} will no longer orchestrate DNS, D
 
 .Procedure
 
-. On {ProjectServer}, enter the following command to disable the Foreman Proxy features for DHCP, DNS, and TFTP:
+. Disable DHCP, DNS, and TFTP integration on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -21,9 +20,10 @@ Disabling these proxy features means {Project} will no longer orchestrate DNS, D
 
 . For every subnet where the {SmartProxy} is set as a DHCP, DNS, or TFTP proxy, disable the proxies:
 
-.. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select a subnet.
+.. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
+.. Select a subnet.
 
-.. Click the *{SmartProxies}* tab and clear the *DHCP {SmartProxy}*, *TFTP {SmartProxy}*, and *Reverse DNS {SmartProxy}* fields.
+.. On the *{SmartProxies}* tab, clear the *DHCP {SmartProxy}*, *TFTP {SmartProxy}*, and *Reverse DNS {SmartProxy}* fields.
 
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains* and select a domain.
 

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -19,7 +19,7 @@ Disabling these proxy features means {Project} will no longer orchestrate DNS, D
 --foreman-proxy-tftp false
 ----
 
-. For every subnet where the {SmartProxy} is set as a TFTP proxy, disable the proxies:
+. For every subnet where the {SmartProxy} is set as a DHCP, DNS, or TFTP proxy, disable the proxies:
 
 .. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select a subnet.
 

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -3,10 +3,15 @@
 
 If you want to manage TFTP, DHCP, and DNS services manually, you must prevent {Project} from maintaining these services on the operating system and disable orchestration to avoid DHCP and DNS validation errors.
 However, {Project} does not remove the back-end services on the operating system.
++
+[IMPORTANT]
+====
+Disabling these proxy features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does stop or remove the corresponding services.
+====
 
 .Procedure
 
-. On {ProjectServer}, enter the following command:
+. On {ProjectServer}, enter the following command to disable the Foreman Proxy features for DHCP, DNS, and TFTP:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
@@ -15,21 +20,7 @@ However, {Project} does not remove the back-end services on the operating system
 --foreman-proxy-tftp false
 ----
 
-. Stop and mask the TFTP and DNS services (FIXME Please confirm that DNS needs to be stopped and masked too):
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# systemctl mask --now tftp.service tftp.socket systemd-resolved.service
-----
-
-. Optional: On RHEL7 hosts, disable the eXtended Internet Services Daemon (xinetd) and delete the `xinetd` package:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-# systemctl mask --now xinetd && yum remove xinetd
-----
-
-. For every subnet where the Capsule is set as a TFTP proxy, disable the proxies:
+. For every subnet where the {SmartProxy} is set as a TFTP proxy, disable the proxies:
 
 .. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets* and select a subnet.
 

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -18,7 +18,7 @@ Disabling these {SmartProxy} features means {Project} will no longer orchestrate
 --foreman-proxy-tftp false
 ----
 
-. For every subnet where the {SmartProxy} is set as a DHCP, DNS, or TFTP proxy, disable the proxies:
+. Disable the {SmartProxy} integration for every subnet:
 
 .. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
 .. Select a subnet.

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -22,7 +22,6 @@ Disabling these {SmartProxy} features means {Project} will no longer orchestrate
 
 .. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
 .. Select a subnet.
-
 .. On the *{SmartProxies}* tab, clear the *DHCP {SmartProxy}*, *TFTP {SmartProxy}*, and *Reverse DNS {SmartProxy}* fields.
 
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Domains* and select a domain.

--- a/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
+++ b/guides/common/modules/proc_disabling-dns-dhcp-tftp-for-unmanaged-networks.adoc
@@ -5,7 +5,7 @@ If you want to manage TFTP, DHCP, and DNS services manually, you must prevent {P
 +
 [IMPORTANT]
 ====
-Disabling these proxy features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does stop or remove the corresponding services.
+Disabling these proxy features means {Project} will no longer orchestrate DNS, DHCP, and TFTP, but it does not stop or remove the corresponding services.
 ====
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

Adding missing steps for disabling TFTP and DNS for unmanaged networks.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-18574

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
