### PR TITLE
Add HTTP(S) proxy username and password Setting

### DIFF
--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -15,6 +15,8 @@ When set to `Yes`, {Project} recreates this cache on the next restart.
 | *Login page footer text* | | Text to be shown in the login-page footer.
 | *HTTP(S) proxy* | | Set a proxy for outgoing HTTP(S) connections from the {Project} product.
 System-wide proxies must be configured at the operating system level.
+| *HTTP(S) proxy username* | | Username for connecting to the HTTP(S) proxy server
+| *HTTP(S) proxy user password* | | User password for connecting to the HTTP(S) proxy server
 | *HTTP(S) proxy except hosts* | [] | Set hostnames to which requests are not to be proxied.
 Requests to the local host are excluded by default.
 | *Show Experimental Labs* | No | Whether or not to show a menu to access experimental lab features (requires reload of page).


### PR DESCRIPTION
#### What changes are you introducing?

- Add HTTP(S) proxy username setting
- Add HTTP(S) proxy password setting

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://github.com/theforeman/foreman/pull/10432
#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
