### PR TITLE
Fix broken link for default HTTP proxy

### DIFF
--- a/guides/common/modules/proc_enabling-red-hat-repositories.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories.adoc
@@ -2,7 +2,7 @@
 = Enabling Red{nbsp}Hat repositories
 
 If outside network access requires usage of an HTTP proxy, configure a default HTTP proxy for your server.
-For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{build}[Adding a Default HTTP Proxy to {Project}].
+For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{project-context}[Adding a default HTTP proxy to {Project}].
 
 To select the repositories to synchronize, you must first identify the product that contains the repository, and then enable that repository based on the relevant release version and base architecture.
 


### PR DESCRIPTION
#### What changes are you introducing?

fix link in https://docs.theforeman.org/nightly/Managing_Content/index-katello.html#Enabling_Red_Hat_Repositories_content-management

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* broken: https://docs.theforeman.org/nightly/Installing_Server/index-katello.html#adding-a-default-http-proxy_katello
* fixed: https://docs.theforeman.org/nightly/Installing_Server/index-katello.html#adding-a-default-http-proxy_foreman

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Also converted to sentence case. Found while reviewing https://github.com/theforeman/foreman-documentation/pull/3545

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
