### PR TITLE
Update postgresql command for RHEL9 for newer versions

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -26,7 +26,7 @@ endif::[]
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# postgresql-setup initdb
+# postgresql-setup --initdb
 ----
 . Edit the `{postgresql-conf-dir}/postgresql.conf` file:
 +


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/3832.

The Installing PostgreSQL as an external database section does not have the command for RHEL9. Dropping the RHEL8 command for newer Project versions.

JIRA: https://issues.redhat.com/browse/SAT-33417

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [X] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
