### PR TITLE
Check URLs on a weekly basis

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,11 +1,10 @@
 ---
-name: linkchecker
+name: "Check URLs"
 
-on:
-  pull_request:
-    branches:
-      - master
-      - "[0-9]+.[0-9]+"
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: "18 4 * * sun"
+
 env:
   RUBY_VERSION: 3.1
   BUNDLE_WITHOUT: "nanoc"


### PR DESCRIPTION
#### What changes are you introducing?

Our docs include links to various external sources, such as "ansible.com" and similar. To provide a good UX, we want to ensure that all external URLs work.

However, due to the active work of contributors, having a GHA that runs for each commit produces a lot of noice on our PRs. Therefore, we want to use a schedule in favor of checks on PRs.

By default, all maintains will get notified for failed checks.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To reduce noice on PRs and therefore improve maintaining Foreman docs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
