### PR TITLE
Fix Cockpit link

### DIFF
--- a/guides/common/modules/proc_configuring-project-to-provision-from-a-builder-image.adoc
+++ b/guides/common/modules/proc_configuring-project-to-provision-from-a-builder-image.adoc
@@ -9,7 +9,7 @@ The preferred image type is TAR.
 Ensure that your blueprint to build the TAR image includes a kernel package.
 
 ifndef::foreman-deb[]
-For more information about integrating {the-Cockpit} with {Project}, see {ManagingHostsDocURL}Host_Management_and_Monitoring_Using_Cockpit_managing-hosts[Host management and monitoring using {the-Cockpit}] in _{ManagingHostsDocTitle}_.
+For more information about integrating {the-Cockpit} with {Project}, see {ManagingHostsDocURL}host-management-and-monitoring-by-using-cockpit_managing-hosts[Host management and monitoring by using {the-Cockpit}] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 .Prerequisites

--- a/guides/common/modules/proc_configuring-project-to-provision-from-a-builder-image.adoc
+++ b/guides/common/modules/proc_configuring-project-to-provision-from-a-builder-image.adoc
@@ -9,7 +9,7 @@ The preferred image type is TAR.
 Ensure that your blueprint to build the TAR image includes a kernel package.
 
 ifndef::foreman-deb[]
-For more information about integrating {the-Cockpit} with {Project}, see {ManagingHostsDocURL}host-management-and-monitoring-by-using-cockpit_managing-hosts[Host management and monitoring by using {the-Cockpit}] in _{ManagingHostsDocTitle}_.
+For more information about integrating {the-Cockpit} with {Project}, see {ManagingHostsDocURL}host-management-and-monitoring-by-using-cockpit[Host management and monitoring by using {the-Cockpit}] in _{ManagingHostsDocTitle}_.
 endif::[]
 
 .Prerequisites


### PR DESCRIPTION
#### What changes are you introducing?

Fixing a link to Cockpit chapter

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's been changed in 3.12

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
