### PR TITLE
Add DR for active-passive with backup&restore

### DIFF
--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,11 @@
+include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc[]
+
+include::modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+
+include::modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+
+include::modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+
+include::modules/proc_retrieving-status-of-services.adoc[leveloffset=+1]
+
+include::modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -16,3 +16,12 @@ include::assembly_disaster-recovery-for-active-and-passive-project-server-with-e
 endif::[]
 :context: {parent-context}
 :!parent-context:
+
+:parent-context: {context}
+:context: dr-backup-restore
+// This depends on the cloning procedure, which is satellite-only.
+ifdef::satellite[]
+include::assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+endif::[]
+:context: {parent-context}
+:!parent-context:

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -19,9 +19,6 @@ endif::[]
 
 :parent-context: {context}
 :context: dr-backup-restore
-// This depends on the cloning procedure, which is satellite-only.
-ifdef::satellite[]
 include::assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
-endif::[]
 :context: {parent-context}
 :!parent-context:

--- a/guides/common/modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc
+++ b/guides/common/modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc
@@ -1,0 +1,6 @@
+[id="disaster-recovery-for-active-and-passive-{project-context}-server-with-backup-and-restore"]
+= Disaster recovery for active and passive {ProjectServer} with backup and restore
+
+To prepare for disaster recovery, you can configure two {ProjectServer}s: an active primary server and a passive secondary server.
+You configure periodic backups of the primary server.
+If the primary server fails, you can restore a backup on the secondary server to turn it into your new primary server.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,43 @@
+[id="preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore"]
+= Preparing for disaster recovery with active and passive {ProjectServer} and backup and restore
+
+Create your passive {ProjectServer} as a clone of your active {ProjectServer}.
+Configure periodic backups on the active server, and restore them on your passive server.
+
+.Procedure
+. Clone your active {ProjectServer}.
+For more information, see xref:cloning_satellite_server[].
+. Keep the source server powered on. Power off the new cloned server.
++
+The source server remains your active primary server, while the clone server becomes the passive secondary server.
+. Define a schedule for periodic offline backups of your active {ProjectServer}.
+Consider your tolerance for potential data loss and your storage options: Taking backups frequently will result in smaller amounts of data loss in case of a disaster, but backups require a significant amount of storage space.
+For information about the size of {Project} backups, see xref:Estimating_the_Size_of_a_Backup_admin[].
++
+You can combine full backups with incremental backups.
+For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
+. Schedule periodic offline backups of your active {ProjectServer}.
+. Define your backup retention policy.
+Consider how many backups you want to store: Regularly removing outdated backups helps optimize storage usage.
+For information about performing the backup, including prerequisites and other important information, see xref:cloning_satellite_server[].
+. {Project} stores the backups in the `_/var/{project-context}-backup_` directory by default.
+Ensure that these backup directories are encrypted and regularly synchronized to a secure location.
++
+[IMPORTANT]
+====
+ifndef::foreman-el,foreman-deb[]
+{ProjectServer} backups contain sensitive information from the `/root/ssl-build` directory.
+For example, they can contain hostnames, ssh keys, request files, and SSL certificates.
+endif::[]
+Encrypting or moving the backups to a secure location helps minimize the risk of damage or unauthorized access to the hosts.
+====
+
+.Verification
+. Verify that {Project} takes backups according to the schedule you defined.
+. Perform further testing steps in an isolated staging environment:
+.. Mimic a full outage on the active server.
+To make sure the active server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+.. Switch DNS records of the active server with the DNS records of the passive server.
+.. Assess the functionality of the test {ProjectServer}.
+See xref:Retrieving_the_Status_of_Services_{context}[].
+.. Perform these verification checks regularly.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,25 +1,17 @@
 [id="preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore"]
 = Preparing for disaster recovery with active and passive {ProjectServer} and backup and restore
 
-Create your passive {ProjectServer} as a clone of your active {ProjectServer}.
-Configure periodic backups on the active server, and restore them on your passive server.
+Create your passive {ProjectServer} by restoring a backup of your active {ProjectServer}.
+Configure periodic backups of the active server.
 
 .Procedure
-. Clone your active {ProjectServer}.
-For more information, see xref:cloning_satellite_server[].
-. Keep the source server powered on. Power off the new cloned server.
-+
-The source server remains your active primary server, while the clone server becomes the passive secondary server.
 . Define a schedule for periodic offline backups of your active {ProjectServer}.
 Consider your tolerance for potential data loss and your storage options: Taking backups frequently will result in smaller amounts of data loss in case of a disaster, but backups require a significant amount of storage space.
 For information about the size of {Project} backups, see xref:Estimating_the_Size_of_a_Backup_admin[].
 +
 You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
-. Schedule periodic offline backups of your active {ProjectServer}.
-. Define your backup retention policy.
-Consider how many backups you want to store: Regularly removing outdated backups helps optimize storage usage.
-For information about performing the backup, including prerequisites and other important information, see xref:cloning_satellite_server[].
+. Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 . {Project} stores the backups in the `_/var/{project-context}-backup_` directory by default.
 Ensure that these backup directories are encrypted and regularly synchronized to a secure location.
 +
@@ -31,6 +23,12 @@ For example, they can contain hostnames, ssh keys, request files, and SSL certif
 endif::[]
 Encrypting or moving the backups to a secure location helps minimize the risk of damage or unauthorized access to the hosts.
 ====
