### PR TITLE
Hide functionality only provided by Katello

### DIFF
--- a/guides/common/modules/con_preparing-client-platforms.adoc
+++ b/guides/common/modules/con_preparing-client-platforms.adoc
@@ -4,7 +4,9 @@
 You have to configure the platforms that you will provision.
 That entails creating a hardware model, CPU architecture, and operating system.
 
+ifdef::katello,orcharhino,satellite[]
 [NOTE]
 ====
 The records for Red{nbsp}Hat supported platforms are created automatically when you enable a Red{nbsp}Hat repository.
 ====
+endif::[]

--- a/guides/common/modules/proc_creating-an-installation-medium-for-debian.adoc
+++ b/guides/common/modules/proc_creating-an-installation-medium-for-debian.adoc
@@ -14,6 +14,8 @@ endif::[]
 . Set the *Path* to the upstream URL `{client-debian-installation-medium-path}`.
 +
 Alternatively, you can also use a {DL} Mirror.
+ifdef::katello,orcharhino,satellite[]
 Note that synchronized content from {Project} does not work for two reasons: first, the `linux` and `initrd.gz` files are not synchronized; second, the `Release` file is not signed with the official {DL} GPG private key.
+endif::[]
 . Set the *Operating System Family* to `Debian`.
 . Click *Submit* to save the installation medium to {Project}.

--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -4,19 +4,14 @@
 An operating system is a collection of resources that define how {ProjectServer} installs a base operating system on a host.
 Operating system entries combine previously defined resources, such as installation media, partition tables, provisioning templates, and others.
 
-ifndef::foreman-deb,orcharhino[]
+ifdef::katello,satellite[]
 Importing operating systems from Red Hat's CDN creates new entries on the *Hosts* > *Provisioning Setup* > *Operating Systems* page.
-endif::[]
-ifdef::foreman-el[]
-Importing operating systems from Red Hat's CDN is only possible when Katello is installed.
-endif::[]
-ifndef::foreman-deb,orcharhino[]
 To import operating systems from Red Hat's CDN, enable the Red Hat repositories of the operating systems and synchronize the repositories to {Project}.
 For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}[Synchronizing Repositories] in _{ContentManagementDocTitle}_.
 
 You can also add custom operating systems using the following procedure.
 endif::[]
-ifdef::foreman-deb,orcharhino[]
+ifndef::katello,satellite[]
 You can add operating systems using the following procedure.
 endif::[]
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-operating-systems_{context}[].


### PR DESCRIPTION
#### What changes are you introducing?

These are some things that jumped out to me when reviewing https://github.com/theforeman/foreman-documentation/pull/3922.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Some functionality is provided by Katello and in guides that don't use it we should hide it.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.