### PR TITLE
Add release note for EL7 client repository removal

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -10,8 +10,16 @@ There are no highlights with Foreman {ProjectVersion}.
 == Upgrade Warnings
 
 // If this section would be empty otherwise, uncomment the following line:
+//There are no upgrade warnings with Foreman {ProjectVersion}.
 ifndef::foreman-deb[]
-There are no upgrade warnings with Foreman {ProjectVersion}.
+=== EL 7 client repositories dropped
+
+RHEL 7 is out of maintenance since June 2024 and at the same time CentOS Linux 7 went end of life.
+With Foreman 3.14, the client repository is no longer built for EL 7.
+This primarily affects Katello and OpenSCAP users.
+
+For more details, see the https://community.theforeman.org/t/drop-el7-packages-from-foreman-client-with-foreman-3-14/40505[removal RFC].
+
 endif::[]
 ifdef::foreman-deb[]
 === Running Foreman on Debian 11 (Bullseye) is not supported anymore


### PR DESCRIPTION
#### What changes are you introducing?

Foreman 3.14 drops EL7 builds for the client repositories.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://community.theforeman.org/t/drop-el7-packages-from-foreman-client-with-foreman-3-14/40505

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I started in https://github.com/theforeman/foreman-documentation/pull/3596 but realized it was more complex. This limits to only adding the release note.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.