### PR TITLE
Add reference to satellite installation helper

### DIFF
--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="preparing-environment-for-capsule-installation"]
 = Preparing your environment for installation
 
-Review prerequisites below before you install {SmartProxyServer}.
+Review the following prerequisites before you install {SmartProxyServer}.
 
 ifdef::satellite[]
 include::modules/snip_red-hat-helper-apps.adoc[]

--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -2,6 +2,9 @@ ifdef::context[:parent-context: {context}]
 
 [id="preparing-environment-for-capsule-installation"]
 = Preparing your environment for installation
+
+Review prerequisites below before you install {SmartProxyServer}.
+
 // System Requirements
 include::modules/ref_system-requirements.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -5,6 +5,10 @@ ifdef::context[:parent-context: {context}]
 
 Review prerequisites below before you install {SmartProxyServer}.
 
+ifdef::satellite[]
+include::modules/snip_red-hat-helper-apps.adoc[]
+endif::[]
+
 // System Requirements
 include::modules/ref_system-requirements.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -5,6 +5,10 @@ ifdef::context[:parent-context: {context}]
 
 Review prerequisites below before you install {ProjectServer}.
 
+ifdef::satellite[]
+include::modules/snip_red-hat-helper-apps.adoc[]
+endif::[]
+
 include::modules/ref_system-requirements.adoc[leveloffset=+1]
 
 include::modules/ref_storage-requirements.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="Preparing_your_Environment_for_Installation_{context}"]
 = Preparing your environment for installation
 
-Review prerequisites below before you install {ProjectServer}.
+Review the following prerequisites before you install {ProjectServer}.
 
 ifdef::satellite[]
 include::modules/snip_red-hat-helper-apps.adoc[]

--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="Preparing_your_Environment_for_Installation_{context}"]
 = Preparing your environment for installation
 
-Before you install {Project}, ensure that your environment meets the following requirements.
+Review prerequisites below before you install {ProjectServer}.
 
 include::modules/ref_system-requirements.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_upgrading-overview.adoc
+++ b/guides/common/modules/con_upgrading-overview.adoc
@@ -4,8 +4,5 @@
 Review prerequisites and available upgrade paths below before upgrading your current {ProjectName} installation to {ProjectName} {ProjectVersion}.
 
 ifdef::satellite[]
-For interactive upgrade instructions, you can also use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
-This application provides you with an exact guide to match your current version number.
-You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
-For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the Red{nbsp}Hat Customer Portal.
+include::snip_red-hat-helper-apps.adoc[]
 endif::[]

--- a/guides/common/modules/con_upgrading-overview.adoc
+++ b/guides/common/modules/con_upgrading-overview.adoc
@@ -1,7 +1,7 @@
 [id="upgrading_overview_{context}"]
 = Upgrading overview
 
-Review prerequisites and available upgrade paths below before upgrading your current {ProjectName} installation to {ProjectName} {ProjectVersion}.
+Review the following prerequisites and available upgrade paths before upgrading your current {ProjectName} installation to {ProjectName} {ProjectVersion}.
 
 ifdef::satellite[]
 include::snip_red-hat-helper-apps.adoc[]

--- a/guides/common/modules/snip_red-hat-helper-apps.adoc
+++ b/guides/common/modules/snip_red-hat-helper-apps.adoc
@@ -1,0 +1,4 @@
+For interactive upgrade instructions, you can also use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
+This application provides you with an exact guide to match your current version number.
+You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
+For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the Red{nbsp}Hat Customer Portal.

--- a/guides/common/modules/snip_red-hat-helper-apps.adoc
+++ b/guides/common/modules/snip_red-hat-helper-apps.adoc
@@ -6,6 +6,6 @@ For more information, see https://access.redhat.com/labs/satelliteupgradehelper/
 endif::[]
 ifdef::installing-satellite-server-connected,installing-satellite-server-disconnected,installing-capsule-server[]
 For interactive installation instructions, you can also use the {ProjectName} Installation Helper on the Red{nbsp}Hat Customer Portal.
-This application provides you with an installation guide to match your required {Project} version number and configuration.
+This application provides you with an interactive way to prepare installation instructions to match your required {Project} version number and configuration.
 For more information, see https://access.redhat.com/labs/rhsih/[{ProjectName} Installation Helper] on the Red{nbsp}Hat Customer Portal.
 endif::[]

