### PR TITLE
Restructure required RHEL repos + 9, 10 to Managing content

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -170,6 +170,8 @@ endif::[]
 
 include::modules/proc_enabling-red-hat-repositories.adoc[leveloffset=+1]
 
+include::modules/ref_required-red-hat-repositories.adoc[leveloffset=+2]
+
 include::modules/proc_synchronizing-repositories.adoc[leveloffset=+1]
 
 include::modules/proc_synchronizing-all-repositories-in-an-organization.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -170,8 +170,6 @@ endif::[]
 
 include::modules/proc_enabling-red-hat-repositories.adoc[leveloffset=+1]
 
-include::modules/ref_required-red-hat-repositories.adoc[leveloffset=+2]
-
 include::modules/proc_synchronizing-repositories.adoc[leveloffset=+1]
 
 include::modules/proc_synchronizing-all-repositories-in-an-organization.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_enabling-red-hat-repositories.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories.adoc
@@ -6,16 +6,7 @@ For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{p
 
 To select the repositories to synchronize, you must first identify the product that contains the repository, and then enable that repository based on the relevant release version and base architecture.
 
-.For {RHEL} 8 hosts
-
-To provision {RHEL} 8 hosts, you require the *{RHEL} 8 for x86_64 - AppStream (RPMs)* and *{RHEL} 8 for x86_64 - BaseOS (RPMs)* repositories.
-
-.For {RHEL} 7 hosts
-
-To provision {RHEL} 7 hosts, you require the *{RHEL} 7 Server (RPMs)* repository.
-
-The difference between associating {RHEL} operating system release version with either *7Server* repositories or *7._X_* repositories is that *7Server* repositories contain all the latest updates while *{RHEL} 7._X_* repositories stop getting updates after the next minor version release.
-Note that Kickstart repositories only have minor versions.
+For an overview of required repositories, see xref:required-red-hat-repositories[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Red{nbsp}Hat Repositories*.

--- a/guides/common/modules/ref_required-red-hat-repositories.adoc
+++ b/guides/common/modules/ref_required-red-hat-repositories.adoc
@@ -23,8 +23,6 @@ You require both:
 
 For {RHEL} 7 hosts::
 You require the *{RHEL} 7 Server (RPMs)* repository.
-+
-The difference between associating {RHEL} operating system release version with either *7Server* repositories or *7._y_* repositories is that *7Server* repositories contain all the latest updates while *{RHEL} 7._y_* repositories stop getting updates after the next minor version release.
 
 .Additional repositories for provisioning
 To provision hosts by using the Anaconda installer with Kickstart, you additionally need the following repositories:
@@ -49,4 +47,3 @@ You require both:
 
 For {RHEL} 7 hosts::
 You require the *{RHEL} 7 Server (Kickstart)* repository.
-Note that Kickstart repositories only have minor versions.

--- a/guides/common/modules/ref_required-red-hat-repositories.adoc
+++ b/guides/common/modules/ref_required-red-hat-repositories.adoc
@@ -1,0 +1,52 @@
+[id="required-red-hat-repositories"]
+= Required Red Hat repositories
+
+You need the following repositories to manage hosts with {RHEL}.
+
+For {RHEL} 10 hosts::
+You require both:
+
+* *{RHEL} 10 for x86_64 - BaseOS (RPMs)*
+* *{RHEL} 10 for x86_64 - AppStream (RPMs)*
+
+For {RHEL} 9 hosts::
+You require both:
+
+* *{RHEL} 9 for x86_64 - BaseOS (RPMs)*
+* *{RHEL} 9 for x86_64 - AppStream (RPMs)*
+
+For {RHEL} 8 hosts::
+You require both:
+
+* *{RHEL} 8 for x86_64 - BaseOS (RPMs)*
+* *{RHEL} 8 for x86_64 - AppStream (RPMs)*
+
+For {RHEL} 7 hosts::
+You require the *{RHEL} 7 Server (RPMs)* repository.
++
+The difference between associating {RHEL} operating system release version with either *7Server* repositories or *7._y_* repositories is that *7Server* repositories contain all the latest updates while *{RHEL} 7._y_* repositories stop getting updates after the next minor version release.
+
+.Additional repositories for provisioning
+To provision hosts by using the Anaconda installer with Kickstart, you additionally need the following repositories:
+
+For {RHEL} 10 hosts::
+You require both:
+
+* *{RHEL} 10 for x86_64 - BaseOS (Kickstart)*
+* *{RHEL} 10 for x86_64 - AppStream (Kickstart)*
+
+For {RHEL} 9 hosts::
+You require both:
+
+* *{RHEL} 9 for x86_64 - BaseOS (Kickstart)*
+* *{RHEL} 9 for x86_64 - AppStream (Kickstart)*
+
+For {RHEL} 8 hosts::
+You require both:
+
+* *{RHEL} 8 for x86_64 - BaseOS (Kickstart)*
+* *{RHEL} 8 for x86_64 - AppStream (Kickstart)*
+
+For {RHEL} 7 hosts::
+You require the *{RHEL} 7 Server (Kickstart)* repository.
+Note that Kickstart repositories only have minor versions.

--- a/guides/common/modules/ref_required-red-hat-repositories.adoc
+++ b/guides/common/modules/ref_required-red-hat-repositories.adoc
@@ -4,46 +4,34 @@
 You need the following repositories to manage hosts with {RHEL}.
 
 For {RHEL} 10 hosts::
-You require both:
-
 * *{RHEL} 10 for x86_64 - BaseOS (RPMs)*
 * *{RHEL} 10 for x86_64 - AppStream (RPMs)*
 
 For {RHEL} 9 hosts::
-You require both:
-
 * *{RHEL} 9 for x86_64 - BaseOS (RPMs)*
 * *{RHEL} 9 for x86_64 - AppStream (RPMs)*
 
 For {RHEL} 8 hosts::
-You require both:
-
 * *{RHEL} 8 for x86_64 - BaseOS (RPMs)*
 * *{RHEL} 8 for x86_64 - AppStream (RPMs)*
 
 For {RHEL} 7 hosts::
-You require the *{RHEL} 7 Server (RPMs)* repository.
+* *{RHEL} 7 Server (RPMs)*
 
 .Additional repositories for provisioning
-To provision hosts by using the Anaconda installer with Kickstart, you additionally need the following repositories:
+To provision hosts by using the Anaconda installer with Kickstart, you additionally need the following repositories.
 
 For {RHEL} 10 hosts::
-You require both:
-
 * *{RHEL} 10 for x86_64 - BaseOS (Kickstart)*
 * *{RHEL} 10 for x86_64 - AppStream (Kickstart)*
 
 For {RHEL} 9 hosts::
-You require both:
-
 * *{RHEL} 9 for x86_64 - BaseOS (Kickstart)*
 * *{RHEL} 9 for x86_64 - AppStream (Kickstart)*
 
 For {RHEL} 8 hosts::
-You require both:
-
 * *{RHEL} 8 for x86_64 - BaseOS (Kickstart)*
 * *{RHEL} 8 for x86_64 - AppStream (Kickstart)*
 
 For {RHEL} 7 hosts::
-You require the *{RHEL} 7 Server (Kickstart)* repository.
+* *{RHEL} 7 Server (Kickstart)*

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -69,6 +69,9 @@ include::common/assembly_managing-python-type-content.adoc[leveloffset=+1]
 endif::[]
 
 [appendix]
+include::common/modules/ref_required-red-hat-repositories.adoc[leveloffset=+1]
+
+[appendix]
 include::common/modules/proc_using-an-nfs-share-for-content-storage.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Splitting off required repos from _Enabling RH repos_ into a reference module
And adding RHEL 9 and 10 repos
Adding Kickstart repos needed for provisioning

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Splitting off because the list would become too long
- Adding RHEL 9 because it was missing, RHEL 10 will soon be available

Bug [SAT-31200](https://issues.redhat.com/browse/SAT-31200) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
