### PR TITLE
Only list required v3_req parameters in openssl.conf

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -49,8 +49,8 @@ commonName = _{ssl-common-name}_
 
 [ v3_req ]
 basicConstraints = CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [ alt_names ]
@@ -74,8 +74,8 @@ commonName = _{ssl-common-name}_ <1>
 
 [ v3_req ]
 basicConstraints = CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-extendedKeyUsage = serverAuth, clientAuth, codeSigning, emailProtection
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [alt_names] <2>
@@ -88,6 +88,8 @@ You can also set a wildcard value `*`.
 If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
 <2> Under `[alt_names]`, include the FQDN of the load balancer as `DNS.1` and the FQDN of {SmartProxyServer} as `DNS.2`.
 endif::[]
++
+For more information about the `[ v3_req ]` parameters and their purpose, see link:https://www.rfc-editor.org/rfc/rfc5280[RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile].
 . Optional: If you want to add Distinguished Name (DN) details to the CSR, add the following information to the `[ req_distinguished_name ]` section:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -49,7 +49,7 @@ commonName = _{ssl-common-name}_
 
 [ v3_req ]
 basicConstraints = CA:FALSE
-keyUsage = digitalSignature
+keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
@@ -74,7 +74,7 @@ commonName = _{ssl-common-name}_ <1>
 
 [ v3_req ]
 basicConstraints = CA:FALSE
-keyUsage = digitalSignature
+keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
@@ -90,16 +90,6 @@ If you set a wildcard value, you must add the `-t {certs-proxy-context}` option 
 endif::[]
 +
 For more information about the `[ v3_req ]` parameters and their purpose, see link:https://www.rfc-editor.org/rfc/rfc5280[RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile].
-+
-[NOTE]
-====
-If you are using the TLS{nbsp}1.2 protocol, add also the `keyEncipherment` key usage bit:
-
-[options="nowrap", subs="+quotes,attributes"]
-----
-keyUsage = digitalSignature,keyEncipherment
-----
-====
 . Optional: If you want to add Distinguished Name (DN) details to the CSR, add the following information to the `[ req_distinguished_name ]` section:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -49,7 +49,7 @@ commonName = _{ssl-common-name}_
 
 [ v3_req ]
 basicConstraints = CA:FALSE
-keyUsage = digitalSignature, keyEncipherment
+keyUsage = digitalSignature
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
@@ -74,7 +74,7 @@ commonName = _{ssl-common-name}_ <1>
 
 [ v3_req ]
 basicConstraints = CA:FALSE
-keyUsage = digitalSignature, keyEncipherment
+keyUsage = digitalSignature
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
@@ -90,6 +90,16 @@ If you set a wildcard value, you must add the `-t {certs-proxy-context}` option 
 endif::[]
 +
 For more information about the `[ v3_req ]` parameters and their purpose, see link:https://www.rfc-editor.org/rfc/rfc5280[RFC 5280: Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile].
++
+[NOTE]
+====
+If you are using the TLS{nbsp}1.2 protocol, add also the `keyEncipherment` key usage bit:
+
+[options="nowrap", subs="+quotes,attributes"]
+----
+keyUsage = digitalSignature,keyEncipherment
+----
+====
 . Optional: If you want to add Distinguished Name (DN) details to the CSR, add the following information to the `[ req_distinguished_name ]` section:
 +
 [options="nowrap", subs="+quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

Removing selected [v3_req] parameters from example openssl.cnf.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current list includes parameters that are not strictly necessary. https://issues.redhat.com/browse/SAT-31112

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
