### PR TITLE
Retire branches older than 3.9

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,4 @@ Please cherry-pick my commits into:
 * [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
 * [ ] Foreman 3.10/Katello 4.12
 * [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
-* [ ] Foreman 3.8/Katello 4.10
-* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
-* We do not accept PRs for Foreman older than 3.7.
+* We do not accept PRs for Foreman older than 3.9.


### PR DESCRIPTION
#### What changes are you introducing?

Retiring branches 3.7 and 3.8 from the PR template and cherry picking

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Satellite 6.14 has been EOL since May 30. The branches don't have to be maintained anymore.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
