### PR TITLE
Revert "Use gh run download in previews (#3579)"

### DIFF
--- a/.github/download_workflow_run_artifact.js
+++ b/.github/download_workflow_run_artifact.js
@@ -1,0 +1,17 @@
+module.exports = async ({github, context, core, fs, artifact_name}) => {
+  let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+     owner: context.repo.owner,
+     repo: context.repo.repo,
+     run_id: context.payload.workflow_run.id,
+  });
+  let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+    return artifact.name == artifact_name
+  })[0];
+  let download = await github.rest.actions.downloadArtifact({
+     owner: context.repo.owner,
+     repo: context.repo.repo,
+     artifact_id: matchArtifact.id,
+     archive_format: 'zip',
+  });
+  fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifact_name}.zip`, Buffer.from(download.data));
+};

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download metadata artifact
-        run: gh run download {{ github.event.worfklow_run.id }} -n pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/download_workflow_run_artifact.js');
+            let fs = require('fs');
+            await script({github, context, core, fs, artifact_name: 'pr'});
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -36,7 +41,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download metadata artifact
-        run: gh run download {{ github.event.worfklow_run.id }} -n pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/download_workflow_run_artifact.js');
+            let fs = require('fs');
+            await script({github, context, core, fs, artifact_name: 'pr'});
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -45,7 +55,14 @@ jobs:
         run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
 
       - name: Download other artifacts
-        run: gh run download {{ github.event.worfklow_run.id }} -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' -n foreman-docs-html-base -n foreman-docs-web-master
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/download_workflow_run_artifact.js');
+            let fs = require('fs');
+            await script({github, context, core, fs, artifact_name: 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}'});
+            await script({github, context, core, fs, artifact_name: 'foreman-docs-html-base'});
+            await script({github, context, core, fs, artifact_name: 'foreman-docs-web-master'});
 
       - name: Set preview domain
         run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV


### PR DESCRIPTION
This reverts commit 242dde2bc3e9aecd70829cfe872da247db7400d3.

Refs https://github.com/theforeman/foreman-documentation/pull/3582#issuecomment-2597848735 and https://github.com/theforeman/foreman-documentation/pull/3579


error message in https://github.com/theforeman/foreman-documentation/actions/runs/12825702836/job/35764179400

````
Run gh run download {{ github.event.worfklow_run.id }} -n pr
accepts at most 1 arg(s), received 3
Error: Process completed with exit code 1.
````