### PR TITLE
Rephrase registration to load-balanced SmartProxy

### DIFF
--- a/guides/common/modules/snip_host-registration-steps.adoc
+++ b/guides/common/modules/snip_host-registration-steps.adoc
@@ -10,7 +10,7 @@ endif::[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Register Host*.
 ifdef::load-balancing[]
-. From the *{SmartProxy}* dropdown list, select the load balancer.
+. From the *{SmartProxy}* dropdown list, select a {SmartProxyServer} configured for load balancing.
 . Select *Force* to register a host that has been previously registered to a {SmartProxyServer}.
 endif::[]
 . From the *Activation Keys* list, select the activation keys to assign to your host.


### PR DESCRIPTION
#### What changes are you introducing?

Rephrasing the step to select a load-balanced Smart Proxy server

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Previous phrasing wasn't precise because the load balancer as such is not offered in the menu

[SAT-33236](https://issues.redhat.com/browse/SAT-33236)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
