### PR TITLE
Updating find_unused_modules script

### DIFF
--- a/guides/scripts/find_unused_modules.py
+++ b/guides/scripts/find_unused_modules.py
@@ -2,6 +2,8 @@
 
 # script to find potentially unused '.adoc' files
 # FIXME: this ignores content in 'find guides -type d -iname "topics"'
+# This script does not work for file includes that contain attributes.
+# Example: "include::modules/proc_configuring-repositories-{build}.adoc[]"
 
 import os
 import glob
@@ -12,10 +14,10 @@ list_of_files = []
 for file in os.listdir(modules_directory):
     list_of_files.append(os.path.basename(file))
 
-
 list_of_assemblies = glob.glob("guides/common/assembly_*.adoc")
 list_of_master_files = glob.glob("guides/*/master.adoc")
-combined_lists = list_of_assemblies + list_of_master_files
+list_of_modules = glob.glob("guides/common/modules/*.adoc")
+combined_lists = list_of_assemblies + list_of_master_files + list_of_modules
 
 for assembly in combined_lists:
     with open(assembly, "r") as f:


### PR DESCRIPTION
#### What changes are you introducing?

Added a line to detect snippets included in modules.

Added a comment that script does not work on file includes that contain attributes. User will have to ignore those files in the output.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Snippets included in modules were reported as false positives.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I tested this with a fake snippet. It was detected.

No style review required.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
