### PR TITLE
Add note about resources searchable by title

### DIFF
--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -96,12 +96,16 @@ The scope of the JWTs is limited to the registration endpoints only and cannot b
 [NOTE]
 ====
 {Project} generates the registration command with parameters that search resources by ID.
-However, you can edit the registration command to search the following resources by name:
+You can edit the registration command to search the following resources by title:
 
-Organization:: URL fragment example: `organization=My+Organization`
-Location:: URL fragment example: `location=My+Location`
-Host group:: URL fragment example: `hostgroup=My+Host+Group`
-Operating system:: URL fragment example: `operatingsystem=My+Operating+System`
+Organization:: URL fragment example: `organization=My%20Organization`
+Location:: URL fragment example: `location=My%20Location`
+Host group:: If a host group is nested, include the parent group separated with the slash character (`/`).
++
+URL fragment example: `hostgroup=Parent%20Group%2FMy%20Host%20Group`
+Operating system:: URL fragment example: `operatingsystem=My%20Operating%20System`
+
+The parameter values must be URL encoded.
 ====
 
 .CLI procedure

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -98,12 +98,12 @@ The scope of the JWTs is limited to the registration endpoints only and cannot b
 {Project} generates the registration command with parameters that search resources by ID.
 You can edit the registration command to search the following resources by title:
 
-Organization:: URL fragment example: `organization=My%20Organization`
-Location:: URL fragment example: `location=My%20Location`
+Organization:: URL fragment example: `organization=My%20Organization` or `organization=My+Organization`
+Location:: URL fragment example: `location=My%20Location` or `location=My+Location`
 Host group:: If a host group is nested, include the parent group separated with the slash character (`/`).
 +
 URL fragment example: `hostgroup=Parent%20Group%2FMy%20Host%20Group`
-Operating system:: URL fragment example: `operatingsystem=My%20Operating%20System`
+Operating system:: URL fragment example: `operatingsystem=My%20Operating%20System` or `operatingsystem=My+Operating+System`
 
 The parameter values must be URL encoded.
 ====

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -93,6 +93,17 @@ Therefore, do not delete, block, or change permissions of the user during the to
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
 
+[NOTE]
+====
+{Project} generates the registration command with parameters that search resources by ID.
+However, you can edit the registration command to search the following resources by name:
+
+Organization:: URL fragment example: `organization=My+Organization`
+Location:: URL fragment example: `location=My+Location`
+Host group:: URL fragment example: `hostgroup=My+Host+Group`
+Operating system:: URL fragment example: `operatingsystem=My+Operating+System`
+====
+
 .CLI procedure
 . Use the `hammer host-registration generate-command` to generate the registration command to register your host.
 . On your host that you want to register, run the registration command as `root`.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a note to global registration for users who need to edit the registration command

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

New feature allows users to search certain resources not only by ID but also by name.
This feature was introduced to ease transition from the bootstrap script to global registration.
Documents https://github.com/theforeman/foreman/pull/10351
[SAT-28832](https://issues.redhat.com/browse/SAT-28832) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I couldn't find any better place.
- I think a formal Note is in order to emphasize this info but feel free to disagree.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
