### PR TITLE
Add info on removing backup PostgreSQL data

### DIFF
--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -11,9 +11,6 @@ This information allows Katello to display manifest labels, annotations, and inf
 As a result, migrations must be performed to pull this content from manifests into the database.
 endif::[]
 
-ifdef::katello[]
-This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.
-
 * Optional: If the upgrade succeeded, you can delete the `/var/lib/pgsql/data-old/` directory:
 +
 [options="nowrap" subs="attributes"]
@@ -25,6 +22,9 @@ This migration takes time, so if you depend on container content and need minima
 If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
 +
 Note, however, that after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore.
+
+ifdef::katello[]
+This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.
 
 .Procedure
 . Enter the following command in a `tmux` window on {ProjectServer} for a pre-migration.
@@ -46,4 +46,3 @@ ifdef::satellite,orcharhino[]
 This migration takes time, so a pre-migration runs automatically after the upgrade to {ProjectVersion} to reduce future upgrade downtime.
 While the pre-migration is running, {ProjectServer} is fully functional but uses more hardware resources.
 endif::[]
-

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -22,7 +22,6 @@ ifdef::katello,orcharhino,satellite[]
 This information allows Katello to display manifest labels, annotations, and information about the manifest type, such as if it is bootable or represents flatpak content.
 As a result, migrations must be performed to pull this content from manifests into the database.
 endif::[]
-
 ifdef::katello[]
 +
 This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -5,13 +5,7 @@
 If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
 For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.
 
-ifdef::katello,orcharhino,satellite[]
-* Pulp is introducing more data about container manifests to the API.
-This information allows Katello to display manifest labels, annotations, and information about the manifest type, such as if it is bootable or represents flatpak content.
-As a result, migrations must be performed to pull this content from manifests into the database.
-endif::[]
-
-* Optional: {Project} creates creates the `/var/lib/pgsql/data-old/` directory for backup purposes during the upgrade. If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
+* Optional: {Project} creates the `/var/lib/pgsql/data-old/` directory for backup purposes during the upgrade. If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
 +
 However, after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore. When this occurs, or if you do not want to keep the data after a successful update, delete the directory:
 +
@@ -20,7 +14,14 @@ However, after several database updates, the backup becomes obsolete, and cannot
 # rm /var/lib/pgsql/data-old/
 ----
 
+ifdef::katello,orcharhino,satellite[]
+* Pulp is introducing more data about container manifests to the API.
+This information allows Katello to display manifest labels, annotations, and information about the manifest type, such as if it is bootable or represents flatpak content.
+As a result, migrations must be performed to pull this content from manifests into the database.
+endif::[]
+
 ifdef::katello[]
++
 This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.
 
 .Procedure
@@ -40,6 +41,7 @@ This command migrates data while {Project} is running without any need for downt
 endif::[]
 
 ifdef::satellite,orcharhino[]
++
 This migration takes time, so a pre-migration runs automatically after the upgrade to {ProjectVersion} to reduce future upgrade downtime.
 While the pre-migration is running, {ProjectServer} is fully functional but uses more hardware resources.
 endif::[]

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -14,6 +14,18 @@ endif::[]
 ifdef::katello[]
 This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.
 
+* Optional: If the upgrade succeeded, you can delete the `/var/lib/pgsql/data-old/` directory:
++
+[options="nowrap" subs="attributes"]
+----
+# rm /var/lib/pgsql/data-old/
+----
++
+{Project} creates this directory for backup purposes during the upgrade. 
+If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
++
+Note, however, that after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore.
+
 .Procedure
 . Enter the following command in a `tmux` window on {ProjectServer} for a pre-migration.
 This command migrates data while {Project} is running without any need for downtime and reduces future upgrade downtime:
@@ -35,13 +47,3 @@ This migration takes time, so a pre-migration runs automatically after the upgra
 While the pre-migration is running, {ProjectServer} is fully functional but uses more hardware resources.
 endif::[]
 
-. Optional: Delete the `/var/lib/pgsql/data-old/` directory by entering the following command:
-+
-[options="nowrap" subs="attributes"]
-----
-# rm /var/lib/pgsql/data-old/
-----
-+
-{ProductName} creates this directory for backup purposes during the upgrade. If the upgrade fails or {ProductName} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
-+
-Note, however, that after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -5,14 +5,15 @@
 If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
 For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.
 
-* Optional: {Project} creates the `/var/lib/pgsql/data-old/` directory for backup purposes during the upgrade. If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
-+
-However, after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore. When this occurs, or if you do not want to keep the data after a successful update, delete the directory:
+* Delete the `/var/lib/pgsql/data-old/` directory:
 +
 [options="nowrap" subs="attributes"]
 ----
-# rm /var/lib/pgsql/data-old/
+# rm -r /var/lib/pgsql/data-old/
 ----
