### PR TITLE
Update DHCPv6 server requirement

### DIFF
--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -5,6 +5,7 @@ Before installing {Project} in an IPv6 network, ensure that you meet the followi
 
 * You must deploy an external DHCPv6 server as a separate, unmanaged service to communicate with the network boot process and to manage IP address assignment.
 This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management.
+For more information about DHCPv6 server configuration, see {ProvisioningHostsDocURL}options-in-unmanaged-dhcpv6[Options in unmanaged DHCPv6] in _{ProvisioningHostsDocTitle}_.
 
 ifdef::satellite[]
 * You must deploy an external HTTP proxy server that supports both IPv4 and IPv6.

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,7 +3,7 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-* You must deploy an external DHCP IPv6 server as a separate, unmanaged service to manage IP address assignment and more importantly to communicate with the network boot process.
+* You must deploy an external IPv6 DHCP server as a separate, unmanaged service to manage IP address assignment and more importantly to communicate with the network boot process.
 This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management yet.
 
 ifdef::satellite[]

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,7 +3,7 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-* You must deploy an external IPv6 DHCP server as a separate, unmanaged service to communicate with the network boot process and to manage IP address assignment.
+* You must deploy an external DHCPv6 server as a separate, unmanaged service to communicate with the network boot process and to manage IP address assignment.
 This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management.
 
 ifdef::satellite[]

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,8 +3,7 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-* You must deploy an external DHCPv6 server as a separate, unmanaged service to communicate with the network boot process and to manage IP address assignment.
-This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management.
+* You must deploy an external DHCPv6 server and cofigure it manually to communicate with the network boot process and to manage IP address assignment because {Project} cannot integrate with a DHCPv6 server and manage its configuration.
 For more information about DHCPv6 server configuration, see {ProvisioningDocURL}options-in-unmanaged-dhcpv6[Options in unmanaged DHCPv6] in _{ProvisioningDocTitle}_.
 
 ifdef::satellite[]

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,8 +3,8 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-* You must deploy an external IPv6 DHCP server as a separate, unmanaged service to manage IP address assignment and more importantly to communicate with the network boot process.
-This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management yet.
+* You must deploy an external IPv6 DHCP server as a separate, unmanaged service to communicate with the network boot process and to manage IP address assignment.
+This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management.
 
 ifdef::satellite[]
 * You must deploy an external HTTP proxy server that supports both IPv4 and IPv6.

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -3,9 +3,8 @@
 
 Before installing {Project} in an IPv6 network, ensure that you meet the following requirements:
 
-* You must deploy an external DHCP IPv6 server as a separate, unmanaged service to bootstrap clients into GRUB2.
-GRUB2 configures IPv6 networking by using DHCPv6 or by assigning a static IPv6 address.
-This is required because the DHCP server in {RHEL} (ISC DHCP) does not provide an integration API for managing IPv6 records, therefore the {SmartProxy} DHCP plugin that provides DHCP management is limited to IPv4 subnets.
+* You must deploy an external DHCP IPv6 server as a separate, unmanaged service to manage IP address assignment and more importantly to communicate with the network boot process.
+This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management yet.
 
 ifdef::satellite[]
 * You must deploy an external HTTP proxy server that supports both IPv4 and IPv6.

--- a/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_requirements-for-installation-in-an-ipv6-network.adoc
@@ -5,7 +5,7 @@ Before installing {Project} in an IPv6 network, ensure that you meet the followi
 
 * You must deploy an external DHCPv6 server as a separate, unmanaged service to communicate with the network boot process and to manage IP address assignment.
 This is required because the {SmartProxy} DHCP plugin does not provide support for DHCPv6 management.
-For more information about DHCPv6 server configuration, see {ProvisioningHostsDocURL}options-in-unmanaged-dhcpv6[Options in unmanaged DHCPv6] in _{ProvisioningHostsDocTitle}_.
+For more information about DHCPv6 server configuration, see {ProvisioningDocURL}options-in-unmanaged-dhcpv6[Options in unmanaged DHCPv6] in _{ProvisioningDocTitle}_.
 
 ifdef::satellite[]
 * You must deploy an external HTTP proxy server that supports both IPv4 and IPv6.


### PR DESCRIPTION
#### What changes are you introducing?

Updating the requirement for the IPv6 DHCP server

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Satellite 6.17 has to comply with US Gov. requirement for IPv6 support

IPv6 is not limited to GRUB2 anymore and will use a different DHCP provider in future. Therefore, dropping mentions of those specifics from the wording.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Related to #3532

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
