### PR TITLE
Add DR scenario for multiple active server setup

### DIFF
--- a/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,7 @@
+include::modules/con_disaster-recovery-with-two-active-project-servers.adoc[]
+
+include::modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]
+
+include::modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]
+
+include::modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -22,3 +22,5 @@ endif::[]
 include::assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
 :context: {parent-context}
 :!parent-context:
+
+include::assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]

--- a/guides/common/modules/con_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/con_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,5 @@
+[id="disaster-recovery-with-two-active-{project-context}-servers"]
+= Disaster recovery with two active {ProjectServer}s
+
+To prepare for disaster recovery, you can configure two {ProjectServer}s and operate each server in a different data center.
+If one of the servers fails, you can re-register all hosts from the failed server to the other server.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -2,7 +2,7 @@
 = Preparing for disaster recovery with two active {ProjectServer}s
 
 Create a second {ProjectServer} by restoring a backup of your first {ProjectServer}.
-Configure both servers to operate independently in their respective data centers, but ensure that their content, such as repositories or host configuration, does not drift apart over time.
+Configure both servers to operate independently in their respective data centers, but ensure that their content does not drift apart over time.
 
 .Procedure
 . Back up your {ProjectServer}.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -19,6 +19,8 @@ This enables you to re-register hosts if one of the servers fails.
 ** If you want both servers to act as sources for synchronization and content view creation, follow these guidelines to prevent content drift:
 *** Regularly synchronize repositories on both servers.
 For more information, see {ContentManagementDocURL}[Synchronizing repositories] in _{ContentManagementDocTitle}_.
++
+You can use the following Ansible modules to automate repository synchronization: `{ansible-namespace}.repository_sync` and `{ansible-namespace}.sync_plan`.
 *** Ensure that content views on both servers match.
 // *** What else?
 ** If you want only one server to manage synchronization and content views and let the other server synchronize its content from the first server, configure Inter-Server Synchronization (ISS).

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -16,14 +16,12 @@ Each server must have a distinct hostname and IP address.
 This enables you to re-register hosts if one of the servers fails.
 ====
 . Ensure that content on your servers remains consistent:
-** If you want both servers to act as sources for synchronization and content view creation, follow these guidelines to prevent content drift:
-*** Regularly synchronize repositories on both servers.
+* If you want both servers to manage content synchronization and content view creation, follow these guidelines to prevent content drift:
+** Regularly synchronize repositories on both servers.
 For more information, see {ContentManagementDocURL}[Synchronizing repositories] in _{ContentManagementDocTitle}_.
-+
 You can use the following Ansible modules to automate repository synchronization: `{ansible-namespace}.repository_sync` and `{ansible-namespace}.sync_plan`.
-*** Ensure that content views on both servers match.
-// *** What else?
-** If you want only one server to manage synchronization and content views and let the other server synchronize its content from the first server, configure Inter-Server Synchronization (ISS).
+** Ensure that content views on both servers match.
+* If you want one server to manage content synchronization and content view creation, you can configure Inter-Server Synchronization (ISS) so that the other server synchronizes its content from the first server.
 For more information, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.
 . Register hosts to your servers so that each server manages hosts in its respective data center.
 . Automate running the `{foreman-maintain} health check` command on both servers.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -18,11 +18,11 @@ This enables you to re-register hosts if one of the servers fails.
 . Ensure that content on your servers remains consistent:
 * If you want both servers to manage content synchronization and content view creation, follow these guidelines to prevent content drift:
 ** Regularly synchronize repositories on both servers.
-For more information, see {ContentManagementDocURL}[Synchronizing repositories] in _{ContentManagementDocTitle}_.
 You can use the following Ansible modules to automate repository synchronization: `{ansible-namespace}.repository_sync` and `{ansible-namespace}.sync_plan`.
 ** Ensure that content views on both servers match.
-* If you want one server to manage content synchronization and content view creation, you can configure Inter-Server Synchronization (ISS) so that the other server synchronizes its content from the first server.
-For more information, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.
+* If you want one server to manage content synchronization and content view creation, use one of these features to prevent content drift:
+** If your disaster recovery site has network access to your primary site, use Inter-Server Synchronization (ISS) to ensure your disaster recovery server synchronizes its content from the primary server.
+** If your disaster recovery site does not have network access to your primary site, synchronize content by using export and import.
 * If you want one server to manage only content view creation but not content synchronization, you can configure the other server or multiple other servers to import content views from the first server but synchronize content from repositories.
 //      |------------ Satellite for CVs only ---------------|
 //                /                               \
@@ -47,3 +47,5 @@ To verify that the server is inaccessible, you can turn the machine off, halt th
 .Additional resources
 * Ansible playbooks can help you automate failover, re-registration, and synchronization.
 For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.
