### PR TITLE
Create RHEL operating system entries on orcharhino

### DIFF
--- a/guides/common/modules/proc_creating-operating-systems.adoc
+++ b/guides/common/modules/proc_creating-operating-systems.adoc
@@ -6,7 +6,7 @@
 An operating system is a collection of resources that define how {ProjectServer} installs a base operating system on a host.
 Operating system entries combine previously defined resources, such as installation media, partition tables, provisioning templates, and others.
 
-ifdef::katello,satellite[]
+ifdef::katello,orcharhino,satellite[]
 Importing operating systems from Red Hat's CDN creates new entries on the *Hosts* > *Provisioning Setup* > *Operating Systems* page.
 To import operating systems from Red Hat's CDN, enable the Red Hat repositories of the operating systems and synchronize the repositories to {Project}.
 For more information, see {ContentManagementDocURL}Enabling_Red_Hat_Repositories_content-management[Enabling Red Hat Repositories] and {ContentManagementDocURL}[Synchronizing Repositories] in _{ContentManagementDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

orcharhino automatically creates an OS entry if you import RHEL content via RH manifests.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Similar to Foreman+Katello and Satellite, if you import Kickstart repositories via RH manifest, orcharhino will setup OS entries for Red Hat Enterprise Linux.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR 3972 on GitHub

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
