### PR TITLE
Add new parameter to reference module

### DIFF
--- a/guides/common/modules/ref_global-parameters-for-registration.adoc
+++ b/guides/common/modules/ref_global-parameters-for-registration.adoc
@@ -5,7 +5,7 @@ You can configure the following global parameters by navigating to *Configure* >
 
 * The `host_registration_insights` parameter is used in the `insights` snippet.
 If the parameter is set to `true`, the registration installs and enables the Red{nbsp}Hat Insights client on the host.
-If the parameter is set to `false`, it prevents {Project} and the Red{nbsp}Hat Insights client from uploading Inventory reports to your {RHCloud}.
+If the parameter is set to `false`, {Project} prevents the installation and registration of the Red{nbsp}Hat Insights client.
 ifdef::satellite[]
 The default value is `true`.
 endif::[]
@@ -13,6 +13,10 @@ ifndef::satellite[]
 The default value is `false`.
 endif::[]
 When overriding the parameter value, set the parameter type to `boolean`.
+* The `host_registration_insights_inventory` parameter controls Inventory uploads.
+If the parameter is set to `true`, the host is included in the Insights Inventory report uploaded to the {RHCloud}. 
+If the parameter is set to `false`, the host is excluded from the Insights Inventory report upload.
+To upload minimal inventory data without registering the host with the Insights client, set the `host_registration_insights` parameter to `false` and set the `host_registration_insights_inventory` to `true`.
 * The `host_packages` parameter is for installing packages on the host.
 * The `host_registration_remote_execution` parameter is used in the `remote_execution_ssh_keys` snippet.
 If it is set to `true`, the registration enables remote execution on the host.


### PR DESCRIPTION
#### What changes are you introducing?
Adding new parameter for `host_registration_insights_inventory`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Change made starting in 6.17 as referenced in https://issues.redhat.com/browse/SAT-33759

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.
