### PR TITLE
Limit SSSD workaround to certain RHEL versions only

### DIFF
--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -83,6 +83,7 @@ lookup_family_order = ipv6_only
 +
 If the DNS name of the AD server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
 Without the option, AD users are unable to use `kinit` to authenticate to {Project}.
+// Related SSSD issue: https://github.com/SSSD/sssd/issues/3057
 .. Restart SSSD:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -73,7 +73,7 @@ ifndef::orcharhino[]
 +
 For more information on GPOs, see {RHELDocsBaseURL}9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}9)_.
 endif::[]
-.. If your {ProjectServer} runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0 and if it runs in an IPv6-only network, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
+.. If your {ProjectServer} runs in an IPv6-only network and if it also runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -73,7 +73,7 @@ ifndef::orcharhino[]
 +
 For more information on GPOs, see {RHELDocsBaseURL}9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}9)_.
 endif::[]
-.. If your {ProjectServer} is running in an IPV6-only network, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
+.. If your {ProjectServer} runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0 and if it runs in an IPv6-only network, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc
@@ -73,7 +73,7 @@ ifndef::orcharhino[]
 +
 For more information on GPOs, see {RHELDocsBaseURL}9/html/integrating_rhel_systems_directly_with_windows_active_directory/managing-direct-connections-to-ad_integrating-rhel-systems-directly-with-active-directory#how-sssd-interprets-gpo-access-control-rules_applying-group-policy-object-access-control-in-rhel[How SSSD interprets GPO access control rules] in _Integrating RHEL systems directly with Windows Active Directory (RHEL{nbsp}9)_.
 endif::[]
-.. If your {ProjectServer} runs in an IPv6-only network and if it also runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
+.. If your {ProjectServer} runs in an IPv6-only network and also runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0, set the `lookup_family_order` option in the `[domain/_ad.example.com_]` section of the `/etc/sssd/sssd.conf` file:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -37,7 +37,7 @@ For example, to disable access to the {Project} API and Hammer CLI:
 ----
 # {foreman-installer} --reset-foreman-ipa-authentication-api
 ----
-. If your {ProjectServer} is running in an IPV6-only network, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
+. If your {ProjectServer} runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0 and if it runs in an IPv6-only network, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -47,6 +47,7 @@ lookup_family_order = ipv6_only
 +
 If the DNS name of the IdM server can be translated to both an IPv4 and IPv6 address but the IPv4 address is not accessible, SSSD requires `lookup_family_order` to translate the DNS name correctly.
 Without the option, IdM users are unable to use `kinit` to authenticate to {Project}.
+// Related SSSD issue: https://github.com/SSSD/sssd/issues/3057
 
 .Verification
 * Log in to {ProjectWebUI} by entering the credentials of a user defined in {FreeIPA}.

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -37,7 +37,7 @@ For example, to disable access to the {Project} API and Hammer CLI:
 ----
 # {foreman-installer} --reset-foreman-ipa-authentication-api
 ----
-. If your {ProjectServer} runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0 and if it runs in an IPv6-only network, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
+. If your {ProjectServer} runs in an IPv6-only network and if it also runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-projectserver.adoc
@@ -37,7 +37,7 @@ For example, to disable access to the {Project} API and Hammer CLI:
 ----
 # {foreman-installer} --reset-foreman-ipa-authentication-api
 ----
-. If your {ProjectServer} runs in an IPv6-only network and if it also runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
+. If your {ProjectServer} runs in an IPv6-only network and also runs on RHEL{nbsp}9.6 and earlier or RHEL{nbsp}10.0, set the `lookup_family_order` option in the `[domain/_{freeipaserver-example-com}_]` section of the `/etc/sssd/sssd.conf` file:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Specifying the RHEL versions that need a workaround for SSSD in IPA and AD setups to be applied.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The SSSD issue: https://github.com/SSSD/sssd/issues/3057

A downstream doc ticket on the Satellite side: https://issues.redhat.com/browse/SAT-32530

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
