### PR TITLE
update release notes 3.14.0 rc2

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman-3.14.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.14.0.adoc
@@ -131,6 +131,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === Web Interface
 
+* pass:[select2 search not working in modals] - https://projects.theforeman.org/issues/38237[#38237]
 * pass:[select 2 not showing placeholders] - https://projects.theforeman.org/issues/38211[#38211]
 * pass:[vmware Create controller select freezes the page ] - https://projects.theforeman.org/issues/38209[#38209]
 * pass:[form_select_f auto selects first option] - https://projects.theforeman.org/issues/38183[#38183]


### PR DESCRIPTION
Updating release notes for 3.14.0 rc2. Waiting on headlines, deprecations, and upgrade warnings
