### PR TITLE
Custom SSL certificate process for Capsules clarification

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -7,8 +7,9 @@ If you already have a custom SSL certificate for {ProductName}, skip this proced
 endif::[]
 
 ifeval::["{context}" == "{smart-proxy-context}"]
-On {ProjectServer}, create a custom certificate for your {ProductName}.
-If you already have a custom SSL certificate for {ProductName}, skip this procedure.
+On {ProjectServer}, you must generate a unique private key and Certificate Signing Request (CSR) for each {ProductName} that you want to secure with a custom SSL certificate.
+
+Use this procedure for each {ProductName} that requires a custom SSL certificate.
 endif::[]
 
 ifdef::load-balancing[]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -13,6 +13,11 @@ For more information, see xref:Registering_Proxy_to_Server_{smart-proxy-context}
 * {SmartProxyServer} packages are installed.
 For more information, see xref:Installing_Proxy_Packages_{smart-proxy-context}[].
 
+[NOTE]
+====
+Once you have obtained the server certificate, private key, and CA chain from the Certificate Authority (CA) for each {SmartProxyServer}, organize these files into separate directories named after each {SmartProxyServer} on your {ProjectServer}.
+====
+
 .Procedure
 . On your {ProjectServer}, generate a certificate bundle:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Procedure clarifications for SSL certs for Capsules.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-22614

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
