### PR TITLE
Fix the binary download procedure

### DIFF
--- a/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
+++ b/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
@@ -11,6 +11,8 @@ Use this procedure to download the ISO images for {RHEL} and {ProjectName}.
 
 . Select *{RHEL}*.
 
+. Click *All {RHEL} Downloads*.
+
 . Ensure that you have the correct product and version for your environment.
 +
 * *Product Variant* is set to *{RHEL} for x86_64*.


### PR DESCRIPTION
To download the binary DVD images, the user now has to perform an additional step to navigate to the RHEL downloads page.

JIRA:https://issues.redhat.com/browse/SAT-29878

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [x] Foreman 3.8/Katello 4.10
* [x] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
