### PR TITLE
Restore subtitle of "Integrating provisioning infrastructure services"

### DIFF
--- a/guides/doc-Integrating_Provisioning_Infrastructure_Services/docinfo.xml
+++ b/guides/doc-Integrating_Provisioning_Infrastructure_Services/docinfo.xml
@@ -1,7 +1,7 @@
 <title>{IntegratingProvisioningInfrastructureServicesDocTitle}</title>
 <productname>Red Hat Satellite</productname>
 <productnumber>{ProjectVersion}</productnumber>
-<subtitle>Integrating provisioning infrastructure services</subtitle>
+<subtitle>Configure DNS, DHCP, and TFTP integration</subtitle>
 <abstract>
 
     <para>


### PR DESCRIPTION
#### What changes are you introducing?

Update the subtitle of "Integrating provisioning infrastructure services".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The subtitle of the "Integrating provisioning infrastructure services" guide was accidentally overridden in a [previous update](https://github.com/theforeman/foreman-documentation/commit/ebf8b4bfdecd904a6ab5758476119930c976e57a#diff-fabc485bc8b8a3568598891f295f4f292bef4ca18e8f1e6f5d8a987d37f56c4cR4). This PR restores the subtitle.


#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
