### PR TITLE
Correct http-booting anchor

### DIFF
--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning.adoc
@@ -8,7 +8,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-hosts-wi
 .Prerequisites
 * Ensure that you meet the requirements for HTTP booting.
 ifndef::orcharhino[]
-For more information, see {PlanningDocURL}http-booting-requirements[HTTP Booting Requirements] in _{PlanningDocTitle}_.
+For more information, see {PlanningDocURL}http-booting[HTTP booting] in _{PlanningDocTitle}_.
 endif::[]
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In fbc716deb22d3ae37db84aeb64b243661fb4a54b the section id was renamed from http-booting-requirements to http-booting.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.