### PR TITLE
Add container content note to load balancing guide

### DIFF
--- a/guides/common/modules/con_registering-clients-to-the-load-balancer.adoc
+++ b/guides/common/modules/con_registering-clients-to-the-load-balancer.adoc
@@ -3,6 +3,9 @@
 
 To balance the load of network traffic from clients, you must register the clients to the load balancer.
 
+To consume container content from a load balancer regardless of client registration, use the load balancer hostname with the container client of choice.
+For example, use `podman login {loadbalancer-example-com}` to log in.
+
 ifdef::orcharhino,satellite[]
 To register clients, proceed with one of the following procedures:
 


### PR DESCRIPTION
#### What changes are you introducing?
Adds a note about how to consume container content to the registration part of the load balancing guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://github.com/Katello/smart_proxy_container_gateway/pull/46 added container support for load balancers, so this adds a small note about how to consume the content.

The fact that you use the LB hostname should be obvious I'd think, but I'm adding this for completion.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