+* For more information on synchronizing repositories, see {ContentManagementDocURL}[Synchronizing repositories] in _{ContentManagementDocTitle}_.
+* For more information on synchronizing content between {Project} servers, including ISS, export, and import, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -23,6 +23,12 @@ You can use the following Ansible modules to automate repository synchronization
 ** Ensure that content views on both servers match.
 * If you want one server to manage content synchronization and content view creation, you can configure Inter-Server Synchronization (ISS) so that the other server synchronizes its content from the first server.
 For more information, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.
+* If you want one server to manage only content view creation but not content synchronization, you can configure the other server or multiple other servers to import content views from the first server but synchronize content from repositories.
+//      |------------ Satellite for CVs only ---------------|
+//                /                               \
+//              /                                   \
+//            /                                       \
+// |--Satellite for Hosts --|     |--Satellite for hosts--|
 . Register hosts to your servers so that each server manages hosts in its respective data center.
 . Automate running the `{foreman-maintain} health check` command on both servers.
 The health check verifies whether the servers remain fully operational.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -40,8 +40,8 @@ Perform this test in an isolated staging environment:
 . Mimic a full outage on one of your servers.
 To verify that the server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
 . Verify that your `{foreman-maintain} health check` automation reported an error.
-. Re-register all hosts from the inaccessible server to the other server.
-. Verify that hosts have been properly re-registered.
+. Re-register all hosts from the inaccessible server to the accessible server.
+. Verify that hosts have been properly re-registered to the accessible server.
 . Perform these verification checks regularly.
 
 .Additional resources

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -47,5 +47,5 @@ To verify that the server is inaccessible, you can turn the machine off, halt th
 .Additional resources
 * Ansible playbooks can help you automate failover, re-registration, and synchronization.
 For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.
-* For more information on synchronizing repositories, see {ContentManagementDocURL}[Synchronizing repositories] in _{ContentManagementDocTitle}_.
-* For more information on synchronizing content between {Project} servers, including ISS, export, and import, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.
+* For more information on synchronizing repositories, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories] in _{ContentManagementDocTitle}_.
+* For more information on synchronizing content between {ProjectServer}s, including ISS, export, and import, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -42,7 +42,6 @@ To verify that the server is inaccessible, you can turn the machine off, halt th
 . Verify that your `{foreman-maintain} health check` automation reported an error.
 . Re-register all hosts from the inaccessible server to the other server.
 . Verify that hosts have been properly re-registered.
-// How?
 . Perform these verification checks regularly.
 
 .Additional resources

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -24,11 +24,11 @@ You can use the following Ansible modules to automate repository synchronization
 ** If your disaster recovery site has network access to your primary site, use Inter-Server Synchronization (ISS) to ensure your disaster recovery server synchronizes its content from the primary server.
 ** If your disaster recovery site does not have network access to your primary site, synchronize content by using export and import.
 * If you want one server to manage only content view creation but not content synchronization, you can configure the other server or multiple other servers to import content views from the first server but synchronize content from repositories.
-//      |------------ Satellite for CVs only ---------------|
+//      |------------ Foreman/Katello for CVs only ---------------|
 //                /                               \
 //              /                                   \
 //            /                                       \
-// |--Satellite for Hosts --|     |--Satellite for hosts--|
+// |--Foreman/Katello for Hosts --|     |--Foreman/Katello for hosts--|
 . Register hosts to your servers so that each server manages hosts in its respective data center.
 . Automate running the `{foreman-maintain} health check` command on both servers.
 The health check verifies whether the servers remain fully operational.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -30,6 +30,7 @@ You can use the following Ansible modules to automate repository synchronization
 //            /                                       \
 // |--Foreman/Katello for Hosts --|     |--Foreman/Katello for hosts--|
 . Register hosts to your servers so that each server manages hosts in its respective data center.
