### PR TITLE
Update postgresql command for RHEL9

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -19,6 +19,14 @@ ifndef::katello,satellite,orcharhino[]
 endif::[]
 ----
 . Initialize the PostgreSQL database:
+** On {RHEL} 9:
++
+[options="nowrap" subs="verbatim,quotes"]
+----
+# postgresql-setup --initdb
+----
+
+** On {RHEL} 8:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -19,19 +19,29 @@ ifndef::katello,satellite,orcharhino[]
 endif::[]
 ----
 . Initialize the PostgreSQL database:
-** On {RHEL} 9:
+ifndef::orcharhino[]
+** On {EL} 9:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 # postgresql-setup --initdb
 ----
 
-** On {RHEL} 8:
+** On {EL} 8:
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
 # postgresql-setup initdb
 ----
+endif::[]
+ifdef::orcharhino[]
++
+[options="nowrap" subs="verbatim,quotes"]
+----
+# postgresql-setup --initdb
+----
+endif::[]
+
 . Edit the `{postgresql-conf-dir}/postgresql.conf` file:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
The `Installing PostgreSQL as an external database` section does not have the command for RHEL9. Adding this to the procedure while keeping the RHEL8 command intact. Dropping the RHEL8 command for newer Project versions.

JIRA: https://issues.redhat.com/browse/SAT-33417

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [X] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
