### PR TITLE
Use attribute for RH Customer Portal

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -27,6 +27,7 @@
 :UpgradingDisconnectedDocURL: {BaseURL}Upgrading_Project_Disconnected/{BaseFilenameURL}#
 
 // Red Hat specific URLs
+:RHCustomerPortal: https://access.redhat.com[Red{nbsp}Hat Customer Portal]
 :RHDocsBaseURL: https://docs.redhat.com/en/documentation/
 :RHELDocsBaseURL: {RHDocsBaseURL}red_hat_enterprise_linux/
 

--- a/guides/common/modules/con_content-flow-in-project.adoc
+++ b/guides/common/modules/con_content-flow-in-project.adoc
@@ -8,7 +8,7 @@ _{SmartProxyServers}_ mirror the content from {ProjectServer} to _hosts_.
 
 External content sources::
 You can configure many content sources with {Project}.
-The supported content sources include the Red{nbsp}Hat Customer Portal,
+The supported content sources include the {RHCustomerPortal},
 ifdef::satellite[]
 custom Yum repositories,
 endif::[]

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -39,7 +39,7 @@ Note that the conversion and the subsequent upgrade without an ELS subscription 
 Alternatively, you can use Ansible variables to tell the role to import the manifest from disk.
 The manifest must be imported to the organization to which you will register hosts for conversion.
 +
-You can update your allocations and download the updated manifest from the https://access.redhat.com[{RHCustomerPortal}].
+You can update your allocations and download the updated manifest from the {RHCustomerPortal}.
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index#proc-exporting-downloading-manifest-satellite-connected[Exporting and downloading a manifest] in _Creating and managing manifests for a connected Satellite Server_.
 * Ensure that you have enabled and synchronized Red Hat repositories in {Project} for the minor {RHEL} version to which you convert your hosts.
 For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/con_converting-a-host-to-rhel.adoc
+++ b/guides/common/modules/con_converting-a-host-to-rhel.adoc
@@ -39,7 +39,7 @@ Note that the conversion and the subsequent upgrade without an ELS subscription 
 Alternatively, you can use Ansible variables to tell the role to import the manifest from disk.
 The manifest must be imported to the organization to which you will register hosts for conversion.
 +
-You can update your allocations and download the updated manifest from the https://access.redhat.com[Red Hat Customer Portal].
+You can update your allocations and download the updated manifest from the https://access.redhat.com[{RHCustomerPortal}].
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index#proc-exporting-downloading-manifest-satellite-connected[Exporting and downloading a manifest] in _Creating and managing manifests for a connected Satellite Server_.
 * Ensure that you have enabled and synchronized Red Hat repositories in {Project} for the minor {RHEL} version to which you convert your hosts.
 For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}Synchronizing_Repositories_content-management[Synchronizing Repositories] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/con_installing-a-project-server.adoc
+++ b/guides/common/modules/con_installing-a-project-server.adoc
@@ -12,7 +12,7 @@ A disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN but you can sti
 You can use the following methods to import content to a disconnected {ProjectServer}:
 
 Content ISO::
-In this setup, you download ISO images with content from the Red{nbsp}Hat Customer Portal and extract them to {ProjectServer} or a local web server.
+In this setup, you download ISO images with content from the {RHCustomerPortal} and extract them to {ProjectServer} or a local web server.
 The content on {ProjectServer} is then synchronized locally.
 +
 This allows for complete network isolation of {ProjectServer}, however, the release frequency of content ISO images is around six weeks and not all product content is included.

--- a/guides/common/modules/con_projectserver-with-multiple-manifests.adoc
+++ b/guides/common/modules/con_projectserver-with-multiple-manifests.adoc
@@ -41,4 +41,4 @@ This enables uninterrupted access to repositories when future-dated subscription
 
 Note that the Red{nbsp}Hat subscription manifest can be modified and reloaded to {ProjectServer} in case of any changes in your infrastructure, or when adding more subscriptions.
 Manifests should not be deleted.
-If you delete the manifest from the Red Hat Customer Portal or in the {ProjectWebUI} it will unregister all of your content hosts.
+If you delete the manifest from the {RHCustomerPortal} or in the {ProjectWebUI} it will unregister all of your content hosts.

--- a/guides/common/modules/con_smartproxy-features.adoc
+++ b/guides/common/modules/con_smartproxy-features.adoc
@@ -21,7 +21,7 @@ Host action delivery::
 {SmartProxyServer} executes scheduled actions on hosts.
 
 Red Hat Subscription Management (RHSM) proxy::
