### PR TITLE
Revert "Consume Salt Minion from upstream (#3411)"

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -187,6 +187,7 @@
 :client-content-content-view-label: AlmaLinux_9
 :client-content-product-label: {client-content-content-view-label}
 :client-content-repository-label: BaseOS
+:client-salt-minion-repository-url: https://packages.broadcom.com/artifactory/saltproject-rpm/
 // Foreman Server and Smart Proxy Server
 :project-minimum-memory: 4 GB
 :project-package-check-update: dnf check-update

--- a/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
+++ b/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
@@ -8,6 +8,31 @@ ifdef::suse_linux_enterprise_server[]
 * Salt minions are part of the default {client-os} repositories.
 endif::[]
 ifndef::suse_linux_enterprise_server[]
-* Provide the Salt Minion repository on your host.
-For more information, see https://packages.broadcom.com/ui/repos/tree/General/saltproject-deb[Salt Minion for {DL}] and https://packages.broadcom.com/ui/repos/tree/General/saltproject-rpm[Salt Minion for {EL}].
+. Create a product called `Salt`.
+For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a product].
+. Create a repository within the _Salt_ product for each operating system supported by {Project} that you want to install the Salt Minion client software on.
+ifdef::client-content-apt[]
+For more information, see {ContentManagementDocURL}Adding_Custom_Deb_Repositories_content-management[Adding Deb repositories].
+endif::[]
+ifdef::client-content-dnf[]
+For more information, see {ContentManagementDocURL}Adding_Custom_RPM_Repositories_content-management[Adding RPM repositories].
+endif::[]
++
+Add the operating system to the name of the repository, for example `Salt for {client-os} {client-os-major}`.
++
+The URL depends on both the Salt version and the operating system, for example `{client-salt-minion-repository-url}`.
+ifdef::katello[]
+For hosts running {DL}, use `https://packages.broadcom.com/artifactory/saltproject-deb` as upstream URL.
+endif::[]
+. Synchronize the previously created products.
+For more information, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories].
+. Create a content view for each repository.
+For more information, see {ContentManagementDocURL}Creating_a_Content_View_content-management[Creating a content view].
+. Create a composite content view for each major version of each operating system to make the new content available.
+For more information, see {ContentManagementDocURL}Creating_a_Composite_Content_View_content-management[Create a composite content view].
+. Add each of your operating system specific Salt content views to your main composite content view for that operating system and version.
+. Publish a new version of the composite content view from the previous step.
+. Promote the content view from the previous step to your lifecycle environments as appropriate.
+For more information, see {ContentManagementDocURL}Promoting_a_Content_View_content-management[Promoting a content view].
+. Optional: Create activation keys for your composite content view and lifecycle environment combinations.
 endif::[]

--- a/guides/doc-Managing_Configurations_Salt/master.adoc
+++ b/guides/doc-Managing_Configurations_Salt/master.adoc
@@ -33,7 +33,9 @@ include::common/modules/proc_activating-salt.adoc[leveloffset=+2]
 
 include::common/modules/proc_setting-up-salt-minions.adoc[leveloffset=+1]
 
+ifdef::orcharhino,katello[]
 include::common/modules/proc_providing-the-salt-client-to-salt-minions.adoc[leveloffset=+2]
+endif::[]
 
 include::common/modules/proc_creating-a-host-group-with-salt.adoc[leveloffset=+2]
 


### PR DESCRIPTION
#### What changes are you introducing?

This reverts commit ba67ea7de5d2556e7486894631b9b80ed4d307dc.

* Updated the upstream URL for Salt Minions
* For Katello, also show URL for Salt Minions on Debian/Ubuntu
* Resolved minor merge conflicts in
  * guides/common/modules/con_introduction-to-salt.adoc
  * guides/common/modules/con_salt-architecture.adoc

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

the upstream repos for Salt Minions are working again:

* https://packages.broadcom.com/artifactory/saltproject-deb with "stable" and "main"
* https://packages.broadcom.com/artifactory/saltproject-rpm

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

"simple" revert

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

cherry-pick to 3.13 if possible