### PR TITLE
Remove trailing underscores from commands

### DIFF
--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -32,9 +32,9 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-PGPASSWORD='_Foreman_Password_' pg_restore -h _postgres.example.com_ -U foreman -d foreman < /var/_My_Migration_Backup_Directory_/foreman.dump_
-PGPASSWORD='_Candlepin_Password_' pg_restore -h _postgres.example.com_ -U candlepin -d candlepin < /var/_My_Migration_Backup_Directory_/candlepin.dump_
-PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d pulpcore < /var/_My_Migration_Backup_Directory_/pulpcore.dump_
+PGPASSWORD='_Foreman_Password_' pg_restore -h _postgres.example.com_ -U foreman -d foreman < /var/_My_Migration_Backup_Directory_/foreman.dump
+PGPASSWORD='_Candlepin_Password_' pg_restore -h _postgres.example.com_ -U candlepin -d candlepin < /var/_My_Migration_Backup_Directory_/candlepin.dump
+PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d pulpcore < /var/_My_Migration_Backup_Directory_/pulpcore.dump
 ----
 . Use the `{foreman-installer}` command to update {Project} to point to the new databases:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Remove unnecessary/confusing trailing underscore

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Users should only replace the name of the migration directory, but not the name of the PostgreSQL dumps -> file name sould not be italic.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
