### PR TITLE
Add install and configure CLA powered by RHEL Lightspeed

### DIFF
--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -55,6 +55,8 @@ include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leve
 
 include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+1]
 
+include::modules/proc_installing-and-configuring-the-command-line-assistant-powered-by-rhel-lightspeed.adoc[leveloffset=+1]
+
 // the workflow is technically required for Foreman + OpenSCAP/REX Pull Mode
 // but the current docs reference "FQDN/pub/" which is Katello-only
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_installing-and-configuring-the-command-line-assistant-powered-by-rhel-lightspeed.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-the-command-line-assistant-powered-by-rhel-lightspeed.adoc
@@ -1,0 +1,51 @@
+[id="installing-and-configuring-the-command-line-assistant-powered-by-rhel-lightspeed"]
+= Installing and configuring the command-line assistant powered by RHEL Lightspeed
+
+You can install the command-line assistant on your {RHEL} hosts and proxy the assistant traffic through your {ProjectServer} or {SmartProxyServer}.
+
+The command-line assistant powered by RHEL Lightspeed is an optional AI tool available within the RHEL command-line interface trained on Red Hat knowledge from Knowledge Centered Service (KCS) articles, RHEL documentation, and other Red{nbsp}Hat resources.
+The command-line assistant provides you with interactive workflows to solve issues, implement new RHEL features, find information, and more.
+
+You have several options how you can install the command-line assistant:
+
+During host registration::
+You can run the installation and configuration commands in a snippet that is executed after the host is registered by using global registration.
+For more information, see xref:customizing-host-registration-by-using-snippets_{context}[].
+
+REX-enabled registered hosts::
+On hosts with remote execution (REX) enabled, you can run the installation and configuration commands by using a REX job, such as *Commands* / *Run Command*.
+
+Manually::
+You can run the installation and configuration commands on your host manually.
+
+.Prerequisites
+* Your host runs {RHEL} 9.6 or 10.0 or later.
+ifdef::satellite[]
+* Your {ProjectServer} is connected to the internet.
+endif::[]
+* Ensure that the AppStream repository is enabled for your host.
+
+.Procedure
+. Install the command-line assistant:
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# dnf install command-line-assistant
+----
+. Configure the command-line assistant to use your {ProjectServer} or {SmartProxyServer} to proxy the traffic:
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# sed -i 's/^endpoint = .*/endpoint = "https:\/\/_{foreman-example-com}_\/api\/lightspeed\/v1"/' \
+/etc/xdg/command-line-assistant/config.toml
+----
+
+.Verification
+* Send a prompt from your host, for example:
+----
+c "What is the latest GA RHEL version?"
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* https://blog.redhat.com/TODO[Announcing the general availability of Red Hat Enterprise Linux Lightspeed]
+* {RHELDocsBaseURL}10/html/solving_rhel_administration_tasks_with_the_command-line_assistant_powered_by_rhel_lightspeed/index[_Solving RHEL administration tasks with the command-line assistant powered by RHEL Lightspeed_]


### PR DESCRIPTION
#### What changes are you introducing?

Adding a procedure to install the command-line assistant powered by RHEL Lightspeed and configure it to proxy traffic through Foreman

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Requested by Satellite PM
[SAT-33464](https://issues.redhat.com/browse/SAT-33464) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Not entirely sure about the placement of the procedure.
- **Merge after the RH Summit** (May 23 or later)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
