### PR TITLE
Drop intro about enabling two keycloak auth methods

### DIFF
--- a/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc
@@ -1,20 +1,12 @@
 [id="registering-{project-context}-as-a-client-of-keycloak_{context}"]
 = Registering {Project} as a client of {keycloak}
 
-ifeval::["{context}" == "keycloak-quarkus"]
 Users defined in {keycloak} can authenticate to {Project} by using one of the following methods:
 
 * The {ProjectWebUI}
 * Hammer CLI
 
 Choose one of these methods to enable in your {Project} deployment.
-endif::[]
-
-ifeval::["{context}" == "keycloak-wildfly"]
-Users defined in {keycloak} can authenticate to {Project} by using the {ProjectWebUI} or by using Hammer CLI.
-Each authentication method requires you to register a separate {Project} client to {keycloak}.
-If you want users to authenticate by using both {ProjectWebUI} and Hammer CLI, you must register two different {Project} clients to {keycloak}.
-endif::[]
 
 .Procedure
 


### PR DESCRIPTION
#### What changes are you introducing?

Dropping information on enabling both CLI and web UI authentication with Keycloak.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I missed this in https://github.com/theforeman/foreman-documentation/pull/3737. Project doesn't support both UI and CLI authentication for Keycloak users.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)

I'll raise a separate PR for 3.10 and below that combines this change and https://github.com/theforeman/foreman-documentation/pull/3737.