### PR TITLE
Use foreman-installer for hammer resource quota

### DIFF
--- a/guides/common/modules/proc_installing-the-resource-quota-plugin.adoc
+++ b/guides/common/modules/proc_installing-the-resource-quota-plugin.adoc
@@ -10,11 +10,9 @@ To limit host resources for your {Project} users, install the Resource Quota plu
 ----
 # {foreman-installer} --enable-foreman-plugin-resource-quota
 ----
-// TODO: As soon as you can install this via foreman-installer:
-// # {foreman-installer} --enable-foreman-cli-resource-quota
 . Optional: Install the Hammer CLI plugin on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {project-package-install} rubygem-hammer_cli_foreman_resource_quota
+# {foreman-installer} --enable-foreman-cli-resource-quota
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Install the hammer cli package for the `foreman_resource_quota` via `foreman-installer` instead of `dnf`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

`foreman-installer` is the preferred installation method and becomes available with https://github.com/theforeman/foreman-installer/pull/1007

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

no cherry-picks: only foreman_resource_quota is part of 3.13; the Hammer CLI plugin is not available in nightly.
