### PR TITLE
Updating documentation for Katello 4.17.0.rc2

### DIFF
--- a/guides/doc-Release_Notes/topics/katello-4.17.0.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.17.0.adoc
@@ -13,7 +13,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 
 === Container
 
-* pass:[As a registered host, I don't need to podman login to access container repositories on satellite server.] - https://projects.theforeman.org/issues/38407[#38407]
+* pass:[As a registered host, I don't need to podman login to access container repositories on katello] - https://projects.theforeman.org/issues/38407[#38407]
 * pass:[Add container upstream name to repository listing API endpoint] - https://projects.theforeman.org/issues/38392[#38392]
 * pass:[Organization-label can break container image sync] - https://projects.theforeman.org/issues/38269[#38269]
 * pass:[Container push should hide expected 404 message from pulp when looking up blobs] - https://projects.theforeman.org/issues/38212[#38212]
@@ -54,6 +54,7 @@ A full list of changes is available on https://projects.theforeman.org/issues?se
 * pass:[Image mode all hosts column title should be 'Type'] - https://projects.theforeman.org/issues/38226[#38226]
 * pass:[Extra tbody left inside booted containers table causes automation issues] - https://projects.theforeman.org/issues/38225[#38225]
 * pass:[Should hide Change content source task when permissions are missing] - https://projects.theforeman.org/issues/38214[#38214]
+* pass:[subscription-manager environments --set raises Forbidden error until the user is Admin] - https://projects.theforeman.org/issues/38448[#38448]
 
 === Lifecycle Environments
 


### PR DESCRIPTION
#### What changes are you introducing?

Updating Katello 4.17.0.rc2 documentation to Foreman 3.15 branch

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Working on Headline features for 4.17 documentation.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
