### PR TITLE
Set the project-client-name to always just be a label

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -118,7 +118,6 @@
 :project-allcaps: FOREMAN
 :project-client-url: https://yum.theforeman.org/client/{ProjectVersion}
 :project-client-name: Foreman Client
-:project-client-RHEL7-url: {project-client-url}/el7/x86_64/foreman-client-release.rpm
 :project-client-RHEL8-url: {project-client-url}/el8/x86_64/foreman-client-release.rpm
 :project-context: foreman
 :project-change-hostname: katello-change-hostname

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -117,7 +117,7 @@
 :PIV: PIV
 :project-allcaps: FOREMAN
 :project-client-url: https://yum.theforeman.org/client/{ProjectVersion}
-:project-client-name: {project-client-url}[Foreman Client]
+:project-client-name: Foreman Client
 :project-client-RHEL7-url: {project-client-url}/el7/x86_64/foreman-client-release.rpm
 :project-client-RHEL8-url: {project-client-url}/el8/x86_64/foreman-client-release.rpm
 :project-context: foreman

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -157,11 +157,7 @@
 :RepoRHEL8ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-8-x86_64-rpms
 
 // RHEL 7 Satellite repos
-:RepoRHEL7ServerSatelliteMaintenanceProjectVersion: rhel-7-server-satellite-maintenance-{RepoSatelliteVersion}-rpms
-:RepoRHEL7ServerSatelliteServerProjectVersion: rhel-7-server-satellite-{RepoSatelliteVersion}-rpms
-:RepoRHEL7ServerSatelliteServerProjectVersionPrevious: rhel-7-server-satellite-{ProjectVersionPrevious}-rpms
 :RepoRHEL7ServerSatelliteToolsProjectVersion: rhel-7-server-satellite-client-6-rpms
-:RepoRHEL7ServerSatelliteUtils: rhel-7-server-satellite-utils-{RepoSatelliteVersion}-rpms
 // Used in downstream guides
 :RepoRHEL7ServerSoftwareCollections: rhel-server-rhscl-7-rpms
 

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -67,7 +67,7 @@ To enable, enter the following command:
 ----
 $ hammer activation-key content-override \
 --name "_My_Activation_Key_" \
---content-label {project-client-RHEL7-url} \
+--content-label {project-client-name} \
 --value 1 \
 --organization "_My_Organization_"
 ----

--- a/guides/common/modules/proc_enabling-the-project-client-name-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-project-client-name-repository.adoc
@@ -13,7 +13,7 @@ For more information, see xref:Importing_a_Red_Hat_Subscription_Manifest_into_Se
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
 . Ensure that the *RPM* repository type is selected.
-. In the search field, type `name ~ "Satellite Client"` and press *Enter*.
+. In the search field, type `name = "{project-client-name}"` and press *Enter*.
 Optionally, enable the *Recommended Repositories* filter to limit the results.
 . Click the name of the required repository to expand the repository set.
 . For the required architecture, click the *+* icon to enable the repository.


### PR DESCRIPTION
#### What changes are you introducing?

Originally this was because Foreman 3.14 dropped the EL7 client repository. However, that was merged elsewhere. This cleans up some parts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* https://github.com/theforeman/foreman-packaging/pull/11493
* https://community.theforeman.org/t/drop-el7-packages-from-foreman-client-with-foreman-3-14/40505

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I have not completely reviewed all the content bits to see if they're still correct.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.