### PR TITLE
Add assembly attribute

### DIFF
--- a/guides/common/assembly_accessing-server.adoc
+++ b/guides/common/assembly_accessing-server.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_accessing-server.adoc[]
 
 include::modules/proc_logging-in-to-the-projectwebui.adoc[leveloffset=+1]

--- a/guides/common/assembly_administer-settings-information.adoc
+++ b/guides/common/assembly_administer-settings-information.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_administration-settings.adoc[]
 
 include::modules/ref_general-settings-information.adoc[leveloffset=+1]

--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_administering-hosts.adoc[]
 
 include::modules/proc_creating-a-host.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-call-authentication.adoc
+++ b/guides/common/assembly_api-call-authentication.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_api-call-authentication.adoc[]
 
 include::modules/con_ssl-authentication-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-cheat-sheet.adoc
+++ b/guides/common/assembly_api-cheat-sheet.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_api-cheat-sheet.adoc[]
 
 include::modules/con_working-with-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-requests-in-various-languages.adoc
+++ b/guides/common/assembly_api-requests-in-various-languages.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_api-requests-in-various-languages.adoc[]
 
 include::modules/con_calling-the-api-in-curl.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-syntax.adoc
+++ b/guides/common/assembly_api-syntax.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_api-syntax.adoc[]
 
 include::modules/con_api-request-composition.adoc[leveloffset=+1]

--- a/guides/common/assembly_backing-up-server-and-proxy.adoc
+++ b/guides/common/assembly_backing-up-server-and-proxy.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_backing-up-server-and-proxy.adoc[]
 
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/assembly_basic-content-management-workflow.adoc
+++ b/guides/common/assembly_basic-content-management-workflow.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_basic-content-management-workflow.adoc[]
 
 include::modules/proc_creating-repositories-to-synchronize.adoc[leveloffset=+1]

--- a/guides/common/assembly_building-cloud-images.adoc
+++ b/guides/common/assembly_building-cloud-images.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_building-cloud-images.adoc[]
 
 include::modules/proc_creating-custom-rhel-images.adoc[leveloffset=+1]

--- a/guides/common/assembly_common-deployment-scenarios.adoc
+++ b/guides/common/assembly_common-deployment-scenarios.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_common-deployment-scenarios.adoc[]
 
 include::modules/con_single-location-with-segregated-subnets.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-an-alternate-cname.adoc
+++ b/guides/common/assembly_configuring-an-alternate-cname.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="configuring-an-alternate-cname_{context}"]

--- a/guides/common/assembly_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/assembly_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc[]
 
 include::modules/proc_configuring-tls-for-secure-ldap.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-and-setting-up-remote-jobs.adoc[]
 
 include::modules/con_remote-execution-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-capsule-custom-server-certificate.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="configuring-capsule-custom-server-certificate_{context}"]

--- a/guides/common/assembly_configuring-dhcp-integration.adoc
+++ b/guides/common/assembly_configuring-dhcp-integration.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-dhcp-integration.adoc[]
 
 include::modules/con_dhcp-service-providers.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-dns-integration.adoc
+++ b/guides/common/assembly_configuring-dns-integration.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-dns-integration.adoc[]
 
 include::modules/con_dns-service-providers.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-email-notifications.adoc
+++ b/guides/common/assembly_configuring-email-notifications.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-email-notifications.adoc[]
 
 include::modules/ref_email-notification-types.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-host-collections.adoc
+++ b/guides/common/assembly_configuring-host-collections.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-host-collections.adoc[]
 
 include::modules/con_host-collections-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-inter-server-synchronization.adoc
+++ b/guides/common/assembly_configuring-inter-server-synchronization.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-inter-server-synchronization.adoc[]
 
 include::modules/proc_configuring-projectserver-to-synchronize-content-by-using-exports.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-kerberos-sso-for-active-directory-users-in-project.adoc[]
 
 include::modules/proc_configuring-the-active-directory-authentication-source-on-projectserver.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc[]
 
 include::modules/proc_enrolling-projectserver-in-freeipa-domain.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -1,1 +1,3 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[]

--- a/guides/common/assembly_configuring-provisioning-resources.adoc
+++ b/guides/common/assembly_configuring-provisioning-resources.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-provisioning-resources.adoc[]
 
 include::modules/con_provisioning-contexts.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-repositories.adoc
