### PR TITLE
Fix a broken link

### DIFF
--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -1,6 +1,6 @@
 ifdef::context[:parent-context: {context}]
 
-[id="Configuring_Server_with_a_Custom_SSL_Certificate_{context}"]
+[id="Configuring_Server_with_a_Custom_SSL_Certificate"]
 = Configuring {ProjectServer} with a custom SSL certificate
 
 By default, {ProjectName} uses a self-signed SSL certificate to enable encrypted communications between {ProjectServer}, external {SmartProxyServers}, and all hosts.

--- a/guides/common/modules/con_ssl-authentication-overview.adoc
+++ b/guides/common/modules/con_ssl-authentication-overview.adoc
@@ -8,7 +8,7 @@ By default, {ProjectServer} uses a self-signed certificate.
 This certificate acts as both the server certificate to verify the encryption key and the certificate authority (CA) to trust the identity of {ProjectServer}.
 
 You can configure {ProjectServer} to use a custom SSL certificate.
-For more information, see {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{project-context}[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDocTitle}_.
 ifdef::satellite[]
-For more information on disconnected {ProjectServer}, see {InstallingServerDisconnectedDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{project-context}[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDisconnectedDocTitle}_.
+For more information on disconnected {ProjectServer}, see {InstallingServerDisconnectedDocURL}Configuring_Server_with_a_Custom_SSL_Certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -7,7 +7,7 @@ Do not use the same command on more than one {SmartProxyServer}.
 
 .Prerequisites
 * {ProjectServer} is configured with a custom certificate.
-For more information, see {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{project-context}[Configuring {ProjectServer} with a Custom SSL Certificate] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate[Configuring {ProjectServer} with a Custom SSL Certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
 For more information, see xref:Registering_Proxy_to_Server_{smart-proxy-context}[].
 * {SmartProxyServer} packages are installed.

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -5,7 +5,7 @@ Use this procedure to update your {customssl} certificate for {ProjectServer}.
 
 .Prerequisites
 * You must create a new Certificate Signing Request (CSR) and send it to the Certificate Authority to sign the certificate.
-Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{context}[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the Server certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
+Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_satellite[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the Server certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
 In return, you will receive the {ProjectServer} certificate and CA bundle.
 
 .Procedure

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -5,7 +5,7 @@ Use this procedure to update your {customssl} certificate for {ProjectServer}.
 
 .Prerequisites
 * You must create a new Certificate Signing Request (CSR) and send it to the Certificate Authority to sign the certificate.
-Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_satellite[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the Server certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
+Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the Server certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
 In return, you will receive the {ProjectServer} certificate and CA bundle.
 
 .Procedure

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -7,7 +7,7 @@ You cannot use the same command on more than one {SmartProxyServer}.
 
 .Prerequisites
 * You must create a new Certificate Signing Request and send it to the Certificate Authority to sign the certificate.
-Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate_{context}[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the {ProjectServer} certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
+Refer to the {InstallingServerDocURL}Configuring_Server_with_a_Custom_SSL_Certificate[Configuring {ProjectServer} with a Custom SSL Certificate] guide before creating a new CSR because the {ProjectServer} certificate must have X.509 v3 `Key Usage` and `Extended Key Usage` extensions with required values.
 In return, you will receive the {SmartProxyServer} certificate and CA bundle.
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

~~Replacing `{context}` with hard-coded `satellite` in a cross-guide link.~~

Dropping `{context}` from a section ID. The section is not reused so `{context}` is actually not needed. And it doesn't really work in cross-guide links anyway.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The link in [Renewing a SSL certificate on Foreman server](https://docs.theforeman.org/nightly/Administering_Project/index-katello.html#Renewing_a_Custom_SSL_Certificate_on_foreman_admin) doesn't take users to the target section in the installation guide. This is because the link contains the `{context}` variable which gets translated to `admin` instead of `katello`/`orcharhino`/`satellite`.

https://issues.redhat.com/browse/SAT-30253

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
