### PR TITLE
Add disaster recovery guide to 3.13

### DIFF
--- a/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,0 +1,9 @@
+include::modules/con_disaster-recovery-by-virtualizing-your-projectserver.adoc[]
+
+include::modules/ref_prerequisites-disaster-recovery-by-virtualizing-your-projectserver.adoc[leveloffset=+1]
+
+include::modules/proc_preparing-for-disaster-recovery-by-virtualizing-your-projectserver.adoc[leveloffset=+1]
+
+include::modules/proc_recovering-from-disaster-by-restoring-a-vm-snapshot-of-projectserver.adoc[leveloffset=+1]
+
+include::modules/proc_retrieving-status-of-services.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
@@ -1,0 +1,9 @@
+include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc[]
+
+include::modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-external-storage.adoc[leveloffset=+1]
+
+include::modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc[leveloffset=+1]
+
+include::modules/proc_recovering-from-disaster-with-active-and-passive-project-server-with-external-storage.adoc[leveloffset=+1]
+
+include::modules/proc_retrieving-status-of-services.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,11 @@
+include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc[]
+
+include::modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+
+include::modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+
+include::modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+
+include::modules/proc_retrieving-status-of-services.adoc[leveloffset=+1]
+
+include::modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,7 @@
+include::modules/con_disaster-recovery-with-two-active-project-servers.adoc[]
+
+include::modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]
+
+include::modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]
+
+include::modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -1,0 +1,23 @@
+include::modules/con_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[]
+
+include::modules/con_overview-of-recommended-disaster-recovery-plans.adoc[leveloffset=+1]
+
+:parent-context: {context}
+:context: dr-virt
+include::assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc[leveloffset=+1]
+:context: {parent-context}
+:!parent-context:
+
+:parent-context: {context}
+:context: dr-storage
+include::assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc[leveloffset=+1]
+:context: {parent-context}
+:!parent-context:
+
+:parent-context: {context}
+:context: dr-backup-restore
+include::assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]
+:context: {parent-context}
+:!parent-context:
+
+include::assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]

--- a/guides/common/modules/con_disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/modules/con_disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,0 +1,10 @@
+[id="disaster-recovery-by-virtualizing-your-{project-context}-server"]
+= Disaster recovery by virtualizing your {ProjectServer}
+
+If you virtualize your {ProjectServer} and ensure that you take regular snapshots of the virtual machine (VM), you can respond to various disaster scenarios by restoring your {Project} deployment from one of your snapshots.
+
+[NOTE]
+====
+The details for how to implement this scenario depend on your choice of a virtualization platform.
+Due to the variety of different hypervisors and their capabilities, {Team} does not provide detailed instructions for any specific virtualization platform.
+====

--- a/guides/common/modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc
+++ b/guides/common/modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc
@@ -1,0 +1,6 @@
+[id="disaster-recovery-for-active-and-passive-{project-context}-server-with-backup-and-restore"]
+= Disaster recovery for active and passive {ProjectServer} with backup and restore
+
+To prepare for disaster recovery, you can configure two {ProjectServer}s: an active primary server and a passive secondary server.
+You configure periodic backups of the primary server.
+If the primary server fails, you can restore a backup on the secondary server to turn it into your new primary server.

--- a/guides/common/modules/con_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/modules/con_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
@@ -1,0 +1,6 @@
+[id="disaster-recovery-for-active-and-passive-{project-context}-server-with-external-storage"]
+= Disaster recovery for active and passive {ProjectServer} with external storage
+
+To prepare for disaster recovery, you can configure two {ProjectServer}s and store critical data externally on shared storage.
+The primary server is active while the secondary server remains passive.
+If the primary server fails, the shared storage is attached to your secondary server, which turns the secondary server into your new primary server.

--- a/guides/common/modules/con_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/con_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,5 @@
+[id="disaster-recovery-with-two-active-{project-context}-servers"]
+= Disaster recovery with two active {ProjectServer}s
+
+To prepare for disaster recovery, you can configure two {ProjectServer}s and operate each server in a different data center.
+If one of the servers fails, you can re-register all hosts from the failed server to the other server.

