### PR TITLE
Do not require Ansible collection on orcharhino

### DIFF
--- a/guides/common/modules/proc_installing-the-project-ansible-modules.adoc
+++ b/guides/common/modules/proc_installing-the-project-ansible-modules.adoc
@@ -2,10 +2,10 @@
 = Installing the {Project} Ansible modules
 
 Modules from the {Project} Ansible Collection are provided by the `{ansible-collection-package}` package.
-ifndef::satellite[]
+ifndef::orcharhino,satellite[]
 Before you can use the modules, you must install the package on the system where you run your playbooks.
 endif::[]
-ifdef::satellite[]
+ifdef::orcharhino,satellite[]
 On your {ProjectServer}, the package is installed by default.
 If you want to execute your playbooks on a different system, you must first install the package that provides them.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

On orcharhino, there is a meta package that is always installed which requires the Foreman Ansible collection. On orcharhino Server:

`$ rpm -qa "ansible-collection-*"`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Refs PR 3844 on GitHub

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick as applicable.