### PR TITLE
Add missing option to self-upgrade command

### DIFF
--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -147,7 +147,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} self-upgrade --maintenance-repo-label Satellite-Maintenance
+# {foreman-maintain} self-upgrade --maintenance-repo-label {Project}-Maintenance
 ----
 
 . If you are using an external database, upgrade your database to PostgreSQL 13.

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -147,7 +147,7 @@ If you lose connection to the command shell where the upgrade command is running
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} self-upgrade
+# {foreman-maintain} self-upgrade --maintenance-repo-label Satellite-Maintenance
 ----
 
 . If you are using an external database, upgrade your database to PostgreSQL 13.


### PR DESCRIPTION
The self-upgrade command for Disconnected upgrade is missing the --maintenance-repo-label option.

JIRA link: https://issues.redhat.com/browse/SAT-31105

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
