### PR TITLE
Show supported EL major version in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 Please cherry-pick my commits into:
 
-* [ ] Foreman 3.13/Katello 4.15
+* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
 * [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
 * [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
 * [ ] Foreman 3.10/Katello 4.12


### PR DESCRIPTION
#### What changes are you introducing?

Add EL major version to GitHub PR template

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

for convenience

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

source: https://docs.theforeman.org/3.13/Installing_Server/index-katello.html

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks necessary