+++ b/guides/common/assembly_configuring-repositories.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-repositories.adoc[]
 
 include::modules/proc_configuring-repositories-{build}.adoc[]

--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-foreman-server-with-a-custom-ssl-certificate.adoc[]
 
 :cert-name: {project-context}

--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="Configuring_Server_with_an_HTTP_Proxy_{context}"]

--- a/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc[]
 
 :parent-context: {context}

--- a/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc[]
 
 :parent-context: {context}

--- a/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc[]
 
 :parent-context: {context}

--- a/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc[]
 
 :parent-context: {context}

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc[]
 
 include::modules/con_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc[]
 
 include::modules/con_prerequisites-for-configuring-project-with-keycloak-wildfly-authentication.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-tftp-integration.adoc
+++ b/guides/common/assembly_configuring-tftp-integration.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-tftp-integration.adoc[]
 
 include::modules/proc_enabling-the-installer-managed-tftp-service.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-virt-who-hyperv.adoc
+++ b/guides/common/assembly_configuring-virt-who-hyperv.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :configuring-virt-who-hyperv:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-kubevirt.adoc
+++ b/guides/common/assembly_configuring-virt-who-kubevirt.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :configuring-virt-who-kubevirt:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-kvm.adoc
+++ b/guides/common/assembly_configuring-virt-who-kvm.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :configuring-virt-who-kvm:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-nutanix.adoc
+++ b/guides/common/assembly_configuring-virt-who-nutanix.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :configuring-virt-who-nutanix:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-openstack.adoc
+++ b/guides/common/assembly_configuring-virt-who-openstack.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :configuring-virt-who-openstack:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-vmware.adoc
+++ b/guides/common/assembly_configuring-virt-who-vmware.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :configuring-virt-who-vmware:
 :parent-context: {context}
 

--- a/guides/common/assembly_content-and-patch-management-with-project.adoc
+++ b/guides/common/assembly_content-and-patch-management-with-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_content-and-patch-management-with-project.adoc[]
 
 include::modules/con_content-flow-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_converting-a-host-to-rhel.adoc
+++ b/guides/common/assembly_converting-a-host-to-rhel.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_converting-a-host-to-rhel.adoc[]

--- a/guides/common/assembly_deployment-path.adoc
+++ b/guides/common/assembly_deployment-path.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_deployment-path.adoc[]
 
 include::modules/con_installing-a-project-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_disaster-recovery-by-virtualizing-your-projectserver.adoc[]
 
 include::modules/ref_prerequisites-disaster-recovery-by-virtualizing-your-projectserver.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc[]
 
 include::modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-external-storage.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc[]
 
 include::modules/ref_prerequisites-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_disaster-recovery-with-two-active-project-servers.adoc[]
 
 include::modules/ref_prerequisites-disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]

--- a/guides/common/assembly_discovering-hosts-on-a-network.adoc
+++ b/guides/common/assembly_discovering-hosts-on-a-network.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_discovering-hosts-on-a-network.adoc[]
 
 include::modules/con_prerequisites-for-using-discovery.adoc[leveloffset=+1]

--- a/guides/common/assembly_foreman-deployment-planning.adoc
+++ b/guides/common/assembly_foreman-deployment-planning.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_foreman-deployment-planning.adoc[]
 
 include::assembly_deployment-path.adoc[leveloffset=+1]

--- a/guides/common/assembly_foreman-overview-and-concepts.adoc
+++ b/guides/common/assembly_foreman-overview-and-concepts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_foreman-overview-and-concepts.adoc[]
 
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_getting-started-with-Ansible-in-project.adoc[]
 
 include::modules/con_supported-ansible-versions.adoc[leveloffset=+1]

--- a/guides/common/assembly_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/assembly_host-management-and-monitoring-using-cockpit.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_host-management-and-monitoring-by-using-cockpit.adoc[]
 
 include::modules/proc_enabling-cockpit-on-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_host-status.adoc
+++ b/guides/common/assembly_host-status.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_host-status.adoc[]
 
 include::modules/con_host-global-status-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_importing-content.adoc[]
 
 include::modules/con_products-and-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-the-project-client-name-repository.adoc
