### PR TITLE
Add instructions to fix Publisher ACL for Salt

### DIFF
--- a/guides/common/modules/proc_configuring-salt-on-project.adoc
+++ b/guides/common/modules/proc_configuring-salt-on-project.adoc
@@ -32,3 +32,38 @@ endif::[]
 The command `adduser saltuser -p password` does not work.
 Using it prevents you from importing Salt States.
 ====
+. Create a directory for a `systemd` service for Salt:
++
+[options="nowrap" subs="attributes"]
+----
+# mkdir /etc/systemd/system/salt-master.service.d
+----
+// the "sleep 10" is necessary to ensure that the "salt-master" service does not overwrite the permissions
+// this is due to a bug in Salt: https://github.com/saltstack/salt/issues/65317
+. Create the `systemd` service `/etc/systemd/system/salt-master.service.d/foreman_override.conf`:
++
+[source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[Service]
+ExecStartPost=/bin/bash -c 'sleep 10'
+ExecStartPost=/bin/bash -c 'chmod o+rx /var/run/salt/master/'
+ExecStartPost=/bin/bash -c 'chmod o+rw /var/run/salt/master/publish_pull.ipc'
+ExecStartPost=/bin/bash -c 'chmod o+rw /var/run/salt/master/master_event_pub.ipc'
+ExecStartPost=/bin/bash -c 'chmod o+rw /var/run/salt/master/master_event_pull.ipc'
+ExecStartPost=/bin/bash -c 'chmod o+rw /var/run/salt/master/workers.ipc'
+----
+. Reload the service files and restart the `salt-master` service:
++
+[options="nowrap" subs="attributes"]
+----
+# systemctl daemon-reload
+# systemctl restart salt-master
+----
++
+The restart takes at least 10 seconds and applies the correct directory and file permissions.
+. Allow the `foreman-proxy` user to write Salt logs:
++
+[options="nowrap" subs="attributes"]
+----
+# chmod g+w /var/log/foreman-proxy/salt.log
+----


### PR DESCRIPTION
#### What changes are you introducing?

Add docs for service file to fix file permissions for Salt.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

due to a bug in Salt

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
