### PR TITLE
Hide KubeVirt for orcharhino

### DIFF
--- a/guides/common/modules/con_virtual-machine-subscriptions-overview.adoc
+++ b/guides/common/modules/con_virtual-machine-subscriptions-overview.adoc
@@ -19,8 +19,8 @@ endif::[]
 * Microsoft Hyper-V
 ifndef::orcharhino[]
 * {OpenStack}
-endif::[]
 * {KubeVirt}
+endif::[]
 
 ifdef::satellite[]
 :FeatureName: The {KubeVirt} hypervisor

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -37,7 +37,9 @@ ifndef::satellite[]
 include::common/assembly_provisioning-virtual-machines-proxmox.adoc[leveloffset=+1]
 endif::[]
 
+ifndef::orcharhino[]
 include::common/assembly_provisioning-virtual-machines-kubevirt.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_provisioning-cloud-instances-openstack.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

Hide compute resource KubeVirt for orcharhino builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

orcharhino 7.3 does not support foreman_kubevirt:
https://docs.orcharhino.com/or/7.3/sources/compute_resources.html

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
