### PR TITLE
Add support for TFTP-boot provisioning in IPv6 networks

### DIFF
--- a/guides/common/assembly_configuring-networking.adoc
+++ b/guides/common/assembly_configuring-networking.adoc
@@ -6,7 +6,11 @@ include::modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
 
 include::modules/con_network-resources.adoc[leveloffset=+1]
 
-include::modules/con_dhcp-options.adoc[leveloffset=+1]
+include::modules/con_foreman-and-dhcp-configuration.adoc[leveloffset=+1]
+
+include::modules/ref_statements-in-managed-dhcpv4.adoc[leveloffset=+2]
+
+include::modules/ref_options-in-unmanaged-dhcpv6.adoc[leveloffset=+2]
 
 include::modules/proc_troubleshooting-dhcp-problems.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_foreman-and-dhcp-configuration.adoc
+++ b/guides/common/modules/con_foreman-and-dhcp-configuration.adoc
@@ -1,0 +1,4 @@
+[id="{project-context}-and-dhcp-configuration"]
+= {Project} and DHCP configuration
+
+{Project} manages DHCP reservations through a DHCP {SmartProxy}.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -2,7 +2,6 @@
 = Creating hosts with UEFI HTTP boot provisioning
 
 You can provision hosts from {Project} using the UEFI HTTP Boot.
-This is the only method with which you can provision hosts in IPv6 network.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-with-uefi-http-boot-provisioning_{context}[].
 

--- a/guides/common/modules/ref_options-in-unmanaged-dhcpv6.adoc
+++ b/guides/common/modules/ref_options-in-unmanaged-dhcpv6.adoc
@@ -1,0 +1,19 @@
+[id="options-in-unmanaged-dhcpv6"]
+= Options in unmanaged DHCPv6
+
+To provision hosts over TFTP in an IPv6-only network, configure the DHCP server to respond with the `bootfile-url` DHCP option.
+{Project} cannot manage the DHCPv6 service, therefore, you have to configure your DHCP server manually.
+
+bootfile-url::
+The URL value of this option has to point to a file on TFTP {SmartProxy} that is a first-stage boot loader, such as `pxelinux.0`.
+Example configuration:
++
+[options="nowrap" subs="+quotes,attributes,verbatim"]
+----
+   "option-data": [
+      {
+         "name": "bootfile-url",
+         "data": "tftp://2001:db8:1::1/pxelinux.0"
+      }
+   ],
+----

--- a/guides/common/modules/ref_statements-in-managed-dhcpv4.adoc
+++ b/guides/common/modules/ref_statements-in-managed-dhcpv4.adoc
@@ -1,24 +1,23 @@
-[id="DHCP_Options_{context}"]
-= {Project} and DHCP options
+[id="statements-in-managed-dhcpv4"]
+= Statements in managed DHCPv4
 
-{Project} manages DHCP reservations through a DHCP {SmartProxy}.
-{Project} also sets the `next-server` and `filename` DHCP options.
+When {Project} manages the DHCP service and can update the DHCP configuration, {Project} sets the `next-server` and `filename` DHCP statements.
 
-.The next-server option
-The `next-server` option provides the IP address of the TFTP server to boot from.
-This option is not set by default and must be set for each TFTP {SmartProxy}.
-You can use the `{foreman-installer}` command with the `--foreman-proxy-tftp-servername` option to set the TFTP server in the `/etc/foreman-proxy/settings.d/tftp.yml` file:
-
+next-server::
+The `next-server` statement provides the IP address of the TFTP server to boot from.
+This statement is not set by default and must be set for each TFTP {SmartProxy}.
+You can use the `{foreman-installer}` command with the `--foreman-proxy-tftp-servername` argument to set the TFTP server in the `/etc/foreman-proxy/settings.d/tftp.yml` file:
++
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --foreman-proxy-tftp-servername _1.2.3.4_
 ----
-
++
 Each TFTP {SmartProxy} then reports this setting through the API and {Project} can retrieve the configuration information when it creates the DHCP record.
-
-When the PXE loader is set to `none`, {Project} does not populate the `next-server` option into the DHCP record.
-
-If the `next-server` option remains undefined, {Project} uses reverse DNS search to find a TFTP server address to assign, but you might encounter the following problems:
++
+When the PXE loader is set to `none`, {Project} does not populate the `next-server` statement into the DHCP record.
++
+If the `next-server` statement remains undefined, {Project} uses reverse DNS search to find a TFTP server address to assign, but you might encounter the following problems:
 
 * DNS timeouts during provisioning
 * Querying of incorrect DNS server.
@@ -26,14 +25,15 @@ For example, authoritative rather than caching
 * Errors about incorrect IP address for the TFTP server.
 For example, `PTR record was invalid`
 
++
 If you encounter these problems, check the DNS setup on both {Project} and {SmartProxy}, specifically the PTR record resolution.
 
-.The filename option
-The `filename` option contains the full path to the file that downloads and executes during provisioning.
-The PXE loader that you select for the host or host group defines which `filename` option to use.
-When the PXE loader is set to `none`, {Project} does not populate the `filename` option into the DHCP record.
+filename::
+The `filename` statement contains the full path to the file that downloads and executes during provisioning.
+The PXE loader that you select for the host or host group defines which `filename` entry to use.
+When the PXE loader is set to `none`, {Project} does not populate the `filename` statement into the DHCP record.
 Depending on the PXE loader option, the `filename` changes as follows:
-
++
 |=======
 |PXE loader option | filename entry| Notes
 


### PR DESCRIPTION
#### What changes are you introducing?

Adding support for TFTP-boot provisioning in IPv6 networks

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Satellite 6.17 has to comply with US Gov. requirement for IPv6 support

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I've restructured a module into multiple modules so that my new module was easier to fit.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
