### PR TITLE
Clarify that SCAP contents on server might not be up-to-date

### DIFF
--- a/guides/common/modules/proc_loading-the-default-scap-contents.adoc
+++ b/guides/common/modules/proc_loading-the-default-scap-contents.adoc
@@ -10,6 +10,14 @@ You can only use this SCAP content to scan hosts that have the same minor RHEL v
 For more information, see xref:getting-supported-scap-contents-for-rhel_{context}[].
 endif::[]
 
+ifdef::satellite[]
+[IMPORTANT]
+====
+The default SCAP contents on {ProjectServer} get updated with every new patch version of {Project}.
+They might not contain the latest available version of security policies but only the version that was available when the patch version was built.
+====
+endif::[]
+
 .Prerequisites
 * Your user account has a role assigned that has the `create_scap_contents` permission.
 

--- a/guides/common/modules/proc_loading-the-default-scap-contents.adoc
+++ b/guides/common/modules/proc_loading-the-default-scap-contents.adoc
@@ -13,8 +13,9 @@ endif::[]
 ifdef::satellite[]
 [IMPORTANT]
 ====
-The default SCAP contents on {ProjectServer} get updated with every new patch version of {Project}.
+The default SCAP contents on {ProjectServer} get updated with new patch versions of {Project}.
 They might not contain the latest available version of security policies but only the version that was available when the patch version was built.
+If the policy files in `/usr/share/xml/scap/ssg/content/` were updated after a new patch version became available, run `hammer scap-content bulk-upload --type default` to load them into {Project}.
 ====
 endif::[]
 

--- a/guides/common/modules/proc_loading-the-default-scap-contents.adoc
+++ b/guides/common/modules/proc_loading-the-default-scap-contents.adoc
@@ -15,7 +15,7 @@ ifdef::satellite[]
 ====
 The default SCAP contents on {ProjectServer} get updated with new patch versions of {Project}.
 They might not contain the latest available version of security policies but only the version that was available when the patch version was built.
-If the policy files in `/usr/share/xml/scap/ssg/content/` were updated after a new patch version became available, run `hammer scap-content bulk-upload --type default` to load them into {Project}.
+If the policy files in `/usr/share/xml/scap/ssg/content/` were updated after a new patch version became available, follow the procedure below to load them into {Project}.
 ====
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Adding a note to clarify the state of default SCAP contents on server.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-30760 and https://issues.redhat.com/browse/SAT-19336

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
