### PR TITLE
Add troubleshooting rex timeout due to yggdrasil version (3.11 and earlier)

### DIFF
--- a/guides/common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc
+++ b/guides/common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc
@@ -1,0 +1,48 @@
+[id="troubleshooting-remote-jobs-timing-out-after-yggdrails-update"]
+= Troubleshooting: Remote jobs timing out after `yggdrasil` update
+
+On hosts that have weak dependencies disabled and are configured to use the `yggdrasil` pull client, remote jobs can start failing due to timeouts after the `yggdrasil` package has been updated to version 0.4.z or later.
+
+The pull-based transport configuration relies on the Yggdrasil service and differs based on the version of the `yggdrasil` package that is installed on the host.
+For pull-based remote execution mode to work correctly after `yggdrasil` version 0.4.z is installed on the host, the Yggdrasil client configuration must be updated.
+Installing the `foreman_ygg_migration` package on the host ensures that {Project} applies the required changes to Yggdrasil configuration.
+
+On hosts with weak dependencies enabled, {Project} automatically installs the `foreman_ygg_migration` package.
+No further steps are required.
+
+On hosts with weak dependencies disabled, you must install the `foreman_ygg_migration` package manually.
+
+.Procedure
+. Determine which version of the `yggdrasil` package is installed on the host:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+. If your host has `yggdrasil` version 0.4.z or later installed, the `yggdrasil` and `com.redhat.Yggdrasil1.Worker1.foreman` services are expected to be running.
+Check the status of these services:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl status yggdrasil com.redhat.Yggdrasil1.Worker1.foreman
+----
++
+If the above services are not running, it means that Yggdrasil might not be configured correctly.
+. Install the `foreman_ygg_migration` package manually:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# dnf install foreman_ygg_migration
+----
++
+Installing `foreman_ygg_migration` ensures that {Project} applies the required Yggdrasil configuration changes and enables remote execution in pull mode to work as expected.
+
+.Verification
+. Check the status of the Yggdrasil services again:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl status yggdrasil com.redhat.Yggdrasil1.Worker1.foreman
+----
++
+These services should now be running.

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -55,8 +55,10 @@ include::common/assembly_managing-packages.adoc[leveloffset=+1]
 
 :numbered!:
 
+ifdef::satellite[]
 [appendix]
 include::common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc[leveloffset=+1]
+endif::[]
 
 [appendix]
 include::common/assembly_template-writing-reference.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -56,6 +56,9 @@ include::common/assembly_managing-packages.adoc[leveloffset=+1]
 :numbered!:
 
 [appendix]
+include::common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc[leveloffset=+1]
+
+[appendix]
 include::common/assembly_template-writing-reference.adoc[leveloffset=+1]
 
 [appendix]


### PR DESCRIPTION
#### What changes are you introducing?

See https://github.com/theforeman/foreman-documentation/pull/3516

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

See https://github.com/theforeman/foreman-documentation/pull/3516 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I opened https://github.com/theforeman/foreman-documentation/pull/3516 for nightly, 3.13, and 3.12: the migration package will get included upstream there.

For 3.11 and below, this will be applicable only to Satellite where the client repo is unversioned.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
