### PR TITLE
Fix EL version for repositories

### DIFF
--- a/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
@@ -13,13 +13,13 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 +
 * If you have {SmartProxyServers}, to upgrade them, enable the following repositories too:
 +
-*{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 8 x86_64) (RPMs)*
+*{ProjectName} {SmartProxy} {ProjectVersion} (for RHEL 9 x86_64) (RPMs)*
 +
-*{ProjectName} Maintenance {ProjectVersion} (for RHEL 8 x86_64) (RPMs)*
+*{ProjectName} Maintenance {ProjectVersion} (for RHEL 9 x86_64) (RPMs)*
 +
-*{EL} 8 (for x86_64 {endash} BaseOS) (RPMs)*
+*{EL} 9 (for x86_64 {endash} BaseOS) (RPMs)*
 +
-*{EL} 8 (for x86_64 {endash} AppStream) (RPMs)*
+*{EL} 9 (for x86_64 {endash} AppStream) (RPMs)*
 
 +
 [NOTE]


### PR DESCRIPTION
The EL version mentioned in the `Synchronizing the new repositories` chapter is 8, changing it to 9 for the newest release.

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
