### PR TITLE
Remove references to the Override checkbox for filters

### DIFF
--- a/guides/common/modules/proc_adding-permissions-to-a-role.adoc
+++ b/guides/common/modules/proc_adding-permissions-to-a-role.adoc
@@ -11,7 +11,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-permission
 The _(Miscellaneous)_ group gathers permissions that are not associated with any resource group.
 . Click the permissions you want to select from the *Permission* list.
 . Depending on the *Resource type* selected, you can select or deselect the *Unlimited* and *Override* checkbox.
-The *Unlimited* checkbox is selected by default, which means that the permission is applied on all resources of the selected type.
+If the *Unlimited* checkbox is selected, the permission is applied on all resources of the selected type.
 When you disable the *Unlimited* checkbox, the *Search* field activates.
 In this field you can specify further filtering with use of the {Project} search syntax.
 For more information, see xref:Granular_Permission_Filtering_{context}[].

--- a/guides/common/modules/proc_adding-permissions-to-a-role.adoc
+++ b/guides/common/modules/proc_adding-permissions-to-a-role.adoc
@@ -10,12 +10,11 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-permission
 . Select the *Resource type* from the drop-down list.
 The _(Miscellaneous)_ group gathers permissions that are not associated with any resource group.
 . Click the permissions you want to select from the *Permission* list.
-. Depending on the *Resource type* selected, you can select or deselect the *Unlimited* and *Override* checkbox.
+. Depending on the *Resource type* selected, you can select or deselect the *Unlimited* checkbox.
 If the *Unlimited* checkbox is selected, the permission is applied on all resources of the selected type.
 When you disable the *Unlimited* checkbox, the *Search* field activates.
 In this field you can specify further filtering with use of the {Project} search syntax.
 For more information, see xref:Granular_Permission_Filtering_{context}[].
-When you enable the *Override* checkbox, you can add additional locations and organizations to allow the role to access the resource type in the additional locations and organizations; you can also remove an already associated location and organization from the resource type to restrict access.
 . Click *Next*.
 . Click *Submit* to save changes.
 

--- a/guides/common/modules/proc_adding-permissions-to-a-role.adoc
+++ b/guides/common/modules/proc_adding-permissions-to-a-role.adoc
@@ -10,9 +10,9 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-permission
 . Select the *Resource type* from the drop-down list.
 The _(Miscellaneous)_ group gathers permissions that are not associated with any resource group.
 . Click the permissions you want to select from the *Permission* list.
-. Depending on the *Resource type* selected, you can select or deselect the *Unlimited* checkbox.
-If the *Unlimited* checkbox is selected, the permission is applied on all resources of the selected type.
-When you disable the *Unlimited* checkbox, the *Search* field activates.
+. For certain *Resource type* options, the *Unlimited* checkbox is available.
+If *Unlimited* is selected, the permission is applied on all resources of the selected type.
+If *Unlimited* is unselected, the *Search* field activates.
 In this field you can specify further filtering with use of the {Project} search syntax.
 For more information, see xref:Granular_Permission_Filtering_{context}[].
 . Click *Next*.

--- a/guides/common/modules/proc_applying-permissions-for-the-host-resource-type.adoc
+++ b/guides/common/modules/proc_applying-permissions-for-the-host-resource-type.adoc
@@ -22,8 +22,3 @@ To do so, specify the environment name in the *Search* field, for example:
 ----
 Dev
 ----
-
-You can limit user permissions to a certain organization or location with the use of the granular permission filter in the *Search* field.
-However, some resource types provide a GUI alternative, an *Override* checkbox that provides the *Locations* and *Organizations* tabs.
-On these tabs, you can select from the list of available organizations and locations.
-For more information, see xref:Creating_an_Organization_Specific_Manager_Role_{context}[].

--- a/guides/common/modules/proc_creating-an-organization-specific-manager-role.adoc
+++ b/guides/common/modules/proc_creating-an-organization-specific-manager-role.adoc
@@ -13,6 +13,4 @@ You are then prompted to insert a name for the cloned role, for example _org-1 a
 . Click _org-1 admin_, and click *Filters* to view all associated filters.
 The default filters work for most use cases.
 However, you can optionally click *Edit* to change the properties for each filter.
-For some filters, you can enable the *Override* option if you want the role to be able to access resources in additional locations and organizations.
-For example, by selecting the *Domain* resource type, the *Override* option, and then additional locations and organizations using the *Locations* and *Organizations* tabs, you allow this role to access domains in the additional locations and organizations that is not associated with this role.
 You can also click *New filter* to associate new filters with this role.


### PR DESCRIPTION
#### What changes are you introducing?

I'm removing references to the ability to override organizations and locations on the filter level.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The option to override orgs and locs on the filter level is being removed in https://github.com/theforeman/foreman/pull/10370

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
