### PR TITLE
Mention dbus-tools package required for EL 9 cloud-init images

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -73,6 +73,8 @@ endif::[]
 ----
 # {client-package-install-el8} cloud-init open-vm-tools perl-interpreter perl-File-Temp
 ----
++
+On {EL} 9, you also require the `dbus-tools` package for network connectivity.
 . Disable network configuration by `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]


### PR DESCRIPTION
#### What changes are you introducing?

Mentioning that the `dbus-tools` package has to be installed on EL 9 cloud-init images

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

[SAT-31366](https://issues.redhat.com/browse/SAT-31366) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Is this okay or should I repeat the install command for EL versions instead?

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
