### PR TITLE
Add workaround for IPA and AD Kerberos auth

### DIFF
--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -81,7 +81,7 @@ endif::[]
 lookup_family_order = ipv6_only
 ----
 +
-When the DNS name of the AD server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
+If the DNS name of the AD server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
 Without the option, AD users are unable to use `kinit` to authenticate to {Project}.
 .. Restart SSSD:
 +

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -59,8 +59,9 @@ security = ads
 ----
 # KRB5_KTNAME=FILE:/etc/httpd/conf/http.keytab net ads keytab add HTTP -U Administrator -s /etc/samba/smb.conf
 ----
-. Configure the System Security Services Daemon (SSSD) to use the AD access control provider to evaluate and enforce Group Policy Object (GPO) access control rules for the `foreman` PAM service:
-.. In the `[domain/_ad.example.com_]` section of your `/etc/sssd/sssd.conf` file, configure the `ad_gpo_access_control` and `ad_gpo_map_service` options as follows:
+. Configure the System Security Services Daemon (SSSD) on your {ProjectServer}:
+.. Configure the AD access control provider to evaluate and enforce Group Policy Object (GPO) access control rules for the `foreman` PAM service.
+In the `[domain/_ad.example.com_]` section of your `/etc/sssd/sssd.conf` file, set the `ad_gpo_access_control` and `ad_gpo_map_service` options as follows:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -73,6 +73,16 @@ ifndef::orcharhino[]
 +
 For more information on GPOs, see {RHELDocsBaseURL}9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}9)_.
 endif::[]
+.. If your {ProjectServer} is running in an IPV6-only network, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
++
+[source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[domain/_ad.example.com_]
+lookup_family_order = ipv6_only
+----
++
+When the DNS name of the AD server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
+Without the option, AD users are unable to use `kinit` to authenticate to {Project}.
 .. Restart SSSD:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -7,6 +7,7 @@ Enable {FreeIPA} users to access {Project} by configuring {FreeIPA} as an authen
 * {ProjectServer} running on a system that is enrolled in the {FreeIPA} domain.
 
 .Procedure
+. Enable access for your preferred login method:
 * To enable access to the {ProjectWebUI} only:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -45,7 +45,7 @@ For example, to disable access to the {Project} API and Hammer CLI:
 lookup_family_order = ipv6_only
 ----
 +
-When the DNS name of the IdM server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
+If the DNS name of the IdM server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
 Without the option, IdM users are unable to use `kinit` to authenticate to {Project}.
 
 .Verification

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -37,6 +37,16 @@ For example, to disable access to the {Project} API and Hammer CLI:
 ----
 # {foreman-installer} --reset-foreman-ipa-authentication-api
 ----
+. If your {ProjectServer} is running in an IPV6-only network, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
++
+[source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[domain/_{freeipaserver-example-com}_]
+lookup_family_order = ipv6_only
+----
++
+When the DNS name of the IdM server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
+Without the option, IdM users are unable to use `kinit` to authenticate to {Project}.
 
 .Verification
 * Log in to {ProjectWebUI} by entering the credentials of a user defined in {FreeIPA}.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a step to configure SSSD to enable Kerberos authentication for IPA and AD users. To be able to fit the new step in neatly, I also tweaked the procedures a little.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-32530 explains the problem and includes a description of the known issue.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is caused by a bug on the SSSD side. The SSSD issue: https://github.com/SSSD/sssd/issues/3057. The bug has been fixed in SSSD but the updated version of SSSD is not yet available for Foreman.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
