### PR TITLE
Add note on enabling minor version of BaseOS and AppStream RPMs

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -20,11 +20,15 @@ ifdef::satellite[]
 +
 Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs):: `{RepoRHEL9BaseOS}`
 +
-Ensure this repository is enabled for the latest minor version, as specified in the {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
+Ensure this repository is enabled for the latest minor and major versions.
++
+For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
 +
 Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs):: `{RepoRHEL9AppStream}`
 +
-Ensure this repository is enabled for the latest minor version, as specified in the {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
+Ensure this repository is enabled for the latest minor and major versions.
++
+For more information, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
 +
 Red Hat Satellite Capsule {ProjectVersion} for RHEL 9 x86_64 RPMs:: `{RepoRHEL9ServerSatelliteCapsuleProjectVersion}`
 +

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -20,7 +20,11 @@ ifdef::satellite[]
 +
 Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs):: `{RepoRHEL9BaseOS}`
 +
+Ensure this repository is enabled for the latest minor version, as specified in the {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
++
 Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs):: `{RepoRHEL9AppStream}`
++
+Ensure this repository is enabled for the latest minor version, as specified in the {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
 +
 Red Hat Satellite Capsule {ProjectVersion} for RHEL 9 x86_64 RPMs:: `{RepoRHEL9ServerSatelliteCapsuleProjectVersion}`
 +


### PR DESCRIPTION
#### What changes are you introducing?

Ads a note to enable minor version of BaseOS and AppStream RPMs.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Based on the the leapp supported upgrade path we currently need 9.5 minor repositories; upgrade fails otherwise

Bug [SAT-29652](https://issues.redhat.com/browse/SAT-29652) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
