### PR TITLE
Add limitations to bootstrap registration

### DIFF
--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -17,6 +17,11 @@ To use the bootstrap script, you must install it on the host.
 As the script is only required once, and only for the `root` user, you can place it in `/root` or `/usr/local/sbin` and remove it after use.
 This procedure uses `/root`.
 
+.Limitations
+Reverse proxying on {SmartProxies} is disabled by default for security reasons.
+Therefore, the bootstrap script will not work if you register hosts through {SmartProxy}.
+{Team} recommends you to use xref:Registering_Hosts_by_Using_Global_Registration_{context}[global registration] to register hosts instead.
+
 .Prerequisites
 * You have a {Project} user with the permissions required to run the bootstrap script.
 The examples in this procedure specify the `admin` user.

--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -20,7 +20,7 @@ This procedure uses `/root`.
 .Limitations
 Reverse proxying on {SmartProxies} is disabled by default for security reasons.
 Therefore, the bootstrap script will not work if you register hosts through {SmartProxy}.
-{Team} recommends you to use xref:Registering_Hosts_by_Using_Global_Registration_{context}[global registration] to register hosts instead.
+{Team} recommends using xref:Registering_Hosts_by_Using_Global_Registration_{context}[global registration] to register hosts instead.
 
 .Prerequisites
 * You have a {Project} user with the permissions required to run the bootstrap script.

--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -19,7 +19,7 @@ This procedure uses `/root`.
 
 .Limitations
 Reverse proxying on {SmartProxies} is disabled by default for security reasons.
-Therefore, the bootstrap script will not work if you register hosts through {SmartProxy}.
+Therefore, the bootstrap script does not work if you register hosts through {SmartProxy}.
 {Team} recommends using xref:Registering_Hosts_by_Using_Global_Registration_{context}[global registration] to register hosts instead.
 
 .Prerequisites


### PR DESCRIPTION
#### What changes are you introducing?

Adding limitations for registering hosts via SmartProxies by using the bootstrap script

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Bootstrap script no longer works because of [Disabled Capsule port 8443](https://docs.redhat.com/en/documentation/red_hat_satellite/6.16/html/release_notes/deprecated-functionality#Jira-SAT-24522)
Bug [SAT-30255](https://issues.redhat.com/browse/SAT-30255)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
