### PR TITLE
Consolidate 'keycloak realm' replaceables

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -90,7 +90,6 @@
 :keycloak-quarkus: Quarkus-based Keycloak
 :keycloak: Keycloak
 :keycloak-example-com: keycloak.example.com
-:keycloak-realm: KEYCLOAK_REALM
 // We need Satellite attributes here because some upstream builds refer to RH SSO and RH BK documentation.
 :RHSSO: Red{nbsp}Hat Single Sign-On
 :RHBK: Red{nbsp}Hat build of Keycloak

--- a/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc
+++ b/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc
@@ -62,14 +62,14 @@ $ hammer settings set --name oidc_audience \
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ hammer settings set --name oidc_issuer \
---value "https://_{keycloak-example-com}_/auth/realms/_{keycloak-realm}_"
+--value "https://_{keycloak-example-com}_/auth/realms/_{Project}_Realm_"
 ----
 . Set the value for Open IDC Java Web Token (JWT):
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ hammer settings set --name oidc_jwks_url \
---value "https://_{keycloak-example-com}_/auth/realms/_{keycloak-realm}_/protocol/openid-connect/certs"
+--value "https://_{keycloak-example-com}_/auth/realms/_{Project}_Realm_/protocol/openid-connect/certs"
 ----
 . Retrieve the ID of the {keycloak} authentication source:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Replacing two (now obsolete) replaceables for Keycloak realm with `{Project}_Realm`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To be consistent with the other references to a Keycloak realm for Foreman, which already use `{Project}_Realm`: https://github.com/theforeman/foreman-documentation/blob/6239e9211bb1a59750d195247290dad8a0969e4e/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc?plain=1#L17

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I seem to have missed these in https://github.com/theforeman/foreman-documentation/commit/50b9023ea0779c82d9b399e428cc1fc1eb159559 where I originally updated the realm replaceable.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
