### PR TITLE
Remove instructions to place GCE key in /etc/foreman

### DIFF
--- a/guides/common/modules/proc_adding-a-google-gce-connection.adoc
+++ b/guides/common/modules/proc_adding-a-google-gce-connection.adoc
@@ -22,38 +22,12 @@ For more information, see https://cloud.google.com/iam/docs/creating-managing-se
 .CLI procedure
 . In Google GCE, generate a service account key in JSON format.
 For more information, see https://cloud.google.com/iam/docs/creating-managing-service-account-keys[Create and manage service account keys] in the GCE documentation.
-. Copy the file from your local machine to {ProjectServer}:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# scp _My_GCE_Key_.json root@{foreman-example-com}:/etc/foreman/_My_GCE_Key_.json
-----
-. On {ProjectServer}, change the owner for your service account key to the `foreman` user:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# chown root:foreman /etc/foreman/_My_GCE_Key_.json
-----
-. On {ProjectServer}, configure permissions for your service account key to ensure that the file is readable:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# chmod 0640 /etc/foreman/_My_GCE_Key_.json
-----
-ifndef::foreman-deb[]
-. On {ProjectServer}, restore SELinux context for your service account key:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# restorecon -vv /etc/foreman/_My_GCE_Key_.json
-----
-endif::[]
 . Use the `hammer compute-resource create` command to add a GCE compute resource to {Project}:
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ hammer compute-resource create \
---key-path "/etc/foreman/_My_GCE_Key_.json" \
+# hammer compute-resource create \
+--key-path "_My_GCE_Key_.json" \
 --name "_My_GCE_Compute_Resource_" \
 --provider "gce" \
 --zone "_My_Zone_"


### PR DESCRIPTION
#### What changes are you introducing?

Remove the instructions to place the key in `/etc/foreman`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Hammer uploads the key to Foreman (just like in the UI procedure) and never read again. This means there's no point in storing the file in /etc/foreman with specific permissions.

It was introduced in 40b118063bf980dbd92469793abfc1229b691d99 (https://github.com/theforeman/foreman-documentation/pull/1949).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I changed the Hammer command to run as root for two reasons: the scp command also uses root and the installer sets up Hammer for root by default.  1137d3a971688a8bfef350962fdb1bc9afc17cae changed it to non-root and this goes against that.

An alternative is to change the instruction to a prerequisite to have Hammer set up and the key file present. Then you only need to list the Hammer command.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.