--- a/guides/common/modules/con_overview-of-recommended-disaster-recovery-plans.adoc
+++ b/guides/common/modules/con_overview-of-recommended-disaster-recovery-plans.adoc
@@ -1,0 +1,75 @@
+[id="overview-of-recommended-disaster-recovery-plans"]
+= Overview of recommended disaster recovery plans
+
+Choose a disaster recovery plan that best helps ensure the continuity of {Project} services in your deployment.
+
+Snapshots of virtualized {ProjectServer}::
+How do I back up?:::
+Virtualize your {ProjectServer} and use the hypervisor tools to take virtual machine snapshots of the server.
+This method is suitable if you can run {Project} in a virtual machine.
+How will I recover in case of a disruptive event?:::
+To recover {Project} services, restore a virtual machine snapshot.
+Disadvantages and expected impact:::
+Expect some amount of data inconsistency after recovery, based on how old your last snapshot is.
+You will lose data changes that have occurred since the snapshot you are using to recover was taken.
+
+Active and passive {ProjectServer}, with external storage::
+How do I back up?:::
+Store the following critical data on network attached storage:
+ifdef::katello,orcharhino,satellite[]
+content in `/var/lib/pulp` and database in `/var/lib/pgsql`.
+endif::[]
+ifdef::foreman-el,foreman-deb[]
+database in `/var/lib/pgsql`.
+endif::[]
+Replicate this storage into a different data center.
+Attach the storage to a {ProjectServer} that is a clone of the primary {ProjectServer} but runs passively.
+How will I recover in case of a disruptive event?:::
+To recover {Project} services, switch DNS records of the active {ProjectServer} with the passive {ProjectServer}.
+This ensures that the passive server becomes the active server.
+All hosts remain connected without configuration updates.
+Disadvantages and expected impact:::
+If the network attached storage is replicated to another location, expect some amount of data inconsistency after recovery based on the synchronization interval.
+
+Active and passive {ProjectServer}, with backup and restore::
+How do I back up?:::
+Ensure periodic backups of your {ProjectServer}.
+Copy this backup to a passive {ProjectServer} and restore it on the passive server.
+How will I recover in case of a disruptive event?:::
+To recover {Project} services, switch DNS records of the active {ProjectServer} with the passive {ProjectServer}.
+This ensures that the passive server becomes the active server.
+All hosts remain connected without configuration updates.
+Disadvantages and expected impact:::
+Expect some amount of data inconsistency after recovery, based on how often you took and restored backups and on how long it takes to complete the restore process.
+
+Dual active {ProjectServer}::
+How do I back up?:::
+Operate an active, independent {ProjectServer} per data center.
+Hosts from each data center are registered to the {ProjectServer} in that data center.
+Then configure automation to ensure recovery in case of a disruptive event.
+For example, you can periodically run a health check and if the health check discovers that the current {ProjectServer} a host is registered to does not resolve, the host is re-registered to the other {ProjectServer}.
++
+To minimize downtime, you can automate the recovery in various ways.
+For example, you can use the {Project} Ansible collection.
+For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.
+How will I recover in case of a disruptive event?:::
+To recover {Project} services, re-register all hosts to the {ProjectServer} in the other data center.
+ifdef::katello,orcharhino,satellite[]
+Disadvantages and expected impact:::
+You must ensure that content synchronization and content view creation are synchronized to create the same content view in each {Project} and prevent content drift.
+Content drift occurs when available content deviates from the intended state defined by a content view.
+If you fail to prevent content drift, expect inconsistency in the content that is available to hosts.
+endif::[]
+
+ifdef::planning[]
+.Additional resources
+* For a complete guide to disaster recovery, see {AdministeringDocURL}preparing-for-disaster-recovery-and-recovering-from-data-loss[Preparing for disaster recovery and recovering from data loss] in _{AdministeringDocTitle}_.
+* To create backups of your {ProjectServer} and {SmartProxyServers}, use the `{foreman-maintain} backup` command.
+For more information, see {AdministeringDocURL}backing-up-{project-context}-server-and-{smart-proxy-context}_admin[Backing up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+* To back up your hosts, you can use remote execution to configure recurring backup tasks that {Project} will run on the hosts.
+For more information, see {ManagingHostsDocURL}Configuring_and_Setting_Up_Remote_Jobs_managing-hosts[Configuring and setting up remote jobs] in _{ManagingHostsDocTitle}_.
+ifndef::satellite[]
+* To create snapshots of hosts, you can use the Snapshot Management plugin.
+For more information, see {ManagingHostsDocURL}Creating_Snapshots_of_a_Host_managing-hosts[Creating snapshots of a host] in _{ManagingHostsDocTitle}_.
+endif::[]
+endif::[]

--- a/guides/common/modules/con_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/modules/con_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -1,0 +1,5 @@
+[id="preparing-for-disaster-recovery-and-recovering-from-data-loss"]
+= Preparing for disaster recovery and recovering from data loss
+
+{Team} recommends preparing a disaster recovery plan to ensure the continuity of {Project} services in case of a disruptive event.
+These guidelines help ensure that you will be able to restore your {Project} deployment to an operational state after an incident.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,0 +1,27 @@
+[id="preparing-for-disaster-recovery-by-virtualizing-your-{project-context}-server"]
+= Preparing for disaster recovery by virtualizing your {ProjectServer}
+
+Implement a reliable process for regularly taking VM snapshots of your virtualized {ProjectServer} and for backing up your snapshots for long-term storage.
+
+.Procedure
+. Define a schedule for taking periodic snapshots of your virtualized {ProjectServer}.
+Consider your tolerance for potential data loss:
+Taking snapshots frequently will result in smaller amounts of data loss in case of a disaster.
+However, creating a snapshot takes time, and the snapshots also require storage space.
+. Define your snapshot retention policy.
+Consider how many snapshots you want to store: Regularly removing outdated snapshots helps optimize storage usage.
+. Using your hypervisor, schedule periodic snapshots of your {ProjectServer}.
+. Schedule periodic backups of the snapshots to prevent data loss in case of hypervisor failure.
++
+[NOTE]
+====
+While snapshots provide quick recovery points, backing up your snapshots gives you the ability for long-term storage and provides extra safety in case of a disaster on the side of your hypervisor.
+====
+. If you are using an external database that runs on a different machine than your {ProjectServer}, create snapshots and backups on the same schedule as your {ProjectServer}.
+
+.Verification
+. Verify that your hypervisor takes the snapshots according to the schedule that you defined.
+. Use the latest snapshot of your {ProjectServer} and restore it in an isolated environment.
+. To verify that you will be able to restore {Project} services in case of a disaster, assess the functionality of the test {ProjectServer}.
+See xref:Retrieving_the_Status_of_Services_{context}[].
+. Perform these verification checks regularly.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,48 @@
+[id="preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore"]
+= Preparing for disaster recovery with active and passive {ProjectServer} and backup and restore
+
+Create your passive {ProjectServer} by restoring a backup of your active {ProjectServer}.
+Configure periodic backups of the active server.
+
+.Procedure
+. Define a schedule for periodic offline backups of your active {ProjectServer}.
+Consider your tolerance for potential data loss and your storage options: Taking backups frequently will result in smaller amounts of data loss in case of a disaster, but backups require a significant amount of storage space.
+ifdef::katello,orcharhino,satellite[]
+For information about the size of {Project} backups, see xref:Estimating_the_Size_of_a_Backup_admin[].
+endif::[]
++
+You can combine full backups with incremental backups.
+For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
+. Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
+For information about performing backups, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[].
+. Ensure that the backup directories are encrypted and regularly synchronized to a secure location.
+By default, {Project} stores the backups in the `_/var/{project-context}-backup_` directory.
++
+[IMPORTANT]
+====
+ifndef::foreman-el,foreman-deb[]
+{ProjectServer} backups contain sensitive information from the `/root/ssl-build` directory.
+For example, they can contain hostnames, ssh keys, request files, and SSL certificates.
+endif::[]
+Encrypting or moving the backups to a secure location helps minimize the risk of damage or unauthorized access to the hosts.
+====
+. Restore the most recent backup on a system that will serve as your passive {ProjectServer}.
+For information about restoring backups, see xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
+. Optional: Automate backup restoration to keep the passive server periodically updated with the latest backup.
+A regularly restored passive server helps reduce switchover time if the active server fails.
++
+Consider how often you want the backups to be restored: More frequent updates reduce potential data loss but increase infrastructure and automation costs.
+. Power off the passive server.
+Keep the active server powered on.
+. Define your backup retention policy.
+Consider how many backups you want to store: Regularly removing outdated backups helps optimize storage usage.
+
+.Verification
+. Verify that {Project} takes backups according to the schedule you defined.
+. Perform further testing steps in an isolated staging environment:
+.. Mimic a full outage on the active server.
+To make sure the active server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+.. Switch DNS records of the active server with the DNS records of the passive server.
+.. Assess the functionality of the test {ProjectServer}.
+For more information, see xref:Retrieving_the_Status_of_Services_{context}[].
+.. Perform these verification checks regularly.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
@@ -1,0 +1,44 @@
+[id="preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage"]
+= Preparing for disaster recovery with active and passive {ProjectServer} with external storage
+
+ifdef::satellite[]
+Create your passive {ProjectServer} as a clone of your active {ProjectServer}.
+endif::[]
+ifndef::satellite[]
+Create your passive {ProjectServer} as a backup of your active {ProjectServer}.
+endif::[]
+Ensure that the `/var/lib/pulp` and `{postgresql-lib-dir}` directories on your shared storage are available to both servers.
+
+.Procedure
+. Replicate the `/var/lib/pulp` and `{postgresql-lib-dir}` directories from the active {ProjectServer} to your shared storage.
+ifdef::satellite[]
+. Clone your active {ProjectServer}.
+For more information, see xref:cloning_satellite_server[].
+endif::[]
+ifndef::satellite[]
+. Back up your active {ProjectServer} and restore it on a system that will serve as your passive {ProjectServer}.
+For more information, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[] and xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
+endif::[]
+. Keep the source server powered on.
+Power off the new server.
++
+The source server remains your active primary server, while the new server becomes the passive secondary server.
+. Determine how you want to attach the database content on the shared storage to your passive server:
+* If you mount the storage directly on both your active and passive server, the servers will always see the same, up-to-date content.
+* If you mount the storage only on your active server, the passive server will access the data only if it takes over as the active server.
+
+.Verification
+Perform this test in an isolated staging environment:
+
+. Mimic a full outage on the active server.
+To make sure the active server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+. Switch DNS records of the active server with the DNS records of the passive server.
+. Verify that your passive server can access the data stored on your shared storage.
+. Assess the functionality of the test {ProjectServer}.
+For more information, see xref:Retrieving_the_Status_of_Services_{context}[].
+. Perform these verification checks regularly.
+
+ifdef::satellite[]
+.Additional resources
+* For more information on mounting directories, see link:{RHELDocsBaseURL}9/html-single/managing_file_systems/index#mounting-file-systems-on-demand_managing-file-systems[Mounting file systems on demand] in _{RHEL}{nbsp}9 Managing file systems_.
+endif::[]

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,51 @@
+[id="preparing-for-disaster-recovery-with-two-active-project-servers"]
+= Preparing for disaster recovery with two active {ProjectServer}s
+
+Create a second {ProjectServer} by restoring a backup of your first {ProjectServer}.
+Configure both servers to operate independently in their respective data centers, but ensure that their content does not drift apart over time.
+
+.Procedure
+. Back up your {ProjectServer}.
+For more information, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_admin[].
+. Restore the backup on a system that will serve as your other {ProjectServer}.
+For more information, see xref:restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[].
++
+[NOTE]
+====
+Each server must have a distinct hostname and IP address.
+This enables you to re-register hosts if one of the servers fails.
+====
+. Ensure that content on your servers remains consistent:
+* If you want both servers to manage content synchronization and content view creation, follow these guidelines to prevent content drift:
+** Regularly synchronize repositories on both servers.
+You can use the following Ansible modules to automate repository synchronization: `{ansible-namespace}.repository_sync` and `{ansible-namespace}.sync_plan`.
+** Ensure that content views on both servers match.
+* If you want one server to manage content synchronization and content view creation, use one of these features to prevent content drift:
+** If your disaster recovery site has network access to your primary site, use {ISS} (ISS) to ensure your disaster recovery server synchronizes its content from the primary server.
+** If your disaster recovery site does not have network access to your primary site, synchronize content by using export and import.
+* If you want one server to manage only content view creation but not content synchronization, you can configure the other server or multiple other servers to import content views from the first server but synchronize content from repositories.
+//      |------------ Foreman/Katello for CVs only ---------------|
+//                /                               \
+//              /                                   \
+//            /                                       \
+// |--Foreman/Katello for Hosts --|     |--Foreman/Katello for hosts--|
+. Register hosts to your servers so that each server manages hosts in its respective data center.
+For example, register all hosts in _My_Data_Center_1_ to one {ProjectServer} and all hosts in _My_Data_Center_2_ to the other {ProjectServer}.
+. Automate running the `{foreman-maintain} health check` command on both servers.
+The health check verifies whether the servers remain fully operational.
+
+.Verification
+Perform this test in an isolated staging environment:
+
+. Mimic a full outage on one of your servers.
+To verify that the server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+. Verify that your `{foreman-maintain} health check` automation reported an error.
+. Re-register all hosts from the inaccessible server to the accessible server.
+. Verify that hosts have been properly re-registered to the accessible server.
+. Perform these verification checks regularly.
+
+.Additional resources
+* Ansible playbooks can help you automate failover, re-registration, and synchronization.
+For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.
+* For more information on synchronizing repositories, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing repositories] in _{ContentManagementDocTitle}_.
+* For more information on synchronizing content between {ProjectServer}s, including ISS, export, and import, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing content between {ProjectServer}s] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_recovering-from-disaster-by-restoring-a-vm-snapshot-of-projectserver.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-by-restoring-a-vm-snapshot-of-projectserver.adoc
@@ -1,0 +1,17 @@
+[id="recovering-from-disaster-by-restoring-a-vm-snapshot-of-{project-context}-server"]
+= Recovering from disaster by restoring a VM snapshot of {ProjectServer}
+
+In case of a disaster, use a virtual machine (VM) snapshot of your {ProjectServer} to restore {Project} services.
+
+include::snip_disaster-recovery-hostname-cannot-change.adoc[]
+
+.Procedure
+. Identify the snapshot from which you want to recover.
+. Use hypervisor tools to restore from the selected snapshot.
+. If you are using an external database that runs on a different machine than your {ProjectServer}, ensure that you restore the database from a snapshot taken at the same time as or before the {ProjectServer} snapshot.
+. Update DNS records so that the {ProjectServer} hostname resolves to the new IP address.
+This redirects traffic from the old server to the new server and you will not need to re-register your hosts.
+
+.Verification
+* Assess the functionality of your restored {ProjectServer}.
+See xref:Retrieving_the_Status_of_Services_{context}[].

