### PR TITLE
Fix broken rendering of ansible-namespace-example attr

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -48,7 +48,6 @@
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
 :ansible-docs-url: https://theforeman.github.io/foreman-ansible-modules/develop/index.html
 :ansible-galaxy-name: Ansible Galaxy
-:ansible-namespace-example: theforeman.foreman._module_name_
 :ansible-namespace: theforeman.foreman
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/
 :awx: AWX

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -47,7 +47,6 @@
 :ansible-doc-activation_key: ansible-doc redhat.satellite.activation_key
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
 :ansible-galaxy-name: Red{nbsp}Hat Ansible Automation Platform
-:ansible-namespace-example: redhat.satellite._module_name_
 :ansible-namespace: redhat.satellite
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
 :awx: Ansible Automation Controller

--- a/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
+++ b/guides/common/modules/proc_viewing-the-project-ansible-modules.adoc
@@ -11,7 +11,7 @@ You can view the installed {Project} Ansible modules by running:
 ifndef::orcharhino[]
 Alternatively, you can also see the complete list of {Project} Ansible modules and other related information at {ansible-galaxy}[{ansible-galaxy-name}].
 
-All modules are in the `{ansible-namespace}` namespace and can be referred to in the format `{ansible-namespace-example}`.
+All modules are in the `{ansible-namespace}` namespace and can be referred to in the format `{ansible-namespace}._module_name_`.
 For example, to display information about the `activation_key` module, enter the following command:
 
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

Replacing the `{ansible-namespace-example}` attribute with a (partially) hardcoded `{ansible-namespace}._module_name_` string.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The markup doesn't seem to get processed when enclosed in an attribute.

![Screenshot From 2025-03-20 12-48-10](https://github.com/user-attachments/assets/6eef7287-9366-43b1-ba62-40fe9ff18f15)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Personally, I'd also say that the same reasoning explained before in https://github.com/theforeman/foreman-documentation/pull/3709#issuecomment-2700417050 applies here too but that is not why I raised this PR.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

Everywhere as long as there really is only one instance of the attribute on all branches.