### PR TITLE
Add Insights settings for proxy/firewall

### DIFF
--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -93,6 +93,7 @@ ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
 | 443 | TCP | HTTPS | console.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
 | 443 | TCP | HTTPS | cdn.redhat.com | Content Sync | https://access.redhat.com/articles/1525183[Red{nbsp}Hat CDN]
+| 443 | TCP | HTTPS | cert.console.redhat.com | Red{nbsp}Hat Insights | When using Insights, required for Inventory upload and Cloud Connector connection
 | 443 | TCP | HTTPS | api.access.redhat.com | SOS report | Assisting support cases filed through the https://access.redhat.com/solutions/1179133[Red{nbsp}Hat Customer Portal] (optional)
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
 endif::[]

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -96,6 +96,7 @@ ifeval::["{mode}" == "connected"]
 | 443 | TCP | HTTPS | cert.console.redhat.com | Red{nbsp}Hat Insights | When using Insights, required for Inventory upload and Cloud Connector connection
 | 443 | TCP | HTTPS | api.access.redhat.com | SOS report | Assisting support cases filed through the https://access.redhat.com/solutions/1179133[Red{nbsp}Hat Customer Portal] (optional)
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
+| 443 | TCP | HTTPS | connect.cloud.redhat.com:443 | RHCD communication with the MQTT message broker |
 endif::[]
 endif::[]
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/snip_host-names-for-http-proxy.adoc
+++ b/guides/common/modules/snip_host-names-for-http-proxy.adoc
@@ -9,6 +9,7 @@ ifdef::satellite[]
 | cert.console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+| console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 endif::[]
 |====
 

--- a/guides/common/modules/snip_host-names-for-http-proxy.adoc
+++ b/guides/common/modules/snip_host-names-for-http-proxy.adoc
@@ -10,6 +10,7 @@ ifdef::satellite[]
 | api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 | console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+| connect.cloud.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
 endif::[]
 |====
 


### PR DESCRIPTION
In order to use Insights with a proxy or firewall, users need to configure connections for both console.redhat.com and cert.console.redhat.com. Added these missing entries to the `Ports and Firewall requirements` and `Hostnames for HTTP proxy` tables.

JIRA: https://issues.redhat.com/browse/SAT-30953

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [X] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