+++ b/guides/common/assembly_importing-the-project-client-name-repository.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_importing-the-project-client-name-repository.adoc[]
 
 include::modules/proc_enabling-the-project-client-name-repository.adoc[leveloffset=+1]

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="installing-capsule-server"]

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="Installing_Server_Disconnected_{context}"]

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_installing-server.adoc[]

--- a/guides/common/assembly_integrating-awx.adoc
+++ b/guides/common/assembly_integrating-awx.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_integrating-project-and-awx.adoc[]
 
 include::modules/proc_adding-project-server-to-awx-as-a-dynamic-inventory-item.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-managing-content.adoc
+++ b/guides/common/assembly_introduction-to-managing-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_introduction-to-content-management.adoc[]
 
 include::modules/con_content-types-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-project-api.adoc
+++ b/guides/common/assembly_introduction-to-project-api.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_introduction-to-project-api.adoc[]
 
 include::modules/con_overview-of-the-project-api.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-provisioning.adoc
+++ b/guides/common/assembly_introduction-to-provisioning.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_introduction-to-provisioning.adoc[]
 
 include::modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_invalidating-registration-tokens.adoc
+++ b/guides/common/assembly_invalidating-registration-tokens.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_invalidating-registration-tokens.adoc[]
 
 include::modules/proc_invalidating-your-own-jwts.adoc[leveloffset=+1]

--- a/guides/common/assembly_job-template-examples-and-extensions.adoc
+++ b/guides/common/assembly_job-template-examples-and-extensions.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_job-template-examples-and-extensions.adoc[]
 
 include::modules/ref_customizing-job-templates.adoc[leveloffset=+1]

--- a/guides/common/assembly_limiting-host-resources.adoc
+++ b/guides/common/assembly_limiting-host-resources.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_limiting-host-resources.adoc[]
 
 include::modules/proc_installing-the-resource-quota-plugin.adoc[leveloffset=+1]

--- a/guides/common/assembly_logging-and-reporting-problems.adoc
+++ b/guides/common/assembly_logging-and-reporting-problems.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_logging-and-reporting-problems.adoc[]
 
 include::modules/proc_increasing-the-logging-levels-to-help-with-debugging.adoc[leveloffset=+1]

--- a/guides/common/assembly_maintaining-server.adoc
+++ b/guides/common/assembly_maintaining-server.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_maintaining-server.adoc[]
 
 include::modules/proc_deleting-audit-records-manually.adoc[leveloffset=+1]

--- a/guides/common/assembly_major-project-components.adoc
+++ b/guides/common/assembly_major-project-components.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_major-project-components.adoc[]
 
 include::modules/con_projectserver-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-activation-keys.adoc
+++ b/guides/common/assembly_managing-activation-keys.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-activation-keys.adoc[]
 
 include::modules/ref_best-practices-for-activation-keys.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-alternate-content-sources.adoc
+++ b/guides/common/assembly_managing-alternate-content-sources.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-alternate-content-sources.adoc[]
 
 include::modules/proc_configuring-custom-alternate-content-sources.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-ansible-content.adoc
+++ b/guides/common/assembly_managing-ansible-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-ansible-content.adoc[]
 
 include::modules/proc_synchronizing-ansible-collections.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-application-lifecycles.adoc
+++ b/guides/common/assembly_managing-application-lifecycles.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-application-lifecycles.adoc[]
 
 include::modules/con_introduction-to-application-lifecycle.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-container-images.adoc
+++ b/guides/common/assembly_managing-container-images.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-container-images.adoc[]
 
 include::modules/proc_importing-container-images.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-view-environments.adoc
+++ b/guides/common/assembly_managing-content-view-environments.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-content-view-environments.adoc[]
 
 include::modules/con_content-view-environments-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-content-views.adoc[]
 
 include::modules/con_content-views-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-custom-file-type-content.adoc
+++ b/guides/common/assembly_managing-custom-file-type-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-custom-file-type-content.adoc[]
 
 include::modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-errata.adoc
+++ b/guides/common/assembly_managing-errata.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-errata.adoc[]
 
 include::modules/ref_best-practices-for-errata.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-flatpak-repositories-in-project.adoc[]
 
 include::modules/proc_enabling-the-flatpak-remote.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-isos-and-files.adoc
+++ b/guides/common/assembly_managing-isos-and-files.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-iso-images.adoc[]
 
 include::modules/proc_importing-iso-images-from-red-hat.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-locations.adoc
