### PR TITLE
Rename Red Hat OpenStack product name

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -94,7 +94,7 @@
 :a-KubeVirt: an OpenShift Virtualization
 :kubevirt-command: oc
 :LoraxCompose: Red{nbsp}Hat Image Builder
-:OpenStack: Red{nbsp}Hat OpenStack Platform
+:OpenStack: Red{nbsp}Hat OpenStack Services on OpenShift
 :ovirt-example-com: rhv.example.com
 :oVirt: Red{nbsp}Hat{nbsp}Virtualization
 :oVirtEngine: Red{nbsp}Hat Virtualization Manager


### PR DESCRIPTION
Red Hat OpenStack Platform was rebranded as "Red Hat OpenStack Services on OpenShift" in v.18. Updating the attribute accordingly.

JIRA: https://issues.redhat.com/browse/SAT-31474

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