+For example, register all hosts in _My_Data_Center_1_ to one {ProjectServer} and all hosts in _My_Data_Center_2_ to the other {ProjectServer}.
 . Automate running the `{foreman-maintain} health check` command on both servers.
 The health check verifies whether the servers remain fully operational.
 

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,44 @@
+[id="preparing-for-disaster-recovery-with-two-active-project-servers"]
+= Preparing for disaster recovery with two active {ProjectServer}s
+
+Create a second {ProjectServer} by restoring a backup of your first {ProjectServer}.
+Configure both servers to operate independently in their respective data centers, but ensure that their content, such as repositories or host configuration, does not drift apart over time.
+
+.Procedure
+. Back up your {ProjectServer}.
+For more information, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[].
+. Restore the backup on a system that will serve as your other {ProjectServer}.
+For more information, see xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
++
+[NOTE]
+====
+Each server must have a distinct hostname and IP address.
+This enables you to re-register hosts if one of the servers fails.
+====
+. Ensure that content on your servers remains consistent:
+** If you want both servers to act as sources for synchronization and content view creation, follow these guidelines to prevent content drift:
+*** Regularly synchronize repositories on both servers.
+For more information, see {ContentManagementDocURL}[Synchronizing repositories] in _{ContentManagementDocTitle}_.
+*** Ensure that content views on both servers match.
+// *** What else?
+** If you want only one server to manage synchronization and content views and let the other server synchronize its content from the first server, configure Inter-Server Synchronization (ISS).
+For more information, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.
+. Register hosts to your servers so that each server manages hosts in its respective data center.
+. Automate running the `{foreman-maintain} health check` command on both servers.
+The health check verifies whether the servers remain fully operational.
+
+
+.Verification
+Perform this test in an isolated staging environment:
+
+. Mimic a full outage on one of your servers.
+To verify that the server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+. Verify that your `{foreman-maintain} health check` automation reported an error.
+. Re-register all hosts from the inaccessible server to the other server.
+. Verify that hosts have been properly re-registered.
+// How?
+. Perform these verification checks regularly.
+
+.Additional resources
+* Ansible playbooks can help you automate failover, re-registration, and synchronization.
+For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -21,7 +21,7 @@ This enables you to re-register hosts if one of the servers fails.
 You can use the following Ansible modules to automate repository synchronization: `{ansible-namespace}.repository_sync` and `{ansible-namespace}.sync_plan`.
 ** Ensure that content views on both servers match.
 * If you want one server to manage content synchronization and content view creation, use one of these features to prevent content drift:
-** If your disaster recovery site has network access to your primary site, use Inter-Server Synchronization (ISS) to ensure your disaster recovery server synchronizes its content from the primary server.
+** If your disaster recovery site has network access to your primary site, use {ISS} (ISS) to ensure your disaster recovery server synchronizes its content from the primary server.
 ** If your disaster recovery site does not have network access to your primary site, synchronize content by using export and import.
 * If you want one server to manage only content view creation but not content synchronization, you can configure the other server or multiple other servers to import content views from the first server but synchronize content from repositories.
 //      |------------ Foreman/Katello for CVs only ---------------|
@@ -32,7 +32,6 @@ You can use the following Ansible modules to automate repository synchronization
 . Register hosts to your servers so that each server manages hosts in its respective data center.
 . Automate running the `{foreman-maintain} health check` command on both servers.
 The health check verifies whether the servers remain fully operational.
-
 
 .Verification
 Perform this test in an isolated staging environment:

--- a/guides/common/modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc
@@ -1,0 +1,23 @@
+[id="recovering-from-disaster-with-two-active-project-servers"]
+= Recovering from disaster with two active {ProjectServer}s
+
+If the health checks implemented in xref:preparing-for-disaster-recovery-with-two-active-project-servers[] report an issue on one of your {ProjectServer}s, it might mean that the server has failed.
+If the server is down, you must re-register hosts to the other server.
+
+.Procedure
+. Verify the status of the server:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {foreman-maintain} health check
+----
+. If `{foreman-maintain} health check` reported a problem, ensure that the server is powered off.
+// Do we need a step to disable ISS if that's what users are using to ensure consistency in content?
+. Re-register all hosts from the data center managed by the failed server to the other, functional server.
+
+.Verification
+* Verify that hosts have been properly re-registered.
+
+.Additional resources
+* Ansible playbooks can help you automate failover, re-registration, and synchronization.
+For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc
@@ -12,7 +12,6 @@ If the server is down, you must re-register hosts to the other server.
 # {foreman-maintain} health check
 ----
 . If `{foreman-maintain} health check` reported a problem, ensure that the server is powered off.
-// Do we need a step to disable ISS if that's what users are using to ensure consistency in content?
 . Re-register all hosts from the data center managed by the failed server to the other, functional server.
 
 .Verification

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,5 @@
+[id="prerequisites-disaster-recovery-with-two-active-project-servers"]
+= Prerequisites
+
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to make sure that this disaster recovery plan works for you.
+* You have a {ProjectServer} installed.

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc
@@ -1,5 +1,5 @@
 [id="prerequisites-disaster-recovery-with-two-active-project-servers"]
 = Prerequisites
 
-* Review xref:overview-of-recommended-disaster-recovery-plans[] to make sure that this disaster recovery plan works for you.
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to ensure that this disaster recovery plan works for you.
 * You have a {ProjectServer} installed.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a new disaster recovery scenario: Two active servers.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

A follow-up to https://github.com/theforeman/foreman-documentation/pull/3558

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
