### PR TITLE
Add note about manifest expiry

### DIFF
--- a/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
+++ b/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
@@ -18,4 +18,6 @@ Alternatively, you can import an updated manifest that contains the changes.
 . In the Manage Manifest window, click *Refresh*.
 
 The {ProjectWebUI} provides a notification before the subscription manifest expires.
+ifdef::satellite[]
 For more information, see https://access.redhat.com/solutions/11101[How and when does a Red Hat Satellite manifest certificate expire?] in the _Red{nbsp}Hat Knowledgebase_.
+endif::[]

--- a/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
+++ b/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
@@ -17,8 +17,5 @@ Alternatively, you can import an updated manifest that contains the changes.
 . In the Subscriptions window, click *Manage Manifest*.
 . In the Manage Manifest window, click *Refresh*.
 
-[NOTE]
-====
-The {Project} web UI notifies you before your subscription manifest expires. 
-The `expire_soon_days` setting determines the number of days in advance that the notification appears.
-====
+The {ProjectWebUI} provides a notification before the subscription manifest expires.
+For more information, see https://access.redhat.com/solutions/11101[How and when does a Red Hat Satellite manifest certificate expire?] in the _Red{nbsp}Hat Knowledgebase_.

--- a/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
+++ b/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
@@ -16,3 +16,9 @@ Alternatively, you can import an updated manifest that contains the changes.
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*.
 . In the Subscriptions window, click *Manage Manifest*.
 . In the Manage Manifest window, click *Refresh*.
+
+[NOTE]
+====
+The {Project} web UI notifies you before your subscription manifest expires. 
+The `expire_soon_days` setting determines the number of days in advance that the notification appears.
+====


### PR DESCRIPTION
#### What changes are you introducing?
Adding a note to 2.5 Updating and refreshing 
Red Hat subscription manifests that tells the user
the web UI notifies them when their subscription
manifest expires.
Copy link

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
In reference to https://issues.redhat.com/browse/SAT-30326

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
