### PR TITLE
Omit equal sign for bool options in foreman-installer/Hammer CLI

### DIFF
--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -16,6 +16,6 @@ To enable OSTree, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-content-enable-ostree=true
+# {foreman-installer} --foreman-proxy-content-enable-ostree true
 ----
 * If you want to use Hammer CLI, you must enable the `hammer-cli-katello` plugin on {ProjectServer}.

--- a/guides/common/modules/con_transport-modes-for-remote-execution.adoc
+++ b/guides/common/modules/con_transport-modes-for-remote-execution.adoc
@@ -28,7 +28,7 @@ If your {SmartProxy} already uses the `pull-mqtt` mode and you want to switch ba
 
 [options="nowrap",subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode=ssh
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode ssh
 ----
 ====
 

--- a/guides/common/modules/proc_configuring-a-bmc-interface.adoc
+++ b/guides/common/modules/proc_configuring-a-bmc-interface.adoc
@@ -17,8 +17,8 @@ You only need the MAC address for the BMC interface if the BMC interface is mana
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} \
---foreman-proxy-bmc-default-provider=ipmitool \
---foreman-proxy-bmc=true
+--foreman-proxy-bmc-default-provider ipmitool \
+--foreman-proxy-bmc true
 ----
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
 . Select the subnet of your host.

--- a/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
+++ b/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
@@ -29,7 +29,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-pam-service=foreman-prod
+# {foreman-installer} --foreman-pam-service foreman-prod
 ----
 
 .Verification
@@ -110,6 +110,6 @@ On {ProjectServer}, a {Project} administrator re-runs {foreman-installer} to loa
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-pam-service={project-context}-prod
+# {foreman-installer} --foreman-pam-service {project-context}-prod
 ----
 ====

--- a/guides/common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc
+++ b/guides/common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc
@@ -25,7 +25,7 @@ endif::[]
 +
 [options="nowrap" subs="quotes,attributes"]
 ----
-# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode=pull-mqtt
+# {foreman-installer} --foreman-proxy-plugin-remote-execution-script-mode pull-mqtt
 ----
 . Configure the firewall to allow the MQTT service on port 1883:
 +

--- a/guides/common/modules/proc_configuring-puma-threads.adoc
+++ b/guides/common/modules/proc_configuring-puma-threads.adoc
@@ -7,8 +7,8 @@ For example, we have compared these two setups:
 [width="100%",cols="50%,50%",options="header",]
 |===
 |{Project} VM with 8 CPUs, 40 GiB RAM |{Project} VM with 8 CPUs, 40 GiB RAM
-|`--foreman-foreman-service-puma-threads-max=16` |`--foreman-foreman-service-puma-threads-max=8`
-|`--foreman-foreman-service-puma-workers=2` |`--foreman-foreman-service-puma-workers=4`
+|`--foreman-foreman-service-puma-threads-max 16` |`--foreman-foreman-service-puma-threads-max 8`
+|`--foreman-foreman-service-puma-workers 2` |`--foreman-foreman-service-puma-workers 4`
 |===
 
 Using more workers and the same total number of threads results in about 11% of speedup in highly concurrent registrations scenario.

--- a/guides/common/modules/proc_configuring-puma-workers.adoc
+++ b/guides/common/modules/proc_configuring-puma-workers.adoc
@@ -8,8 +8,8 @@ For example, we have compared {Project} setups with 8 and 16 CPUs:
 [width="100%",cols="50%,50%",options="header",]
 |===
 |{Project} VM with 8 CPUs, 40 GiB RAM |{Project} VM with 16 CPUs, 40 GiB RAM
