### PR TITLE
Remove system purpose addons references

### DIFF
--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -47,7 +47,7 @@ $ hammer activation-key update \
 --name "_My_Activation_Key_" \
 --service-level "_Standard_" \
 --purpose-usage "_Development/Test_" \
---purpose-role "_{RHELServer}_" \
+--purpose-role "_{RHELServer}_"
 ----
 . List the product content associated with the activation key:
 +

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -48,7 +48,6 @@ $ hammer activation-key update \
 --service-level "_Standard_" \
 --purpose-usage "_Development/Test_" \
 --purpose-role "_{RHELServer}_" \
---purpose-addons "_addons_"
 ----
 . List the product content associated with the activation key:
 +

--- a/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
+++ b/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 .CLI procedure
 . Log in to the host and edit the required system purpose attributes.
-For example, set the usage type to `Production`, the role to `{RHELServer}`, and add the `addon` add on.
+For example, set the usage type to `Production`, and the role to `{RHELServer}`.
 ifndef::orcharhino[]
 For the list of values, see {RHELDocsBaseURL}8/html/automatically_installing_rhel/proc_configuring-system-purpose-using-the-subscription-manager-command-line-tool_rhel-installer[Configuring System Purpose using the subscription-manager command-line tool] in _Automatically installing RHEL{nbsp}8_.
 endif::[]
@@ -28,7 +28,6 @@ endif::[]
 ----
 # subscription-manager syspurpose set usage '_Production_'
 # subscription-manager syspurpose set role '_Red Hat Enterprise Linux Server_'
-# subscription-manager syspurpose add addons '_your_addon_'
 ----
 . Verify the system purpose attributes for this host:
 +

--- a/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
+++ b/guides/common/modules/proc_editing-the-system-purpose-of-a-host.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 .CLI procedure
 . Log in to the host and edit the required system purpose attributes.
-For example, set the usage type to `Production`, and the role to `{RHELServer}`.
+For example, set the usage type to `Production` and the role to `{RHELServer}`.
 ifndef::orcharhino[]
 For the list of values, see {RHELDocsBaseURL}8/html/automatically_installing_rhel/proc_configuring-system-purpose-using-the-subscription-manager-command-line-tool_rhel-installer[Configuring System Purpose using the subscription-manager command-line tool] in _Automatically installing RHEL{nbsp}8_.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

We removed system purpose addons in Katello, this is a PR to remove and references from the docs.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We removed addons here https://github.com/Katello/katello/pull/11196

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
