### PR TITLE
Add troubleshooting rex timeout due to yggdrasil version

### DIFF
--- a/guides/common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc
+++ b/guides/common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc
@@ -1,0 +1,48 @@
+[id="troubleshooting-remote-jobs-timing-out-after-yggdrails-update"]
+= Troubleshooting: Remote jobs timing out after `yggdrasil` update
+
+On hosts that have weak dependencies disabled and are configured to use the `yggdrasil` pull client, remote jobs can start failing due to timeouts after the `yggdrasil` package has been updated to version 0.4.z or later.
+
+The pull-based transport configuration relies on the Yggdrasil service and differs based on the version of the `yggdrasil` package that is installed on the host.
+For pull-based remote execution mode to work correctly after `yggdrasil` version 0.4.z is installed on the host, the Yggdrasil client configuration must be updated.
+Installing the `foreman_ygg_migration` package on the host ensures that {Project} applies the required changes to Yggdrasil configuration.
+
+On hosts with weak dependencies enabled, {Project} automatically installs the `foreman_ygg_migration` package.
+No further steps are required.
+
+On hosts with weak dependencies disabled, you must install the `foreman_ygg_migration` package manually.
+
+.Procedure
+. Determine which version of the `yggdrasil` package is installed on the host:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+. If your host has `yggdrasil` version 0.4.z or later installed, the `yggdrasil` and `com.redhat.Yggdrasil1.Worker1.foreman` services are expected to be running.
+Check the status of these services:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl status yggdrasil com.redhat.Yggdrasil1.Worker1.foreman
+----
++
+If the above services are not running, it means that Yggdrasil might not be configured correctly.
+. Install the `foreman_ygg_migration` package manually:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# dnf install foreman_ygg_migration
+----
++
+Installing `foreman_ygg_migration` ensures that {Project} applies the required Yggdrasil configuration changes and enables remote execution in pull mode to work as expected.
+
+.Verification
+. Check the status of the Yggdrasil services again:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl status yggdrasil com.redhat.Yggdrasil1.Worker1.foreman
+----
++
+These services should now be running.

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -58,6 +58,9 @@ include::common/assembly_managing-packages.adoc[leveloffset=+1]
 :numbered!:
 
 [appendix]
+include::common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc[leveloffset=+1]
+
+[appendix]
 include::common/assembly_template-writing-reference.adoc[leveloffset=+1]
 
 [appendix]


### PR DESCRIPTION
#### What changes are you introducing?

Users can now end up with different versions of yggdrasil on their host. This PR adds steps to troubleshoot potential issues and remedy them.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This was originally included in https://github.com/theforeman/foreman-documentation/pull/3492 but we should cherry-pick the troubleshooting part to earlier versions, hence a separate PR.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

More packages should get names as epic as [yggdrasil](https://en.wikipedia.org/wiki/Yggdrasil).

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
