### PR TITLE
Drop procedures that use an obsolete API endpoint

### DIFF
--- a/guides/common/assembly_api-cheat-sheet.adoc
+++ b/guides/common/assembly_api-cheat-sheet.adoc
@@ -34,10 +34,6 @@ include::modules/proc_uploading-content-larger-than-2-mb.adoc[leveloffset=+2]
 
 include::modules/proc_uploading-duplicate-content.adoc[leveloffset=+2]
 
-include::modules/proc_applying-errata-to-hosts.adoc[leveloffset=+1]
-
-include::modules/proc_applying-errata-to-a-host-collection.adoc[leveloffset=+1]
-
 include::modules/proc_using-extended-searches.adoc[leveloffset=+1]
 
 include::modules/proc_using-searches-with-pagination-control.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_applying-errata-to-a-host-collection.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host-collection.adoc
@@ -3,7 +3,6 @@
 
 You can use {Project} to apply errata to a host collection.
 
-ifndef::rest-api[]
 [id="cli-applying-errata-to-a-host-collection"]
 .CLI procedure
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -13,4 +12,3 @@ $ hammer job-invocation create \
 --inputs errata=_ERRATUM_ID1_,_ERRATUM_ID2_,... \
 --search-query "host_collection = _HOST_COLLECTION_NAME_"
 ----
-endif::[]

--- a/guides/common/modules/proc_applying-errata-to-a-host-collection.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host-collection.adoc
@@ -14,16 +14,3 @@ $ hammer job-invocation create \
 --search-query "host_collection = _HOST_COLLECTION_NAME_"
 ----
 endif::[]
-
-[id="api-applying-errata-to-a-host-collection"]
-.API procedure
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ curl \
---header "Accept:application/json" \
---header "Content-Type:application/json" \
---request PUT \
---user _My_User_Name_:__My_Password__ \
---data "{\"organization_id\":1,\"included\":{\"search\":\"host_collection=\\\"_my-collection_\\\"\"},\"content_type\":\"errata\",\"content\":[\"_RHBA-2016:1981_\"]}" \
-https://_{foreman-example-com}_/api/v2/hosts/bulk/install_content
-----

--- a/guides/common/modules/proc_applying-errata-to-hosts.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts.adoc
@@ -3,7 +3,6 @@
 
 You can use {Project} apply errata to hosts.
 ifndef::rest-api[]
-To use the API instead of the {ProjectWebUI}, see the xref:api-applying-errata-to-hosts[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
@@ -11,16 +10,3 @@ To use the API instead of the {ProjectWebUI}, see the xref:api-applying-errata-t
 . On the *Content* tab, select the *Errata* tab.
 . Select errata and click *Apply*.
 endif::[]
-
-[id="api-applying-errata-to-hosts"]
-.API procedure
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ curl \
---header "Accept:application/json" \
---header "Content-Type:application/json" \
---request PUT \
---user _My_User_Name_:__My_Password__ \
---data "{\"organization_id\":1,\"included\":{\"search\":\"_my-host_\"},\"content_type\":\"errata\",\"content\":[\"_RHBA-2016:1981_\"]}" \
-https://_{foreman-example-com}_/api/v2/hosts/bulk/install_content
-----

--- a/guides/common/modules/proc_applying-errata-to-hosts.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts.adoc
@@ -2,11 +2,9 @@
 = Applying errata to hosts
 
 You can use {Project} apply errata to hosts.
-ifndef::rest-api[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select a host.
 . On the *Content* tab, select the *Errata* tab.
 . Select errata and click *Apply*.
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Removing procedures that reference `install_content`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The `install_content` endpoint was removed. According to Satellite downstream release notes, this happened in 6.15: https://docs.redhat.com/en/documentation/red_hat_satellite/6.15/html-single/release_notes/index#removed-functionality

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

https://issues.redhat.com/browse/SAT-31867 requests replacing the old procedures with an example that uses `job_invocations` but looking at the API guide, I think the cheat sheet chapter already has enough examples on working with hosts so I think we're fine just dropping the obsolete ones.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
