### PR TITLE
Add information	about the client-2 repository

### DIFF
--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -46,12 +46,7 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Configure* > *Global Parameters* to add host parameters globally.
 Alternatively, you can navigate to *Configure* > *Host Groups* and edit or create a host group to add host parameters only to a host group.
 . Enable the Puppet agent using a host parameter in global parameters or a host group.
-// consolidate with line 54 as soon as Satellite client contains Puppet agent 8
-ifdef::satellite[]
-+
-Add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.
-endif::[]
-ifdef::katello,orcharhino[]
+ifdef::satellite,katello,orcharhino[]
 +
 * To use Puppet 8, add a host parameter named `enable-puppet8`, select the *boolean* type, and set the value to `true`.
 * To use Puppet 7, add a host parameter named `enable-puppet7`, select the *boolean* type, and set the value to `true`.

--- a/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
@@ -10,6 +10,9 @@ You must enable and synchronize the new {ProjectVersion} repositories before you
 . From the list of results, expand the following repositories and click the *Enable* icon to enable the repositories:
 +
 * To upgrade {Project} clients, enable the *{project-client-name}* repositories for all {RHEL} versions that clients use.
+ifdef::satellite[]
+To upgrade Puppet agent to Puppet agent 8, enable the *{project-client-name}-2* repositories for all {RHEL} versions that clients use.
+endif::[]
 +
 * If you have {SmartProxyServers}, to upgrade them, enable the following repositories too:
 +

--- a/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
+++ b/guides/common/modules/ref_supported-puppet-versions-and-system-requirements.adoc
@@ -12,11 +12,9 @@ ifndef::satellite[]
 endif::[]
 Ensure that the Puppet modules used to configure your hosts are compatible with your Puppet version.
 +
-ifdef::satellite[]
-On hosts, you can use Puppet agent 7.
-endif::[]
-ifndef::satellite[]
 On hosts, you can use either Puppet agent 8 or Puppet agent 7.
+ifdef::satellite[]
+To use Puppet agent 8 on the host, enable the *{project-client-name}-2* repository. 
 endif::[]
 
 System Requirements::

--- a/guides/common/modules/snip_prerequisite-project-client-repository-ak.adoc
+++ b/guides/common/modules/snip_prerequisite-project-client-repository-ak.adoc
@@ -3,6 +3,8 @@ ifdef::foreman-el[]
 endif::[]
 ifndef::foreman-el[]
 * {project-client-name} repository for the operating system version of the host is synchronized on {ProjectServer} and enabled in the activation key you use.
+ifdef::satellite[]
+{project-client-name}-2 repository for the operating system version of the host is synchronized on {ProjectServer} and enabled in the activation key you use, if you want to use Puppet agent 8 on the host.
 ifndef::orcharhino[]
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
 endif::[]


### PR DESCRIPTION
Puppet agent 8 is provided via the client-2 repository as, the client repo is release neutral and cannot contain both Puppet agents 7 and 8.

Adding information about the client-2 repository where necessary.

JIRA:
https://issues.redhat.com/browse/SAT-28268
https://issues.redhat.com/browse/SAT-27092
https://issues.redhat.com/browse/SAT-28287

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
