### PR TITLE
Deprecate old keycloak and redirect all users to new keycloak

### DIFF
--- a/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -1,6 +1,9 @@
 [id="configuring-sso-and-2fa-with-keycloak-wildfly-in-project_{context}"]
 = Configuring SSO and 2FA with {keycloak-wildfly} in {Project}
 
+:FeatureName: Configuring {Project} with {keycloak-wildfly}
+include::snip_deprecated-feature.adoc[]
+
 ifndef::satellite[]
 [NOTE]
 ====

--- a/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -15,6 +15,16 @@ For information about configuring {keycloak-quarkus} authentication, see xref:co
 For information about migrating from {keycloak-wildfly} to {keycloak-quarkus}, see link:https://www.keycloak.org/migration/migrating-to-quarkus[Migrating to Quarkus distribution].
 ====
 endif::[]
+ifdef::satellite[]
+[NOTE]
+====
+The {keycloak-wildfly}{nbsp}7 product family has reached End of Full Support.
+Use {keycloak-quarkus} instead in your {Project} deployments.
+For information about configuring {keycloak-quarkus} authentication, see xref:configuring-sso-and-2fa-with-keycloak-in-project_keycloak-quarkus[].
+
+For information about migrating from {keycloak-wildfly} to {keycloak-quarkus}, see link:{RHDocsBaseURL}red_hat_build_of_keycloak/26.0[documentation for {keycloak-quarkus}].
+====
+endif::[]
 
 {keycloak} is an open-source identity and access management solution that provides authentication features, such as single sign-on functionality, user federation, and centralized authentication management.
 With {keycloak-wildfly}, you can integrate {ProjectServer} with your existing {keycloak} server to delegate user authentication and authorization to {keycloak}.

--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -3,7 +3,7 @@
 
 You can use the bootstrap script to automate content registration and Puppet configuration.
 
-:FeatureName: bootstrap script
+:FeatureName: The bootstrap script
 :FeatureAlternative: xref:Registering_Hosts_by_Using_Global_Registration_{context}[]
 include::snip_deprecated-feature.adoc[]
 

--- a/guides/common/modules/snip_deprecated-feature.adoc
+++ b/guides/common/modules/snip_deprecated-feature.adoc
@@ -3,7 +3,7 @@
 
 [IMPORTANT]
 ====
-The {FeatureName} is a deprecated feature.
+{FeatureName} is a deprecated feature.
 Deprecated functionality is still included in {Project} and continues to be supported.
 However, it will be removed in a future release of this product and is not recommended for new deployments.
 

--- a/guides/doc-Configuring_User_Authentication/master.adoc
+++ b/guides/doc-Configuring_User_Authentication/master.adoc
@@ -36,14 +36,17 @@ ifdef::satellite[]
 :!keycloak:
 endif::[]
 
-ifndef::satellite[]
+// The following ifdef sets :keycloak: to `Red Hat Build of Keycloak` for Satellite builds only. For, non-Satellite builds, :keycloak: stays set to `Keycloak`.
+ifdef::satellite[]
+:keycloak: {keycloak-quarkus}
+:keycloak-example-com: rhbk.example.com
+endif::[]
 // The following attribute definitions ensure that modules can be reused between the two included Keycloak assemblies: parent-context saves the original context, context defines a new, unique context to enable the reuse.
 :parent-context: {context}
 :context: keycloak-quarkus
 include::common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc[leveloffset=+1]
 // The following attribute reloads the original context value from parent-context that was defined earlier.
 :context: {parent-context}
-endif::[]
 
 include::common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

* Deprecating procedures for the Wildfly distribution of Keycloak (all builds)
* Including procedures for the Quarkus distribution of Keycloak (Satellite only because they are already included in the other builds)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Keycloak based on Wildfly itself has been deprecated for a long time.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
