### PR TITLE
Remove git conflict markers

### DIFF
--- a/guides/common/modules/proc_creating-a-playbook-with-modules-from-project-ansible-collection.adoc
+++ b/guides/common/modules/proc_creating-a-playbook-with-modules-from-project-ansible-collection.adoc
@@ -53,22 +53,13 @@ _My_Username_: _My_Admin_User_Account_
 _My_Password_: _My_PAT_
 _My_Server_URL_: _https://{foreman-example-com}_
 ----
-<<<<<<< HEAD
-=======
 +
-If you want to authenticate with a Kerberos ticket:
-+
-[source,ini,subs="+quotes,attributes"]
-----
-_My_Server_URL_: _https://{foreman-example-com}_
-----
 .. If you use an HTTP proxy to reach the {Project} API, store it in the vault too:
 +
 [source,ini,subs="+quotes,attributes"]
 ----
 _My_HTTP_Proxy_: "_http://proxy.example.com:8080_"
 ----
->>>>>>> 9b0f02c490 (Document how to use an http proxy with the ansible collection (#3881))
 .. Save your changes and close the editor.
 Ansible encrypts the data in the vault.
 . Create a playbook file that references the vault file:
@@ -95,23 +86,7 @@ If you are authenticating with {Project} username and password or PAT, map the `
       server_url: "{{ _My_Server_URL_ }}"
   tasks:
 ----
-<<<<<<< HEAD
-=======
 +
-If you are authenticating with a Kerberos ticket, map the `server_url` parameter to the contents of _My_Vault.yml_ and add `use_gssapi: true` to enable Kerberos authentication:
-+
-[source,yaml,subs="+quotes,attributes"]
-----
-- name: _My Playbook_
-  hosts: _localhost_
-  vars_files:
-    - _My_Vault.yml_
-  module_defaults:
-    group/{ansible-module-defaults-group}:
-      server_url: "{{ _My_Server_URL_ }}"
-      use_gssapi: true
-  tasks:
-----
 .. If you need to use an HTTP proxy to reach the {Project} API, set the `https_proxy` environment variable:
 +
 [source,yaml,subs="+quotes,attributes"]
@@ -129,7 +104,6 @@ If you are authenticating with a Kerberos ticket, map the `server_url` parameter
       server_url: "{{ _My_Server_URL_ }}"
   tasks:
 ----
->>>>>>> 9b0f02c490 (Document how to use an http proxy with the ansible collection (#3881))
 .. In the `tasks:` section, define the tasks that you want your playbook to perform.
 . Validate the playbook syntax:
 +


### PR DESCRIPTION
#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

b7572a7a13d7 was a bad cherry pick and created this.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I don't see the markers in 3.15 nor 3.13 so it specifically affects 3.14.

#### Checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* [ ] Foreman 3.8/Katello 4.10
* [ ] Foreman 3.7/Katello 4.9 (Satellite 6.14)
* We do not accept PRs for Foreman older than 3.7.