--- a/guides/common/modules/snip_red-hat-helper-apps.adoc
+++ b/guides/common/modules/snip_red-hat-helper-apps.adoc
@@ -1,4 +1,11 @@
+ifdef::upgrading-connected,upgrading-disconnected[]
 For interactive upgrade instructions, you can also use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
 This application provides you with an exact guide to match your current version number.
 You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
 For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the Red{nbsp}Hat Customer Portal.
+endif::[]
+ifdef::installing-satellite-server-connected,installing-satellite-server-disconnected,installing-capsule-server[]
+For interactive installation instructions, you can also use the {ProjectName} Installation Helper on the Red{nbsp}Hat Customer Portal.
+This application provides you with an installation guide to match your required {Project} version number and configuration.
+For more information, see https://access.redhat.com/labs/rhsih/[{ProjectName} Installation Helper] on the Red{nbsp}Hat Customer Portal.
+endif::[]

--- a/guides/common/modules/snip_red-hat-helper-apps.adoc
+++ b/guides/common/modules/snip_red-hat-helper-apps.adoc
@@ -1,11 +1,11 @@
 ifdef::upgrading-connected,upgrading-disconnected[]
-For interactive upgrade instructions, you can also use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
+For interactive upgrade instructions, you can use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
 This application provides you with an exact guide to match your current version number.
 You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
 For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the Red{nbsp}Hat Customer Portal.
 endif::[]
 ifdef::installing-satellite-server-connected,installing-satellite-server-disconnected,installing-capsule-server[]
-For interactive installation instructions, you can also use the {ProjectName} Installation Helper on the Red{nbsp}Hat Customer Portal.
+For interactive installation instructions, you can use the {ProjectName} Installation Helper on the Red{nbsp}Hat Customer Portal.
 This application provides you with an interactive way to prepare installation instructions to match your required {Project} version number and configuration.
 For more information, see https://access.redhat.com/labs/rhsih/[{ProjectName} Installation Helper] on the Red{nbsp}Hat Customer Portal.
 endif::[]

--- a/guides/common/modules/snip_red-hat-helper-apps.adoc
+++ b/guides/common/modules/snip_red-hat-helper-apps.adoc
@@ -1,11 +1,11 @@
 ifdef::upgrading-connected,upgrading-disconnected[]
-For interactive upgrade instructions, you can use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
-This application provides you with an exact guide to match your current version number.
-You can find instructions that are specific to your upgrade path, as well as steps to prevent known issues.
+For interactive instructions for performing the upgrade, you can use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
+This application provides upgrade instructions customized for your current version number of {Project}.
+As a result, you receive instructions that are specific to your upgrade path, as well as steps to prevent known issues.
 For more information, see https://access.redhat.com/labs/satelliteupgradehelper/[{Project} Upgrade Helper] on the Red{nbsp}Hat Customer Portal.
 endif::[]
 ifdef::installing-satellite-server-connected,installing-satellite-server-disconnected,installing-capsule-server[]
-For interactive installation instructions, you can use the {ProjectName} Installation Helper on the Red{nbsp}Hat Customer Portal.
-This application provides you with an interactive way to prepare installation instructions to match your required {Project} version number and configuration.
+For interactive instructions for performing the installation, you can use the {ProjectName} Installation Helper on the Red{nbsp}Hat Customer Portal.
+This application provides you with an interactive way to prepare installation instructions customized for your required {Project} version number and configuration.
 For more information, see https://access.redhat.com/labs/rhsih/[{ProjectName} Installation Helper] on the Red{nbsp}Hat Customer Portal.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Consolidating introductions in the installation and upgrade guides
* Moving the (satellite-only) paragraph about upgrade helper app to a snippet
* Extending the new snippet with a similar paragraph about installation helper app
* EDIT: Improving the existing wording in introductions and the app descriptions

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The installation helper app is a new feature.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I'd like to find a solution that is consistent across all the installation (connected, disconnected, proxy) and upgrade (connected, disconnected) guides. This is so that users can expect to find a reference to the installation/upgrade apps at approximately the same place in all of the guides.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
