### PR TITLE
Temporarily hide broken diagrams

### DIFF
--- a/guides/common/modules/con_smartproxy-networking.adoc
+++ b/guides/common/modules/con_smartproxy-networking.adoc
@@ -11,20 +11,20 @@ However, {SmartProxyServer} ensures that all communications from the host to {Pr
 In this topology, {SmartProxy} provides a single endpoint for all host network communications so that in remote network segments, only firewall ports to the {SmartProxy} itself must be open.
 
 // TODO: Replace graphic with simpler graphic and reference to "Port and firewall requirements"
-ifdef::satellite[]
-.How {Project} components interact when hosts connect to a {SmartProxy}
-image::common/topology-isolated-satellite.png[{ProjectName} topology with a host]
-endif::[]
+//ifdef::satellite[]
+//.How {Project} components interact when hosts connect to a {SmartProxy}
+//image::common/topology-isolated-satellite.png[{ProjectName} topology with a host]
+//endif::[]
 
 .{Project} topology with hosts connecting directly to {ProjectServer}
 In this topology, hosts connect to {ProjectServer} rather than a {SmartProxy}.
 This applies also to {SmartProxies} themselves because the {SmartProxyServer} is a host of {ProjectServer}.
 
 // TODO: Replace graphic with simpler graphic and reference to "Port and firewall requirements"
-ifdef::satellite[]
-.How {Project} components interact when hosts connect directly to {ProjectServer}
-image::common/topology-direct-satellite.png[{ProjectName} topology with a direct host]
-endif::[]
+//ifdef::satellite[]
+//.How {Project} components interact when hosts connect directly to {ProjectServer}
+//image::common/topology-direct-satellite.png[{ProjectName} topology with a direct host]
+//endif::[]
 
 .Additional resources
 * {InstallingServerDocURL}Port_and_firewall_requirements_{project-context}[Ports and firewall requirements] in _{InstallingServerDocTitle}_


### PR DESCRIPTION
#### What changes are you introducing?

Commenting out two diagrams with Satellite architecture.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We've received multiple bug reports for issues in these diagrams. https://github.com/theforeman/foreman-documentation/pull/3905 intends to fix one of them but based on the conversation there, it will take time. That's why I propose to hide both broken diagrams in the meantime.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
