### PR TITLE
Build web directory from PR for previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,10 +130,15 @@ jobs:
   build-web:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
+      - name: Checkout master
+        if: github.event_name != 'pull_request' || github.base_ref != 'master'
         uses: actions/checkout@v4
         with:
           ref: master
+
+      - name: Checkout PR
+        if: github.event_name == 'pull_request' && github.base_ref == 'master'
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
#### What changes are you introducing?

When a PR is submitted against master then it uses the PR to build the web layout rather than what's already in master. This allows making changes to the navigation and previewing them.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I was working on https://github.com/theforeman/foreman-documentation/pull/3915 and it was really annoying you couldn't see what I did.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.