### PR TITLE
Drop note about keycloak reset

### DIFF
--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -84,8 +84,3 @@ Use `hammer-openidc` as the application name.
 ----
 # systemctl restart httpd
 ----
-
-[NOTE]
-====
-To disable {keycloak} authentication in {Project}, reset {keycloak} support to the default value by using `{foreman-installer} --reset-foreman-keycloak`.
-====


### PR DESCRIPTION
#### What changes are you introducing?

Removing a reference to `foreman-installer --reset-foreman-keycloak`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

~~After discussing the purpose and expected effect of  `foreman-installer --reset-foreman-keycloak`, there was a suggestion to drop the note until we can investigate its behavior more closely.~~

`--reset-foreman-keycloak` doesn't disable Keycloak authentication as currently documented but rather makes the installer ignore previously generated files.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
