### PR TITLE
Add prerequisite for product existing

### DIFF
--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -8,6 +8,7 @@ For more information about OCI, see link:https://opencontainers.org/[Open Contai
 .Prerequisites
 * To push content to {Project}, ensure your {Project} account has the `edit_products` permission.
 * Ensure that a product exists before pushing a repository.
+For more information, see xref:Creating_a_Custom_Product_{context}[].
 * To pull content from {Project}, ensure that your {Project} account has the `view_lifecycle_environments`, `view_products`, and `view_content_views` permissions, unless the lifecycle environment allows unauthenticated pull.
 
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -7,6 +7,7 @@ For more information about OCI, see link:https://opencontainers.org/[Open Contai
 
 .Prerequisites
 * To push content to {Project}, ensure your {Project} account has the `edit_products` permission.
+* Ensure that a product exists before pushing a repository.
 * To pull content from {Project}, ensure that your {Project} account has the `view_lifecycle_environments`, `view_products`, and `view_content_views` permissions, unless the lifecycle environment allows unauthenticated pull.
 
 ifndef::orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?
New prerequisite in a procedure.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Not clearly explained that a product must exist to push a repository.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
