### PR TITLE
Show insights procedure for orcharhino

### DIFF
--- a/guides/common/assembly_monitoring-hosts-by-using-red-hat-insights.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-red-hat-insights.adoc
@@ -8,7 +8,7 @@ include::modules/ref_access-to-information-from-insights-in-project.adoc[levelof
 
 // By default, Satellite sets "host_registration_insights" to true
 // https://github.com/RedHatSatellite/foreman_theme_satellite/blob/develop/db/migrate/20201118090534_insights_param.rb
-ifdef::satellite[]
+ifdef::satellite,orcharhino[]
 include::modules/proc_excluding-hosts-from-rh-cloud-and-insights-client-reports.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
On orcharhino, the default is "false" but users can change it to "true".

#### What changes are you introducing?

show procedure about RH Insights also for orcharhino

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To fix a broken link on https://docs.orcharhino.com/or/docs/sources/guides/red_hat_enterprise_linux/rhel_subscriptions.html in the second paragraph.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I take my live docs as tech review -> only style review required.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
