### PR TITLE
Pluralize lifecycle environment

### DIFF
--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -72,7 +72,7 @@ endif::[]
 .Incorporating all strategies
 A particular package or repository is available to a host only if all of the following are true:
 
-* The repository is included in the host's content view and lifecycle environment.
+* The repository is included in the host's content view and lifecycle environment(s).
 * The host's content view has been published after the repository was added to it.
 * The repository has not been filtered out by a content view filter.
 * The repository is enabled by default or overridden to *Enabled* by using a content override.


### PR DESCRIPTION
#### What changes are you introducing?
Adding (s) to lifecycle environment to say lifecycle environment(s).

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Link to doc bug ticket: https://issues.redhat.com/browse/SAT-33205

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
