### PR TITLE
Use SmartProxy SSL certs for Salt

### DIFF
--- a/guides/common/modules/proc_enabling-salt-grain-uploads.adoc
+++ b/guides/common/modules/proc_enabling-salt-grain-uploads.adoc
@@ -7,14 +7,14 @@ Salt Grains are collected system properties, for example the operating system or
 .Procedure
 * On your Salt Master, edit `/etc/salt/foreman.yaml`:
 +
-[options="nowrap" subs="attributes"]
+[source, yaml, options="nowrap", subs="verbatim,quotes,attributes"]
 ----
 :proto: https
 :host: {foreman-example-com}
 :port: 443
-:ssl_ca: "/etc/puppetlabs/puppet/ssl/ssl_ca.pem"
-:ssl_cert: "/etc/puppetlabs/puppet/ssl/client_cert.pem"
-:ssl_key: "/etc/puppetlabs/puppet/ssl/client_key.pem"
+:ssl_ca: "/etc/foreman-proxy/foreman_ssl_ca.pem"
+:ssl_cert: "/etc/foreman-proxy/foreman_ssl_cert.pem"
+:ssl_key: "/etc/foreman-proxy/foreman_ssl_key.pem"
 :timeout: 10
 :salt: /usr/bin/salt
 :upload_grains: true


### PR DESCRIPTION
#### What changes are you introducing?

Ensure that using foreman_salt does not rely on SSL certs created by/used by foreman_puppet.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To allow users to use Salt without Puppet.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
