### PR TITLE
Make guide dropdown scrollable

### DIFF
--- a/web/content/css/_nav.scss
+++ b/web/content/css/_nav.scss
@@ -81,6 +81,8 @@ nav .dropdown-menu {
   border-radius: 0.5em;
   background-color: #fff;
   width: max-content;
+  max-height: 80vh;
+  overflow: scroll;
 }
 nav .dropdown-menu-left {
   left: auto;


### PR DESCRIPTION
#### What changes are you introducing?

This makes the dropdown lists in the top navigation bar scrollable.

![Screenshot From 2025-01-10 14-48-39](https://github.com/user-attachments/assets/b7bb2400-3d2d-4d3c-b02c-ef9ac4800502)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/issues/2752

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
