### PR TITLE
Remove link macro from DocURL attributes

### DIFF
--- a/guides/common/modules/con_importing-the-project-client-name-repository.adoc
+++ b/guides/common/modules/con_importing-the-project-client-name-repository.adoc
@@ -7,7 +7,7 @@ You must enable the repository, synchronize the repository to your {ProjectServe
 ifeval::["{mode}" == "disconnected"]
 .Prerequisites
 * Ensure that the {project-client-name} repository is enabled and synchronized from the {Team} CDN on your connected {ProjectServer}.
-For more information, see link:{InstallingServerDocURL}importing-the-project-client-name-repository_satellite[Importing the {project-client-name} repository] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}importing-the-project-client-name-repository_satellite[Importing the {project-client-name} repository] in _{InstallingServerDocTitle}_.
 * Your disconnected {ProjectServer} is configured to synchronize content either over the network or by using export.
 
 .Next steps
@@ -20,5 +20,5 @@ For more information, see link:{InstallingServerDocURL}importing-the-project-cli
 You must synchronize the {project-client-name} repository for every RHEL version you intend to run on your hosts.
 
 .Additional resources
-* link:{ContentManagementDocURL}synchronizing_content_between_servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_
+* {ContentManagementDocURL}synchronizing_content_between_servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_
 endif::[]

--- a/guides/common/modules/con_project-api-compared-to-hammer-cli.adoc
+++ b/guides/common/modules/con_project-api-compared-to-hammer-cli.adoc
@@ -6,4 +6,4 @@ You can use Hammer as a human-friendly interface to {Project} API.
 For example, to test responses to API calls before applying them in a script, use the `--debug` option to inspect API calls that Hammer issues: `hammer --debug organization list`.
 In contrast, scripts that use API commands communicate directly with the {Project} API.
 
-For more information, see the link:{HammerDocURL}[_{HammerDocTitle}_].
+For more information, see the {HammerDocURL}[_{HammerDocTitle}_].

--- a/guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc
+++ b/guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc
@@ -53,6 +53,6 @@ $ hammer host list
 
 * For more information about authenticating with Hammer, see
 ifdef::satellite[]
-link:{HammerDocURL}sect-CLI_Guide-Authentication[{HammerDocTitle}] or
+{HammerDocURL}sect-CLI_Guide-Authentication[{HammerDocTitle}] or
 endif::[]
 `hammer auth --help`.

--- a/guides/common/modules/proc_synchronizing-the-project-client-name-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-the-project-client-name-repository.adoc
@@ -14,4 +14,4 @@ Synchronize the {project-client-name} repository to import the content to your {
 
 .Additional resources
 * You can create a sync plan to update the content regularly.
-For more information, see link:{ContentManagementDocURL}Creating_a_Sync_Plan_content-management[Creating a sync plan] in _{ContentManagementDocTitle}_.
+For more information, see {ContentManagementDocURL}Creating_a_Sync_Plan_content-management[Creating a sync plan] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/ref_preparing-smartproxyservers-for-load-balancing-additional-resources.adoc
+++ b/guides/common/modules/ref_preparing-smartproxyservers-for-load-balancing-additional-resources.adoc
@@ -1,4 +1,4 @@
 [id="preparing-{smart-proxy-context}-servers-for-load-balancing-additional-resources_{context}"]
 = Additional resources
 
-* For more information about installing {SmartProxyServers}, see link:{InstallingSmartProxyDocURL}[_{InstallingSmartProxyDocTitle}_].
+* For more information about installing {SmartProxyServers}, see {InstallingSmartProxyDocURL}[_{InstallingSmartProxyDocTitle}_].


### PR DESCRIPTION
$ rg -i "DocURL" | rg "link"

#### What changes are you introducing?

remove `link:` macro from links that use `{xDocURL}` attributes

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

the combination of that macro and the attributes breaks things in downstream for me.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

changes are cherry-picked from a downstream-only stable branch -> no tech review/ACK by anyone from ATIX necessary

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
