### PR TITLE
Add mod doc type attribute to script

### DIFF
--- a/guides/scripts/generate-hammer-reference.sh
+++ b/guides/scripts/generate-hammer-reference.sh
@@ -3,6 +3,7 @@
 SRC=
 ASMB_DIR=common # assembly destination folder
 MOD_DIR=modules
+MOD_TYPE=":_mod-docs-content-type: REFERENCE"
 ASMB_FILENAME=assembly_hammer-reference.adoc
 NOOP= # dry run
 DEBUG=
@@ -121,7 +122,7 @@ cat "$SRC" | while read line ; do
             id='[id="hammer"]'
             heading='= hammer'
             [ -n "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] || \
-                echo -e "$id\n$heading" >$mod_file
+                echo -e "$MOD_TYPE\n\n$id\n$heading" >$mod_file
             { [ -z "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] ; } && \
                 echo -e "include::modules/ref_hammer.adoc[leveloffset=+1]\n" >>$asmb_file
             begin_section=yes
@@ -136,7 +137,7 @@ cat "$SRC" | while read line ; do
             id=[id=\"$id_core\"]
             heading=`echo -e $line | sed 's/^## hammer/=/'`
             [ -n "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] || \
-                echo -e "$id\n$heading" >$mod_file
+                echo -e "$MOD_TYPE\n\n$id\n$heading" >$mod_file
             { [ -z "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] ; } && \
                 echo -e "include::modules/$filename[leveloffset=+1]\n" >>$asmb_file
             begin_section=yes
@@ -154,7 +155,7 @@ cat "$SRC" | while read line ; do
             id=[id=\"$id_core\"]
             heading=`echo -e $line | sed 's/^### hammer/==/'`
             [ -n "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] || \
-                echo -e "$id\n$heading" >>$mod_file
+                echo -e "$MOD_TYPE\n\n$id\n$heading" >>$mod_file
             begin_section=yes
             skip_section=
             options=
@@ -170,7 +171,7 @@ cat "$SRC" | while read line ; do
             id=[id=\"$id_core\"]
             heading=`echo -e $line | sed 's/^#### hammer/===/'`
             [ -n "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] || \
-                echo -e "$id\n$heading" >>$mod_file
+                echo -e "$MOD_TYPE\n\n$id\n$heading" >>$mod_file
             begin_section=yes
             skip_section=
             options=
@@ -186,7 +187,7 @@ cat "$SRC" | while read line ; do
             id=[id=\"$id_core\"]
             heading=`echo -e $line | sed 's/^##### hammer/====/'`
             [ -n "$NOOP" ] || [ -n "$ASSEMBLY_ONLY" ] || \
-                echo -e "$id\n$heading" >>$mod_file
+                echo -e "$MOD_TYPE\n\n$id\n$heading" >>$mod_file
             begin_section=yes
             skip_section=
             options=


### PR DESCRIPTION
#### What changes are you introducing?

Adding the mod docs type attribute to generate-hammer-reference script so that modules are generated with the attribute.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This attribute will be required if we try to set up a CI job to migrate foreman docs continuously to the d/s repo after we migrate to new tooling.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
