### PR TITLE
Allow italic emphasis for host group CLI command

### DIFF
--- a/guides/common/modules/proc_creating-a-host-group.adoc
+++ b/guides/common/modules/proc_creating-a-host-group.adoc
@@ -33,8 +33,9 @@ To create a suitable Puppet environment to be associated with a host group, manu
 * Create the host group with the `hammer hostgroup create` command.
 For example:
 +
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer hostgroup create --name "Base" \
+$ hammer hostgroup create \
 --architecture "My_Architecture" \
 --content-source-id _My_Content_Source_ID_ \
 --content-view "_My_Content_View_" \
@@ -42,12 +43,13 @@ $ hammer hostgroup create --name "Base" \
 --lifecycle-environment "_My_Lifecycle_Environment_" \
 --locations "_My_Location_" \
 --medium-id _My_Installation_Medium_ID_ \
+--name "_My_Host_Group_" \
 --operatingsystem "_My_Operating_System_" \
 --organizations "_My_Organization_" \
 --partition-table "_My_Partition_Table_" \
 --puppet-ca-proxy-id _My_Puppet_CA_Proxy_ID_ \
 --puppet-environment "_My_Puppet_Environment_" \
 --puppet-proxy-id _My_Puppet_Proxy_ID_ \
---root-pass "My_Password" \
+--root-pass "_My_Password_" \
 --subnet "_My_Subnet_"
 ----


### PR DESCRIPTION
#### What changes are you introducing?

* Make example password italic
* Sort attributes in alphabetical order
* Use one option per line

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

currently, example values are not italic.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
