### PR TITLE
Update package cleanup for EL 8+ cloud-init images

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -147,12 +147,24 @@ endif::[]
 ----
 # update-ca-trust extract
 ----
-. Clean the image:
+. Stop the `rsyslog` and `auditd` services:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # systemctl stop rsyslog
 # systemctl stop auditd
+----
+. Clean packages on the image:
+* On {EL} 8 and newer:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# yum remove $(yum repoquery --installonly --latest-limit=-1 -q)
+----
+* On {EL} 7 and older:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
 # package-cleanup --oldkernels --count=1
 # dnf clean all
 ----

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -155,13 +155,13 @@ endif::[]
 # systemctl stop auditd
 ----
 . Clean packages on the image:
-* On {EL} 8 and newer:
+* On {EL} 8 and later:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# yum remove $(yum repoquery --installonly --latest-limit=-1 -q)
+# dnf remove --oldinstallonly
 ----
-* On {EL} 7 and older:
+* On {EL} 7 and earlier:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Adding a package clean-up command for EL 8+

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The previous command only works until EL 7

Bug [SAT-24621](https://issues.redhat.com/browse/SAT-24621) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I haven't tested the new command but it's based on a RH knowledgebase solution

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
