### PR TITLE
Fix various broken links to/in Configuring User Authentication chapter

### DIFF
--- a/guides/common/modules/con_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/modules/con_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
@@ -11,7 +11,7 @@ With {Project}, you can use one or multiple LDAP directories for external authen
 ====
 While you can configure the LDAP server integrated with {FreeIPA} as an external authentication source, {FreeIPA} users will not be able to log in by using single sign-on.
 Instead, consider configuring {FreeIPA} as an external identity provider.
-For more information, see xref:configuring-kerberos-sso-with-{Freeipa-context}-in-project_{context}[].
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
 ====
 
 [IMPORTANT]

--- a/guides/common/modules/con_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
+++ b/guides/common/modules/con_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
@@ -15,7 +15,7 @@ You can also connect your {Project} deployment to AD in the following ways:
 
 * By using indirect AD integration.
 With indirect integration, your {ProjectServer} is connected to a {FreeIPA} server which is then connected to AD.
-For more information, see xref:configuring-kerberos-sso-with-{Freeipa-context}-in-project_{context}[].
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
 * By attaching the LDAP server of the AD domain as an external authentication source with no single sign-on support.
 For more information, see xref:configuring-an-ldap-server-as-an-external-identity-provider-for-project_{context}[].
 ifndef::orcharhino[]

--- a/guides/common/modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc
+++ b/guides/common/modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc
@@ -1,4 +1,4 @@
-[id="configuring-kerberos-sso-with-{FreeIPA-context}-in-project_{context}"]
+[id="configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}"]
 = Configuring Kerberos SSO with {FreeIPA} in {Project}
 
 {FreeIPA} is an open-source identity management solution that provides centralized authentication, authorization, and account management services.

