### PR TITLE
Add port 9090 for MQTT

### DIFF
--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -16,8 +16,8 @@ ifndef::foreman-el[]
 * The AppStream repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]
-* The host can communicate with its {SmartProxy} over MQTT using port`1883`.
-* The host can communicate with its {SmartProxy} over HTTPS using port`9090`.
+* The host can communicate with its {SmartProxy} over MQTT using port `1883`.
+* The host can communicate with its {SmartProxy} over HTTPS using port `{smartproxy_port}`.
 
 .Procedure
 * Install the `katello-pull-transport-migrate` package on your host:

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -16,8 +16,8 @@ ifndef::foreman-el[]
 * The AppStream repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]
-* The host can communicate with its {SmartProxy} over MQTT using port`1883` and `9090`.
-* The host can communicate with its {SmartProxy} over HTTPS.
+* The host can communicate with its {SmartProxy} over MQTT using port`1883`.
+* The host can communicate with its {SmartProxy} over HTTPS using port`9090`.
 
 .Procedure
 * Install the `katello-pull-transport-migrate` package on your host:

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -16,7 +16,7 @@ ifndef::foreman-el[]
 * The AppStream repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]
-* The host can communicate with its {SmartProxy} over MQTT using port `1883`.
+* The host can communicate with its {SmartProxy} over MQTT using port`1883` and `9090`.
 * The host can communicate with its {SmartProxy} over HTTPS.
 
 .Procedure

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -42,7 +42,7 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
-| 9090 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
+| 9090 | TCP | HTTPS | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -42,6 +42,7 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
+| 9090 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -42,7 +42,6 @@ ifdef::katello,satellite,orcharhino[]
 | 443, 80 | TCP | HTTPS, HTTP | {SmartProxy} | Content Retrieval | Content
 | 443, 80 | TCP | HTTPS, HTTP | Client | Content Retrieval | Content
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
-| 9090 | TCP | HTTPS | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
@@ -51,6 +50,9 @@ endif::[]
 | {smartproxy_port} | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | {smartproxy_port} | TCP | HTTPS | Client | OpenSCAP | Configure Client (if the OpenSCAP plugin is installed)
 | {smartproxy_port} | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning (if the discovery plugin is installed)
+ifdef::katello,satellite,orcharhino[]
+| {smartproxy_port} | TCP | HTTPS | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
+endif::[]
 |====
 
 Any host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -41,7 +41,7 @@ Uploading facts
 
 Sending installed packages and traces
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
-| 9090 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
+| 9090 | TCP | HTTPS | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTP | Client | PXE Boot | Installation

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -41,7 +41,6 @@ Uploading facts
 
 Sending installed packages and traces
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
-| 9090 | TCP | HTTPS | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTP | Client | PXE Boot | Installation
@@ -53,6 +52,9 @@ endif::[]
 | {smartproxy_port} | TCP | HTTPS | Client | Register Endpoint | Client registration with an external {SmartProxyServer}
 | {smartproxy_port} | TCP | HTTPS | Client | OpenSCAP | Configure Client (if the OpenSCAP plugin is installed)
 | {smartproxy_port} | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning (if the discovery plugin is installed)
+ifdef::katello,satellite,orcharhino[]
+| {smartproxy_port} | TCP | HTTPS | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
+endif::[]
 |====
 
 Any host that is directly connected to {ProjectServer} is a client in this context because it is a client of the integrated {SmartProxy}.

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -41,6 +41,7 @@ Uploading facts
 
 Sending installed packages and traces
 | 1883 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
+| 9090 | TCP | MQTT | Client | Pull based REX (optional) | Content hosts for REX job notification (optional)
 endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTP | Client | PXE Boot | Installation


### PR DESCRIPTION
For remote execution pull-mode to work,	port 9090 should be accessible as well.

JIRA: https://issues.redhat.com/browse/SAT-32031

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
