### PR TITLE
Deprecate oVirt in 3.15

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -19,5 +19,5 @@ There are no upgrade warnings with Foreman {ProjectVersion}.
 
 === Compute resources - {oVirt}
 
-* The {oVirt} compute resource has been deprecated and will be removed in the 3.16 release.
-* https://community.theforeman.org/t/rfc-deprecation-and-removal-of-ovirt-compute-resource/42527[RFC: Deprecation and removal of oVirt Compute Resource]
+The {oVirt} compute resource has been deprecated and will be removed in the 3.16 release.
+For more information, see https://community.theforeman.org/t/rfc-deprecation-and-removal-of-ovirt-compute-resource/42527[RFC: Deprecation and removal of oVirt Compute Resource]

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -15,4 +15,9 @@ There are no upgrade warnings with Foreman {ProjectVersion}.
 [id="foreman-deprecations"]
 == Deprecations
 
-There are no deprecations with Foreman {ProjectVersion}.
+// There are no deprecations with Foreman {ProjectVersion}.
+
+=== Compute resources - {oVirt}
+
+* The {oVirt} compute resource has been deprecated and will be removed in the 3.16 release.
+* https://community.theforeman.org/t/rfc-deprecation-and-removal-of-ovirt-compute-resource/42527[RFC: Deprecation and removal of oVirt Compute Resource]


### PR DESCRIPTION
#### What changes are you introducing?

oVirt integration is deprecated in 3.15 and removed in 3.16

Replaces #3724

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://community.theforeman.org/t/rfc-deprecation-and-removal-of-ovirt-compute-resource/42527
https://projects.theforeman.org/issues/38266
https://issues.redhat.com/browse/SAT-12005

Filing a new PR because the 3.15 release has been branched.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Migration is covered in PR #3871

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
