### PR TITLE
Add install procedures for IoP Advisor

### DIFF
--- a/guides/common/modules/con_installing-and-configuring-the-iop-advisor-engine-in-a-disconnected-environment.adoc
+++ b/guides/common/modules/con_installing-and-configuring-the-iop-advisor-engine-in-a-disconnected-environment.adoc
@@ -1,0 +1,4 @@
+[id="installing-and-configuring-the-iop-advisor-engine-in-a-disconnected-environment"]
+= Installing and configuring the IoP Advisor Engine in a disconnected environment
+
+You can install and configure the IoP Advisor Engine on a disconnected {ProjectServer} by using either the {Project} installation ISO or a container image import and export. 

--- a/guides/common/modules/proc_installing-the-iop-advisor-engine-in-a-disconnected-environment.adoc
+++ b/guides/common/modules/proc_installing-the-iop-advisor-engine-in-a-disconnected-environment.adoc
@@ -1,0 +1,27 @@
+[id="installing-the-iop-advisor-engine-in-a-disconnected-environment"]
+= Installing the IoP Advisor Engine in a disconnected environment
+
+.Prerequisites
+Ensure you have the {Project} installation ISO downloaded or obtain the exported container image.
+
+Use this procedure if your {ProjectServer} has access to the {Team} container registry. 
+
+.Procedure
+. Log in to the Red Hat registry using Podman:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ podman login registry.redhat.io
+----
+. Pull the IoP Advisor Engine container image:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ podman pull registry.redhat.io/{foreman}/iop-advisor-engine-rhel9:{ProjectVersion}
+----
+. Enable the plugin:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --foreman-plugin-rh-cloud-enable-iop-advisor-engine true
+----

--- a/guides/common/modules/proc_installing-the-iop-advisor-engine-using-import-and-export.adoc
+++ b/guides/common/modules/proc_installing-the-iop-advisor-engine-using-import-and-export.adoc
@@ -1,0 +1,31 @@
+[id="installing-the-iop-advisor-engine-using-import-and-export"]
+= Installing the IoP Advisor Engine using import and export
+
+Use this procedure to transfer the IoP Advisor Engine container image from a connected system to a disconnected {ProjectServer}. 
+
+.Procedure
+To transfer and install the container image from a connected system:
+
+. On the connected system, export the container image:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# skopeo copy oci-archive:/tmp/iop-advisor-engine.tar \
+containers-storage:registry.redhat.io/{foreman}/iop-advisor-engine-rhel9:latest
+----
+. Transfer the `iop-advisor-engine.tar` file to the disconnected {ProjectServer}.
+. On the disconnected {ProjectServer}, import the container image:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# skopeo copy oci-archive:/tmp/iop-advisor-engine.tar \
+containers-storage:registry.redhat.io/{foreman}/iop-advisor-engine-rhel9:latest
+----
+. Enable the plugin:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --foreman-plugin-rh-cloud-enable-iop-advisor-engine true
+----
+
+

--- a/guides/common/modules/proc_installing-the-iop-advisor-engine-with-the-project-iso.adoc
+++ b/guides/common/modules/proc_installing-the-iop-advisor-engine-with-the-project-iso.adoc
@@ -1,0 +1,17 @@
+[id="installing-the-iop-advisor-engine-with-the-project-iso"]
+= Installing the IoP Advisor Engine with the {Project} ISO
+
+If your {ProjectServer} is in a disconnected environment, use the {Project} installation ISO to access the required container content. 
+
+.Procedure
+To install using the {Project} ISO:
+. Download and mount the {Project} ISO.
+. Set up the local repositories using the procedure for disconnected environments. *For more information, see*
+. Navigate to the `/media/sat6/containers` directory:
+. Run the `./setup_containers` script.
+. Enable the plugin:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --foreman-plugin-rh-cloud-enable-iop-advisor-engine true
+----

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -19,6 +19,8 @@ include::common/assembly_preparing-environment-for-installation.adoc[leveloffset
 
 include::common/assembly_installing-satellite-server-disconnected.adoc[leveloffset=+1]
 
+include::common/assembly_installing-and-configuring-the-iop-advisor-engine-in-a-disconnected-environment.adoc[leveloffset=+1]
+
 [id="performing-additional-configuration"]
 == Performing Additional Configuration on {ProjectServer}
 
@@ -39,7 +41,6 @@ include::common/assembly_configuring-satellite-custom-server-certificate.adoc[le
 
 include::common/assembly_using-external-databases.adoc[leveloffset=+2]
 endif::[]
-
 
 include::common/assembly_configuring-external-services.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?
Add install procedures for local insights advisor.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-30263

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
