### PR TITLE
Publish Administering Foreman for all flavours

### DIFF
--- a/guides/common/assembly_administer-settings-information.adoc
+++ b/guides/common/assembly_administer-settings-information.adoc
@@ -14,7 +14,9 @@ ifdef::satellite,orcharhino[]
 include::modules/ref_redhat-cloud-settings.adoc[leveloffset=+1]
 endif::[]
 
+ifdef::katello,satellite,orcharhino[]
 include::modules/ref_content-settings.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/ref_authentication-settings.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_backing-up-server-and-proxy.adoc
+++ b/guides/common/assembly_backing-up-server-and-proxy.adoc
@@ -1,10 +1,14 @@
 include::modules/con_backing-up-server-and-proxy.adoc[]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_estimating-the-size-of-a-backup.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_performing-a-full-backup.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_performing-a-backup-without-pulp-content.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_performing-an-incremental-backup.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -6,4 +6,6 @@ include::modules/proc_restoring-from-incremental-backups.adoc[leveloffset=+1]
 
 include::modules/con_backup-and-restore-smartproxyserver-by-using-a-virtual-machine-snapshot.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_synchronizing-content-from-project-server-to-smart-proxy-servers.adoc[leveloffset=+2]
+endif::[]

--- a/guides/common/modules/con_backup-and-restore-smartproxyserver-by-using-a-virtual-machine-snapshot.adoc
+++ b/guides/common/modules/con_backup-and-restore-smartproxyserver-by-using-a-virtual-machine-snapshot.adoc
@@ -3,9 +3,16 @@
 
 If your {SmartProxyServer} is a virtual machine, you can restore it from a snapshot.
 Creating weekly snapshots to restore from is recommended.
+ifdef::katello,orcharhino,satellite[]
 In the event of failure, you can install, or configure a new {SmartProxyServer}, and then synchronize the database content from {ProjectServer}.
+endif::[]
+ifdef::foreman-el,foreman-deb[]
+In the event of failure, you can install or configure a new {SmartProxyServer}.
+endif::[]
 
 If required, deploy a new {SmartProxyServer}, ensuring the host name is the same as before, and then install the {SmartProxy} certificates.
 You may still have them on {ProjectServer}, the package name ends in -certs.tar, alternately create new ones.
 Follow the procedures in {InstallingSmartProxyDocURL}[Installing {SmartProxyServer}] until you can confirm, in the {ProjectWebUI}, that {SmartProxyServer} is connected to {ProjectServer}.
+ifdef::katello,orcharhino,satellite[]
 Then use the procedure xref:Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_{context}[] to synchronize from {Project}.
+endif::[]

--- a/guides/common/modules/con_maintaining-server.adoc
+++ b/guides/common/modules/con_maintaining-server.adoc
@@ -1,4 +1,10 @@
 [id="maintaining-{project-context}-server_{context}"]
 = Maintaining {ProjectServer}
 
-This chapter provides information on how to maintain a {ProjectServer}, including information on how to work with audit records, how to clean unused tasks, and how to recover Pulp from a full disk.
+This chapter provides information on how to maintain {ProjectServer}, including information on
+ifdef::katello,orcharhino,satellite[]
+how to recover Pulp from a full disk, how to work with audit records, and how to clean unused tasks.
+endif::[]
+ifdef::foreman-el,foreman-deb[]
+how to work with audit records and how to clean unused tasks.
+endif::[]

--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -1,10 +1,6 @@
 [id="Estimating_the_Size_of_a_Backup_{context}"]
 = Estimating the size of a backup
 
-ifndef::satellite,orcharhino[]
-Note that estimations in this section are for the installations that use the Katello plugin.
-endif::[]
-
 The full backup creates uncompressed archives of PostgreSQL and Pulp database files, and {Project} configuration files.
 Compression occurs after the archives are created to decrease the time when {Project} services are unavailable.
 

