### PR TITLE
Fix procedure to migrate to external database

### DIFF
--- a/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
@@ -21,6 +21,6 @@ endif::[]
 To migrate from the default internal databases to external databases, you must complete the following procedures:
 
 . xref:installing-postgresql_{context}[].
-Prepare PostgreSQL with databases for {Project}, Pulp and Candlepin with dedicated users owning them.
+Prepare PostgreSQL with databases for Foreman, Pulp, and Candlepin with dedicated users owning them.
 . xref:migrating-to-external-databases_{context}[].
 Edit the parameters of `{foreman-installer}` to point to the new databases, and run `{foreman-installer}`.

--- a/guides/common/modules/con_postgresql-as-an-external-database-considerations.adoc
+++ b/guides/common/modules/con_postgresql-as-an-external-database-considerations.adoc
@@ -6,13 +6,11 @@ If you want to use PostgreSQL as an external database, the following information
 {Project} supports PostgreSQL version 13.
 
 .Advantages of external PostgreSQL
-
 * Increase in free memory and free CPU on {Project}
 * Flexibility to set `shared_buffers` on the PostgreSQL database to a high number without the risk of interfering with other services on {Project}
 * Flexibility to tune the PostgreSQL server's system without adversely affecting {Project} operations
 
 .Disadvantages of external PostgreSQL
-
 * Increase in deployment complexity that can make troubleshooting more difficult
 * The external PostgreSQL server is an additional system to patch and maintain
 * If either {Project} or the PostgreSQL database server suffers a hardware or storage failure, {Project} is not operational

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -11,7 +11,6 @@ include::snip_firewalld.adoc[]
 * The prepared host has base operating system repositories enabled.
 
 .Procedure
-
 . To install PostgreSQL, enter the following command:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
@@ -23,14 +22,12 @@ ifndef::katello,satellite,orcharhino[]
 # dnf install {postgresql-server-package}
 endif::[]
 ----
-
 . To initialize PostgreSQL, enter the following command:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 # postgresql-setup initdb
 ----
