### PR TITLE
Deprecate oVirt

### DIFF
--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -1,6 +1,9 @@
 [id="performing-post-upgrade-tasks_{context}"]
 = Performing post-upgrade tasks
 
+* Optional: If you are utilizing the oVirt compute resource, it's crucial to migrate your data by executing the `foreman-rake ovirt:drop` task.
+Remember that with the upcoming release of version 3.16, oVirt will be officially phased out, and this migration will be automatically managed during the upgrade process.
+
 * Optional: If the default provisioning templates have been changed during the upgrade, recreate any templates cloned from the default templates.
 If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
 For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -15,4 +15,10 @@ There are no upgrade warnings with Foreman {ProjectVersion}.
 [id="foreman-deprecations"]
 == Deprecations
 
-There are no deprecations with Foreman {ProjectVersion}.
+// There are no deprecations with Foreman {ProjectVersion}
+
+=== Compute resources - {oVirt}
+
+* The {oVirt} compute resource has been deprecated and will be removed in the 3.16 release.
+* Migrate your data with the `foreman-rake ovirt:drop` task.
+* https://community.theforeman.org/t/rfc-deprecation-and-removal-of-ovirt-compute-resource/42527[RFC: Deprecation and removal of oVirt Compute Resource]


### PR DESCRIPTION
#### What changes are you introducing?
oVirt integration is going to be deprecated in 3.15 and removed in 3.16

#### Why are you introducing these changes?
https://community.theforeman.org/t/rfc-deprecation-and-removal-of-ovirt-compute-resource/42527
https://projects.theforeman.org/issues/38266
https://issues.redhat.com/browse/SAT-12005


#### Anything else to add? 
@maximiliankolb Atix folks probably take over the ownership and extract the code to the plugin, so there should be a doc variant for your docs.
