### PR TITLE
Add docs for rolling content views

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -16,6 +16,10 @@ include::modules/proc_viewing-module-streams.adoc[leveloffset=+1]
 
 include::modules/proc_promoting-a-content-view.adoc[leveloffset=+1]
 
+include::modules/con_rolling-content-views.adoc[leveloffset=+1]
+
+include::modules/proc_creating-a-rolling-content-view.adoc[leveloffset=+1]
+
 include::modules/con_composite-content-views-overview.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-composite-content-view.adoc[leveloffset=+1]

--- a/guides/common/modules/con_rolling-content-views.adoc
+++ b/guides/common/modules/con_rolling-content-views.adoc
@@ -1,0 +1,9 @@
+[id="rolling-content-views"]
+= Rolling content views
+
+A rolling content view is a curated subset of content that your hosts can access.
+It is a subset of the Library environment and contains the latest synchronized content from one or multiple repositories.
+You can use a rolling content view to provide a continuous stream of synchronized content to hosts.
+
+When you synchronize repositories to {Project}, all rolling content views that contain them get automatically updated to include the latest changes.
+You do not have to publish and/or promote a rolling content view compared to content views or composite content views.

--- a/guides/common/modules/proc_creating-a-rolling-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-rolling-content-view.adoc
@@ -1,0 +1,44 @@
+[id="creating-a-rolling-content-view"]
+= Creating a rolling content view
+
+You can create a rolling content view in the {ProjectWebUI}.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-rolling-content-view[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
+. Click *Create content view*.
+. In the *Create content view* window, enter a name for the content view in the *Name* field.
+{Project} automatically completes the *Label* field from the name you enter.
+. Optional: In the *Description* field, enter a description of the content view.
+. On the *Type* tab, select *Rolling content view*.
+. Click *Create content view*.
+. Click *Show repositories*.
+. Select the repositories that you want to add to your rolling content view.
+. Click *Add repositories* to add all selected repositories to your rolling content view.
+
+[id="cli-creating-a-rolling-content-view"]
+.CLI procedure
+. List all available repositories to identify IDs of repositories to add to your rolling content view:
++
+[options="nowrap" subs="+quotes"]
+----
+$ hammer repository list \
+--fields id,name,product \
+--organization "_My_Organization_"
+----
+. Create your rolling content view:
++
+[options="nowrap" subs="+quotes"]
+----
+$ hammer content-view create \
+--name "_My_Rolling_Content_View_" \
+--organization "_My_Organization_" \
+--repository-ids _My_List_Of_Repository_IDs_ \
+--rolling
+----
+
+.Next steps
+* You cannot publish or promote your rolling content view.
+Instead, continue by adding it to your activation key.
+For more information, see xref:Creating_an_Activation_Key_{context}[].
+* To register a host to your rolling content view, see {ManagingHostsDocURL}registering-a-host_managing-hosts[Registering a host] in _{ManagingHostsDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

documentation for rolling content views:

![image](https://github.com/user-attachments/assets/57a62039-c543-4425-8cec-7ac8fdc9d261)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

new feature -> new docs

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR 11240 in katello on GitHub
Refs 38048 in Redmine

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:
no cherry-picks