### PR TITLE
Rebrand Insights to Lightspeed

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -43,7 +43,7 @@
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#
 
 // Overrides for satellite build
-:advisorengine: Insights advisor in Satellite
+:advisorengine: Lightspeed advisor in Satellite
 :ansible-collection-package: ansible-collection-redhat-satellite
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
 :ansible-galaxy-name: Red{nbsp}Hat Ansible Automation Platform

--- a/guides/common/modules/con_additional-deployment-tasks.adoc
+++ b/guides/common/modules/con_additional-deployment-tasks.adoc
@@ -41,8 +41,8 @@ With load balancing configured on your {SmartProxyServers}, you can improve perf
 For more information, see {ConfiguringLoadBalancerDocURL}[_{ConfiguringLoadBalancerDocTitle}_].
 
 ifdef::satellite,orcharhino[]
-Incident management with Red{nbsp}Hat Insights::
-With Red{nbsp}Hat Insights enabled on your {ProjectServer}, you can identify key risks to stability, security, and performance.
+Incident management with Red{nbsp}Hat Lightspeed::
+With Red{nbsp}Hat Lightspeed enabled on your {ProjectServer}, you can identify key risks to stability, security, and performance.
 +
-For more information, see {InstallingServerDocURL}[Using Red{nbsp}Hat Insights with {ProjectServer}] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}[Using Red{nbsp}Hat Lightspeed with {ProjectServer}] in _{InstallingServerDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -108,7 +108,7 @@ Possible values:
 | Successfully uploaded to your RH cloud inventory | OK | 1
 |===
 
-Insights::
+Lightspeed::
 Indicates if the host is synchronized to {RHCloud}.
 This synchronization is performed by the host.
 The host uploads more information than the {ProjectServer}.

--- a/guides/common/modules/con_installing-and-configuring-advisor-engine.adoc
+++ b/guides/common/modules/con_installing-and-configuring-advisor-engine.adoc
@@ -4,9 +4,9 @@
 The {advisorengine} helps {RHEL} systems perform efficiently, keeping them secure and available.
 
 It analyzes system health and configuration by applying predefined rules to a small set of local data, such as installed packages, running services, and configuration settings. 
-When you deploy the Insights advisor engine locally on {Project}, you can generate Insights recommendations without sending system data to Red{nbsp}Hat services.
+When you deploy the Lightspeed advisor engine locally on {Project}, you can generate Lightspeed recommendations without sending system data to Red{nbsp}Hat services.
 
-You can install and configure the Insights advisor on a disconnected {ProjectServer} by using either the {Project} installation ISO or a container image import and export.
+You can install and configure the Lightspeed advisor on a disconnected {ProjectServer} by using either the {Project} installation ISO or a container image import and export.
 
-:FeatureName: Insights advisor
+:FeatureName: Lightspeed advisor
 include::snip_technology-preview.adoc[]

--- a/guides/common/modules/con_monitoring-hosts-by-using-red-hat-insights.adoc
+++ b/guides/common/modules/con_monitoring-hosts-by-using-red-hat-insights.adoc
@@ -1,28 +1,28 @@
 [id="monitoring-hosts-by-using-red-hat-insights"]
-= Monitoring hosts by using Red{nbsp}Hat Insights
+= Monitoring hosts by using Red{nbsp}Hat Lightspeed
 
-You can use Insights to diagnose systems and downtime related to security exploits, performance degradation, and stability failures.
-You can use the Insights dashboard to quickly identify key risks to stability, security, and performance.
+You can use Lightspeed to diagnose systems and downtime related to security exploits, performance degradation, and stability failures.
+You can use the Lightspeed dashboard to quickly identify key risks to stability, security, and performance.
 You can sort by category, view details of the impact and resolution, and then determine what systems are affected.
 
-To use Insights to monitor hosts that you manage with {Project}, you must first install Insights on your hosts and register your hosts with Insights.
+To use Lightspeed to monitor hosts that you manage with {Project}, you must first install Lightspeed on your hosts and register your hosts with Lightspeed.
 
-For new {Project} hosts, you can install and configure Insights during host registration to {Project}.
+For new {Project} hosts, you can install and configure Lightspeed during host registration to {Project}.
 For more information, see xref:Registering_Hosts_by_Using_Global_Registration_{context}[].
 
-For hosts already registered to {Project}, you can install and configure Insights on your hosts by using an Ansible role.
+For hosts already registered to {Project}, you can install and configure Lightspeed on your hosts by using an Ansible role.
 For more information, see xref:deploying-red-hat-insights-by-using-the-ansible-role[].
 
 ifdef::satellite[]
-If you register your host to a new {ProjectServer}, reregister the host to Insights to avoid creating duplicate entries.
-For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights_with_fedramp/assembly-client-configuring-insights-client#proc-reregistering-system-insights_insights-cg-configuring-client[Re-registering your system with Red Hat Insights].
+If you register your host to a new {ProjectServer}, reregister the host to Lightspeed to avoid creating duplicate entries.
+For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights_with_fedramp/assembly-client-configuring-insights-client#proc-reregistering-system-insights_insights-cg-configuring-client[Re-registering your system with Red Hat Lightspeed].
 endif::[]
 
 .Additional information
 * To view the logs for all plugins, go to `/var/log/foreman/production.log`.
-* If you have problems connecting to Insights, ensure that your certificates are up-to-date.
+* If you have problems connecting to Lightspeed, ensure that your certificates are up-to-date.
 Refresh your subscription manifest to update your certificates.
 * You can change the default schedule for running `insights-client` by configuring `insights-client.timer` on a host.
 ifdef::satellite[]
-For more information, see {RHDocsBaseURL}/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see {RHDocsBaseURL}/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Lightspeed_.
 endif::[]

--- a/guides/common/modules/proc_configuring-automatic-removal-of-hosts-from-the-insights-inventory.adoc
+++ b/guides/common/modules/proc_configuring-automatic-removal-of-hosts-from-the-insights-inventory.adoc
@@ -13,5 +13,5 @@ If any hosts are registered through other {Project} instances or directly to the
 * Your user account must have the permission of `view_foreman_rh_cloud` to view the Inventory Upload page in {ProjectWebUI}.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Insights* > *Inventory Upload*.
+. In the {ProjectWebUI}, navigate to *Lightspeed* > *Inventory Upload*.
 . Enable the *Automatic mismatch deletion* setting.

--- a/guides/common/modules/proc_configuring-automatic-removal-of-hosts-from-the-insights-inventory.adoc
+++ b/guides/common/modules/proc_configuring-automatic-removal-of-hosts-from-the-insights-inventory.adoc
@@ -1,8 +1,8 @@
 [id="configuring_automatic_removal_of_hosts_from_the_insights_inventory_{context}"]
-= Configuring automatic removal of hosts from the Insights Inventory
+= Configuring automatic removal of hosts from the Lightspeed Inventory
 
-When hosts are removed from {Project}, they can also be removed from the inventory of Red{nbsp}Hat Insights, either automatically or manually.
-You can configure automatic removal of hosts from the Insights Inventory during {RHCloud} synchronization with {Project} that occurs daily by default.
+When hosts are removed from {Project}, they can also be removed from the inventory of Red{nbsp}Hat Lightspeed, either automatically or manually.
+You can configure automatic removal of hosts from the Lightspeed Inventory during {RHCloud} synchronization with {Project} that occurs daily by default.
 If you leave the setting disabled, you can still remove the bulk of hosts from the Inventory manually.
 
 If *Automatic mismatch deletion* is enabled, {Project} removes any hosts from the {RHCloud} that are not registered in {Project}. 

--- a/guides/common/modules/proc_configuring-synchronization-of-insights-recommendations-for-hosts.adoc
+++ b/guides/common/modules/proc_configuring-synchronization-of-insights-recommendations-for-hosts.adoc
@@ -7,10 +7,10 @@ If you leave the setting disabled, you can synchronize the recommendations manua
 .Procedures
 * To get the recommendations automatically:
 
-. In the {ProjectWebUI}, navigate to *Insights* > *Recommendations*.
+. In the {ProjectWebUI}, navigate to *Lightspeed* > *Recommendations*.
 . Enable *Sync Automatically*.
 
 * To get the recommendations manually:
 
-. In the {ProjectWebUI}, navigate to *Insights* > *Recommendations*.
+. In the {ProjectWebUI}, navigate to *Lightspeed* > *Recommendations*.
 . On the vertical ellipsis, click *Sync Recommendations*.

--- a/guides/common/modules/proc_configuring-synchronization-of-insights-recommendations-for-hosts.adoc
+++ b/guides/common/modules/proc_configuring-synchronization-of-insights-recommendations-for-hosts.adoc
@@ -1,5 +1,5 @@
 [id="configuring_synchronization_of_insights_recommendations_for_hosts_{context}"]
-= Configuring synchronization of Insights recommendations for hosts
+= Configuring synchronization of Lightspeed recommendations for hosts
 
 You can enable automatic synchronization of the recommendations from {RHCloud} that occurs daily by default.
 If you leave the setting disabled, you can synchronize the recommendations manually.

--- a/guides/common/modules/proc_creating-an-insights-remediation-plan-for-hosts.adoc
+++ b/guides/common/modules/proc_creating-an-insights-remediation-plan-for-hosts.adoc
@@ -4,8 +4,8 @@
 With {Project}, you can create a Red{nbsp}Hat Lightspeed remediation plan and run the plan on {Project} hosts.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Insights* > *Recommendations*.
-. Select the recommendations that you want to include in your Lightspeed plan.
+. In the {ProjectWebUI}, navigate to *Lightspeed* > *Recommendations*.
+. On the Red{nbsp}Hat Lightspeed page, select the number of recommendations that you want to include in an Lightspeed plan.
 +
 You can only select the recommendations that have an associated playbook.
 . Click *Remediate*.
@@ -23,6 +23,6 @@ Alternatively:
 . In the {ProjectWebUI}, navigate to *Hosts* *>* *All Hosts*.
 . Select a host.
 . On the Host details page, click *Recommendations*.
-. Select the recommendations you want to include in your Lightspeed plan and proceed as before.
+. On the Red{nbsp}Hat Lightspeed page, select the number of recommendations you want to include in an Lightspeed plan and proceed as before.
 
 In the Jobs window, you can view the progress of your plan.

--- a/guides/common/modules/proc_creating-an-insights-remediation-plan-for-hosts.adoc
+++ b/guides/common/modules/proc_creating-an-insights-remediation-plan-for-hosts.adoc
@@ -1,11 +1,11 @@
-[id="Creating_an_Insights_Remediation_Plan_for_Hosts_{context}"]
-= Creating an Insights remediation plan for hosts
+[id="Creating_an_Lightspeed_Remediation_Plan_for_Hosts_{context}"]
+= Creating an Lightspeed remediation plan for hosts
 
-With {Project}, you can create a Red{nbsp}Hat Insights remediation plan and run the plan on {Project} hosts.
+With {Project}, you can create a Red{nbsp}Hat Lightspeed remediation plan and run the plan on {Project} hosts.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Insights* > *Recommendations*.
-. On the Red{nbsp}Hat Insights page, select the number of recommendations that you want to include in an Insights plan.
+. Select the recommendations that you want to include in your Lightspeed plan.
 +
 You can only select the recommendations that have an associated playbook.
 . Click *Remediate*.
@@ -23,6 +23,6 @@ Alternatively:
 . In the {ProjectWebUI}, navigate to *Hosts* *>* *All Hosts*.
 . Select a host.
 . On the Host details page, click *Recommendations*.
-. On the Red{nbsp}Hat Insights page, select the number of recommendations you want to include in an Insights plan and proceed as before.
+. Select the recommendations you want to include in your Lightspeed plan and proceed as before.
 
 In the Jobs window, you can view the progress of your plan.

--- a/guides/common/modules/proc_deploying-red-hat-insights-by-using-the-ansible-role.adoc
+++ b/guides/common/modules/proc_deploying-red-hat-insights-by-using-the-ansible-role.adoc
@@ -1,16 +1,16 @@
 [id="deploying-red-hat-insights-by-using-the-ansible-role"]
-= Deploying Red{nbsp}Hat Insights by using the Ansible role
+= Deploying Red{nbsp}Hat Lightspeed by using the Ansible role
 
-The *RedHatInsights.insights-client* Ansible role is used to automate the installation and registration of hosts with Insights.
+The *RedHatLightspeed.insights-client* Ansible role is used to automate the installation and registration of hosts with Lightspeed.
 For more information about adding this role to your {Project}, see {ManagingConfigurationsAnsibleDocURL}Getting_Started_with_Ansible_in_{project-context}_ansible[Getting Started with Ansible in {Project}] in _{ManagingConfigurationsAnsibleDocTitle}_.
 
 .Procedure
-. Add the *RedHatInsights.insights-client* role to the hosts.
+. Add the *RedHatLightspeed.insights-client* role to the hosts.
 +
 For new hosts, see xref:Creating_a_Host_{context}[].
 +
 For existing hosts, see {ManagingConfigurationsAnsibleDocURL}Using_Ansible_Roles_to_Automate_Repetitive_Tasks_on_Clients_ansible[Using Ansible Roles to Automate Repetitive Tasks on Clients] in _{ManagingConfigurationsAnsibleDocTitle}_.
 +
-. To run the *RedHatInsights.insights-client* role on your host, navigate to *Hosts* > *All Hosts* and click the name of the host that you want to use.
+. To run the *RedHatLightspeed.insights-client* role on your host, navigate to *Hosts* > *All Hosts* and click the name of the host that you want to use.
 . On the host details page, expand the *Schedule a job* dropdown menu.
 . Click *Run Ansible roles*.

--- a/guides/common/modules/proc_disabling-registration-to-insights.adoc
+++ b/guides/common/modules/proc_disabling-registration-to-insights.adoc
@@ -1,13 +1,13 @@
 [id='disabling-red-hat-insights-registration_{context}']
-= Disabling Red Hat Insights registration
+= Disabling Red Hat Lightspeed registration
 
-If you decide that you will not use Red Hat Insights, you can unregister {ProjectServer} from Insights.
+If you decide that you will not use Red Hat Lightspeed, you can unregister {ProjectServer} from Lightspeed.
 
 .Prerequisites
-* You have registered {Project} to Red Hat Insights.
+* You have registered {Project} to Red Hat Lightspeed.
 
 .Procedure
-* To unregister {ProjectServer} from Red Hat Insights, enter the following command:
+* To unregister {ProjectServer} from Red Hat Lightspeed, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -6,7 +6,7 @@ After installing {SmartProxyServer} packages, if there is more than one organiza
 ifdef::satellite[]
 [NOTE]
 ====
-Assigning a {SmartProxy} to the same location as your {ProjectServer} with an embedded {SmartProxy} prevents {Team}{nbsp}Insights from uploading the Insights inventory.
+Assigning a {SmartProxy} to the same location as your {ProjectServer} with an embedded {SmartProxy} prevents {Team}{nbsp}Lightspeed from uploading the Lightspeed inventory.
 To enable the inventory upload, synchronize SSH keys for both {SmartProxies}.
 ====
 endif::[]

--- a/guides/common/modules/proc_enabling-rh-cloud-and-insights-client-reports-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-rh-cloud-and-insights-client-reports-on-hosts.adoc
@@ -1,10 +1,10 @@
 [id="enabling-rh-cloud-and-insights-client-reports-on-hosts_{context}"]
-= Enabling RH Cloud and Insights client reports on hosts
+= Enabling RH Cloud and Lightspeed client reports on hosts
 
-You can enable the Red Hat Insights client on hosts and have {Project} upload hosts inventory to the Insights service in the {RHCloud}.
+You can enable the Red Hat Lightspeed client on hosts and have {Project} upload hosts inventory to the Lightspeed service in the {RHCloud}.
 
 ifdef::katello,foreman-el,foreman-deb[]
-Red Hat Insights is a service by Red Hat for {RHEL} hosts.
+Red Hat Lightspeed is a service by Red Hat for {RHEL} hosts.
 Ensure to set this parameter for {RHEL} hosts only.
 If you set the parameter on any non-{RHEL} operating systems, {Project} automatically uploads new reports to the {RHCloud} when enabled in RH Cloud {Project} settings.
 endif::[]

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -13,7 +13,7 @@ ifdef::satellite,orcharhino,katello[]
 include::snip_prerequisite-activation-key-available.adoc[]
 endif::[]
 ifdef::satellite[]
-* Optional: If you want to register your host to Red{nbsp}Hat Insights, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
+* Optional: If you want to register your host to Red{nbsp}Hat Lightspeed, you must synchronize the `{RepoRHEL8BaseOS}` and `{RepoRHEL8AppStream}` repositories and make them available in the activation key that you use.
 This is required to install the `insights-client` package on your host.
 endif::[]
 ifdef::katello,orcharhino,satellite[]
@@ -150,7 +150,7 @@ To verify synchronized {client-content-type} content, you can use {Project} API 
 For example, `\https://{foreman-example-com}/katello/api/v2/repositories/_My_Repository_ID_/gpg_key_content`.
 endif::[]
 endif::[]
-* On the *Advanced* tab, you can configure remote execution, Red{nbsp}Hat Insights, and packages to be installed.
+* On the *Advanced* tab, you can configure remote execution, Red{nbsp}Hat Lightspeed, and packages to be installed.
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated registration command works.
 +

--- a/guides/common/modules/proc_setting-minimal-data-collection.adoc
+++ b/guides/common/modules/proc_setting-minimal-data-collection.adoc
@@ -24,7 +24,7 @@ To remove existing data of a system, navigate to *Inventory* > *Systems* in the 
 * You have selected an organization and location.       
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Insights* > *Inventory Upload*.
+. In the {ProjectWebUI}, navigate to *Lightspeed* > *Inventory Upload*.
 . Select the *Minimal data collection* setting from the dropdown menu under *Settings*.
-When you select this option, {Project} also updates the corresponding setting on the *Insights* tab under *Administer* > *Settings*. 
+When you select this option, {Project} also updates the corresponding setting on the *Lightspeed* tab under *Administer* > *Settings*. 
 . Click the *Generate and upload report* button to create a new inventory report and send it to the {RHCloud}.

--- a/guides/common/modules/proc_setting-minimal-data-collection.adoc
+++ b/guides/common/modules/proc_setting-minimal-data-collection.adoc
@@ -3,7 +3,7 @@
 
 You can configure {Project} to use minimal reporting if you want to limit the data sent to Red{nbsp}Hat.
 You can use minimal reporting to limit the amount of system data sent to the Subscriptions service, which remains active.
-Other Insights services are disabled because they require installed package data, which minimal reports do not include.
+Other Lightspeed services are disabled because they require installed package data, which minimal reports do not include.
 Reports are still processed daily during the midnight synchronization cycle.
 
 Minimal reports also exclude hostnames, IP addresses, and installed packages.
@@ -19,7 +19,7 @@ Review and adjust these settings to control what data {Project} shares.
 
 .Prerequisites
 * Your user account has a role that grants the `edit_settings` permission.
-* Ensure that you delete existing data in Insights Inventory before switching to minimal reporting.
+* Ensure that you delete existing data in Lightspeed Inventory before switching to minimal reporting.
 To remove existing data of a system, navigate to *Inventory* > *Systems* in the {RHCloud}, select the system, and click *Delete*.
 * You have selected an organization and location.       
 

--- a/guides/common/modules/proc_tracking-subscription-usage-by-using-the-subscriptions-service.adoc
+++ b/guides/common/modules/proc_tracking-subscription-usage-by-using-the-subscriptions-service.adoc
@@ -13,7 +13,7 @@ ifndef::satellite[]
 endif::[]
 
 Connected {Project}::
-In the {ProjectWebUI}, navigate to *Insights* > *Inventory Upload* to configure the `foreman_rh_cloud` plugin and share inventory information with the {RHCloud}.
+In the {ProjectWebUI}, navigate to *Lightspeed* > *Inventory Upload* to configure the `foreman_rh_cloud` plugin and share inventory information with the {RHCloud}.
 Ensure that the *Automatic Inventory Upload* setting is enabled.
 The plugin enables the subscriptions service to track usage information across connected systems.
 +

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -7,14 +7,14 @@ You can use the dashboard to quickly identify key risks to stability, security, 
 You can sort by category, view details of the impact and resolution, and then determine what systems are affected.
 
 Note that you do not require a Red{nbsp}Hat Lightspeed entitlement in your subscription manifest.
-For more information about Red{nbsp}Hat Lightspeed, see https://access.redhat.com/products/red-hat-insights/[Red Hat Insights] on the Red{nbsp}Hat Customer Portal.
+For more information about Red{nbsp}Hat Lightspeed, see https://access.redhat.com/products/red-hat-insights/[Red Hat Lightspeed] on the Red{nbsp}Hat Customer Portal.
 
 To maintain your {ProjectServer}, and improve your ability to monitor and diagnose problems you might have with {Project}, install Red{nbsp}Hat Lightspeed on {ProjectServer} and register {ProjectServer} with Red{nbsp}Hat Lightspeed.
 
 .Scheduling insights-client
 
 Note that you can change the default schedule for running `insights-client` by configuring `insights-client.timer` on {Project}.
-For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Lightspeed_.
 
 .Procedure
 

--- a/guides/common/modules/proc_using-insights-with-satellite-server.adoc
+++ b/guides/common/modules/proc_using-insights-with-satellite-server.adoc
@@ -1,15 +1,15 @@
 [id='using-insights-with-server_{context}']
 [id='using-insights-with-satellite-server_{context}']
-= Using Red{nbsp}Hat Insights with {ProjectServer}
+= Using Red{nbsp}Hat Lightspeed with {ProjectServer}
 
-You can use Red{nbsp}Hat Insights to diagnose systems and downtime related to security exploits, performance degradation and stability failures.
+You can use Red{nbsp}Hat Lightspeed to diagnose systems and downtime related to security exploits, performance degradation and stability failures.
 You can use the dashboard to quickly identify key risks to stability, security, and performance.
 You can sort by category, view details of the impact and resolution, and then determine what systems are affected.
 
-Note that you do not require a Red{nbsp}Hat Insights entitlement in your subscription manifest.
-For more information about Red{nbsp}Hat Insights, see https://access.redhat.com/products/red-hat-insights/[Red Hat Insights] on the Red{nbsp}Hat Customer Portal.
+Note that you do not require a Red{nbsp}Hat Lightspeed entitlement in your subscription manifest.
+For more information about Red{nbsp}Hat Lightspeed, see https://access.redhat.com/products/red-hat-insights/[Red Hat Insights] on the Red{nbsp}Hat Customer Portal.
 
-To maintain your {ProjectServer}, and improve your ability to monitor and diagnose problems you might have with {Project}, install Red{nbsp}Hat Insights on {ProjectServer} and register {ProjectServer} with Red{nbsp}Hat Insights.
+To maintain your {ProjectServer}, and improve your ability to monitor and diagnose problems you might have with {Project}, install Red{nbsp}Hat Lightspeed on {ProjectServer} and register {ProjectServer} with Red{nbsp}Hat Lightspeed.
 
 .Scheduling insights-client
 
@@ -18,14 +18,14 @@ For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_c
 
 .Procedure
 
-. To install Red{nbsp}Hat Insights on {ProjectServer}, enter the following command:
+. To install Red{nbsp}Hat Lightspeed on {ProjectServer}, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {project-package-install} insights-client
 ----
 +
-. To register {ProjectServer} with Red{nbsp}Hat Insights, enter the following command:
+. To register {ProjectServer} with Red{nbsp}Hat Lightspeed, enter the following command:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_using-the-project-content-dashboard.adoc
+++ b/guides/common/modules/proc_using-the-project-content-dashboard.adoc
@@ -82,10 +82,10 @@ Click the policy for more details on that policy.
 
 *Compliance Reports Breakdown*:: A pie chart shows the distribution of compliance reports according to their status.
 
-*Red{nbsp}Hat Insights Actions*:: Red{nbsp}Hat Lightspeed is a tool embedded in {Project} that checks the environment and suggests actions you can take.
+*Red{nbsp}Hat Lightspeed Actions*:: Red{nbsp}Hat Lightspeed is a tool embedded in {Project} that checks the environment and suggests actions you can take.
 The actions are divided into 4 categories: Availability, Stability, Performance, and Security.
 
-*Red{nbsp}Hat Insights Risk Summary*:: A table shows the distribution of the actions according to the risk levels.
+*Red{nbsp}Hat Lightspeed Risk Summary*:: A table shows the distribution of the actions according to the risk levels.
 Risk level represents how critical the action is and how likely it is to cause an actual issue.
 The possible risk levels are: Low, Medium, High, and Critical.
 +

--- a/guides/common/modules/proc_using-the-project-content-dashboard.adoc
+++ b/guides/common/modules/proc_using-the-project-content-dashboard.adoc
@@ -82,7 +82,7 @@ Click the policy for more details on that policy.
 
 *Compliance Reports Breakdown*:: A pie chart shows the distribution of compliance reports according to their status.
 
-*Red{nbsp}Hat Insights Actions*:: Red{nbsp}Hat Insights is a tool embedded in {Project} that checks the environment and suggests actions you can take.
+*Red{nbsp}Hat Insights Actions*:: Red{nbsp}Hat Lightspeed is a tool embedded in {Project} that checks the environment and suggests actions you can take.
 The actions are divided into 4 categories: Availability, Stability, Performance, and Security.
 
 *Red{nbsp}Hat Insights Risk Summary*:: A table shows the distribution of the actions according to the risk levels.

--- a/guides/common/modules/ref_access-to-information-from-insights-in-project.adoc
+++ b/guides/common/modules/ref_access-to-information-from-insights-in-project.adoc
@@ -3,9 +3,9 @@
 
 You can access the additional information available for hosts from Red{nbsp}Hat Lightspeed in the following places in the {ProjectWebUI}:
 
-* Navigate to *Insights* > *Recommendations* where the vertical ellipsis next to the *Remediate* button provides a *View in Red{nbsp}Hat Insights* link to the general recommendations page.
-On each recommendation line, the vertical ellipsis provides a *View in Red{nbsp}Hat Insights* link to the recommendation rule, and, if one is available for that recommendation, a *Knowledgebase article* link.
+* Navigate to *Lightspeed* > *Recommendations* where the vertical ellipsis next to the *Remediate* button provides a *View in Red{nbsp}Hat Lightspeed* link to the general recommendations page.
+On each recommendation line, the vertical ellipsis provides a *View in Red{nbsp}Hat Lightspeed* link to the recommendation rule, and, if one is available for that recommendation, a *Knowledgebase article* link.
 
 * For additional information, navigate to *Hosts* > *All Hosts*.
 If the host has recommendations listed, click on the number of recommendations.
-On the *Insights* tab, the vertical ellipsis next to the *Remediate* button provides a *Go To {Project} Insights page* link to information for the system, and a *View in Red{nbsp}Hat Insights* link to host details on the console.
+On the *Lightspeed* tab, the vertical ellipsis next to the *Remediate* button provides a *Go To {Project} Lightspeed page* link to information for the system, and a *View in Red{nbsp}Hat Lightspeed* link to host details on the console.

--- a/guides/common/modules/ref_access-to-information-from-insights-in-project.adoc
+++ b/guides/common/modules/ref_access-to-information-from-insights-in-project.adoc
@@ -1,7 +1,7 @@
 [id="access_to_information_from_insights_in_{Project}_{context}"]
-= Access to information from Insights in {Project}
+= Access to information from Lightspeed in {Project}
 
-You can access the additional information available for hosts from Red{nbsp}Hat Insights in the following places in the {ProjectWebUI}:
+You can access the additional information available for hosts from Red{nbsp}Hat Lightspeed in the following places in the {ProjectWebUI}:
 
 * Navigate to *Insights* > *Recommendations* where the vertical ellipsis next to the *Remediate* button provides a *View in Red{nbsp}Hat Insights* link to the general recommendations page.
 On each recommendation line, the vertical ellipsis provides a *View in Red{nbsp}Hat Insights* link to the recommendation rule, and, if one is available for that recommendation, a *Knowledgebase article* link.

--- a/guides/common/modules/ref_global-parameters-for-registration.adoc
+++ b/guides/common/modules/ref_global-parameters-for-registration.adoc
@@ -4,8 +4,8 @@
 You can configure the following global parameters by navigating to *Configure* > *Global Parameters*:
 
 * The `host_registration_insights` parameter is used in the `insights` snippet.
-If the parameter is set to `true`, the registration installs and enables the Red{nbsp}Hat Insights client on the host.
-If the parameter is set to `false`, {Project} prevents the installation and registration of the Red{nbsp}Hat Insights client.
+If the parameter is set to `true`, the registration installs and enables the Red{nbsp}Hat Lightspeed client on the host.
+If the parameter is set to `false`, {Project} prevents the installation and registration of the Red{nbsp}Hat Lightspeed client.
 ifdef::satellite[]
 The default value is `true`.
 endif::[]
@@ -14,9 +14,9 @@ The default value is `false`.
 endif::[]
 When overriding the parameter value, set the parameter type to `boolean`.
 * The `host_registration_insights_inventory` parameter controls Inventory uploads.
-If the parameter is set to `true`, the host is included in the Insights Inventory report uploaded to the {RHCloud}. 
-If the parameter is set to `false`, the host is excluded from the Insights Inventory report upload.
-To upload inventory data without registering the host with the Insights client, set the `host_registration_insights` parameter to `false` and set the `host_registration_insights_inventory` to `true`.
+If the parameter is set to `true`, the host is included in the Lightspeed Inventory report uploaded to the {RHCloud}. 
+If the parameter is set to `false`, the host is excluded from the Lightspeed Inventory report upload.
+To upload inventory data without registering the host with the Lightspeed client, set the `host_registration_insights` parameter to `false` and set the `host_registration_insights_inventory` to `true`.
 * The `host_packages` parameter is for installing packages on the host.
 * The `host_registration_remote_execution` parameter is used in the `remote_execution_ssh_keys` snippet.
 If it is set to `true`, the registration enables remote execution on the host.

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -102,7 +102,7 @@ ifdef::satellite[]
 ifeval::["{mode}" == "connected"]
 | 443 | TCP | HTTPS | console.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
 | 443 | TCP | HTTPS | cdn.redhat.com | Content Sync | https://access.redhat.com/articles/1525183[Red{nbsp}Hat CDN]
-| 443 | TCP | HTTPS | cert.console.redhat.com | Red{nbsp}Hat Insights | When using Insights, required for Inventory upload and Cloud Connector connection
+| 443 | TCP | HTTPS | cert.console.redhat.com | Red{nbsp}Hat Lightspeed | When using Lightspeed, required for Inventory upload and Cloud Connector connection
 | 443 | TCP | HTTPS | api.access.redhat.com | SOS report | Assisting support cases filed through the https://access.redhat.com/solutions/1179133[Red{nbsp}Hat Customer Portal] (optional)
 | 443 | TCP | HTTPS | cert-api.access.redhat.com | Telemetry data upload and report |
 | 443 | TCP | HTTPS | connect.cloud.redhat.com:443 | RHCD communication with the MQTT message broker |

--- a/guides/common/modules/ref_redhat-cloud-settings.adoc
+++ b/guides/common/modules/ref_redhat-cloud-settings.adoc
@@ -5,7 +5,7 @@
 |====
 | Setting | Default Value | Description
 | *Automatic inventory upload* | Yes | Enable automatic upload of your host inventory to the Red{nbsp}Hat cloud.
-| *Synchronize recommendations Automatically* | No | Enable automatic synchronization of Insights recommendations from the Red{nbsp}Hat cloud.
+| *Synchronize recommendations Automatically* | No | Enable automatic synchronization of Lightspeed recommendations from the Red{nbsp}Hat cloud.
 | *Obfuscate host names* | No | Obfuscate hostnames sent to the Red{nbsp}Hat cloud.
 | *Obfuscate host ipv4 addresses* | No | Obfuscate IPv4 addresses sent to the Red{nbsp}Hat cloud.
 | *ID of the RHC daemon* | \\***** | RHC daemon id.

--- a/guides/common/modules/ref_registration-methods.adoc
+++ b/guides/common/modules/ref_registration-methods.adoc
@@ -10,7 +10,7 @@ For more information, see xref:Registering_Hosts_by_Using_Global_Registration_{c
 By using this method, you can also deploy {Project} SSH keys to hosts during registration to {Project} to enable hosts for remote execution jobs.
 For more information, see xref:Configuring_and_Setting_Up_Remote_Jobs_{context}[].
 +
-By using this method, you can also configure hosts with Red{nbsp}Hat Insights during registration to {Project}.
+By using this method, you can also configure hosts with Red{nbsp}Hat Lightspeed during registration to {Project}.
 For more information, see xref:monitoring-hosts-by-using-red-hat-insights[].
 
 ifndef::satellite,orcharhino[]

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -31,7 +31,7 @@ endif::[]
 |Actions Remote Execution Run Host Job Ansible Run {SmartProxy} Upgrade Succeeded |Upgrade {SmartProxies} on given {SmartProxyServers}.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Configure Cloud Connector Succeeded |Configure Cloud Connector on given hosts.|Actions::RemoteExecution::RunHostJob
 ifdef::satellite[]
-|Actions Remote Execution Run Host Job Ansible Run Insights Plan Succeeded |Runs a given maintenance plan from Red Hat Access Lightspeed given an ID.|Actions::RemoteExecution::RunHostJob
+|Actions Remote Execution Run Host Job Ansible Run Lightspeed Plan Succeeded |Runs a given maintenance plan from Red Hat Access Lightspeed given an ID.|Actions::RemoteExecution::RunHostJob
 endif::[]
 |Actions Remote Execution Run Host Job Ansible Run Playbook Succeeded |Run an Ansible Playbook against given hosts.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Enable Web Console Succeeded |Run an Ansible Playbook to enable the web console on given hosts.|Actions::RemoteExecution::RunHostJob

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -31,7 +31,7 @@ endif::[]
 |Actions Remote Execution Run Host Job Ansible Run {SmartProxy} Upgrade Succeeded |Upgrade {SmartProxies} on given {SmartProxyServers}.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Configure Cloud Connector Succeeded |Configure Cloud Connector on given hosts.|Actions::RemoteExecution::RunHostJob
 ifdef::satellite[]
-|Actions Remote Execution Run Host Job Ansible Run Insights Plan Succeeded |Runs a given maintenance plan from Red Hat Access Insights given an ID.|Actions::RemoteExecution::RunHostJob
+|Actions Remote Execution Run Host Job Ansible Run Insights Plan Succeeded |Runs a given maintenance plan from Red Hat Access Lightspeed given an ID.|Actions::RemoteExecution::RunHostJob
 endif::[]
 |Actions Remote Execution Run Host Job Ansible Run Playbook Succeeded |Run an Ansible Playbook against given hosts.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Enable Web Console Succeeded |Run an Ansible Playbook to enable the web console on given hosts.|Actions::RemoteExecution::RunHostJob

--- a/guides/common/modules/snip_host-names-for-http-proxy.adoc
+++ b/guides/common/modules/snip_host-names-for-http-proxy.adoc
@@ -6,11 +6,11 @@
 | subscription.rhsm.redhat.com | 443 | HTTPS
 | cdn.redhat.com | 443 | HTTPS
 ifdef::satellite[]
-| cert.console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-| api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-| cert-api.access.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-| console.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
-| connect.cloud.redhat.com (if using Red{nbsp}Hat Insights) | 443 | HTTPS
+| cert.console.redhat.com (if using Red{nbsp}Hat Lightspeed) | 443 | HTTPS
+| api.access.redhat.com (if using Red{nbsp}Hat Lightspeed) | 443 | HTTPS
+| cert-api.access.redhat.com (if using Red{nbsp}Hat Lightspeed) | 443 | HTTPS
+| console.redhat.com (if using Red{nbsp}Hat Lightspeed) | 443 | HTTPS
+| connect.cloud.redhat.com (if using Red{nbsp}Hat Lightspeed) | 443 | HTTPS
 endif::[]
 |====
 


### PR DESCRIPTION
#### What changes are you introducing?

Rebranding Insights to Lightspeed

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The product name is changing

[SAT-35246](https://issues.redhat.com/browse/SAT-35246) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: ???

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
