### PR TITLE
Add a prerequisite to update any SHA1 certificates

### DIFF
--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -18,7 +18,7 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 ifdef::satellite[]
 * Migrate all organizations to Simple Content Access (SCA).
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/articles/simple-content-access[Simple Content Access]. 
-* Update certificates that use `sha1` checksum to newer hashing algorithms.
+* Update certificates that use `sha1` checksum to a newer hashing algorithm.
 
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -18,6 +18,7 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 ifdef::satellite[]
 * Migrate all organizations to Simple Content Access (SCA).
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/articles/simple-content-access[Simple Content Access]. 
+* Update certifictes that use `sha1` checksum to newer hashing algorithms.
 
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]

--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -18,7 +18,7 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 ifdef::satellite[]
 * Migrate all organizations to Simple Content Access (SCA).
 For more information, see the Red Hat Knowledgebase solution https://access.redhat.com/articles/simple-content-access[Simple Content Access]. 
-* Update certifictes that use `sha1` checksum to newer hashing algorithms.
+* Update certificates that use `sha1` checksum to newer hashing algorithms.
 
 Ensure that all {ProjectServer}s are on the same version.
 endif::[]


### PR DESCRIPTION
Since SHA1 is not supported, any certificates that use these need to be updated otherwise the upgrade fails.

JIRA: https://issues.redhat.com/browse/SAT-30262

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
