### PR TITLE
Clarify that Keycloak doesn't work with both UI and CLI

### DIFF
--- a/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
+++ b/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
@@ -6,7 +6,14 @@ With {keycloak-quarkus}, you can integrate {ProjectServer} with your existing {k
 
 {keycloak} users can log in using the following login methods:
 
-* User name and password in {ProjectWebUI} and Hammer CLI
+* User name and password in {ProjectWebUI}
+* User name and password in Hammer CLI
+
+[NOTE]
+====
+{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project}.
+====
+
 * Time-based one-time password (TOTP), an implementation of two-factor authentication (2FA)
 ifndef::satellite,orcharhino[]
 * {PIV} cards

--- a/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
+++ b/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
@@ -11,7 +11,7 @@ With {keycloak-quarkus}, you can integrate {ProjectServer} with your existing {k
 
 [NOTE]
 ====
-{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project}.
+{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project} at the same time.
 ====
 
 * Time-based one-time password (TOTP), an implementation of two-factor authentication (2FA)

--- a/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -31,7 +31,14 @@ With {keycloak-wildfly}, you can integrate {ProjectServer} with your existing {k
 
 {keycloak} users can log in using the following login methods:
 
-* User name and password in {ProjectWebUI} and Hammer CLI
+* User name and password in {ProjectWebUI}
+* User name and password in Hammer CLI
+
+[NOTE]
+====
+{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project}.
+====
+
 * Time-based one-time password (TOTP)
 ifndef::satellite,orcharhino[]
 * {PIV} cards

--- a/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -36,7 +36,7 @@ With {keycloak-wildfly}, you can integrate {ProjectServer} with your existing {k
 
 [NOTE]
 ====
-{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project}.
+{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project} at the same time.
 ====
 
 * Time-based one-time password (TOTP)

--- a/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc
+++ b/guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc
@@ -54,17 +54,6 @@ $ hammer settings set --name oidc_algorithm --value 'RS256'
 $ hammer settings set --name oidc_audience \
 --value "['_{foreman-example-com}_-hammer-openidc']"
 ----
-+
-[NOTE]
-====
-If you register several {keycloak} clients to {Project}, ensure that you append all audiences in the array.
-For example:
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ hammer settings set --name oidc_audience \
---value "['_{foreman-example-com}_-foreman-openidc', '_{foreman-example-com}_-hammer-openidc']"
-----
-====
 . Set the value for the Open IDC issuer:
 +
 ifeval::["{context}" == "keycloak-quarkus"]


### PR DESCRIPTION
#### What changes are you introducing?

* Removing references to enabling both UI and CLI authentication for Keycloak users
* Clarifying that Project doesn't support both UI and CLI authentication for Keycloak users

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-31480

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)

A separate PR will probably be needed for the earlier versions.