### PR TITLE
Treat unused modules as errors

### DIFF
--- a/guides/scripts/find_unused_modules
+++ b/guides/scripts/find_unused_modules
@@ -44,7 +44,8 @@ if unused.any?
   puts unused
   if ENV.key?('GITHUB_ACTIONS')
     unused.each do |file|
-      puts "::warning file=#{file}::File is unused"
+      puts "::error file=#{file}::File is unused"
     end
   end
+  exit(1)
 end


### PR DESCRIPTION
#### What changes are you introducing?

Treating it as errors means CI will fail on it and make it clear there's something to act on.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/3790#discussion_r2046832997 I asked if it should be an error. Since then the warnings have been resolved and we can make it fatal.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.