### PR TITLE
Simplify flavor+version navigation paths

### DIFF
--- a/web/content/index.adoc.erb
+++ b/web/content/index.adoc.erb
@@ -12,9 +12,9 @@ For official documentation, see link:https://theforeman.org/manuals/latest/index
 For Foreman plugin overview, see link:https://theforeman.org/plugins/[Plugins].
 ====
 
-== Navigating the docs.theforeman.org site
+=== Navigating the docs.theforeman.org site
 
-Use the top menu bar to select your release version and flavor.
+Start by selecting your release version in the top menu bar.
 
 For questions, visit the https://community.theforeman.org/c/support/10[support forum].
 For contribution, visit the https://github.com/theforeman/foreman-documentation[GitHub repository].

--- a/web/content/js/nav.js
+++ b/web/content/js/nav.js
@@ -23,18 +23,6 @@ function buildNavigation() {
 </button>
 <ul class="nav-menu">
   <li class="nav-item"><a href="https://theforeman.org/">About Foreman</a></li>`
-    + navBuilds.map(function(build){
-      return(
-        `<li class="nav-item dropdown">
-          <a href="#" data-action="dropdown-toggle">${build.title}</a>
-            <div class="dropdown-menu">`
-            + build.guides.map(function(guide){
-              const url = `/${currentVer}/${guide.path}/${build.filename}`;
-              return `<div class="dropdown-div"><a class="dropdown-item" href="${url}">${guide.title}</a></div>`;
-            }).join("")
-            +`</div>
-        </li>`
-      )}).join("")
     + `<li class="nav-item dropdown">
         <a href="#" data-action="dropdown-toggle">Version ${currentVer}</a>
         <div class="dropdown-menu dropdown-menu-left">`

--- a/web/releases/2.4.adoc
+++ b/web/releases/2.4.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 .Upgrading
 * link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 

--- a/web/releases/2.4.adoc
+++ b/web/releases/2.4.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_Guide/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy_on_Red_Hat/index-katello.html[Installing Smart Proxy with Content]
@@ -17,11 +17,11 @@
 * link:/{FOREMAN_VER}/Deploying_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Application_Centric_Deployment/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
 * link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
 * link:/{FOREMAN_VER}/Provisioning_Guide/index-katello.html[Provisioning Guide]

--- a/web/releases/2.4.adoc
+++ b/web/releases/2.4.adoc
@@ -2,17 +2,26 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+.Upgrading
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_Guide/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy_on_Red_Hat/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Application_Centric_Deployment/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+* link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
+* link:/{FOREMAN_VER}/Provisioning_Guide/index-katello.html[Provisioning Guide]

--- a/web/releases/2.5.adoc
+++ b/web/releases/2.5.adoc
@@ -2,17 +2,25 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Upgrading
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_Guide/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy_on_Red_Hat/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Application_Centric_Deployment/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+* link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
+* link:/{FOREMAN_VER}/Provisioning_Guide/index-katello.html[Provisioning Guide]

--- a/web/releases/2.5.adoc
+++ b/web/releases/2.5.adoc
@@ -8,7 +8,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_Guide/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy_on_Red_Hat/index-katello.html[Installing Smart Proxy with Content]
@@ -16,11 +16,11 @@
 * link:/{FOREMAN_VER}/Deploying_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Application_Centric_Deployment/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
 * link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
 * link:/{FOREMAN_VER}/Provisioning_Guide/index-katello.html[Provisioning Guide]

--- a/web/releases/3.0.adoc
+++ b/web/releases/3.0.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_Guide/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy_on_Red_Hat/index-katello.html[Installing Smart Proxy with Content]
@@ -17,11 +17,11 @@
 * link:/{FOREMAN_VER}/Deploying_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Application_Centric_Deployment/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
 * link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
 * link:/{FOREMAN_VER}/Provisioning_Guide/index-katello.html[Provisioning Guide]

--- a/web/releases/3.0.adoc
+++ b/web/releases/3.0.adoc
@@ -2,18 +2,26 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_Guide/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy_on_Red_Hat/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Application_Centric_Deployment/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart_Guide/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Red_Hat_Satellite/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Content_Management_Guide/index-katello.html[Content Management Guide]
+* link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server_on_Red_Hat/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
+* link:/{FOREMAN_VER}/Provisioning_Guide/index-katello.html[Provisioning Guide]

--- a/web/releases/3.1.adoc
+++ b/web/releases/3.1.adoc
@@ -2,18 +2,29 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Converting_a_Host_to_RHEL/index-katello.html[Converting a Host to RHEL]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Guide]

--- a/web/releases/3.1.adoc
+++ b/web/releases/3.1.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Converting_a_Host_to_RHEL/index-katello.html[Converting a Host to RHEL]
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts Guide]

--- a/web/releases/3.10.adoc
+++ b/web/releases/3.10.adoc
@@ -2,32 +2,65 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on RHEL/CentOS quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS quickstart guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning hosts]
+====
 
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+.Server administration
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-=== Upgrading
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
+====
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes]
 
-// Upgrading guides are not ready for non-Katello
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+.Server administration
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts  by using Ansible]
+====

--- a/web/releases/3.10.adoc
+++ b/web/releases/3.10.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -37,7 +37,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -52,7 +52,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.10.adoc
+++ b/web/releases/3.10.adoc
@@ -12,7 +12,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
@@ -20,14 +20,14 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
@@ -44,10 +44,10 @@
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
 ====
 
@@ -58,9 +58,9 @@
 .Release notes and upgrading
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts  by using Ansible]
 ====

--- a/web/releases/3.11.adoc
+++ b/web/releases/3.11.adoc
@@ -2,31 +2,66 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on RHEL/CentOS quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS quickstart guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning hosts]
+====
 
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+.Server administration
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-=== Upgrading
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
+====
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman to {FOREMAN_VER}]
 
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+.Server administration
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
+====

--- a/web/releases/3.11.adoc
+++ b/web/releases/3.11.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -37,7 +37,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -52,7 +52,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.11.adoc
+++ b/web/releases/3.11.adoc
@@ -12,7 +12,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
@@ -20,14 +20,14 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
@@ -44,10 +44,10 @@
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
 ====
 
@@ -59,9 +59,9 @@
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman to {FOREMAN_VER}]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
 ====

--- a/web/releases/3.12.adoc
+++ b/web/releases/3.12.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -42,7 +42,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -62,7 +62,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.12.adoc
+++ b/web/releases/3.12.adoc
@@ -12,7 +12,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
@@ -20,7 +20,7 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
@@ -28,7 +28,7 @@
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
@@ -52,12 +52,12 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
 ====
 
@@ -72,11 +72,11 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
 ====

--- a/web/releases/3.12.adoc
+++ b/web/releases/3.12.adoc
@@ -2,25 +2,81 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on RHEL/CentOS quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS quickstart guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning hosts]
 
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+.Reference
+* link:/{FOREMAN_VER}/Project_API/index-katello.html[Using Foreman API]
+* link:/{FOREMAN_VER}/Hammer_CLI/index-katello.html[Using Hammer CLI]
+====
 
-=== Upgrading
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+.Server administration
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
+====
+
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman to {FOREMAN_VER}]
+
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
+
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
+====

--- a/web/releases/3.13.adoc
+++ b/web/releases/3.13.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -42,7 +42,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -64,7 +64,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.13.adoc
+++ b/web/releases/3.13.adoc
@@ -12,7 +12,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
@@ -20,7 +20,7 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
@@ -28,7 +28,7 @@
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
@@ -52,11 +52,11 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
 
 .Reference
@@ -74,11 +74,11 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
 
 .Reference

--- a/web/releases/3.13.adoc
+++ b/web/releases/3.13.adoc
@@ -2,27 +2,85 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on Enterprise Linux quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on Enterprise Linux quickstart guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning hosts]
 
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on Enterprise Linux]
+.Reference
+* link:/{FOREMAN_VER}/Project_API/index-katello.html[Using Foreman API]
+* link:/{FOREMAN_VER}/Hammer_CLI/index-katello.html[Using Hammer CLI]
+====
 
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on Enterprise Linux]
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-=== Upgrading
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on Enterprise Linux]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on Enterprise Linux]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
+
+.Reference
+* link:/{FOREMAN_VER}/Hammer_CLI/index-foreman-el.html[Using Hammer CLI]
+====
+
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman to {FOREMAN_VER}]
+
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
+
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
+
+.Reference
+* link:/{FOREMAN_VER}/Hammer_CLI/index-foreman-deb.html[Using Hammer CLI]
+====

--- a/web/releases/3.14.adoc
+++ b/web/releases/3.14.adoc
@@ -12,14 +12,14 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
 * link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-katello.html[Configuring DNS, DHCP, and TFTP integration]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
@@ -28,7 +28,7 @@
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
@@ -52,13 +52,13 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-el.html[Configuring DNS, DHCP, and TFTP integration]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
 
 .Reference
@@ -76,15 +76,15 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
 
-//.Deployment and installation
+//.Deploying Foreman
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-deb.html[Configuring DNS, DHCP, and TFTP integration]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
 
 .Reference

--- a/web/releases/3.14.adoc
+++ b/web/releases/3.14.adoc
@@ -2,26 +2,91 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on Enterprise Linux quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on Enterprise Linux quickstart guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-katello.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning hosts]
 
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on Enterprise Linux]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on Enterprise Linux]
+.Reference
+* link:/{FOREMAN_VER}/Project_API/index-katello.html[Using Foreman API]
+* link:/{FOREMAN_VER}/Hammer_CLI/index-katello.html[Using Hammer CLI]
+====
 
-=== Upgrading
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on Enterprise Linux]
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on Enterprise Linux]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-el.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
+
+.Reference
+* link:/{FOREMAN_VER}/Hammer_CLI/index-foreman-el.html[Using Hammer CLI]
+====
+
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman to {FOREMAN_VER}]
+
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
+
+//.Deployment and installation
+
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-deb.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
+
+.Reference
+* link:/{FOREMAN_VER}/Hammer_CLI/index-foreman-deb.html[Using Hammer CLI]
+====

--- a/web/releases/3.14.adoc
+++ b/web/releases/3.14.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -42,7 +42,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -66,7 +66,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.2.adoc
+++ b/web/releases/3.2.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Converting_a_Host_to_RHEL/index-katello.html[Converting a Host to RHEL]
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]

--- a/web/releases/3.2.adoc
+++ b/web/releases/3.2.adoc
@@ -2,18 +2,29 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_Ansible/index-katello.html[Configuring Foreman to use Ansible]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Converting_a_Host_to_RHEL/index-katello.html[Converting a Host to RHEL]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Guide]

--- a/web/releases/3.3.adoc
+++ b/web/releases/3.3.adoc
@@ -2,18 +2,29 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]

--- a/web/releases/3.3.adoc
+++ b/web/releases/3.3.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]

--- a/web/releases/3.4.adoc
+++ b/web/releases/3.4.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing a Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]

--- a/web/releases/3.4.adoc
+++ b/web/releases/3.4.adoc
@@ -2,18 +2,29 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing a Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]

--- a/web/releases/3.5.adoc
+++ b/web/releases/3.5.adoc
@@ -2,19 +2,29 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]

--- a/web/releases/3.5.adoc
+++ b/web/releases/3.5.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]

--- a/web/releases/3.6.adoc
+++ b/web/releases/3.6.adoc
@@ -2,19 +2,31 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_and_Updating/index-katello.html[Upgrading and Updating Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing Security Compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]

--- a/web/releases/3.6.adoc
+++ b/web/releases/3.6.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]

--- a/web/releases/3.7.adoc
+++ b/web/releases/3.7.adoc
@@ -2,19 +2,31 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
-
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
-
-=== Upgrading
-
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing Security Compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]

--- a/web/releases/3.7.adoc
+++ b/web/releases/3.7.adoc
@@ -9,7 +9,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -17,13 +17,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]

--- a/web/releases/3.8.adoc
+++ b/web/releases/3.8.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -36,7 +36,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -47,7 +47,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.8.adoc
+++ b/web/releases/3.8.adoc
@@ -2,19 +2,57 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing Security Compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]
+====
 
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release Notes]
 
-=== Upgrading
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring Hosts Using Ansible]
+====
 
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring Hosts Using Ansible]
+====

--- a/web/releases/3.8.adoc
+++ b/web/releases/3.8.adoc
@@ -12,7 +12,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -20,13 +20,13 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]
@@ -42,7 +42,7 @@
 .Release notes and upgrading
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release Notes]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring Hosts Using Ansible]
 ====
 
@@ -53,6 +53,6 @@
 .Release notes and upgrading
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring Hosts Using Ansible]
 ====

--- a/web/releases/3.9.adoc
+++ b/web/releases/3.9.adoc
@@ -12,7 +12,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
@@ -20,14 +20,14 @@
 * link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
 * link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman Performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]
@@ -44,10 +44,10 @@
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release Notes]
 * link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring Hosts Using Ansible]
 ====
 
@@ -58,9 +58,9 @@
 .Release notes and upgrading
 * link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman Performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring Hosts Using Ansible]
 ====

--- a/web/releases/3.9.adoc
+++ b/web/releases/3.9.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -37,7 +37,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -52,7 +52,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/3.9.adoc
+++ b/web/releases/3.9.adoc
@@ -2,25 +2,65 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart Guide]
 
-=== Quickstart
+.Deployment and installation
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning Guide]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with Content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a Load Balancer]
+* link:/{FOREMAN_VER}/Deploying_Project_on_AWS/index-katello.html[Deploying Foreman on Amazon Web Services]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application Centric Deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on RHEL/CentOS Quickstart Guide]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing Content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing Organizations and Locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman Performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning Performance]
 
-=== Installation
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring Hosts Using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring Hosts Using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring Hosts Using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing Hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing Security Compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning Hosts]
+====
 
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-=== Upgrading
+.Server administration
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on RHEL/CentOS]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on RHEL/CentOS]
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring Hosts Using Ansible]
+====
 
-// Upgrading guides are not ready for non-Katello
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on RHEL/CentOS]
-//* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on RHEL/CentOS]
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
+
+.Server administration
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman Performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring Hosts Using Ansible]
+====

--- a/web/releases/nightly.adoc
+++ b/web/releases/nightly.adoc
@@ -2,7 +2,7 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -47,7 +47,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Enterprise Linux
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading
@@ -84,7 +84,7 @@
 ====
 
 == Foreman {FOREMAN_VER} on Debian/Ubuntu
-.Show all guides
+.Show documentation
 [%collapsible]
 ====
 .Release notes and upgrading

--- a/web/releases/nightly.adoc
+++ b/web/releases/nightly.adoc
@@ -2,31 +2,114 @@
 :KATELLO_VER: <%= @item[:katello] %>
 
 == Foreman {FOREMAN_VER} and Katello {KATELLO_VER}
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+//Sorted chronologically based on lifecycle stage
+* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello to {KATELLO_VER}]
 
-Use the top menu bar for navigation for all guides.
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-=== Quickstart
+.Deployment and installation
+//Sorted chronologically based on lifecycle stage
+* link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
+* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content]
+* link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Foreman on Enterprise Linux quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Foreman on Debian/Ubuntu quickstart guide]
-* link:/{FOREMAN_VER}/Quickstart/index-katello.html[Katello on Enterprise Linux quickstart guide]
+.Server administration
+//Sorted alphabetically
+* link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-katello.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-katello.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Managing_Content/index-katello.html[Managing content]
+* link:/{FOREMAN_VER}/Managing_Organizations_and_Locations/index-katello.html[Managing organizations and locations in Foreman]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
+* link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-=== Installation
+.Host administration
+//Sorted alphabetically
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-katello.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-katello.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-katello.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-katello.html[Provisioning hosts]
 
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello on Enterprise Linux]
+.Reference
+//Sorted alphabetically
+* link:/{FOREMAN_VER}/Project_API/index-katello.html[Using Foreman API]
+* link:/{FOREMAN_VER}/Hammer_CLI/index-katello.html[Using Hammer CLI]
+====
 
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy on Enterprise Linux]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-deb.html[Installing Smart Proxy on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Installing_Proxy/index-katello.html[Installing Smart Proxy with content on Enterprise Linux]
+== Foreman {FOREMAN_VER} on Enterprise Linux
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman to {FOREMAN_VER}]
 
-=== Upgrading
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-el.html[Release notes for Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release notes for Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Release_Notes/index-katello.html[Release notes for Katello on Enterprise Linux]
+.Deployment and installation
+* link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman Server]
+* link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy]
+* link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-foreman-el.html[Application centric deployment]
 
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-el.html[Upgrading Foreman on Enterprise Linux]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman on Debian/Ubuntu]
-* link:/{FOREMAN_VER}/Upgrading_Project/index-katello.html[Upgrading Katello on Enterprise Linux]
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-el.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-el.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-el.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-foreman-el.html[Configuring hosts by using Salt]
+* link:/{FOREMAN_VER}/Managing_Hosts/index-foreman-el.html[Managing hosts]
+* link:/{FOREMAN_VER}/Managing_Security_Compliance/index-foreman-el.html[Managing security compliance]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-foreman-el.html[Provisioning hosts]
+
+.Reference
+* link:/{FOREMAN_VER}/Project_API/index-foreman-el.html[Using Foreman API]
+* link:/{FOREMAN_VER}/Hammer_CLI/index-foreman-el.html[Using Hammer CLI]
+====
+
+== Foreman {FOREMAN_VER} on Debian/Ubuntu
+.Show all guides
+[%collapsible]
+====
+.Release notes and upgrading
+* link:/{FOREMAN_VER}/Release_Notes/index-foreman-deb.html[Release Notes]
+* link:/{FOREMAN_VER}/Upgrading_Project/index-foreman-deb.html[Upgrading Foreman to {FOREMAN_VER}]
+
+.Quickstart
+* link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
+
+.Deployment and installation
+* link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman Server]
+
+.Server administration
+* link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
+* link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-deb.html[Configuring DNS, DHCP, and TFTP integration]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
+* link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
+
+.Host administration
+* link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
+* link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-deb.html[Configuring hosts by using Puppet]
+* link:/{FOREMAN_VER}/Provisioning_Hosts/index-foreman-deb.html[Provisioning hosts]
+
+.Reference
+* link:/{FOREMAN_VER}/Project_API/index-foreman-deb.html[Using Foreman API]
+* link:/{FOREMAN_VER}/Hammer_CLI/index-foreman-deb.html[Using Hammer CLI]
+====

--- a/web/releases/nightly.adoc
+++ b/web/releases/nightly.adoc
@@ -13,7 +13,7 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-katello.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman and Katello
 //Sorted chronologically based on lifecycle stage
 * link:/{FOREMAN_VER}/Planning_for_Project/index-katello.html[Planning for Foreman with Katello]
 * link:/{FOREMAN_VER}/Installing_Server/index-katello.html[Installing Katello server]
@@ -21,7 +21,7 @@
 * link:/{FOREMAN_VER}/Configuring_Load_Balancer/index-katello.html[Configuring Smart Proxies with a load balancer]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-katello.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 //Sorted alphabetically
 * link:/{FOREMAN_VER}/Administering_Project/index-katello.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-katello.html[Configuring DNS, DHCP, and TFTP integration]
@@ -31,7 +31,7 @@
 * link:/{FOREMAN_VER}/Monitoring_Project/index-katello.html[Monitoring Foreman performance]
 * link:/{FOREMAN_VER}/Tuning_Performance/index-katello.html[Tuning performance]
 
-.Host administration
+.Administering hosts
 //Sorted alphabetically
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-katello.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-katello.html[Configuring hosts by using Puppet]
@@ -57,12 +57,12 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-el.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman
 * link:/{FOREMAN_VER}/Installing_Server/index-foreman-el.html[Installing Foreman Server]
 * link:/{FOREMAN_VER}/Installing_Proxy/index-foreman-el.html[Installing Smart Proxy]
 * link:/{FOREMAN_VER}/Deploying_Hosts_AppCentric/index-foreman-el.html[Application centric deployment]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-el.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-el.html[Configuring DNS, DHCP, and TFTP integration]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-el.html[Configuring DNS, DHCP, and TFTP integration]
@@ -70,7 +70,7 @@
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-el.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-el.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-el.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-el.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Managing_Configurations_Salt/index-foreman-el.html[Configuring hosts by using Salt]
@@ -94,17 +94,17 @@
 .Quickstart
 * link:/{FOREMAN_VER}/Quickstart/index-foreman-deb.html[Quickstart guide]
 
-.Deployment and installation
+.Deploying Foreman
 * link:/{FOREMAN_VER}/Installing_Server/index-foreman-deb.html[Installing Foreman Server]
 
-.Server administration
+.Administering Foreman server
 * link:/{FOREMAN_VER}/Administering_Project/index-foreman-deb.html[Administering Foreman]
 * link:/{FOREMAN_VER}/Configuring_DNS_DHCP_TFTP/index-foreman-deb.html[Configuring DNS, DHCP, and TFTP integration]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Configuring_User_Authentication/index-foreman-deb.html[Configuring user authentication]
 * link:/{FOREMAN_VER}/Monitoring_Project/index-foreman-deb.html[Monitoring Foreman performance]
 
-.Host administration
+.Administering hosts
 * link:/{FOREMAN_VER}/Managing_Configurations_Ansible/index-foreman-deb.html[Configuring hosts by using Ansible]
 * link:/{FOREMAN_VER}/Managing_Configurations_Puppet/index-foreman-deb.html[Configuring hosts by using Puppet]
 * link:/{FOREMAN_VER}/Provisioning_Hosts/index-foreman-deb.html[Provisioning hosts]


### PR DESCRIPTION
#### What changes are you introducing?

This is an attempt to simplify the way users can navigate docs.theforeman.org, namely by:

* Removing the current flavor dropdowns from the top menu bar and replacing them with new version pages, each with collapsible lists
* Removing a few links from the main landing page and adding them to the top menu bar instead

Wherever possible, I'm making use of native AsciiDoc features (hence the use of collapsibles) so that the result is easy to understand and modify by any writer familiar with AsciiDoc.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I'm trying to address these issues that currently affect docs.theforeman.org:

* Users can't use full-text search to find the guide they need
* Navigating between the flavors and versions is not straightforward enough

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The idea is to split the navigation path into two steps: First choose the version, then choose the flavor. This is to give users one choice at a time. With the existing navigation, they can choose either the version or the flavor at the beginning of their navigation path, which is confusing.

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
