### PR TITLE
Create a section for helper app references

### DIFF
--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -5,10 +5,6 @@ ifdef::context[:parent-context: {context}]
 
 Review the following prerequisites before you install {SmartProxyServer}.
 
-ifdef::satellite[]
-include::modules/snip_red-hat-helper-apps.adoc[]
-endif::[]
-
 // System Requirements
 include::modules/ref_system-requirements.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -5,10 +5,6 @@ ifdef::context[:parent-context: {context}]
 
 Review the following prerequisites before you install {ProjectServer}.
 
-ifdef::satellite[]
-include::modules/snip_red-hat-helper-apps.adoc[]
-endif::[]
-
 include::modules/ref_system-requirements.adoc[leveloffset=+1]
 
 include::modules/ref_storage-requirements.adoc[leveloffset=+1]

--- a/guides/common/modules/con_preparing-for-project-upgrade.adoc
+++ b/guides/common/modules/con_preparing-for-project-upgrade.adoc
@@ -2,7 +2,3 @@
 = Preparing for {Project} upgrade
 
 Review the following prerequisites and available upgrade paths before upgrading your current {ProjectName} installation to {ProjectName} {ProjectVersion}.
-
-ifdef::satellite[]
-include::snip_red-hat-helper-apps.adoc[]
-endif::[]

--- a/guides/common/modules/con_red-hat-helper-app.adoc
+++ b/guides/common/modules/con_red-hat-helper-app.adoc
@@ -1,4 +1,11 @@
 ifdef::upgrading-connected,upgrading-disconnected[]
+= {ProjectName} Upgrade Helper app
+endif::[]
+ifdef::installing-satellite-server-connected,installing-satellite-server-disconnected,installing-capsule-server[]
+= {ProjectName} Installation Helper app
+endif::[]
+
+ifdef::upgrading-connected,upgrading-disconnected[]
 For interactive instructions for performing the upgrade, you can use the {ProjectName} Upgrade Helper on the Red{nbsp}Hat Customer Portal.
 This application provides upgrade instructions customized for your current version number of {Project}.
 As a result, you receive instructions that are specific to your upgrade path, as well as steps to prevent known issues.

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -18,6 +18,10 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
+ifdef::satellite[]
+include::common/modules/con_red-hat-helper-app.adoc[leveloffset=+1]
+endif::[]
+
 // Preparing your Environment for Installation
 include::common/assembly_preparing-environment-for-capsule-installation.adoc[leveloffset=+1]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -17,6 +17,10 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
+ifdef::satellite[]
+include::common/modules/con_red-hat-helper-app.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_preparing-environment-for-installation.adoc[leveloffset=+1]
 
 include::common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -17,6 +17,10 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 
 include::common/modules/con_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
 
+ifdef::satellite[]
+include::common/modules/con_red-hat-helper-app.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_preparing-environment-for-installation.adoc[leveloffset=+1]
 
 include::common/assembly_installing-satellite-server-disconnected.adoc[leveloffset=+1]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -17,6 +17,10 @@ If you have installed the Katello plugin, you must use {BaseURL}Upgrading_Projec
 ====
 endif::[]
 
+ifdef::satellite[]
+include::common/modules/con_red-hat-helper-app.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_preparing-for-project-upgrade.adoc[leveloffset=+1]
 
 include::common/modules/con_upgrading-project.adoc[leveloffset=+1]

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -16,6 +16,10 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 
 include::common/modules/con_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
 
+ifdef::satellite[]
+include::common/modules/con_red-hat-helper-app.adoc[leveloffset=+1]
+endif::[]
+
 include::common/assembly_preparing-for-project-upgrade.adoc[leveloffset=+1]
 
 include::common/modules/con_upgrading-project.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Moving the current snippet about Satellite helper apps to a separate section.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We have feedback saying that customers are often not aware of the helper apps' existence. Giving the references to the apps their own section with a title could help with that.

https://issues.redhat.com/browse/SAT-34067

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