+++ b/guides/common/assembly_managing-locations.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-locations.adoc[]
 
 include::modules/proc_creating-a-location.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-network-interfaces.adoc
+++ b/guides/common/assembly_managing-network-interfaces.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-network-interfaces.adoc[]
 
 include::modules/proc_configuring-a-physical-interface.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-organizations.adoc
+++ b/guides/common/assembly_managing-organizations.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-organizations.adoc[]
 
 include::modules/ref_examples-of-organization-management-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-ostree-content.adoc
+++ b/guides/common/assembly_managing-ostree-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-ostree-content.adoc[]
 
 include::modules/proc_importing-ostree-content.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-packages.adoc[]
 
 include::modules/proc_enabling-and-disabling-repositories-on-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-project-with-ansible-collection.adoc
+++ b/guides/common/assembly_managing-project-with-ansible-collection.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 include::modules/con_automating-project-management-with-project-ansible-collection.adoc[]
 

--- a/guides/common/assembly_managing-python-type-content.adoc
+++ b/guides/common/assembly_managing-python-type-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-python-type-content.adoc[]
 
 include::modules/proc_synchronizing-python-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-red-hat-subscriptions.adoc
+++ b/guides/common/assembly_managing-red-hat-subscriptions.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-red-hat-subscriptions.adoc[]
 
 include::modules/proc_tracking-subscription-usage-by-using-the-subscriptions-service.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-suse-content.adoc
+++ b/guides/common/assembly_managing-suse-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-suse-content.adoc[]
 
 include::modules/proc_preparing-suse-installation-media.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-users-and-roles.adoc
+++ b/guides/common/assembly_managing-users-and-roles.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-users-and-roles.adoc[]
 
 include::modules/con_managing-users.adoc[leveloffset=+1]

--- a/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_migrating-from-internal-databases-to-external-databases.adoc[]

--- a/guides/common/assembly_monitoring-hosts-by-using-red-hat-insights.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-red-hat-insights.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_monitoring-hosts-by-using-red-hat-insights.adoc[]
 
 ifdef::orcharhino[]

--- a/guides/common/assembly_monitoring-resources.adoc
+++ b/guides/common/assembly_monitoring-resources.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_monitoring-resources.adoc[]
 
 include::modules/proc_using-the-project-content-dashboard.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-hosts.adoc
+++ b/guides/common/assembly_overview-of-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_overview-of-hosts-in-project.adoc[]
 
 include::modules/con_browsing-hosts-in-foreman-webui.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-load-balancing-in-project.adoc
+++ b/guides/common/assembly_overview-of-load-balancing-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_overview-of-load-balancing-in-project.adoc[]
 
 include::modules/con_components-of-a-load-balanced-setup.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-vm-subscriptions.adoc
+++ b/guides/common/assembly_overview-of-vm-subscriptions.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_virtual-machine-subscriptions-overview.adoc[]
 
 include::modules/ref_virt-who-configuration-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_package-mode-and-image-mode-hosts.adoc
+++ b/guides/common/assembly_package-mode-and-image-mode-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_package-mode-and-image-mode-hosts.adoc[]
 
 include::modules/proc_viewing-booted-container-images.adoc[leveloffset=+1]

--- a/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_performing-additional-configuration-on-smart-proxy-server.adoc[]
 
 // Configuring SmartProxy for Host Registration and Provisioning

--- a/guides/common/assembly_planning-project-server-installation.adoc
+++ b/guides/common/assembly_planning-project-server-installation.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_planning-project-server-installation.adoc[]
 
 include::modules/ref_system-requirements.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-client-platforms.adoc
+++ b/guides/common/assembly_preparing-client-platforms.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-client-platforms.adoc[]
 
 include::modules/proc_creating-operating-systems.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="preparing-environment-for-capsule-installation"]

--- a/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation-in-ipv6-network.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 [id="preparing-environment-for-installation-in-ipv6-network_{context}"]

--- a/guides/common/assembly_preparing-environment-for-project-server-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-project-server-installation.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-environment-for-project-server-installation.adoc[]
 
 include::modules/proc_enabling-client-connections-to-satellite.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[]
 
 include::modules/con_overview-of-recommended-disaster-recovery-plans.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-project-upgrade.adoc
+++ b/guides/common/assembly_preparing-for-project-upgrade.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-for-project-upgrade.adoc[]
 
 include::modules/con_upgrade-path-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-networking.adoc
