### PR TITLE
Redeprecate bootstrap registration more strongly

### DIFF
--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -1,9 +1,12 @@
 [id="Registering_Hosts_by_Using_the_Bootstrap_Script_{context}"]
 = Registering hosts by using the bootstrap script
 
-**Deprecated** Use xref:Registering_Hosts_by_Using_Global_Registration_{context}[] instead.
+You can use the bootstrap script to automate content registration and Puppet configuration.
 
-Use the bootstrap script to automate content registration and Puppet configuration.
+:FeatureName: bootstrap script
+:FeatureAlternative: xref:Registering_Hosts_by_Using_Global_Registration_{context}[]
+include::snip_deprecated-feature.adoc[]
+
 You can use the bootstrap script to register new hosts, or to migrate existing hosts from RHN, SAM, RHSM, or another {ProjectName} instance.
 
 The `katello-client-bootstrap` package is installed by default on {ProjectServer}'s base operating system.

--- a/guides/common/modules/snip_deprecated-feature.adoc
+++ b/guides/common/modules/snip_deprecated-feature.adoc
@@ -1,0 +1,18 @@
+// When including this file, ensure that attributes set immediately before
+// the include. Otherwise it might result in an incorrect replacement.
+
+[IMPORTANT]
+====
+The {FeatureName} is a deprecated feature.
+Deprecated functionality is still included in {Project} and continues to be supported.
+However, it will be removed in a future release of this product and is not recommended for new deployments.
+
+ifdef::FeatureAlternative[]
+Use {FeatureAlternative} instead.
+endif::[]
+
+For the most recent list of major functionality that has been deprecated or removed within {Project}, refer to the _Deprecated features_ section of the {Project} release notes.
+====
+// Undefine attributes, so that any mistakes are easily spotted
+:!FeatureName:
+:!FeatureAlternative:


### PR DESCRIPTION
#### What changes are you introducing?

Making the deprecation more visible and the first sentence less prescriptive in registration by using bootstrap.py

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's too encouraging
Bug [SAT-30255](https://issues.redhat.com/browse/SAT-30255) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I've introduced a snippet for feature deprecation so that we have a unified form for deprecations in docs.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
