### PR TITLE
Document to fix EVR permissions after PostgreSQL 13 upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-the-external-database.adoc
+++ b/guides/common/modules/proc_upgrading-the-external-database.adoc
@@ -13,6 +13,15 @@ endif::[]
 .Procedure
 . Create a backup.
 . Restore the backup on the new server.
+ifdef::katello,satellite,orcharhino[]
+. Correct the permissions on the `evr` extension:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# runuser -l postgres -c \
+"psql -d foreman -c \"UPDATE pg_extension SET extowner = (SELECT oid FROM pg_authid WHERE rolname='foreman') WHERE extname='evr';\""
+----
+endif::[]
 . If {Project} reaches the new database server via the old name, no further changes are required.
 Otherwise reconfigure {Project} to use the new name:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Document to fix EVR permissions after PostgreSQL 13 upgrade

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Otherwise DB restore using foreman-maintain will fail.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Inspired by #3167

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
