### PR TITLE
Meaningful intros for sections in "Integrating provisioning infrastructure services"

### DIFF
--- a/guides/common/modules/con_configuring-dhcp-integration.adoc
+++ b/guides/common/modules/con_configuring-dhcp-integration.adoc
@@ -1,5 +1,5 @@
 [id="configuring-dhcp-integration"]
 = Configuring DHCP integration
 
-{Project} can manage IP leases on a DHCP server through a {SmartProxy}.
-This includes querying for available IP addresses, adding new reservations, and deleting existing reservations from the lease database.
+You can integrate DHCP with {Project} to automatically manage IP leases and boot configurations on a DHCP server during the provisioning of hosts.
+This helps to simplify the automated provisioning of new machines.

--- a/guides/common/modules/con_configuring-dns-integration.adoc
+++ b/guides/common/modules/con_configuring-dns-integration.adoc
@@ -1,5 +1,5 @@
 [id="configuring-dns-integration"]
 = Configuring DNS integration
 
-{Project} can manage DNS records by using {SmartProxy}.
-This DNS management contains updating and removing DNS records from existing DNS zones.
+You can integrate DNS with {Project} to automate the creation and management of DNS records during host provisioning and de-provisioning.
+This helps to ensure a consistent and error-free network configuration.

--- a/guides/common/modules/con_configuring-tftp-integration.adoc
+++ b/guides/common/modules/con_configuring-tftp-integration.adoc
@@ -1,4 +1,4 @@
 [id="configuring-tftp-integration"]
 = Configuring TFTP integration
 
-By integrating a TFTP server, you can perform unattended installations.
+You can integrate TFTP with {Project} to perform unattended installations by booting the operating system's setup over the network.

--- a/guides/common/modules/con_integrating-a-generic-tftp-server.adoc
+++ b/guides/common/modules/con_integrating-a-generic-tftp-server.adoc
@@ -1,9 +1,11 @@
 [id="integrating-a-generic-tftp-server"]
 = Integrating a generic TFTP server
 
-If you have an existing TFTP server in your network, you can integrate it into {Project} to perform unattended installations.
-If the installer does not manages the TFTP service, you must share the root directory of the TFTP service over the network to enable {Project} to access the files.
-However, in this case, {Project} does not manage the files on the TFTP server.
+If you have an TFTP server in your network, you can integrate this service into your {ProjectServer}.
+The integration enables you to continue using your existing TFTP server.
+
+With this type of integration, {Project} uses the Network File System (NFS) protocol to access the root directory of the TFTP service.
+However, if you use a generic TFTP server, {Project} does not manage the files on the TFTP server.
 
 [NOTE]
 ====

--- a/guides/common/modules/con_integrating-a-remote-isc-dhcp-server.adoc
+++ b/guides/common/modules/con_integrating-a-remote-isc-dhcp-server.adoc
@@ -1,4 +1,7 @@
 [id="integrating-a-remote-isc-dhcp-server"]
 = Integrating a remote ISC DHCP server
 
-If you already have an ISC DHCP server in your network, you can configure {ProjectServer} and {SmartProxyServer} to integrate this server to manage IP leases.
+If you have an ISC DHCP server in your network, but not on the same host as your {ProjectServer}, you can integrate this service into your {ProjectServer}.
+The integration enables you to continue using your existing DHCP server, and {Project} manages IP leases and boot configurations on the DHCP server during the provisioning of hosts.
+
+With this type of integration, {Project} uses an Object Management Application Programming Interface (OMAPI) key to update leases and the Network File System (NFS) protocol to access the ISC DHCP server's configuration files and lease database.

--- a/guides/common/modules/proc_configuring-isc-dhcp-to-use-with-server.adoc
+++ b/guides/common/modules/proc_configuring-isc-dhcp-to-use-with-server.adoc
@@ -1,9 +1,8 @@
 [id="configuring-isc-dhcp-to-use-with-server"]
 = Configuring ISC DHCP to use with {ProjectServer}
 
