### PR TITLE
Formally turn snippet into module

### DIFF
--- a/guides/common/modules/con_guide-not-ready.adoc
+++ b/guides/common/modules/con_guide-not-ready.adoc
@@ -1,3 +1,5 @@
+== Guide not ready yet
+
 This guide is not ready yet.
 
 Foreman is a community project.

--- a/guides/common/modules/con_guide-not-ready.adoc
+++ b/guides/common/modules/con_guide-not-ready.adoc
@@ -1,4 +1,4 @@
-== Guide not ready yet
+= Guide not ready yet
 
 This guide is not ready yet.
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -8,7 +8,7 @@ include::common/header.adoc[]
 
 // This guide only works on content proxies, which is Katello only
 ifdef::foreman-deb,foreman-el[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::foreman-deb,foreman-el[]
 

--- a/guides/doc-Configuring_Load_Balancer/master.adoc
+++ b/guides/doc-Configuring_Load_Balancer/master.adoc
@@ -8,7 +8,7 @@ include::common/header.adoc[]
 
 // This guide only works on content proxies, which is Katello only
 ifdef::foreman-deb,foreman-el[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::foreman-deb,foreman-el[]
 

--- a/guides/doc-Configuring_User_Authentication/master.adoc
+++ b/guides/doc-Configuring_User_Authentication/master.adoc
@@ -6,7 +6,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Configuring_User_Authentication/master.adoc
+++ b/guides/doc-Configuring_User_Authentication/master.adoc
@@ -6,7 +6,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Deploying_Hosts_AppCentric/master.adoc
+++ b/guides/doc-Deploying_Hosts_AppCentric/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // Render only for relevant and finished contexts
 ifdef::HideDocumentOnStable,foreman-deb,satellite[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable,foreman-deb,satellite[]
 

--- a/guides/doc-Deploying_Hosts_AppCentric/master.adoc
+++ b/guides/doc-Deploying_Hosts_AppCentric/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // Render only for relevant and finished contexts
 ifdef::HideDocumentOnStable,foreman-deb,satellite[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable,foreman-deb,satellite[]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Deploying_Project_on_AWS/master.adoc
+++ b/guides/doc-Deploying_Project_on_AWS/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -10,7 +10,7 @@ include::common/header.adoc[]
 // This guide is not ready for stable releases and on Debian
 // Though it also contains many errors on EL
 ifdef::HideDocumentOnStable,foreman-deb[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -10,7 +10,7 @@ include::common/header.adoc[]
 // This guide is not ready for stable releases and on Debian
 // Though it also contains many errors on EL
 ifdef::HideDocumentOnStable,foreman-deb[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -9,7 +9,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -9,7 +9,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -9,7 +9,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifndef::satellite[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifdef::satellite[]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -9,7 +9,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifndef::satellite[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifdef::satellite[]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Managing_Configurations_Salt/master.adoc
+++ b/guides/doc-Managing_Configurations_Salt/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable,satellite[]
 

--- a/guides/doc-Managing_Configurations_Salt/master.adoc
+++ b/guides/doc-Managing_Configurations_Salt/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable,satellite[]
 

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases and not on Debian
 ifdef::HideDocumentOnStable,foreman-deb[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases and not on Debian
 ifdef::HideDocumentOnStable,foreman-deb[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable,foreman-deb[]
 

--- a/guides/doc-Managing_Organizations_and_Locations/master.adoc
+++ b/guides/doc-Managing_Organizations_and_Locations/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 // This guide is not ready for stable releases
 // Satellite publishes this documentation elsewhere
 ifdef::HideDocumentOnStable,satellite[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable,satellite[]
 

--- a/guides/doc-Managing_Organizations_and_Locations/master.adoc
+++ b/guides/doc-Managing_Organizations_and_Locations/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 // This guide is not ready for stable releases
 // Satellite publishes this documentation elsewhere
 ifdef::HideDocumentOnStable,satellite[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable,satellite[]
 

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -13,7 +13,7 @@ ifndef::foreman-deb[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -13,7 +13,7 @@ ifndef::foreman-deb[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is Katello specific, in particular the diagrams
 ifdef::foreman-el,foreman-deb[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::foreman-el,foreman-deb[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is Katello specific, in particular the diagrams
 ifdef::foreman-el,foreman-deb[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::foreman-el,foreman-deb[]
 

--- a/guides/doc-Project_API/master.adoc
+++ b/guides/doc-Project_API/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Project_API/master.adoc
+++ b/guides/doc-Project_API/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Provisioning_Installer/master.adoc
+++ b/guides/doc-Provisioning_Installer/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Provisioning_Installer/master.adoc
+++ b/guides/doc-Provisioning_Installer/master.adoc
@@ -7,7 +7,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -6,7 +6,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -6,7 +6,7 @@ include::common/header.adoc[]
 
 // This guide is not ready for stable releases
 ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::HideDocumentOnStable[]
 

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -8,7 +8,7 @@ include::common/header.adoc[]
 // This guide is not ready because it uses foreman-maintain to update to .z
 // releases but that is not implemented upstream
 ifdef::foreman-el,foreman-deb,katello[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifndef::foreman-el,foreman-deb,katello[]
 

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -8,7 +8,7 @@ include::common/header.adoc[]
 // This guide is not ready because it uses foreman-maintain to update to .z
 // releases but that is not implemented upstream
 ifdef::foreman-el,foreman-deb,katello[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::foreman-el,foreman-deb,katello[]
 

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -8,7 +8,7 @@ include::common/header.adoc[]
 
 // Only Satellite supports installing Foreman Server/Smart Proxy Servers in a disconnected environment
 ifndef::satellite[]
-include::common/modules/con_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifdef::satellite[]
 

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -8,7 +8,7 @@ include::common/header.adoc[]
 
 // Only Satellite supports installing Foreman Server/Smart Proxy Servers in a disconnected environment
 ifndef::satellite[]
-include::common/modules/snip_guide-not-ready.adoc[]
+include::common/modules/con_guide-not-ready.adoc[]
 endif::[]
 ifdef::satellite[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Turning the 'guide not ready yet' snippet into a proper module with its own heading.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This came up in https://github.com/theforeman/foreman-documentation/pull/3653. Adding the ribbon/banner causes build failures if there are headings missing in certain places. The 'guide not ready yet' snippet is one of them.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
