### PR TITLE
Add container image naming upgrade warning

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -9,7 +9,13 @@ There are no headline features with Katello {KatelloVersion}.
 [id="katello-upgrade-warnings"]
 == Upgrade Warnings
 
-There are no upgrade warnings with Katello {KatelloVersion}.
+=== New container repository naming standard
+
+An upgrade warning was originally missed in Katello 4.16, so the following is repeated for users who missed it:
+New container repositories will have names with slashes '/' in their published paths instead of dashes '-'. 
+This is to conform to the latest container image standards.
+If the old dash standard is still needed, the Registry Name Pattern can be changed per lifecycle environment.
+Updating the Registry Name Pattern will immediately update all container repositories in that lifecycle environment.
 
 [id="katello-deprecations"]
 == Deprecations


### PR DESCRIPTION
Adds an upgrade warning in 4.17 in case users didn't see the late addition https://github.com/theforeman/foreman-documentation/pull/3928