### PR TITLE
Assign rolling CV to LE (to omit synchronizing Library to Smart Proxy Servers to use RCV)

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -22,6 +22,8 @@ include::modules/con_rolling-content-views.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-rolling-content-view.adoc[leveloffset=+1]
 
+include::modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments.adoc[leveloffset=+1]
+
 include::modules/con_composite-content-views-overview.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-composite-content-view.adoc[leveloffset=+1]

--- a/guides/common/modules/con_rolling-content-views.adoc
+++ b/guides/common/modules/con_rolling-content-views.adoc
@@ -9,3 +9,6 @@ You can use a rolling content view to provide a continuous stream of synchronize
 
 When you synchronize repositories to {Project}, all rolling content views that contain them get automatically updated to include the latest changes.
 You do not have to publish and/or promote a rolling content view compared to content views or composite content views.
+
+Instead, you can assign rolling content views to one or multiple lifecycle environments.
+This allows you to control which content is synchronized from {ProjectServer} to {SmartProxyServers}.

--- a/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments.adoc
@@ -1,0 +1,38 @@
+[id="assigning-a-rolling-content-view-to-lifecycle-environments"]
+= Assigning a rolling content view to lifecycle environments
+
+You can assign your rolling content view to lifecycle environments to limit content synchronized to {SmartProxyServers}.
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli-assigning-a-rolling-content-view-to-lifecycle-environments[].
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
+. Select your rolling content view.
+. Select the *Details* tab.
+. In the *Lifecycle Environments* field, assign your rolling content view to your lifecycle environments.
+. Click *Save Environments* to submit your changes to {Project}.
+
+[id="cli-assigning-a-rolling-content-view-to-lifecycle-environments"]
+.CLI procedure
+. List all content views:
++
+[options="nowrap" subs="+quotes"]
+----
+$ hammer content-view list \
+--fields id,name \
+--organization "_My_Organization_"
+----
+. Assign your rolling content view to lifecycle environments:
++
+[options="nowrap" subs="+quotes"]
+----
+$ hammer content-view update \
+--id _My_Rolling_Content_View_ID_ \
+--lifecycle-environment-ids _My_List_Of_Lifecycle_Environment_IDs_ \
+--organization "_My_Organization_"
+----
++
+If you want to remove your rolling content view from all lifecycle environments, pass an empty list.
+
+.Next steps
+* Synchronize lifecycle environments to {SmartProxyServers}.
+For more information, see {AdministeringDocURL}Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_admin[Synchronizing content from {ProjectServer} to {SmartProxyServers}] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_creating-a-rolling-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-rolling-content-view.adoc
@@ -13,6 +13,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-rollin
 {Project} automatically completes the *Label* field from the name you enter.
 . Optional: In the *Description* field, enter a description of the content view.
 . On the *Type* tab, select *Rolling content view*.
+. Optional: In the *Lifecycle Environments* field, assign your rolling content view to your lifecycle environments.
 . Click *Create content view*.
 . Click *Show repositories*.
 . Select the repositories that you want to add to your rolling content view.
@@ -20,6 +21,14 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-rollin
 
 [id="cli-creating-a-rolling-content-view"]
 .CLI procedure
+. List all available lifecycle environments:
++
+[options="nowrap" subs="+quotes"]
+----
+$ hammer lifecycle-environment list \
+--fields id,name \
+--organization "_My_Organization_"
+----
 . List all available repositories to identify IDs of repositories to add to your rolling content view:
 +
 [options="nowrap" subs="+quotes"]
@@ -33,6 +42,7 @@ $ hammer repository list \
 [options="nowrap" subs="+quotes"]
 ----
 $ hammer content-view create \
+--lifecycle-environment-ids _My_List_Of_Lifecycle_Environment_IDs_ \
 --name "_My_Rolling_Content_View_" \
 --organization "_My_Organization_" \
 --repository-ids _My_List_Of_Repository_IDs_ \

--- a/guides/common/modules/ref_best-practices-for-content-views.adoc
+++ b/guides/common/modules/ref_best-practices-for-content-views.adoc
@@ -6,6 +6,7 @@
 * Content views that bundle content, such as {client-os} and additional software like `Apache-2.4` or `PostgreSQL-16.2`, are easier to maintain.
 Content views that are too small require more maintenance.
 * If you require daily updated content, use the content view `Default Organization View`, which contains the latest synchronized content from all repositories and is available in the Library lifecycle environment.
+* If you require daily updated content for hosts registered to a specific {SmartProxyServer}, use rolling content views and assign them to a lifecycle environment other than *Library*.
 * To give hosts access to content from multiple content views, such as when you update one content view weekly and another monthly, you have two options:
 ** Assign multiple content view environments to hosts. 
 For more information, see xref:assigning-content-view-environments-to-hosts[].


### PR DESCRIPTION
#### What changes are you introducing?

document assigning rolling content views to lifecycle environments.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

this will simplify RCV usage because users no longer have to sync Library to Smart Proxy Servers. Instead, they can either create new or use existing LE that are on SmartProxyServers and sync RCV to those Smart Proxy Servers.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I was unsure if we need a new procedure, so I have added it to a second commit. We should either squash them or drop it.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.