### PR TITLE
Add note about virt-who not supporting IPv6 in 6.17

### DIFF
--- a/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
@@ -7,3 +7,8 @@
 
 * Although {Project} provisioning templates include IPv6 support for PXE and HTTP (iPXE) provisioning, the only tested and certified provisioning workflow is the UEFI HTTP Boot provisioning.
 This limitation only relates to users who plan to use {Project} to provision hosts.
+
+[NOTE]
+====
+In {ProjectVersion}, virt-who does not support IPv6.
+====

--- a/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
@@ -7,8 +7,4 @@
 
 * Although {Project} provisioning templates include IPv6 support for PXE and HTTP (iPXE) provisioning, the only tested and certified provisioning workflow is the UEFI HTTP Boot provisioning.
 This limitation only relates to users who plan to use {Project} to provision hosts.
-
-[NOTE]
-====
-In {ProjectVersion}, virt-who does not support IPv6.
-====
+* {Project} does not support virt-who in an IPv6 network.


### PR DESCRIPTION
#### What changes are you introducing?
Adding a note that virt-who does not
support IPv6 in 6.17.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Referring to https://issues.redhat.com/browse/SAT-31196.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
