### PR TITLE
Split arguments in code blocks into separate lines

### DIFF
--- a/guides/common/modules/proc_enabling-the-flatpak-remote.adoc
+++ b/guides/common/modules/proc_enabling-the-flatpak-remote.adoc
@@ -18,8 +18,10 @@ For example, `rhel9/firefox-flatpak` depends on `rhel9/flatpak-runtime`.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer flatpak-remote create --name=_My_Flatpak_Remote_Name_ --url=_My_Flatpak_Remote_URL_ \
---organization=your_organization
+$ hammer flatpak-remote create \
+--name=_My_Flatpak_Remote_Name_ \
+--organization=_My_Organization_ \
+--url=_My_Flatpak_Remote_URL_
 ----
 +
 You can include authentication details by using the options `--username=_My_User_Name_ --token=_My_Token_`.
@@ -32,7 +34,9 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer flatpak-remote update --username=_My_User_Name_ --token=_My_Token_
+$ hammer flatpak-remote update \
+--token=_My_Token_ \
+--username=_My_User_Name_
 ----
 . Optional: List and view information about the Flatpak remote:
 +
@@ -57,7 +61,9 @@ $ hammer flatpak-remote repository list --flatpak-remote-id=_My_ID_
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer flatpak-remote remote-repository mirror --id=_My_Remote_Repo_id_ --product-id=_{Project}_Product_ID_
+$ hammer flatpak-remote remote-repository mirror \
+--id=_My_Remote_Repo_ID_ \
+--product-id=_{Project}_Product_ID_
 ----
 You can view the repository under the selected product in {ProjectWebUI}.
 Set the *Include Tags* field to *latest*.

--- a/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
+++ b/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
@@ -12,13 +12,15 @@ For more information about enabling the Flatpak remote, see xref:enabling-the-fl
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer content-export start --id=_My_Product_ID_ --export-to=_Path_to_Export_Directory_
+$ hammer content-export start \
+--export-to=_My_Path_to_Export_Directory_ \
+--id=_My_Product_ID_
 ----
 . Import the exported content to the disconnected {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer content-import start --path=_Path_to_Export_Directory_/export.tar
+$ hammer content-import start --path=_My_Path_to_Export_Directory_/export.tar
 ----
 . Add the disconnected {Project} as a Flatpak remote:
 +

--- a/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
+++ b/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
@@ -1,4 +1,4 @@
-[id="importing_and_exporting_content_to_project_server_for_flatpak"]
+[id="importing-and-exporting-content-to-{project-context}-server-for-flatpak"]
 = Importing and exporting content to {ProjectServer} for Flatpak 
 
 Use Hammer CLI to transfer Flatpak content to {ProjectServer} in environments with disconnected {ProjectServer} instances.

--- a/guides/common/modules/proc_installing-flatpak-applications-on-project-hosts.adoc
+++ b/guides/common/modules/proc_installing-flatpak-applications-on-project-hosts.adoc
@@ -1,4 +1,4 @@
-[id="installing-flatpak-applications-on-project-hosts"]
+[id="installing-flatpak-applications-on-{project-context}-hosts"]
 = Installing Flatpak applications on {Project} hosts
 
 Use the command line to install selected applications from the enabled Flatpak remotes.

--- a/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
+++ b/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
@@ -1,4 +1,4 @@
-[id="setting-up-Flatpak-remote_for_Smartproxy"]
+[id="setting-up-flatpak-remote-for-{smart-proxy-context}"]
 = Setting up Flatpak remote for {SmartProxy}
 
 Configure {SmartProxy} servers to synchronize and distribute Flatpak repositories to managed hosts. 

--- a/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
+++ b/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
@@ -1,7 +1,7 @@
 [id="setting-up-flatpak-remote-for-{smart-proxy-context}"]
 = Setting up Flatpak remote for {SmartProxy}
 
-Configure {SmartProxy} servers to synchronize and distribute Flatpak repositories to managed hosts. 
+Configure {SmartProxyServers} to synchronize and distribute Flatpak repositories to managed hosts.
 
 [NOTE]
 ====
@@ -26,7 +26,7 @@ $ flatpak remote-add --authenticator-name=org.flatpak.Authenticator.Oci katello 
 ----
 $ podman login
 ----
-For more information about logging in using Podman, see xref:Configuring_podman_to_trust_the_CA_{context}[Configuring Podman and Docker to trust the certificate authority].
+For more information about logging in using Podman, see xref:Configuring_podman_to_trust_the_CA_{context}[].
 +
 You might need to log in to the registry again if you have not saved your credentials.
 
@@ -35,15 +35,13 @@ You might need to log in to the registry again if you have not saved your creden
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ cp $XDG_RUNTIME_DIR/containers/auth.json \
-   $HOME/.config/flatpak/oci-auth.json
+$ cp $XDG_RUNTIME_DIR/containers/auth.json $HOME/.config/flatpak/oci-auth.json
 ----
 * To save the credentials system-wide:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ cp $XDG_RUNTIME_DIR/containers/auth.json \
-   /etc/flatpak/oci-auth.json
+$ cp $XDG_RUNTIME_DIR/containers/auth.json /etc/flatpak/oci-auth.json
 ----
 . Install your application.
 For example, to install the Mozilla Firefox Flatpak:
@@ -52,4 +50,3 @@ For example, to install the Mozilla Firefox Flatpak:
 ----
 $ flatpak install firefox
 ----
-


### PR DESCRIPTION
#### What changes are you introducing?

* split lines in code blocks
* align anchors to current conventions (they're not published anywhere yet)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Minor mostly cosmetic follow-up to https://github.com/theforeman/foreman-documentation/pull/3624

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
