### PR TITLE
Fix and simplify links part 5

### DIFF
--- a/guides/common/assembly_configuring-external-services.adoc
+++ b/guides/common/assembly_configuring-external-services.adoc
@@ -1,4 +1,4 @@
-ifdef::context[:parent-context: {context}]
+:parent-context: {context}
 
 include::modules/con_configuring-project-with-external-services.adoc[]
 
@@ -16,5 +16,5 @@ include::assembly_configuring-external-idm-dns.adoc[leveloffset=+1]
 
 include::assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+1]
 
-ifdef::parent-context[:context: {parent-context}]
-ifndef::parent-context[:!context:]
+:context: {parent-context}
+:!parent-context:

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -73,12 +73,7 @@ Execute a remote job with the following settings:
 * If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `yes`.
 
 +
-ifdef::managing-hosts[]
 For more information, see xref:executing-a-remote-job_{context}[].
-endif::[]
-ifndef::managing-hosts[]
-For more information, see {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a Remote Job] in _{ManagingHostsDocTitle}_.
-endif::[]
 
 +
 Review pre-conversion analysis reports and resolve all issues that are blocking the conversion.
@@ -94,12 +89,7 @@ Execute a remote job with the following settings:
 * If you want to use an Extended Lifecycle Support add-on subscription, set the **ELS** option to `yes`.
 
 +
-ifdef::managing-hosts[]
 For more information, see xref:executing-a-remote-job_{context}[].
-endif::[]
-ifndef::managing-hosts[]
-For more information, see {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a Remote Job] in _{ManagingHostsDocTitle}_.
-endif::[]
 
 .Additional resources
 * https://access.redhat.com/articles/2360841[How to perform an unsupported conversion from a RHEL-derived Linux distribution to RHEL] in the _Red{nbsp}Hat Knowledgebase_

--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -53,7 +53,7 @@ endif::[]
 ifdef::katello,satellite,orcharhino[]
 * {ContentManagementDocURL}[{ContentManagementDocTitle}]
 endif::[]
-* {ManagingHostsDocURL}Registering_Hosts_managing-hosts[Registering Hosts] in the _Managing Hosts Guide_
-* {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and Setting Up Remote Jobs] in the _Managing Hosts Guide_
+* {ManagingHostsDocURL}registering-hosts-and-setting-up-host-integration_managing-hosts[Registering hosts and setting up host integration] in _{ManagingHostsDocTitle}_
+* {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and setting up remote jobs] in _{ManagingHostsDocTitle}_
 
 The following procedures outline how to use a Puppet module to install, configure, and manage the _ntp_ service to provide examples.

--- a/guides/common/modules/con_project-server-upgrade-considerations.adoc
+++ b/guides/common/modules/con_project-server-upgrade-considerations.adoc
@@ -4,7 +4,7 @@
 This section describes how to upgrade {ProjectServer} from {ProjectVersionPrevious} to {ProjectVersion}.
 You can upgrade from any minor version of {ProjectServer} {ProjectVersionPrevious}.
 
-include::snip_prerequisites-upgrading-project-server.adoc[leveloffset=+3]
+include::snip_prerequisites-upgrading-project-server.adoc[]
 
 ifdef::satellite[]
 .Upgrade scenarios

--- a/guides/common/modules/con_remote-execution-in-project.adoc
+++ b/guides/common/modules/con_remote-execution-in-project.adoc
@@ -28,10 +28,14 @@ For more information, see {ManagingHostsDocURL}Template_Writing_Reference_managi
 endif::[]
 
 By default, {Project} includes several job templates for shell scripts and Ansible.
-For more information, see {ManagingHostsDocURL}setting-up-job-templates_managing-hosts[Setting up job templates] in _{ManagingHostsDocTitle}_.
+ifdef::configuring-ansible,managing-hosts[]
+For more information, see xref:setting-up-job-templates_{context}[].
+endif::[]
 
 .Additional resources
-* See {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a remote job] in _{ManagingHostsDocTitle}_.
+ifdef::configuring-ansible,managing-hosts[]
+* See xref:executing-a-remote-job_{context}[].
+endif::[]
 ifeval::["{context}" == "planning"]
 * See {ManagingConfigurationsAnsibleDocURL}Configuring_and_Setting_Up_Remote_Jobs_ansible[Configuring and setting up remote jobs] in _{ManagingConfigurationsAnsibleDocTitle}_.
 endif::[]