-To configure an external DHCP server running {EL} to use with {ProductName}, you must install the ISC DHCP Service and Berkeley Internet Name Domain (BIND) utilities packages.
-You must also share the DHCP configuration and lease files with {ProductName}.
-The example in this procedure uses the distributed Network File System (NFS) protocol to share the DHCP configuration and lease files.
+Before you can integrate an existing remote ISC DHCP server, you must prepare this host.
+The preparation work enables {ProjectServer} to update the leases and access the configuration files and lease database.
 
 ifdef::foreman-deb[]
 [NOTE]

--- a/guides/common/modules/proc_configuring-server-for-use-with-tftp.adoc
+++ b/guides/common/modules/proc_configuring-server-for-use-with-tftp.adoc
@@ -1,7 +1,7 @@
 [id="configuring-server-for-use-with-tftp"]
 = Configuring {ProductName} for use with tftp
 
-After you prepared the TFTP server and shared the root directory of the TFTP service over the network, integrate the service into {Project}.
+After you have prepared the TFTP server, integrate it into the {ProjectServer} or {SmartProxyServer}.
 
 .Prerequisites
 * You shared the `/exports/var/lib/tftpboot` on the TFTP server with NFS.

--- a/guides/common/modules/proc_configuring-server-or-proxy-for-use-with-isc-dhcp.adoc
+++ b/guides/common/modules/proc_configuring-server-or-proxy-for-use-with-isc-dhcp.adoc
@@ -1,11 +1,7 @@
 [id="configuring-server-or-proxy-for-use-with-isc-dhcp"]
 = Configuring {ProjectServer} or {SmartProxyServer} for use with ISC DHCP
 
-You can configure {ProductName} with a non-installer-managed DHCP server. Perform the steps on the {ProjectServer} or {SmartProxyServer}.
-
-.Prerequisites
-* You configured the DHCP service and shared the configuration and lease files over the network.
-For more information, see xref:configuring-isc-dhcp-to-use-with-server[].
+After you have prepared the DHCP server as described in xref:configuring-isc-dhcp-to-use-with-server[], integrate the ISC DHCP server into the {ProjectServer} or {SmartProxyServer}.
 
 .Procedure
 . Install the required package:

--- a/guides/common/modules/proc_disabling-dhcp-for-integration.adoc
+++ b/guides/common/modules/proc_disabling-dhcp-for-integration.adoc
@@ -1,7 +1,7 @@
 [id="disabling-dhcp-for-integration"]
 = Disabling DHCP for integration
 
-If you want to manually manage a DHCP service, you must prevent {Project} from maintaining this service on the operating system and disable orchestration to avoid errors.
+If you want to manually manage a DHCP service and not integrate it into {ProjectServer}, you must prevent {Project} from maintaining this service on the operating system and disable orchestration to avoid errors.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_disabling-dns-for-integration.adoc
+++ b/guides/common/modules/proc_disabling-dns-for-integration.adoc
@@ -1,7 +1,7 @@
 [id="disabling-dns-for-integration"]
 = Disabling DNS for integration
 
-If you want to manually manage a DNS service, you must prevent {Project} from maintaining this service on the operating system and disable orchestration to avoid errors.
+If you want to manually manage a DNS service and not integrate it into {ProjectServer}, you must prevent {Project} from maintaining this service on the operating system and disable orchestration to avoid errors.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_disabling-tftp-for-integration.adoc
+++ b/guides/common/modules/proc_disabling-tftp-for-integration.adoc
@@ -1,7 +1,7 @@
 [id="disabling-tftp-for-integration"]
 = Disabling TFTP for integration
 
-If you want to manually manage a TFTP service, you must prevent {Project} from maintaining this service on the operating system and disable orchestration to avoid errors.
+If you want to manually manage a TFTP service and not integrate it into {Project}, you must prevent {Project} from maintaining this service on the operating system and disable orchestration to avoid errors.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_enabling-the-installer-managed-dhcp-service.adoc
+++ b/guides/common/modules/proc_enabling-the-installer-managed-dhcp-service.adoc
@@ -4,8 +4,6 @@
 If you do not have a DHCP server available in your network, you can use the installer-managed DHCP service.
 This feature enables you to provide a DHCP service with low maintenance overhead.
 
