### PR TITLE
Change part of step in procedure

### DIFF
--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -87,13 +87,6 @@ You can then check the upgrade progress without staying connected to the command
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
-Ensure {SmartProxy} has access to `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}` and execute:
-+
-[options="nowrap" subs="attributes"]
-----
-# {foreman-maintain} self-upgrade
-----
-+
 Ensure that the {Project} Maintenance repository is enabled:
 +
 [options="nowrap" subs="attributes"]
@@ -101,6 +94,14 @@ Ensure that the {Project} Maintenance repository is enabled:
 # subscription-manager repos --enable \
 {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
+Ensure {SmartProxy} has access to `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}` and execute:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-maintain} self-upgrade
+----
++
+
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:
 +
 ----

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -87,6 +87,13 @@ You can then check the upgrade progress without staying connected to the command
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
+Ensure {SmartProxy} has access to `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}` and execute:
++
+[options="nowrap" subs="attributes"]
+----
+# {foreman-maintain} self-upgrade
+----
++
 Ensure that the {Project} Maintenance repository is enabled:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -94,13 +94,13 @@ Ensure that the {Project} Maintenance repository is enabled:
 # subscription-manager repos --enable \
 {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
++
 Ensure {SmartProxy} has access to `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}` and execute:
 +
 [options="nowrap" subs="attributes"]
 ----
 # {foreman-maintain} self-upgrade
 ----
-+
 
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:
 +

--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -87,11 +87,12 @@ You can then check the upgrade progress without staying connected to the command
 If you lose connection to the command shell where the upgrade command is running, you can see the logged messages in the `{installer-smartproxy-log-file}` file to check if the process completed successfully.
 . The `rubygem-foreman_maintain` is installed from the {Project} Maintenance repository or upgraded from the {Project} Maintenance repository if currently installed.
 +
-Ensure {SmartProxy} has access to `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}` and execute:
+Ensure that the {Project} Maintenance repository is enabled:
 +
 [options="nowrap" subs="attributes"]
 ----
-# {foreman-maintain} self-upgrade
+# subscription-manager repos --enable \
+{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
 . On {SmartProxyServer}, verify that the `foreman_url` setting points to the {Project} FQDN:
 +


### PR DESCRIPTION
#### What changes are you introducing?
Changing part of a step as requested in 
https://issues.redhat.com/browse/SAT-33478 to 
the same step in #3848 as requested in the
comments in Jira.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Comment in Jira suggested "In step 6, we can replace text "Ensure Capsule has access to satellite-maintenance-6.17-for-rhel-9-x86_64-rpms and execute:" with the command to enable the repository.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