--- a/guides/common/modules/proc_assigning-a-host-to-a-specific-location.adoc
+++ b/guides/common/modules/proc_assigning-a-host-to-a-specific-location.adoc
@@ -2,7 +2,13 @@
 = Assigning a host to a specific location
 
 Use this procedure to assign a host to a specific location.
-For general information about locations and how to configure them, see {ContentManagementDocURL}Creating_a_Location_content-management[Creating a Location] in _{ContentManagementDocTitle}_.
+For general information about locations and how to configure them,
+ifdef::satellite[]
+see {AdministeringDocURL}Managing_Locations_admin[Managing locations] in _{AdministeringDocTitle}_.
+endif::[]
+ifndef::satellite[]
+see {ManagingOrganizationsLocationsDocURL}[_{ManagingOrganizationsLocationsDocTitle}_].
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
+++ b/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
@@ -2,11 +2,12 @@
 = Assigning a host to a specific organization
 
 Use this procedure to assign a host to a specific organization.
+For general information about organizations and how to configure them,
 ifdef::satellite[]
-For general information about organizations and how to configure them, see {AdministeringDocURL}Managing_Organizations_admin[Managing Organizations] in _{AdministeringDocTitle}_.
+see {AdministeringDocURL}Managing_Organizations_admin[Managing organizations] in _{AdministeringDocTitle}_.
 endif::[]
 ifndef::satellite[]
-For general information about organizations and how to configure them, see {ManagingOrganizationsLocationsDocURL}Managing_Organizations_managing-organizations-locations[Managing Organizations] in _{ManagingOrganizationsLocationsDocTitle}_.
+see {ManagingOrganizationsLocationsDocURL}[_{ManagingOrganizationsLocationsDocTitle}_].
 endif::[]
 
 [NOTE]

--- a/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
+++ b/guides/common/modules/proc_configuring-kerberos-authentication-for-remote-execution.adoc
@@ -23,9 +23,4 @@ In the *SSH User* row, edit the second column and add the user name for the Kerb
 
 .Verification
 * To confirm that Kerberos authentication is ready to use, run a remote job on the host.
-ifeval::["{context}" == "managing-hosts"]
-For more information, see {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a Remote Job] in _{ManagingHostsDocTitle}_.
-endif::[]
-ifeval::["{context}" == "ansible"]
-For more information, see {ManagingConfigurationsAnsibleDocURL}executing-a-remote-job_ansible[Executing a Remote Job] in _{ManagingConfigurationsAnsibleDocTitle}_.
-endif::[]
+For more information, see xref:executing-a-remote-job_{context}[].

--- a/guides/common/modules/proc_configuring-your-project-to-run-ansible-roles.adoc
+++ b/guides/common/modules/proc_configuring-your-project-to-run-ansible-roles.adoc
@@ -40,7 +40,7 @@ If you want to use custom or third party Ansible roles, ensure to configure an e
 # {foreman-installer} --enable-foreman-proxy-plugin-ansible
 ----
 . Distribute SSH keys to enable {SmartProxies} to connect to hosts using SSH.
-For more information, see {ManagingHostsDocURL}Distributing_SSH_Keys_for_Remote_Execution_managing-hosts[Distributing SSH keys for remote execution] in _{ManagingHostsDocTitle}_.
+For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{context}[].
 {Project} runs Ansible roles the same way it runs remote execution jobs.
 . Import the Ansible roles into {Project}.
 . Proceed to xref:Using_Ansible_Roles_to_Automate_Repetitive_Tasks_on_Clients_{context}[].

--- a/guides/common/modules/proc_creating-a-job-template.adoc
+++ b/guides/common/modules/proc_creating-a-job-template.adoc
@@ -11,7 +11,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-job-te
 . Select *Default* to make the template available for all organizations and locations.
 . Create the template directly in the template editor or upload it from a text file by clicking *Import*.
 . Optional: In the *Audit Comment* field, add information about the change.
-. Click the *Job* tab, and in the *Job category* field, enter your own category or select from the default categories listed in {ManagingHostsDocURL}default-job-template-categories_managing-hosts[Default Job Template Categories] in _{ManagingHostsDocTitle}_.
+. Click the *Job* tab, and in the *Job category* field, enter your own category or select from the default categories listed in xref:default-job-template-categories_{context}[].
 . Optional: In the *Description Format* field, enter a description template.
 For example, `Install package %\{package_name}`.
 You can also use `%\{template_name}` and `%\{job_category}` in your template.

