### PR TITLE
Update SMTP configuration for Gmail

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -32,17 +32,18 @@ The `SMTP username` and `SMTP password` specify the login credentials for the SM
 .. The following example uses *gmail.com* as an SMTP server:
 +
 .Using gmail.com as an SMTP server
-[cols=",",options="header"]
+[cols="1,1,2",options="header"]
 |====
-|Name| Example value
-|Delivery method           | SMTP
-|SMTP address              | smtp.gmail.com
-|SMTP authentication       | plain
-|SMTP HELO/EHLO domain     | smtp.gmail.com
-|SMTP enable StartTLS auto | Yes
-|SMTP password             | _password_
-|SMTP port                 | 587
-|SMTP username             | _user_@gmail.com
+|Name| Example value| Additional information
+|Delivery method           | SMTP |
+|SMTP address              | smtp.gmail.com |
+|SMTP authentication       | plain |
+|SMTP HELO/EHLO domain     | smtp.gmail.com |
+|SMTP enable StartTLS auto | Yes |
+|SMTP password             | _app password_ | Use the Google app password.
+For more information, see https://support.google.com/mail/answer/185833[Sign in with app passwords] in _Google Help Center_.
+|SMTP port                 | 587 |
+|SMTP username             | _user_@gmail.com | Use the Google account name.
 |====
 +
 .. The following example uses the `sendmail` command as a delivery method:

--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -15,20 +15,17 @@ The changes have an immediate effect.
 .. The following example shows the configuration options for using an SMTP server:
 +
 .Using an SMTP server as a delivery method
-[cols=",",options="header"]
+[cols="1,1,2",options="header"]
 |====
-|Name| Example value
-|Delivery method       | SMTP
-|SMTP address          | _smtp.example.com_
-|SMTP authentication   | login
-|SMTP HELO/EHLO domain | _example.com_
-|SMTP password         | _password_
-|SMTP port             | 25
-|SMTP username         | _user@example.com_
+|Name| Example value| Additional information
+|Delivery method       | SMTP |
+|SMTP address          | _smtp.example.com_ |
+|SMTP authentication   | login |
+|SMTP HELO/EHLO domain | _example.com_ |
+|SMTP password         | _password_ | Use the login credentials for the SMTP server.
+|SMTP port             | 25 |
+|SMTP username         | _user@example.com_ | Use the login credentials for the SMTP server.
 |====
-+
-The `SMTP username` and `SMTP password` specify the login credentials for the SMTP server.
-+
 .. The following example uses *gmail.com* as an SMTP server:
 +
 .Using gmail.com as an SMTP server
@@ -49,20 +46,18 @@ For more information, see https://support.google.com/mail/answer/185833[Sign in 
 .. The following example uses the `sendmail` command as a delivery method:
 +
 .Using sendmail as a delivery method
-[cols=",",options="header"]
+[cols="1,1,2",options="header"]
 |====
-|Name| Example value
-|Delivery method | Sendmail
-|Sendmail location | /usr/sbin/sendmail
-|Sendmail arguments | -i
-|====
-+
-For security reasons, both Sendmail location and Sendmail argument settings are read-only and can be only set in `/etc/foreman/settings.yaml`.
+|Name| Example value| Additional information
+|Delivery method | Sendmail |
+|Sendmail location | /usr/sbin/sendmail .2+| For security reasons, both Sendmail location and Sendmail argument settings are read-only and can be only set in `/etc/foreman/settings.yaml`.
 Both settings currently cannot be set via `{foreman-installer}`.
 ifndef::satellite,orcharhino[]
 This is being tracked in https://projects.theforeman.org/issues/33543[issue #33543].
 endif::[]
 For more information see the *sendmail 1* man page.
+|Sendmail arguments | -i
+|====
 
 . If you decide to send email using an SMTP server which uses TLS authentication, also perform one of the following steps:
 +


### PR DESCRIPTION
#### What changes are you introducing?

* Updating the configuration example for using gmail.com as an SMTP server
* Changing the layout of the tables with example to better support adding the new information

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Reported in https://issues.redhat.com/browse/SAT-32049

Per https://support.google.com/a/answer/176600?hl=en, using the app password is now the only supported way while before the standard Google password was also possible.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
