### PR TITLE
Clarify that some data may be missing from the host table if not provided by any source

### DIFF
--- a/guides/common/modules/proc_selecting-host-columns.adoc
+++ b/guides/common/modules/proc_selecting-host-columns.adoc
@@ -2,8 +2,9 @@
 = Selecting Host Columns
 
 You can select what columns you want to see in the host table on the *Hosts* > *All Hosts* page.
-{ProjectWebUI} collects information from multiple sources, which report different sets of facts.
-Some data will not be displayed if it is not provided by any source.
+Columns under the Reported Data category, such as Disk Space, BIOS vendor, and RAM, are populated based on available facts from the host’s configuration management or system inventory tools.
+Subscription Manager does not report disk space by default.
+To populate this data, the host must be configured to report facts through a tool that includes this information, such as Ansible or Puppet.
 For a complete list of host columns, see xref:overview-of-the-host-columns_{context}[].
 
 [NOTE]

--- a/guides/common/modules/proc_selecting-host-columns.adoc
+++ b/guides/common/modules/proc_selecting-host-columns.adoc
@@ -2,7 +2,7 @@
 = Selecting Host Columns
 
 You can select what columns you want to see in the host table on the *Hosts* > *All Hosts* page.
-Columns under the Reported Data category, such as Disk Space, BIOS vendor, and RAM, are populated based on available facts from the host’s configuration management or system inventory tools.
+Columns under the *Reported Data* category, such as *Disk Space*, *BIOS vendor*, and *RAM*, are populated based on available facts from the host configuration management or system inventory tools.
 Subscription Manager does not report disk space.
 To populate this data, the host must be configured to report facts through a tool that includes this information, such as Ansible or Puppet.
 For a complete list of host columns, see xref:overview-of-the-host-columns_{context}[].

--- a/guides/common/modules/proc_selecting-host-columns.adoc
+++ b/guides/common/modules/proc_selecting-host-columns.adoc
@@ -2,6 +2,8 @@
 = Selecting Host Columns
 
 You can select what columns you want to see in the host table on the *Hosts* > *All Hosts* page.
+{ProjectWebUI} collects information from multiple sources, which report different sets of facts.
+Some data will not be displayed if it is not provided by any source.
 For a complete list of host columns, see xref:overview-of-the-host-columns_{context}[].
 
 [NOTE]

--- a/guides/common/modules/proc_selecting-host-columns.adoc
+++ b/guides/common/modules/proc_selecting-host-columns.adoc
@@ -3,7 +3,7 @@
 
 You can select what columns you want to see in the host table on the *Hosts* > *All Hosts* page.
 Columns under the Reported Data category, such as Disk Space, BIOS vendor, and RAM, are populated based on available facts from the host’s configuration management or system inventory tools.
-Subscription Manager does not report disk space by default.
+Subscription Manager does not report disk space.
 To populate this data, the host must be configured to report facts through a tool that includes this information, such as Ansible or Puppet.
 For a complete list of host columns, see xref:overview-of-the-host-columns_{context}[].
 


### PR DESCRIPTION
#### What changes are you introducing?

Clarified that some data may be missing from the host table if no source provides it. Updated the documentation to reflect that Web UI collects data from multiple sources, which report different sets of facts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Bug [SAT-23504](https://issues.redhat.com/browse/SAT-23504)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