-+
 . Edit the `{postgresql-conf-dir}/postgresql.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
@@ -52,7 +49,6 @@ The base recommended external database configuration adjustments are as follows:
 ----
 listen_addresses = '*'
 ----
-+
 . Add the following line to the end of the file to use SCRAM for authentication:
 +
 [options="nowrap" subs="verbatim,quotes"]
@@ -65,21 +61,18 @@ password_encryption=scram-sha-256
 -----
 # vi {postgresql-conf-dir}/pg_hba.conf
 -----
-+
 . Add the following line to the file:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
   host  all   all   _{Project}_ip_/32   scram-sha-256
 ----
-
 . To start, and enable PostgreSQL service, enter the following commands:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 # systemctl enable --now postgresql
 ----
-
 . Open the *postgresql* port on the external PostgreSQL server:
 +
 [options="nowrap" subs="verbatim,quotes"]
@@ -93,7 +86,6 @@ include::snip_make-firewall-settings-persistent.adoc[]
 ----
 $ su - postgres -c psql
 ----
-+
 . Create three databases and dedicated roles: one for Foreman, one for Candlepin, and one for Pulp:
 +
 [options="nowrap" subs="verbatim,quotes"]
@@ -105,20 +97,18 @@ CREATE DATABASE foreman OWNER foreman;
 CREATE DATABASE candlepin OWNER candlepin;
 CREATE DATABASE pulpcore OWNER pulp;
 ----
-+
 . Exit the `postgres` user:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 # \q
 ----
-+
 . From {ProjectServer}, test that you can access the database.
 If the connection succeeds, the commands return `1`.
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# PGPASSWORD='_Foreman_Password_' psql -h _postgres.example.com_  -p 5432 -U foreman -d foreman -c "SELECT 1 as ping"
+# PGPASSWORD='_Foreman_Password_' psql -h _postgres.example.com_ -p 5432 -U foreman -d foreman -c "SELECT 1 as ping"
 # PGPASSWORD='_Candlepin_Password_' psql -h _postgres.example.com_ -p 5432 -U candlepin -d candlepin -c "SELECT 1 as ping"
 # PGPASSWORD='_Pulpcore_Password_' psql -h _postgres.example.com_ -p 5432 -U pulp -d pulpcore -c "SELECT 1 as ping"
 ----

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -11,7 +11,7 @@ include::snip_firewalld.adoc[]
 * The prepared host has base operating system repositories enabled.
 
 .Procedure
-. To install PostgreSQL, enter the following command:
+. On your new database server, install PostgreSQL:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
@@ -22,7 +22,7 @@ ifndef::katello,satellite,orcharhino[]
 # dnf install {postgresql-server-package}
 endif::[]
 ----
-. To initialize PostgreSQL, enter the following command:
+. Initialize the PostgreSQL database:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
@@ -67,13 +67,13 @@ password_encryption=scram-sha-256
 ----
   host  all   all   _{Project}_ip_/32   scram-sha-256
 ----
-. To start, and enable PostgreSQL service, enter the following commands:
+. Start and enable the PostgreSQL service:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 # systemctl enable --now postgresql
 ----
-. Open the *postgresql* port on the external PostgreSQL server:
+. Open the *postgresql* port:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -106,20 +106,6 @@ CREATE DATABASE candlepin OWNER candlepin;
 CREATE DATABASE pulpcore OWNER pulp;
 ----
 +
-. Connect to the Pulp database:
-+
-[options="nowrap" subs="verbatim,quotes"]
-----
-postgres=# \c pulpcore
-You are now connected to database "pulpcore" as user "postgres".
-----
-. Create the `hstore` extension:
-+
-[options="nowrap" subs="verbatim,quotes"]
-----
-pulpcore=# CREATE EXTENSION IF NOT EXISTS "hstore";
-CREATE EXTENSION
-----
 . Exit the `postgres` user:
 +
 [options="nowrap" subs="verbatim,quotes"]

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -94,7 +94,7 @@ include::snip_make-firewall-settings-persistent.adoc[]
 $ su - postgres -c psql
 ----
 +
-. Create three databases and dedicated roles: one for {Project}, one for Candlepin, and one for Pulp:
+. Create three databases and dedicated roles: one for Foreman, one for Candlepin, and one for Pulp:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -14,6 +14,12 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 ----
 # {foreman-maintain} service stop --exclude postgresql
 ----
+. Create your target directory for the {Project} backup:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# mkdir _/var/migration_backup_
+----
 . Back up the internal databases:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -7,7 +7,6 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 * You have installed and configured a PostgreSQL server on a {EL} server.
 
 .Procedure
-
 . On {ProjectServer}, stop all {Project} services except for PostgreSQL:
 +
 [options="nowrap", subs="+quotes,attributes"]
@@ -18,7 +17,7 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# mkdir _/var/migration_backup_
+# mkdir /var/_My_Migration_Backup_Directory_
 ----
 . Back up the internal databases:
 +
@@ -27,15 +26,15 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 # {foreman-maintain} backup online \
 --preserve-directory \
 --skip-pulp-content \
-_/var/migration_backup_
+/var/_My_Migration_Backup_Directory_
 ----
 . Transfer the data to the new external databases:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-PGPASSWORD='_Foreman_Password_' pg_restore -h _postgres.example.com_ -U foreman -d foreman < _/var/migration_backup/foreman.dump_
-PGPASSWORD='_Candlepin_Password_' pg_restore -h _postgres.example.com_ -U candlepin -d candlepin < _/var/migration_backup/candlepin.dump_
-PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d pulpcore < _/var/migration_backup/pulpcore.dump_
+PGPASSWORD='_Foreman_Password_' pg_restore -h _postgres.example.com_ -U foreman -d foreman < /var/_My_Migration_Backup_Directory_/foreman.dump_
+PGPASSWORD='_Candlepin_Password_' pg_restore -h _postgres.example.com_ -U candlepin -d candlepin < /var/_My_Migration_Backup_Directory_/candlepin.dump_
+PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d pulpcore < /var/_My_Migration_Backup_Directory_/pulpcore.dump_
 ----
 . Use the `{foreman-installer}` command to update {Project} to point to the new databases:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Users must not manually create the "hstore" extension when preparing an external database host. If they do, the import of the pulpcore DB fails as follows:

````
# PGPASSWORD='my_pw' pg_restore -h db.example.com -U pulp -d pulpcore < /var/migration_backup/pulpcore.dump
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 6115; 0 0 COMMENT EXTENSION hstore 
pg_restore: error: could not execute query: ERROR:  must be owner of extension hstore
Command was: COMMENT ON EXTENSION hstore IS 'data type for storing sets of (key, value) pairs';
````

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

to fix the procedure :)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Only tested on Foreman 3.12 on EL9 with an external DB host on EL9 running PostgreSQL 13.20

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
