### PR TITLE
Stop in the workflow run ID to gh run download

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,13 +55,13 @@ jobs:
 
       - name: Create preview layout
         run: |
-          gh run download '${{ github.event.worfklow_run.id }}' --name 'foreman-docs-web-master' --dir preview
-          gh run download '${{ github.event.worfklow_run.id }}' --name 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' --dir 'preview/${{ fromJSON(env.PR_DATA).target_name }}'
+          gh run download '${{ github.event.workflow_run.id }}' --name 'foreman-docs-web-master' --dir preview
+          gh run download '${{ github.event.workflow_run.id }}' --name 'foreman-docs-html-${{ fromJSON(env.PR_DATA).branch_name }}' --dir 'preview/${{ fromJSON(env.PR_DATA).target_name }}'
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create old base
-        run: gh run download '${{ github.event.worfklow_run.id }}' --name foreman-docs-html-base --dir old
+        run: gh run download '${{ github.event.workflow_run.id }}' --name foreman-docs-html-base --dir old
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
#### What changes are you introducing?

In 078bc30e4d6912068d14851e4244b2ec0af9ae91 I reintroduced a typo in the variable because of a merge conflict, making it end up as an empty string again. It happened to work because it was the last run (default behavior) but there's no guarantee this is correct.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.