-|`--foreman-foreman-service-puma-threads-max=16` |`--foreman-foreman-service-puma-threads-max=16`
-|`--foreman-foreman-service-puma-workers={2\|4\|8\|16}` |`--foreman-foreman-service-puma-workers={2\|4\|8\|16}`
+|`--foreman-foreman-service-puma-threads-max 16` |`--foreman-foreman-service-puma-threads-max 16`
+|`--foreman-foreman-service-puma-workers {2\|4\|8\|16}` |`--foreman-foreman-service-puma-workers {2\|4\|8\|16}`
 |===
 
 In 8 CPUs setup, changing the number of workers from 2 to 16, improved concurrent registration time by 36%.

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -94,7 +94,7 @@ Without the option, AD users are unable to use `kinit` to authenticate to {Proje
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --foreman-ipa-authentication=true
+# {foreman-installer} --foreman-ipa-authentication true
 ----
 
 .Verification

--- a/guides/common/modules/proc_configuring-the-fallback-to-any-smartproxy-remote-execution-setting-in-project.adoc
+++ b/guides/common/modules/proc_configuring-the-fallback-to-any-smartproxy-remote-execution-setting-in-project.adoc
@@ -26,6 +26,6 @@ To set the value to `true`, enter the following command:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ hammer settings set \
---name=remote_execution_fallback_proxy \
---value=true
+--name remote_execution_fallback_proxy \
+--value true
 ----

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -13,15 +13,15 @@ Enable {FreeIPA} users to access {Project} by configuring {FreeIPA} as an authen
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} \
---foreman-ipa-authentication=true
+--foreman-ipa-authentication true
 ----
 * To enable access to the {ProjectWebUI} and the {Project} API, including Hammer CLI:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} \
---foreman-ipa-authentication-api=true \
---foreman-ipa-authentication=true
+--foreman-ipa-authentication-api true \
+--foreman-ipa-authentication true
 ----
 +
 [WARNING]

--- a/guides/common/modules/proc_configuring-the-global-smartproxy-remote-execution-setting-in-project.adoc
+++ b/guides/common/modules/proc_configuring-the-global-smartproxy-remote-execution-setting-in-project.adoc
@@ -19,6 +19,6 @@ To set the value to `true`, enter the following command:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ hammer settings set \
---name=remote_execution_global_proxy \
---value=true
+--name remote_execution_global_proxy \
+--value true
 ----

--- a/guides/common/modules/proc_executing-a-remote-job.adoc
+++ b/guides/common/modules/proc_executing-a-remote-job.adoc
@@ -76,8 +76,8 @@ You have the option to return to any part of the job wizard and edit the informa
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ hammer settings set \
---name=remote_execution_global_proxy \
---value=false
+--name remote_execution_global_proxy \
+--value false
 ----
 . Find the ID of the job template you want to use:
 +

--- a/guides/common/modules/proc_installing-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-server.adoc
@@ -10,15 +10,15 @@ ifdef::foreman-el,foreman-deb[]
 # {foreman-installer} \
 --enable-foreman-proxy \
 --enable-puppet \
---foreman-proxy-foreman-base-url=https://_{foreman-example-com}_ \
---foreman-proxy-oauth-consumer-key=_My_oAuth_Consumer_Key_ \
---foreman-proxy-oauth-consumer-secret=_My_oAuth_Consumer_Secret_ \
---foreman-proxy-puppetca=false \
---foreman-proxy-tftp=false \
---foreman-proxy-trusted-hosts=_{foreman-example-com}_ \
+--foreman-proxy-foreman-base-url https://_{foreman-example-com}_ \
+--foreman-proxy-oauth-consumer-key _My_oAuth_Consumer_Key_ \
+--foreman-proxy-oauth-consumer-secret _My_oAuth_Consumer_Secret_ \
+--foreman-proxy-puppetca false \
+--foreman-proxy-tftp false \
+--foreman-proxy-trusted-hosts _{foreman-example-com}_ \
 --no-enable-foreman \
 --no-enable-foreman-cli \
---puppet-server-ca=false
+--puppet-server-ca false
 ----
 endif::[]
 ifdef::katello[]

--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -45,7 +45,7 @@ ifndef::satellite,orcharhino[]
 # {foreman-installer} \
 --enable-foreman-plugin-discovery \
 --enable-foreman-proxy-plugin-discovery \
---foreman-proxy-plugin-discovery-install-images=true
+--foreman-proxy-plugin-discovery-install-images true
 ----
 +
 This command downloads the latest Discovery ISO.
@@ -53,7 +53,7 @@ If you require another version, add the following argument:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
---foreman-proxy-plugin-discovery-source-url=https://downloads.theforeman.org/discovery/releases/_x.y_/
+--foreman-proxy-plugin-discovery-source-url https://downloads.theforeman.org/discovery/releases/_x.y_/
 ----
 endif::[]
 ifdef::satellite,orcharhino[]
@@ -81,7 +81,7 @@ ifndef::satellite,orcharhino[]
 ----
 # {foreman-installer} \
 --enable-foreman-proxy-plugin-discovery \
