### PR TITLE
Bring back the Puma workers and threads recommendations

### DIFF
--- a/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
@@ -1,0 +1,57 @@
+[id="Puma_Workers_and_Threads_Recommendations_{context}"]
+= Puma workers and threads recommendations
+
+In order to recommend thread and worker configurations for the different tuning profiles, we conducted Puma tuning testing on {Project} with different tuning profiles.
+The main test used in this testing was concurrent registration with the following combinations along with different number of workers and threads.
+Our recommendation is based purely on concurrent registration performance, so it might not reflect your exact use-case.
+For example, if your setup is very content oriented with lots of publishes and promotes, you might want to limit resources consumed by Puma in favor of Pulp and PostgreSQL.
+
+[width="100%",cols="16%,19%,7%,7%,31%,20%",options="header",]
+|===
+|Name |Number of hosts |RAM |Cores |Recommended Puma threads |Recommended Puma workers
+|default |0{range}5000 |20 GiB |4 |16 |4{range}6
+|medium |5000{range}10000 |32 GiB |8 |16 |8{range}12
+|large |10000{range}20000 |64 GiB |16 |16 |12{range}18
+|extra-large |20000{range}60000 |128 GiB |32 |16 |16{range}24
+|extra-extra-large |60000+ |256 GiB+ |48+ |16 |20{range}26
+|===
+
+Tuning number of workers is the more important aspect here and in some case we have seen up to 52% performance increase.
+Although installer uses 5 threads by default, we recommend 16 threads with all the tuning profiles in the table above.
+That is because we have seen up to 23% performance increase with 16 threads (14% for 8 and 10% for 32) when compared to setup with 4 threads.
+
+To figure out these recommendations we used concurrent registrations test case which is a very specific use-case.
+It can be different on your {Project} which might have more balanced use-case (not only registrations).
+Keeping default 5 threads is a good choice as well.
+
+These are some of our measurements that lead us to these recommendations:
+
+[width="100%",cols="17%,21%,20%,21%,21%",options="header",]
+|===
+| |4 workers, 4 threads |4 workers, 8 threads |4 workers, 16 threads |4 workers, 32 threads
+|Improvement| 0%| 14%| 23%| 10%
+|===
+
+Use 4{range}6 workers on a default setup (4 CPUs) {endash} we have seen about 25% higher performance with 5 workers when compared to 2 workers, but 8% lower performance with 8 workers when compared to 2 workers {endash} see table below:
+
+[width="100%",cols="17%,21%,20%,21%,21%",options="header",]
+|===
+| |2 workers, 16 threads |4 workers, 16 threads |6 workers, 16 threads |8 workers, 16 threads
+|Improvement |0% |26% |22% |-8%
+|===
+
+Use 8{range}12 workers on a medium setup (8 CPUs) {endash} see table below:
+
+[width="100%",cols="16%,17%,16%,17%,17%,17%",options="header",]
+|===
+| |2 workers, 16 threads |4 workers, 16 threads |8 workers, 16 threads |12 workers, 16 threads |16 workers, 16 threads
+|Improvement |0% |51% |52% |52% |42%
+|===
+
+Use 16{range}24 workers on a 32 CPUs setup (this was tested on a 90 GiB RAM machine and memory turned out to be a factor here as system started swapping {endash} proper _extra-large_ should have 128 GiB), higher number of workers was problematic for higher registration concurrency levels we tested, so we cannot recommend it.
+
+[width="100%",cols="13%,14%,14%,14%,15%,15%,15%",options="header",]
+|===
+| |4 workers, 16 threads |8 workers, 16 threads |16 workers, 16 threads |24 workers, 16 threads |32 workers, 16 threads |48 workers, 16 threads
+|Improvement |0% |37% |44% |52% |too many failures |too many failures
+|===

--- a/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
@@ -4,7 +4,7 @@
 In order to recommend thread and worker configurations for the different tuning profiles, we conducted Puma tuning testing on {Project} with different tuning profiles.
 The main test used in this testing was concurrent registration with the following combinations along with different number of workers and threads.
 Our recommendation is based purely on concurrent registration performance, so it might not reflect your exact use-case.
-For example, if your setup is very content oriented with lots of publishes and promotes, you might want to limit resources consumed by Puma in favor of Pulp and PostgreSQL.
+For example, if your setup is very content oriented with many publishes and promotes, you might want to limit resources consumed by Puma in favor of Pulp and PostgreSQL.
 
 [width="100%",cols="16%,19%,7%,7%,31%,20%",options="header",]
 |===

--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -40,6 +40,8 @@ include::common/modules/con_puma-workers-and-threads-autotuning.adoc[leveloffset
 
 include::common/modules/proc_manually-tuning-puma-workers-and-threads-count.adoc[leveloffset=+3]
 
+include::common/modules/con_puma-workers-and-threads-recommendations.adoc[leveloffset=+3]
+
 include::common/modules/proc_configuring-puma-workers.adoc[leveloffset=+3]
 
 include::common/modules/proc_configuring-puma-threads.adoc[leveloffset=+3]


### PR DESCRIPTION
#### What changes are you introducing?

This reverts commit b3491afcd5fdc5ea1145e052d39c20f4272b9a9c and instead brings back the inclusion.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It was unintentionally removed in https://github.com/theforeman/foreman-documentation/pull/3534

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Pointed out by @pablomh.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.