### PR TITLE
Reword external Smart Proxies to Smart Proxy Servers

### DIFF
--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -3,7 +3,7 @@ ifdef::context[:parent-context: {context}]
 [id="configuring-capsule-custom-server-certificate_{context}"]
 = Configuring {SmartProxyServer} with a custom SSL certificate
 
-If you configure {ProjectServer} to use a custom SSL certificate, you must also configure each of your external {SmartProxyServers} with a distinct custom SSL certificate.
+If you configure {ProjectServer} to use a custom SSL certificate, you must also configure each of your {SmartProxyServers} with a distinct custom SSL certificate.
 
 To configure your {SmartProxyServer} with a custom certificate, complete the following procedures on each {SmartProxyServer}:
 

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -29,8 +29,8 @@ endif::[]
 // Installing {SmartProxyServer} Packages
 include::modules/proc_installing-capsule-server-packages.adoc[leveloffset=+1]
 
-ifndef::satellite[]
-include::modules/proc_installing-smart-proxy-upstream.adoc[leveloffset=+1]
+ifdef::foreman-el,foreman-deb,katello[]
+include::modules/proc_installing-smart-proxy-server.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello,satellite[]
@@ -39,12 +39,12 @@ ifdef::katello,satellite[]
 endif::[]
 
 ifdef::katello,satellite[]
-{ProjectName} uses SSL certificates to enable encrypted communications between {ProjectServer}, external {SmartProxyServers}, and all hosts.
+{ProjectName} uses SSL certificates to enable encrypted communications between {ProjectServer}, {SmartProxyServers}, and all hosts.
 Depending on the requirements of your organization, you must configure your {SmartProxyServer} with a default or custom certificate.
 
-* If you use a default SSL certificate, you must also configure each external {SmartProxyServer} with a distinct default SSL certificate.
+* If you use a default SSL certificate, you must also configure each {SmartProxyServer} with a distinct default SSL certificate.
 For more information, see xref:configuring-capsule-default-certificate_{smart-proxy-context}[].
-* If you use a custom SSL certificate, you must also configure each external {SmartProxyServer} with a distinct custom SSL certificate.
+* If you use a custom SSL certificate, you must also configure each {SmartProxyServer} with a distinct custom SSL certificate.
 For more information, see xref:configuring-capsule-custom-server-certificate_{smart-proxy-context}[].
 
 // Configuring {SmartProxyServer} Using the Default Certificate

--- a/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -7,7 +7,7 @@ As well as providing access to {ProjectServer}, hosts provisioned with {Project}
 Use this section to configure {ProjectServer} or {SmartProxyServer} for {FreeIPA} realm support, then add hosts to the {FreeIPA} realm group.
 
 .Prerequisites
-* {ProjectServer} that is registered to the Content Delivery Network or an external {SmartProxyServer} that is registered to {ProjectServer}.
+* {ProjectServer} that is registered to the Content Delivery Network or your {SmartProxyServer} that is registered to {ProjectServer}.
 * A deployed realm or domain provider such as {FreeIPA}.
 
 .To install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}:
@@ -89,7 +89,7 @@ You can also use these options when you first configure the {ProjectServer}.
 
 .To create a realm for the {FreeIPA}-enabled {SmartProxy}
 
-After you configure your integrated or external {SmartProxy} with {FreeIPA}, you must create a realm and add the {FreeIPA}-configured {SmartProxy} to the realm.
+After you configure your {SmartProxy} with {FreeIPA}, you must create a realm and add the {FreeIPA}-configured {SmartProxy} to the realm.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Realms* and click *Create Realm*.

--- a/guides/common/modules/con_preparing-networking.adoc
+++ b/guides/common/modules/con_preparing-networking.adoc
@@ -2,14 +2,13 @@
 = Preparing networking
 
 Each provisioning type requires some network configuration.
-Use this chapter to configure network services in your integrated {SmartProxy} on {ProjectServer}.
+Use this chapter to configure network services on your {SmartProxies}.
 
