### PR TITLE
Add missing steps to disable Puppet

### DIFF
--- a/guides/common/modules/proc_disabling-puppet.adoc
+++ b/guides/common/modules/proc_disabling-puppet.adoc
@@ -8,7 +8,7 @@ With the `--remove-all-data` argument, the command additionally removes Puppet s
 
 [WARNING]
 ====
-If you disable Puppet with the `--remove-all-data` argument, you will not be able to re-enable Puppet afterwards.
+If you purge Puppet data with the `--remove-all-data` argument, you will not be able to re-enable Puppet afterwards.
 ifndef::orcharhino[]
 This is a known issue, see the https://bugzilla.redhat.com/show_bug.cgi?id=2087067[Bug 2087067].
 endif::[]
@@ -18,13 +18,25 @@ endif::[]
 * Puppet is enabled on {Project}.
 
 .Procedure
-. If you have used Puppet server on any {SmartProxies}, disable Puppet server on all {SmartProxies}:
+. If you have been using Puppet server on any {SmartProxies}, disable Puppet server on all {SmartProxies}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --puppet-server false --foreman-proxy-puppet false
+----
+. If you have been using Puppet on any {SmartProxies}, purge Puppet data on all {SmartProxies}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} plugin purge-puppet --remove-all-data
 ----
 . Disable Puppet server on {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --puppet-server false --foreman-proxy-puppet false
+----
+. Purge Puppet data on {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Add a missing command to disable Puppet on both Foreman server and SmartProxy servers

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Without running the missing command, Foreman relies on the Puppet service which can cause an upgrade failure.
[SAT-24485](https://issues.redhat.com/browse/SAT-24485) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
