### PR TITLE
Simplify built-in API doc link

### DIFF
--- a/guides/common/modules/proc_accessing-the-built-in-api-reference.adoc
+++ b/guides/common/modules/proc_accessing-the-built-in-api-reference.adoc
@@ -8,7 +8,7 @@ You can access the full API reference on your {ProjectServer}.
 +
 [source, none, options="nowrap", subs="+quotes,attributes"]
 ----
-https://_{foreman-example-com}_/apidoc/v2.html
+https://_{foreman-example-com}_/apidoc/
 ----
 +
 Replace _{foreman-example-com}_ with the FQDN of your {ProjectServer}.


### PR DESCRIPTION
#### What changes are you introducing?

Replacing `.../apidoc/v2.html` with `.../apidoc/`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3859#discussion_r2092493117

Tested, works :) 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

There are plenty of examples that use a path with `v2`. I'm not updating those because I can't test them. Hopefully, changing the path in the "Where to get help" section of the API guide is enough of an improvement already.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

All applicable branches