### PR TITLE
Replace server-pkg-install with pkg-install

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -197,4 +197,4 @@
 :project-package-remove: dnf remove
 :project-package-update: dnf upgrade
 // Foreman Server and Smart Proxy Server platform
-:server-package-install: {project-package-install}
+:package-install: {project-package-install}

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -102,7 +102,7 @@
 :project-package-install: satellite-maintain packages install
 :project-package-remove: satellite-maintain packages remove
 :project-package-update: satellite-maintain packages update
-:server-package-install: dnf install
+:package-install: dnf install
 :PIV: CAC
 :project-allcaps: SATELLITE
 :project-context: satellite

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -9,13 +9,13 @@ However, you can install any suitable load balancing software solution that supp
 +
 [options="nowrap" subs="attributes"]
 ----
-# {server-package-install} haproxy
+# {package-install} haproxy
 ----
 . Install the following package that includes the `semanage` tool:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {server-package-install} policycoreutils-python-utils
+# {package-install} policycoreutils-python-utils
 ----
 . Configure SELinux to allow HAProxy to bind any port:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Simplifying `server-package-install` to `package-install`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/3605, I introduced `server-package-install` as an attribute for installing packages on the base platform of Foreman server and proxy. When picking, I hit a conflict on 3.8 and noticed that on this branch, a simpler `package-install` is used for the same purpose.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