++
+{ProductName} creates this directory for backup purposes during the upgrade.
+If the upgrade finishes successfully, the data in this directory can no longer be used.
 
 ifdef::katello,orcharhino,satellite[]
 * Pulp is introducing more data about container manifests to the API.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -34,3 +34,12 @@ ifdef::satellite,orcharhino[]
 This migration takes time, so a pre-migration runs automatically after the upgrade to {ProjectVersion} to reduce future upgrade downtime.
 While the pre-migration is running, {ProjectServer} is fully functional but uses more hardware resources.
 endif::[]
+
+. Optional: Delete the `/var/lib/pgsql/data-old/` directory by entering the following command:
++
+[options="nowrap" subs="attributes"]
+----
+# rm /var/lib/pgsql/data-old/
+----
++
+{ProductName} creates this directory for backup purposes during the upgrade. If the upgrade has finished successfully, the directory is no longer needed.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -11,17 +11,14 @@ This information allows Katello to display manifest labels, annotations, and inf
 As a result, migrations must be performed to pull this content from manifests into the database.
 endif::[]
 
-* Optional: If the upgrade succeeded, you can delete the `/var/lib/pgsql/data-old/` directory:
+* Optional: {Project} creates creates the `/var/lib/pgsql/data-old/` directory for backup purposes during the upgrade. If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
++
+However, after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore. When this occurs, or if you do not want to keep the data after a successful update, delete the directory:
 +
 [options="nowrap" subs="attributes"]
 ----
 # rm /var/lib/pgsql/data-old/
 ----
-+
-{Project} creates this directory for backup purposes during the upgrade. 
-If the upgrade fails or {Project} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
-+
-Note, however, that after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore.
 
 ifdef::katello[]
 This migration takes time, so if you depend on container content and need minimal upgrade downtime, use this procedure to migrate data.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -42,7 +42,6 @@ This command migrates data while {Project} is running without any need for downt
 # foreman-rake katello:import_container_manifest_labels
 ----
 endif::[]
-
 ifdef::satellite,orcharhino[]
 +
 This migration takes time, so a pre-migration runs automatically after the upgrade to {ProjectVersion} to reduce future upgrade downtime.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -5,11 +5,11 @@
 If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
 For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.
 
-* Delete the `/var/lib/pgsql/data-old/` directory:
+* Delete the `{postgresql-lib-dir}/data-old/` directory:
 +
 [options="nowrap" subs="attributes"]
 ----
-# rm -r /var/lib/pgsql/data-old/
+# rm -r {postgresql-lib-dir}/data-old/
 ----
 +
 {Project} creates this directory for backup purposes during the upgrade.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -12,7 +12,7 @@ For more information about configuring custom provisioning snippets, see {Provis
 # rm -r /var/lib/pgsql/data-old/
 ----
 +
-{ProductName} creates this directory for backup purposes during the upgrade.
+{Project} creates this directory for backup purposes during the upgrade.
 If the upgrade finishes successfully, the data in this directory can no longer be used.
 
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -5,6 +5,7 @@
 If the custom code is executed before and/or after the provisioning process, use custom provisioning snippets to avoid recreating cloned templates.
 For more information about configuring custom provisioning snippets, see {ProvisioningDocURL}Creating_Custom_Provisioning_Snippets_provisioning[Creating Custom Provisioning Snippets] in _{ProvisioningDocTitle}_.
 
+ifndef::foreman-deb[]
 * Delete the `{postgresql-lib-dir}/data-old/` directory:
 +
 [options="nowrap" subs="attributes"]
@@ -14,6 +15,7 @@ For more information about configuring custom provisioning snippets, see {Provis
 +
 {Project} creates this directory for backup purposes during the upgrade.
 If the upgrade finishes successfully, the data in this directory can no longer be used.
+endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 * Pulp is introducing more data about container manifests to the API.

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -13,7 +13,7 @@ ifndef::foreman-deb[]
 # rm -r {postgresql-lib-dir}/data-old/
 ----
 +
-{Project} creates this directory for backup purposes during the upgrade.
+PostgreSQL creates this directory for backup purposes during the upgrade.
 If the upgrade finishes successfully, the data in this directory can no longer be used.
 endif::[]
 

--- a/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
+++ b/guides/common/modules/proc_performing-post-upgrade-tasks.adoc
@@ -42,4 +42,6 @@ endif::[]
 # rm /var/lib/pgsql/data-old/
 ----
 +
-{ProductName} creates this directory for backup purposes during the upgrade. If the upgrade has finished successfully, the directory is no longer needed.
+{ProductName} creates this directory for backup purposes during the upgrade. If the upgrade fails or {ProductName} loses PostgreSQL data shortly after the upgrade, you can use this directory to restore your external PostgreSQL database.
++
+Note, however, that after several database updates, the backup becomes obsolete, and cannot be used for disaster recovery anymore.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a single step on deleting a directory with backup PostgreSQL data after upgrading.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Based on https://issues.redhat.com/browse/SAT-32182

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Since this update seems to apply only to upgrading to Sat 6.16, I'm branching it out from the corresponding Foreman branch (3.12). 

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