--- a/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,11 @@
+[id="recovering-from-disaster-with-active-and-passive-server-and-backup-and-restore"]
+= Recovering from disaster with active and passive server and backup and restore
+
+If your active {ProjectServer} fails, activate your passive secondary server.
+
+.Procedure
+. Verify that the failed active server is powered off and that backups are no longer being synchronized to your passive server.
+. Switch DNS records of the active server with the DNS records of the passive server.
+This ensures that hosts remain connected and you do not need to re-register them.
+. Assess the functionality of your new active {ProjectServer}.
+For more information, see xref:Retrieving_the_Status_of_Services_{context}[].

--- a/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-active-and-passive-project-server-with-external-storage.adoc
@@ -1,0 +1,15 @@
+[id="recovering-from-disaster-with-active-and-passive-server-with-external-storage"]
+= Recovering from disaster with active and passive server with external storage
+
+If your active {ProjectServer} fails, detach it from the shared storage and make sure your passive server can access the data stored on the shared storage.
+This turns the passive server into your new active server.
+
+.Procedure
+. Verify that the failed active server is powered off or fully detached from the shared storage.
+This ensures that the failed server cannot keep writing to the shared storage.
+. Switch DNS records of the active server with the DNS records of the passive server.
+This ensures that hosts remain connected and you do not need to re-register them.
+. If your shared storage was mounted on both your active and passive servers, your passive server can already access the data.
+. If your shared storage was mounted only on your active server, re-mount it on your passive server.
+. Assess the functionality of your new active {ProjectServer}.
+For more information, see xref:Retrieving_the_Status_of_Services_{context}[].

