### PR TITLE
Fix broken xrefs in satellite d/s

### DIFF
--- a/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
+++ b/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
@@ -23,8 +23,9 @@ Configure an LDAP authentication source to enable users to log in to {Project} w
 +
 For TLS encrypted connections, select *LDAPS* to enable encryption.
 . On the *Account* tab, enter the account information and domain name details.
-+
-See xref:Example_Settings_for_LDAP_Connections_{context}[] and xref:Example_LDAP_Filters_{context}[].
+For more information, see the following sections:
+** xref:Example_Settings_for_LDAP_Connections_{context}[]
+** xref:Example_LDAP_Filters_{context}[]
 . On the *Attribute mappings* tab, map LDAP attributes to {Project} attributes.
 . On the *Locations* tab, select the locations you want {Project} to assign to users created from the LDAP authentication source.
 These locations are available to users after they log in for the first time.

--- a/guides/common/modules/proc_creating-an-api-only-user.adoc
+++ b/guides/common/modules/proc_creating-an-api-only-user.adoc
@@ -6,7 +6,9 @@ You can create users that can interact only with the {Project} API.
 .Prerequisites
 * You have created a user and assigned roles to them.
 Note that this user must be authorized internally.
-For more information, see xref:Creating_a_User_{context}[] and xref:Assigning_Roles_to_a_User_{context}[].
+For more information, see the following sections:
+** xref:Creating_a_User_{context}[]
+** xref:Assigning_Roles_to_a_User_{context}[]
 
 .Procedure
 . Log in to your {Project} as admin.

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -3,8 +3,9 @@
 
 Use this procedure to export templates to a git repository.
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[].
-To use the API, see the xref:api_Exporting_Templates_{context}[].
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[CLI procedure].
+
+To use the API, see the xref:api_Exporting_Templates_{context}[API procedure].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.

--- a/guides/common/modules/proc_exporting-templates.adoc
+++ b/guides/common/modules/proc_exporting-templates.adoc
@@ -3,9 +3,9 @@
 
 Use this procedure to export templates to a git repository.
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[CLI procedure].
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Exporting_Templates_{context}[].
 
-To use the API, see the xref:api_Exporting_Templates_{context}[API procedure].
+To use the API, see the xref:api_Exporting_Templates_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -32,8 +32,9 @@ organizations:
 %>
 ----
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[].
-To use the API, see the xref:api_Importing_Templates_{context}[].
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[CLI procedure].
+
+To use the API, see the xref:api_Importing_Templates_{context}[API procedure].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -32,9 +32,9 @@ organizations:
 %>
 ----
 
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[CLI procedure].
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[].
 
-To use the API, see the xref:api_Importing_Templates_{context}[API procedure].
+To use the API, see the xref:api_Importing_Templates_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.


### PR DESCRIPTION
#### What changes are you introducing?

This combines https://github.com/theforeman/foreman-documentation/pull/3692 (where there was a conflict on 3.11) and https://github.com/theforeman/foreman-documentation/pull/3706 (where I fixed a mistake I made in the first PR).

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Satellite d/s toolchain doesn't support multiple xrefs on a single line.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