+. Restore the most recent backup on a system that will serve as your passive {ProjectServer}.
+. Keep the active server powered on.
+Power off the passive server.
+. Define your backup retention policy.
+Consider how many backups you want to store: Regularly removing outdated backups helps optimize storage usage.
+For information about performing the backup, including prerequisites and other important information, see xref:cloning_satellite_server[].
 
 .Verification
 . Verify that {Project} takes backups according to the schedule you defined.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -32,8 +32,8 @@ For information about restoring backups, see xref:restoring-{project-context}-se
 A regularly restored passive server helps reduce switchover time if the active server fails.
 +
 Consider how often you want the backups to be restored: More frequent updates reduce potential data loss but increase infrastructure and automation costs.
-. Keep the active server powered on.
-Power off the passive server.
+. Power off the passive server.
+Keep the active server powered on.
 . Define your backup retention policy.
 Consider how many backups you want to store: Regularly removing outdated backups helps optimize storage usage.
 

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -7,11 +7,14 @@ Configure periodic backups of the active server.
 .Procedure
 . Define a schedule for periodic offline backups of your active {ProjectServer}.
 Consider your tolerance for potential data loss and your storage options: Taking backups frequently will result in smaller amounts of data loss in case of a disaster, but backups require a significant amount of storage space.
+ifdef::katello,orcharhino,satellite[]
 For information about the size of {Project} backups, see xref:Estimating_the_Size_of_a_Backup_admin[].
+endif::[]
 +
 You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
+For information about performing backups, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[].
 . {Project} stores the backups in the `_/var/{project-context}-backup_` directory by default.
 Ensure that these backup directories are encrypted and regularly synchronized to a secure location.
 +
@@ -24,11 +27,11 @@ endif::[]
 Encrypting or moving the backups to a secure location helps minimize the risk of damage or unauthorized access to the hosts.
 ====
 . Restore the most recent backup on a system that will serve as your passive {ProjectServer}.
+For information about restoring backups, see xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
 . Keep the active server powered on.
 Power off the passive server.
 . Define your backup retention policy.
 Consider how many backups you want to store: Regularly removing outdated backups helps optimize storage usage.
-For information about performing the backup, including prerequisites and other important information, see xref:cloning_satellite_server[].
 
 .Verification
 . Verify that {Project} takes backups according to the schedule you defined.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -15,8 +15,8 @@ You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 For information about performing backups, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[].
-. {Project} stores the backups in the `_/var/{project-context}-backup_` directory by default.
-Ensure that these backup directories are encrypted and regularly synchronized to a secure location.
+. Ensure that the backup directories are encrypted and regularly synchronized to a secure location.
+By default, {Project} stores the backups in the `_/var/{project-context}-backup_` directory.
 +
 [IMPORTANT]
 ====
@@ -44,5 +44,5 @@ Consider how many backups you want to store: Regularly removing outdated backups
 To make sure the active server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
 .. Switch DNS records of the active server with the DNS records of the passive server.
 .. Assess the functionality of the test {ProjectServer}.
-See xref:Retrieving_the_Status_of_Services_{context}[].
+For more information, see xref:Retrieving_the_Status_of_Services_{context}[].
 .. Perform these verification checks regularly.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -28,6 +28,10 @@ Encrypting or moving the backups to a secure location helps minimize the risk of
 ====
 . Restore the most recent backup on a system that will serve as your passive {ProjectServer}.
 For information about restoring backups, see xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
+. Optional: Automate backup restoration to keep the passive server periodically updated with the latest backup.
+A regularly restored passive server helps reduce switchover time if the active server fails.
++
+Consider how often you want the backups to be restored: More frequent updates reduce potential data loss but increase infrastructure and automation costs.
 . Keep the active server powered on.
 Power off the passive server.
 . Define your backup retention policy.

--- a/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,11 @@
+[id="recovering-from-disaster-with-active-and-passive-server-and-backup-and-restore"]
+= Recovering from disaster with active and passive server and backup and restore
+
+If your active {ProjectServer} fails, activate your passive secondary server.
+
+.Procedure
+. Verify that the failed active server is powered off and that backups are no longer being synchronized to your passive server.
+. Switch DNS records of the active server with the DNS records of the passive server.
+This ensures that hosts remain connected and you do not need to re-register them.
+. Assess the functionality of your new active {ProjectServer}.
+See xref:Retrieving_the_Status_of_Services_{context}[].

--- a/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -8,4 +8,4 @@ If your active {ProjectServer} fails, activate your passive secondary server.
 . Switch DNS records of the active server with the DNS records of the passive server.
 This ensures that hosts remain connected and you do not need to re-register them.
 . Assess the functionality of your new active {ProjectServer}.
-See xref:Retrieving_the_Status_of_Services_{context}[].
+For more information, see xref:Retrieving_the_Status_of_Services_{context}[].

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,5 +1,5 @@
 [id="prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore"]
 = Prerequisites
 
-* Review xref:overview-of-recommended-disaster-recovery-plans[] to make sure that this disaster recovery plan works for you.
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to ensure that this disaster recovery plan works for you.
 * You have a {ProjectServer} installed.

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,5 @@
+[id="prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore"]
+= Prerequisites
+
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to make sure that this disaster recovery plan works for you.
+* You have a {ProjectServer} installed.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a new disaster recovery scenario: Active and passive server with backup and restore.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

A follow-up to https://github.com/theforeman/foreman-documentation/pull/3558

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

With this scenario, it's becoming especially clear that it might be better to turn some of the procedure steps into separate modules (steps like cloning or taking backups). But for now, what matters is to get an agreement on the steps and record those. We can tweak the assembly structure later -- if there is time.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
