### PR TITLE
Add new guide to web navigation

### DIFF
--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -39,6 +39,10 @@
           "path": "Provisioning_Hosts"
         },
         {
+          "title": "Provisioning hosts by using an installer",
+          "path": "Provisioning_Installer"
+        },
+        {
           "title": "Managing hosts",
           "path": "Managing_Hosts"
         },
@@ -111,6 +115,10 @@
         {
           "title": "Provisioning hosts",
           "path": "Provisioning_Hosts"
+        },
+        {
+          "title": "Provisioning hosts by using an installer",
+          "path": "Provisioning_Installer"
         },
         {
           "title": "Configuring hosts by using Ansible",
@@ -193,6 +201,10 @@
         {
           "title": "Provisioning hosts",
           "path": "Provisioning_Hosts"
+        },
+        {
+          "title": "Provisioning hosts by using an installer",
+          "path": "Provisioning_Installer"
         },
         {
           "title": "Managing hosts",


### PR DESCRIPTION
Refs PR 3472 on GitHub

#### What changes are you introducing?

Adding https://docs.theforeman.org/nightly/Provisioning_Installer/index-katello.html to the nav

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Follow-up to #3472 by Lena

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

built in nightly only; no cherry-picks needed because it's `web/`.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.