### PR TITLE
Move parent-context from master.adoc to assembly

### DIFF
--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -2,4 +2,8 @@ include::modules/con_preparing-for-disaster-recovery-and-recovering-from-data-lo
 
 include::modules/con_overview-of-recommended-disaster-recovery-plans.adoc[leveloffset=+1]
 
+:parent-context: {context}
+:context: dr-virt
 include::assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc[leveloffset=+1]
+:context: {parent-context}
+:!parent-context:

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -60,11 +60,7 @@ include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 
 include::common/assembly_searching-and-bookmarking.adoc[leveloffset=+1]
 
-:parent-context: {context}
-:context: disaster-recovery
 include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
-:context: {parent-context}
-:!parent-context:
 
 [appendix]
 ifdef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Moving {parent-context} magic from master.adoc to a disaster recovery assembly.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The {parent-context} attribute is defined to enable reusing a procedure. However, I want to reuse the procedure in all upcoming DR scenarios so it can't stay in master.adoc; it needs to be set and unset for each of the DR assemblies.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is a bit of a prerequisite for https://github.com/theforeman/foreman-documentation/pull/3679.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
