### PR TITLE
Salt report upload

### DIFF
--- a/guides/common/modules/con_introduction-to-salt.adoc
+++ b/guides/common/modules/con_introduction-to-salt.adoc
@@ -16,6 +16,10 @@ Salt plugin in {Project} supports exclusively the Salt Minion approach.
 endif::[]
 ====
 
+ifdef::orcharhino[]
+{Project} supports Salt 3006.
+endif::[]
+
 .Additional resources
 * The https://docs.saltproject.io/en/latest/contents.html[official Salt documentation] is a good entry point when starting with Salt.
 * You can download the Salt packages from the official Salt package repository at link:https://packages.broadcom.com[].

--- a/guides/common/modules/proc_enabling-salt-report-uploads.adoc
+++ b/guides/common/modules/proc_enabling-salt-report-uploads.adoc
@@ -43,7 +43,8 @@ The Salt Master can directly upload Salt reports to {Project}.
 
 Alternatively, you can upload Salt reports from your Salt Master to {Project} manually:
 
+// Python version depends on Salt version
 [options="nowrap" subs="attributes"]
 ----
-# /usr/sbin/upload-salt-reports
+# /opt/saltstack/salt/bin/python3.10 /usr/sbin/upload-salt-reports
 ----


### PR DESCRIPTION
#### What changes are you introducing?

* specify supported Salt version
* fix command to manually upload reports

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

command is broken; command uses Python which depends on a Salt version

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