+++ b/guides/common/assembly_preparing-networking.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-networking.adoc[]
 
 include::modules/con_facts-and-nic-filtering.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-provisioning-content.adoc
+++ b/guides/common/assembly_preparing-provisioning-content.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-provisioning-content.adoc[]
 
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
+++ b/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-smartproxyservers-for-load-balancing.adoc[]
 
 ifdef::satellite,katello[]

--- a/guides/common/assembly_preparing-templates-for-provisioning.adoc
+++ b/guides/common/assembly_preparing-templates-for-provisioning.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_preparing-templates-for-provisioning.adoc[]
 
 include::modules/con_provisioning-templates.adoc[leveloffset=+1]

--- a/guides/common/assembly_project-infrastructure-organization-concepts.adoc
+++ b/guides/common/assembly_project-infrastructure-organization-concepts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_project-infrastructure-organization-concepts.adoc[]
 
 include::modules/con_organizations-and-locations-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: azure-provisioning
 :azure-provisioning:

--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: ec2-provisioning
 :ec2-provisioning:

--- a/guides/common/assembly_provisioning-cloud-instances-gce.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-gce.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: gce-provisioning
 :gce-provisioning:

--- a/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: openstack-provisioning
 :openstack-provisioning:

--- a/guides/common/assembly_provisioning-fips-compliant-hosts.adoc
+++ b/guides/common/assembly_provisioning-fips-compliant-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_provisioning-fips-compliant-hosts.adoc[]
 
 include::modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-management-with-project.adoc
+++ b/guides/common/assembly_provisioning-management-with-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_provisioning-management-with-project.adoc[]
 
 include::modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-requirements.adoc
+++ b/guides/common/assembly_provisioning-requirements.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_provisioning-requirements.adoc[]
 
 include::modules/con_pxe-booting.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: kubevirt-provisioning
 :kubevirt-provisioning:

--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: kvm-provisioning
 :kvm-provisioning:

--- a/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: proxmox-provisioning
 :proxmox-provisioning:

--- a/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :parent-context: {context}
 :context: vmware-provisioning
 :vmware-provisioning:

--- a/guides/common/assembly_refreshing-the-self-signed-ca-certificate-on-hosts.adoc
+++ b/guides/common/assembly_refreshing-the-self-signed-ca-certificate-on-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_refreshing-the-self-signed-ca-certificate-on-hosts.adoc[]
 
 include::modules/proc_deploying-the-ca-certificate-on-a-host-by-using-script-rex.adoc[leveloffset=+1]

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_registering-hosts-and-setting-up-host-integration.adoc[]
 
 include::modules/ref_supported-clients-in-registration.adoc[leveloffset=+1]

--- a/guides/common/assembly_renaming-server-or-smart-proxy.adoc
+++ b/guides/common/assembly_renaming-server-or-smart-proxy.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_renaming-server-or-smart-proxy.adoc[]
 
 include::modules/proc_renaming-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_renewing-certificates.adoc
+++ b/guides/common/assembly_renewing-certificates.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_renewing-certificates.adoc[]
 
 include::modules/proc_planning-for-self-signed-ca-certificate-renewal.adoc[leveloffset=+1]

--- a/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc[]
 
 include::modules/proc_restoring-from-a-full-backup.adoc[leveloffset=+1]

--- a/guides/common/assembly_restricting-hosts-access-to-content.adoc
+++ b/guides/common/assembly_restricting-hosts-access-to-content.adoc
@@ -1,1 +1,3 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_restricting-hosts-access-to-content.adoc[]

--- a/guides/common/assembly_searching-and-bookmarking.adoc
+++ b/guides/common/assembly_searching-and-bookmarking.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_searching-and-bookmarking.adoc[]
 
 include::modules/con_building-search-queries.adoc[leveloffset=+1]

--- a/guides/common/assembly_security-settings.adoc
+++ b/guides/common/assembly_security-settings.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_security-settings.adoc[]
 
 include::modules/proc_configuring-the-security-token-validity-duration.adoc[leveloffset=+1]

--- a/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
+++ b/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_supported-usage-and-versions-of-project-components.adoc[]
 
 ifdef::satellite[]

--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_synchronizing-content-between-servers.adoc[]
 
 include::modules/con_content-synchronization-by-using-export-and-import.adoc[leveloffset=+1]

