### PR TITLE
Update link from RHEL 8 to RHEL 9

### DIFF
--- a/guides/common/modules/con_managing-ssh-keys.adoc
+++ b/guides/common/modules/con_managing-ssh-keys.adoc
@@ -5,5 +5,5 @@ Adding SSH keys to a user allows deployment of SSH keys during provisioning.
 For information on deploying SSH keys during provisioning, see {ProvisioningDocURL}Deploying_SSH_Keys_During_Provisioning_provisioning[Deploying SSH Keys during Provisioning] in _{ProvisioningDocTitle}_.
 
 ifndef::orcharhino[]
-For information on SSH keys and SSH key creation, see {RHELDocsBaseURL}8/html-single/configuring_basic_system_settings/index#setting-an-openssh-server-for-key-based-authentication_assembly_using-secure-communications-between-two-systems-with-openssh[Using SSH-based Authentication] in _{RHEL}{nbsp}8 Configuring basic system settings_.
+For information on SSH keys and SSH key creation, see {RHELDocsBaseURL}9/html-single/configuring_basic_system_settings/index#assembly_using-secure-communications-between-two-systems-with-openssh_configuring-basic-system-settings[Using secure communications between two systems with OpenSSH] in _{RHEL}{nbsp}9 Configuring basic system settings_.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Updating a link to an SSH key procedure in RHEL docs from RHEL 8 to RHEL 9. Also, the new link now points to the chapter rather than a low-level section (I expect chapter links to be more stable).

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-31199 reports this particular link.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

There might be more links to update but because I don't have a good plan for how to address this across the whole repo, I'd like to update just this one to address the bug report.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
