### PR TITLE
Add ELS option to convert2rhel

### DIFF
--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -31,7 +31,7 @@ The duration of the conversion process depends on the number of packages that ha
 
 .Using an Extended Lifecycle Support add-on subscription on converted hosts
 If you convert to a RHEL version that is in the https://access.redhat.com/support/policy/updates/errata#Life_Cycle_Dates[phase of Extended Lifecycle Support] (ELS) and you do not plan to upgrade your host to a fully supported RHEL version, Red{nbsp}Hat recommends to use an ELS add-on subscription during the conversion.
-Note that the conversion and the subsequent upgrade without an ELS subscription come with a limited support scope per the [Convert2RHEL Support Policy](https://access.redhat.com/support/policy/convert2rhel-support) and the [In-place upgrade Support Policy](https://access.redhat.com/support/policy/ipu-support).
+Note that the conversion and the subsequent upgrade without an ELS subscription come with a limited support scope per the https://access.redhat.com/support/policy/convert2rhel-support[Convert2RHEL Support Policy] and the https://access.redhat.com/support/policy/ipu-support[In-place upgrade Support Policy].
 
 .Prerequisites
 * Review {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#con_supported-conversion-paths_converting-from-a-linux-distribution-to-rhel[Supported conversion paths] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -70,7 +70,7 @@ endif::[]
 Execute a remote job with the following settings:
 * **Job category**: `Convert 2 RHEL`
 * **Job template**: `Convert2RHEL analyze`
-* If you want to use an Extended Lifecycle Support add-on subscription on converted hosts, select the **ELS** option.
+* If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `true`.
 
 +
 ifdef::managing-hosts[]
@@ -91,7 +91,7 @@ Execute a remote job with the following settings:
 * **Activation key**:
 ** `convert2rhel_rhel7` if you convert to {RHEL} 7
 ** `convert2rhel_rhel8` if you convert to {RHEL} 8
-* If you want to use an Extended Lifecycle Support add-on subscription on converted hosts, select the **ELS** option.
+* If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `true`.
 
 +
 ifdef::managing-hosts[]

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -29,6 +29,10 @@ The utility also subscribes the host to Red{nbsp}Hat Subscription Management.
 
 The duration of the conversion process depends on the number of packages that have to be replaced, network speed, storage speed, and similar factors.
 
+.Using an Extended Lifecycle Support add-on subscription on converted hosts
+If you convert to a RHEL version that is in the https://access.redhat.com/support/policy/updates/errata#Life_Cycle_Dates[phase of Extended Lifecycle Support] (ELS) and you do not plan to upgrade your host to a fully supported RHEL version, Red{nbsp}Hat recommends to use an ELS add-on subscription during the conversion.
+Note that the conversion and the subsequent upgrade without an ELS subscription come with a limited support scope per the [Convert2RHEL Support Policy](https://access.redhat.com/support/policy/convert2rhel-support) and the [In-place upgrade Support Policy](https://access.redhat.com/support/policy/ipu-support).
+
 .Prerequisites
 * Review {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#con_supported-conversion-paths_converting-from-a-linux-distribution-to-rhel[Supported conversion paths] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
 * Ensure you have a subscription manifest uploaded to your {Project} and that there are sufficient {RHEL} entitlements allocated for the conversions you intend.
@@ -66,6 +70,7 @@ endif::[]
 Execute a remote job with the following settings:
 * **Job category**: `Convert 2 RHEL`
 * **Job template**: `Convert2RHEL analyze`
+* If you want to use an Extended Lifecycle Support add-on subscription on converted hosts, select the **ELS** option.
 
 +
 ifdef::managing-hosts[]
@@ -86,6 +91,7 @@ Execute a remote job with the following settings:
 * **Activation key**:
 ** `convert2rhel_rhel7` if you convert to {RHEL} 7
 ** `convert2rhel_rhel8` if you convert to {RHEL} 8
+* If you want to use an Extended Lifecycle Support add-on subscription on converted hosts, select the **ELS** option.
 
 +
 ifdef::managing-hosts[]

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -30,8 +30,8 @@ The utility also subscribes the host to Red{nbsp}Hat Subscription Management.
 The duration of the conversion process depends on the number of packages that have to be replaced, network speed, storage speed, and similar factors.
 
 .Using an Extended Lifecycle Support add-on subscription on converted hosts
-If you convert to a RHEL version that is in the https://access.redhat.com/support/policy/updates/errata#Life_Cycle_Dates[phase of Extended Lifecycle Support] (ELS) and you do not plan to upgrade your host to a fully supported RHEL version, Red{nbsp}Hat recommends to use an ELS add-on subscription during the conversion.
-Note that the conversion and the subsequent upgrade without an ELS subscription come with a limited support scope per the https://access.redhat.com/support/policy/convert2rhel-support[Convert2RHEL Support Policy] and the https://access.redhat.com/support/policy/ipu-support[In-place upgrade Support Policy].
+If you convert to a RHEL version that is in the https://access.redhat.com/support/policy/updates/errata#Extended_Life_Cycle_Phase[Extended Life Phase] and you do not plan to upgrade your host to a fully supported RHEL version, Red{nbsp}Hat recommends to use an Extended Life Cycle Support (ELS) Add-On subscription during the conversion.
+Note that the conversion and the subsequent upgrade without an ELS subscription come with a limited support scope per the https://access.redhat.com/support/policy/convert2rhel-support[RHEL Conversion Support Policy] and the https://access.redhat.com/support/policy/ipu-support[RHEL In-place upgrade Support Policy].
 
 .Prerequisites
 * Review {RHELDocsBaseURL}8/html-single/converting_from_a_linux_distribution_to_rhel_using_the_convert2rhel_utility/index#con_supported-conversion-paths_converting-from-a-linux-distribution-to-rhel[Supported conversion paths] in _{RHEL}{nbsp}8 Converting from a Linux distribution to RHEL using the Convert2RHEL utility_.
@@ -70,7 +70,7 @@ endif::[]
 Execute a remote job with the following settings:
 * **Job category**: `Convert 2 RHEL`
 * **Job template**: `Convert2RHEL analyze`
-* If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `true`.
+* If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `yes`.
 
 +
 ifdef::managing-hosts[]
@@ -91,7 +91,7 @@ Execute a remote job with the following settings:
 * **Activation key**:
 ** `convert2rhel_rhel7` if you convert to {RHEL} 7
 ** `convert2rhel_rhel8` if you convert to {RHEL} 8
-* If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `true`.
+* If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `yes`.
 
 +
 ifdef::managing-hosts[]

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -30,7 +30,7 @@ The utility also subscribes the host to Red{nbsp}Hat Subscription Management.
 The duration of the conversion process depends on the number of packages that have to be replaced, network speed, storage speed, and similar factors.
 
 .Using an Extended Lifecycle Support add-on subscription on converted hosts
-If you convert to a RHEL version that is in the https://access.redhat.com/support/policy/updates/errata#Extended_Life_Cycle_Phase[Extended Life Phase] and you do not plan to upgrade your host to a fully supported RHEL version, Red{nbsp}Hat recommends to use an Extended Life Cycle Support (ELS) Add-On subscription during the conversion.
+If you convert to a RHEL version that is in the https://access.redhat.com/support/policy/updates/errata#Extended_Life_Cycle_Phase[Extended Life Phase] and you do not plan to upgrade your host to a fully supported RHEL version, Red{nbsp}Hat recommends using an Extended Life Cycle Support (ELS) Add-On subscription during the conversion.
 Note that the conversion and the subsequent upgrade without an ELS subscription come with a limited support scope per the https://access.redhat.com/support/policy/convert2rhel-support[RHEL Conversion Support Policy] and the https://access.redhat.com/support/policy/ipu-support[RHEL In-place upgrade Support Policy].
 
 .Prerequisites


### PR DESCRIPTION
#### What changes are you introducing?

Adding an option to convert2rhel to convert to a RHEL version in the Extended Lifecycle Support (ELS) phase.
This currently applies to RHEL 7, but I tried to write it in version-neutral terms for future times.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Documents https://github.com/theforeman/foreman_ansible/pull/746,  https://github.com/theforeman/foreman_remote_execution/pull/933, and https://github.com/theforeman/foreman_remote_execution/pull/937

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
