### PR TITLE
Reword the step to reboot

### DIFF
--- a/guides/common/modules/snip_steps-needs-reboot.adoc
+++ b/guides/common/modules/snip_steps-needs-reboot.adoc
@@ -18,7 +18,7 @@ ifndef::foreman-deb[]
 endif::[]
 endif::[]
 ifdef::satellite[]
-. Reboot the system:
+. If the {foreman-maintain} command told you to reboot, then reboot the system:
 endif::[]
 +
 [options="nowrap"]

--- a/guides/common/modules/snip_steps-needs-reboot.adoc
+++ b/guides/common/modules/snip_steps-needs-reboot.adoc
@@ -18,7 +18,7 @@ ifndef::foreman-deb[]
 endif::[]
 endif::[]
 ifdef::satellite[]
-. If the previous command told you to reboot, then reboot the system:
+. Reboot the system:
 endif::[]
 +
 [options="nowrap"]


### PR DESCRIPTION
The step for rebooting for Satellite build, currently reads "If the previous command told you to reboot, then reboot the system". This does not make sense for Satellite as the command to determine whether a reboot is required is only rendered for non-Satellite builds.

JIRA: https://issues.redhat.com/browse/SAT-33361

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