--- a/guides/common/modules/proc_executing-a-restorecon-template-on-multiple-hosts.adoc
+++ b/guides/common/modules/proc_executing-a-restorecon-template-on-multiple-hosts.adoc
@@ -1,7 +1,7 @@
 [id="Executing_a_restorecon_Template_on_Multiple_Hosts_{context}"]
 = Executing a restorecon template on multiple hosts
 
-This example shows how to run a job based on the template created in {ManagingHostsDocURL}Example_restorecon_Template_managing-hosts[Example restorecon Template] on multiple hosts.
+This example shows how to run a job based on the template created in xref:Example_restorecon_Template_{context}[] on multiple hosts.
 The job restores the SELinux context in all files under the `/home/` directory.
 
 .Procedure

--- a/guides/common/modules/proc_setting-up-job-templates.adoc
+++ b/guides/common/modules/proc_setting-up-job-templates.adoc
@@ -3,7 +3,7 @@
 
 {Project} provides default job templates that you can use for executing jobs.
 To view the list of job templates, navigate to *Hosts* > *Templates* > *Job templates*.
-If you want to use a template without making changes, proceed to {ManagingHostsDocURL}executing-a-remote-job_managing-hosts[Executing a Remote Job] in _{ManagingHostsDocTitle}_.
+If you want to use a template without making changes, proceed to xref:executing-a-remote-job_{context}[].
 
 You can use default templates as a base for developing your own.
 Default job templates are locked for editing.

--- a/guides/common/modules/ref_example-including-power-options-in-a-job-template.adoc
+++ b/guides/common/modules/ref_example-including-power-options-in-a-job-template.adoc
@@ -4,7 +4,7 @@
 This example shows how to set up a job template for performing power actions, such as reboot.
 This procedure prevents {Project} from interpreting the disconnect exception upon reboot as an error, and consequently, remote execution of the job works correctly.
 
-Create a new template as described in {ManagingHostsDocURL}setting-up-job-templates_managing-hosts[Setting up Job Templates], and specify the following string in the template editor:
+Create a new template as described in xref:setting-up-job-templates_{context}[], and specify the following string in the template editor:
 
 [source, ruby]
 ----

--- a/guides/common/modules/ref_example-restorecon-template.adoc
+++ b/guides/common/modules/ref_example-restorecon-template.adoc
@@ -24,4 +24,4 @@ The input name must match the value specified in the template editor.
 . Select *User input* from the *Input type* list.
 Enter a description to be shown during job invocation, for example `Target directory for restorecon`.
 . Click *Submit*.
-For more information, see {ManagingHostsDocURL}Executing_a_restorecon_Template_on_Multiple_Hosts_managing-hosts[Executing a restorecon Template on Multiple Hosts] in _{ManagingHostsDocTitle}_.
+For more information, see xref:Executing_a_restorecon_Template_on_Multiple_Hosts_{context}[].

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -455,7 +455,9 @@ Repository::
 A repository is a single source and the smallest unit of content in {Project}.
 You can either synchronize a repository with a URL or manually upload content to {Project}.
 {Project} supports multiple content types.
+ifndef::orcharhino[]
 For more information, see {ContentManagementDocURL}Content_Types_in_{ProjectNameID}_content-management[Content types in {Project}] in _{ContentManagementDocTitle}_.
+endif::[]
 One or more repositories form a xref:Product[product].
 endif::[]
 

--- a/guides/common/modules/ref_rendering-a-restorecon-template.adoc
+++ b/guides/common/modules/ref_rendering-a-restorecon-template.adoc
@@ -1,10 +1,10 @@
 [id="Rendering_a_restorecon_Template_{context}"]
 = Rendering a restorecon template
 
-This example shows how to create a template derived from the *Run command - restorecon* template created in {ManagingHostsDocURL}Example_restorecon_Template_managing-hosts[Example restorecon Template].
+This example shows how to create a template derived from the *Run command - restorecon* template created in xref:Example_restorecon_Template_{context}[].
 This template does not require user input on job execution, it will restore the SELinux context in all files under the `/home/` directory on target hosts.
 
-Create a new template as described in {ManagingHostsDocURL}setting-up-job-templates_managing-hosts[Setting up Job Templates], and specify the following string in the template editor:
+Create a new template as described in xref:setting-up-job-templates_{context}[], and specify the following string in the template editor:
 
 [source, ruby]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

* fix broken links
* avoid cross-guide linking, e.g. when "run REX jobs" is part of managing hosts and configuring hosts by using Ansible, when we should not link to the managing hosts guide by default.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

improve UX :)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

follow-up to https://github.com/theforeman/foreman-documentation/pull/3756

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
