### PR TITLE
Document new usage metrics timer

### DIFF
--- a/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
+++ b/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
@@ -15,8 +15,3 @@ This timer collects the same set of metrics as `satellite-usage-metrics-generate
 The timer runs weekly.
 
 When you use the `sos report` command to generate a report for Red{nbsp}Hat Technical Support, the report will include the `satellite_metrics.yml` and `/etc/rhsm/facts/foreman.yml` files, along with the other configuration, diagnostics, and troubleshooting data that `sos` collects.
-
-[NOTE]
-====
-The collected metrics are stored securely in the described files and are only shared in sos reports.
-====

--- a/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
+++ b/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
@@ -14,4 +14,4 @@ The timer runs weekly.
 This timer collects the same set of metrics as `satellite-usage-metrics-generate.timer`, condenses them so that they can be uploaded as custom Red{nbsp}Hat Subscription Manager facts, and stores them in the `/etc/rhsm/facts/foreman.facts` file.
 The timer runs weekly.
 
-When you use the `sos report` command to generate a report for Red{nbsp}Hat Technical Support, the report will include the `satellite_metrics.yml` and `/etc/rhsm/facts/foreman.yml` files, along with the other configuration, diagnostics, and troubleshooting data that `sos` collects.
+When you use the `sos report` command to generate a report for Red{nbsp}Hat Technical Support, the report will include the `satellite_metrics.yml` and `/etc/rhsm/facts/foreman.facts` files, along with the other configuration, diagnostics, and troubleshooting data that `sos` collects.

--- a/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
+++ b/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
@@ -3,12 +3,20 @@
 
 {Project} includes the `satellite-maintain report generate` command, which can collect information from user environments to better understand how {Project} is used.
 
-A `systemd` timer named `satellite-usage-metrics-generate.timer` runs weekly to collect the data.
-The timer executes the `{foreman-maintain} report generate` command on your {ProjectServer} and then stores the collected data in the `/var/lib/foreman-maintain/satellite_metrics.yml` file.
+The following `systemd` timers collect the data:
 
-When you use the `sos report` command to generate a report for Red{nbsp}Hat Technical Support, the `satellite_metrics.yml` file is included in the report along with the other configuration, diagnostics, and troubleshooting data that `sos` collects.
+`satellite-usage-metrics-generate.timer`::
+This timer collects the full list of usage metrics.
+It executes the `{foreman-maintain} report generate` command on your {ProjectServer} and then stores the collected data in the `/var/lib/foreman-maintain/satellite_metrics.yml` file.
+The timer runs weekly.
+
+`satellite-usage-metrics-condense.timer`::
+This timer collects the same set of metrics as `satellite-usage-metrics-generate.timer`, condenses them so that they can be uploaded as custom Red{nbsp}Hat Subscription Manager facts, and stores them in the `/etc/rhsm/facts/foreman.yml` file.
+The timer runs weekly.
+
+When you use the `sos report` command to generate a report for Red{nbsp}Hat Technical Support, the report will include the `satellite_metrics.yml` and `/etc/rhsm/facts/foreman.yml` files, along with the other configuration, diagnostics, and troubleshooting data that `sos` collects.
 
 [NOTE]
 ====
-The collected metrics are stored securely in `/var/lib/foreman-maintain/satellite_metrics.yml` and are only shared in sos reports.
+The collected metrics are stored securely in the described files and are only shared in sos reports.
 ====

--- a/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
+++ b/guides/common/modules/con_overview-of-usage-metrics-collection-in-project.adoc
@@ -11,7 +11,7 @@ It executes the `{foreman-maintain} report generate` command on your {ProjectSer
 The timer runs weekly.
 
 `satellite-usage-metrics-condense.timer`::
-This timer collects the same set of metrics as `satellite-usage-metrics-generate.timer`, condenses them so that they can be uploaded as custom Red{nbsp}Hat Subscription Manager facts, and stores them in the `/etc/rhsm/facts/foreman.yml` file.
+This timer collects the same set of metrics as `satellite-usage-metrics-generate.timer`, condenses them so that they can be uploaded as custom Red{nbsp}Hat Subscription Manager facts, and stores them in the `/etc/rhsm/facts/foreman.facts` file.
 The timer runs weekly.
 
 When you use the `sos report` command to generate a report for Red{nbsp}Hat Technical Support, the report will include the `satellite_metrics.yml` and `/etc/rhsm/facts/foreman.yml` files, along with the other configuration, diagnostics, and troubleshooting data that `sos` collects.

--- a/guides/common/modules/proc_disabling-the-collection-of-usage-metrics.adoc
+++ b/guides/common/modules/proc_disabling-the-collection-of-usage-metrics.adoc
@@ -1,7 +1,7 @@
 [id="disabling-the-collection-of-usage-metrics"]
 = Disabling the collection of usage metrics
 
-You can opt out of the default usage metrics collection by masking the `systemd` timer that collects the data on your {ProjectServer}.
+You can opt out of the default usage metrics collection by masking the `systemd` timers that collect the data on your {ProjectServer}.
 
 .Procedure
 . To disable the collection of the full usage metrics:
@@ -28,7 +28,7 @@ You can opt out of the default usage metrics collection by masking the `systemd`
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# rm /etc/rhsm/facts/foreman.yml
+# rm /etc/rhsm/facts/foreman.facts
 ----
 
 .Verification

--- a/guides/common/modules/proc_disabling-the-collection-of-usage-metrics.adoc
+++ b/guides/common/modules/proc_disabling-the-collection-of-usage-metrics.adoc
@@ -1,24 +1,39 @@
 [id="disabling-the-collection-of-usage-metrics"]
 = Disabling the collection of usage metrics
 
-You can opt out of the default usage metrics collection by masking the `systemd` timer that collects the data.
+You can opt out of the default usage metrics collection by masking the `systemd` timer that collects the data on your {ProjectServer}.
 
 .Procedure
-. On your {ProjectServer}, mask the `satellite-usage-metrics-generate.timer` unit:
+. To disable the collection of the full usage metrics:
+.. Mask the `satellite-usage-metrics-generate.timer` unit:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # systemctl mask satellite-usage-metrics-generate.timer
 ----
-. If the timer has been executed already at least once, remove the generated usage metrics file:
+.. If the timer has been executed already at least once, remove the generated usage metrics file:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # rm /var/lib/foreman-maintain/satellite_metrics.yml
 ----
+. To disable the collection of the condensed usage metrics:
+.. Mask the `satellite-usage-metrics-condensed.timer` unit:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# systemctl mask satellite-usage-metrics-generate.timer
+----
+.. If the timer has been executed already at least once, remove the generated usage metrics file:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# rm /etc/rhsm/facts/foreman.yml
+----
 
 .Verification
-. On your {ProjectServer}, verify the status of the `satellite-usage-metrics-generate.timer` unit:
+. On your {ProjectServer}, verify the status of the timer you want to disable.
+For example, to verify the status of the `satellite-usage-metrics-generate.timer` unit:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_disabling-the-collection-of-usage-metrics.adoc
+++ b/guides/common/modules/proc_disabling-the-collection-of-usage-metrics.adoc
@@ -22,7 +22,7 @@ You can opt out of the default usage metrics collection by masking the `systemd`
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# systemctl mask satellite-usage-metrics-generate.timer
+# systemctl mask satellite-usage-metrics-condensed.timer
 ----
 .. If the timer has been executed already at least once, remove the generated usage metrics file:
 +

--- a/guides/common/modules/proc_reviewing-usage-metrics-collected-from-your-project.adoc
+++ b/guides/common/modules/proc_reviewing-usage-metrics-collected-from-your-project.adoc
@@ -1,7 +1,7 @@
 [id="reviewing-usage-metrics-collected-from-your-{project-context}"]
 = Reviewing usage metrics collected from your {Project}
 
-You can review the usage metrics that {Project} collects from your deployment by using the `satellite-maintain report` command on your {ProjectServer}.
+You can review the usage metrics that {Project} collects from your deployment by using the `{foreman-maintain} report` command on your {ProjectServer}.
 
 .Procedure
 . Display the list of full usage metrics:

--- a/guides/common/modules/proc_reviewing-usage-metrics-collected-from-your-project.adoc
+++ b/guides/common/modules/proc_reviewing-usage-metrics-collected-from-your-project.adoc
@@ -1,14 +1,20 @@
 [id="reviewing-usage-metrics-collected-from-your-{project-context}"]
 = Reviewing usage metrics collected from your {Project}
 
-You can review the usage metrics that {Project} collects from your deployment by running the `satellite-maintain report generate` command.
+You can review the usage metrics that {Project} collects from your deployment by using the `satellite-maintain report` command on your {ProjectServer}.
 
 .Procedure
-* On your {ProjectServer}, display the list of collected usage metrics:
+. Display the list of full usage metrics:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {foreman-maintain} report generate
+----
+. Display the list of condensed usage metrics:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {foreman-maintain} report condense
 ----
 
 .Example output of `{foreman-maintain} report generate`


### PR DESCRIPTION
#### What changes are you introducing?

Adding information about a new timer that collects usage metrics from Satellite.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman_maintain/pull/996

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
