### PR TITLE
Drop step to reset keycloak auth

### DIFF
--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -93,12 +93,6 @@ endif::[]
 --foreman-keycloak-app-name "hammer-openidc" \
 --foreman-keycloak-realm "_{Project}_Realm_"
 ----
-.. Reset {keycloak} support to the default value to ensure that users are not authenticated also in {ProjectWebUI}:
-+
-[options="nowrap", subs="verbatim,quotes,attributes"]
-----
-# {foreman-installer} --reset-foreman-keycloak
-----
 . Restart the `httpd` service:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

Removing a step from the Keycloak setup.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Feedback from additional testing.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
