### PR TITLE
Use AAP as the value of :awx: attribute for Satellite

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -54,6 +54,7 @@
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/theforeman/foreman/plugins/modules/
 :awx: AWX
 :awx-context: {awx}
+:awx-example-com: awx.example.com
 :bind-package: bind-utils
 :certs-generate: foreman-proxy-certs-generate
 :certs-proxy-context: foreman-proxy

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -52,6 +52,7 @@
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
 :awx: Ansible Automation Platform
 :awx-context: Ansible_Automation_Platform
+:awx-example-com: aap.example.com
 :certs-generate: capsule-certs-generate
 :certs-proxy-context: capsule
 :client-os: {RHEL}

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -50,8 +50,8 @@
 :ansible-namespace: redhat.satellite
 :ansible-module-defaults-group: {ansible-namespace}.satellite
 :ansiblefilepath: /usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules/
-:awx: Ansible Automation Controller
-:awx-context: Ansible_Automation_Controller
+:awx: Ansible Automation Platform
+:awx-context: Ansible_Automation_Platform
 :certs-generate: capsule-certs-generate
 :certs-proxy-context: capsule
 :client-os: {RHEL}

--- a/guides/common/modules/con_integrating-project-and-awx.adoc
+++ b/guides/common/modules/con_integrating-project-and-awx.adoc
@@ -2,9 +2,6 @@
 = Integrating {ProjectName} and {awx}
 
 You can integrate {ProjectName} and {awx} to use {ProjectServer} as a dynamic inventory source for {awx}.
-ifdef::satellite[]
-{awx} is a component of the {Team} Ansible Automation Platform.
-endif::[]
 
 You can also use the provisioning callback function to run playbooks on hosts managed by {Project}, from either the host or {awx}.
 When provisioning new hosts from {ProjectServer}, you can use the provisioning callback function to trigger playbook runs from {awx}.

--- a/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
+++ b/guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
@@ -72,7 +72,7 @@ endif::[]
 |====
 |Name |Value |Description
 |`ansible_tower_provisioning` |true |Enables Provisioning Callback.
-|`ansible_tower_api_url` |_https://controller.example.com/api/controller/v2_ | Defines the URL of your {awx}, including the required API path.
+|`ansible_tower_api_url` |_https://{awx-example-com}/api/controller/v2_ | Defines the URL of your {awx}, including the required API path.
 For older versions of {awx}, use `/api/v2` instead of `/api/controller/v2`.
 If unsure, check the API endpoints of your instance to verify the correct path.
 |`ansible_job_template_id` |_template_ID_ |The ID of your provisioning template that you can find in the URL of the template: `/templates/job_template/_5_`.
@@ -112,7 +112,7 @@ $ curl \
 --insecure \
 --show-error \
 --silent \
-https://_controller.example.com_/api/v2/job_templates/_8_/callback/
+https://_{awx-example-com}_/api/v2/job_templates/_8_/callback/
 ----
 +
 Ensure that you use `https` when you enter the provisioning callback URL.


### PR DESCRIPTION
#### What changes are you introducing?

Fixing AWX as an equivalent of Ansible Automation Platform instead of Ansible Automation Controller for Satellite

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

[SAT-32610](https://issues.redhat.com/browse/SAT-32610) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Only the following files use the `{awx}` attribute:
- guides/common/attributes-base.adoc
- guides/common/modules/proc_configuring-provisioning-callback-for-a-host.adoc
- guides/common/modules/con_integrating-project-and-awx.adoc - _updated_
- guides/common/modules/proc_adding-project-server-to-awx-as-a-dynamic-inventory-item.adoc

Only one of them seems to have required an additional change.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
