### PR TITLE
Update /auth context path requirements for Keycloak

### DIFF
--- a/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc
+++ b/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc
@@ -10,11 +10,19 @@ On your {ProjectServer}:
 # {project-package-install} mod_auth_openidc keycloak-httpd-client-install python3-lxml
 ----
 // python3-lxml is only needed on EL8 because of https://issues.redhat.com/browse/RHEL-31496
+ifeval::["{context}" == "keycloak-quarkus"]
+* Check which `keycloak-httpd-client-install` version is installed:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# rpm --query keycloak-httpd-client-install
+----
+endif::[]
 
 On the {keycloak} side, ensure you meet the following requirements:
 
 ifeval::["{context}" == "keycloak-quarkus"]
-* You must use a {keycloak} server that has been initialized with the `--http-relative-path=/auth` context path.
+* If `keycloak-httpd-client-install` version 1.2 or earlier is installed on your {ProjectServer}, you must use a {keycloak} server that has been initialized with the `--http-relative-path=/auth` context path.
 To access a {keycloak} server initialized with `--http-relative-path=/auth` from its web UI, go to `https://_{keycloak-example-com}_:8443/auth`.
 +
 [NOTE]
@@ -24,6 +32,8 @@ ifndef::orcharhino[]
 For more information about configuring a different context path, see the {RHDocsBaseURL}red_hat_build_of_keycloak/24.0/html-single/server_guide/index#reverseproxy-different-context-path-on-reverse-proxy[_{RHBK} Administration Guide_].
 endif::[]
 ====
++
+If `keycloak-httpd-client-install` version 1.3 or later is installed, your {keycloak} server does not need to be initialized with the `--http-relative-path=/auth` context path.
 endif::[]
 * Your {keycloak} server uses HTTPS instead of HTTP.
 * If the certificates or the CA are self-signed, they have been added to the end-user certificate truststore.

--- a/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc
+++ b/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc
@@ -1,8 +1,20 @@
 [id="prerequisites-for-configuring-{project-context}-with-keycloak-authentication_{context}"]
 = Prerequisites for configuring {Project} with {keycloak-quarkus} authentication
 
-* A {keycloak} account with administrative privileges.
-* A {keycloak} server that uses HTTPS instead of HTTP and has been initialized with the `--http-relative-path=/auth` context path.
+On your {ProjectServer}:
+
+* Install the packages required for registering a {keycloak} client:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# {project-package-install} mod_auth_openidc keycloak-httpd-client-install python3-lxml
+----
+// python3-lxml is only needed on EL8 because of https://issues.redhat.com/browse/RHEL-31496
+
+On the {keycloak} side, ensure you meet the following requirements:
+
+ifeval::["{context}" == "keycloak-quarkus"]
+* You must use a {keycloak} server that has been initialized with the `--http-relative-path=/auth` context path.
 To access a {keycloak} server initialized with `--http-relative-path=/auth` from its web UI, go to `https://_{keycloak-example-com}_:8443/auth`.
 +
 [NOTE]
@@ -12,9 +24,12 @@ ifndef::orcharhino[]
 For more information about configuring a different context path, see the {RHDocsBaseURL}red_hat_build_of_keycloak/24.0/html-single/server_guide/index#reverseproxy-different-context-path-on-reverse-proxy[_{RHBK} Administration Guide_].
 endif::[]
 ====
-* If the certificates or the CA are self-signed, add them to the end-user certificate truststore.
-* A {keycloak} realm created for {Project} user accounts, for example `_{Project}_Realm_`.
-* Users imported or added to {keycloak}.
+endif::[]
+* Your {keycloak} server uses HTTPS instead of HTTP.
+* If the certificates or the CA are self-signed, they have been added to the end-user certificate truststore.
+* Your {keycloak} account has administrative privileges.
+* A realm is created on the {keycloak} server for {Project} user accounts, for example `_{Project}_Realm_`.
+* User accounts have been imported or added to {keycloak}.
 ifndef::orcharhino[]
 For more information on importing or creating users, see the {RHDocsBaseURL}red_hat_build_of_keycloak/24.0/html/server_administration_guide/user-storage-federation[_{RHBK} Administration Guide_].
 endif::[]

