### PR TITLE
Rely on gh run download to extract the artifacts

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,9 +19,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Unzip artifact
-        run: unzip pr.zip
-
       - name: Read PR data
         run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
 
@@ -42,16 +39,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Unzip artifact
-        run: unzip pr.zip
-
       - name: Read PR data
         run: echo "PR_DATA=$(cat ./pr.json)" >> $GITHUB_ENV
-
-      - name: Download other artifacts
-        run: gh run download '${{ github.event.workflow_run.id }}' -n 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' -n foreman-docs-html-base -n foreman-docs-web-master
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Set preview domain
         run: echo "PREVIEW_DOMAIN=$(echo ${{ github.repository }} | tr / - )-${{ github.job }}-pr-${{ fromJSON(env.PR_DATA).pr_number }}.surge.sh" >> $GITHUB_ENV
@@ -66,14 +55,18 @@ jobs:
 
       - name: Create preview layout
         run: |
-          mkdir -p preview/${{ fromJSON(env.PR_DATA).target_name }}
-          unzip -d preview foreman-docs-web-master.zip
-          unzip -d preview/${{ fromJSON(env.PR_DATA).target_name }} foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}.zip
+          gh run download '${{ github.event.worfklow_run.id }}' --name 'foreman-docs-web-master' --dir preview
+          gh run download '${{ github.event.worfklow_run.id }}' --name 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' --dir 'preview/${{ fromJSON(env.PR_DATA).target_name }}'
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create old base
+        run: gh run download '${{ github.event.worfklow_run.id }}' --name foreman-docs-html-base --dir old
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create diff to old base
         run: |
-          mkdir old
-          unzip -d old foreman-docs-html-base.zip
           diff -Nrwu old/ preview/${{ fromJSON(env.PR_DATA).target_name }}/ | cat > preview/diff.patch
           pygmentize -o preview/diff.html -l diff -f html -O full preview/diff.patch
           diffstat -l -p2 preview/diff.patch > diff.txt


### PR DESCRIPTION
#### What changes are you introducing?

Turns out gh already unpacks the artifact so the unzip steps are no longer needed. This also means we need multiple indivual commands because they need to be extract to different directories.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3588#issuecomment-2598421476

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I promise I'm trying to make things easier ;)

I also verified I can download manually:

```console
$ gh run download --repo theforeman/foreman-documentation '12830208840' --name foreman-docs-web-master --dir ~/tmp-docs/preview
$ gh run download --repo theforeman/foreman-documentation '12830208840' --name foreman-docs-html-provide_env_var --dir ~/tmp-docs/preview/master
$ ls ~/tmp-docs
preview
$ ls ~/tmp-docs/preview/
404.html  CNAME  css  favicon.ico  img  index.html  js  master  release
```

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.