--- a/guides/common/modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-with-two-active-project-servers.adoc
@@ -1,0 +1,22 @@
+[id="recovering-from-disaster-with-two-active-project-servers"]
+= Recovering from disaster with two active {ProjectServer}s
+
+If the health checks implemented in xref:preparing-for-disaster-recovery-with-two-active-project-servers[] report an issue on one of your {ProjectServer}s, it might mean that the server has failed.
+If the server is down, you must re-register hosts to the other server.
+
+.Procedure
+. Verify the status of the server:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {foreman-maintain} health check
+----
+. If `{foreman-maintain} health check` reported a problem, ensure that the server is powered off.
+. Re-register all hosts from the data center managed by the failed server to the other, functional server.
+
+.Verification
+* Verify that hosts have been properly re-registered.
+
+.Additional resources
+* Ansible playbooks can help you automate failover, re-registration, and synchronization.
+For more information, see {AdministeringDocURL}managing-{project-context}-with-ansible[Managing {Project} with Ansible] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,0 +1,5 @@
+[id="prerequisites-disaster-recovery-by-virtualizing-{project-context}-server"]
+= Prerequisites
+
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to make sure that this disaster recovery plan works for you.
+* Your {ProjectServer} is deployed as a VM.

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,0 +1,5 @@
+[id="prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore"]
+= Prerequisites
+
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to ensure that this disaster recovery plan works for you.
+* You have a {ProjectServer} installed.

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-external-storage.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-external-storage.adoc
@@ -1,0 +1,8 @@
+[id="prerequisites-disaster-recovery-with-active-and-passive-project-server-and-external-storage"]
+= Prerequisites
+
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to ensure that this disaster recovery plan works for you.
+* Review {InstallingServerDocURL}storage-requirements_{project-context}[Storage requirements] and {InstallingServerDocURL}storage-guidelines_{project-context}[Storage guidelines] in _{InstallingServerDocTitle}_.
+Ensure that your shared storage meets the requirements of holding the contents of `/var/lib/pulp` and `{postgresql-lib-dir}`.
+* You have configured your {ProjectServer} to use external databases.
+For more information, see {InstallingServerDocURL}using-external-databases_{project-context}[Using external databases] in _{InstallingServerDocTitle}_.

