### PR TITLE
Avoid running katello-certs-check in most cases

### DIFF
--- a/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_configuring-remaining-smart-proxy-servers-with-custom-ssl-certificates.adoc
@@ -4,12 +4,6 @@
 On each load-balancing {SmartProxyServer}, excluding the {SmartProxyServer} configured to sign Puppet certificates, configure the system to use Puppet certificates.
 
 .Procedure
-. Append the following option to the `{certs-generate}` command that you obtain from the output of the `katello-certs-check` command:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
---foreman-proxy-cname _{loadbalancer-example-com}_
-----
 . On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -4,12 +4,6 @@
 On each {SmartProxyServer} you want to configure for load balancing, install Katello certificates.
 
 .Procedure
-. Append the following option to the `{certs-generate}` command that you obtain from the output of the `katello-certs-check` command:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
---foreman-proxy-cname _{loadbalancer-example-com}_
-----
 . On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -4,12 +4,6 @@
 On the {SmartProxyServer} that will generate Puppet certificates for all other load-balancing {SmartProxyServers}, configure Puppet certificate generation and signing.
 
 .Procedure
-. Append the following option to the `{certs-generate}` command that you obtain from the output of the `katello-certs-check` command:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
---foreman-proxy-cname _{loadbalancer-example-com}_
-----
 . On {ProjectServer}, enter the `{certs-generate}` command to generate {SmartProxy} certificates:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -85,7 +85,6 @@ DNS.2 = _{smartproxy-example-com}_
 <1> The certificate's common name must match the FQDN of {SmartProxyServer}.
 Ensure to change this when running the command on each {SmartProxyServer} that you configure for load balancing.
 You can also set a wildcard value `*`.
-If you set a wildcard value, you must add the `-t {certs-proxy-context}` option when you use the `katello-certs-check` command.
 <2> Under `[alt_names]`, include the FQDN of the load balancer as `DNS.1` and the FQDN of {SmartProxyServer} as `DNS.2`.
 endif::[]
 +
@@ -131,6 +130,9 @@ ifdef::load-balancing[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # katello-certs-check \
+ifeval::["{context}" == "{smart-proxy-context}"]
+-t {certs-proxy-context}
+endif::[]
 -c /root/{cert-name}_cert/{cert-name}_cert.pem \ <1>
 -k /root/{cert-name}_cert/{cert-name}_cert_key.pem \ <2>
 -b /root/{cert-name}_cert/ca_cert_bundle.pem <3>
@@ -138,8 +140,6 @@ ifdef::load-balancing[]
 <1> {SmartProxyServer} certificate file, provided by your Certificate Authority
 <2> {SmartProxyServer} private key that you used to sign the certificate
 <3> Certificate Authority bundle, provided by your Certificate Authority
-+
-If you set the `commonName=` to a wildcard value `*`, you must add the `-t {certs-proxy-context}` option to the `katello-certs-check` command.
 +
 Retain a copy of the example `{certs-generate}` command that is output by the `katello-certs-check` command for creating the Certificate Archive File for this {SmartProxyServer}.
 endif::[]

--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -125,21 +125,4 @@ The method for sending the certificate request varies, so consult the CA for the
 In response to the request, you can expect to receive a CA bundle and a signed certificate, in separate files.
 ifdef::load-balancing[]
 . Copy the Certificate Authority bundle and {SmartProxyServer} certificate file that you receive from the Certificate Authority, and {SmartProxyServer} private key to your {ProjectServer}.
-. On {ProjectServer}, validate {SmartProxyServer} certificate input files:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# katello-certs-check \
-ifeval::["{context}" == "{smart-proxy-context}"]
--t {certs-proxy-context}
-endif::[]
--c /root/{cert-name}_cert/{cert-name}_cert.pem \ <1>
--k /root/{cert-name}_cert/{cert-name}_cert_key.pem \ <2>
--b /root/{cert-name}_cert/ca_cert_bundle.pem <3>
-----
-<1> {SmartProxyServer} certificate file, provided by your Certificate Authority
-<2> {SmartProxyServer} private key that you used to sign the certificate
-<3> Certificate Authority bundle, provided by your Certificate Authority
-+
-Retain a copy of the example `{certs-generate}` command that is output by the `katello-certs-check` command for creating the Certificate Archive File for this {SmartProxyServer}.
 endif::[]

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-server.adoc
@@ -9,19 +9,7 @@ Refer to the {InstallingServerDocURL}configuring-{project-context}-server-with-a
 In return, you will receive the {ProjectServer} certificate and CA bundle.
 
 .Procedure
-* Before deploying a renewed custom certificate on your {ProjectServer}, validate the {customssl} input files.
-Note that for the `katello-certs-check` command to work correctly, Common Name (CN) in the certificate must match the FQDN of {ProjectServer}:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# katello-certs-check -t {project-context} \
--b /root/_{project-context}_cert/ca_cert_bundle.pem_ \
--c /root/_{project-context}_cert/{project-context}_cert.pem_ \
--k /root/_{project-context}_cert/{project-context}_cert_key.pem_
-----
-+
-If the command is successful, it returns the following `{foreman-installer}` command.
-You can use this command to deploy the renewed CA certificates to {ProjectServer}:
+* Deploy the renewed CA certificates to {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-ssl-certificate-on-smart-proxy.adoc
@@ -11,15 +11,6 @@ Refer to the {InstallingServerDocURL}configuring-{project-context}-server-with-a
 In return, you will receive the {SmartProxyServer} certificate and CA bundle.
 
 .Procedure
-. On your {ProjectServer}, validate the {customssl} certificate input files:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# katello-certs-check -t {smart-proxy-context} \
--b /root/_{smart-proxy-context}_cert/ca_cert_bundle.pem_ \
--c /root/_{smart-proxy-context}_cert/{smart-proxy-context}_cert.pem_ \
--k /root/_{smart-proxy-context}_cert/{smart-proxy-context}_cert_key.pem_
-----
 . On your {ProjectServer}, generate the certificate archive file for your {SmartProxyServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

We've been pushing users away from katello-certs-check now that it's always called by foreman-installer and foreman-proxy-certs-generate. This simplifies operation by having fewer steps which also simplifies documentation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's a further follow up of https://github.com/theforeman/foreman-documentation/commit/7394c6a882228c2c9405721c687fc117cfb9984f and https://issues.redhat.com/browse/SAT-3878 was the trigger to look at this.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.