### PR TITLE
Remove custom xref labels

### DIFF
--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -3,9 +3,9 @@
 
 You can export templates to an existing repository.
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[CLI procedure].
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[].
 
-To use the API, see the xref:api_Exporting_Templates_{context}[API procedure].
+To use the API, see the xref:api_Exporting_Templates_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -32,11 +32,11 @@ organizations:
 %>
 ----
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[CLI procedure].
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[].
 
-To use the API, see the xref:api_Importing_Templates_{context}[API procedure].
+To use the API, see the xref:api_Importing_Templates_{context}[].
 
-To use Ansible, see the xref:ansible_Importing_Templates_{context}[Ansible procedure].
+To use Ansible, see the xref:ansible_Importing_Templates_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.


### PR DESCRIPTION
#### What changes are you introducing?

Removing several custom xref labels.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I accidentally included them in https://github.com/theforeman/foreman-documentation/pull/3692.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
