### PR TITLE
Replace `ansible_tower_fqdn` with `ansible_tower_api_url` in docs

### DIFF
--- a/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
+++ b/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
@@ -47,8 +47,9 @@ For more information about job templates, see http://docs.ansible.com/automation
 |====
 |Name |Value |Description
 |`ansible_tower_provisioning` |true |Enables Provisioning Callback.
-|`ansible_tower_fqdn` |_controller.example.com_ |The fully qualified domain name (FQDN) of your {awx}.
-Do not add `https` because this is appended by {Project}.
+|`ansible_tower_api_url` |_https://controller.example.com/api/controller/v2_ | Defines the URL of your {awx}, including the required API path.
+For older versions of {awx}, use `/api/v2` instead of `/api/controller/v2`.
+If unsure, check the API endpoints of your instance to verify the correct path.
 |`ansible_job_template_id` |_template_ID_ |The ID of your provisioning template that you can find in the URL of the template: `/templates/job_template/_5_`.
 |`ansible_host_config_key` |_config_KEY_ |The host configuration key that your job template generates in {awx}.
 |====


### PR DESCRIPTION
#### What changes are you introducing?
Update provisioning callback documentation to use `ansible_tower_api_url`,
ensuring the required API path is included. Clarify the correct path for older versions of AWX.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
See `Update Ansible Tower API URL for AAP 2.5+ compatibility` PR: https://github.com/theforeman/foreman/pull/10445

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
