### PR TITLE
Improve Secure Boot provisioning

### DIFF
--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -94,11 +94,11 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 :grub_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
 :grub_efi_package_name: grub2-efi-x64
-:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{client-os-context}/grubx64.efi
+:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/grubx64.efi
 :shim_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
 :shim_efi_downloaded_package_name: shim-x64.rpm
 :shim_efi_package_name: shim-x64
-:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{client-os-context}/shimx64.efi
+:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/shimx64.efi
 :extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
 :extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -10,8 +10,6 @@ include::modules/con_prerequisites-for-network-boot-provisioning.adoc[leveloffse
 
 include::modules/ref_required-boot-order-for-network-boot.adoc[leveloffset=+1]
 
-include::modules/con_configuring-smartproxy-for-secure-boot.adoc[leveloffset=+1]
-
 :extract_deb_prefix: cd /tmp && ar x /tmp
 :extract_deb_xz_suffix: && tar -xf data.tar.xz && cd -
 :extract_deb_zst_suffix: && tar --use-compress-program=unzstd -xf data.tar.zst && cd -
@@ -19,9 +17,28 @@ include::modules/con_configuring-smartproxy-for-secure-boot.adoc[leveloffset=+1]
 :extract_rpm_suffix: | cpio -idv --directory /tmp
 :parent-client-os: {client-os}
 :parent-client-pkg-ext: {client-pkg-ext}
-:secureboot-os-name: My_Operating_System_In_Lowercase
+
+ifdef::satellite[]
+:client-os-context: rhel
+:client-os: {RHEL}
+:secureboot-os-name: redhat
+:client-pkg-ext: rpm
+:grub_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
+:grub_efi_downloaded_package_name: grub2-efi-x64.rpm
+:grub_efi_package_name: grub2-efi-x64
+:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/grubx64.efi
+:shim_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
+:shim_efi_downloaded_package_name: shim-x64.rpm
+:shim_efi_package_name: shim-x64
+:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/shimx64.efi
+:extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
+:extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
+include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+1]
+endif::[]
 
 ifndef::satellite[]
+include::modules/con_configuring-smartproxy-for-secure-boot.adoc[leveloffset=+1]
+
 :client-os-context: almalinux
 :client-os: AlmaLinux
 :secureboot-os-name: almalinux
@@ -69,7 +86,6 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 :extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
 :extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
-endif::[]
 
 :client-os-context: rhel
 :client-os: {RHEL}
@@ -85,9 +101,8 @@ endif::[]
 :shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{client-os-context}/shimx64.efi
 :extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
 :extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
-include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+1]
+include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
 
-ifndef::satellite[]
 :client-os-context: ubuntu
 :client-os: Ubuntu
 :secureboot-os-name: ubuntu

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -24,6 +24,7 @@ include::modules/con_configuring-smartproxy-for-secure-boot.adoc[leveloffset=+1]
 ifndef::satellite[]
 :client-os-context: almalinux
 :client-os: AlmaLinux
+:secureboot-os-name: almalinux
 :client-pkg-ext: rpm
 :grub_efi_download_url: https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
@@ -39,6 +40,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 
 :client-os-context: debian
 :client-os: Debian
+:secureboot-os-name: debian
 :client-pkg-ext: deb
 :grub_efi_download_url: http://security.debian.org/debian-security/pool/updates/main/g/grub-efi-amd64-signed/
 :grub_efi_downloaded_package_name: grub-efi-amd64-signed.deb
@@ -54,6 +56,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 
 :client-os-context: rocky
 :client-os: Rocky Linux
+:secureboot-os-name: rocky_linux
 :client-pkg-ext: rpm
 :grub_efi_download_url: http://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages/g/
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
@@ -70,6 +73,7 @@ endif::[]
 
 :client-os-context: rhel
 :client-os: {RHEL}
+:secureboot-os-name: redhat
 :client-pkg-ext: rpm
 :grub_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
@@ -86,6 +90,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 ifndef::satellite[]
 :client-os-context: ubuntu
 :client-os: Ubuntu
+:secureboot-os-name: ubuntu
 :client-pkg-ext: deb
 :grub_efi_download_url: http://security.ubuntu.com/ubuntu/pool/main/g/grub2-signed/
 :grub_efi_downloaded_package_name: grub-efi-amd64-signed.deb

