### PR TITLE
Change guide name in navigation to lowercase

### DIFF
--- a/web/releases/3.14.json
+++ b/web/releases/3.14.json
@@ -19,7 +19,7 @@
           "path": "Upgrading_Project"
         },
         {
-          "title": "Integrating Provisioning Infrastructure Services",
+          "title": "Integrating provisioning infrastructure services",
           "path": "Integrating_Provisioning_Infrastructure_Services"
         },
         {
@@ -61,7 +61,7 @@
           "path": "Upgrading_Project"
         },
         {
-          "title": "Integrating Provisioning Infrastructure Services",
+          "title": "Integrating provisioning infrastructure services",
           "path": "Integrating_Provisioning_Infrastructure_Services"
         },
         {
@@ -115,7 +115,7 @@
           "path": "Upgrading_Project"
         },
         {
-          "title": "Integrating Provisioning Infrastructure Services",
+          "title": "Integrating provisioning infrastructure services",
           "path": "Integrating_Provisioning_Infrastructure_Services"
         },
         {

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -27,7 +27,7 @@
           "path": "Upgrading_Project"
         },
         {
-          "title": "Integrating Provisioning Infrastructure Services",
+          "title": "Integrating provisioning infrastructure services",
           "path": "Integrating_Provisioning_Infrastructure_Services"
         },
         {
@@ -101,7 +101,7 @@
           "path": "Upgrading_Project"
         },
         {
-          "title": "Integrating Provisioning Infrastructure Services",
+          "title": "Integrating provisioning infrastructure services",
           "path": "Integrating_Provisioning_Infrastructure_Services"
         },
         {
@@ -171,7 +171,7 @@
           "path": "Upgrading_Project"
         },
         {
-          "title": "Integrating Provisioning Infrastructure Services",
+          "title": "Integrating provisioning infrastructure services",
           "path": "Integrating_Provisioning_Infrastructure_Services"
         },
         {


### PR DESCRIPTION
#### What changes are you introducing?

#3830 accidentally uses title case for a guide in the navigation. This update changes the name to sentence case in the master branch.


#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Consistency in the navigation

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
