### PR TITLE
Remove references to 'install_content'

### DIFF
--- a/guides/common/modules/proc_applying-errata-to-hosts.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts.adoc
@@ -17,33 +17,3 @@ You can use the {ProjectWebUI} to help discover the format for the search query.
 Navigate to *Hosts* > *Host Collections* and select a host collection.
 Go to *Collection Actions* > *Errata Installation* and notice the search query box contents.
 For example, for a Host Collection called _my-collection_, the search box contains `host_collection="my-collection"`.
-
-[id="exam-API_Guide-Applying_Errata_to_a_Host"]
-.Applying errata to a host
-
-This example uses the API URL for bulk actions `/katello/api/hosts/bulk/install_content` to show the format required for a simple search.
-
-Example request:
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ curl --header "Accept:application/json" \
---header "Content-Type:application/json" --request PUT \
---user _My_User_Name_:__My_Password__ \
---data "{\"organization_id\":1,\"included\":{\"search\":\"_my-host_\"},\"content_type\":\"errata\",\"content\":[\"_RHBA-2016:1981_\"]}" \
-https://_{foreman-example-com}_/api/v2/hosts/bulk/install_content
-----
-
-[id="exam-API_Guide-Applying_Errata_to_a_Host_Collection"]
-.Applying errata to a host collection
-
-In this example, notice the level of escaping required to pass the search string `host_collection="my-collection"` as seen in the {ProjectWebUI}.
-Example request:
-
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ curl --header "Accept:application/json" \
---header "Content-Type:application/json" --request PUT \
---user _My_User_Name_:__My_Password__ \
---data "{\"organization_id\":1,\"included\":{\"search\":\"host_collection=\\\"_my-collection_\\\"\"},\"content_type\":\"errata\",\"content\":[\"_RHBA-2016:1981_\"]}" \
-https://_{foreman-example-com}_/api/v2/hosts/bulk/install_content
-----


### PR DESCRIPTION
#### What changes are you introducing?

Removing procedures that reference install_content.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The install_content endpoint was removed. See https://github.com/theforeman/foreman-documentation/pull/3780 which removes the references for branches 3.13 and above.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

No picks because the guide doesn't exist on 3.11 and lower.