### PR TITLE
Hide foreman_resource_quota plugin for Satellite

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -56,7 +56,9 @@ include::common/assembly_logging-and-reporting-problems.adoc[leveloffset=+1]
 
 include::common/assembly_monitoring-resources.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::common/assembly_limiting-host-resources.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Satellite 6.17 does not provide the "rubygem-foreman_resource_quota" package.

#### What changes are you introducing?

Remove https://docs.redhat.com/en/documentation/red_hat_satellite/6.17/html/administering_red_hat_satellite/index

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

`ssh satellite dnf search rubygem-foreman_resource_quota` -> plugin is not packaged by RH.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Needs tech ACK.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.