### PR TITLE
Add newline between two xrefs

### DIFF
--- a/guides/common/modules/proc_invalidating-jwts-of-other-users.adoc
+++ b/guides/common/modules/proc_invalidating-jwts-of-other-users.adoc
@@ -4,6 +4,7 @@
 You can invalidate all registration JSON Web Tokens of one or more users.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-invalidating-jwts-of-other-users[].
+
 To use the API, see the xref:api-invalidating-jwts-of-other-users[].
 
 .Prerequisites

--- a/guides/common/modules/proc_invalidating-your-own-jwts.adoc
+++ b/guides/common/modules/proc_invalidating-your-own-jwts.adoc
@@ -4,6 +4,7 @@
 You can invalidate all registration JSON Web Tokens of the current user.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-invalidating-your-own-jwts[].
+
 To use the API, see the xref:api-invalidating-your-own-jwts[].
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

Adding a newline between two sentences with xrefs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Our downstream build cannot handle two xrefs in one paragraph

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
