### PR TITLE
Limit host resources via Hammer CLI

### DIFF
--- a/guides/common/modules/proc_assigning-resource-quotas-to-a-user-group.adoc
+++ b/guides/common/modules/proc_assigning-resource-quotas-to-a-user-group.adoc
@@ -3,8 +3,34 @@
 
 You can assign resource quotas to a user group to limit the resource consumption of that {Project} user group.
 All users of the user group share the pool of resources.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-assigning-resource-quotas-to-a-user-group[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *User Groups*.
 . On the *Resource Quota* tab, assign resource quotas to the user group.
 . Click *Submit* to assign resource quotas to a user group.
+
+[id="cli-assigning-resource-quotas-to-a-user-group"]
+.CLI procedure
+. Optional: List all {Project} user groups:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer user-group list --fields id,name
+----
+. Optional: List all resource quotas:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota list --fields id,name
+----
+. Assign resource quotas to a user group:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer user-group update \
+--id _My_User_Group_ID_ \
+--resource-quota-ids _My_Resource_Quota_IDs_
+----
++
+For all options, see `hammer user-group update --help`.

--- a/guides/common/modules/proc_assigning-resource-quotas-to-a-user.adoc
+++ b/guides/common/modules/proc_assigning-resource-quotas-to-a-user.adoc
@@ -2,6 +2,7 @@
 = Assigning resource quotas to a user
 
 You can assign resource quotas to a user to limit the resource consumption of that {Project} user.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-assigning-resource-quotas-to-a-user[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Users*.
@@ -11,3 +12,30 @@ You can assign resource quotas to a user to limit the resource consumption of th
 +
 This means that {Project} will not prevent users from consuming more resources than their assigned quota.
 . Click *Submit* to assign resource quotas to a user.
+
+[id="cli-assigning-resource-quotas-to-a-user"]
+.CLI procedure
+. Optional: List all {Project} users:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer user list --fields id,login
+----
+. Optional: List all resource quotas:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota list --fields id,name
+----
+. Assign resource quotas to a user:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer user update \
+--id _My_User_ID_ \
+--resource-quota-ids _My_Resource_Quota_IDs_
+----
++
+If you want to make resouce quota optional, add the `--resource-quota-is-optional true` option.
++
+For all options, see `hammer user update --help`.

--- a/guides/common/modules/proc_creating-a-resource-quota.adoc
+++ b/guides/common/modules/proc_creating-a-resource-quota.adoc
@@ -2,9 +2,26 @@
 = Creating a resource quota
 
 Create a resource quota to limit the resource consumption of {Project} users.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-resource-quota[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Resource Quotas*.
 . Click *Create resource quota*.
 . Specify the name, CPU cores, memory, and disk space.
 . Click *Create resource quota* to submit the resource quota to {Project}.
+
+[id="cli-creating-a-resource-quota"]
+.CLI procedure
+* Create a resource quota:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota create \
+--cpu-cores _My_CPU_Cores_ \
+--description _My_Resource_Quota_Description_ \
+--disk-space _My_Disk_Space_in_GiB_ \
+--memory _My_Memory_in_MiB_ \
+--name "_My_Resource_Quota_Name_"
+----
++
+For all options, see `hammer resource-quota create --help`.

--- a/guides/common/modules/proc_deleting-a-resource-quota.adoc
+++ b/guides/common/modules/proc_deleting-a-resource-quota.adoc
@@ -2,7 +2,25 @@
 = Deleting a resource quota
 
 You can delete a resource quota from {Project}.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-deleting-a-resource-quota[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Resource Quotas*.
 . In the *Actions* column, click *Delete* for your resource quota.
+
+[id="cli-deleting-a-resource-quota"]
+.CLI procedure
+. Optional: List all resource quotas:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota list --fields id,name
+----
+. Delete a resource quota:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota delete --id _My_Resource_Quota_ID_
+----
++
+For all options, see `hammer resource-quota delete --help`.

--- a/guides/common/modules/proc_editing-a-resource-quota.adoc
+++ b/guides/common/modules/proc_editing-a-resource-quota.adoc
@@ -2,9 +2,36 @@
 = Editing a resource quota
 
 You can edit a resource quota to adjust available resources to {Project} users.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-editing-a-resource-quota[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Resource Quotas*.
 . Select your resource quota.
 . Adjust the *CPU cores*, *Memory*, or *Disk space* and click *Apply* to submit your changes to {Project}.
 . Click *Create resource quota* to submit the resource quota to {Project}.
+
+[id="cli-editing-a-resource-quota"]
+.CLI procedure
+. Optional: List all resource quotas:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota list --fields id,name
+----
+. Edit a resource quota:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer resource-quota update \
+--cpu-cores _My_CPU_Cores_ \
+--description _My_Resource_Quota_Description_ \
+--disk-space _My_Disk_Space_in_GiB_ \
+--id _My_Resource_Quota_ID_ \
+--memory _My_Memory_in_MiB_ \
+--name "_My_Resource_Quota_Name_"
+----
++
+If you set the value to `0`, users cannot consume any resource at all.
+To reset resource quotas, you can use `--remove-cpu-cores-limit`, `--remove-disk-space-limit`, and `--remove-memory-limit`.
++
+For all options, see `hammer resource-quota update --help`.

--- a/guides/common/modules/proc_installing-the-resource-quota-plugin.adoc
+++ b/guides/common/modules/proc_installing-the-resource-quota-plugin.adoc
@@ -4,9 +4,17 @@
 To limit host resources for your {Project} users, install the Resource Quota plugin.
 
 .Procedure
-* Install the plugin on your {ProjectServer}:
+. Install the plugin on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} --enable-foreman-plugin-resource-quota
+----
+// TODO: As soon as you can install this via foreman-installer:
+// # {foreman-installer} --enable-foreman-cli-resource-quota
+. Optional: Install the Hammer CLI plugin on your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {project-package-install} rubygem-hammer_cli_foreman_resource_quota
 ----


### PR DESCRIPTION
#### What changes are you introducing?

* Add command to install Hammer CLI plugin for foreman_resource_quota
* Use Hammer CLI to assign resource quotes to users
* Use Hammer CLI to manage resource quotas

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* Refs [PR 97 in foreman_resource_quota on GitHub](https://github.com/ATIX-AG/foreman_resource_quota/pull/97)
* Refs new Hammer CLI plugin https://github.com/ATIX-AG/hammer-cli-foreman-resource-quota/

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks: only foreman_resource_quota is part of 3.13; the Hammer CLI plugin is not available in nightly.