### PR TITLE
Remove SCA prerequisite

### DIFF
--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -16,7 +16,7 @@ endif::[]
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 ifdef::satellite[]
-Ensure that all {ProjectServer}s are on the same version.
+* Ensure that all {ProjectServer}s are on the same version.
 endif::[]
 
 include::snip_warning-maintain-config-noop.adoc[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -16,9 +16,6 @@ endif::[]
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 ifdef::satellite[]
-* Migrate all organizations to Simple Content Access (SCA).
-For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/articles/simple-content-access[Simple Content Access]. 
-
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]
 


### PR DESCRIPTION
Migrating to SCA is a one-time thing and has been a part of the earlier version. Removing it as it is not required in later versions.

JIRA:
https://issues.redhat.com/browse/SAT-27580
Earlier PR for reference:
https://github.com/theforeman/foreman-documentation/pull/3228

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
