### PR TITLE
Add vTPM to VMware provisioning

### DIFF
--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -46,7 +46,7 @@ $ hammer compute-profile create --name "_My_Compute_Profile_"
 [options="nowrap" subs="+quotes"]
 ----
 $ hammer compute-profile values create \
---compute-attributes "cpus=1,corespersocket=2,memory_mb=1024,cluster=MyCluster,path=MyVMs,start=true" \
+--compute-attributes "cpus=1,corespersocket=2,memory_mb=1024,firmware=uefi_secure_boot,cluster=MyCluster,path=MyVMs,virtual_tpm=true,start=true" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-resource "_My_VMware_" \
 --interface "compute_type=VirtualE1000,compute_network=mynetwork \

--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -28,6 +28,7 @@ By default, this is set to _automatic_.
 . From the *SCSI controller* list, select the disk access method for the host.
 . If you want to use eager zero thick provisioning, select the *Eager zero* checkbox.
 By default, the disk uses lazy zero thick provisioning.
+. Select *Virtual TPM* if you want to add a Virtual Trusted Platform Module for enhanced security.
 . From the *Network Interfaces* list, select the network parameters for the host's network interface.
 At least one interface must point to a {SmartProxy}-managed network.
 . Optional: Click *Add Interface* to create another network interfaces.

--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -13,6 +13,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_VMware_Det
 . In the *Cores per socket* field, enter the number of cores to allocate to each CPU.
 . In the *Memory* field, enter the amount of memory in MiB to allocate to the host.
 . In the *Firmware* field, select the firmware type for the host.
+By default, this is set to *automatic*.
 . In the *Cluster* list, select the name of the target host cluster on the VMware environment.
 . From the *Resource pool* list, select an available resource allocations for the host.
 . In the *Folder* list, select the folder to organize the host.
@@ -27,7 +28,8 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_VMware_Det
 . From the *SCSI controller* list, select the disk access method for the host.
 . If you want to use eager zero thick provisioning, select the *Eager zero* checkbox.
 By default, the disk uses lazy zero thick provisioning.
-. Select *Virtual TPM* if you want to add a Virtual Trusted Platform Module for enhanced security.
+. Optional: Select *Virtual TPM* if you want to add a Virtual Trusted Platform Module for enhanced security.
+This is compatible with UEFI firmware only.
 . From the *Network Interfaces* list, select the network parameters for the host's network interface.
 At least one interface must point to a {SmartProxy}-managed network.
 . Optional: Click *Add Interface* to create another network interfaces.
@@ -46,7 +48,7 @@ $ hammer compute-profile create --name "_My_Compute_Profile_"
 [options="nowrap" subs="+quotes"]
 ----
 $ hammer compute-profile values create \
---compute-attributes "cpus=1,corespersocket=2,memory_mb=1024,firmware=uefi_secure_boot,cluster=MyCluster,path=MyVMs,virtual_tpm=true,start=true" \
+--compute-attributes "cpus=1,corespersocket=2,memory_mb=1024,cluster=MyCluster,path=MyVMs,virtual_tpm=true,start=true" \
 --compute-profile "_My_Compute_Profile_" \
 --compute-resource "_My_VMware_" \
 --interface "compute_type=VirtualE1000,compute_network=mynetwork \

--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -12,8 +12,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_VMware_Det
 . In the *CPUs* field, enter the number of CPUs to allocate to the host.
 . In the *Cores per socket* field, enter the number of cores to allocate to each CPU.
 . In the *Memory* field, enter the amount of memory in MiB to allocate to the host.
-. In the *Firmware* checkbox, select either _BIOS_ or _UEFI_ as firmware for the host.
-By default, this is set to _automatic_.
+. In the *Firmware* field, select the firmware type for the host.
 . In the *Cluster* list, select the name of the target host cluster on the VMware environment.
 . From the *Resource pool* list, select an available resource allocations for the host.
 . In the *Folder* list, select the folder to organize the host.

--- a/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
+++ b/guides/common/modules/proc_adding-vmware-details-to-a-compute-profile.adoc
@@ -13,7 +13,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_VMware_Det
 . In the *Cores per socket* field, enter the number of cores to allocate to each CPU.
 . In the *Memory* field, enter the amount of memory in MiB to allocate to the host.
 . In the *Firmware* field, select the firmware type for the host.
-By default, this is set to *automatic*.
+By default, this is set to *Automatic*.
 . In the *Cluster* list, select the name of the target host cluster on the VMware environment.
 . From the *Resource pool* list, select an available resource allocations for the host.
 . In the *Folder* list, select the folder to organize the host.

--- a/guides/common/modules/proc_creating-a-vmware-user.adoc
+++ b/guides/common/modules/proc_creating-a-vmware-user.adoc
@@ -3,9 +3,7 @@
 
 The VMware vSphere server requires an administration-like user for {ProjectServer} communication.
 For security reasons, do not use the `administrator` user for such communication.
-Instead, create a user with the following permissions:
-
-For VMware vCenter Server version 8.0 or 7.0, set the following permissions:
+Instead, create a user with the following privileges:
 
 * All Privileges -> Datastore -> Allocate Space, Browse datastore, Update Virtual Machine files, Low level file operations
 * All Privileges -> Network -> Assign Network
@@ -15,3 +13,8 @@ For VMware vCenter Server version 8.0 or 7.0, set the following permissions:
 * All Privileges -> Virtual Machine -> Edit Inventory (All)
 * All Privileges -> Virtual Machine -> Provisioning (All)
 * All Privileges -> Virtual Machine -> Guest Operations (All)
+
+Additionally, if you want to create virtual machines with a Virtual Trusted Platform Module (TPM) for enhanced security, set the following privileges:
+
+* All Privileges -> Cryptographic operations -> Clone, Encrypt, Encrypt new, Migrate, Register VM
+* All Privileges -> Cryptographic operations -> Direct Access {endash} required to open a console session

--- a/guides/common/modules/proc_creating-a-vmware-user.adoc
+++ b/guides/common/modules/proc_creating-a-vmware-user.adoc
@@ -3,7 +3,9 @@
 
 The VMware vSphere server requires an administration-like user for {ProjectServer} communication.
 For security reasons, do not use the `administrator` user for such communication.
-Instead, create a user with the following privileges:
+Instead, create a user with the required privileges.
+
+In VMware vCenter Server version 8.0 or 7.0, set the following privileges:
 
 * All Privileges -> Datastore -> Allocate Space, Browse datastore, Update Virtual Machine files, Low level file operations
 * All Privileges -> Network -> Assign Network


### PR DESCRIPTION
#### What changes are you introducing?

Adding Virtual Trusted Platform Module compute-profile option and user permissions to VMware provisioning

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Documents https://github.com/theforeman/foreman/pull/10324

[SAT-30464](https://issues.redhat.com/browse/SAT-30464) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: probably none

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
