### PR TITLE
Provide env var to use gh CLI in GHA

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,9 +7,6 @@ on:
     types:
       - completed
 
-env:
-  GH_TOKEN: ${{ github.token }}
-
 jobs:
   preview-failed:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'success'
@@ -19,6 +16,8 @@ jobs:
 
       - name: Download metadata artifact
         run: gh run download '${{ github.event.workflow_run.id }}' -n pr
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -40,6 +39,8 @@ jobs:
 
       - name: Download metadata artifact
         run: gh run download '${{ github.event.workflow_run.id }}' -n pr
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Unzip artifact
         run: unzip pr.zip
@@ -49,6 +50,8 @@ jobs:
 
       - name: Download other artifacts
         run: gh run download '${{ github.event.workflow_run.id }}' -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' -n foreman-docs-html-base -n foreman-docs-web-master
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Set preview domain
         run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   preview-failed:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'success'


### PR DESCRIPTION
#### What changes are you introducing?

Provide env vars to use `gh` in GHA

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Original error message:
````
  Run gh run download '' -n pr
    gh run download '' -n pr
    shell: /usr/bin/bash -e {0}
  gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
    env:
      GH_TOKEN: ${{ github.token }}
````

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs 71b572445ab8a4ab156e5a9e66463ce57b76b6fa (PR 3587 on GitHub)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks.