### PR TITLE
Remove references to both CLI and web UI login with Keycloak

### DIFF
--- a/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
+++ b/guides/common/modules/proc_configuring-project-settings-for-keycloak-authentication-using-the-cli.adoc
@@ -40,17 +40,6 @@ Note that you can navigate to the following URL within your realm to obtain valu
 # hammer settings set --name oidc_audience \
 --value "['_{foreman-example-com}_-hammer-openidc']"
 ----
-+
-[NOTE]
-====
-If you register several {Keycloak} clients to {Project}, ensure that you append all audiences in the array.
-For example:
-[options="nowrap", subs="+quotes,attributes"]
-----
-# hammer settings set --name oidc_audience \
---value "['_{foreman-example-com}_-foreman-openidc', '_{foreman-example-com}_-hammer-openidc']"
-----
-====
 
 . Set the value for the Open IDC issuer:
 +

--- a/guides/common/modules/proc_registering-project-as-a-keycloak-client.adoc
+++ b/guides/common/modules/proc_registering-project-as-a-keycloak-client.adoc
@@ -2,15 +2,18 @@
 = Registering {Project} as a {Keycloak} client
 Use this procedure to register {Project} to {Keycloak} as a client and configure {Project} to use {Keycloak} as an authentication source.
 
-You can configure {Project} and {Keycloak} with two different authentication methods:
+You can configure {Project} and {Keycloak} with one of these authentication methods:
 
 . Users authenticate to {Project} using the {ProjectWebUI}.
 . Users authenticate to {Project} using the {Project} CLI.
 
+[NOTE]
+====
+{keycloak} users cannot use both {ProjectWebUI} and Hammer CLI authentication in {Project} at the same time.
+====
+
 You must decide on how you want your users to authenticate in advance because both methods require different {Project} clients to be registered to {Keycloak} and configured.
 The steps to register and configure {Project} client in {Keycloak} are distinguished within the procedure.
-
-You can also register two different {Project} clients to {Keycloak} if you want to use both authentication methods and configure both clients accordingly.
 
 .Procedure
 
@@ -24,7 +27,6 @@ You can also register two different {Project} clients to {Keycloak} if you want 
 
 . Register {Project} to {Keycloak} as a client.
 Note that you the registration process for logging in using the web UI and the CLI are different.
-You can register two clients {Project} clients to {Keycloak} to be able to log in to {Project} from the web UI and the CLI.
 +
 * If you want you users to authenticate to {Project} using the web UI, create a client as follows:
 +


### PR DESCRIPTION
#### What changes are you introducing?

I reviewed the information we have on Keycloak on branch 3.10 and want to remove references to configuring both CLI and web UI login methods.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/3737 and https://github.com/theforeman/foreman-documentation/pull/3759, I removed this information from 3.11 and above. This is because as noted in https://github.com/theforeman/foreman-documentation/pull/3737, during testing it was uncovered that both login methods cannot be configured at the same time even when using multiple Keycloak clients.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
