### PR TITLE
Use attribute in favor of downstream product name

### DIFF
--- a/guides/common/modules/con_hammer-cli-overview.adoc
+++ b/guides/common/modules/con_hammer-cli-overview.adoc
@@ -20,7 +20,7 @@ Therefore, some features that are available in the {ProjectWebUI} might not yet 
 
 In the background, each Hammer command first establishes a binding to the API, then sends a request.
 This can have performance implications when executing a large number of Hammer commands in sequence.
-In contrast, scripts that use API commands communicate directly with the Satellite API and they establish the binding only once.
+In contrast, scripts that use API commands communicate directly with the {Project} API and they establish the binding only once.
 
 .Additional resources
 * For more information about Hammer CLI, see {HammerDocURL}[_{HammerDocTitle}_].


### PR DESCRIPTION
cherry-pick as necessary.