### PR TITLE
Updating information on local testing in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [README in the `web/` subdirectory](web/README.md) for more information.
 
 ## Testing locally
 
-To build both static site and guides for easy local testing, there is the global `Makefile` in the root directory with the following targets:
+To build both the static site and the guides for easy local testing, a global `Makefile` is provided in the root directory with the following targets:
 
 * `html`: builds HTML guides with all contexts (`foreman-el`, `foreman-deb`, `katello`, `satellite`, and `orcharhino`)
 * `web`: builds static site using the `nanoc` tool
@@ -35,10 +35,11 @@ To build both static site and guides for easy local testing, there is the global
 * `serve`: serves the result directory via a python web server (the default target)
 
 To use the `Makefile`, you must first install the `gcc`, `gcc-c++`, and `ruby-devel` packages.
-To test the whole site locally, perform `make serve` command and open up `http://localhost:5000`.
+Then, to test the entire site locally, perform `make serve` command and open up `http://localhost:5000`.
 Use `PORT=5008` to change the web server port (5000 by default).
-It builds all contexts so the initial build can be slow, make sure to use `-j` option for faster builds on modern multi-core machines.
-Stable versions are symlink to the nightly (current) version, this can cause issues for deleted (or renamed) guides.
+This builds all contexts, so the initial build might be slow. 
+For faster builds on modern multi-core machines, use the `-j` option.
+Stable versions are symlinks to the nightly (current) version, which can cause issues for deleted (or renamed) guides.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To build both static site and guides for easy local testing, there is the global
 * `compile`: compiles all content into a single directory `./result`
 * `serve`: serves the result directory via a python web server (the default target)
 
+To use the `Makefile`, you must first install the `gcc`, `gcc-c++`, and `ruby-devel` packages.
 To test the whole site locally, perform `make serve` command and open up `http://localhost:5000`.
 Use `PORT=5008` to change the web server port (5000 by default).
 It builds all contexts so the initial build can be slow, make sure to use `-j` option for faster builds on modern multi-core machines.


### PR DESCRIPTION
#### What changes are you introducing?

Expanding and updating the local building information in the README for better usability and easier accessibility by new contributors.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current wording is not very beginner-friendly, and does not mention that you need to have certain packages installed to use the makefile, otherwise it fails (which yields an error that is difficult to interpret, on top of it).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

It would be ideal to rewrite the information as a procedure with numbered steps, but I don't yet have enough experience with the tooling to do that, so this PR is more of a band-aid (but still, I think, an improvement).

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
