### PR TITLE
Remove manual steps from prerequisites - convert2rhel

### DIFF
--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -31,7 +31,6 @@ The duration of the conversion process depends on the number of packages that ha
 
 .Prerequisites
 * Review {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#con_supported-conversion-paths_converting-from-a-linux-distribution-to-rhel[Supported conversion paths] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
-* You must have completed the steps 1.{range}5. of the procedure {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#converting-using-the-command-line_converting-from-a-linux-distribution-to-rhel[Preparing for a RHEL conversion] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
 * Ensure you have a subscription manifest uploaded to your {Project} and that there are sufficient {RHEL} entitlements allocated for the conversions you intend.
 Alternatively, you can use Ansible variables to tell the role to import the manifest from disk.
 The manifest must be imported to the organization to which you will register hosts for conversion.


### PR DESCRIPTION
#### What changes are you introducing?

Removing manual steps from convert2rhel prerequisites

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The Ansible role takes care of those steps.

Bug [SAT-30149](https://issues.redhat.com/browse/SAT-30149) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
