### PR TITLE
Declare a cipher unsupported for direct AD integration

### DIFF
--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -3,6 +3,14 @@
 
 Enable Active Directory (AD) users to access {Project} by configuring the corresponding authentication provider on your {ProjectServer}.
 
+[NOTE]
+====
+{Project} does not support using the `TLS_DHE_RSA_WITH_AES_256_GCM_SHA384` cipher suite.
+ifdef::satellite[]
+For more information, see the Red{nbsp}Hat Knowledgebase solution link:https://access.redhat.com/solutions/4870221[API calls to Red Hat Satellite 6 fail intermittently on LDAP authentication].
+endif::[]
+====
+
 .Prerequisites
 * The base system of your {ProjectServer} must be joined to an Active Directory (AD) domain.
 To enable AD users to sign in with Kerberos single sign-on, use the System Security Services Daemon (SSSD) and Samba services to join the base system to the AD domain:


### PR DESCRIPTION
#### What changes are you introducing?

I'm adding a note about the TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 cipher suite being unsupported. For Satellite, I'm also adding a link to a KBase solution.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-25882 reports errors in user environments that rely on the cipher.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
