### PR TITLE
Remove Foreman on AWS from navigation

### DIFF
--- a/web/releases/3.14.json
+++ b/web/releases/3.14.json
@@ -127,10 +127,6 @@
           "path": "Managing_Content"
         },
         {
-          "title": "Deploying Foreman on AWS",
-          "path": "Deploying_Project_on_AWS"
-        },
-        {
           "title": "Provisioning hosts",
           "path": "Provisioning_Hosts"
         },

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -31,10 +31,6 @@
           "path": "Configuring_User_Authentication"
         },
         {
-          "title": "Deploying Foreman on AWS",
-          "path": "Deploying_Project_on_AWS"
-        },
-        {
           "title": "Provisioning hosts",
           "path": "Provisioning_Hosts"
         },
@@ -103,10 +99,6 @@
         {
           "title": "Configuring user authentication",
           "path": "Configuring_User_Authentication"
-        },
-        {
-          "title": "Deploying Foreman on AWS",
-          "path": "Deploying_Project_on_AWS"
         },
         {
           "title": "Provisioning hosts",
@@ -189,10 +181,6 @@
         {
           "title": "Managing content",
           "path": "Managing_Content"
-        },
-        {
-          "title": "Deploying Foreman on AWS",
-          "path": "Deploying_Project_on_AWS"
         },
         {
           "title": "Provisioning hosts",


### PR DESCRIPTION
#### What changes are you introducing?

Drop unmaintained guide from navigation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Refs da81664d2ee91df36a8ac83173a53f02662973f4 on "3.14" Refs b0dd9eb8a8f32c35230f2b970f8ff61a5e81d5b7 on "master"

Refs PR 3815 on GitHub

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
