### PR TITLE
Fix broken link in Using noVNC

### DIFF
--- a/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
+++ b/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
@@ -55,7 +55,7 @@ ifndef::foreman-deb[]
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 . If you use a {customssl} certificate, import the SSL certificate from {ProjectServer} into your browser.
-For more information, see {AdministeringDocURL}Importing_the_Katello_Root_CA_Certificate_admin[Importing the Katello Root CA Certificate] in _{AdministeringDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Importing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 +
 The remote console connection to your host will fail if you choose to temporarily accept not checking the certificates in your browser.
 endif::[]

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
@@ -9,7 +9,7 @@ For more information, see xref:Creating_a_Custom_File_Type_Repository_{context}[
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 ** The `katello-server-ca.crt`.
-For more information, see {AdministeringDocURL}Importing_the_Katello_Root_CA_Certificate_admin[Importing the Katello Root CA Certificate] in _{AdministeringDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Importing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
+++ b/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
@@ -8,7 +8,7 @@ You can download files to a client over HTTPS using `curl -O`, and optionally ov
 * You know the name of the Python package you want to download to clients from the Python type repository.
 * To download the Python packages over HTTPS to your hosts, you require:
 ** The `katello-server-ca.crt`.
-For more information, see {AdministeringDocURL}Importing_the_Katello_Root_CA_Certificate_admin[Importing the Katello Root CA Certificate] in _{AdministeringDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Importing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.
 

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -14,7 +14,7 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 * For existing virtual machines, ensure that the *Display type* in the *Compute Resource* settings is *VNC*.
 * You must import the Katello root CA certificate into your {ProjectServer}.
 Adding a security exception in the browser is not enough for using noVNC.
-For more information, see {AdministeringDocURL}Importing_the_Katello_Root_CA_Certificate_admin[Installing the Katello Root CA Certificate] in _{AdministeringDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Installing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 
 .Procedure
 . On your {ProjectServer}, configure the firewall to allow VNC service on ports 5900 to 5930.


### PR DESCRIPTION
#### What changes are you introducing?

Fixing a wrong link.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-30160

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I would prefer to include the module in the provisioning guide directly but that would require changes in structure so as an alternative, I think this is good enough.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