-New hosts must have access to your {SmartProxyServer}.
-{SmartProxyServer} can be either your integrated {SmartProxy} on {ProjectServer} or an external {SmartProxyServer}.
-You might want to provision hosts from an external {SmartProxyServer} when the hosts are on isolated networks and cannot connect to {ProjectServer} directly, or when the content is synchronized with {SmartProxyServer}.
+New hosts must have access to either your {ProjectServer} or any {SmartProxyServer}.
+If your hosts are on isolated networks and cannot connect to {ProjectServer} directly, you must provision your hosts from {SmartProxyServers}.
 Provisioning by using {SmartProxyServers} can save on network bandwidth.
 
-Configuring {SmartProxyServer} has two basic requirements:
+Configuring {SmartProxies} has two basic requirements:
 
 . Configuring network services.
 This includes:
@@ -18,7 +17,7 @@ This includes:
 ** Puppet configuration
 . Defining network resource data in {ProjectServer} to help configure network interfaces on new hosts.
 
-The following instructions have similar applications to configuring standalone {SmartProxies} managing a specific network.
+The following instructions have similar applications to configuring {SmartProxyServers} managing a specific network.
 ifndef::orcharhino[]
 To configure {Project} to use external DHCP, DNS, and TFTP services, see {InstallingServerDocURL}configuring-external-services[Configuring External Services] in _{InstallingServerDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_prerequisites-for-image-based-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-image-based-provisioning.adoc
@@ -2,7 +2,7 @@
 = Prerequisites for image-based provisioning
 
 .Post-boot configuration method
-Images that use the `finish` post-boot configuration scripts require a managed DHCP server, such as {Project}'s integrated {SmartProxy} or an external {SmartProxy}.
+Images that use the `finish` post-boot configuration scripts require a managed DHCP server, for example, your {ProjectServer} or {SmartProxyServers}.
 The host must be created with a subnet associated with a DHCP {SmartProxy}, and the IP address of the host must be a valid IP address from the DHCP range.
 
 It is possible to use an external DHCP service, but IP addresses must be entered manually.

--- a/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
@@ -3,9 +3,9 @@
 
 The Proxmox provisioning process provides the option to create hosts over a network connection or using an existing image.
 
-For network-based provisioning, you must create a host to access either integrated {SmartProxy} or an external {SmartProxyServer} on a Proxmox virtual network, so that the host has access to PXE provisioning services.
+For network-based provisioning, you must create a host to access either {ProjectServer} or {SmartProxyServers} on a Proxmox virtual network, so that the host has access to PXE provisioning services.
 The new host entry triggers the Proxmox node to create the virtual machine.
-If the virtual machine detects the defined {SmartProxyServer} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
+If the virtual machine detects the defined {SmartProxy} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
 
 .DHCP conflicts
 If you use a virtual network on the Proxmox node for provisioning, ensure that you select a virtual network that does not provide DHCP assignments.

--- a/guides/common/modules/proc_creating-hosts-on-vmware.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-vmware.adoc
@@ -3,9 +3,9 @@
 
 The VMware vSphere provisioning process provides the option to create hosts over a network connection or using an existing image.
 
-For network-based provisioning, you must create a host to access either {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} on a VMware vSphere virtual network, so that the host has access to PXE provisioning services.
+For network-based provisioning, you must create a host to access either {ProjectServer} or {SmartProxyServers} on a VMware vSphere virtual network, so that the host has access to PXE provisioning services.
 The new host entry triggers the VMware vSphere server to create the virtual machine.
-If the virtual machine detects the defined {SmartProxyServer} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
+If the virtual machine detects the defined {SmartProxy} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
 
 .DHCP conflicts
 If you use a virtual network on the VMware vSphere server for provisioning, ensure that you select a virtual network that does not provide DHCP assignments.

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts.adoc
@@ -3,7 +3,7 @@
 
 In {Project}, you can use {CRname} provisioning to create hosts over a network connection or from an existing image:
 
-* If you want to create a host over a network connection, the new host must be able to access either {ProjectServer}'s integrated {SmartProxy} or an external {SmartProxyServer} on a {CRname} virtual network, so that the host has access to PXE provisioning services.
+* If you want to create a host over a network connection, the new host must be able to access your {ProjectServer} or {SmartProxyServers} on a {CRname} virtual network, so that the host has access to PXE provisioning services.
 This new host entry triggers the {CRname} server to create and start a virtual machine.
 If the virtual machine detects the defined {SmartProxyServer} through the virtual network, the virtual machine boots to PXE and begins to install the chosen operating system.
 

--- a/guides/common/modules/proc_installing-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_installing-smart-proxy-server.adoc
@@ -1,4 +1,4 @@
-[id="installing-an-external-smart-proxy-upstream_{context}"]
+[id="installing-a-smart-proxy-server"]
 = Installing {SmartProxyServer}
 
 .Procedure

--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -46,7 +46,7 @@ To create a suitable Puppet environment to be associated with a host group, foll
 ----
 . In the {ProjectWebUI}, navigate to *Configure* > *Puppet ENC* > *Environments*.
 . Click *Import environment from*.
-The button name includes the FQDN of your {ProjectServer} and {SmartProxyServers}.
+. Select your {SmartProxy}.
 . Choose the created directory and click *Update*.
 
 .Procedure

--- a/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
+++ b/guides/common/modules/proc_registering-hosts-by-using-the-bootstrap-script.adoc
@@ -46,7 +46,7 @@ To create a suitable Puppet environment to be associated with a host group, foll
 ----
 . In the {ProjectWebUI}, navigate to *Configure* > *Puppet ENC* > *Environments*.
 . Click *Import environment from*.
-The button name includes the FQDN of the internal or external {SmartProxy}.
+The button name includes the FQDN of your {ProjectServer} and {SmartProxyServers}.
 . Choose the created directory and click *Update*.
 
 .Procedure

--- a/guides/common/modules/proc_troubleshooting-dhcp-problems.adoc
+++ b/guides/common/modules/proc_troubleshooting-dhcp-problems.adoc
@@ -1,7 +1,7 @@
 [id="troubleshooting-dhcp-problems"]
 = Troubleshooting DHCP problems
 
-{Project} can manage an ISC DHCP server on internal or external DHCP {SmartProxy}.
+{Project} can manage an ISC DHCP server on {ProjectServer} or {SmartProxyServers}.
 {Project} can list, create, and delete DHCP reservations and leases.
 However, there are a number of problems that you might encounter on occasions.
 

--- a/guides/common/modules/proc_troubleshooting-dhcp-problems.adoc
+++ b/guides/common/modules/proc_troubleshooting-dhcp-problems.adoc
@@ -3,7 +3,7 @@
 
 {Project} can manage an ISC DHCP server on {ProjectServer} or {SmartProxyServers}.
 {Project} can list, create, and delete DHCP reservations and leases.
-However, there are a number of problems that you might encounter on occasions.
+However, there are several problems that you might encounter on occasions.
 
 .Out of sync DHCP records
 When an error occurs during DHCP orchestration, DHCP records in the {Project} database and the DHCP server might not match.

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -49,7 +49,7 @@ ifdef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | Content Host registration | Deprecated and only needed for Client hosts deployed before upgrades
 endif::[]
 | {smartproxy_port} | TCP | HTTPS | {ProjectName} | {SmartProxy} API | {SmartProxy} functionality
-| {smartproxy_port} | TCP | HTTPS | Client | Register Endpoint | Client registration with an external {SmartProxyServer}
+| {smartproxy_port} | TCP | HTTPS | Client | Register Endpoint | Client registration with {SmartProxyServers}
 | {smartproxy_port} | TCP | HTTPS | Client | OpenSCAP | Configure Client (if the OpenSCAP plugin is installed)
 | {smartproxy_port} | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning (if the discovery plugin is installed)
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/ref_smart-proxy-server-scalability-considerations-when-managing-puppet-clients.adoc
+++ b/guides/common/modules/ref_smart-proxy-server-scalability-considerations-when-managing-puppet-clients.adoc
@@ -10,8 +10,8 @@ Depending on the number of Puppet clients required, the {Project} installation c
 
 If you want to scale your {SmartProxyServer} when managing Puppet clients, the following assumptions are made:
 
-* There are no external Puppet clients reporting directly to the {Project} integrated {SmartProxy}.
-* All other Puppet clients report directly to an external {SmartProxy}.
+* There are no external Puppet clients reporting directly to your {ProjectServer}.
+* All other Puppet clients report directly to {SmartProxyServers}.
 * There is an evenly distributed run-interval of all Puppet agents.
 
 [NOTE]


### PR DESCRIPTION
#### What changes are you introducing?

Use proper attribute for Smart Proxies and Smart Proxy Servers.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

fixes #2774

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
