### PR TITLE
Correctly invoke gh run download

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download metadata artifact
-        run: gh run download {{ github.event.worfklow_run.id }} -n pr
+        run: gh run download '${{ github.event.worfklow_run.id }}' -n pr
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download metadata artifact
-        run: gh run download {{ github.event.worfklow_run.id }} -n pr
+        run: gh run download '${{ github.event.worfklow_run.id }}' -n pr
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -45,10 +45,7 @@ jobs:
         run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
 
       - name: Download other artifacts
-        run: |
-          gh run download {{ github.event.worfklow_run.id }} -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}'
-          gh run download {{ github.event.worfklow_run.id }} -n foreman-docs-html-base
-          gh run download {{ github.event.worfklow_run.id }} -n foreman-docs-web-master
+        run: gh run download '${{ github.event.worfklow_run.id }}' -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' -n foreman-docs-html-base -n foreman-docs-web-master
 
       - name: Set preview domain
         run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV


### PR DESCRIPTION
#### What changes are you introducing?

In 242dde2bc3e9aecd70829cfe872da247db7400d3 I forgot to add $ to the variable, so it was taking it literally. This is something I tried to fix in 313e77e4229b120955cf18a2295d3e836cb923ee but didn't.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Still broken.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

If this doesn't work it's probably best to revert the changes.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.