### PR TITLE
Make DR with external storage work for upstream

### DIFF
--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -10,10 +10,7 @@ include::assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc[leve
 
 :parent-context: {context}
 :context: dr-storage
-// This depends on the cloning procedure, which is satellite-only.
-ifdef::satellite[]
 include::assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc[leveloffset=+1]
-endif::[]
 :context: {parent-context}
 :!parent-context:
 

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
@@ -1,17 +1,28 @@
 [id="preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage"]
 = Preparing for disaster recovery with active and passive {ProjectServer} with external storage
 
+ifdef::satellite[]
 Create your passive {ProjectServer} as a clone of your active {ProjectServer}.
+endif::[]
+ifndef::satellite[]
+Create your passive {ProjectServer} as a backup of your active {ProjectServer}.
+endif::[]
 Ensure that the `/var/lib/pulp` and `{postgresql-lib-dir}` directories on your shared storage are available to both servers.
 
 .Procedure
 . Replicate the `/var/lib/pulp` and `{postgresql-lib-dir}` directories from the active {ProjectServer} to your shared storage.
+ifdef::satellite[]
 . Clone your active {ProjectServer}.
 For more information, see xref:cloning_satellite_server[].
+endif::[]
+ifndef::satellite[]
+. Back up your active {ProjectServer} and restore it on a system that will serve as your passive {ProjectServer}.
+For more information, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[] and xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
+endif::[]
 . Keep the source server powered on.
-Power off the new cloned server.
+Power off the new server.
 +
-The source server remains your active primary server, while the clone server becomes the passive secondary server.
+The source server remains your active primary server, while the new server becomes the passive secondary server.
 . Determine how you want to attach the database content on the shared storage to your passive server:
 * If you mount the storage directly on both your active and passive server, the servers will always see the same, up-to-date content.
 * If you mount the storage only on your active server, the passive server will access the data only if it takes over as the active server.


### PR DESCRIPTION
#### What changes are you introducing?

Replacing references to cloning in the "DR with external storage" scenario with steps to back up and restore. Cloning is documented only for downstream Satellite and to be able to include the scenario upstream, backup and restore is an alternative.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/issues/3717

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
