### PR TITLE
Add "Configuring DNS, DHCP, and TFTP integration" title to 3.14 and nightly

### DIFF
--- a/web/releases/3.14.json
+++ b/web/releases/3.14.json
@@ -19,6 +19,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Configuring DNS, DHCP, and TFTP integration",
+          "path": "Configuring_DNS_DHCP_TFTP"
+        },
+        {
           "title": "Configuring user authentication",
           "path": "Configuring_User_Authentication"
         },
@@ -55,6 +59,10 @@
         {
           "title": "Upgrading Foreman to 3.14",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Configuring DNS, DHCP, and TFTP integration",
+          "path": "Configuring_DNS_DHCP_TFTP"
         },
         {
           "title": "Configuring user authentication",
@@ -105,6 +113,10 @@
         {
           "title": "Upgrading Katello to 4.16",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Configuring DNS, DHCP, and TFTP integration",
+          "path": "Configuring_DNS_DHCP_TFTP"
         },
         {
           "title": "Configuring user authentication",

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -27,6 +27,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Configuring DNS, DHCP, and TFTP integration",
+          "path": "Configuring_DNS_DHCP_TFTP"
+        },
+        {
           "title": "Configuring user authentication",
           "path": "Configuring_User_Authentication"
         },
@@ -101,6 +105,10 @@
           "path": "Upgrading_Project"
         },
         {
+          "title": "Configuring DNS, DHCP, and TFTP integration",
+          "path": "Configuring_DNS_DHCP_TFTP"
+        },
+        {
           "title": "Configuring user authentication",
           "path": "Configuring_User_Authentication"
         },
@@ -169,6 +177,10 @@
         {
           "title": "Upgrading Katello to Nightly",
           "path": "Upgrading_Project"
+        },
+        {
+          "title": "Configuring DNS, DHCP, and TFTP integration",
+          "path": "Configuring_DNS_DHCP_TFTP"
         },
         {
           "title": "Configuring user authentication",


### PR DESCRIPTION
#### What changes are you introducing?

Add "Configuring DNS, DHCP, and TFTP integration" guide to navigation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Content was moved from other guides to this new guide.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)


#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
