### PR TITLE
Use dollar sign prefix for variables for GHA

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download metadata artifact
-        run: gh run download {{ github.event.worfklow_run.id }} -n pr
+        run: gh run download ${{ github.event.worfklow_run.id }} -n pr
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download metadata artifact
-        run: gh run download {{ github.event.worfklow_run.id }} -n pr
+        run: gh run download ${{ github.event.worfklow_run.id }} -n pr
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -46,9 +46,9 @@ jobs:
 
       - name: Download other artifacts
         run: |
-          gh run download {{ github.event.worfklow_run.id }} -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}'
-          gh run download {{ github.event.worfklow_run.id }} -n foreman-docs-html-base
-          gh run download {{ github.event.worfklow_run.id }} -n foreman-docs-web-master
+          gh run download ${{ github.event.worfklow_run.id }} -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}'
+          gh run download ${{ github.event.worfklow_run.id }} -n foreman-docs-html-base
+          gh run download ${{ github.event.worfklow_run.id }} -n foreman-docs-web-master
 
       - name: Set preview domain
         run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV


### PR DESCRIPTION
`rg "\{\{" .github`

* Refs 242dde2bc3e9aecd70829cfe872da247db7400d3 (PR 3579 on GitHub)
* Refs 313e77e4229b120955cf18a2295d3e836cb923ee (PR 3584 on GitHub)

#### What changes are you introducing?

add missing dollar signs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

to make GH previews  work again :crossed_fingers: 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks