### PR TITLE
Drop references to servers on RHEL 8

### DIFF
--- a/guides/common/modules/proc_configuring-a-cross-forest-trust-between-freeipa-and-active-directory-for-project.adoc
+++ b/guides/common/modules/proc_configuring-a-cross-forest-trust-between-freeipa-and-active-directory-for-project.adoc
@@ -5,7 +5,7 @@ When your {FreeIPA} deployment includes a cross-forest trust with Active Directo
 
 .Prerequisites
 * An existing {FreeIPA} server with a cross-forest trust with AD established.
-For more information, see link:{RHELDocsBaseURL}8/html-single/installing_identity_management/index#installing-trust-between-idm-and-ad_installing-identity-management[{RHEL}{nbsp}8 _Installing trust between IdM and AD_].
+For more information, see link:{RHELDocsBaseURL}9/html/installing_trust_between_idm_and_ad[{RHEL}{nbsp}9 _Installing trust between IdM and AD_].
 
 .Procedure
 

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -68,10 +68,7 @@ ad_gpo_map_service = +foreman
 ----
 ifndef::orcharhino[]
 +
-For more information on GPOs, see the following documents:
-+
-* link:{RHELDocsBaseURL}9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}9)_
-* link:{RHELDocsBaseURL}8/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#applying-group-policy-object-access-control-in-rhel_managing-direct-connections-to-ad[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}8)_
+For more information on GPOs, see {RHELDocsBaseURL}9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}9)_.
 endif::[]
 .. Restart SSSD:
 +

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -1,7 +1,7 @@
 [id="Installing_the_Load_Balancer_{context}"]
 = Installing the load balancer
 
-The following example provides general guidance for configuring an HAProxy load balancer using {EL} 9 or {EL} 8.
+The following example provides general guidance for configuring an HAProxy load balancer using {EL} 9.
 However, you can install any suitable load balancing software solution that supports TCP forwarding.
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

I'm removing a few references to running servers and proxy servers on RHEL 8. Some of them are links to RHEL 8 docs in places where it's now only RHEL 9 that should be linked.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I checked all guides to see if there is anything left that we should remove.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