---foreman-proxy-plugin-discovery-install-images=true
+--foreman-proxy-plugin-discovery-install-images true
 ----
 +
 This command downloads the latest Discovery image.
@@ -89,7 +89,7 @@ If you require another version, add the following argument:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
---foreman-proxy-plugin-discovery-source-url=https://downloads.theforeman.org/discovery/releases/_x.y_/
+--foreman-proxy-plugin-discovery-source-url https://downloads.theforeman.org/discovery/releases/_x.y_/
 ----
 endif::[]
 ifdef::satellite,orcharhino[]

--- a/guides/common/modules/proc_manually-tuning-puma-workers-and-threads-count.adoc
+++ b/guides/common/modules/proc_manually-tuning-puma-workers-and-threads-count.adoc
@@ -7,6 +7,6 @@ In the example below we are using 2 workers and 5 threads:
 [options="nowrap", subs="+attributes"]
 ----
 # {foreman-installer} \
---foreman-foreman-service-puma-workers=2 \
---foreman-foreman-service-puma-threads-max=5
+--foreman-foreman-service-puma-workers 2 \
+--foreman-foreman-service-puma-threads-max 5
 ----

--- a/guides/common/modules/proc_restoring-manual-changes-overwritten-by-a-puppet-run.adoc
+++ b/guides/common/modules/proc_restoring-manual-changes-overwritten-by-a-puppet-run.adoc
@@ -3,7 +3,7 @@
 
 If your manual configuration has been overwritten by a Puppet run, you can restore the files to the previous state.
 
-For example, when you install and configure {Project} for the first time by using `{foreman-installer}`, you can use the `--foreman-proxy-dns-managed=false` and `--foreman-proxy-dhcp-managed=false` options to specify that the DNS and DHCP configuration files are not to be managed by Puppet.
+For example, when you install and configure {Project} for the first time by using `{foreman-installer}`, you can use the `--foreman-proxy-dns-managed false` and `--foreman-proxy-dhcp-managed false` options to specify that the DNS and DHCP configuration files are not to be managed by Puppet.
 If you do not use these options during the initial `{foreman-installer}` run, rerunning `{foreman-installer}` overwrites all manual changes.
 The following example shows you how to restore a DHCP configuration file overwritten by a Puppet run.
 

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -12,8 +12,8 @@ include::snip_warning-maintain-config-noop.adoc[]
 [options="nowrap" subs="attributes"]
 ----
 # {foreman-installer} \
---foreman-proxy-dhcp-managed=false \
---foreman-proxy-dns-managed=false
+--foreman-proxy-dhcp-managed false \
+--foreman-proxy-dns-managed false
 ----
 +
 This prevents the upgrade process from overwriting your DNS and DHCP configuration.

--- a/guides/common/modules/proc_upgrading-your-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-your-project-server.adoc
@@ -11,8 +11,8 @@ include::snip_warning-maintain-config-noop.adoc[]
 [options="nowrap" subs="attributes"]
 ----
 # {foreman-installer} \
---foreman-proxy-dhcp-managed=false \
---foreman-proxy-dns-managed=false
+--foreman-proxy-dhcp-managed false \
+--foreman-proxy-dns-managed false
 ----
 +
 This prevents the upgrade process from overwriting your DNS and DHCP configuration.

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -59,7 +59,7 @@ Any host that is directly connected to {ProjectServer} is a client in this conte
 This includes the base operating system on which a {SmartProxyServer} is running.
 
 A DHCP {SmartProxy} performs ICMP ping or TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
-This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
+This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip false`.
 
 [NOTE]
 ====

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -61,7 +61,7 @@ Any host that is directly connected to {ProjectServer} is a client in this conte
 This includes the base operating system on which a {SmartProxyServer} is running.
 
 A DHCP {SmartProxy} performs ICMP ping and TCP echo connection attempts to hosts in subnets with DHCP IPAM set to find out if an IP address considered for use is free.
-This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip=false`.
+This behavior can be turned off using `{foreman-installer} --foreman-proxy-dhcp-ping-free-ip false`.
 
 .{SmartProxy} outgoing traffic
 [cols="15%,15%,15%,15%,20%,20%",options="header"]


### PR DESCRIPTION
#### What changes are you introducing?

Use whitespace in favor of equal sign for `foreman-installer` and `hammer` commands for `true` and `false`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

fixes #2881

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I do not have a regexp at hand right now to find _all_ instances, so I am limiting this PR to boolean options.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
