### PR TITLE
creating-an-installation-medium-for-ubuntu-22-04: add ISO image note

### DIFF
--- a/guides/common/modules/proc_creating-an-installation-medium-for-ubuntu-22-04.adoc
+++ b/guides/common/modules/proc_creating-an-installation-medium-for-ubuntu-22-04.adoc
@@ -43,5 +43,10 @@ Ensure the path in `/pub/` matches the path in your _Preseed default PXELinux Au
 # rm -f {iso_image}
 ----
 
+As an alternative to copying the content of the ISO image, one may instead mount the ISO image somewhere, such as under `/mnt`,
+then create `/var/www/html/pub/installation_media/ubuntu/22.04-x86_64` as a symbolic link to the mounted image. The ISO image
+should not be mounted directly under `/var/lib/foreman`, because on Debian and Ubuntu this will cause the package postinst script
+to fail at the `chmod -Rf /var/lib/foreman` command.
+
 Use `\http://{foreman-example-com}/pub/installation_media/ubuntu/22.04-x86_64/` to set up your installation media entry in {Project}.
 For more information, see xref:adding-installation-media_{context}[].


### PR DESCRIPTION
I ran into difficulties with mounting the Ubuntu ISO image under `/var/lib/foreman` since I manage foreman with puppet, and mounting the ISO is more doable with puppet compared with copying the content. This commit just adds a note for other people who might want to try the same thing. This note may help someone avoid this particular pitfall.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
