### PR TITLE
Remove a few unused Keycloak modules

### DIFF
--- a/guides/common/modules/con_configuring-keycloak-quarkus-authentication-with-piv-cards-for-project.adoc
+++ b/guides/common/modules/con_configuring-keycloak-quarkus-authentication-with-piv-cards-for-project.adoc
@@ -1,4 +1,0 @@
-[id="Configuring_Keycloak_Authentication_with_CAC_Cards_for_Project_{context}"]
-= Configuring {keycloak-quarkus} authentication with {PIV} cards for {Project}
-
-Use this section to configure {Project} to use {keycloak-quarkus} as an OpenID provider for external authentication with {PIV} cards.

--- a/guides/common/modules/con_configuring-keycloak-quarkus-authentication-with-totp-cards-for-project.adoc
+++ b/guides/common/modules/con_configuring-keycloak-quarkus-authentication-with-totp-cards-for-project.adoc
@@ -1,4 +1,0 @@
-[id="configuring-keycloak-authentication-with-totp-cards-for-project_{context}"]
-= Configuring {keycloak-quarkus} authentication with TOTP cards for {Project}
-
-Use this section to configure {Project} to use {keycloak-quarkus} as an OpenID provider for external authentication with TOTP cards.

--- a/guides/common/modules/con_configuring-keycloak-wildfly-authentication-with-totp-cards-for-project.adoc
+++ b/guides/common/modules/con_configuring-keycloak-wildfly-authentication-with-totp-cards-for-project.adoc
@@ -1,4 +1,0 @@
-[id="configuring-keycloak-authentication-with-totp-cards-for-project_{context}"]
-= Configuring {keycloak-wildfly} authentication with TOTP cards for {Project}
-
-Use this section to configure {Project} to use {keycloak-wildfly} as an OpenID provider for external authentication with TOTP cards.


### PR DESCRIPTION
#### What changes are you introducing?

Removing a few intro modules on Keycloak.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Unused modules are a bad thing.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Thanks @apinnick for finding these.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
