### PR TITLE
Drop support for running on Debian 11

### DIFF
--- a/guides/common/modules/con_projectserver-operating-system.adoc
+++ b/guides/common/modules/con_projectserver-operating-system.adoc
@@ -1,7 +1,7 @@
 [id="ProjectServer-Operating-System_{context}"]
 = {ProjectServer} operating system
 
-{Project} has packages for {EL} 9, Debian 12 and Ubuntu 22.04.
+{Project} has packages for {EL} 9, Debian 12, and Ubuntu 22.04.
 Katello plugin packages, which provide content management capabilities, are only available for {EL}.
 
 {Team} only packages {Project} for x86_64.

--- a/guides/common/modules/con_projectserver-operating-system.adoc
+++ b/guides/common/modules/con_projectserver-operating-system.adoc
@@ -1,7 +1,7 @@
 [id="ProjectServer-Operating-System_{context}"]
 = {ProjectServer} operating system
 
-{Project} has packages for {EL} 9, Debian 11, Debian 12 and Ubuntu 22.04.
+{Project} has packages for {EL} 9, Debian 12 and Ubuntu 22.04.
 Katello plugin packages, which provide content management capabilities, are only available for {EL}.
 
 {Team} only packages {Project} for x86_64.

--- a/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-deb.adoc
@@ -3,13 +3,6 @@
 // List of supported operating systems for foreman-deb has to match "guides/common/modules/proc_upgrading-a-connected-project-server.adoc"
 [tabs]
 =====
-Debian 11 (Bullseye)::
-+
---
-:distribution-codename: bullseye
-include::proc_configuring-repositories-deb.adoc[]
---
-
 Debian 12 (Bookworm)::
 +
 --

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -96,7 +96,6 @@ deb http://deb.theforeman.org/ plugins {ProjectVersion}
 // List of supported operating systems for foreman-deb has to match "guides/common/modules/proc_configuring-repositories-foreman-deb.adoc"
 Replace _My_Distribution_Code_Name_ with the proper distribution code name based on the operating system of your {ProjectServer}:
 +
-* `bullseye` for Debian 11
 * `bookworm` for Debian 12
 * `jammy` for Ubuntu 22.04
 . Update to {Project} {ProjectVersion}:

--- a/guides/common/modules/ref_supported-operating-systems.adoc
+++ b/guides/common/modules/ref_supported-operating-systems.adoc
@@ -19,7 +19,6 @@ ifdef::satellite[]
 | {RHEL} 9 | x86_64 only |
 endif::[]
 ifdef::foreman-deb[]
-| Debian 11 (Bullseye) | amd64 |
 | Debian 12 (Bookworm) | amd64 |
 | Ubuntu 22.04 (Jammy) | amd64 |
 endif::[]

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -4,14 +4,7 @@
 [id="foreman-headline-features"]
 == Headline Features
 
-ifndef::foreman-deb[]
 There are no highlights with Foreman {ProjectVersion}.
-endif::[]
-ifdef::foreman-deb[]
-=== Running Foreman on Debian 12 (Bookworm)
-
-Foreman now supports running on Debian 12 (Bookworm).
-endif::[]
 
 [id="foreman-upgrade-warnings"]
 == Upgrade Warnings
@@ -21,14 +14,16 @@ ifndef::foreman-deb[]
 There are no upgrade warnings with Foreman {ProjectVersion}.
 endif::[]
 ifdef::foreman-deb[]
-=== Running Foreman on Ubuntu 20.04 (Focal) is not supported anymore
+=== Running Foreman on Debian 11 (Bullseye) is not supported anymore
 
-Foreman supports running on Ubuntu 22.04 LTS (Jammy Jellyfish) since 3.11.
-Running Foreman on Ubuntu 20.04 LTS has been deprecated since 3.12.
-Support for running Foreman on Ubuntu 20.04 LTS has been removed.
+Foreman supports running on Debian 12 (Bullseye) since 3.11.4.
+Running Foreman on Debian 11 has been deprecated since 3.13.
+Support for running Foreman on Debian 11 has been removed.
 
 Note this is for running Foreman itself.
 Clients will remain supported.
+
+For more details, see the https://community.theforeman.org/t/drop-debian-11-ruby-2-7-and-nodejs-14-support-in-foreman-3-14/40503[removal RFC].
 endif::[]
 
 [id="foreman-deprecations"]


### PR DESCRIPTION
#### What changes are you introducing?

Foreman nightly has dropped Debian 11 packages and this reflects it in the documentation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://community.theforeman.org/t/drop-debian-11-ruby-2-7-and-nodejs-14-support-in-foreman-3-14/40503

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.