### PR TITLE
Add upgrade warning for `ansible_tower_fqdn` removal

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -34,6 +34,14 @@ Clients will remain supported.
 For more details, see the https://community.theforeman.org/t/drop-debian-11-ruby-2-7-and-nodejs-14-support-in-foreman-3-14/40503[removal RFC].
 endif::[]
 
+=== {awx} Parameter Change
+The `ansible_tower_fqdn` parameter has been removed and replaced with `ansible_tower_api_url`.
+This new parameter includes both the previous `ansible_tower_fqdn` value and the required API path for {awx}.
+
+By default, the API path is set to `/api/controller/v2`.
+If you are using an older {awx} version, update the API path manually to `/api/v2`.
+If you're unsure which version you have, check your instance's API endpoints to confirm the correct path.
+
 [id="foreman-deprecations"]
 == Deprecations
 


### PR DESCRIPTION
#### What changes are you introducing?   
Add a release note about the parameter change, explaining that
`ansible_tower_fqdn` has been replaced and highlighting the default API path behavior.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
See `Update Ansible Tower API URL for AAP 2.5+ compatibility` PR: https://github.com/theforeman/foreman/pull/10445

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
