### PR TITLE
Change steps and remove a step

### DIFF
--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -73,40 +73,11 @@ Reboot these hosts after the upgrade has completed.
 # rm /etc/yum.repos.d/*
 ----
 
-. Obtain the latest ISO files by following the {InstallingServerDisconnectedDocURL}downloading-the-binary-dvd-images_satellite[Downloading the Binary DVD Images] procedure in _{InstallingServerDisconnectedDocTitle}_.
+. Create a syncable format export for the {Project} tools and {Project} maintenance repositories. 
+For a list of additional repositories, see xref:synchronizing_the_new_repositories_{context}[].
 
-. Create directories to serve as a mount point, mount the ISO images, and configure the `rhel8` repository by following the {InstallingServerDisconnectedDocURL}configuring-the-base-operating-system-with-offline-repositories_satellite[Configuring the base operating system with offline repositories] procedure in _{InstallingServerDisconnectedDocTitle}_.
-+
-Do not install or update any packages at this stage.
-
-. Configure the {Project} {ProjectVersion} repository from the ISO file.
-
-.. Copy the ISO file's repository data file for the {ProjectName} packages:
-+
-[options="nowrap"]
-----
-# cp /media/sat6/Satellite/media.repo /etc/yum.repos.d/satellite.repo
-----
-
-.. Edit the `/etc/yum.repos.d/satellite.repo` file:
-+
-----
-# vi /etc/yum.repos.d/satellite.repo
-----
-
-... Change the default `InstallMedia` repository name to `{Project}-{ProjectVersion}`:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-[{Project}-{ProjectVersion}]
-----
-
-... Add the `baseurl` directive:
-+
-[options="nowrap"]
-----
-baseurl=file:///media/sat6/Satellite
-----
+. Configure the {Project} {ProjectVersion} repository from the syncable format export.
+For more information, see {ContentManagementDocURL}Exporting_a_Repository_in_a_Syncable_Format[Exporting a repository in a syncable format] in _{ContentManagementDocTitle}_.
 
 . Configure the {ProjectName} Maintenance repository from the ISO file.
 


### PR DESCRIPTION
#### What changes are you introducing?
Removed steps 9 and 10.
Revised the instruction to obtain the latest 
ISO files. Instead of directing users to download 
the Binary DVD Images, the updated step now 
instructs them to create a syncable format export 
for the Satellite tools and Satellite maintenance repositories.
Updated step 11 to replace "Configure the {Project}{ProjectVersion}
repository from the ISO file" with "Configure the {Project}{ProjectVersion}
repository from the syncable format export."

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Directed from development in https://issues.redhat.com/browse/SAT-24753.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
