### PR TITLE
Update link to RHEL docs from 8 to 9

### DIFF
--- a/guides/common/modules/con_kickstart-workflow.adoc
+++ b/guides/common/modules/con_kickstart-workflow.adoc
@@ -14,4 +14,4 @@ When you run a {ProjectName} Kickstart script, the script performs the following
 . It runs user defined snippets.
 
 .Additional resources
-For more information about Kickstart, see {RHELDocsBaseURL}8/html/automatically_installing_rhel/automated-installation-workflow_rhel-installer[Automated installation workflow] in _Automatically installing RHEL{nbsp}8_.
+For more information about Kickstart, see {RHELDocsBaseURL}9/html/automatically_installing_rhel/automated-installation-workflow_rhel-installer[Automated installation workflow] in _Automatically installing RHEL{nbsp}9_.


### PR DESCRIPTION
#### What changes are you introducing?

Updating a link to RHEL docs to point to the latest major version.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3598/files#r1923189288

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I don't think we need to list all supported versions (7-9), let's stick with the latest major as discussed in https://github.com/theforeman/foreman-documentation/issues/3448

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
