### PR TITLE
Revert "Add HTTP(S) proxy username and password Setting"

### DIFF
--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -15,8 +15,6 @@ When set to `Yes`, {Project} recreates this cache on the next restart.
 | *Login page footer text* | | Text to be shown in the login-page footer.
 | *HTTP(S) proxy* | | Set a proxy for outgoing HTTP(S) connections from the {Project} product.
 System-wide proxies must be configured at the operating system level.
-| *HTTP(S) proxy username* | | Username for connecting to the HTTP(S) proxy server
-| *HTTP(S) proxy user password* | | User password for connecting to the HTTP(S) proxy server
 | *HTTP(S) proxy except hosts* | [] | Set hostnames to which requests are not to be proxied.
 Requests to the local host are excluded by default.
 | *Show Experimental Labs* | No | Whether or not to show a menu to access experimental lab features (requires reload of page).


### PR DESCRIPTION
#### What changes are you introducing?

This reverts commit 9a795c2f4c7eaf02e8ae5784acb76b8ef9be7aca.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3635#issuecomment-2683234003

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Changes in https://github.com/theforeman/foreman-documentation/pull/3635 will need a new PR if the corresponding code gets merged.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
