### PR TITLE
Add note about IPv6 and proxy failing

### DIFF
--- a/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
@@ -9,13 +9,6 @@ Before installing {Project} in an IPv6 network, view the limitations and ensure 
 To provision hosts in an IPv6 network, after installing {Project}, you must also configure {Project} for the UEFI HTTP boot provisioning.
 For more information, see xref:configuring-for-uefi-http-boot-provisioning-in-an-ipv6-network_{context}[].
 
-[NOTE]
-====
-{Project} does not support configuring an HTTP proxy using a direct IPv6 address.
-Instead, configure the HTTP proxy with a FQDN that resolves to the IPv6 address. 
-Using an IPv6 address as the HTTP proxy URL causes it to fail.
-====
-
 include::modules/con_limitations-of-installation-in-an-ipv6-network.adoc[leveloffset=+1]
 
 include::modules/con_requirements-for-installation-in-an-ipv6-network.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
@@ -11,9 +11,9 @@ For more information, see xref:configuring-for-uefi-http-boot-provisioning-in-an
 
 [NOTE]
 ====
-{Project} does not support configuring a proxy using a direct IPv6 address.
-Instead, configure the proxy with a FQDN that resolves to the IPv6 address. 
-Using an IPv6 address as the proxy URL causes the proxy to fail.
+{Project} does not support configuring an HTTP proxy using a direct IPv6 address.
+Instead, configure the HTTP proxy with a FQDN that resolves to the IPv6 address. 
+Using an IPv6 address as the HTTP proxy URL causes it to fail.
 ====
 
 include::modules/con_limitations-of-installation-in-an-ipv6-network.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
@@ -9,6 +9,13 @@ Before installing {Project} in an IPv6 network, view the limitations and ensure 
 To provision hosts in an IPv6 network, after installing {Project}, you must also configure {Project} for the UEFI HTTP boot provisioning.
 For more information, see xref:configuring-for-uefi-http-boot-provisioning-in-an-ipv6-network_{context}[].
 
+[NOTE]
+====
+{Project} does not support configuring a proxy using a direct IPv6 address.
+Instead, configure the proxy with a FQDN that resolves to the IPv6 address. 
+Using an IPv6 address as the proxy URL causes the proxy to fail.
+====
+
 include::modules/con_limitations-of-installation-in-an-ipv6-network.adoc[leveloffset=+1]
 
 include::modules/con_requirements-for-installation-in-an-ipv6-network.adoc[leveloffset=+1]

--- a/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
+++ b/guides/common/modules/con_limitations-of-installation-in-an-ipv6-network.adoc
@@ -7,3 +7,7 @@
 
 * Although {Project} provisioning templates include IPv6 support for PXE and HTTP (iPXE) provisioning, the only tested and certified provisioning workflow is the UEFI HTTP Boot provisioning.
 This limitation only relates to users who plan to use {Project} to provision hosts.
+
+* {Project} does not support configuring an HTTP proxy using a direct IPv6 address.
+Instead, configure the HTTP proxy with a FQDN that resolves to the IPv6 address.
+Using an IPv6 address as the HTTP proxy URL causes it to fail.


### PR DESCRIPTION
#### What changes are you introducing?
A note saying Satellite does not support 
configuring a proxy using a direct IPv6 address
and to use a FQDN.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
DDF request in https://issues.redhat.com/browse/SAT-25719

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [X] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [X] Foreman 3.10/Katello 4.12
* [X] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [X] Foreman 3.8/Katello 4.10
* [X] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
