### PR TITLE
Add permission to take snapshots of VMs on VMware

### DIFF
--- a/guides/common/modules/proc_creating-a-vmware-user.adoc
+++ b/guides/common/modules/proc_creating-a-vmware-user.adoc
@@ -20,3 +20,9 @@ Additionally, if you want to create virtual machines with a Virtual Trusted Plat
 
 * All Privileges -> Cryptographic operations -> Clone, Encrypt, Encrypt new, Migrate, Register VM
 * All Privileges -> Cryptographic operations -> Direct Access {endash} required to open a console session
+
+ifndef::satellite[]
+Additionally, if you want to take snapshots of virtual machines by using the Snapshot Management plugin, set the following privileges:
+
+* All Privileges -> Virtual Machine -> Snapshot management (All)
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Add name of required permission to create VM snapshots on VMware.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

required to use foreman_snapshot_management

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

![image](https://github.com/user-attachments/assets/b2d297ef-cd15-49a8-9159-0e31a9f11eb2)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
