### PR TITLE
Use common Client OS attributes for KernelCare

### DIFF
--- a/guides/common/assembly_using-kernelcare.adoc
+++ b/guides/common/assembly_using-kernelcare.adoc
@@ -5,14 +5,17 @@ include::modules/proc_installing-the-kernelcare-plugin.adoc[leveloffset=+1]
 ifdef::katello,orcharhino[]
 include::modules/con_kernelcare_client.adoc[leveloffset=+1]
 
-:os_major: 9
+:parent-client-os-major: {client-os-major}
+:client-os-major: 9
 include::modules/proc_creating-kernelcare-repositories-el.adoc[leveloffset=+2]
 
-:os_major: 8
+:client-os-major: 8
 include::modules/proc_creating-kernelcare-repositories-el.adoc[leveloffset=+2]
 
-:os_major: 7
+:client-os-major: 7
 include::modules/proc_creating-kernelcare-repositories-el.adoc[leveloffset=+2]
+:client-os-major: {parent-client-os-major}
+:!parent-client-os-major:
 endif::[]
 
 include::modules/proc_installing-the-kernelcare-package-on-hosts.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_creating-kernelcare-repositories-el.adoc
+++ b/guides/common/modules/proc_creating-kernelcare-repositories-el.adoc
@@ -1,16 +1,16 @@
-[id="Creating_KernelCare_Repositories_for_{EL}_{os_major}_{context}"]
-= Creating KernelCare repositories for {EL} {os_major}
+[id="Creating_KernelCare_Repositories_for_{client-os-context}_{client-os-major}_{context}"]
+= Creating KernelCare repositories for {client-os} {client-os-major}
 
 You need to provide the KernelCare client on your hosts to live-patch their Linux kernel.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click *Create Product* to create a product named `KernelCare {EL}`.
+. Click *Create Product* to create a product named `KernelCare {client-os}`.
 For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a product] in _{ContentManagementDocTitle}_.
 . On the *Repositories* tab, click *New Repository* to create a repository of type `yum` as follows:
 +
-* *Name*: `KernelCare {EL} {os_major}`
-* *Upstream URL*: `https://repo.cloudlinux.com/kernelcare/{os_major}/x86_64/`
+* *Name*: `KernelCare {client-os} {client-os-major}`
+* *Upstream URL*: `https://repo.cloudlinux.com/kernelcare/{client-os-major}/x86_64/`
 * Optional: Add the KernelCare GPG pub key as content credential: `https://repo.cloudlinux.com/kernelcare/RPM-GPG-KEY-KernelCare`.
 
 +

--- a/guides/common/modules/proc_live-patching-hosts-using-kernelcare.adoc
+++ b/guides/common/modules/proc_live-patching-hosts-using-kernelcare.adoc
@@ -7,7 +7,6 @@ If the automatic installation of patches is disabled or if you want to install p
 
 .Prerequisites
 * Ensure your hosts have the `kernelcare` package installed.
-* Ensure your hosts run {EL} 7, {EL} 8, or {EL} 9.
 * Ensure your hosts have access to the internet to connect to cloudlinux.com.
 +
 If your host is in a disconnected environment, you can use ePortal by Tuxcare to provide Linux kernel patches.


### PR DESCRIPTION
#### What changes are you introducing?

Drop "os_major" as attribute in `guides/common/assembly_using-kernelcare.adoc` and any included files

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This simplifies overwriting the attribute in downstream docs because we build the guide for each host OS: [example 1](https://docs.orcharhino.com/or/docs/sources/guides/red_hat_enterprise_linux/managing_hosts/kernelcare.html#Creating_KernelCare_Repositories_for_Red%20Hat%20Enterprise%20Linux_7_managing-hosts) and [example 2](https://docs.orcharhino.com/or/docs/sources/guides/almalinux/managing_hosts/kernelcare.html#Creating_KernelCare_Repositories_for_AlmaLinux_9_managing-hosts).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I also dropped the limitation to EL 7-9 because we do not document any other OS name + OS version anyway.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