--- a/guides/common/modules/proc_managing-tasks.adoc
+++ b/guides/common/modules/proc_managing-tasks.adoc
@@ -23,6 +23,7 @@ Adjusting the _%_finish_timeout_ values might help in case of low bandwidth.
 Adjusting the _%_accept_timeout_ values might help in case of high latency.
 ====
 
+ifdef::katello,orcharhino,satellite[]
 When a task is initialized, any back-end service that will be used in the task, such as Candlepin or Pulp, will be checked for correct functioning.
 If the check fails, you will receive an error similar to the following one:
 
@@ -32,6 +33,7 @@ There was an issue with the backend service candlepin: Connection refused – co
 ----
 
 If the back-end service checking feature turns out to be causing any trouble, it can be disabled as follows.
+endif::[]
 
 .To disable checking for services
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings*.

--- a/guides/common/modules/proc_monitoring-services.adoc
+++ b/guides/common/modules/proc_monitoring-services.adoc
@@ -2,7 +2,13 @@
 = Monitoring services
 
 In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* and click the name of the selected {SmartProxy}.
-At the *Services* tab, you can find basic information on {SmartProxy} services, such as the list of DNS domains, or the number of Pulp workers.
+At the *Services* tab, you can find basic information on {SmartProxy} services,
+ifdef::katello,orcharhino,satellite[]
+such as the list of DNS domains, or the number of Pulp workers.
+endif::[]
+ifdef::foreman-el,foreman-deb[]
+for example, the list of DNS domains.
+endif::[]
 The appearance of the page depends on what services are enabled on {SmartProxyServer}.
 Services providing more detailed status information can have dedicated tabs at the {SmartProxy} page.
 For more information, see xref:Monitoring_Puppet_{context}[].

--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -59,7 +59,9 @@ endif::[]
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.
+ifdef::katello,orcharhino,satellite[]
 For more information, see xref:Estimating_the_Size_of_a_Backup_{context}[].
+endif::[]
 
 [WARNING]
 ====

--- a/guides/common/modules/proc_performing-an-incremental-backup.adoc
+++ b/guides/common/modules/proc_performing-an-incremental-backup.adoc
@@ -14,7 +14,9 @@ Ensure no other tasks are scheduled for the same time as the backup.
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.
+ifdef::katello,orcharhino,satellite[]
 For more information, see xref:Estimating_the_Size_of_a_Backup_{context}[].
+endif::[]
 
 .Procedure
 . To perform a full offline backup, enter the following command:

--- a/guides/common/modules/proc_performing-an-online-backup.adoc
+++ b/guides/common/modules/proc_performing-an-online-backup.adoc
@@ -3,9 +3,11 @@
 
 Perform an online backup only for debugging purposes.
 
+ifdef::katello,orcharhino,satellite[]
 .Risks associated with online backups
 When performing an online backup, if there are procedures affecting the Pulp database, the Pulp part of the backup procedure repeats until it is no longer being altered.
 Because the backup of the Pulp database is the most time consuming part of backing up {Project}, if you make a change that alters the Pulp database during this time, the backup procedure keeps restarting.
+endif::[]
 
 For production environments, use the offline method.
 For more information, see xref:Performing_a_Full_Backup_{context}[].
@@ -19,7 +21,9 @@ Ensure no other tasks are scheduled for the same time as the backup.
 
 .Prerequisites
 * Ensure that your backup location has sufficient available disk space to store the backup.
+ifdef::katello,orcharhino,satellite[]
 For more information, see xref:Estimating_the_Size_of_a_Backup_{context}[].
+endif::[]
 
 .Procedure
 * To perform an online backup, enter the following command:

--- a/guides/common/modules/proc_viewing-general-smart-proxy-information.adoc
+++ b/guides/common/modules/proc_viewing-general-smart-proxy-information.adoc
@@ -7,7 +7,13 @@ The information contained in the table answers the following questions:
 *Is {SmartProxyServer} running?*:: This is indicated by a green icon in the *Status* column.
 A red icon indicates an inactive {SmartProxy}, use the `service foreman-proxy restart` command on {SmartProxyServer} to activate it.
 
