### PR TITLE
Show Administering Foreman for 3.12 and 3.13

### DIFF
--- a/web/releases/3.12.json
+++ b/web/releases/3.12.json
@@ -19,6 +19,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Administering Foreman",
+          "path": "Administering_Project"
+        },
+        {
           "title": "Configuring user authentication",
           "path": "Configuring_User_Authentication"
         },
@@ -47,6 +51,10 @@
         {
           "title": "Upgrading Foreman to 3.12",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Administering Foreman",
+          "path": "Administering_Project"
         },
         {
           "title": "Configuring user authentication",

--- a/web/releases/3.13.json
+++ b/web/releases/3.13.json
@@ -19,6 +19,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Administering Foreman",
+          "path": "Administering_Project"
+        },
+        {
           "title": "Configuring hosts by using Ansible",
           "path": "Managing_Configurations_Ansible"
         },
@@ -47,6 +51,10 @@
         {
           "title": "Upgrading Foreman to 3.13",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Administering Foreman",
+          "path": "Administering_Project"
         },
         {
           "title": "Configuring hosts by using Ansible",


### PR DESCRIPTION
I forgot to add this to the navigation with https://github.com/theforeman/foreman-documentation/pull/3515 Guides are now built and published:

* https://docs.theforeman.org/3.12/Administering_Project/index-foreman-deb.html
* https://docs.theforeman.org/3.13/Administering_Project/index-foreman-deb.html
* https://docs.theforeman.org/3.12/Administering_Project/index-foreman-el.html
* https://docs.theforeman.org/3.13/Administering_Project/index-foreman-el.html

no cherry-picks necessary