### PR TITLE
Update REX pull client procedure for EL 10 hosts

### DIFF
--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -22,7 +22,7 @@ endif::[]
 .Procedure
 * Install the `katello-pull-transport-migrate` package on your host:
 ifdef::client-content-dnf[]
-** On {EL} 9 and {EL} 8 hosts:
+** On {EL} 10, {EL} 9, and {EL} 8 hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Adding RHEL 10 hosts to the procedure for configuring a REX pull client.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-27076
https://issues.redhat.com/browse/SAT-28102

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