-*What services are enabled on {SmartProxyServer}?*:: In the *Features* column you can verify if {SmartProxy} for example provides a DHCP service or acts as a Pulp mirror.
+*What services are enabled on {SmartProxyServer}?*::
+ifdef::katello,orcharhino,satellite[]
+In the *Features* column, you can verify if, for example, your {SmartProxy} provides a DHCP service or acts as a Pulp mirror.
+endif::[]
+ifdef::foreman-el,foreman-deb[]
+In the *Features* column, you can verify if, for example, your {SmartProxy} provides a DHCP service.
+endif::[]
 {SmartProxy} features can be enabled during installation or configured in addition.
 For more information, see {InstallingSmartProxyDocURL}[Installing {SmartProxyServer}].
 

--- a/guides/common/modules/ref_authentication-settings.adoc
+++ b/guides/common/modules/ref_authentication-settings.adoc
@@ -23,8 +23,10 @@ endif::[]
 | *SSL client verify env* | HTTP_SSL_CLIENT_VERIFY | Environment variable containing the verification status of a client SSL certificate.
 | *SSL client cert env* | HTTP_SSL_CLIENT_CERT | Environment variable containing a client's SSL certificate.
 | *Server CA file* | | SSL CA file path used in templates to verify the connection to {Project}.
+ifdef::katello,orcharhino,satellite[]
 | *Websockets SSL key* | `etc/pki/katello/private/katello-apache.key` | Private key file path that {Project} uses to encrypt websockets.
 | *Websockets SSL certificate* | `/etc/pki/katello/certs/katello-apache.crt` | Certificate path that {Project} uses to encrypt websockets.
+endif::[]
 | *Websockets encryption* | Yes | VNC/SPICE websocket proxy console access encryption (`websockets_ssl_key/cert` setting required).
 | *Login delegation logout URL* | | Redirect your users to this URL on logout.
 Enable *Authorize login delegation* also.

