### PR TITLE
Replace ping command and output with dig command and output for DNS resolution

### DIFF
--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -32,7 +32,7 @@ my_system.domain.com.			0	IN	A	XXX.XXX.X.XX
 my_system.domain.com.			0	IN	A	XX.XX.XXX.X
 ----
 
-. To avoid discrepancies with static and transient host names, set all the host names on the system with the following command:
+. To avoid discrepancies with static and transient host names, set all the host names on the system:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_verifying-dns-resolution.adoc
+++ b/guides/common/modules/proc_verifying-dns-resolution.adoc
@@ -9,33 +9,30 @@ Verify the full forward and reverse DNS resolution using a fully-qualified domai
 +
 [options="nowrap"]
 ----
-# ping -c1 localhost
-# ping -c1 `hostname -f` # my_system.domain.com
+# dig localhost
+# dig `hostname -f` # my_system.domain.com
 ----
 +
-Successful name resolution results in output similar to the following:
+When name resolution succeeds, the output resembles the following:
 +
 [options="nowrap"]
 ----
-# ping -c1 localhost
-PING localhost (127.0.0.1) 56(84) bytes of data.
-64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.043 ms
+# dig localhost
+; <<>> DiG 9.18.30 <<>> localhost
+...
+;; ANSWER SECTION:
+localhost.		0	IN	A	127.0.0.1
+...
 
---- localhost ping statistics ---
-1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 0.043/0.043/0.043/0.000 ms
-
-# ping -c1 `hostname -f`
-PING hostname.gateway (XX.XX.XX.XX) 56(84) bytes of data.
-64 bytes from hostname.gateway (XX.XX.XX.XX): icmp_seq=1 ttl=64 time=0.019 ms
-
---- localhost.gateway ping statistics ---
-1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 0.019/0.019/0.019/0.000 ms
-
+# dig  `hostname -f`
+; <<>> DiG 9.18.30 <<>> my_system.domain.com
+...
+;; ANSWER SECTION:
+my_system.domain.com.			0	IN	A	XXX.XXX.X.XX
+my_system.domain.com.			0	IN	A	XX.XX.XXX.X
 ----
 
-. To avoid discrepancies with static and transient host names, set all the host names on the system by entering the following command:
+. To avoid discrepancies with static and transient host names, set all the host names on the system with the following command:
 +
 [options="nowrap" subs="+quotes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Replaced the ping command and its related output with the dig command, as dig is more appropriate for demonstrating DNS resolution.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Since the goal is to demonstrate DNS resolution, the dig command is a more accurate and reliable tool for this purpose.

Bug [SAT-28901](https://issues.redhat.com/browse/SAT-28901) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Alternatively, ping command can be replaced with nslookup command.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
