### PR TITLE
Add ID arg to CV sync to Smart Proxy Servers

### DIFF
--- a/guides/common/modules/proc_adding-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_adding-lifecycle-environments.adoc
@@ -31,21 +31,21 @@ Note the {SmartProxy} ID of the {SmartProxy} to which you want to add a lifecycl
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} info \
---id _My_{smart-proxy-context}_ID_
+--id __My_{smart-proxy-context-titlecase}_ID__
 ----
 . To view the lifecycle environments available for your {SmartProxyServer}, enter the following command and note the ID and the organization name:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} content available-lifecycle-environments \
---id _My_{smart-proxy-context}_ID_
+--id __My_{smart-proxy-context-titlecase}_ID__
 ----
 . Add the lifecycle environment to your {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} content add-lifecycle-environment \
---id _My_{smart-proxy-context}_ID_ \
+--id __My_{smart-proxy-context-titlecase}_ID__ \
 --lifecycle-environment-id _My_Lifecycle_Environment_ID_
 --organization "_My_Organization_"
 ----
@@ -58,7 +58,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} content synchronize \
---id _My_{smart-proxy-context}_ID_
+--id __My_{smart-proxy-context-titlecase}_ID__
 ----
 +
 * To synchronize a specific lifecycle environment from your {ProjectServer} to {SmartProxyServer}, enter the following command:
@@ -66,7 +66,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} content synchronize \
---id _My_{smart-proxy-context}_ID_
+--id __My_{smart-proxy-context-titlecase}_ID__ \
 --lifecycle-environment-id _My_Lifecycle_Environment_ID_
 ----
 +
@@ -75,7 +75,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} content synchronize \
---id _My_{smart-proxy-context}_ID_ \
+--id __My_{smart-proxy-context-titlecase}_ID__ \
 --skip-metadata-check true
 ----
 +

--- a/guides/common/modules/proc_importing-all-available-ansible-playbooks.adoc
+++ b/guides/common/modules/proc_importing-all-available-ansible-playbooks.adoc
@@ -16,7 +16,7 @@ If you have a custom collection, place it in `/etc/ansible/collections/ansible_c
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# curl -X PUT -H 'Content-Type: application/json' https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/sync?proxy_id=__My_{smart-proxy-context}_ID__
+# curl -X PUT -H 'Content-Type: application/json' https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/sync?proxy_id=__My_{smart-proxy-context-titlecase}_ID__
 ----
 +
 You get a notification in the {ProjectWebUI} after the import completes.

--- a/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
+++ b/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
@@ -19,7 +19,7 @@ If you have a custom collection, place it in `/etc/ansible/collections/ansible_c
 $ curl \
 --header 'Content-Type: application/json' \
 --request GET \
-https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/fetch?proxy_id=__My_{smart-proxy-context}_ID__
+https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/fetch?proxy_id=__My_{smart-proxy-context-titlecase}_ID__
 ----
 . Select the Ansible Playbook you want to import and note its name.
 . Import the Ansible Playbook by its name:
@@ -30,7 +30,7 @@ $ curl \
 --data '{ "playbook_names": ["_My_Playbook_Name_"] }' \
 --header 'Content-Type: application/json' \
 --request PUT \
-https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/sync?proxy_id=__My_{smart-proxy-context}_ID__
+https://_{foreman-example-com}_/ansible/api/v2/ansible_playbooks/sync?proxy_id=__My_{smart-proxy-context-titlecase}_ID__
 ----
 +
 You get a notification in the {ProjectWebUI} after the import completes.

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy.adoc
@@ -12,8 +12,9 @@ You can track the progress of a command by navigating to *Monitor* > *{Project} 
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ {hammer-smart-proxy} content verify-checksum \
+--content-view-id _My_Content_View_ID_ \
 --id __My_{smart-proxy-context-titlecase}_ID__ \
---organization-id 1 --content-view-id 3
+--organization-id _My_Organization_ID_
 ----
 * To repair content in a lifecycle environment, run Hammer on your {SmartProxy}:
 +
@@ -21,7 +22,8 @@ $ {hammer-smart-proxy} content verify-checksum \
 ----
 $ {hammer-smart-proxy} content verify-checksum \
 --id __My_{smart-proxy-context-titlecase}_ID__ \
---organization-id 1 --lifecycle-environment-id 1
+--lifecycle-environment-id _My_Lifecycle_Environment_ID_ \
+--organization-id _My_Organization_ID_
 ----
 * To repair content in a repository, run Hammer on your {SmartProxy}:
 +
@@ -29,7 +31,8 @@ $ {hammer-smart-proxy} content verify-checksum \
 ----
 $ {hammer-smart-proxy} content verify-checksum \
 --id __My_{smart-proxy-context-titlecase}_ID__ \
---organization-id 1 --repository-id 1
+--organization-id _My_Organization_ID_ \
+--repository-id _My_Repository_ID_
 ----
 * To repair all content on {SmartProxy}, run the following command:
 +

--- a/guides/common/modules/proc_renaming-server.adoc
+++ b/guides/common/modules/proc_renaming-server.adoc
@@ -70,7 +70,7 @@ For more information, see {ManagingHostsDocURL}Registering_Hosts_managing-hosts[
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {hammer-smart-proxy} content synchronize \
---id __My_{smart-proxy-context}_ID__
+--id __My_{smart-proxy-context-titlecase}_ID__
 ----
 . If you use the _virt-who_ agent, update the _virt-who_ configuration files with the new host name.
 ifdef::satellite[]

--- a/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
@@ -5,11 +5,13 @@ In the {ProjectWebUI}, you can only synchronize all selected lifecycle environme
 If you need to synchronize smaller items, such as individual lifecycle environments, single content views, and single repositories, use the Hammer CLI.
 
 .CLI procedure
-* Synchronize a content view to your {SmartProxyServer} by using Hammer:
+* Synchronize a content view to your {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-$ {hammer-smart-proxy} content synchronize --content-view "_My_Content_View_Name_"
+$ {hammer-smart-proxy} content synchronize \
+--content-view "_My_Content_View_Name_" \
+--id _My_{smart-proxy-context-titlecase}_Server_ID_
 ----
 
 .Additional resources

--- a/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
@@ -11,7 +11,7 @@ If you need to synchronize smaller items, such as individual lifecycle environme
 ----
 $ {hammer-smart-proxy} content synchronize \
 --content-view "_My_Content_View_Name_" \
---id _My_{smart-proxy-context-titlecase}_Server_ID_
+--id __My_{smart-proxy-context-titlecase}_Server_ID__
 ----
 
 .Additional resources


### PR DESCRIPTION
#### What changes are you introducing?

* Add missing argument for Hammer CLI command

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

````
# hammer proxy content synchronize --content-view-id 1
Could not synchronize capsule content:
  Missing arguments for '--id'.
````

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* tested on Foreman+Katello 3.11/4.13; should affect all versions

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