-Perform the steps on the {Project} or {SmartProxyServer} that you want to configure to manage the DHCP service for the subnet.
-
 .Prerequisites
 * You know the following network information:
 ** The range of IP addresses the DHCP should manage

--- a/guides/common/modules/proc_enabling-the-installer-managed-dns-service.adoc
+++ b/guides/common/modules/proc_enabling-the-installer-managed-dns-service.adoc
@@ -4,8 +4,6 @@
 If you do not have a DNS server available in your network, you can use the installer-managed DNS service.
 This feature enables you to provide a DNS service with low maintenance overhead.
 
-Perform the steps on the {Project} or {SmartProxyServer} that you want to configure to manage the DNS service for the domain.
-
 .Procedure
 . Configure {Project} or {SmartProxy} as DNS server:
 +

--- a/guides/common/modules/proc_integrating-a-generic-rfc-2136-compatible-remote-dns-server.adoc
+++ b/guides/common/modules/proc_integrating-a-generic-rfc-2136-compatible-remote-dns-server.adoc
@@ -1,8 +1,10 @@
 [id="integrating-a-generic-rfc-2136-compatible-remote-dns-server"]
 = Integrating a generic RFC 2136-compatible remote DNS server
 
-You can configure {ProductName} to integrate a remote DNS server that supports dynamic updates as defined in link:https://datatracker.ietf.org/doc/html/rfc2136[RFC 2136].
-In this case, {ProductName} uses the `nsupdate` utility to update DNS records on the remote server.
+If you have a DNS service in your network and it supports RFC 2136-compatible dynamic updates, you can integrate this service into your {ProjectServer}.
+The integration enables you to continue using your existing DNS server, and {Project} manages DNS records for systems provisioned, updated, and decommissioned.
+
+With this type of integration, {Project} uses a transaction signature (TSIG) key to authenticate to the DNS server and the `nsupdate` utility to manage DNS records.
 
 .Prerequisites
 * The remote DNS service is configured and can be queried.
@@ -18,7 +20,7 @@ In this case, {ProductName} uses the `nsupdate` utility to update DNS records on
 # chmod -v 640 /etc/foreman-proxy/rndc.key
 ----
 ifndef::foreman-deb[]
-. Restore the SELinux context on `/etc/foreman-proxy/rndc.key`::
+. Restore the SELinux context on `/etc/foreman-proxy/rndc.key`:
 +
 [options="nowrap"]
 ----

--- a/guides/common/modules/proc_integrating-a-local-self-managed-dns-service.adoc
+++ b/guides/common/modules/proc_integrating-a-local-self-managed-dns-service.adoc
@@ -3,9 +3,7 @@
 
 The installer exposes a limited feature set for the {Project} installer-managed DNS service.
 For example, you can configure only a single forward DNS zone.
-As an alternative to the installer-managed DNS service, you can run a DNS server locally on the {Project} or {SmartProxyServer} to bypass these limitations.
-
-Perform the steps on the {ProjectServer} or {SmartProxyServer} that runs the self-managed DNS service.
+As an alternative to the installer-managed DNS service, you can run a DNS server locally on the {ProjectServer} or {SmartProxyServer} to bypass these limitations.
 
 .Prerequisites
 * You installed and configured a DNS service on the {ProjectServer} or {SmartProxyServer} host.

--- a/guides/common/modules/proc_integrating-dnsmasq-dhcp-by-using-the-libvirt-api.adoc
+++ b/guides/common/modules/proc_integrating-dnsmasq-dhcp-by-using-the-libvirt-api.adoc
@@ -1,8 +1,10 @@
 [id="integrating-dnsmasq-dhcp-by-using-the-libvirt-api"]
 = Integrating dnsmasq DHCP by using the libvirt API
 
-The `dhcp_libvirt` plugin manages IP reservations and leases using `dnsmasq` through the `libvirt` API.
-It uses `ruby-libvirt` to connect to the local or remote instance of the `libvirt` service.
+If you manage VMs through the `libvirt` API and `libvirt` uses the `dnsmasq` DHCP service, you can integrate `dnsmasq` into {ProjectServer}.
+The integration enables you to continue using your existing DHCP server, and {Project} manages IP leases and boot configurations on the DHCP server during the provisioning of hosts.
+
+With this type of integration, {Project} uses the `libvirt` API to manage DHCP leases in local or remote `dnsmasq` instances.
 
 .Procedure
 . Configure {ProjectServer} or {SmartProxyServer} to connect to the `libvirt` API:

