### PR TITLE
Remove VMware vCenter 6.x (EOL)

### DIFF
--- a/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-vmware-provisioning.adoc
@@ -7,8 +7,6 @@ The requirements for VMware vSphere provisioning include:
 The following versions have been fully tested with {Project}:
 ** vCenter Server 8.0
 ** vCenter Server 7.0
-** vCenter Server 6.7 (EOL)
-** vCenter Server 6.5 (EOL)
 * A {SmartProxyServer} managing a network on the vSphere environment.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_creating-a-vmware-user.adoc
+++ b/guides/common/modules/proc_creating-a-vmware-user.adoc
@@ -5,7 +5,7 @@ The VMware vSphere server requires an administration-like user for {ProjectServe
 For security reasons, do not use the `administrator` user for such communication.
 Instead, create a user with the following permissions:
 
-For VMware vCenter Server version 8.0, 7.0, or 6.7, set the following permissions:
+For VMware vCenter Server version 8.0 or 7.0, set the following permissions:
 
 * All Privileges -> Datastore -> Allocate Space, Browse datastore, Update Virtual Machine files, Low level file operations
 * All Privileges -> Network -> Assign Network
@@ -13,16 +13,5 @@ For VMware vCenter Server version 8.0, 7.0, or 6.7, set the following permission
 * All Privileges -> Virtual Machine -> Change Config (All)
 * All Privileges -> Virtual Machine -> Interaction (All)
 * All Privileges -> Virtual Machine -> Edit Inventory (All)
-* All Privileges -> Virtual Machine -> Provisioning (All)
-* All Privileges -> Virtual Machine -> Guest Operations (All)
-
-For VMware vCenter Server version 6.5, set the following permissions:
-
-* All Privileges -> Datastore -> Allocate Space, Browse datastore, Update Virtual Machine files, Low level file operations
-* All Privileges -> Network -> Assign Network
-* All Privileges -> Resource -> Assign virtual machine to resource pool
-* All Privileges -> Virtual Machine -> Configuration (All)
-* All Privileges -> Virtual Machine -> Interaction (All)
-* All Privileges -> Virtual Machine -> Inventory (All)
 * All Privileges -> Virtual Machine -> Provisioning (All)
 * All Privileges -> Virtual Machine -> Guest Operations (All)


### PR DESCRIPTION
#### What changes are you introducing?

Removing VMware vCenter Server versions 6.x

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

They are EOL and no longer tested nor supported in Satellite

[SAT-30483](https://issues.redhat.com/browse/SAT-30483) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Do we want to keep them in upstream?

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
