### PR TITLE
Fix maintenance	repo version

### DIFF
--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -44,7 +44,7 @@ ifdef::satellite[]
 [options="nowrap" subs="attributes"]
 ----
 # subscription-manager repos --enable \
-{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+{RepoRHEL8ServerSatelliteMaintenanceProjectVersion}
 ----
 . Upgrade {foreman-maintain} to its next version:
 +


### PR DESCRIPTION


#### What changes are you introducing?
Changing the EL 9 repo in the step prior to the self-upgrade EL 8 maintenance repo.

JIRA: https://issues.redhat.com/browse/SAT-34218

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
- The step prior to the self-upgrade mentions the EL 9 maintenance repo.
- However, EL 8 to EL 9 upgrade can take place only after the Project server has been upgraded to 3.12.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
