### PR TITLE
Fix vague AK parameter instruction step

### DIFF
--- a/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
@@ -33,7 +33,6 @@ endif::[]
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your requirements.
 ifdef::satellite,orcharhino,katello[]
-. On the *Parameters* tab, ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to provision your host on Proxmox.

--- a/guides/common/modules/proc_creating-hosts-on-vmware.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-vmware.adoc
@@ -36,10 +36,7 @@ endif::[]
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your requirements.
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab and ensure that a parameter exists that provides an activation key.
-If a parameter does not exist, click *+ Add Parameter*.
-In the field *Name*, enter *kt_activation_keys*.
-In the field *Value*, enter the name of the activation key used to register the Content Hosts.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to provision your host on VMware.
 

--- a/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning.adoc
@@ -18,8 +18,7 @@ Confirm each aspect of the operating system.
 +
 For more information about associating provisioning templates, see xref:provisioning-templates[].
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save the host details.
 +

--- a/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxeless-provisioning.adoc
@@ -72,8 +72,7 @@ Confirm each aspect of the operating system.
 +
 For more information about associating provisioning templates, see xref:provisioning-templates[].
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save the host details.
 This creates a host entry and the host details page appears.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -36,8 +36,7 @@ Confirm each aspect of the operating system.
 +
 For more information about associating provisioning templates, see xref:creating-provisioning-templates[].
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save the host details.
 +

--- a/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-unattended-provisioning.adoc
@@ -18,8 +18,7 @@ Confirm each aspect of the operating system.
 +
 For more information about associating provisioning templates, see xref:provisioning-templates[].
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save the host details.
 +

--- a/guides/common/modules/proc_creating-image-based-hosts-on-amazon-ec2.adoc
+++ b/guides/common/modules/proc_creating-image-based-hosts-on-amazon-ec2.adoc
@@ -12,8 +12,7 @@ include::snip_steps-create-a-host-tab-interfaces.adoc[]
 . Click the *Operating System* tab and confirm that all fields are populated with values.
 . Click the *Virtual Machine* tab and confirm that all fields are populated with values.
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save your changes.
 

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -21,8 +21,7 @@ ifdef::azure-provisioning[. In the *Root Password* field, enter the root passwor
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your needs.
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save the host entry.
 

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -30,8 +30,7 @@ include::snip_steps-create-a-host-tab-interfaces.adoc[]
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your needs.
 ifdef::katello,satellite,orcharhino[]
-. Click the *Parameters* tab, and ensure that a parameter exists that provides an activation key.
-If not, add an activation key.
+include::snip_step-parameter-ak.adoc[]
 endif::[]
 . Click *Submit* to save the host entry.
 

--- a/guides/common/modules/snip_step-parameter-ak.adoc
+++ b/guides/common/modules/snip_step-parameter-ak.adoc
@@ -1,4 +1,4 @@
-. Click the *Parameters* tab.
-Add the `kt_activation_keys` parameter and enter the name of the activation key as the value.
+. On the *Parameters* tab, click *Add parameter*.
+Add a parameter named `kt_activation_keys`, select the *string* type, and enter the name of the activation key as the value.
 The activation key has to belong to the same organization as your host.
 You can also enter a comma-separated list of multiple activation keys.

--- a/guides/common/modules/snip_step-parameter-ak.adoc
+++ b/guides/common/modules/snip_step-parameter-ak.adoc
@@ -1,0 +1,4 @@
+. Click the *Parameters* tab.
+Add the `kt_activation_keys` parameter and enter the name of the activation key as the value.
+The activation key has to belong to the same organization as your host.
+You can also enter a comma-separated list of multiple activation keys.


### PR DESCRIPTION
#### What changes are you introducing?

Introducing a snippet for a repeating instruction step that was too vague in most places of provisioning

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Specific parameter is needed and docs failed to mention it.

https://issues.redhat.com/browse/SAT-32160

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
