### PR TITLE
Replace client-install with server-install for LB

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -196,4 +196,5 @@
 :project-package-install: dnf install
 :project-package-remove: dnf remove
 :project-package-update: dnf upgrade
+// Foreman Server and Smart Proxy Server platform
 :server-package-install: {project-package-install}

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -196,3 +196,4 @@
 :project-package-install: dnf install
 :project-package-remove: dnf remove
 :project-package-update: dnf upgrade
+:server-package-install: {project-package-install}

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -102,6 +102,7 @@
 :project-package-install: satellite-maintain packages install
 :project-package-remove: satellite-maintain packages remove
 :project-package-update: satellite-maintain packages update
+:server-package-install: dnf install
 :PIV: CAC
 :project-allcaps: SATELLITE
 :project-context: satellite

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -9,13 +9,13 @@ However, you can install any suitable load balancing software solution that supp
 +
 [options="nowrap" subs="attributes"]
 ----
-# {client-package-install-el8} haproxy
+# {server-package-install} haproxy
 ----
 . Install the following package that includes the `semanage` tool:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {client-package-install-el8} policycoreutils-python-utils
+# {server-package-install} policycoreutils-python-utils
 ----
 . Configure SELinux to allow HAProxy to bind any port:
 +


### PR DESCRIPTION
#### What changes are you introducing?

"Installing the load balancer" currently uses the `client-package-install` attribute even though the procedure is not expected to be performed on a client. At the same time, the existing `project-package-install` attribute is not a good fit either because HAProxy is installed on a host without doesn't yet use satellite-maintain to install packages.

This introduces a new `server-package-install` attribute that resolves to `dnf install`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3598/files#r1922720268

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
