### PR TITLE
Use attribute for FreeIPA server name

### DIFF
--- a/guides/common/modules/proc_enrolling-projectserver-in-freeipa-domain.adoc
+++ b/guides/common/modules/proc_enrolling-projectserver-in-freeipa-domain.adoc
@@ -82,7 +82,7 @@ Specify that you want to use a random password for the enrollment.
   Random password: W5YpARl=7M.n
   Password: True
   Keytab: False
-  Managed by: ipa-server.example.com
+  Managed by: {freeipaserver-example-com}
 ----
 . Enable access to the keytab file by creating a service principal for your {ProjectServer}:
 +


### PR DESCRIPTION
#### What changes are you introducing?

This replaces literal `ipa-server.example.com` with the proper attribute.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Using the attribute ensures that the server name is displayed correctly in all flavors.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

All applicable branches.