### PR TITLE
Add a note about IP addresses after migration

### DIFF
--- a/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup-restore.adoc
+++ b/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup-restore.adoc
@@ -26,8 +26,6 @@ endif::[]
 ifndef::satellite[]
 . Restore the {ProjectServer} or {SmartProxyServer} backups.
 For more information, see {AdministeringDocURL}restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[Restoring {ProjectServer} or {SmartProxyServer} from a backup] in _{AdministeringDocTitle}_.
+. Shut down the old {EL}{nbsp}8 {ProjectServer} or {SmartProxyServer} and reassign its IP address to the new {EL}{nbsp}9 system.
 endif::[]
-[NOTE]
-====
-DNS changes take time, ensure that the new {EL}{nbsp}9 system is reachable using the IP address before initiating any tasks.
-====
+Ensure the DNS resolution works correctly before initiating any tasks.

--- a/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup-restore.adoc
+++ b/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup-restore.adoc
@@ -28,4 +28,3 @@ ifndef::satellite[]
 For more information, see {AdministeringDocURL}restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[Restoring {ProjectServer} or {SmartProxyServer} from a backup] in _{AdministeringDocTitle}_.
 . Shut down the old {EL}{nbsp}8 {ProjectServer} or {SmartProxyServer} and reassign its IP address to the new {EL}{nbsp}9 system.
 endif::[]
-Ensure the DNS resolution works correctly before initiating any tasks.

--- a/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup-restore.adoc
+++ b/guides/common/modules/proc_migrating-project-or-smartproxy-using-backup-restore.adoc
@@ -21,8 +21,13 @@ Restore does not significantly alter the target system and requires additional c
 For more information, see {AdministeringDocURL}restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[Restoring {ProjectServer} or {SmartProxyServer} from a backup] in _{AdministeringDocTitle}_.
 . Restore the {SmartProxyServer} backup.
 For more information, see {AdministeringDocURL}restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[Restoring {ProjectServer} or {SmartProxyServer} from a backup] in _{AdministeringDocTitle}_. 
+. Shut down the old {EL}{nbsp}8 {SmartProxyServer} and reassign its IP address to the new {EL}{nbsp}9 system.
 endif::[]
 ifndef::satellite[]
 . Restore the {ProjectServer} or {SmartProxyServer} backups.
 For more information, see {AdministeringDocURL}restoring-{project-context}-server-or-{smart-proxy-context}-from-a-backup_admin[Restoring {ProjectServer} or {SmartProxyServer} from a backup] in _{AdministeringDocTitle}_.
 endif::[]
+[NOTE]
+====
+DNS changes take time, ensure that the new {EL}{nbsp}9 system is reachable using the IP address before initiating any tasks.
+====


### PR DESCRIPTION
After migrating from EL8 to EL9, the sync tasks fail with a network error. This is because DNS changes takes time.
Adding a note about this and also a step to shut down the old system and reassign the IP to the new EL9 system.

JIRA:
https://issues.redhat.com/browse/SAT-28024

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
