### PR TITLE
Add Secure Boot to provisioning overview

### DIFF
--- a/guides/common/modules/con_provisioning-methods-in-project.adoc
+++ b/guides/common/modules/con_provisioning-methods-in-project.adoc
@@ -9,6 +9,7 @@ When provisioning bare-metal hosts with {Project}, you can do the following:
 +
 * Create host entries and specify the MAC address of the physical host to provision.
 * Boot blank hosts to use the {Project} Discovery service, which creates a pool of hosts that are ready for provisioning.
+* Provision hosts with UEFI Secure Boot.
 ifndef::satellite[]
 * Boot and provision hosts by using PXE-less methods.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding a reference to Secure Boot to Planning.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-30959

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
