### PR TITLE
Drop instructions to update grub2-efi

### DIFF
--- a/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-for-uefi-http-boot-ipv6-provisioning.adoc
@@ -16,11 +16,3 @@ For more information, see {ProvisioningDocURL}Adding_a_Subnet_to_Server_provisio
 . You must disable DHCP management in the installer or not use it.
 . For all IPv6 subnets created in {Project}, set the *DHCP {SmartProxy}* to blank.
 . Optional: If the host and the DHCP server are separated by a router, configure the DHCP relay agent and point to the DHCP server.
-ifndef::foreman-deb[]
-. On {Project} or {SmartProxy} from which you provision, update the `grub2-efi` package to the latest version:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {project-package-update} grub2-efi
-----
-endif::[]

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -12,14 +12,6 @@ For more information, see {PlanningDocURL}http-booting-requirements[HTTP Booting
 endif::[]
 
 .Procedure
-ifndef::foreman-deb[]
-. On {SmartProxy} that you use for provisioning, update the `grub2-efi` package to the latest version:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {project-package-update} grub2-efi
-----
-endif::[]
 . Enable `foreman-proxy-http`, `foreman-proxy-httpboot`, and `foreman-proxy-tftp` features.
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -64,14 +56,6 @@ endif::[]
 
 [id="cli-creating-hosts-with-uefi-http-boot-provisioning_{context}"]
 .CLI procedure
-ifndef::foreman-deb[]
-. On {SmartProxy} that you use for provisioning, update the `grub2-efi` package to the latest version:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {project-package-update} grub2-efi
-----
-endif::[]
 . Enable `foreman-proxy-http`, `foreman-proxy-httpboot`, and `foreman-proxy-tftp true` features:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
+++ b/guides/doc-Planning_for_Project/topics/Provisioning_Concepts.adoc
@@ -79,17 +79,6 @@ For HTTP booting to work, ensure that {Project} has the following configurations
 * The TCP port {smartproxy_port} is open for the client to download the boot loader from the {SmartProxy} using the HTTPS protocol.
 * The subnet that functions as the host's provisioning interface has a DHCP {SmartProxy}, an HTTP Boot {SmartProxy}, a TFTP {SmartProxy}, and a Templates {SmartProxy}
 
-ifndef::foreman-deb[]
-* The `grub2-efi` package is updated to the latest version.
-To update the `grub2-efi` package to the latest version and execute the installer to copy the recent boot loader from `/boot` into `/var/lib/tftpboot` directory, enter the following commands:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {project-package-update} grub2-efi
-# {foreman-installer}
-----
-endif::[]
-
 ==== HTTP booting requirements with unmanaged DHCP
 To provision machines through HTTP booting without managed DHCP ensure that you meet the following requirements:
 
@@ -120,16 +109,6 @@ Although TFTP protocol is not used for HTTP UEFI Booting, {Project} use TFTP {Sm
 * Ensure that the host provisioning interface subnet has an HTTP Boot {SmartProxy} set.
 * Ensure that the host provisioning interface subnet has a TFTP {SmartProxy} set.
 * Ensure that the host provisioning interface subnet has a Templates {SmartProxy} set.
-
-ifndef::foreman-deb[]
-* Update the `grub2-efi` package to the latest version and execute the installer to copy the recent boot loader from the `/boot` directory into the `/var/lib/tftpboot` directory:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {project-package-update} grub2-efi
-# {foreman-installer}
-----
-endif::[]
 
 ifdef::foreman-el,katello,orcharhino[]
 === Secure boot


### PR DESCRIPTION
#### What changes are you introducing?

As the title says: it drops the manual instruction to install/update the grub2-efi package.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

As far as I can tell this was needed in the past because RHEL 7.9 contained an updated grub2-efi with support for HTTPBoot. Now that EL7 has been dropped, this is irrelevant and any installed version will do. The installer when enabling the tftp feature the already guarantees that the package is installed so the instruction can be dropped.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I only selected Foreman 3.13 as a cherry pick so we don't modify existing Satellite releases, but it's probably safe there as well.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.