### PR TITLE
Fix Azure image gallery path

### DIFF
--- a/guides/common/modules/proc_adding-images-to-server.adoc
+++ b/guides/common/modules/proc_adding-images-to-server.adoc
@@ -38,7 +38,7 @@ ifdef::azure-provisioning[]
 * For a custom image, use the prefix `custom`.
 For example, *custom://image-name*.
 * For a shared gallery image, use the prefix `gallery`.
-For example, *gallery://image-name*.
+For example, *gallery://Templates/image-name*.
 * For public and RHEL Bring Your Own Subscription (BYOS) images, use the prefix `marketplace`.
 For example, *marketplace://OpenLogicCentOS:7.5:latest*.
 +


### PR DESCRIPTION
#### What changes are you introducing?

Fixing Azure gallery path for image import

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Wrong example path

[SAT-35280](https://issues.redhat.com/browse/SAT-35280) (public)

Found during bug fixing [SAT-31966](https://issues.redhat.com/browse/SAT-31966) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
