### PR TITLE
Add option set new HTTP proxy as default

### DIFF
--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -15,7 +15,9 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 . Optional: If authentication is required, in the *Username* field, enter the username to authenticate with.
 . Optional: If authentication is required, in the *Password* field, enter the password to authenticate with.
 . To test connection to the proxy, click *Test Connection*.
+ifdef::katello,orcharhino,satellite[]
 . Select the *Default content HTTP proxy* option.
+endif::[]
 . Click *Submit*.
 
 [id="cli-adding-a-default-http-proxy_{context}"]

--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -15,9 +15,8 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 . Optional: If authentication is required, in the *Username* field, enter the username to authenticate with.
 . Optional: If authentication is required, in the *Password* field, enter the password to authenticate with.
 . To test connection to the proxy, click *Test Connection*.
+. Select the *Default content HTTP proxy* option.
 . Click *Submit*.
-. In the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Content* tab.
-. Set the *Default HTTP Proxy* setting to the created HTTP proxy.
 
 [id="cli-adding-a-default-http-proxy_{context}"]
 .CLI procedure

--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -28,6 +28,20 @@ endif::[]
 ----
 # unset http_proxy https_proxy no_proxy
 ----
+ifdef::katello,orcharhino,satellite[]
+. Add an HTTP proxy entry to {Project} and set the HTTP proxy as default for content synchronization:
++
+[options="nowrap" subs="+quotes"]
+----
+$ hammer http-proxy create \
+--name=_My_HTTP_Proxy_ \
+--username=_My_HTTP_Proxy_User_Name_ \
+--password=_My_HTTP_Proxy_Password_ \
+--url http://_http-proxy.example.com_:8080
+--content_default_http_proxy
+----
+endif::[]
+ifndef::katello,orcharhino,satellite[]
 . Add an HTTP proxy entry to {Project}:
 +
 [options="nowrap" subs="+quotes"]
@@ -38,11 +52,4 @@ $ hammer http-proxy create \
 --password=_My_HTTP_Proxy_Password_ \
 --url http://_http-proxy.example.com_:8080
 ----
-. Configure {Project} to use this HTTP proxy by default:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-$ hammer settings set \
---name=content_default_http_proxy \
---value=__My_HTTP_Proxy__
-----
+endif::[]

--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -16,7 +16,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-default-
 . Optional: If authentication is required, in the *Password* field, enter the password to authenticate with.
 . To test connection to the proxy, click *Test Connection*.
 ifdef::katello,orcharhino,satellite[]
-. Select the *Default content HTTP proxy* option.
+. Select the *Default content HTTP proxy* option to set the new HTTP proxy as default for content synchronization.
 endif::[]
 . Click *Submit*.
 

--- a/guides/common/modules/proc_adding-a-default-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-a-default-http-proxy.adoc
@@ -37,8 +37,8 @@ $ hammer http-proxy create \
 --name=_My_HTTP_Proxy_ \
 --username=_My_HTTP_Proxy_User_Name_ \
 --password=_My_HTTP_Proxy_Password_ \
---url http://_http-proxy.example.com_:8080
---content_default_http_proxy
+--url http://_http-proxy.example.com_:8080 \
+--content-default-http-proxy true
 ----
 endif::[]
 ifndef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -33,9 +33,9 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 $ hammer http-proxy create \
 --name _My_HTTP_Proxy_ \
 --url _http-proxy.example.com:8080_
---content_default_http_proxy <1>
 ----
-<1> Optional: Set the HTTP proxy as default for content synchronization.
++
+Optional: To set the HTTP proxy as default for content synchronization, add the `--content-default-http-proxy true` option.
 +
 If your HTTP proxy requires authentication, add the `--username _My_User_Name_` and `--password _My_Password_` options.
 

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -19,6 +19,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
+. Optional: Select the *Default content HTTP proxy* option to set the new HTTP proxy as default.
 . Click the *Locations* tab and add a location.
 . Click the *Organization* tab and add an organization.
 . Click *Submit*.

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -19,7 +19,9 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
+ifdef::katello,orcharhino,satellite[]
 . Optional: Select the *Default content HTTP proxy* option to set the new HTTP proxy as default.
+endif::[]
 . Click the *Locations* tab and add a location.
 . Click the *Organization* tab and add an organization.
 . Click *Submit*.

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -19,9 +19,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 . In the *URL* field, enter the URL for the HTTP proxy, including the port number.
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
-ifdef::katello,orcharhino,satellite[]
 . Optional: Select the *Default content HTTP proxy* option to set the new HTTP proxy as default for content synchronization.
-endif::[]
 . Click the *Locations* tab and add a location.
 . Click the *Organization* tab and add an organization.
 . Click *Submit*.

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -20,7 +20,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . Optional: In the *Test URL* field, enter the HTTP proxy URL, then click *Test Connection* to ensure that you can connect to the HTTP proxy from {Project}.
 ifdef::katello,orcharhino,satellite[]
-. Optional: Select the *Default content HTTP proxy* option to set the new HTTP proxy as default.
+. Optional: Select the *Default content HTTP proxy* option to set the new HTTP proxy as default for content synchronization.
 endif::[]
 . Click the *Locations* tab and add a location.
 . Click the *Organization* tab and add an organization.

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -33,7 +33,9 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-an-http-pr
 $ hammer http-proxy create \
 --name _My_HTTP_Proxy_ \
 --url _http-proxy.example.com:8080_
+--content_default_http_proxy <1>
 ----
+<1> Optional: Set the HTTP proxy as default for content synchronization.
 +
 If your HTTP proxy requires authentication, add the `--username _My_User_Name_` and `--password _My_Password_` options.
 


### PR DESCRIPTION
#### What changes are you introducing?

Replacing manual configuration of the default content HTTP proxy with a new option to configure the global setting automatically.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Documents https://github.com/theforeman/foreman/pull/10372, https://github.com/Katello/katello/pull/11183, and https://github.com/Katello/katello/pull/11266

https://issues.redhat.com/browse/SAT-28860 (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Not sure if there are any other places where an update is needed.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
