### PR TITLE
Set SSL certificate paths based on platform OS

### DIFF
--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -14,23 +14,38 @@ endif::[]
 .. Download the LDAP server certificate to a temporary location on the {ProjectServer}, such as `/tmp/_example.crt_`.
 You will remove the certificate when finished.
 +
+ifdef::foreman-deb[]
+{Project} only accepts the `.crt` file extension for certificates in PEM ASCII format.
+endif::[]
+ifndef::foreman-deb[]
 The filename extensions `.cer` and `.crt` are only conventions and can refer to DER binary or PEM ASCII format certificates.
+endif::[]
 . Add the LDAP server certificate to the system truststore:
 .. Import the certificate:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
+ifdef::foreman-deb[]
+# cp /tmp/_example.crt_ /usr/local/share/ca-certificates
+endif::[]
+ifndef::foreman-deb[]
 # cp /tmp/_example.crt_ /etc/pki/tls/source/anchors
+endif::[]
 ----
 .. Update the certificate authority truststore:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
+ifdef::foreman-deb[]
+# update-ca-certificates
+endif::[]
+ifndef::foreman-deb[]
 # update-ca-trust extract
+endif::[]
 ----
 . Delete the downloaded LDAP certificate from the temporary location on your {ProjectServer}.
 
-ifndef::orcharhino[]
+ifndef::orcharhino,foreman-deb[]
 .Additional resources
 * For more information about adding certificates to the system truststore, see link:{RHELDocsBaseURL}9/html/securing_networks/using-shared-system-certificates_securing-networks[Using shared system certificates] in _{RHEL}{nbsp}9 Securing networks_.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Hide link to RHEL docs for Foreman on Deb
* Note that Debian/Ubuntu only accept ".crt" as file extension

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

fixes [3500](https://github.com/theforeman/foreman-documentation/issues/3500)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
