### PR TITLE
Add custom provisioning snippet for SLES

### DIFF
--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -80,6 +80,10 @@ endif::[]
 
 include::modules/ref_custom-provisioning-snippet-example-for-enterprise-linux.adoc[leveloffset=+1]
 
+ifndef::satellite[]
+include::modules/ref_custom-provisioning-snippet-example-for-sles.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_associating-templates-with-operating-systems.adoc[leveloffset=+1]
 
 include::modules/proc_creating-compute-profiles.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-templates-for-provisioning.adoc
+++ b/guides/common/assembly_preparing-templates-for-provisioning.adoc
@@ -16,6 +16,10 @@ endif::[]
 
 include::modules/ref_custom-provisioning-snippet-example-for-enterprise-linux.adoc[leveloffset=+1]
 
+ifndef::satellite[]
+include::modules/ref_custom-provisioning-snippet-example-for-sles.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_associating-templates-with-operating-systems.adoc[leveloffset=+1]
 
 include::modules/proc_creating-partition-tables.adoc[leveloffset=+1]

--- a/guides/common/modules/ref_custom-provisioning-snippet-example-for-sles.adoc
+++ b/guides/common/modules/ref_custom-provisioning-snippet-example-for-sles.adoc
@@ -1,0 +1,17 @@
+[id="custom-provisioning-snippet-example-for-sles"]
+= Custom provisioning snippet example for {SLES}
+
+You can use `Custom Post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
+
+.`AutoYaST default custom post` Example for {SLES}
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+echo "Calling API to report successful host deployment"
+
+{client-package-install-sles} -y curl ca-certificates
+
+curl -X POST \
+-H "Content-Type: application/json" \
+-d '{"name": "<%= @host.name %>", "operating_system": "<%= @host.operatingsystem.name %>", "status": "provisioned",}' \
+"https://api.example.com/"
+----


### PR DESCRIPTION
#### What changes are you introducing?

Add new example for custom provisioning snippets for SUSE family

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We only had examples for Debian and EL.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I have tested the installation command in a container.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