--- a/guides/common/modules/proc_integrating-dnsmasq-dns-by-using-the-libvirt-api.adoc
+++ b/guides/common/modules/proc_integrating-dnsmasq-dns-by-using-the-libvirt-api.adoc
@@ -1,8 +1,10 @@
 [id="integrating-dnsmasq-dns-by-using-the-libvirt-api"]
 = Integrating dnsmasq DNS by using the libvirt API
 
-The `dns_libvirt` DNS provider manages DNS records using `dnsmasq` through the `libvirt` API.
-It uses `ruby-libvirt` gem to connect to the local or a remote instance of the `libvirt` service.
+If you manage VMs through the `libvirt` API and `libvirt` uses the `dnsmasq` DNS service, you can integrate `dnsmasq` into {ProjectServer}.
+The integration enables you to continue using `dnsmasq` in `libvirt`, and {Project} manages DNS records for systems provisioned, updated, and decommissioned.
+
+With this type of integration, {Project} uses the `libvirt` API to manage DNS records in local or remote `dnsmasq` instances.
 
 .Procedure
 . Configure {ProjectServer} or {SmartProxyServer} to connect to the `libvirt` API:

--- a/guides/common/modules/proc_integrating-idm-dns-with-gss-tsig-authentication.adoc
+++ b/guides/common/modules/proc_integrating-idm-dns-with-gss-tsig-authentication.adoc
@@ -1,8 +1,10 @@
 [id="integrating-idm-dns-update-with-gss-tsig-authentication"]
 = Integrating {FreeIPA} DNS with GSS-TSIG authentication
 
-You can configure the {FreeIPA} server to use the generic security service algorithm for secret key transaction (GSS-TSIG) technology defined in https://tools.ietf.org/html/rfc3645[RFC3645].
-To configure the {FreeIPA} server to use the GSS-TSIG technology, you must install the {FreeIPA} client on the {ProductName} base operating system.
+If you use {FreeIPA} to centrally manage hosts in your domain, you can integrate the {FreeIPA} DNS service into {ProjectServer}.
+The integration enables you to continue using your existing {FreeIPA} DNS service, and {Project} manages DNS records for provisioned, updated, and decommissioned systems.
+
+If your {FreeIPA} DNS server supports generic security service transaction signature (GSS-TSIG) authentication, {Project} uses Kerberos to authenticate to the DNS server and the `nsupdate` utility to manage DNS records.
 
 .Prerequisites
 * The {FreeIPA} server is deployed and functional.
@@ -18,7 +20,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# kinit _My_{FreeIPA}_User_
+# kinit __My_{FreeIPA}_User__
 ----
 .. Create a new Kerberos principal {ProductName} to use to authenticate on the {FreeIPA} server:
 *** For a {ProjectServer}, enter:

--- a/guides/common/modules/proc_integrating-idm-dns-with-tsig-authentication.adoc
+++ b/guides/common/modules/proc_integrating-idm-dns-with-tsig-authentication.adoc
@@ -1,8 +1,16 @@
 [id="integrating-idm-dns-with-tsig-authentication"]
 = Integrating {FreeIPA} DNS with TSIG authentication
 
-You can configure {FreeIPA} to use the secret key transaction authentication for DNS (TSIG) technology that uses a key file for authentication.
-The TSIG protocol is defined in https://tools.ietf.org/html/rfc2845[RFC2845].
+If you use {FreeIPA} to centrally manage hosts in your domain, you can integrate the {FreeIPA} DNS service into {ProjectServer}.
+The integration enables you to continue using your existing {FreeIPA} DNS service, and {Project} manages DNS records for systems provisioned, updated, and decommissioned.
+
+If your {FreeIPA} DNS server supports only a transaction signature (TSIG) key for authentication, {Project} uses this key to authenticate to the DNS server and the `nsupdate` utility to manage DNS records.
+
+[NOTE]
+====
+If your {FreeIPA} DNS server supports Kerberos and generic security service transaction signature (GSS-TSIG) authentication, prefer this method over TSIG for improved security and reduced key management effort.
+For more information, see xref:integrating-idm-dns-update-with-gss-tsig-authentication[].
+====
 
 .Prerequisites
 * The {FreeIPA} server is deployed and functional.

