### PR TITLE
Add RHEL 9 and 10 repos for system roles

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -36,6 +36,8 @@
 :RepoRHEL8BaseOS: rhel-8-for-x86_64-baseos-rpms
 :RepoRHEL9AppStream: rhel-9-for-x86_64-appstream-rpms
 :RepoRHEL9BaseOS: rhel-9-for-x86_64-baseos-rpms
+:RepoRHEL10AppStream: rhel-10-for-x86_64-appstream-rpms
+:RepoRHEL10BaseOS: rhel-10-for-x86_64-baseos-rpms
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
 
 // Base attributes

--- a/guides/common/modules/proc_adding-rhel-system-roles.adoc
+++ b/guides/common/modules/proc_adding-rhel-system-roles.adoc
@@ -8,14 +8,16 @@ Using Ansible Roles in {Project} can make configuration faster and easier.
 Support levels for some of the {RHEL} System Roles might be in Technology Preview.
 For up-to-date information about support levels and general information about {RHEL} System Roles, see https://access.redhat.com/articles/3050101[{RHEL} System Roles].
 
-Before subscribing to the Extras channels, see the https://access.redhat.com/support/policy/updates/extras[{RHEL} Extras Product Lifecycle] article.
+Before subscribing to the Extras or Appstream channels, see https://access.redhat.com/support/policy/updates/extras[{RHEL} Extras Product Lifecycle] or https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 
 .Procedure
 . Ensure that the following repository is enabled:
-* On {RHEL} 8, ensure that the *Appstream* repository is enabled:
+* On {RHEL} 10, 9, or 8, ensure that the *Appstream* repository is enabled:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
+# subscription-manager repos --enable={RepoRHEL10AppStream}
+# subscription-manager repos --enable={RepoRHEL9AppStream}
 # subscription-manager repos --enable={RepoRHEL8AppStream}
 ----
 +


### PR DESCRIPTION
#### What changes are you introducing?

Adding RHEL 9 and 10 repos for adding Ansible system roles

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

RHEL 9 was missing and RHEL 10 will be available soon
Bug [SAT-31201](https://issues.redhat.com/browse/SAT-31201) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
