### PR TITLE
Hide clickable links to "*.example.com"

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -52,5 +52,5 @@
 // Overwritten in downstream for docs.orcharhino.com
 :client-package-install: dnf install
 :client-package-remove: dnf remove
-:client-repo-url: http://_{foreman-example-com}_/pulp/content/_My_Organization_/Library/custom/{client-os}_Client/{client-os}_Client_{client-os-major}/
+:client-repo-url: {foreman-example-com}/pulp/content/My_Organization/Library/custom/{client-os-context}_Client/{client-os-context}_Client_{client-os-major}/
 :client-puppet-repo-url: http://_{foreman-example-com}_/pulp/content/_My_Organization_/Library/custom/Puppet_Agent/Puppet_Agent_{client-os}_{client-os-major}/

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -13,12 +13,9 @@ ignore=example.com
   file:///js/versions.js
   file:///js/nav.js
   tools.ietf.org
-  host/unattended/provision
   projects.theforeman.org
   access.redhat.com/solutions
   forge.puppetlabs.com
-  keycloak.com
-  rhsso.com
   sources/
   atixservice.zendesk.com
   # 6.17 docs are not yet published

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -21,7 +21,7 @@ You can register a host to the _Library_ environment on {Project} to consume the
 
 ifndef::satellite[]
 You can access unprotected repositories in the _Default Organization View_ content view.
-The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Library/custom/{client-content-product-label}/{client-content-repository-label}/`.
+The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://{foreman-example-com}/pulp/content/Example/Library/custom/{client-content-product-label}/{client-content-repository-label}/`.
 ifdef::katello,orcharhino[]
 ifdef::content-management[]
 For more information, see
@@ -68,9 +68,9 @@ This ensures hosts are designated to a specific environment but receive updates 
 
 ifndef::satellite[]
 With `Distribute archived content view versions` enabled, you can access unprotected repositories in published content view versions.
-The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/content_views/`, your content view, your content view version, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/content_views/{client-content-content-view-label}/2.1/custom/{client-content-product-label}/{client-content-repository-label}/`.
+The URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/content_views/`, your content view, your content view version, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://{foreman-example-com}/pulp/content/Example/content_views/{client-content-content-view-label}/2.1/custom/{client-content-product-label}/{client-content-repository-label}/`.
 
-If you want to access the latest published content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, your lifecycle, your content view, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `https://{foreman-example-com}/pulp/content/Example/Production/{client-content-content-view-label}/custom/{client-content-product-label}/{client-content-content-view-label}/`.
+If you want to access the latest published content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, your lifecycle, your content view, `/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://{foreman-example-com}/pulp/content/Example/Production/{client-content-content-view-label}/custom/{client-content-product-label}/{client-content-content-view-label}/`.
 endif::[]
 
 ifdef::orcharhino[]

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -5,7 +5,7 @@
 * If the repository requires SSL authentication, import the SSL certificate and key to the {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.
 * Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide.
-For example, if your base URL is `https://{server-example-com}` and your subpaths are `rhel7/` and `rhel8/`, then both `https://{server-example-com}/rhel7/` and `https://{server-example-com}/rhel8/` will be searched.
+For example, if your base URL is `\https://{server-example-com}` and your subpaths are `rhel7/` and `rhel8/`, then both `\https://{server-example-com}/rhel7/` and `\https://{server-example-com}/rhel8/` will be searched.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.

--- a/guides/common/modules/proc_configuring-hosts-to-use-an-alternate-cname-for-content-management.adoc
+++ b/guides/common/modules/proc_configuring-hosts-to-use-an-alternate-cname-for-content-management.adoc
@@ -7,11 +7,11 @@ You can do this using the bootstrap script or manually.
 
 .Configuring hosts with the bootstrap script
 
-On the host, run the bootstrap script with the `--server _alternate_fqdn.example.com_` option to register the host to the alternate {Project} CNAME:
+On the host, run the bootstrap script with the `--server _My-Alternate-FQDN.example.com_` option to register the host to the alternate {Project} CNAME:
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# ./bootstrap.py --server _alternate_fqdn.example.com_
+# ./bootstrap.py --server _My-Alternate-FQDN.example.com_
 ----
 
 .Configuring hosts manually
@@ -22,13 +22,13 @@ On the host, edit the `/etc/rhsm/rhsm.conf` file to update `hostname` and `baseu
 ----
 [server]
 # Server hostname:
-hostname = _alternate_fqdn.example.com_
+hostname = _My-Alternate-FQDN.example.com_
 
 _content omitted_
 
 [rhsm]
 # Content base URL:
-baseurl=https://_alternate_fqdn.example.com_/pulp/content/
+baseurl=https://_My-Alternate-FQDN.example.com_/pulp/content/
 ----
 
 Now you can register the host with the `subscription-manager`.

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -13,7 +13,7 @@ Execute the following command on your RHUA server:
 # rhui-manager repo info --repo_id _My_Repo_ID_
 ----
 * Note that the alternate content source paths consist of a base URL appended with the subpaths that you provide.
-For example, if your base URL is `https://{server-example-com}` and your subpaths are `rhel7/` and `rhel8/`, then both `https://{server-example-com}/rhel7/` and `https://{server-example-com}/rhel8/` will be searched.
+For example, if your base URL is `\https://{server-example-com}` and your subpaths are `rhel7/` and `rhel8/`, then both `\https://{server-example-com}/rhel7/` and `\https://{server-example-com}/rhel8/` will be searched.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -41,7 +41,7 @@ They are required when upgrading {ProjectServer}.
 
 .Verification
 . Access the {ProjectWebUI} from your local machine.
-For example, `https://{foreman-example-com}`.
+For example, `\https://{foreman-example-com}`.
 . In your browser, view the certificate details to verify the deployed certificate.
 
 .Next steps

--- a/guides/common/modules/snip_host-parameters-for-orcharhino-clients.adoc
+++ b/guides/common/modules/snip_host-parameters-for-orcharhino-clients.adoc
@@ -1,4 +1,4 @@
-. On the *Parameters* tab, add the `or_client_repo_url` parameter, select the *string* type, and enter the value `{client-repo-url}`.
+. On the *Parameters* tab, add the `or_client_repo_url` parameter, select the *string* type, and enter the value `\http://{client-repo-url}`.
 +
 If you want to provision hosts through {SmartProxyServers}, you have to use the `or_client_repo_path` parameter containing the *Published At* path of your content on {ProjectServer}.
 {SmartProxyServer} will add the FQDN of your {SmartProxyServer} to generate the URL based on the content source setting of your host.


### PR DESCRIPTION
#### What changes are you introducing?

Make links to `*.example.com` not clickable

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* to improve SEO by removing broken links

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
