### PR TITLE
Properly use ifdef to hide Katello content

### DIFF
--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -46,7 +46,9 @@ include::modules/proc_creating-architectures.adoc[leveloffset=+1]
 
 include::modules/proc_creating-hardware-models.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_preparing-a-synchronized-kickstart-repository.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_adding-installation-media.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_preparing-provisioning-content.adoc
+++ b/guides/common/assembly_preparing-provisioning-content.adoc
@@ -1,6 +1,8 @@
 include::modules/con_preparing-provisioning-content.adoc[]
 
+ifdef::katello,orcharhino,satellite[]
 include::modules/proc_preparing-a-synchronized-kickstart-repository.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_configuring-project-to-provision-from-a-builder-image.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_preparing-provisioning-content.adoc
+++ b/guides/common/modules/con_preparing-provisioning-content.adoc
@@ -3,6 +3,8 @@
 
 You have to configure provisioning content that will be used for installation of the operating system on the provisioned host.
 
+ifdef::katello,orcharhino,satellite[]
 [role="_additional-resources"]
 .Additional resources
 * {ContentManagementDocURL}[_{ContentManagementDocTitle}_]
+endif::[]

--- a/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
+++ b/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
@@ -1,10 +1,6 @@
 [id="preparing-a-synchronized-kickstart-repository"]
 = Preparing a synchronized Kickstart repository
 
-ifdef::foreman-el,katello[]
-The following feature is provided by the Katello plugin.
-endif::[]
-
 {Project} contains a set of synchronized Kickstart repositories that you use to install the provisioned host's operating system.
 For more information about adding repositories, see {ContentManagementDocURL}Synchronizing_Repositories_content-management[Syncing Repositories] in _{ContentManagementDocTitle}_.
 

--- a/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
+++ b/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
@@ -1,14 +1,6 @@
 [id="Initialization_Script_for_Provisioning_Examples_{context}"]
 = Initialization script for provisioning examples
 
-ifdef::foreman-el,katello[]
-[NOTE]
-====
-The following chapter describes Red Hat content management provided by Katello plugin.
-Deployments without the plugin use Installation Media to fetch content from remote or local mirrors.
-====
-endif::[]
-
 If you have not followed the examples in _{ContentManagementDocTitle}_, you can use the following initialization script to create an environment for provisioning examples.
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

Previously this included notes that Katello provided a feature, but it's better to hide the text altogether on irrelevant builds. That is done around the include statement.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

On Katello builds this hides a redundant note and on foreman-el builds it hides an irrelevant chapter that users must always skip.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.