### PR TITLE
Include	information about N-2 Smart Proxy support

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -3,6 +3,7 @@
 :BaseURL: https://docs.orcharhino.com/
 :ProjectVersion: 7.0
 :ProjectVersionPrevious: 6.11
+:ProjectVersionPrevious-Previous: 6.10
 :Project: orcharhino
 :project-allcaps: ORCHARHINO
 :project-context: {Project}

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -2,6 +2,7 @@
 :install-on-os: RHEL
 :ProjectVersion: 6.17
 :ProjectVersionPrevious: 6.16
+:ProjectVersionPrevious-Previous: 6.15
 // Add -beta for Beta releases
 :ProjectVersionRepoTitle: {ProjectVersion}
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -5,6 +5,7 @@
 // Version numbers
 :ProjectVersion: nightly
 :ProjectVersionPrevious: 3.13
+:ProjectVersionPrevious-Previous: 3.12
 :KatelloVersion: nightly
 :PulpcoreVersion: 3.63
 :CandlepinVersion: 4.4

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -27,7 +27,7 @@ ifdef::foreman-deb[]
 . Upgrade all {SmartProxyServers} to {ProjectVersion}.
 endif::[]
 
-{SmartProxies} at version {ProjectVersionPrevious} will keep working with your upgraded {ProjectServer} {ProjectVersion}.
+{SmartProxies} at version {ProjectVersionPrevious} and {ProjectVersionPrevious-Previous} will keep working with your upgraded {ProjectServer} {ProjectVersion}.
 After you upgrade {ProjectServer} to {ProjectVersion}, you can upgrade your {SmartProxies} separately over multiple maintenance windows.
 ifdef::foreman-el,katello,satellite[]
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].

--- a/guides/common/modules/con_upgrade-paths.adoc
+++ b/guides/common/modules/con_upgrade-paths.adoc
@@ -27,7 +27,12 @@ ifdef::foreman-deb[]
 . Upgrade all {SmartProxyServers} to {ProjectVersion}.
 endif::[]
 
+ifdef::orcharhino[]
+{SmartProxies} at version {ProjectVersionPrevious} will keep working with your upgraded {ProjectServer} {ProjectVersion}.
+endif::[]
+ifndef::orcharhino[]
 {SmartProxies} at version {ProjectVersionPrevious} and {ProjectVersionPrevious-Previous} will keep working with your upgraded {ProjectServer} {ProjectVersion}.
+endif::[]
 After you upgrade {ProjectServer} to {ProjectVersion}, you can upgrade your {SmartProxies} separately over multiple maintenance windows.
 ifdef::foreman-el,katello,satellite[]
 For more information, see xref:Upgrading_Proxies_Separately_from_Server_{context}[].

--- a/guides/common/modules/con_upgrading-smartproxies-separately-from-project.adoc
+++ b/guides/common/modules/con_upgrading-smartproxies-separately-from-project.adoc
@@ -1,9 +1,17 @@
 [id="Upgrading_Proxies_Separately_from_Server_{context}"]
 = Upgrading {SmartProxies} separately from {Project}
 
+ifdef::orcharhino[]
+You can upgrade {Project} to version {ProjectVersion} and keep {SmartProxies} at version {ProjectVersionPrevious} until you have the capacity to upgrade them too.
+
+All the functionality that worked previously works on {ProjectVersionPrevious} {SmartProxies}.
+endif::[]
+ifndef::orcharhino[]
 You can upgrade {Project} to version {ProjectVersion} and keep {SmartProxies} at version {ProjectVersionPrevious} or {ProjectVersionPrevious-Previous} until you have the capacity to upgrade them too.
 
 All the functionality that worked previously works on {ProjectVersionPrevious-Previous} and {ProjectVersionPrevious} {SmartProxies}.
+endif::[]
+
 However, the functionality added in the {ProjectVersion} release will not work until you upgrade {SmartProxies} to {ProjectVersion}.
 
 Upgrading {SmartProxies} after upgrading {Project} can be useful in the following example scenarios:

--- a/guides/common/modules/con_upgrading-smartproxies-separately-from-project.adoc
+++ b/guides/common/modules/con_upgrading-smartproxies-separately-from-project.adoc
@@ -1,9 +1,9 @@
 [id="Upgrading_Proxies_Separately_from_Server_{context}"]
 = Upgrading {SmartProxies} separately from {Project}
 
-You can upgrade {Project} to version {ProjectVersion} and keep {SmartProxies} at version {ProjectVersionPrevious} until you have the capacity to upgrade them too.
+You can upgrade {Project} to version {ProjectVersion} and keep {SmartProxies} at version {ProjectVersionPrevious} or {ProjectVersionPrevious-Previous} until you have the capacity to upgrade them too.
 
-All the functionality that worked previously works on {ProjectVersionPrevious} {SmartProxies}.
+All the functionality that worked previously works on {ProjectVersionPrevious-Previous} and {ProjectVersionPrevious} {SmartProxies}.
 However, the functionality added in the {ProjectVersion} release will not work until you upgrade {SmartProxies} to {ProjectVersion}.
 
 Upgrading {SmartProxies} after upgrading {Project} can be useful in the following example scenarios:

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -24,7 +24,12 @@ endif::[]
 ifdef::katello,orcharhino,satellite[]
 * If you use content views to control updates to the base operating system of {SmartProxyServer}, or for {SmartProxyServer} repository, you must publish updated versions of those content views.
 endif::[]
+ifdef::orcharhino[]
+* Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServers} still at {ProjectVersionPrevious}.
+endif::[]
+ifndef::orcharhino[]
 * Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServers} still at {ProjectVersionPrevious-Previous} and {ProjectVersionPrevious}.
+endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 [WARNING]

--- a/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
+++ b/guides/common/modules/snip_prerequisites-upgrading-project-server.adoc
@@ -24,7 +24,7 @@ endif::[]
 ifdef::katello,orcharhino,satellite[]
 * If you use content views to control updates to the base operating system of {SmartProxyServer}, or for {SmartProxyServer} repository, you must publish updated versions of those content views.
 endif::[]
-* Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServers} still at {ProjectVersionPrevious}.
+* Note that {ProjectServer} upgraded from {ProjectVersionPrevious} to {ProjectVersion} can use {SmartProxyServers} still at {ProjectVersionPrevious-Previous} and {ProjectVersionPrevious}.
 
 ifdef::katello,orcharhino,satellite[]
 [WARNING]


### PR DESCRIPTION
Project	now supports Smart Proxies of verions N-1 and N-2. Added a	new attribute for N-2 Smart Proxy : {ProjectVersionPrevious-Previous}. Added information about N-2 Smart Proxy support for Upgrade guide modules.

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
