### PR TITLE
Update Discovery image base

### DIFF
--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -22,7 +22,7 @@ ifndef::satellite,orcharhino[]
 {Project} provides link:https://downloads.theforeman.org/discovery/releases/[multiple versions] of the Foreman Discovery image (FDI):
 
 * FDI version 5.0 is based on CentOS Stream 9.
-* FDI version 4.0 and 4.1 are based on CentOS Stream 8.
+* FDI versions 4.0 and 4.1 are based on CentOS Stream 8.
 * FDI versions older than 4.0 are based on CentOS Stream 7.
 endif::[]
 

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -13,15 +13,16 @@ The Discovery service requires a Discovery image, which is provided with {Projec
 The Discovery image uses a minimal operating system that is booted on hosts to acquire initial hardware information and check in with {Project}.
 
 ifdef::satellite[]
-The Foreman Discovery image provided with {Project} is based on {EL} 8.
+The Foreman Discovery image provided with {Project} is based on {EL} 9.
 endif::[]
 ifdef::orcharhino[]
-The Foreman Discovery image provided with {Project} is based on CentOS Stream 8.
+The Foreman Discovery image provided with {Project} is based on CentOS Stream 9.
 endif::[]
 ifndef::satellite,orcharhino[]
 {Project} provides link:https://downloads.theforeman.org/discovery/releases/[multiple versions] of the Foreman Discovery image (FDI):
 
-* FDI version 4.0 and newer are based on CentOS Stream 8.
+* FDI version 5.0 is based on CentOS Stream 9.
+* FDI version 4.0 and 4.1 are based on CentOS Stream 8.
 * FDI versions older than 4.0 are based on CentOS Stream 7.
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Updating the operating system versions on which the Discovery images are based.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The newest FDI is now based on EL 9.
[SAT-27541](https://issues.redhat.com/browse/SAT-27541) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

* [ ] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
