### PR TITLE
Fix attribute for Smart Proxy Server

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -10,7 +10,7 @@ include::modules/proc_creating-a-content-view.adoc[leveloffset=+1]
 
 include::modules/proc_copying-a-content-view.adoc[leveloffset=+1]
 
-include::modules/proc_synchronizing-a-content-view-to-a-smartproxy.adoc[leveloffset=+1]
+include::modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc[leveloffset=+1]
 
 include::modules/proc_viewing-module-streams.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
@@ -1,11 +1,11 @@
-[id="Synchronizing_a_Content_View_to_a_{smart-proxy-context}_{context}"]
-= Synchronizing a content view to a {SmartProxy}
+[id="synchronizing-a-content-view-to-a-{smart-proxy-context}-server"]
+= Synchronizing a content view to a {SmartProxyServer}
 
 In the {ProjectWebUI}, you can only synchronize all selected lifecycle environments simultaneously.
 If you need to synchronize smaller items, such as individual lifecycle environments, single content views, and single repositories, use the Hammer CLI.
 
 .CLI procedure
-* Synchronize a content view to your {SmartProxy} by using Hammer:
+* Synchronize a content view to your {SmartProxyServer} by using Hammer:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
@@ -9,7 +9,7 @@ If you need to synchronize smaller items, such as individual lifecycle environme
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content synchronize --content-view "my content view name"
+$ {hammer-smart-proxy} content synchronize --content-view "_My_Content_View_Name_"
 ----
 
 .Additional resources


### PR DESCRIPTION
#### What changes are you introducing?

I came to fix the example user input but stayed to fix the attribute.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

You can synchronized a CV to a Smart Proxy Server but not from your Foreman Server onto your Smart Proxy that's on your Foreman Server.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
