### PR TITLE
Fix next-server behavior

### DIFF
--- a/guides/common/modules/ref_options-in-managed-dhcpv4.adoc
+++ b/guides/common/modules/ref_options-in-managed-dhcpv4.adoc
@@ -17,16 +17,8 @@ Each TFTP {SmartProxy} then reports this setting through the API and {Project} c
 +
 When the PXE loader is set to `none`, {Project} does not populate the `next-server` option into the DHCP record.
 +
-If the `next-server` option remains undefined, {Project} uses reverse DNS search to find a TFTP server address to assign, but you might encounter the following problems:
-
-* DNS timeouts during provisioning
-* Querying of incorrect DNS server.
-For example, authoritative rather than caching
-* Errors about incorrect IP address for the TFTP server.
-For example, `PTR record was invalid`
-
-+
-If you encounter these problems, check the DNS setup on both {Project} and {SmartProxy}, specifically the PTR record resolution.
+If the `next-server` option remains undefined, {Project} calls the {SmartProxy} API to retrieve the server name as specified by the `--foreman-proxy-tftp-servername` argument in a `{foreman-installer}` run.
+If the {SmartProxy} API call does not return a server name, {Project} uses the hostname of the {SmartProxy}.
 
 `filename`::
 The `filename` option contains the full path to the file that downloads and executes during provisioning.


### PR DESCRIPTION
#### What changes are you introducing?

Fixing how the `next-server` DHCP option is determined when it isn't defined

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3532#discussion_r1890805941

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Original behavior removed in Foreman 2.5

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A -- see #3561 for CPs