--- a/guides/common/assembly_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-pxe-to-provision-hosts.adoc
@@ -18,11 +18,11 @@ include::modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc[level
 :extract_rpm_suffix: | cpio -idv --directory /tmp
 :parent-client-os: {client-os}
 :parent-client-pkg-ext: {client-pkg-ext}
-:secureboot-os-name: My_Operating_System_In_Lowercase
 
 ifndef::satellite[]
 :client-os-context: almalinux
 :client-os: AlmaLinux
+:secureboot-os-name: almalinux
 :client-pkg-ext: rpm
 :grub_efi_download_url: https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
@@ -38,6 +38,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 
 :client-os-context: debian
 :client-os: Debian
+:secureboot-os-name: debian
 :client-pkg-ext: deb
 :grub_efi_download_url: http://security.debian.org/debian-security/pool/updates/main/g/grub-efi-amd64-signed/
 :grub_efi_downloaded_package_name: grub-efi-amd64-signed.deb
@@ -53,6 +54,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 
 :client-os-context: rocky
 :client-os: Rocky Linux
+:secureboot-os-name: rocky_linux
 :client-pkg-ext: rpm
 :grub_efi_download_url: http://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages/g/
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
@@ -69,6 +71,7 @@ endif::[]
 
 :client-os-context: rhel
 :client-os: {RHEL}
+:secureboot-os-name: redhat
 :client-pkg-ext: rpm
 :grub_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
@@ -85,6 +88,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 ifndef::satellite[]
 :client-os-context: ubuntu
 :client-os: Ubuntu
+:secureboot-os-name: ubuntu
 :client-pkg-ext: deb
 :grub_efi_download_url: http://security.ubuntu.com/ubuntu/pool/main/g/grub2-signed/
 :grub_efi_downloaded_package_name: grub-efi-amd64-signed.deb

--- a/guides/common/assembly_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-pxe-to-provision-hosts.adoc
@@ -76,11 +76,11 @@ endif::[]
 :grub_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
 :grub_efi_package_name: grub2-efi-x64
-:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{client-os-context}/grubx64.efi
+:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/grubx64.efi
 :shim_efi_download_url: https://access.redhat.com/downloads/content/package-browser[Package browser] on the Red{nbsp}Hat Customer Portal
 :shim_efi_downloaded_package_name: shim-x64.rpm
 :shim_efi_package_name: shim-x64
-:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{client-os-context}/shimx64.efi
+:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/shimx64.efi
 :extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
 :extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+1]

--- a/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
@@ -43,8 +43,15 @@ In {Project} provisioning, the PXE loader option defines the DHCP `filename` opt
 * For BIOS systems, select the *PXELinux BIOS* option to enable a provisioned host to download the `pxelinux.0` file over TFTP.
 * For UEFI systems, select the *Grub2 UEFI* option to enable a TFTP client to download `grubx64.efi` file, or select the *Grub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` with the HTTP Boot feature.
 
+{ProjectName} supports UEFI Secure Boot.
+SecureBoot PXE loaders enable a client to download the `shimx64.efi` bootstrap boot loader that then loads the signed `grubx64.efi`.
+Use the *Grub2 UEFI SecureBoot* PXE loader for PXE-boot provisioning.
+ifndef::satellite[]
+Use the *Grub2 UEFI HTTPS SecureBoot* PXE loader for HTTP-boot provisioning.
+endif::[]
+
 ifdef::satellite[]
-By default, you can provision the RHEL version of your {ProjectServer} on Secure Boot enabled hosts.
+By default, you can provision the same RHEL version as your {ProjectServer} on Secure Boot enabled hosts.
 To provision other versions of {RHEL}, you have to provide signed shim and GRUB2 binaries of those RHEL versions.
 For more information, see xref:configuring-{smart-proxy-context}-to-provision-rhel-on-Secure-Boot-enabled-hosts[].
 endif::[]

--- a/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
@@ -64,6 +64,7 @@ For more information, see:
 
 * xref:configuring-{smart-proxy-context}-to-provision-almalinux-on-Secure-Boot-enabled-hosts[]
 * xref:configuring-{smart-proxy-context}-to-provision-debian-on-Secure-Boot-enabled-hosts[]
+* xref:configuring-{smart-proxy-context}-to-provision-rhel-on-Secure-Boot-enabled-hosts[]
 * xref:configuring-{smart-proxy-context}-to-provision-rocky-on-Secure-Boot-enabled-hosts[]
 * xref:configuring-{smart-proxy-context}-to-provision-ubuntu-on-Secure-Boot-enabled-hosts[]
 endif::[]

--- a/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
@@ -43,7 +43,7 @@ In {Project} provisioning, the PXE loader option defines the DHCP `filename` opt
 * For BIOS systems, select the *PXELinux BIOS* option to enable a provisioned host to download the `pxelinux.0` file over TFTP.
 * For UEFI systems, select the *Grub2 UEFI* option to enable a TFTP client to download `grubx64.efi` file, or select the *Grub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` with the HTTP Boot feature.
 
-{ProjectName} supports UEFI Secure Boot.
+{ProjectName} supports provisioning hosts with UEFI Secure Boot.
 SecureBoot PXE loaders enable a client to download the `shimx64.efi` bootstrap boot loader that then loads the signed `grubx64.efi`.
 Use the *Grub2 UEFI SecureBoot* PXE loader for PXE-boot provisioning.
 ifndef::satellite[]

