### PR TITLE
Remove Postgres space prerequisite

### DIFF
--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -7,11 +7,6 @@ Before proceeding, complete the following:
 * Read the {ProjectName} {ProjectVersion} {ReleaseNotesDocURL}[Release Notes].
 * Ensure that you have sufficient storage space on your server.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_ and {InstallingSmartProxyDocURL}preparing-environment-for-capsule-installation[Preparing your Environment for Installation] in _Installing {SmartProxyServer}_.
-ifndef::foreman-deb[]
-* Ensure that you have at least the same amount of free space on `{postgresql-lib-dir}` as that consumed by `{postgresql-data-dir}`.
-Upgrading to {Project} {ProjectVersion} involves a PostgreSQL 12 to PostgreSQL 13 upgrade.
-The contents of `{postgresql-data-dir}` are backed up during the PostgreSQL upgrade. 
-endif::[]
 * Back up your {ProjectServer} and all {SmartProxyServers}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing Up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.


### PR DESCRIPTION
As  PostgreSQL 12 to PostgreSQL 13 upgrade is already performed in the previous upgrade, there is no need to repeat it in the prerequisites again. Removing this line.

JIRA: https://issues.redhat.com/browse/SAT-31306

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
