### PR TITLE
Use multiple gh run download commands

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,10 @@ jobs:
         run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
 
       - name: Download other artifacts
-        run: gh run download {{ github.event.worfklow_run.id }} -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' -n foreman-docs-html-base -n foreman-docs-web-master
+        run: |
+          gh run download {{ github.event.worfklow_run.id }} -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}'
+          gh run download {{ github.event.worfklow_run.id }} -n foreman-docs-html-base
+          gh run download {{ github.event.worfklow_run.id }} -n foreman-docs-web-master
 
       - name: Set preview domain
         run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV


### PR DESCRIPTION
#### What changes are you introducing?

In 242dde2bc3e9aecd70829cfe872da247db7400d3 I tried to combine multiple downloads into a single command because from the man page made me think that. In practice it says:

> accepts at most 1 arg(s), received 3

This splits it back in to 3 separate commands as it previously was.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Becaue I broke things in #3579.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I'm sorry.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.