### PR TITLE
Fix wording for installing capsule packages

### DIFF
--- a/guides/common/modules/proc_installing-proxy-packages.adoc
+++ b/guides/common/modules/proc_installing-proxy-packages.adoc
@@ -12,7 +12,7 @@ ifndef::satellite[]
 endif::[]
 ----
 ifdef::satellite[]
-. Install the {ProjectServer} packages:
+. Install the {SmartProxyServer} packages:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Replacing step description that says "install server packages" with "install capsule packages".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It _is_ a procedure for installing a capsule. https://issues.redhat.com/browse/SAT-32158

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Affects Satellite only.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