--- a/guides/common/modules/proc_integrating-infoblox-dhcp.adoc
+++ b/guides/common/modules/proc_integrating-infoblox-dhcp.adoc
@@ -1,7 +1,10 @@
 [id="integrating-infoblox-dhcp"]
 = Integrating Infoblox DHCP
 
-Install the DHCP Infoblox provider on {ProductName}.
+If you have an Infoblox DHCP service in your network, you can integrate this service into {ProjectServer}.
+The integration enables you to continue using your existing DHCP server, and {Project} manages IP leases and boot configurations on the DHCP server during the provisioning of hosts.
+
+With this type of integration, {Project} uses the Infoblox API to authenticate and manage DHCP leases in local or remote Infoblox DHCP instances.
 
 .Limitations
 * You can manage DHCP entries only in a single network and view, and you cannot edit the view after you create it.

--- a/guides/common/modules/proc_integrating-infoblox-dns.adoc
+++ b/guides/common/modules/proc_integrating-infoblox-dns.adoc
@@ -1,7 +1,10 @@
 [id="integrating-infoblox-dns"]
 = Integrating Infoblox DNS
 
-Install the DNS Infoblox provider on {ProductName}.
+If you have an Infoblox DNS service in your network, you can integrate this service into {ProjectServer}.
+The integration enables you to continue using your existing DNS server, and {Project} manages DNS records for systems provisioned, updated, and decommissioned.
+
+With this type of integration, {Project} uses the Infoblox API to authenticate and manage DNS records in local or remote Infoblox DNS instances.
 
 .Limitations
 * You can manage DNS entries only in a single view, and you cannot edit the view after you create it.

--- a/guides/common/modules/proc_integrating-powerdns.adoc
+++ b/guides/common/modules/proc_integrating-powerdns.adoc
@@ -1,7 +1,10 @@
 [id="integrating-powerdns"]
 = Integrating PowerDNS
 
-The _dns_powerdns_ DNS provider manages DNS records using the https://www.powerdns.com/[PowerDNS] REST API.
+If you have a PowerDNS service in your network, you can integrate this service into {ProjectServer}.
+The integration enables you to continue using your existing DNS server, and {Project} manages DNS records for systems provisioned, updated, and decommissioned.
+
+With this type of integration, {Project} uses the PowerDNS REST API to authenticate and manage DNS records in local or remote PowerDNS instances.
 
 .Procedure
 . Configure {ProjectServer} or {SmartProxyServer} to connect to the PowerDNS service:

--- a/guides/common/modules/proc_integrating-route-53-dns.adoc
+++ b/guides/common/modules/proc_integrating-route-53-dns.adoc
@@ -1,8 +1,10 @@
 [id="integrating-route-53"]
 = Integrating Route 53 DNS
 
-_Route 53_ is a DNS provider by Amazon.
-For more information, see https://aws.amazon.com/route53/[aws.amazon.com/route53].
+If you have an Amazon Route 53 DNS service in your network, you can integrate this service into {ProjectServer}.
+The integration enables you to continue using your existing DNS server, and {Project} manages DNS records for systems provisioned, updated, and decommissioned.
+
+With this type of integration, {Project} uses the Route 53 API to authenticate and manage DNS records in Amazon Web Services (AWS).
 
 .Procedure
 . Configure {ProjectServer} or {SmartProxyServer} to connect to the Amazon Route 53 DNS service:


### PR DESCRIPTION
#### What changes are you introducing?

New introductions for all sections with weak intros in the "Integrating provisioning infrastructure services" guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Many introductions only repeated the section title, summarized instructions from the procedure (install this, configure that,...), etc. They weren't helpful for the reader.

The new intros give an overview of what to expect from the procedure and they explain the "why" and in which cases the user should follow the procedure.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [X] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
