### PR TITLE
Fix next-server behavior 3.13-3.7

### DIFF
--- a/guides/common/modules/con_dhcp-options.adoc
+++ b/guides/common/modules/con_dhcp-options.adoc
@@ -18,15 +18,8 @@ Each TFTP {SmartProxy} then reports this setting through the API and {Project} c
 
 When the PXE loader is set to `none`, {Project} does not populate the `next-server` option into the DHCP record.
 
-If the `next-server` option remains undefined, {Project} uses reverse DNS search to find a TFTP server address to assign, but you might encounter the following problems:
-
-* DNS timeouts during provisioning
-* Querying of incorrect DNS server.
-For example, authoritative rather than caching
-* Errors about incorrect IP address for the TFTP server.
-For example, `PTR record was invalid`
-
-If you encounter these problems, check the DNS setup on both {Project} and {SmartProxy}, specifically the PTR record resolution.
+If the `next-server` option remains undefined, {Project} calls the {SmartProxy} API to retrieve the server name as specified by the `--foreman-proxy-tftp-servername` argument in a `{foreman-installer}` run.
+If the {SmartProxy} API call does not return a server name, {Project} uses the hostname of the {SmartProxy}.
 
 .The filename option
 The `filename` option contains the full path to the file that downloads and executes during provisioning.


### PR DESCRIPTION
#### What changes are you introducing?

Cherry picks for #3540 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
