### PR TITLE
Fix asciidoc syntax to show numbered steps

### DIFF
--- a/guides/common/modules/proc_upgrading-the-external-database-operating-system.adoc
+++ b/guides/common/modules/proc_upgrading-the-external-database-operating-system.adoc
@@ -13,6 +13,7 @@ endif::[]
 . Create a backup of your existing external database.
 . Restore the backup on the new {EL} 9 server.
 . Verify that {Project} can reach the new database:
++
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # PGPASSWORD='_My_Foreman_Database_Password_' psql -h _postgres.example.com_ -p 5432 -U foreman -d foreman -c "SELECT 1 as ping"


### PR DESCRIPTION
This PR ensures that the numbered steps are shown in order.

Found while reviewing https://github.com/theforeman/foreman-documentation/pull/3865.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick as necessary.