### PR TITLE
Add review checklists to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
 
-#### Checklists
+#### Contributor checklists
 
 * [x] I am okay with my commits getting squashed when you merge this PR.
 * [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.
@@ -19,3 +19,16 @@ Please cherry-pick my commits into:
 * [ ] Foreman 3.10/Katello 4.12
 * [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
 * We do not accept PRs for Foreman older than 3.9.
+
+#### Review checklists
+
+Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):
+
+* [ ] The PR documents a recommended, user-friendly path.
+* [ ] The PR removes steps that have been made unnecessary or obsolete.
+* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.
+
+Style review (by a Technical Writer who did not author the PR):
+
+* [ ] The PR conforms with the team's style guidelines.
+* [ ] The PR introduces documentation that describes a user story rather than a product feature.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ We respect each others time and energy spent on Foreman documentation.
 * help less experienced community members with git, Github, PRs, asciidoc, and asciidoctor.
 * expect a basic effort in contributions, including the [pull request template](PULL_REQUEST_TEMPLATE.md) being filled out.
 * only merge PRs if the Github Actions are green.
-* only merge PRs that have the `style review done` and `tech review done` labels set, indicating that a technical author has provided editorial review and a subject matter expert (SME) has provided technical review.
 For an overview of what to expect from editorial review, see [Red Hat peer review guide for technical documentation](https://redhat-documentation.github.io/peer-review/#checklist).
 * read the proposed change and make friendly and helpful comments.
 * ping community members with more experience if they are unsure about specific details.


### PR DESCRIPTION
#### What changes are you introducing?

Adding 'review checklists' to the PR template.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Discussions over what conditions need to be met for a PR to be considered reviewed have been popping up recently. For example: Should we request a second opinion for PRs filed by engineers? How to introduce the requirement for QE/testing review when the concept of QE reviews is not native to upstream? What should be the scope of a review anyway?

Standardizing expectations could be beneficial for all sides: both writers and reviewers. These checklists could also eliminate the need to manually assign the `needs testing`/`testing done` labels (because they include testing as part of the regular tech review).
~~EDIT: This might actually eliminate the tech and style review labels too!~~

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

A previous suggestion by @ekohl was to use [Github's saved replies](https://docs.github.com/en/get-started/writing-on-github/working-with-saved-replies/using-saved-replies) feature and maintain the lists manually for each reviewer. Adding them to the PR template would make the template even longer than it already is but it would mean we only have one place where we store it.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
