### PR TITLE
Remove update-ca-trust enable step

### DIFF
--- a/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -74,8 +74,7 @@ You can also use these options when you first configure the {ProjectServer}.
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # cp /etc/ipa/ca.crt /etc/pki/ca-trust/source/anchors/ipa.crt
-# update-ca-trust enable
-# update-ca-trust
+# update-ca-trust extract
 ----
 . Optional: If you configure {FreeIPA} on an existing {ProjectServer} or {SmartProxyServer}, complete the following steps to ensure that the configuration changes take effect:
 .. Restart the *foreman-proxy* service:

--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -67,8 +67,7 @@ To do so, execute the following commands on {ProjectServer}:
 [options="nowrap"]
 ----
 # cp mailca.crt /etc/pki/ca-trust/source/anchors/
-# update-ca-trust enable
-# update-ca-trust
+# update-ca-trust extract
 ----
 +
 Where `_mailca.crt_` is the CA certificate of the SMTP server.

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -124,12 +124,6 @@ system_info:
   ssh_svcname: sshd
 EOM
 ----
-. Enable the CA certificates for the image:
-+
-[options="nowrap" subs="+quotes"]
-----
-# update-ca-trust enable
-----
 ifdef::katello,satellite,orcharhino[]
 . Download the `katello-server-ca.crt` file from {ProjectServer}:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Always only run `update-ca-trust extract`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The enable command was never valid. On EL 7 & 8 it was just ignored so effectively it ran twice. On EL 9 there is argument parsing and enable emits a deprecation warning to use extract. On EL 10 the enable command is no longer accepted and only extract is valid.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

https://github.com/voxpupuli/puppet-trusted_ca/commit/b3416c58e6a0d72ef8c49725a6193c3217b001cc is where I originally wrote down my findings in the period that ca-certificates on EL9 didn't accept `enable` at all. It has since started to accept it again, with a deprecation warning.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.