### PR TITLE
Add KernelCare Clients for Debian/Ubuntu

### DIFF
--- a/guides/common/assembly_using-kernelcare.adoc
+++ b/guides/common/assembly_using-kernelcare.adoc
@@ -20,6 +20,48 @@ include::modules/proc_adding-kernelcare-client-for-el.adoc[leveloffset=+2]
 :!parent-client-os-major:
 endif::[]
 
+:parent-client-os: {client-os}
+:parent-client-os-major: {client-os-major}
+:client-os: Debian
+:client-os-architectures: amd64
+:client-os-components: main
+:client-os-major: 12
+:client-os-releases: stable
+:client-os-repository: debian
+include::modules/proc_adding-kernelcare-client-for-deb.adoc[leveloffset=+2]
+
+:client-os: Debian
+:client-os-architectures: amd64
+:client-os-components: main
+:client-os-major: 11
+:client-os-releases: stable
+:client-os-repository: debian
+include::modules/proc_adding-kernelcare-client-for-deb.adoc[leveloffset=+2]
+
+:client-os: Ubuntu
+:client-os-architectures: amd64
+:client-os-components: main
+:client-os-major: 24.04
+:client-os-releases: noble
+:client-os-repository: ubuntu
+include::modules/proc_adding-kernelcare-client-for-deb.adoc[leveloffset=+2]
+
+:client-os: Ubuntu
+:client-os-architectures: amd64
+:client-os-components: main
+:client-os-major: 22.04
+:client-os-releases: jammy
+:client-os-repository: ubuntu
+include::modules/proc_adding-kernelcare-client-for-deb.adoc[leveloffset=+2]
+:client-os: {parent-client-os}
+:client-os-major: {parent-client-os-major}
+:!client-os-architectures:
+:!client-os-components:
+:!client-os-major:
+:!client-os-releases:
+:!parent-client-os-major:
+:!parent-client-os:
+
 include::modules/proc_installing-the-kernelcare-package-on-hosts.adoc[leveloffset=+1]
 
 include::modules/proc_viewing-patched-kernel-version.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-kernelcare.adoc
+++ b/guides/common/assembly_using-kernelcare.adoc
@@ -9,13 +9,13 @@ include::modules/con_kernelcare-client.adoc[leveloffset=+1]
 
 :parent-client-os-major: {client-os-major}
 :client-os-major: 9
-include::modules/proc_creating-kernelcare-repositories-el.adoc[leveloffset=+2]
+include::modules/proc_adding-kernelcare-client-for-el.adoc[leveloffset=+2]
 
 :client-os-major: 8
-include::modules/proc_creating-kernelcare-repositories-el.adoc[leveloffset=+2]
+include::modules/proc_adding-kernelcare-client-for-el.adoc[leveloffset=+2]
 
 :client-os-major: 7
-include::modules/proc_creating-kernelcare-repositories-el.adoc[leveloffset=+2]
+include::modules/proc_adding-kernelcare-client-for-el.adoc[leveloffset=+2]
 :client-os-major: {parent-client-os-major}
 :!parent-client-os-major:
 endif::[]

--- a/guides/common/modules/proc_adding-kernelcare-client-for-deb.adoc
+++ b/guides/common/modules/proc_adding-kernelcare-client-for-deb.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="adding-kernelcare-client-for-{client-os-context}-{client-os-major}"]
+= Adding KernelCare Client for {client-os} {client-os-major}
+
+You need to provide the KernelCare client on your hosts to live-patch their Linux kernel.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Products*.
+. Click *Create Product* to create a product named `KernelCare {client-os}`.
+For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_content-management[Creating a product] in _{ContentManagementDocTitle}_.
+. On the *Repositories* tab, click *New Repository* to create a repository of type `deb` as follows:
++
+* *Name*: `KernelCare {client-os} {client-os-major}`
+* *Upstream URL*: `https://repo.cloudlinux.com/kernelcare-{client-os-repository}/{client-os-major}/`
+* *Releases/Distributions*: `{client-os-releases}`
+* *Components*: `{client-os-components}`
+* *Architectures*: `{client-os-architectures}`
+* Optional: Add the KernelCare GPG public key as content credential: `https://repo.cloudlinux.com/kernelcare/kernelcare.gpg`.
+
++
+For more information, see {ContentManagementDocURL}Adding_Custom_Deb_Repositories_content-management[Adding Deb repositories] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_adding-kernelcare-client-for-el.adoc
+++ b/guides/common/modules/proc_adding-kernelcare-client-for-el.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Creating_KernelCare_Repositories_for_{client-os-context}_{client-os-major}_{context}"]
-= Creating KernelCare repositories for {client-os} {client-os-major}
+[id="adding-kernelcare-client-for-{client-os-context}-{client-os-major}"]
+= Adding KernelCare Client for {client-os} {client-os-major}
 
 You need to provide the KernelCare client on your hosts to live-patch their Linux kernel.
 
@@ -13,7 +13,7 @@ For more information, see {ContentManagementDocURL}Creating_a_Custom_Product_con
 +
 * *Name*: `KernelCare {client-os} {client-os-major}`
 * *Upstream URL*: `https://repo.cloudlinux.com/kernelcare/{client-os-major}/x86_64/`
-* Optional: Add the KernelCare GPG pub key as content credential: `https://repo.cloudlinux.com/kernelcare/RPM-GPG-KEY-KernelCare`.
+* Optional: Add the KernelCare GPG public key as content credential: `https://repo.cloudlinux.com/kernelcare/RPM-GPG-KEY-KernelCare`.
 
 +
-For more information, see {ContentManagementDocURL}Adding_Custom_RPM_Repositories_content-management[Adding RPM Repositories] in _{ContentManagementDocTitle}_.
+For more information, see {ContentManagementDocURL}Adding_Custom_RPM_Repositories_content-management[Adding RPM repositories] in _{ContentManagementDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

Add KernelCare Clients for Debian/Ubuntu

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I was only checking for EL10 which are not yet released, but then realized that they're missing for Debian & Ubuntu. I did not find any Clients for SLES.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
