### PR TITLE
Add info about CLA powered by RHEL Lightspeed

### DIFF
--- a/guides/common/modules/con_command-line-assistant-on-project-hosts.adoc
+++ b/guides/common/modules/con_command-line-assistant-on-project-hosts.adoc
@@ -1,0 +1,15 @@
+[id="command-line-assistant-on-{project-context}-hosts"]
+= Command-line assistant on {Project} hosts
+
+You can use the command-line assistant powered by RHEL Lightspeed on systems that are registered to {ProjectName}.
+The command-line assistant is available on {RHEL} 9.6, 10.0, or later.
+
+You can proxy the assistant traffic through {ProjectServer} or {SmartProxyServer}.
+To do so, you have to modify configuration of the command-line assistant.
+For more information, see {RHELDocsBaseURL}10/html/interacting_with_the_command-line_assistant_powered_by_rhel_lightspeed/provisioning-the-command-line-assistant-to-rhel-deployments-with-red-hat-satellite[Provisioning the command-line assistant to RHEL deployments with Red Hat Satellite].
+
+Note that if you enable the {advisorengine} plugin, {Project} will not be able to intermediate the connection for the command-line assistant.
+
+[role="_additional-resources"]
+.Additional resources
+* {RHELDocsBaseURL}10/html/interacting_with_the_command-line_assistant_powered_by_rhel_lightspeed/index[_{RHEL}{nbsp}10 Interacting with the command-line assistant powered by RHEL Lightspeed_]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -32,6 +32,10 @@ ifdef::katello,orcharhino,satellite[]
 include::common/assembly_converting-a-host-to-rhel.adoc[leveloffset=+1]
 endif::[]
 
+ifdef::satellite[]
+include::common/modules/con_command-line-assistant-on-project-hosts.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_host-management-and-monitoring-using-cockpit.adoc[leveloffset=+1]
 
 ifdef::satellite,orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding info about command-line assistant powered by RHEL Lightspeed

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

[SAT-33464](https://issues.redhat.com/browse/SAT-33464)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Not sure about the placement.
- Not sure whether this info should be available in upstream docs or not.
- Replaces PR #3857
- **To be merged after RHEL 10 GA**

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15
* [x] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
