### PR TITLE
Update list of Client OS for file-type content

### DIFF
--- a/guides/common/modules/snip_tip-file-repositories-by-atix.adoc
+++ b/guides/common/modules/snip_tip-file-repositories-by-atix.adoc
@@ -8,6 +8,7 @@ For the upstream URLs, see https://atixservice.zendesk.com/hc/de/articles/704408
 * Debian 12
 * Debian 11
 * Debian 10
+* Ubuntu 24.04
 * Ubuntu 22.04
 * Ubuntu 20.04
 * Ubuntu 18.04


### PR DESCRIPTION
#### What changes are you introducing?

orcharhino provides several file-type repositories to deploy hosts in disconnected environments.

source: ATIX Service Portal

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Previously, this was a downstream-only commit.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
