### PR TITLE
Reword SSH connection SmartProxy to host for mqtt

### DIFF
--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -2,7 +2,7 @@
 = Configuring a host to use the pull client
 
 For {SmartProxies} configured to use `pull-mqtt` mode, hosts can subscribe to remote jobs using the remote execution pull client.
-Hosts do not require an SSH connection from their {SmartProxyServer}.
+This does not use SSH and hosts do not require opening up any incoming firewall ports.
 
 .Prerequisites
 * You have registered the host to {Project}.


### PR DESCRIPTION
#### What changes are you introducing?

Clarify the direction of SSH connections between Smart Proxies and hosts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I suggest to flip the wording to make it easier to understand which SSH connection is not required when using Pull Clients compared to "normal" REX.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Needs tech ACK.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
