### PR TITLE
Align IdM rndc key handling

### DIFF
--- a/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_configuring-dynamic-dns-update-with-tsig-authentication.adoc
@@ -65,24 +65,16 @@ Enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# scp /etc/rndc.key root@_{foreman-example-com}_:/etc/rndc.key
+# scp /etc/rndc.key root@_{foreman-example-com}_:/etc/foreman-proxy/rndc.key
 ----
 
 . To set the correct ownership, permissions, and SELinux context for the `rndc.key` file, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# restorecon -v /etc/rndc.key
-# chown -v root:named /etc/rndc.key
-# chmod -v 640 /etc/rndc.key
-----
-
-.  Assign the `foreman-proxy` user to the `named` group manually.
-Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to the `named` UNIX group, however, in this scenario {Project} does not manage users and groups, therefore you need to assign the `foreman-proxy` user to the `named` group manually.
-+
-[options="nowrap"]
-----
-# usermod -a -G named foreman-proxy
+# restorecon -v /etc/foreman-proxy/rndc.key
+# chown -v root:foreman-proxy /etc/foreman-proxy/rndc.key
+# chmod -v 640 /etc/foreman-proxy/rndc.key
 ----
 
 . On {ProjectServer}, enter the following `{foreman-installer}` command to configure {Project} to use the external DNS server:
@@ -95,20 +87,10 @@ Normally, {foreman-installer} ensures that the `foreman-proxy` user belongs to t
 --foreman-proxy-dns-server="_IdM_Server_IP_Address_" \
 --foreman-proxy-dns-ttl=86400 \
 --foreman-proxy-dns=true \
---foreman-proxy-keyfile=/etc/rndc.key
+--foreman-proxy-keyfile=/etc/foreman-proxy/rndc.key
 ----
 
 .Testing external updates to the DNS zone in the IdM server
-
-. Ensure that the key in the `/etc/rndc.key` file on {ProjectServer} is the same key file that is used on the IdM server:
-+
-[source,none, options="nowrap" subs="+quotes,attributes"]
-----
-key "rndc-key" {
-        algorithm hmac-md5;
-        secret "_secret-key_==";
-};
-----
 
 . On {ProjectServer}, create a test DNS entry for a host.
 For example, host `_test.example.com_` with an A record of `192.168.25.20` on the IdM server at `192.168.25.1`.
@@ -117,7 +99,7 @@ For example, host `_test.example.com_` with an A record of `192.168.25.20` on th
 ----
 # echo -e "server 192.168.25.1\n \
 update add _test.example.com_ 3600 IN A 192.168.25.20\n \
-send\n" | nsupdate -k /etc/rndc.key
+send\n" | nsupdate -k /etc/foreman-proxy/rndc.key
 ----
 
 . On {ProjectServer}, test the DNS entry:
@@ -147,7 +129,7 @@ Click the name of the zone and search for the host by name.
 ----
 # echo -e "server 192.168.25.1\n \
 update delete _test.example.com_ 3600 IN A 192.168.25.20\n \
-send\n" | nsupdate -k /etc/rndc.key
+send\n" | nsupdate -k /etc/foreman-proxy/rndc.key
 ----
 
 . Confirm that the DNS entry was removed:


### PR DESCRIPTION
#### What changes are you introducing?

In 3630ab70abbe7a8c506401b044b22c3eca42950d the external DNS procedure was modified to simplify key handling. The procedure for setting up IdM DNS updates with TSIG authentication is, after setting up IdM, the exact same procedure. Now the steps use the same steps for the rndc key handling.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This came up while reviewing https://github.com/theforeman/foreman-documentation/pull/3530.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Merging this will create conflicts https://github.com/theforeman/foreman-documentation/pull/3530 and @mmuehlfeldRH may prefer to incorporate the changes in the new guide. In that case we can close this.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.