### PR TITLE
Fix anchor ID

### DIFF
--- a/guides/common/modules/proc_creating-a-virt-who-configuration.adoc
+++ b/guides/common/modules/proc_creating-a-virt-who-configuration.adoc
@@ -135,7 +135,7 @@ endif::[]
 <6> Optional.
 --
 
-[id="virt-who configuration example_{context}"]
+[id="virt-who-configuration-example_{context}"]
 .Virt-who configuration example
 
 .{provider} virt-who configuration example


### PR DESCRIPTION
#### What changes are you introducing?

Fixing an anchor ID that was missing hyphens

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

No issue. However, d/s doc will not build.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No style review or tech review required. I have tested this fix downstream.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