--- a/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
@@ -64,6 +64,7 @@ For more information, see:
 
 * xref:configuring-{smart-proxy-context}-to-provision-almalinux-on-Secure-Boot-enabled-hosts[]
 * xref:configuring-{smart-proxy-context}-to-provision-debian-on-Secure-Boot-enabled-hosts[]
+* xref:configuring-{smart-proxy-context}-to-provision-rhel-on-Secure-Boot-enabled-hosts[]
 * xref:configuring-{smart-proxy-context}-to-provision-rocky-on-Secure-Boot-enabled-hosts[]
 * xref:configuring-{smart-proxy-context}-to-provision-ubuntu-on-Secure-Boot-enabled-hosts[]
 endif::[]

--- a/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-pxe-to-provision-hosts.adoc
@@ -44,11 +44,14 @@ In {Project} provisioning, the PXE loader option defines the DHCP `filename` opt
 * For UEFI systems, select the *Grub2 UEFI* option to enable a TFTP client to download `grubx64.efi` file, or select the *Grub2 UEFI HTTP* option to enable an UEFI HTTP client to download `grubx64.efi` with the HTTP Boot feature.
 
 {ProjectName} supports UEFI Secure Boot.
-SecureBoot PXE loaders enable a client to download the `shim.efi` bootstrap boot loader that then loads the signed `grubx64.efi`.
-Use the *Grub2 UEFI SecureBoot* PXE loader for PXE-boot provisioning or *Grub2 UEFI HTTPS SecureBoot* for HTTP-boot provisioning.
+SecureBoot PXE loaders enable a client to download the `shimx64.efi` bootstrap boot loader that then loads the signed `grubx64.efi`.
+Use the *Grub2 UEFI SecureBoot* PXE loader for PXE-boot provisioning.
+ifndef::satellite[]
+Use the *Grub2 UEFI HTTPS SecureBoot* PXE loader for HTTP-boot provisioning.
+endif::[]
 
 ifdef::satellite[]
-By default, you can provision the RHEL version of your {ProjectServer} on Secure Boot enabled hosts.
+By default, you can provision the same RHEL version as your {ProjectServer} on Secure Boot enabled hosts.
 To provision other versions of {RHEL}, you have to provide signed shim and GRUB2 binaries of those RHEL versions.
 For more information, see xref:configuring-{smart-proxy-context}-to-provision-rhel-on-Secure-Boot-enabled-hosts[].
 endif::[]

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -4,17 +4,23 @@
 Secure Boot follows a chain of trust from the start of the host to the loading of Linux kernel modules.
 The first shim that is loaded determines which distribution can be booted or loaded by using a `kexec` system call until the next reboot.
 
+ifdef::satellite[]
+You can provision the same RHEL version as your {ProjectServer} on Secure Boot enabled hosts out of the box and you can skip this procedure.
+To provision other RHEL versions, you have to provide signed shim and GRUB2 binaries  for those RHEL versions.
+endif::[]
+ifndef::satellite[]
 To provision {client-os} on Secure Boot enabled hosts, you have to provide signed shim and GRUB2 binaries provided by the vendor of your operating system.
+endif::[]
 
 [IMPORTANT]
 ====
 You have to perform the following configuration steps on each TFTP {SmartProxy} for a subnet to provision Secure Boot enabled hosts on that subnet.
 ====
 
-ifdef::satellite[]
+ifeval::["{client-os-context}" == "rhel"]
 {client-os} supports Secure Boot on x86_64 architecture only.
 endif::[]
-ifndef::satellite[]
+ifeval::["{client-os-context}" != "rhel"]
 The following example works for {client-os} on x86_64 architecture.
 endif::[]
 
@@ -34,7 +40,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# BOOTLOADER_PATH="/var/lib/tftpboot/bootloader-universe/pxegrub2/_{secureboot-os-name}_/default/x86_64"
+# BOOTLOADER_PATH="/var/lib/tftpboot/bootloader-universe/pxegrub2/{secureboot-os-name}/default/x86_64"
 ----
 +
 If you require specific versions of the shim and GRUB2 binaries for the version of the operating system of your host, replace `default` with the *Major* and *Minor* version of the operating system separated by a dot.
@@ -47,7 +53,12 @@ If no *Minor* version is set, replace `default` with the *Major* version.
 ----
 # install -o foreman-proxy -g foreman-proxy -d $BOOTLOADER_PATH
 ----
