### PR TITLE
Modify production environment backup recommendation

### DIFF
--- a/guides/common/modules/proc_performing-an-online-backup.adoc
+++ b/guides/common/modules/proc_performing-an-online-backup.adoc
@@ -9,10 +9,6 @@ When performing an online backup, if there are procedures affecting the Pulp dat
 Because the backup of the Pulp database is the most time consuming part of backing up {Project}, if you make a change that alters the Pulp database during this time, the backup procedure keeps restarting.
 endif::[]
 
-For production environments, use the offline method.
-For more information, see xref:Performing_a_Full_Backup_{context}[].
-If you want to use the online backup method in production, proceed with caution and ensure that no modifications occur during the backup.
-
 [WARNING]
 ====
 Request other users of {ProjectServer} or {SmartProxyServer} to save any changes and warn them that {Project} services are unavailable for the duration of the backup.

--- a/guides/common/modules/proc_performing-an-online-backup.adoc
+++ b/guides/common/modules/proc_performing-an-online-backup.adoc
@@ -4,8 +4,9 @@
 ifdef::katello,orcharhino,satellite[]
 .Risks associated with online backups
 When you perform an online backup, most {Project} services remain running and usable.
-Background workers are shut down to ensure consistent backup and operations that require these workers remain in pending state.
-Additionally the backup process ensures that the Pulp data (`/var/lib/pulp`) is not altered during the backup.
+Background workers are shut down to ensure consistent backups.
+Operations that require background workers remain in pending state.
+The backup process ensures that the Pulp data (`/var/lib/pulp`) is not altered during the backup.
 Any changes to the Pulp data during the backup will result in restart of the backup process, taking additional time.
 endif::[]
 

--- a/guides/common/modules/proc_performing-an-online-backup.adoc
+++ b/guides/common/modules/proc_performing-an-online-backup.adoc
@@ -1,17 +1,17 @@
 [id="Performing_an_Online_Backup_{context}"]
 = Performing an online backup
 
-Perform an online backup only for debugging purposes.
-
 ifdef::katello,orcharhino,satellite[]
 .Risks associated with online backups
-When performing an online backup, if there are procedures affecting the Pulp database, the Pulp part of the backup procedure repeats until it is no longer being altered.
-Because the backup of the Pulp database is the most time consuming part of backing up {Project}, if you make a change that alters the Pulp database during this time, the backup procedure keeps restarting.
+When you perform an online backup, most {Project} services remain running and usable.
+Background workers are shut down to ensure consistent backup and operations that require these workers remain in pending state.
+Additionally the backup process ensures that the Pulp data (`/var/lib/pulp`) is not altered during the backup.
+Any changes to the Pulp data during the backup will result in restart of the backup process, taking additional time.
 endif::[]
 
 [WARNING]
 ====
-Request other users of {ProjectServer} or {SmartProxyServer} to save any changes and warn them that {Project} services are unavailable for the duration of the backup.
+Request other users of {ProjectServer} or {SmartProxyServer} to save any changes and warn them that some {Project} services may be unavailable for the duration of the backup.
 Ensure no other tasks are scheduled for the same time as the backup.
 ====
 


### PR DESCRIPTION
Since online backups are supported for production, after snapshot backups were dropped [1], removing the now irrelevant line about online backups being unsupported. [1] https://issues.redhat.com/browse/SAT-25667

JIRA: https://issues.redhat.com/browse/SAT-29507

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