--- a/guides/common/modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc
@@ -1,0 +1,5 @@
+[id="prerequisites-disaster-recovery-with-two-active-project-servers"]
+= Prerequisites
+
+* Review xref:overview-of-recommended-disaster-recovery-plans[] to ensure that this disaster recovery plan works for you.
+* You have a {ProjectServer} installed.

--- a/guides/common/modules/snip_disaster-recovery-hostname-cannot-change.adoc
+++ b/guides/common/modules/snip_disaster-recovery-hostname-cannot-change.adoc
@@ -1,0 +1,5 @@
+[IMPORTANT]
+====
+Ensure that the hostname of your {ProjectServer} does not change during recovery.
+The IP address can change.
+====

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -24,6 +24,8 @@ endif::[]
 
 include::common/assembly_managing-project-with-ansible-collections.adoc[leveloffset=+1]
 
+include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
+
 ifdef::satellite[]
 include::common/assembly_managing-organizations.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

Adding documentation on disaster recovery to versions 3.13 and earlier.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Previously included only on 3.14 and later, this now adds the documentation to 3.13 and earlier because the content is valid for these versions too.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I didn't look for all the individual commits to cherry-pick them because, among other things, those commits also add a module to Planning where the structure is very different between 3.13 and 3.14. Instead, I copied whole files.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
