### PR TITLE
Show managing hosts for all flavours

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -6,17 +6,15 @@ include::modules/proc_cloning-hosts.adoc[leveloffset=+1]
 
 include::modules/proc_associating-a-virtual-machine-from-a-hypervisor.adoc[leveloffset=+1]
 
-ifdef::satellite[]
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_editing-the-system-purpose-of-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc[leveloffset=+1]
-endif::[]
 
 include::modules/proc_changing-the-module-stream-for-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_enabling-custom-repositories-on-content-hosts.adoc[leveloffset=+1]
 
-ifdef::katello,satellite,orcharhino[]
 include::modules/proc_changing-the-content-source-of-a-host.adoc[leveloffset=+1]
 endif::[]
 
@@ -24,9 +22,11 @@ include::modules/proc_changing-the-environment-of-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_changing-the-managed-status-of-a-host.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_configuring-tracer-on-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_restarting-applications-on-a-host.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_assigning-a-host-to-a-specific-organization.adoc[leveloffset=+1]
 
@@ -34,7 +34,9 @@ include::modules/proc_assigning-a-host-to-a-specific-location.adoc[leveloffset=+
 
 include::modules/con_switching-between-hosts.adoc[leveloffset=+1]
 
+ifdef::katello,satellite,orcharhino[]
 include::modules/proc_viewing-host-details-from-a-content-host.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_selecting-host-columns.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -73,6 +73,8 @@ include::modules/proc_scheduling-a-recurring-ansible-job-for-a-host.adoc[levelof
 
 include::modules/proc_scheduling-a-recurring-ansible-job-for-a-host-group.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_using-ansible-provider-for-package-and-errata-actions.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_setting-the-job-rate-limit-on-smartproxy.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -8,6 +8,10 @@ include::modules/con_permissions-for-remote-execution.adoc[leveloffset=+1]
 
 include::modules/con_transport-modes-for-remote-execution.adoc[leveloffset=+1]
 
+ifdef::foreman-el,foreman-deb[]
+include::modules/proc_installing-the-remote-execution-plugin.adoc[leveloffset=+1]
+endif::[]
+
 ifdef::katello,orcharhino,satellite[]
 include::modules/proc_configuring-a-host-to-use-the-pull-client.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -55,6 +55,9 @@ include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leve
 
 include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+1]
 
+// the workflow is technically required for Foreman + OpenSCAP/REX Pull Mode
+// but the current docs reference "FQDN/pub/" which is Katello-only
+ifdef::katello,orcharhino,satellite[]
 include::modules/con_using-custom-ssl-certificate-for-hosts.adoc[leveloffset=+1]
 
 :common-example-com: {foreman-example-com}
@@ -62,3 +65,4 @@ include::modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc[leveloffs
 :!common-example-com:
 
 include::modules/ref_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-hosts.adoc[leveloffset=+1]
+endif::[]

--- a/guides/common/assembly_using-report-templates.adoc
+++ b/guides/common/assembly_using-report-templates.adoc
@@ -12,6 +12,8 @@ include::modules/proc_importing-report-templates.adoc[leveloffset=+1]
 
 include::modules/proc_importing-report-templates-using-the-api.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_generating-a-list-of-installed-packages.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/con_report-templates-safe-mode.adoc[leveloffset=+1]

--- a/guides/common/modules/con_browsing-hosts-in-foreman-webui.adoc
+++ b/guides/common/modules/con_browsing-hosts-in-foreman-webui.adoc
@@ -5,8 +5,10 @@ In the {ProjectWebUI}, you can browse all hosts recognized by {Project}, grouped
 
 * *All Hosts* {endash} a list of all hosts recognized by {Project}.
 * *Discovered Hosts* {endash} a list of bare-metal hosts detected on the provisioning network by the Discovery plugin.
+ifdef::katello,orcharhino,satellite[]
 * *Content Hosts* {endash} a list of hosts that manage tasks related to content and subscriptions.
 * *Host Collections* {endash} a list of user-defined collections of hosts used for bulk actions such as errata installation.
+endif::[]
 
 To search for a host, type in the *Search* field, and use an asterisk ({asterisk}) to perform a partial string search.
 For example, if searching for a content host named `{server-example-com}`, click the *Content Hosts* page and type `server*` in the *Search* field.

--- a/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
+++ b/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
@@ -7,6 +7,8 @@ You can register hosts through {ProjectServer} or {SmartProxyServer}.
 You must also install and configure tools on your hosts, depending on which integration features you want to use.
 Use the following procedures to install and configure host tools:
 
+ifdef::katello,orcharhino,satellite[]
 * xref:configuring-tracer-on-a-host_{context}[]
+endif::[]
 * xref:installing-and-configuring-puppet-agent-during-host-registration_{context}[]
 * xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[]

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -11,6 +11,12 @@ A job completes only after the Ansible Playbook runs on all hosts in the batch.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-executing-a-remote-job_{context}[].
 
+ifdef::foreman-el,foreman-deb[]
+.Prerequisites
+* You have the Remote Execution plugin enabled.
+For more information, see xref:installing-the-remote-execution-plugin[].
+endif::[]
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Monitor* > *Jobs* and click *Run job*.
 . Select the *Job category* and the *Job template* you want to use, then click *Next*.

--- a/guides/common/modules/proc_installing-the-remote-execution-plugin.adoc
+++ b/guides/common/modules/proc_installing-the-remote-execution-plugin.adoc
@@ -1,0 +1,29 @@
+[id="installing-the-remote-execution-plugin"]
+= Installing the Remote Execution plugin
+
+You can install and enable the Remote Execution plugin to run commands and jobs on hosts.
+
+.Procedure
+. Install the Remote Execution plugin on your {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-plugin-remote-execution \
+--enable-foreman-plugin-remote-execution-cockpit \
+--enable-foreman-proxy-plugin-remote-execution-script
+----
+. Optional: Enable the Hammer CLI plugin on your {ProjectServer}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-cli-remote-execution
+----
+. Optional: Install the Remote Execution plugin on your {SmartProxyServers}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} \
+--enable-foreman-proxy-plugin-remote-execution-script
+----

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -5,12 +5,6 @@ include::common/header.adoc[]
 
 = {ManagingHostsDocTitle}
 
-// This guide is not ready for stable releases and not on Debian
-ifdef::HideDocumentOnStable,foreman-deb[]
-include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-ifndef::HideDocumentOnStable,foreman-deb[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -29,9 +23,14 @@ ifdef::katello,orcharhino,satellite[]
 include::common/assembly_refreshing-the-self-signed-ca-certificate-on-hosts.adoc[leveloffset=+1]
 endif::[]
 
+// We do not package foreman_leapp for Foreman on Debian/Ubuntu
+ifndef::foreman-deb[]
 include::common/modules/proc_upgrading-hosts-to-next-major-release.adoc[leveloffset=+1]
+endif::[]
 
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_converting-a-host-to-rhel.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_host-management-and-monitoring-using-cockpit.adoc[leveloffset=+1]
 
@@ -53,7 +52,9 @@ include::common/assembly_configuring-and-setting-up-remote-jobs.adoc[leveloffset
 
 include::common/assembly_host-status.adoc[leveloffset=+1]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-packages.adoc[leveloffset=+1]
+endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_package-mode-and-image-mode-hosts.adoc[leveloffset=+1]
@@ -69,5 +70,3 @@ include::common/assembly_template-writing-reference.adoc[leveloffset=+1]
 
 [appendix]
 include::common/assembly_job-template-examples-and-extensions.adoc[leveloffset=+1]
-
-endif::[]

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -113,6 +113,10 @@
           "path": "Provisioning_Hosts"
         },
         {
+          "title": "Managing hosts",
+          "path": "Managing_Hosts"
+        },
+        {
           "title": "Configuring hosts by using Ansible",
           "path": "Managing_Configurations_Ansible"
         },


### PR DESCRIPTION
#### What changes are you introducing?

Show "Managing Hosts" for all flavours

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Part of https://github.com/theforeman/foreman-documentation/issues/396

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Needs tech ACK for:
* Is "tracer" a Katello-only feature? -> Yes :heavy_check_mark: 
* Does Leapp on EL hosts work without Katello? -> Yes, no change necessary.
* Is "Deploying a SSL certificate to hosts" Katello-only? -> in some use cases yes -> shown for all flavours :heavy_check_mark: 

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks