### PR TITLE
Add mod docs content attribute guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ See [LICENSE](LICENSE).
 * [ ] When creating my PR, I select all branches I want my change to get cherry-picked to.
 * [ ] I am familiar to proper capitalization for project-specific terminology.
 See [Capitalization](#Capitalization).
+* [ ] The first line of the file contains the modular docs content type attribute, for example, `:_mod-docs-content-type: ASSEMBLY` for assemblies.
 
 ## Capitalization
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -167,10 +167,13 @@ Please do not wrap lines by hand.
 This makes `git diff` much easier to read and helps when reviewing changes.
 * No trailing whitespace on lines and in files.
 Whitespace after partial files has to be handled in the file using the `include::` directive.
-* Image file names use dashes (`-`) and suffix a build target, e.g. `foreman`.
+* Image file names use dashes (`-`) and suffix a build target, for example, `foreman`.
 See also [Images](#Images).
-* User input is surrounded by underscores (`_`) to indicate variable input, e.g. `hammer organization create --name "_My Organization_" --label "_my_organization_"`.
+* User input is surrounded by underscores (`_`) to indicate variable input, for example, `hammer organization create --name "_My Organization_" --label "_my_organization_"`.
 * Links to different guides are followed by the title of the guide in italics, for example `in _{ManagingHostsDocTitle}_`.
+* The first line of a file contains the modular docs content type attribute, for example, `:_mod-docs-content-type: ASSEMBLY` for assemblies.
+The content type reflects the file prefix: `ASSEMBLY`, `PROCEDURE`, `CONCEPT`, `REFERENCE`, or `SNIPPET`.
+The only exceptions are `master.adoc` files, which do not require this attribute.
 
 ### Images
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -172,7 +172,7 @@ See also [Images](#Images).
 * User input is surrounded by underscores (`_`) to indicate variable input, for example, `hammer organization create --name "_My Organization_" --label "_my_organization_"`.
 * Links to different guides are followed by the title of the guide in italics, for example `in _{ManagingHostsDocTitle}_`.
 * The first line of a file contains the modular docs content type attribute, for example, `:_mod-docs-content-type: ASSEMBLY` for assemblies.
-The content type reflects the file prefix: `ASSEMBLY`, `PROCEDURE`, `CONCEPT`, `REFERENCE`, or `SNIPPET`.
+The content type reflects the file prefix: `ASSEMBLY`, `PROCEDURE`, `CONCEPT`, or `REFERENCE`.
 The only exceptions are `master.adoc` files, which do not require this attribute.
 
 ### Images


### PR DESCRIPTION
#### What changes are you introducing?

Adding guidelines for the mod docs content attribute.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This attribute is required for migrating d/s files to DITA.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
