### PR TITLE
Add IPv4 installation requirements

### DIFF
--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -29,3 +29,7 @@ endif::[]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
+
+ifdef::installing-satellite-server-connected[]
+include::modules/proc_requirements-for-installation-in-an-ipv4-network.adoc[leveloffset=+1]
+endif::[]

--- a/guides/common/modules/proc_requirements-for-installation-in-an-ipv4-network.adoc
+++ b/guides/common/modules/proc_requirements-for-installation-in-an-ipv4-network.adoc
@@ -1,0 +1,13 @@
+[id="requirements-for-installation-in-an-ipv4-network"]
+= Requirements for installation in an IPv4 network
+
+The following requirements apply to installations in an IPv4 network:
+
+* An IPv6 loopback must be configured on the base system.
+The loopback is typically configured by default.
+Do not disable it.
+* Do not disable IPv6 in kernel by adding the `ipv6.disable=1` kernel parameter.
+ifdef::satellite[]
++
+For a supported way to disable the IPv6 protocol, see link:https://access.redhat.com/solutions/5045841[How do I disable the IPv6 protocol on Red Hat Satellite and/or Red Hat Capsule server?] in Red{nbsp}Hat Knowledgebase.
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding details on requirements for installation in an IPv4 network.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-29764 requests adding this.

I started working on this in https://github.com/theforeman/foreman-documentation/pull/3545 but actually want to get it merged in a separate PRs due to different cherry-pick requirements.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
