### PR TITLE
Move ISS deployment scenarios to Planning

### DIFF
--- a/guides/common/assembly_common-deployment-scenarios.adoc
+++ b/guides/common/assembly_common-deployment-scenarios.adoc
@@ -11,3 +11,5 @@ include::modules/con_projectserver-with-multiple-manifests.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/con_host-group-structures.adoc[leveloffset=+1]
+
+include::modules/con_iss-scenarios.adoc[leveloffset=+1]

--- a/guides/common/assembly_common-deployment-scenarios.adoc
+++ b/guides/common/assembly_common-deployment-scenarios.adoc
@@ -12,4 +12,6 @@ endif::[]
 
 include::modules/con_host-group-structures.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/con_iss-scenarios.adoc[leveloffset=+1]
+endif::[]

--- a/guides/common/assembly_configuring-inter-server-synchronization.adoc
+++ b/guides/common/assembly_configuring-inter-server-synchronization.adoc
@@ -1,7 +1,5 @@
 include::modules/con_configuring-inter-server-synchronization.adoc[]
 
-include::modules/con_iss-scenarios.adoc[leveloffset=+1]
-
 include::modules/proc_configuring-projectserver-to-synchronize-content-by-using-exports.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-projectserver-to-synchronize-content-over-a-network.adoc[leveloffset=+1]

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -19,7 +19,7 @@ Configure your {Project} to synchronize content by using export and import.
 For more information, see xref:configuring-projectserver-to-synchronize-content-by-using-exports_{context}[].
 
 .Additional resources
-* For more information on ISS use cases and scenarios, see xref:iss-scenarios_{context}[].
+* For more information on ISS use cases and scenarios, see {PlanningDocURL}iss-scenarios_{context}[{ISS} scenarios] in _{PlanningDocTitle}_.
 endif::[]
 
 ifdef::satellite[]

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -19,7 +19,7 @@ Configure your {Project} to synchronize content by using export and import.
 For more information, see xref:configuring-projectserver-to-synchronize-content-by-using-exports_{context}[].
 
 .Additional resources
-* For more information on ISS use cases and scenarios, see {PlanningDocURL}iss-scenarios_{context}[{ISS} scenarios] in _{PlanningDocTitle}_.
+* For more information on ISS use cases and scenarios, see {PlanningDocURL}iss-scenarios_planning[{ISS} scenarios] in _{PlanningDocTitle}_.
 endif::[]
 
 ifdef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Moving ISS deployment scenarios from Managing Content to Planning.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I found these deployment scenarios for ISS when browsing Managing Content and thought they might be a better fit for Planning. We have a chapter dedicated to listing deployment scenarios in Planning.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This time, I even remembered to check the repo for all occurrences of the anchor I'm moving.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
