### PR TITLE
Dissociate Smart Proxies unmanaged IPv6

### DIFF
--- a/guides/common/modules/proc_adding-a-domain.adoc
+++ b/guides/common/modules/proc_adding-a-domain.adoc
@@ -22,6 +22,11 @@ If you experience timeouts during DNS conflict resolution, check the following s
 * The domain name must have a Start of Authority (SOA) record available from {ProjectServer}.
 * The system resolver in the `/etc/resolv.conf` file must have a valid and working configuration.
 
+[IMPORTANT]
+====
+In an IPv6 network with unmanaged DNS, do not assign DNS {SmartProxy} to your domain.
+====
+
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-domain_{context}[].
 
 .Procedure

--- a/guides/common/modules/proc_adding-a-domain.adoc
+++ b/guides/common/modules/proc_adding-a-domain.adoc
@@ -44,14 +44,13 @@ For example, user defined Boolean or string parameters to use in templates.
 .CLI procedure
 * Use the `hammer domain create` command to create a domain:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 $ hammer domain create \
 --description "_My_Domain_" \
---dns-id _My_DNS_ID_ \
+--dns-id _My_DNS_{smart-proxy-context}_ID_ \
 --locations "_My_Location_" \
 --name "_my-domain.tld_" \
 --organizations "_My_Organization_"
 ----
 
-In this example, the `--dns-id` option uses `1`, which is the ID of your integrated {SmartProxy} on {ProjectServer}.

--- a/guides/common/modules/proc_adding-a-subnet.adoc
+++ b/guides/common/modules/proc_adding-a-subnet.adoc
@@ -43,13 +43,13 @@ For example, user defined Boolean or string parameters to use in templates.
 .CLI procedure
 * Create the subnet with the following command:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap" subs="+quotes,attributes"]
 ----
 $ hammer subnet create \
 --boot-mode "DHCP" \
 --description "_My_Description_" \
---dhcp-id _My_DHCP_ID_ \
---dns-id _My_DNS_ID_ \
+--dhcp-id _My_DHCP_{smart-proxy-context}_ID_ \
+--dns-id _My_DNS_{smart-proxy-context}_ID_ \
 --dns-primary "192.168.140.2" \
 --dns-secondary "8.8.8.8" \
 --domains "_my-domain.tld" \
@@ -64,8 +64,3 @@ $ hammer subnet create \
 --tftp-id _My_TFTP_ID_ \
 --to "192.168.140.250"
 ----
-
-[NOTE]
-====
-In this example, the `--dhcp-id`, `--dns-id`, and `--tftp-id` options use 1, which is the ID of the integrated {SmartProxy} in {ProjectServer}.
-====

--- a/guides/common/modules/proc_adding-a-subnet.adoc
+++ b/guides/common/modules/proc_adding-a-subnet.adoc
@@ -22,7 +22,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-subnet_{
 . In the *Primary DNS server* field, enter a primary DNS for the subnet.
 . In the *Secondary DNS server*, enter a secondary DNS for the subnet.
 . From the *IPAM* list, select the method that you want to use for IP address management (IPAM).
-For more information about IPAM, see xref:preparing-networking[].
+For more information about IPAM, see xref:Network_Resources_{context}[].
 +
 . Enter the information for the IPAM method that you select.
 ifdef::satellite,orcharhino[]

--- a/guides/common/modules/proc_adding-a-subnet.adoc
+++ b/guides/common/modules/proc_adding-a-subnet.adoc
@@ -4,6 +4,11 @@
 You must add information for each of your subnets to {ProjectServer} because {Project} configures interfaces for new hosts.
 To configure interfaces, {ProjectServer} must have all the information about the network that connects these interfaces.
 
+[IMPORTANT]
+====
+In an IPv6 network with unmanaged DHCP and DNS, do not assign DHCP {SmartProxy} and Reverse DNS {SmartProxy} to your subnet.
+====
+
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-a-subnet_{context}[].
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

Adding important instructions for subnets and domains in IPv6 networks, where DHCP and DNS cannot be managed by Foreman
...and a couple of cosmetic improvements

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Users need to know this if they work in IPv6 networks.
- "Once no proxies are associated, the system will allow creating hosts without IPs specified." [SAT-30604](https://issues.redhat.com/browse/SAT-30604)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
