### PR TITLE
Add a note about RHOKP in the disconnected guides

### DIFF
--- a/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
@@ -3,5 +3,5 @@
 [id="red-hat-offline-knowledge-portal_{context}"]
 = Red{nbsp}Hat Offline Knowledge Portal
 
-You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the Red{nbsp}Hat KnowledgeBase offline in a restricted or secure network environment.
+You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the Red{nbsp}Hat Knowledgebase offline in a restricted or secure network environment.
 For more information, see {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation].

--- a/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
@@ -1,7 +1,7 @@
-[prefce]
+[preface]
 
 [id="red-hat-offline-knowledge-portal_{context}"]
 = Red{nbsp}Hat Offline Knowledge Portal
 
-You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the KnowledgeBase offline in a restricted or secure network environment.
+You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the Red{nbsp}Hat KnowledgeBase offline in a restricted or secure network environment.
 For more information, see {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation].

--- a/guides/common/modules/snip_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/snip_red-hat-offline-knowledge-portal.adoc
@@ -1,5 +1,5 @@
 [id="red-hat-offline-knowledge-portal_{context}"]
 = Red{nbsp}Hat Offline Knowledge Portal
 
-You can install the Red{nbps}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the KnowledgeBase offline in a restricted or secure network environment.
+You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the KnowledgeBase offline in a restricted or secure network environment.
 For more information, see {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation].

--- a/guides/common/modules/snip_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/snip_red-hat-offline-knowledge-portal.adoc
@@ -1,3 +1,5 @@
+[prefce]
+
 [id="red-hat-offline-knowledge-portal_{context}"]
 = Red{nbsp}Hat Offline Knowledge Portal
 

--- a/guides/common/modules/snip_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/snip_red-hat-offline-knowledge-portal.adoc
@@ -1,0 +1,5 @@
+[id="red-hat-offline-knowledge-portal_{context}"]
+= Red{nbsp}Hat Offline Knowledge Portal
+
+You can install the Red{nbps}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the KnowledgeBase offline in a restricted or secure network environment.
+For more information, see {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation].

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -15,6 +15,8 @@ ifdef::satellite[]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 
+include::common/modules/snip_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
+
 include::common/assembly_preparing-environment-for-installation.adoc[leveloffset=+1]
 
 include::common/assembly_installing-satellite-server-disconnected.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -15,7 +15,7 @@ ifdef::satellite[]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 
-include::common/modules/snip_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
+include::common/modules/con_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
 
 include::common/assembly_preparing-environment-for-installation.adoc[leveloffset=+1]
 

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -14,6 +14,8 @@ ifdef::satellite[]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 
+include::common/modules/snip_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
+
 // Upgrading Project Server overview
 include::common/modules/con_upgrading-overview.adoc[leveloffset=+1]
 

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -14,7 +14,7 @@ ifdef::satellite[]
 
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 
-include::common/modules/snip_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
+include::common/modules/con_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
 
 // Upgrading Project Server overview
 include::common/modules/con_upgrading-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
The Red Hat Offline Knowledge Portal (RHOKP) will be included with the Satellite subscription for 6.17. Created a snippet and added it to the disconnected install and disconnected upgrade guides.

JIRA:
https://issues.redhat.com/browse/SAT-31163
https://issues.redhat.com/browse/SAT-31164

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
