### PR TITLE
Allow attributes in code blocks

### DIFF
--- a/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
+++ b/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
@@ -29,7 +29,7 @@ The output reflects the `Library/cv1` content view environment:
 ----
 
 This results in the following output:
-[source, none, options="nowrap" subs="+quotes"]
+[source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 +----------------------------------------------------------+
     Available Repositories in /etc/yum.repos.d/redhat.repo
@@ -61,7 +61,7 @@ After reordering, inspecting the repositories again shows the `dev/cv1` content 
 ----
 
 This results in the following output:
-[source, none, options="nowrap" subs="+quotes"]
+[source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 +----------------------------------------------------------+
     Available Repositories in /etc/yum.repos.d/redhat.repo


### PR DESCRIPTION
#### What changes are you introducing?

Allow usage of asciidoc attributes in two specific code blocks.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes https://docs.theforeman.org/nightly/Managing_Content/index-katello.html#content-view-environment-ordering-and-priority

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
