### PR TITLE
Add step to enable Satellite repositories

### DIFF
--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -39,6 +39,13 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
+. Ensure that the {Project} Maintenance repository is enabled:
++
+[options="nowrap" subs="attributes"]
+----
+# subscription-manager repos --enable \
+{RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
+----
 . Upgrade {foreman-maintain} to its next version:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -44,7 +44,7 @@ ifdef::satellite[]
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
-{RepoRHEL9ServerSatelliteServerProjectVersion}
+{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
 . Upgrade {foreman-maintain} to its next version:
 +

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -44,7 +44,7 @@ ifdef::satellite[]
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
-{RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
+{RepoRHEL9ServerSatelliteServerProjectVersion}
 ----
 . Upgrade {foreman-maintain} to its next version:
 +


### PR DESCRIPTION
#### What changes are you introducing?
Adding step 7 from Upgrading Guide in 6.15 
https://docs.redhat.com/en/documentation/red_hat_satellite/6.15/html-single/upgrading_connected_red_hat_satellite_to_6.15/index#upgrading_a_connected_satellite_server_upgrading-connected back to the latest version because it was affecting
upgrading to 6.17. 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-33478 raised an urgent doc bug because it was causing
users to fail upgrading to 6.17.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
