### PR TITLE
Replace ID-based xrefs with path-based xrefs - Planning

### DIFF
--- a/guides/common/modules/con_content-flow-in-project.adoc
+++ b/guides/common/modules/con_content-flow-in-project.adoc
@@ -38,7 +38,7 @@ image::common/system-architecture-satellite.png[Content flow in {ProjectName}]
 endif::[]
 
 .Additional resources
-* See xref:Major-{Project}-Components_{context}[] for details.
+* See xref:con_major-project-components.adoc#Major-{Project}-Components_{context}[] for details.
 ifdef::satellite[]
 * See {ContentManagementDocURL}Managing_Red_Hat_Subscriptions_content-management[Managing Red Hat subscriptions] in _{ContentManagementDocTitle}_ for information about Content Delivery Network (CDN).
 endif::[]

--- a/guides/common/modules/con_defining-content-access-strategies-for-hosts.adoc
+++ b/guides/common/modules/con_defining-content-access-strategies-for-hosts.adoc
@@ -19,4 +19,4 @@ In smaller deployments or when you do not require content versioning and environ
 
 .Additional resources
 * For more information, see {ContentManagementDocURL}Managing_Application_Lifecycles_content-management[Managing application lifecycles], {ContentManagementDocURL}Managing_Content_Views_content-management[Managing content views], and {ContentManagementDocURL}Restricting_Hosts_Access_to_Content_content-management[Restricting hosts' access to content] in _{ContentManagementDocTitle}_.
-* For examples of content view deployments, see xref:common-deployment-scenarios[].
+* For examples of content view deployments, see xref:con_common-deployment-scenarios.adoc#common-deployment-scenarios[].

--- a/guides/common/modules/con_http-booting-requirements-with-managed-dhcp.adoc
+++ b/guides/common/modules/con_http-booting-requirements-with-managed-dhcp.adoc
@@ -9,7 +9,7 @@ To provision machines through HTTP booting ensure that you meet the following re
 For HTTP booting to work, ensure that your environment has the following client-side configurations:
 
 * All the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{smart-proxy-context}-networking_{context}[].
+For more information, see xref:con_smartproxy-networking.adoc#{smart-proxy-context}-networking_{context}[].
 * Your client has access to the DHCP and DNS servers.
 * Your client has access to the HTTP UEFI Boot {SmartProxy}.
 

--- a/guides/common/modules/con_http-booting-requirements-with-unmanaged-dhcp.adoc
+++ b/guides/common/modules/con_http-booting-requirements-with-unmanaged-dhcp.adoc
@@ -12,7 +12,7 @@ To provision machines through HTTP booting without managed DHCP ensure that you 
 * Ensure that your client has access to the DHCP and DNS servers.
 * Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{smart-proxy-context}-networking_{context}[].
+For more information, see xref:con_smartproxy-networking.adoc#{smart-proxy-context}-networking_{context}[].
 
 .Network requirements
 * An unmanaged DHCP server available for clients.

--- a/guides/common/modules/con_planning-organization-and-location-context.adoc
+++ b/guides/common/modules/con_planning-organization-and-location-context.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 ifeval::["{context}" == "planning"]
 .Additional resources
-* For examples of deployment scenarios, see xref:common-deployment-scenarios[].
+* For examples of deployment scenarios, see xref:con_common-deployment-scenarios.adoc#common-deployment-scenarios[].
 ifdef::katello[]
 * For information about managing organizations and locations, see {ManagingOrganizationsLocationsDocURL}[_{ManagingOrganizationsLocationsDocTitle}_].
 endif::[]

--- a/guides/common/modules/con_pxe-booting-requirements.adoc
+++ b/guides/common/modules/con_pxe-booting-requirements.adoc
@@ -10,7 +10,7 @@ To provision machines using PXE booting, ensure that you meet the following requ
 
 .Client requirements
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{smart-proxy-context}-networking_{context}[].
+For more information, see xref:con_smartproxy-networking.adoc#{smart-proxy-context}-networking_{context}[].
 
 * Ensure that your client has access to the DHCP and TFTP servers.
 

--- a/guides/common/modules/con_smartproxy-overview.adoc
+++ b/guides/common/modules/con_smartproxy-overview.adoc
@@ -12,5 +12,5 @@ ifdef::katello,orcharhino,satellite[]
 By registering a host to a {SmartProxyServer}, you can configure this host to receive content and configuration from the {SmartProxy} in their location instead of from the central {ProjectServer}.
 
 By using content views, you can specify the exact subset of content that {SmartProxyServer} makes available to hosts.
-For more information, see xref:content-and-patch-management-with-{project-context}[].
+For more information, see xref:con_content-and-patch-management-with-project.adoc#content-and-patch-management-with-{project-context}[].
 endif::[]

--- a/guides/common/modules/ref_additional-resources-project-infrastructure-organization-concepts.adoc
+++ b/guides/common/modules/ref_additional-resources-project-infrastructure-organization-concepts.adoc
@@ -3,4 +3,4 @@
 [id="additional-resources-project-infrastructure-organization-concepts_{context}"]
 = Additional resources
 
-* For examples of {Project} deployment, see xref:{project-context}-deployment-planning[].
+* For examples of {Project} deployment, see xref:con_foreman-deployment-planning.adoc#{project-context}-deployment-planning[].


### PR DESCRIPTION
#### What changes are you introducing?

Replacing ID-based xrefs with path-based xrefs in the Planning guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Preparation for [DITA migration](https://community.theforeman.org/t/red-hat-documentation-team-plans-to-migrate-to-a-different-markup-and-toolchain/43737)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
