### PR TITLE
Add a missing plus sign to ensure list continuation

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -37,6 +37,7 @@ If you already have a private key for this {ProductName}, skip this step.
 +
 ifndef::load-balancing[]
 . Create the `/root/{cert-name}_cert/openssl.cnf` configuration file for the CSR and include the following content:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 [ req ]


### PR DESCRIPTION
#### What changes are you introducing?

I'm adding a plus sign to fix a broken ordered list in versions 3.8 and earlier.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-30254 reports an incorrectly displayed attribute:

![Screenshot From 2025-01-03 16-22-44](https://github.com/user-attachments/assets/4674e52e-7dc8-4552-8017-408adf7e40a8)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