--- a/guides/common/modules/ref_email-notification-types.adoc
+++ b/guides/common/modules/ref_email-notification-types.adoc
@@ -8,21 +8,29 @@ ifdef::satellite[]
 {SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
 endif::[]
 Compliance policy summary:: A summary of OpenSCAP policy reports and their results.
+ifdef::katello,orcharhino,satellite[]
 Content view promote failure:: A notification sent after content view promotion fails.
 Content view publish failure:: A notification sent after content view publication fails.
+endif::[]
 Host built:: A notification sent after a host is built.
+ifdef::katello,orcharhino,satellite[]
 Host errata advisory:: A summary of applicable and installable errata for hosts managed by the user.
+endif::[]
 ifdef::orcharhino[]
 {SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
 endif::[]
+ifdef::katello,orcharhino,satellite[]
 Promote errata:: A notification sent only after a content view promotion.
 It contains a summary of errata applicable and installable to hosts registered to the promoted content view.
 This allows a user to monitor what updates have been applied to which hosts.
 Repository sync failure:: A notification sent after repository synchronization fails.
-ifdef::foreman-el,foreman-deb,katello[]
+endif::[]
+ifdef::katello[]
 {SmartProxy} sync failure:: A notification sent after {SmartProxy} synchronization fails.
 endif::[]
+ifdef::katello,orcharhino,satellite[]
 Sync errata:: A notification sent only after synchronizing a repository.
 It contains a summary of new errata introduced by the synchronization.
+endif::[]
 
 For a complete list of email notification types, navigate to *Administer* > *Users* in the {ProjectWebUI}, click the *Username* of the required user, and select the *Email Preferences* tab.

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -11,9 +11,12 @@ Some events are marked as *custom*, in that case, the payload is an object objec
 [cols="40%,30%,30%",options="header"]
 |====
 |Event name |Description|Payload
+ifdef::katello,orcharhino,satellite[]
 |Actions Katello Content View Promote Succeeded |A content view was successfully promoted.|Actions::Katello::ContentView::Promote
 |Actions Katello Content View Publish Succeeded |A repository was successfully synchronized.|Actions::Katello::ContentView::Publish
+endif::[]
 |Actions Remote Execution Run Host Job Succeeded |A generic remote execution job succeeded for a host. This event is emitted for all Remote Execution jobs, when complete.|Actions::RemoteExecution::RunHostJob
+ifdef::katello,orcharhino,satellite[]
 |Actions Remote Execution Run Host Job Katello Errata Install Succeeded |Install errata using the Katello interface.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Katello Group Install Succeeded |Install package group using the Katello interface.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Katello Package Install Succeeded |Install package using the Katello interface.|Actions::RemoteExecution::RunHostJob
@@ -22,6 +25,7 @@ Some events are marked as *custom*, in that case, the payload is an object objec
 |Actions Remote Execution Run Host Job Katello Service Restart Succeeded |Restart Services using the Katello interface.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Katello Group Update Succeeded |Update package group using the Katello interface.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Katello Package Update Succeeded |Update package using the Katello interface.|Actions::RemoteExecution::RunHostJob
+endif::[]
 |Actions Remote Execution Run Host Job Foreman OpenSCAP Run Scans Succeeded |Run OpenSCAP scan.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Run Host Succeeded |Runs an Ansible Playbook containing all the roles defined for a host.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Run {SmartProxy} Upgrade Succeeded |Upgrade {SmartProxies} on given {SmartProxyServers}.|Actions::RemoteExecution::RunHostJob
@@ -32,13 +36,17 @@ endif::[]
 |Actions Remote Execution Run Host Job Ansible Run Playbook Succeeded |Run an Ansible Playbook against given hosts.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Enable Web Console Succeeded |Run an Ansible Playbook to enable the web console on given hosts.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Puppet Run Host Succeeded |Perform a single Puppet run.|Actions::RemoteExecution::RunHostJob
+ifdef::katello,orcharhino,satellite[]
 |Actions Remote Execution Run Host Job Katello Module Stream Action Succeeded |Perform a module stream action using the Katello interface.|Actions::RemoteExecution::RunHostJob
+endif::[]
 |Actions Remote Execution Run Host Job Leapp Pre-upgrade Succeeded |Upgradeability check for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Leapp Remediation Plan Succeeded |Run Remediation plan with Leapp.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Leapp Upgrade Succeeded |Run Leapp upgrade job for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
 |Build Entered |A host entered the build mode.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
 |Build Exited |A host build mode was canceled, either it was successfully provisioned or the user canceled the build manually.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
+ifdef::katello,orcharhino,satellite[]
 |Content View Created/Updated/Destroyed |Common database operations on a content view.|Katello::ContentView
+endif::[]
 |Domain Created/Updated/Destroyed |Common database operations on a domain.|Domain
 |Host Created/Updated/Destroyed |Common database operations on a host.|Host
 |Hostgroup Created/Updated/Destroyed |Common database operations on a hostgroup.|Hostgroup

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -4,12 +4,6 @@ include::common/header.adoc[]
 
 = {AdministeringDocTitle}
 
-// This guide is not ready for stable releases
-ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
-endif::[]
-ifndef::HideDocumentOnStable[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -73,4 +67,3 @@ endif::[]
 
 [appendix]
 include::common/assembly_administer-settings-information.adoc[leveloffset=+1]
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Estimate disk usage for backups is Katello-only
* Backups without Pulp are Katello-only
* Hide Pulp database for Foreman because it's Katello-only
* Do not sync content to Smart Proxy Servers for Foreman Content on Smart Proxy Servers is Katello-only.
* Hide Katello-specific events for Foreman
* Hide Pulp for non-Katello
* Hide Pulp mirror for Foreman
* Show content and content settings for Katello only

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

closes 676

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