--- a/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
+++ b/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
@@ -55,7 +55,7 @@ ifndef::foreman-deb[]
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 . If you use a {customssl} certificate, import the SSL certificate from {ProjectServer} into your browser.
-For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Importing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate[Importing the Katello root CA certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 +
 The remote console connection to your host will fail if you choose to temporarily accept not checking the certificates in your browser.
 endif::[]

--- a/guides/common/modules/proc_configuring-external-user-groups.adoc
+++ b/guides/common/modules/proc_configuring-external-user-groups.adoc
@@ -17,7 +17,7 @@ For more information, see xref:configuring-an-ldap-server-as-an-external-identit
 When using external user groups from an LDAP source, you cannot use the `$login` variable as a substitute for the account user name.
 You must use either an anonymous or dedicated service user.
 * If you use a {FreeIPA} or AD server, configure {Project} to use {FreeIPA} or AD authentication.
-For more information, see {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}[_{ConfiguringUserAuthenticationDocTitle}_].
 * Ensure that at least one external user authenticates for the first time.
 * Retain a copy of the external group names you want to use.
 To find the group membership of external users, enter the following command:

--- a/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
+++ b/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
@@ -1,4 +1,4 @@
-[id="configuring-host-based-access-control-for-{Freeipa-context}-users-logging-in-to-project_{context}"]
+[id="configuring-host-based-access-control-for-{FreeIPA-context}-users-logging-in-to-project_{context}"]
 = Configuring host-based access control for {FreeIPA} users logging in to {Project}
 
 You can use host-based access control (HBAC) rules to manage access control within your {FreeIPA} domain.

--- a/guides/common/modules/proc_creating-a-user.adoc
+++ b/guides/common/modules/proc_creating-a-user.adoc
@@ -16,7 +16,7 @@ The user account details that you can specify include the following:
 * On the *User* tab, select an authentication source from the *Authorized by* list:
 ** *INTERNAL*: to manage the user inside {ProjectServer}.
 ** *EXTERNAL*: to manage the user with external authentication.
-For more information, see {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}[_{ConfiguringUserAuthenticationDocTitle}_].
 * On the *Organizations* tab, select an organization for the user.
 Specify the default organization {Project} selects for the user after login from the *Default on login* list.
 +

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
@@ -9,7 +9,7 @@ For more information, see xref:Creating_a_Custom_File_Type_Repository_{context}[
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 ** The `katello-server-ca.crt`.
-For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Importing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate[Importing the Katello root CA certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
+++ b/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
@@ -8,7 +8,7 @@ You can download files to a client over HTTPS using `curl -O`, and optionally ov
 * You know the name of the Python package you want to download to clients from the Python type repository.
 * To download the Python packages over HTTPS to your hosts, you require:
 ** The `katello-server-ca.crt`.
-For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Importing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate[Importing the Katello root CA certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.
 

--- a/guides/common/modules/proc_importing-the-katello-root-ca-certificate.adoc
+++ b/guides/common/modules/proc_importing-the-katello-root-ca-certificate.adoc
@@ -1,10 +1,10 @@
-[id="Importing_the_Katello_Root_CA_Certificate_{context}"]
+[id="importing-the-katello-root-ca-certificate"]
 = Importing the Katello root CA certificate
 
 The first time you log in to {Project}, you might see a warning informing you that you are using the default self-signed certificate and you might not be able to connect this browser to {Project} until the root CA certificate is imported in the browser.
 Use the following procedure to locate the root CA certificate on {Project} and to import it into your browser.
 
-To use the CLI instead of the {ProjectWebUI}, see xref:CLI_Importing_the_Katello_Root_CA_Certificate_{context}[CLI Procedure].
+To use the CLI instead of the {ProjectWebUI}, see xref:cli-importing-the-katello-root-ca-certificate[].
 
 .Prerequisites
 * Your {ProjectName} is installed and configured.
@@ -29,7 +29,7 @@ Ensure that the {Project} URL is valid before you accept the security exception.
 . Select `katello-server-ca.crt`.
 . Import the certificate into your browser as a certificate authority and trust it to identify websites.
 
-[id="CLI_Importing_the_Katello_Root_CA_Certificate_{context}"]
+[id="cli-importing-the-katello-root-ca-certificate"]
 .CLI procedure
 . From the {Project} CLI, copy the `katello-server-ca.crt` file to the machine you use to access the {ProjectWebUI}:
 +

--- a/guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc
+++ b/guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc
@@ -1,4 +1,4 @@
-[id="Using_{FreeIPA-context}_credentials_to_log_in_to_the_{project-context}_Hammer_CLI_{context}"]
+[id="logging-in-to-hammer-cli-with-{FreeIPA-context}-credentials"]
 = Logging in to Hammer CLI with {FreeIPA} credentials
 
 Authenticate to the {Project} Hammer CLI with your {FreeIPA} username and password.

--- a/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc
@@ -7,11 +7,7 @@ Use the latest stable Chrome browser.
 
 .Prerequisites
 * You have {FreeIPA} authentication configured in your {Project} environment.
-ifeval::["{context}" != "{project-context}"]
-ifndef::orcharhino[]
-For more information, see {InstallingServerDocURL}configuring-kerberos-sso-with-{Freeipa-context}-in-project_{project-context}[{InstallingServerDocTitle}].
-endif::[]
-endif::[]
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
 * The host on which you are using Chrome is a client in the {FreeIPA} domain.
 
 .Procedure

--- a/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc
@@ -1,4 +1,4 @@
-[id="Using_{FreeIPA-context}_credentials_to_log_in_to_the_{ProjectWebUI-context}-with-a-Chrome-browser_{context}"]
+[id="logging-in-to-the-webui-with-{FreeIPA-context}-credentials-in-chrome"]
 = Logging in to the {ProjectWebUI} with {FreeIPA} credentials in Chrome
 
 You can use Chrome to log in to the {ProjectWebUI} with your {FreeIPA} credentials.

--- a/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-mozilla-firefox.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-mozilla-firefox.adoc
@@ -1,4 +1,4 @@
-[id="Using_{FreeIPA-context}_credentials_to_log_in_to_the_{ProjectWebUI-context}-with-Mozilla-Firefox_{context}"]
+[id="logging-in-to-the-webui-with-{FreeIPA-context}-credentials-in-mozilla-firefox"]
 = Logging in to the {ProjectWebUI} with {FreeIPA} credentials in Mozilla Firefox
 
 You can use Mozilla Firefox to log in to the {ProjectWebUI} with your {FreeIPA} credentials.

--- a/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-mozilla-firefox.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-mozilla-firefox.adoc
@@ -7,11 +7,7 @@ Use the latest stable Mozilla Firefox browser.
 
 .Prerequisites
 * You have {FreeIPA} authentication configured in your {Project} environment.
-ifeval::["{context}" != "{project-context}"]
-ifndef::orcharhino[]
-For more information, see {InstallingServerDocURL}configuring-kerberos-sso-with-{Freeipa-context}-in-project_{project-context}[{InstallingServerDocTitle}].
-endif::[]
-endif::[]
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
 * The host on which you are using Mozilla Firefox is a client in the {FreeIPA} domain.
 * Your Mozilla Firefox is configured for Single Sign-On (SSO).
 ifdef::satellite[]

--- a/guides/common/modules/proc_logging-in-to-the-projectwebui.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-projectwebui.adoc
@@ -6,7 +6,7 @@ Use the web user interface to log in to {Project} for further configuration.
 ifdef::katello,orcharhino,satellite[]
 .Prerequisites
 * Ensure that the Katello root CA certificate is installed in your browser.
-For more information, see xref:Importing_the_Katello_Root_CA_Certificate_{context}[].
+For more information, see xref:importing-the-katello-root-ca-certificate[].
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -77,6 +77,4 @@ ifdef::satellite[]
 For more information, see {ConfiguringVMSubscriptionsDocURL}troubleshooting-virt-who#modifying-virt-who-configuration_vm-subs-satellite[Modifying a virt-who Configuration] in _{ConfiguringVMSubscriptionsDocTitle}_.
 endif::[]
 . If you use external authentication, reconfigure {ProjectServer} for external authentication after you run the `{project-change-hostname}` script.
-ifndef::orcharhino[]
-For more information, see {InstallingServerDocURL}Configuring_External_Authentication_{project-context}[Configuring External Authentication] in _{InstallingServerDocTitle}_.
-endif::[]
+For more information, see {ConfiguringUserAuthenticationDocURL}[_{ConfiguringUserAuthenticationDocTitle}_].

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -14,7 +14,7 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 * For existing virtual machines, ensure that the *Display type* in the *Compute Resource* settings is *VNC*.
 * You must import the Katello root CA certificate into your {ProjectServer}.
 Adding a security exception in the browser is not enough for using noVNC.
-For more information, see {ConfiguringUserAuthenticationDocURL}Importing_the_Katello_Root_CA_Certificate_authentication[Installing the Katello Root CA Certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate[Installing the Katello root CA certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
 
 .Procedure
 . On your {ProjectServer}, configure the firewall to allow VNC service on ports 5900 to 5930.

--- a/guides/common/modules/ref_overview-of-authentication-methods-in-project.adoc
+++ b/guides/common/modules/ref_overview-of-authentication-methods-in-project.adoc
@@ -77,7 +77,7 @@ endif::[]
 ifndef::satellite[]
 |No
 endif::[]
-|xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-project_{context}[]
+|xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[]
 ifndef::satellite[]
 |{Keycloak-quarkus}|Yes|Yes|Yes|Yes
 ifndef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

* Fix broken links
* Align anchors to file names
* Fix capitalization when changing the link

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

some links are broken in nightly docs

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