--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_synchronizing-template-repositories.adoc[]
 
 ifndef::satellite[]

--- a/guides/common/assembly_template-writing-reference.adoc
+++ b/guides/common/assembly_template-writing-reference.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_template-writing-reference.adoc[]
 
 include::modules/proc_accessing-the-template-writing-reference.adoc[leveloffset=+1]

--- a/guides/common/assembly_tools-for-administration-of-project.adoc
+++ b/guides/common/assembly_tools-for-administration-of-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_tools-for-administration-of-project.adoc[]
 
 include::modules/con_web-ui-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_troubleshooting-virt-who.adoc
+++ b/guides/common/assembly_troubleshooting-virt-who.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_troubleshooting-virt-who.adoc[]
 
 include::modules/proc_checking-virt-who-status.adoc[leveloffset=+1]

--- a/guides/common/assembly_usage-metrics-collection-in-project.adoc
+++ b/guides/common/assembly_usage-metrics-collection-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_usage-metrics-collection-in-project.adoc[]
 
 include::modules/con_overview-of-usage-metrics-collection-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-ansible-roles.adoc
+++ b/guides/common/assembly_using-ansible-roles.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_using-ansible-roles-to-automate-repetitive-tasks-on-clients.adoc[]
 
 include::modules/proc_assigning-ansible-roles-to-an-existing-host.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-boot-disks-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-boot-disks-to-provision-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :using-bootdisks-to-provision-hosts:
 :parent-context: {context}
 :context: using-bootdisks

--- a/guides/common/assembly_using-external-databases.adoc
+++ b/guides/common/assembly_using-external-databases.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_using-external-databases.adoc[]
 
 include::modules/con_configuring-project-server-with-external-database.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-foreman-webhooks.adoc
+++ b/guides/common/assembly_using-foreman-webhooks.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_using-webhooks.adoc[]

--- a/guides/common/assembly_using-ipxe-to-reduce-provisioning-times.adoc
+++ b/guides/common/assembly_using-ipxe-to-reduce-provisioning-times.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_using-ipxe-to-reduce-provisioning-times.adoc[]
 
 include::modules/con_prerequisites-for-using-ipxe.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-kernelcare.adoc
+++ b/guides/common/assembly_using-kernelcare.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_using-the-kernelcare-plugin.adoc[]
 
 include::modules/proc_installing-the-kernelcare-plugin.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :using-network-boot-to-provision-hosts:
 :parent-context: {context}
 :context: using-netboot

--- a/guides/common/assembly_using-pxe-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-pxe-to-provision-hosts.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 :using-pxe-to-provision-hosts:
 include::modules/con_using-pxe-to-provision-hosts.adoc[]
 

--- a/guides/common/assembly_using-report-templates.adoc
+++ b/guides/common/assembly_using-report-templates.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_using-report-templates-to-monitor-hosts.adoc[]
 
 include::modules/proc_generating-host-monitoring-reports.adoc[leveloffset=+1]

--- a/guides/common/assembly_working-with-host-groups.adoc
+++ b/guides/common/assembly_working-with-host-groups.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_working-with-host-groups.adoc[]
 
 include::modules/con_host-groups-overview.adoc[leveloffset=+1]

--- a/guides/scripts/generate-hammer-reference.sh
+++ b/guides/scripts/generate-hammer-reference.sh
@@ -84,7 +84,7 @@ echo -e >$details_tmp # reset
 details_file="$mod_path/ref_hammer-option-details.adoc"
 details_header='[id="hammer-option-details"]\n= Option details\n\nHammer options accept the following option types and values:'
 
-asmb_header='// DO NOT EDIT MANUALLY\n// Use the generate-hammer-reference.sh script to update\n\ninclude::modules/con_hammer-reference.adoc[]\n\n'
+asmb_header=':_mod-docs-content-type: ASSEMBLY\n\n// DO NOT EDIT MANUALLY\n// Use the generate-hammer-reference.sh script to update\n\ninclude::modules/con_hammer-reference.adoc[]\n\n'
 asmb_footer='include::modules/ref_hammer-option-details.adoc[leveloffset=+1]\n'
 
 # Create folders


### PR DESCRIPTION
#### What changes are you introducing?

Adding content type attribute to assemblies.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Required for tooling migration.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
