### PR TITLE
Remove unnecessary macros

### DIFF
--- a/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
+++ b/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
@@ -2,18 +2,14 @@ include::modules/con_supported-usage-and-versions-of-project-components.adoc[]
 
 ifdef::satellite[]
 include::modules/con_supported-usage-of-project-components.adoc[leveloffset=+1]
-endif::[]
 
-ifdef::satellite[]
 include::modules/con_supported-client-architectures-for-content-management.adoc[leveloffset=+1]
-endif::[]
 
-ifdef::satellite[]
 include::modules/con_supported-client-architectures-for-host-provisioning.adoc[leveloffset=+1]
-endif::[]
 
-ifdef::satellite[]
 include::modules/con_supported-client-architectures-for-configuration-management.adoc[leveloffset=+1]
+
+include::modules/con_supported-usage-and-versions-of-project-components-additional-resources.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::satellite,orcharhino[]
@@ -22,8 +18,4 @@ endif::[]
 
 ifndef::satellite[]
 include::modules/con_client-operating-systems.adoc[leveloffset=+1]
-endif::[]
-
-ifdef::satellite[]
-include::modules/con_supported-usage-and-versions-of-project-components-additional-resources.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/con_client-operating-systems.adoc
+++ b/guides/common/modules/con_client-operating-systems.adoc
@@ -11,9 +11,7 @@ include::snip_supported-client-operating-systems.adoc[]
 * OpenSCAP
 * OpenSSH
 * Puppet
-ifndef::satellite[]
 * Salt
-endif::[]
 * Windows Remote Management (WinRM)
 * Operating system installers that can perform unattended installations, such as Anaconda or Debian-installer
 


### PR DESCRIPTION
#### What changes are you introducing?

Remove unnecessary macros to simplify reading the source code of foreman-documentation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

As a response to https://github.com/theforeman/foreman-documentation/issues/2773, I looked at these files.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Refs https://github.com/theforeman/foreman-documentation/issues/2773#issuecomment-2626640057
* GHA bot proofs that output does not change

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