--- a/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-wildfly-authentication.adoc
+++ b/guides/common/modules/con_prerequisites-for-configuring-project-with-keycloak-wildfly-authentication.adoc
@@ -1,11 +1,23 @@
 [id="prerequisites-for-configuring-{project-context}-with-keycloak-authentication_{context}"]
 = Prerequisites for configuring {Project} with {keycloak-wildfly} authentication
 
-* A {keycloak} account with administrative privileges.
-* A {keycloak} server that uses HTTPS instead of HTTP.
-* If the certificates or the CA are self-signed, ensure that they are added to the end-user certificate truststore.
-* A {keycloak} realm created for {Project} user accounts, for example `_{Project}_Realm_`.
-* Users imported or added to {keycloak}.
+On your {ProjectServer}:
+
+* Install the packages required for registering a {keycloak} client:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+# {project-package-install} mod_auth_openidc keycloak-httpd-client-install python3-lxml
+----
+// python3-lxml is only needed on EL8 because of https://issues.redhat.com/browse/RHEL-31496
+
+On the {keycloak} side, ensure you meet the following requirements:
+
+* Your {keycloak} server uses HTTPS instead of HTTP.
+* If the certificates or the CA are self-signed, they have been added to the end-user certificate truststore.
+* Your {keycloak} account has administrative privileges.
+* A realm is created on the {keycloak} server for {Project} user accounts, for example `_{Project}_Realm_`.
+* User accounts have been imported or added to {keycloak}.
 ifndef::orcharhino[]
 For more information about importing or creating users, see the {RHDocsBaseURL}red_hat_single_sign-on/7.6/html/server_administration_guide/assembly-managing-users_server_administration_guide#proc-creating-user_server_administration_guide[_{RHSSO} Server Administration Guide_].
 endif::[]

--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -20,13 +20,6 @@ endif::[]
 
 On your {ProjectServer}:
 
-. Install the packages required for registering a {keycloak} client:
-+
-[options="nowrap", subs="verbatim,quotes,attributes"]
-----
-# {project-package-install} mod_auth_openidc keycloak-httpd-client-install python3-lxml
-----
-// python3-lxml is only needed on EL8 because of https://issues.redhat.com/browse/RHEL-31496
 . Choose the authentication method you want {keycloak} users to use when authenticating to {Project}:
 * If you want users to authenticate by using the {ProjectWebUI}:
 .. Create a client for {Project}.


### PR DESCRIPTION
#### What changes are you introducing?

We need to update the procedures for configuring Keycloak as an authentication source for Foreman to reflect changes in `keycloak-httpd-client-install` version 1.3.

This PR reshuffles existing prerequisites for the setup (to better enable adding the new information) and then on top of that explains which steps users need to take depending on whether 1.3 or 1.2 is installed on their Foreman server.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Existing procedures for configuring Quarkus-based Keycloak as an authentication source currently contain a workaround because they are based on the fact that `keycloak-httpd-client-install` requires the Keycloak server to be initialized with `--http-relative-path=/auth`. That is no longer the case because with version 1.3, `keycloak-httpd-client-install` has been updated. Notable commits:

*   https://github.com/latchset/keycloak-httpd-client-install/commit/67a05be47ecabf9e0dcacdd85a9c050a2e2c89d4 removes /auth from URLs
*  https://github.com/latchset/keycloak-httpd-client-install/commit/ef7df4e33a298b37ae6632c1710042c52dab2a37 autodetects whether /auth is needed

Therefore, the support matrix that we are dealing with now involves two versions of Keycloak (one based on the Quarkus application server, the other based on the deprecated Wildfly server) and two versions of the `keycloak-httpd-client-install` utility (1.2 and 1.3).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Thanks to @ekohl for investigating the situation and recording his findings in https://issues.redhat.com/browse/SAT-29434.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
