### PR TITLE
Removing obsolete RHEL conversion doc

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -40,7 +40,6 @@
 
 // Not upstreamed
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#
-:ConversionsToolkitDocURL: {BaseURL}converting_hosts_to_rhel_by_using_satellite_conversions_toolkit/index#
 
 // Overrides for satellite build
 :ansible-collection-package: ansible-collection-redhat-satellite

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -34,9 +34,6 @@
 :UpgradingPreviousDocTitle: Upgrading connected {ProjectName} to {ProjectVersionPrevious}
 :UpgradingDisconnectedPreviousDocTitle: Upgrading disconnected {ProjectName} to {ProjectVersionPrevious}
 
-// Not upstreamed
-:ConversionsToolkitDocTitle: Converting hosts to RHEL by using Satellite conversions toolkit
-
 // Overrides for titles per product
 
 ifdef::katello[]


### PR DESCRIPTION
#### What changes are you introducing?

Removing D/S RHEL conversion toolkit doc, which was last published for Sat 6.15.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
