### PR TITLE
Add RHEL 10 to Planning guide

### DIFF
--- a/guides/common/modules/con_supported-client-architectures-for-configuration-management.adoc
+++ b/guides/common/modules/con_supported-client-architectures-for-configuration-management.adoc
@@ -7,6 +7,7 @@ You can use the following combinations of major versions of {RHEL} and hardware 
 [options="header",cols="2,1"]
 |====
 |Platform |Architectures
+|{RHEL} 10 |x86_64
 |{RHEL} 9 |x86_64
 |{RHEL} 8 |x86_64, aarch64
 |{RHEL} 7 |x86_64

--- a/guides/common/modules/con_supported-client-architectures-for-configuration-management.adoc
+++ b/guides/common/modules/con_supported-client-architectures-for-configuration-management.adoc
@@ -12,3 +12,5 @@ You can use the following combinations of major versions of {RHEL} and hardware 
 |{RHEL} 8 |x86_64, aarch64
 |{RHEL} 7 |x86_64
 |====
+
+Note that Puppet agent is currently unavailable for {RHEL} 10.

--- a/guides/common/modules/con_supported-client-architectures-for-content-management.adoc
+++ b/guides/common/modules/con_supported-client-architectures-for-content-management.adoc
@@ -8,6 +8,7 @@ The {project-client-name} repositories are also available for these combinations
 [options="header"]
 |====
 |Platform |Architectures
+|{RHEL} 10 |x86_64, ppc64le, s390x, aarch64
 |{RHEL} 9 |x86_64, ppc64le, s390x, aarch64
 |{RHEL} 8 |x86_64, ppc64le, s390x
 |{RHEL} 7 |x86_64, ppc64 (BE), ppc64le, aarch64, s390x

--- a/guides/common/modules/con_supported-client-architectures-for-host-provisioning.adoc
+++ b/guides/common/modules/con_supported-client-architectures-for-host-provisioning.adoc
@@ -7,6 +7,7 @@ You can use the following combinations of major versions of {RHEL} and hardware 
 [options="header"]
 |====
 |Platform |Architectures
+|{RHEL} 10 |x86_64
 |{RHEL} 9 |x86_64
 |{RHEL} 8 |x86_64
 |{RHEL} 7 |x86_64


### PR DESCRIPTION
#### What changes are you introducing?

Adding RHEL 10 and supported architectures to the Planning guide for Satellite

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

RHEL 10 is supported in Satellite 6.17+

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I've only copy-pasted architectures of RHEL 9. This has to be confirmed by SMEs.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
