### PR TITLE
Add required Yum repos for OpenSCAP on EL10 and rename "Appstream" to "AppStream" to match "BaseOS"

### DIFF
--- a/guides/common/modules/proc_adding-rhel-system-roles.adoc
+++ b/guides/common/modules/proc_adding-rhel-system-roles.adoc
@@ -8,11 +8,11 @@ Using Ansible Roles in {Project} can make configuration faster and easier.
 Support levels for some of the {RHEL} System Roles might be in Technology Preview.
 For up-to-date information about support levels and general information about {RHEL} System Roles, see https://access.redhat.com/articles/3050101[{RHEL} System Roles].
 
-Before subscribing to the Extras or Appstream channels, see https://access.redhat.com/support/policy/updates/extras[{RHEL} Extras Product Lifecycle] or https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
+Before subscribing to the Extras or AppStream channels, see https://access.redhat.com/support/policy/updates/extras[{RHEL} Extras Product Lifecycle] or https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 
 .Procedure
 . Ensure that the following repository is enabled:
-* On {RHEL} 10, 9, or 8, ensure that the *Appstream* repository is enabled:
+* On {RHEL} 10, 9, or 8, ensure that the *AppStream* repository is enabled:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -21,7 +21,7 @@ Before subscribing to the Extras or Appstream channels, see https://access.redha
 # subscription-manager repos --enable={RepoRHEL8AppStream}
 ----
 +
-You must enable an Appstream repository that is designated for your architecture.
+You must enable an AppStream repository that is designated for your architecture.
 ifdef::satellite[]
 For more information, see {RHELDocsBaseURL}8/html/upgrading_from_rhel_7_to_rhel_8/appendix_rhel-8-repositories_upgrading-from-rhel-7-to-rhel-8[RHEL 8 repositories].
 endif::[]

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -40,7 +40,7 @@ cost=500
 baseurl=file:///media/rhel/BaseOS/
 
 [RHEL-AppStream]
-name=Red Hat Enterprise Linux Appstream
+name=Red Hat Enterprise Linux AppStream
 mediaid=None
 metadata_expire=-1
 gpgcheck=0

--- a/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
+++ b/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
@@ -7,7 +7,7 @@ For more information about adding repositories, see {ContentManagementDocURL}Syn
 Use this procedure to set up a Kickstart repository.
 
 .Prerequisites
-You must enable both *BaseOS* and *Appstream Kickstart* before provisioning.
+You must enable both *BaseOS* and *AppStream Kickstart* before provisioning.
 
 .Procedure
 . Add the synchronized Kickstart repository that you want to use to the existing content view, or create a new content view and add the Kickstart repository.

--- a/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
+++ b/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
@@ -7,9 +7,9 @@ ifdef::client-content-dnf[]
 ifndef::satellite[]
 For example, for {EL} you might require:
 endif::[]
-** {EL} 10 BaseOS and Appstream RPMs repositories
-** {EL} 9 BaseOS and Appstream RPMs repositories
-** {EL} 8 BaseOS and Appstream RPMs repositories
+** {EL} 10 BaseOS and AppStream RPMs repositories
+** {EL} 9 BaseOS and AppStream RPMs repositories
+** {EL} 8 BaseOS and AppStream RPMs repositories
 ** {EL} 7 Server and Extras RPMs repositories
 endif::[]
 endif::[]

--- a/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
+++ b/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
@@ -7,6 +7,7 @@ ifdef::client-content-dnf[]
 ifndef::satellite[]
 For example, for {EL} you might require:
 endif::[]
+** {EL} 10 BaseOS and Appstream RPMs repositories
 ** {EL} 9 BaseOS and Appstream RPMs repositories
 ** {EL} 8 BaseOS and Appstream RPMs repositories
 ** {EL} 7 Server and Extras RPMs repositories


### PR DESCRIPTION
#### What changes are you introducing?

Add required Yum repos for OpenSCAP on EL10 and rename "Appstream" to "AppStream" to match "BaseOS"

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* EL10 is missing
* If we say BaseOS, we should also say "AppStream".

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
