### PR TITLE
Run linkchecker on Ubuntu 24.04

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check-html:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -21,7 +21,7 @@ linkchecker:
 	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern
 
 linkchecker-tryer:
-	find build -type f -name index\*html | xargs linkchecker -r1 -f common/linkchecker.ini --check-extern | ./scripts/linkchecker-tryer
+	find build -type f -name index\*html | xargs linkchecker --no-warnings -r1 -f common/linkchecker.ini --check-extern | ./scripts/linkchecker-tryer
 
 ccutil: $(SUBDIRS)
 

--- a/guides/scripts/linkchecker-tryer
+++ b/guides/scripts/linkchecker-tryer
@@ -22,7 +22,7 @@ def parse_linkchecker_output(linkchecker_output):
 
 
 def is_good_link(link):
-    return call(["linkchecker", "-r0", link], stdout=DEVNULL, stderr=STDOUT) == 0
+    return call(["linkchecker", "--no-warnings", "-r0", link], stdout=DEVNULL, stderr=STDOUT) == 0
 
 
 def find_bad_links(linkchecker_output):


### PR DESCRIPTION
Add `--no-warnings` as otherwise `linkchecker-tryer` gets confused

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