-Hosts are registered to their associated {SmartProxyServers} rather than to the central {ProjectServer} or the Red{nbsp}Hat Customer Portal.
+Hosts are registered to their associated {SmartProxyServers} rather than to the central {ProjectServer} or the {RHCustomerPortal}.
 
 You can use {SmartProxy} to run the following services for infrastructure and host management:
 endif::[]

--- a/guides/common/modules/proc_cloning-satellite-server.adoc
+++ b/guides/common/modules/proc_cloning-satellite-server.adoc
@@ -142,7 +142,7 @@ If you copy to a different folder, update the `backup_dir` variable in the `/etc
 . Place the backup files from the source {Project} in the `/backup/` folder on the target server.
 You can either mount the shared storage or copy the backup files to the `/backup/` folder on the target server.
 . Power off the source server.
-. Register your instance to the Red Hat Customer Portal and enable only the required repositories:
+. Register your instance to the {RHCustomerPortal} and enable only the required repositories:
 +
 [options="nowrap" subs="quotes,attributes"]
 ----

--- a/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
+++ b/guides/common/modules/proc_downloading-the-binary-dvd-images.adoc
@@ -5,7 +5,7 @@ Use this procedure to download the ISO images for {RHEL} and {ProjectName}.
 
 .Procedure
 
-. Go to https://access.redhat.com/[Red Hat Customer Portal] and log in.
+. Log in to the {RHCustomerPortal}.
 
 . Click *DOWNLOADS*.
 

--- a/guides/common/modules/proc_getting-supported-scap-contents-for-rhel.adoc
+++ b/guides/common/modules/proc_getting-supported-scap-contents-for-rhel.adoc
@@ -1,7 +1,7 @@
 [id="getting-supported-scap-contents-for-rhel_{context}"]
 = Getting supported SCAP contents for RHEL
 
-You can get the latest SCAP Security Guide (SSG) for {RHEL} on the Red Hat Customer Portal.
+You can get the latest SCAP Security Guide (SSG) for {RHEL} on the {RHCustomerPortal}.
 You have to get a version of SSG that is designated for the minor RHEL version of your hosts.
 
 .Procedure

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -24,7 +24,7 @@ For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-sing
 endif::[]
 endif::[]
 ifeval::["{mode}" == "disconnected"]
-* Ensure you have a Red{nbsp}Hat subscription manifest exported from the Red Hat Customer Portal.
+* Ensure you have a Red{nbsp}Hat subscription manifest exported from the {RHCustomerPortal}.
 You will use the same manifest in xref:configuring-server-to-synchronize-content-over-a-network_{context}[].
 ifndef::orcharhino[]
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_disconnected_satellite_server/index[Creating and managing manifests for a disconnected Satellite Server] in _Subscription Central_.
@@ -36,7 +36,7 @@ ifdef::content-management[]
 ifndef::orcharhino[]
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected Satellite Server] in _Subscription Central_.
 endif::[]
-** If your {Project} is disconnected, use the Red Hat Customer Portal to create and export the manifest.
+** If your {Project} is disconnected, use the {RHCustomerPortal} to create and export the manifest.
 ifndef::orcharhino[]
 For more information, see {RHDocsBaseURL}subscription_central/1-latest/html-single/creating_and_managing_manifests_for_a_disconnected_satellite_server/index[Creating and managing manifests for a disconnected Satellite Server] in _Subscription Central_.
 endif::[]

--- a/guides/common/modules/proc_registering-to-red-hat-subscription-management.adoc
+++ b/guides/common/modules/proc_registering-to-red-hat-subscription-management.adoc
@@ -10,7 +10,7 @@ This includes content such as {RHEL} and {ProjectName}.
 
 .Procedure
 
-* Register your system with the Red Hat Content Delivery Network, entering your Customer Portal user name and password when prompted:
+* Register your system with the Red Hat Content Delivery Network, entering your {RHCustomerPortal} user name and password when prompted:
 +
 [options="nowrap"]
 ----

--- a/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-manifests.adoc
+++ b/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-manifests.adoc
@@ -6,7 +6,7 @@ Use the following procedure to remove Red Hat subscriptions from a subscription 
 [NOTE]
 ====
 Manifests must not be deleted.
-If you delete the manifest from the Red Hat Customer Portal or in the {ProjectWebUI}, all of the entitlements for all of your content hosts will be removed.
+If you delete the manifest from the {RHCustomerPortal} or in the {ProjectWebUI}, all of the entitlements for all of your content hosts will be removed.
 ====
 
 .Prerequisites

--- a/guides/common/modules/proc_resolving-package-dependency-errors.adoc
+++ b/guides/common/modules/proc_resolving-package-dependency-errors.adoc
@@ -1,14 +1,14 @@
 [id="resolving-package-dependency-errors_{context}"]
 = Resolving package dependency errors
 
-If there are package dependency errors during installation of {ProjectServer} packages, you can resolve the errors by downloading and installing packages from Red Hat Customer Portal.
+If there are package dependency errors during installation of {ProjectServer} packages, you can resolve the errors by downloading and installing packages from {RHCustomerPortal}.
 For more information about resolving dependency errors, see the KCS solution https://access.redhat.com/solutions/262323[How can I use the yum output to solve yum dependency errors?].
 
 If you have successfully installed the {Project} packages, skip this procedure.
 
 .Procedure
 
-. Go to the https://access.redhat.com/[Red Hat Customer Portal] and log in.
+. Log in to the {RHCustomerPortal}.
 . Click *DOWNLOADS*.
 . Click the product that contains the package that you want to download.
 . Ensure that you have the correct *Product Variant*, *Version*, and *Architecture* for your environment.

--- a/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-the-new-repositories.adoc
@@ -25,7 +25,7 @@ In the {ProjectWebUI}, navigate to *Content* > *Subscriptions* > *Manage Manifes
 +
 [WARNING]
 ====
-Do not delete the manifest from the Customer Portal or in the {ProjectWebUI}.
+Do not delete the manifest from the {RHCustomerPortal} or in the {ProjectWebUI}.
 Deleting your manifest removes all the entitlements of your hosts.
 ====
 

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -306,7 +306,7 @@ You can promote a content view through a typical promotion path, for example, fr
 All lifecycle environment paths originate from the _Library_ environment, which is always present by default.
 
 [[Manifest]]
-Manifest (Red{nbsp}Hat subscription manifest):: A mechanism for transferring subscriptions from the Red{nbsp}Hat Customer Portal to {ProjectName}.
+Manifest (Red{nbsp}Hat subscription manifest):: A mechanism for transferring subscriptions from the {RHCustomerPortal} to {ProjectName}.
 Do not confuse with xref:Puppet_manifest[Puppet manifest].
 endif::[]
 

--- a/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
+++ b/guides/common/modules/ref_initialization-script-for-provisioning-examples.adoc
@@ -99,7 +99,7 @@ hammer content-view version promote \
 ----
 # chmod +x content-init.sh
 ----
-. Download a copy of your Red{nbsp}Hat Subscription Manifest from the Red Hat Customer Portal and run the script on the manifest:
+. Download a copy of your Red{nbsp}Hat Subscription Manifest from the {RHCustomerPortal} and run the script on the manifest:
 +
 ----
 # ./content-init.sh manifest_98f4290e-6c0b-4f37-ba79-3a3ec6e405ba.zip

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -38,9 +38,9 @@ If your territory is USA and your language is English, set `en_US.utf-8` as the 
 For more information about configuring system locale in {EL}, see {RHELDocsBaseURL}9/html/configuring_basic_system_settings/assembly_changing-basic-environment-settings_configuring-basic-system-settings#proc_configuring-the-system-locale_assembly_changing-basic-environment-settings[Configuring the system locale] in _{RHEL}{nbsp}9 Configuring basic system settings_.
 
 ifdef::satellite[]
-Your {Project} must have the {SatelliteSub} manifest in your Customer Portal.
+Your {Project} must have the {SatelliteSub} manifest in your {RHCustomerPortal}.
 {Project} must have {project-context}-{smart-proxy-context}-6.x repository enabled and synced.
-To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the Customer Portal, see {RHDocsBaseURL}subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
+To create, manage, and export a Red{nbsp}Hat Subscription Manifest in the {RHCustomerPortal}, see {RHDocsBaseURL}subscription_central/1-latest/html/creating_and_managing_manifests_for_a_connected_satellite_server/index[Creating and managing manifests for a connected {ProjectServer}] in _Subscription Central_.
 endif::[]
 
 {ProjectServer} and {SmartProxyServer} do not support shortnames in the hostnames.


### PR DESCRIPTION
#### What changes are you introducing?

Replace "Red Hat Customer Portal", "Red{nbsp}Hat Customer Portal", and "Customer Portal", in this order, with an attribute. Only in cases where that occurrence is not preceded by another link to RH CP.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Primary objective: unify the wording
- UX improvement: users can click the link to access the portal

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
