### PR TITLE
Remove libvirt specific text from VMware procedure

### DIFF
--- a/guides/common/modules/proc_adding-a-vmware-connection-to-server.adoc
+++ b/guides/common/modules/proc_adding-a-vmware-connection-to-server.adoc
@@ -22,15 +22,6 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-vmware-vsp
 . From the *Display Type* list, select a console type, for example, *VNC* or *VMRC*.
 Note that VNC consoles are unsupported on VMware ESXi 6.5 and later.
 . Optional: In the *VNC Console Passwords* field, select the *Set a randomly generated password on the display connection* checkbox to secure console access for new hosts with a randomly generated password.
-You can retrieve the password for the VNC console to access guest virtual machine console from the `libvirtd` host from the output of the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# virsh edit _your_VM_name_
-<graphics type='vnc' port='-1' autoport='yes' listen='0.0.0.0' passwd='_your_randomly_generated_password_'>
-----
-+
-The password randomly generates every time the console for the virtual machine opens, for example, with virt-manager.
 . From the *Enable Caching* list, you can select whether to enable caching of compute resources.
 For more information, see xref:Caching_of_Compute_Resources_{context}[].
 . Click the *Locations* and *Organizations* tabs and verify that the values are automatically set to your current context.


### PR DESCRIPTION
#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This only works on libvirt, but is in the VMware connection instructions.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

It was present all the way back in the initial version (156d071a3e61).

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.