### PR TITLE
Clean up master.adoc in Planning

### DIFF
--- a/guides/common/assembly_foreman-deployment-planning.adoc
+++ b/guides/common/assembly_foreman-deployment-planning.adoc
@@ -1,0 +1,7 @@
+include::modules/con_foreman-deployment-planning.adoc[leveloffset=+1]
+
+include::assembly_deployment-path.adoc[leveloffset=+2]
+
+include::assembly_common-deployment-scenarios.adoc[leveloffset=+2]
+
+include::assembly_provisioning-requirements.adoc[leveloffset=+2]

--- a/guides/common/assembly_foreman-deployment-planning.adoc
+++ b/guides/common/assembly_foreman-deployment-planning.adoc
@@ -1,7 +1,7 @@
-include::modules/con_foreman-deployment-planning.adoc[leveloffset=+1]
+include::modules/con_foreman-deployment-planning.adoc[]
 
-include::assembly_deployment-path.adoc[leveloffset=+2]
+include::assembly_deployment-path.adoc[leveloffset=+1]
 
-include::assembly_common-deployment-scenarios.adoc[leveloffset=+2]
+include::assembly_common-deployment-scenarios.adoc[leveloffset=+1]
 
-include::assembly_provisioning-requirements.adoc[leveloffset=+2]
+include::assembly_provisioning-requirements.adoc[leveloffset=+1]

--- a/guides/common/assembly_foreman-overview-and-concepts.adoc
+++ b/guides/common/assembly_foreman-overview-and-concepts.adoc
@@ -1,15 +1,15 @@
-include::modules/con_foreman-overview-and-concepts.adoc[leveloffset=+1]
+include::modules/con_foreman-overview-and-concepts.adoc[]
 
 ifdef::katello,satellite,orcharhino[]
-include::assembly_content-and-patch-management-with-project.adoc[leveloffset=+2]
+include::assembly_content-and-patch-management-with-project.adoc[leveloffset=+1]
 endif::[]
 
-include::assembly_provisioning-management-with-project.adoc[leveloffset=+2]
+include::assembly_provisioning-management-with-project.adoc[leveloffset=+1]
 
-include::assembly_major-project-components.adoc[leveloffset=+2]
+include::assembly_major-project-components.adoc[leveloffset=+1]
 
-include::assembly_project-infrastructure-organization-concepts.adoc[leveloffset=+2]
+include::assembly_project-infrastructure-organization-concepts.adoc[leveloffset=+1]
 
-include::assembly_tools-for-administration-of-project.adoc[leveloffset=+2]
+include::assembly_tools-for-administration-of-project.adoc[leveloffset=+1]
 
-include::assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+2]
+include::assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]

--- a/guides/common/assembly_foreman-overview-and-concepts.adoc
+++ b/guides/common/assembly_foreman-overview-and-concepts.adoc
@@ -1,0 +1,15 @@
+include::modules/con_foreman-overview-and-concepts.adoc[leveloffset=+1]
+
+ifdef::katello,satellite,orcharhino[]
+include::assembly_content-and-patch-management-with-project.adoc[leveloffset=+2]
+endif::[]
+
+include::assembly_provisioning-management-with-project.adoc[leveloffset=+2]
+
+include::assembly_major-project-components.adoc[leveloffset=+2]
+
+include::assembly_project-infrastructure-organization-concepts.adoc[leveloffset=+2]
+
+include::assembly_tools-for-administration-of-project.adoc[leveloffset=+2]
+
+include::assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+2]

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -9,29 +9,9 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/modules/con_foreman-overview-and-concepts.adoc[]
+include::common/assembly_foreman-overview-and-concepts.adoc[]
 
-ifdef::katello,satellite,orcharhino[]
-include::common/assembly_content-and-patch-management-with-project.adoc[leveloffset=+1]
-endif::[]
-
-include::common/assembly_provisioning-management-with-project.adoc[leveloffset=+1]
-
-include::common/assembly_major-project-components.adoc[leveloffset=+1]
-
-include::common/assembly_project-infrastructure-organization-concepts.adoc[leveloffset=+1]
-
-include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1]
-
-include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]
-
-include::common/modules/con_foreman-deployment-planning.adoc[]
-
-include::common/assembly_deployment-path.adoc[leveloffset=+1]
-
-include::common/assembly_common-deployment-scenarios.adoc[leveloffset=+1]
-
-include::common/assembly_provisioning-requirements.adoc[leveloffset=+1]
+include::common/assembly_foreman-deployment-planning.adoc[]
 
 :!numbered:
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -9,9 +9,9 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/assembly_foreman-overview-and-concepts.adoc[]
+include::common/assembly_foreman-overview-and-concepts.adoc[leveloffset=+1]
 
-include::common/assembly_foreman-deployment-planning.adoc[]
+include::common/assembly_foreman-deployment-planning.adoc[leveloffset=+1]
 
 :!numbered:
 


### PR DESCRIPTION
#### What changes are you introducing?

Include "overview & concepts" and "deployment planning" as assemblies rather than AsciiDoc parts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To clean up master.adoc a bit and also to resolve errors about too many level 0 headings.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I'm adding a new part/assembly to the Planning guide and this would help keep things a bit more tidy.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
