### PR TITLE
Move DR assembly to somewhere more prominent

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -24,6 +24,8 @@ endif::[]
 
 include::common/assembly_managing-project-with-ansible-collections.adoc[leveloffset=+1]
 
+include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
+
 ifdef::satellite[]
 include::common/assembly_managing-organizations.adoc[leveloffset=+1]
 
@@ -59,8 +61,6 @@ include::common/assembly_limiting-host-resources.adoc[leveloffset=+1]
 include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 
 include::common/assembly_searching-and-bookmarking.adoc[leveloffset=+1]
-
-include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
 
 [appendix]
 ifdef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Moving the chapter on disaster recovery closer to the beginning of the Admin guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

As I noted in https://github.com/theforeman/foreman-documentation/pull/3614, I don't know how much point there is in worrying about the exact placement of the DR chapter in the (very large) guide. But still, a chapter on disaster recovery probably shouldn't follow _after_ a chapter on searching and bookmarking. So I decided to try to find a more prominent place after all.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
