### PR TITLE
Do not use assembly within another assembly

### DIFF
--- a/guides/common/assembly_invalidating-registration-tokens.adoc
+++ b/guides/common/assembly_invalidating-registration-tokens.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-
-include::modules/con_invalidating-registration-tokens.adoc[]
-
-include::modules/proc_invalidating-your-own-jwts.adoc[leveloffset=+1]
-
-include::modules/proc_invalidating-jwts-of-other-users.adoc[leveloffset=+1]
-
-include::modules/proc_invalidating-jwts-of-all-users.adoc[leveloffset=+1]

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -21,7 +21,13 @@ include::modules/proc_customizing-host-registration-by-using-snippets.adoc[level
 
 include::modules/proc_customizing-the-registration-templates.adoc[leveloffset=+2]
 
-include::assembly_invalidating-registration-tokens.adoc[leveloffset=+2]
+include::modules/con_invalidating-registration-tokens.adoc[leveloffset=+2]
+
+include::modules/proc_invalidating-your-own-jwts.adoc[leveloffset=+3]
+
+include::modules/proc_invalidating-jwts-of-other-users.adoc[leveloffset=+3]
+
+include::modules/proc_invalidating-jwts-of-all-users.adoc[leveloffset=+3]
 
 ifdef::satellite,orcharhino[]
 // Bootstrap script


### PR DESCRIPTION
#### What changes are you introducing?

drop an assembly that is only used once.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This simplifies consuming the content for ATIX in downstream.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I do not expect any change in the rendered docs.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
