### PR TITLE
Hide certain links for orcharhino

### DIFF
--- a/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
+++ b/guides/common/modules/con_configuring-project-with-external-idm-dns.adoc
@@ -25,6 +25,7 @@ To revert to internal DNS service, use the following procedure:
 You are not required to use {ProductName} to manage DNS.
 When you are using the realm enrollment feature of {Project}, where provisioned hosts are enrolled automatically to IdM, the `ipa-client-install` script creates DNS records for the client.
 Configuring {ProductName} with external IdM DNS and realm enrollment are mutually exclusive.
+ifndef::orcharhino[]
 For more information about configuring realm enrollment, see
 ifeval::["{context}" == "{project-context}"]
 ifeval::["{mode}" == "connected"]
@@ -36,4 +37,5 @@ endif::[]
 endif::[]
 ifeval::["{context}" == "{smart-proxy-context}"]
 {InstallingServerDocURL}configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm_{project-context}[Configuring {Project} to manage the lifecycle of a host registered to a {FreeIPA} realm] in _{InstallingServerDocTitle}_.
+endif::[]
 endif::[]

--- a/guides/common/modules/con_managing-dhcp-by-using-smartproxy.adoc
+++ b/guides/common/modules/con_managing-dhcp-by-using-smartproxy.adoc
@@ -9,7 +9,9 @@ Note that your {SmartProxy} cannot manage subnet declarations.
 .Available DHCP providers
 * `dhcp_infoblox` {endash} For more information, see xref:Using_Infoblox_as_DHCP_and_DNS_Providers_{smart-proxy-context}[].
 * `dhcp_isc` {endash} ISC DHCP server over OMAPI.
+ifndef::orcharhino[]
 For more information, see xref:configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[].
+endif::[]
 * `dhcp_remote_isc` {endash} ISC DHCP server over OMAPI with leases mounted through networking.
 For more information, see xref:configuring-external-dhcp_{smart-proxy-context}[].
 ifndef::satellite[]

--- a/guides/common/modules/con_ssl-authentication-overview.adoc
+++ b/guides/common/modules/con_ssl-authentication-overview.adoc
@@ -8,7 +8,12 @@ By default, {ProjectServer} uses a self-signed certificate.
 This certificate acts as both the server certificate to verify the encryption key and the certificate authority (CA) to trust the identity of {ProjectServer}.
 
 You can configure {ProjectServer} to use a custom SSL certificate.
+ifdef::orcharhino[]
+For more information, see xref:sources/installation_and_maintenance/using_custom_certificates.adoc[Using custom certificates].
+endif::[]
+ifndef::orcharhino[]
 For more information, see {InstallingServerDocURL}configuring-{project-context}-server-with-a-custom-ssl-certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDocTitle}_.
+endif::[]
 ifdef::satellite[]
 For more information on disconnected {ProjectServer}, see {InstallingServerDisconnectedDocURL}configuring-{project-context}-server-with-a-custom-ssl-certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]

--- a/guides/common/modules/proc_reverting-to-internal-dns-service.adoc
+++ b/guides/common/modules/proc_reverting-to-internal-dns-service.adoc
@@ -31,11 +31,13 @@ To configure {Project} or {SmartProxy} as DNS server without using an answer fil
 --foreman-proxy-dns=true
 ----
 +
+ifndef::orcharhino[]
 ifeval::["{context}" == "{smart-proxy-context}"]
 For more information, see xref:configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[].
 endif::[]
 ifeval::["{context}" == "{project-context}"]
 For more information, see {InstallingSmartProxyDocURL}configuring-dns-dhcp-and-tftp-on-productname_{smart-proxy-context}[Configuring DNS, DHCP, and TFTP on {SmartProxyServer}].
+endif::[]
 endif::[]
 
 After you run the `{foreman-installer}` command to make any changes to your {SmartProxy} configuration, you must update the configuration of each affected {SmartProxy} in the {ProjectWebUI}.


### PR DESCRIPTION
#### What changes are you introducing?

Hide various broken links for orcharhino builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

to fix them :)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* affects nightly to at least 3.12
* cherry-picked from a stable downstream-only branch

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
