### PR TITLE
Bump orcharhino version to 7.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Please cherry-pick my commits into:
 
 * [ ] Foreman 3.14/Katello 4.16
 * [ ] Foreman 3.13/Katello 4.15 (EL9 only)
-* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
+* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
 * [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
 * [ ] Foreman 3.10/Katello 4.12
 * [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,8 +1,8 @@
 // Overrides for orcharhino build
 :BaseURL: https://docs.orcharhino.com/
-:ProjectVersion: 7.1
-:ProjectVersionPrevious: 7.0
-:ProjectVersionPrevious-Previous: 6.11
+:ProjectVersion: 7.2
+:ProjectVersionPrevious: 7.1
+:ProjectVersionPrevious-Previous: 7.0
 :Project: orcharhino
 :project-allcaps: ORCHARHINO
 :project-context: {Project}


### PR DESCRIPTION
orcharhino 7.2 has been released: https://orcharhino.com/en/ressourcen/release-notes/orcharhino-7-2/ :tada: 