### PR TITLE
Retroactively add 4.16 warning about container naming

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -58,7 +58,12 @@ With this feature, you can now install on systems like Amazon RDS or Azure Datab
 [id="katello-upgrade-warnings"]
 == Upgrade Warnings
 
-There are no upgrade warnings with Katello {KatelloVersion}.
+=== New container repository naming standard
+
+New container repositories will have names with slashes '/' in their published paths instead of dashes '-'.
+This is to conform to the latest container image standards.
+If the old dash standard is still needed, the Registry Name Pattern can be changed per lifecycle environment.
+Updating the Registry Name Pattern will immediately update all container repositories in that lifecycle environment.
 
 [id="katello-deprecations"]
 == Deprecations


### PR DESCRIPTION
Adds a release warning for 4.16 as as response to https://community.theforeman.org/t/docker-image-repos-renamned-with-foreman-3-14-katello-4-16/43493