-. Download the shim and GRUB2 packages for the operating system of your host:
+. Download the shim and GRUB2 packages for the operating system of your host.
+ifeval::["{client-os-context}" == "rhel"]
+You can download the `{grub_efi_package_name}` and `{shim_efi_package_name}` packages from {grub_efi_download_url}.
+endif::[]
+ifeval::["{client-os-context}" != "rhel"]
+For example:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
@@ -55,10 +66,6 @@ If no *Minor* version is set, replace `default` with the *Major* version.
 # wget -O /tmp/{shim_efi_downloaded_package_name} _https://{server-example-com}/{shim_efi_downloaded_package_name}_
 ----
 +
-ifdef::satellite[]
-You can download the `{grub_efi_package_name}` and `{shim_efi_package_name}` packages from {grub_efi_download_url}.
-endif::[]
-ifndef::satellite[]
 You can download the `{grub_efi_package_name}` package from {grub_efi_download_url}.
 You can download the `{shim_efi_package_name}` package from {shim_efi_download_url}.
 endif::[]
@@ -96,7 +103,7 @@ endif::[]
 # tree /var/lib/tftpboot/bootloader-universe
 /var/lib/tftpboot/bootloader-universe
 └── pxegrub2
-    └── _{secureboot-os-name}_
+    └── {secureboot-os-name}
         └── default
             └── x86_64
                 ├── boot.efi -> grubx64.efi

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -6,7 +6,7 @@ The first shim that is loaded determines which distribution can be booted or loa
 
 ifdef::satellite[]
 You can provision the same RHEL version as your {ProjectServer} on Secure Boot enabled hosts out of the box and you can skip this procedure.
-To provision other RHEL versions, you have to provide signed shim and GRUB2 binaries  for those RHEL versions.
+To provision other RHEL versions, you have to provide signed shim and GRUB2 binaries for those RHEL versions.
 endif::[]
 ifndef::satellite[]
 To provision {client-os} on Secure Boot enabled hosts, you have to provide signed shim and GRUB2 binaries provided by the vendor of your operating system.

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -106,4 +106,9 @@ endif::[]
 ----
 
 .Next steps
+ifdef::satellite[]
+* You can now provision Secure Boot enabled {client-os} hosts by using the *Grub2 UEFI SecureBoot* PXE loader.
+endif::[]
+ifdef::satellite[]
 * You can now provision Secure Boot enabled {client-os} hosts by using the *Grub2 UEFI SecureBoot* and *Grub2 UEFI HTTPS SecureBoot* PXE loaders.
+endif::[]

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -4,7 +4,7 @@
 Secure Boot follows a chain of trust from the start of the host to the loading of Linux kernel modules.
 The first shim that is loaded determines which distribution can be booted or loaded by using a `kexec` system call until the next reboot.
 
-To provision {client-os} on Secure Boot enabled hosts with the *Grub2 UEFI SecureBoot* and *Grub2 UEFI HTTPS SecureBoot* PXE loaders, you have to provide signed shim and GRUB2 binaries provided by the vendor of your operating system.
+To provision {client-os} on Secure Boot enabled hosts, you have to provide signed shim and GRUB2 binaries provided by the vendor of your operating system.
 
 [IMPORTANT]
 ====
@@ -55,8 +55,13 @@ If no *Minor* version is set, replace `default` with the *Major* version.
 # wget -O /tmp/{shim_efi_downloaded_package_name} _https://{server-example-com}/{shim_efi_downloaded_package_name}_
 ----
 +
+ifdef::satellite[]
+You can download the `{grub_efi_package_name}` and `{shim_efi_package_name}` packages from {grub_efi_download_url}.
+endif::[]
+ifndef::satellite[]
 You can download the `{grub_efi_package_name}` package from {grub_efi_download_url}.
 You can download the `{shim_efi_package_name}` package from {shim_efi_download_url}.
+endif::[]
 . Extract the shim and GRUB2 binaries:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
@@ -72,8 +77,7 @@ You can download the `{shim_efi_package_name}` package from {shim_efi_download_u
 # cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shimx64.efi
 # ln -sr $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/boot.efi
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
-# chmod 644 $BOOTLOADER_PATH/grubx64.efi
-# chmod 644 $BOOTLOADER_PATH/shimx64.efi
+# chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi
 ----
 ifeval::["{client-pkg-ext}" == "deb"]
 . Link the `grub.cfg` file from the TFTP servers `grub2` folder to the legacy `grub` folder:

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -109,6 +109,6 @@ endif::[]
 ifdef::satellite[]
 * You can now provision Secure Boot enabled {client-os} hosts by using the *Grub2 UEFI SecureBoot* PXE loader.
 endif::[]
-ifdef::satellite[]
+ifndef::satellite[]
 * You can now provision Secure Boot enabled {client-os} hosts by using the *Grub2 UEFI SecureBoot* and *Grub2 UEFI HTTPS SecureBoot* PXE loaders.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Improving texts around Secure Boot - text missing, a feature unsupported in Satellite, links missing...

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Feedback from QE review in [SAT-23380](https://issues.redhat.com/browse/SAT-23380)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: Not sure

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
