### PR TITLE
Deprecated feature snippet

### DIFF
--- a/guides/common/modules/snip_deprecated-feature.adoc
+++ b/guides/common/modules/snip_deprecated-feature.adoc
@@ -1,0 +1,13 @@
+// When including this file, ensure that {FeatureName} is set immediately before
+// the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+{FeatureName} is a deprecated feature.
+Deprecated functionality is still included in {Project} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+For the most recent list of major functionality that has been deprecated or removed within {Project}, refer to the _Deprecated features_ section of the {Project} release notes.
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:


### PR DESCRIPTION
#### What changes are you introducing?

Adding a "Deprecated snippet" for Satellite only.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I want to increase the visibility of deprecated features in the documentation.

This snippet is used in other Red Hat documentation repos and aligns with our downstream conventions.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No tech review or testing required.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
