### PR TITLE
Bump orcharhino version to 7.3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Please cherry-pick my commits into:
 * [ ] Foreman 3.15/Katello 4.17
 * [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
 * [ ] Foreman 3.13/Katello 4.15 (EL9 only)
-* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
+* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
 * [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
 * [ ] Foreman 3.10/Katello 4.12
 * [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,8 +1,8 @@
 // Overrides for orcharhino build
 :BaseURL: https://docs.orcharhino.com/
-:ProjectVersion: 7.2
-:ProjectVersionPrevious: 7.1
-:ProjectVersionPrevious-Previous: 7.0
+:ProjectVersion: 7.3
+:ProjectVersionPrevious: 7.2
+:ProjectVersionPrevious-Previous: 7.1
 :Project: orcharhino
 :project-allcaps: ORCHARHINO
 :project-context: {Project}


### PR DESCRIPTION
#### What changes are you introducing?

orcharhino 7.3 is based on Foreman 3.12 and runs on EL9 only.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Refs https://orcharhino.com/en/ressourcen/release-notes/orcharhino-7-3/

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
