### PR TITLE
Drop upgrade step to upgrade to PostgreSQL 13

### DIFF
--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -53,7 +53,6 @@ ifdef::satellite[]
 # {foreman-maintain} self-upgrade
 ----
 
-. If you are using an external database, upgrade your database to PostgreSQL 13.
 . Use the health check option to determine if the system is ready for upgrade.
 When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials.
 These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -148,7 +148,6 @@ If you lose connection to the command shell where the upgrade command is running
 # {foreman-maintain} self-upgrade --maintenance-repo-label {Project}-Maintenance
 ----
 
-. If you are using an external database, upgrade your database to PostgreSQL 13.
 . Use the health check option to determine if the system is ready for upgrade.
 When prompted, enter the hammer admin user credentials to configure `{foreman-maintain}` with hammer credentials.
 These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.


### PR DESCRIPTION
#### What changes are you introducing?

Removing a step in the upgrade procedure for upgrading the external database to PostgreSQL 13.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Upgrading to PostgreSQL 13 was already a mandatory step in the Foreman 3.12/Satellite 6.16 upgrade guides. This means that we can remove the step starting with Foreman 3.13.

https://issues.redhat.com/browse/SAT-34149

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
