### PR TITLE
Use SmartProxy in favor of proxy

### DIFF
--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -18,7 +18,7 @@ include::modules/proc_using-an-http-proxy-for-all-http-requests.adoc[leveloffset
 include::modules/proc_excluding-hosts-from-receiving-proxied-requests.adoc[leveloffset=+1]
 
 ifndef::satellite[]
-include::modules/proc_configuring-pxe-files-proxy.adoc[leveloffset=+1]
+include::modules/proc_configuring-http-proxy-for-pxe-file-downloads-on-smart-proxies.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_resetting-the-http-proxy.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_configuring-http-proxy-for-pxe-file-downloads-on-smart-proxies.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-for-pxe-file-downloads-on-smart-proxies.adoc
@@ -7,15 +7,15 @@ For Red Hat content served through the Content Delivery Network, {SmartProxy} do
 However, when configuring and installing an operating system using Installation Media, {SmartProxy} connects directly using the `wget` utility.
 
 .Procedure
-. On your TFTP {SmartProxy}, verify the ports that are permitted by SELinux for the HTTP cache:
+. On your TFTP {SmartProxy}, edit the `foreman-proxy` service:
 +
 [options="nowrap",subs="+quotes"]
 ----
 # systemctl edit foreman-proxy
 ----
-. Configure the HTTP proxy in `/etc/systemd/system/foreman-proxy.service.d/overrides.conf`:
+. Provide details of your HTTP proxy:
 +
-[source, none, options="nowrap",subs="+quotes"]
+[source, ini, options="nowrap",subs="+quotes"]
 ----
 [Service]
 Environment="http_proxy=http://_http-proxy.example.com:8080_"

--- a/guides/common/modules/proc_configuring-http-proxy-for-pxe-file-downloads-on-smart-proxies.adoc
+++ b/guides/common/modules/proc_configuring-http-proxy-for-pxe-file-downloads-on-smart-proxies.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-proxy-for-pxe-files_{context}"]
-= Configuring a proxy for PXE file downloads
+[id="configuring-http-proxy-for-pxe-file-downloads-on-{smart-proxy-context}"]
+= Configuring HTTP proxy for PXE file downloads on {SmartProxies}
 
 For Red Hat content served through the Content Delivery Network, {SmartProxy} downloads PXE files from synchronized repositories.
 However, when configuring and installing an operating system using Installation Media, {SmartProxy} connects directly using the `wget` utility.
 
 .Procedure
-. On your TFTP {SmartProxy}, verify the ports that are permitted by SELinux for the HTTP cache by entering the following command:
+. On your TFTP {SmartProxy}, verify the ports that are permitted by SELinux for the HTTP cache:
 +
 [options="nowrap",subs="+quotes"]
 ----
@@ -27,4 +27,6 @@ Environment="https_proxy=https://_http-proxy.example.com:8443_"
 ----
 # systemctl restart foreman-proxy
 ----
-. Create a host or enter build mode for an existing host to re-download PXE files to the TFTP {SmartProxy}.
+
+.Next steps
+* Create a host or enter build mode for an existing host to re-download PXE files to the TFTP {SmartProxy}.


### PR DESCRIPTION
#### What changes are you introducing?

While reviewing an unreleated PR, I found myself wondering "which proxy" the docs are talking about & I realized that the anchor, title, and file name do not match.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We must use the correct terminology "Smart Proxy" in favor of "proxy" which could leads users to think of  "HTTP proxy", "Smart Proxy", or even something completely unreleated.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The procedure is only used for non-Satellite builds.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
