### PR TITLE
Simplify upgrade backup step

### DIFF
--- a/guides/common/modules/snip_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/snip_upgrading-smartproxy-server.adoc
@@ -1,19 +1,6 @@
 . Create a backup of your {SmartProxyServer}.
-* If your {SmartProxyServer} runs on a virtual machine:
-.. Stop all {Project} services:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service stop
-----
-.. Take a snapshot.
-.. Start all {Project} services:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service start
-----
-* If your {SmartProxyServer} runs on a physical machine, create a backup as described in {AdministeringDocURL}[Backing up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+The backup can be a virtual machine (VM) snapshot or a regular full backup.
+For more information, see {AdministeringDocURL}[Backing up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 ifdef::foreman-el,katello[]
 . Update repositories:
 +

--- a/guides/common/modules/snip_upgrading-your-project-server.adoc
+++ b/guides/common/modules/snip_upgrading-your-project-server.adoc
@@ -1,19 +1,6 @@
 . Create a backup of your {ProjectServer}.
-* If your {ProjectServer} runs on a virtual machine:
-.. Stop all {Project} services:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service stop
-----
-.. Take a snapshot.
-.. Start all {Project} services:
-+
-[options="nowrap" subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} service start
-----
-* If your {ProjectServer} runs on a physical machine, create a backup as described in {AdministeringDocURL}[Backing up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
+The backup can be a virtual machine (VM) snapshot or a regular full backup.
+For more information, see {AdministeringDocURL}[Backing up {ProjectServer} and {SmartProxyServer}] in _{AdministeringDocTitle}_.
 ifdef::satellite[]
 . Ensure that the {Project} Maintenance repository is enabled:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Replacing the existing step with substeps with a simpler step that links to other docs.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Suggested in https://github.com/theforeman/foreman-documentation/pull/3885#discussion_r2154111900. It fits well into our overall goal to provide simpler upgrade instructions.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The backup chapter the step links to could use some improving but that's a problem for future us :)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
