### PR TITLE
Make registering proxy mandatory for katello

### DIFF
--- a/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
@@ -1,10 +1,7 @@
 [id="Registering_Proxy_to_Server_{context}"]
 = Registering to {ProjectServer}
 
-Use this procedure to register the base operating system on which you want to install {SmartProxyServer} to {ProjectServer}.
-ifdef::katello[]
-Registering your {SmartProxyServer} as a content host enables you to download the installation packages from your synced repositories.
-endif::[]
+Registering the base operating system on which you want to install {SmartProxyServer} to {ProjectServer} enables you to download the installation packages from your synchronized repositories.
 
 .Red{nbsp}Hat subscription manifest prerequisites
 * On {ProjectServer}, a manifest must be installed and it must contain the appropriate repositories for the organization you want {SmartProxy} to belong to.

--- a/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
@@ -1,7 +1,8 @@
 [id="Registering_Proxy_to_Server_{context}"]
 = Registering to {ProjectServer}
 
-Registering the base operating system on which you want to install {SmartProxyServer} to {ProjectServer} enables you to download the installation packages from your synchronized repositories.
+Register the base operating system on which you want to install {SmartProxyServer} to {ProjectServer}.
+This enables you to download the installation packages from your synchronized repositories.
 
 .Red{nbsp}Hat subscription manifest prerequisites
 * On {ProjectServer}, a manifest must be installed and it must contain the appropriate repositories for the organization you want {SmartProxy} to belong to.

--- a/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
+++ b/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc
@@ -2,9 +2,8 @@
 = Registering to {ProjectServer}
 
 Use this procedure to register the base operating system on which you want to install {SmartProxyServer} to {ProjectServer}.
-
 ifdef::katello[]
-Registering your {SmartProxyServer} as a content host is optional unless you wish to download the installation packages from your synced repositories.
+Registering your {SmartProxyServer} as a content host enables you to download the installation packages from your synced repositories.
 endif::[]
 
 .Red{nbsp}Hat subscription manifest prerequisites


### PR DESCRIPTION
#### What changes are you introducing?

Turning the step to register content proxy to Foreman from optional to mandatory.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/3855#pullrequestreview-2842525514, it was suggested that the proxy installation instructions and upgrade instructions for katello are inconsistent.

* Registering the proxy base system is a mandatory step in the upgrade process: https://github.com/theforeman/foreman-documentation/blob/028b74684e59bcb042835d20da4713e095cd67ed/guides/common/modules/proc_upgrading-smartproxy-server.adoc?plain=1#L20
* Syncing repositories is also mandatory in the upgrade process: https://github.com/theforeman/foreman-documentation/blob/028b74684e59bcb042835d20da4713e095cd67ed/guides/common/modules/proc_synchronizing-the-new-repositories.adoc?plain=1#L4 and https://github.com/theforeman/foreman-documentation/blob/028b74684e59bcb042835d20da4713e095cd67ed/guides/common/modules/proc_upgrading-smartproxy-server.adoc?plain=1#L13-L14

* However, in the proxy installation guide, these are labeled as optional: https://github.com/theforeman/foreman-documentation/blob/028b74684e59bcb042835d20da4713e095cd67ed/guides/common/modules/proc_registering-capsule-to-satellite-server.adoc?plain=1#L7

All of this means that users who installed Foreman with Katello but didn't register their content proxies to Foreman don't have upgrade steps available.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is just a very primitive fix to address the inconsistency between installing and upgrading. It doesn't address the needs of users who have already installed without registering their content proxies (will they need steps to convert?).

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
