### PR TITLE
Remove distribution attribute when configuring repos

### DIFF
--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -1,4 +1,4 @@
-[id="configuring-repositories-{distribution}-{distribution-major-version}"]
+[id="configuring-repositories-el-{distribution-major-version}"]
 
 . Clear any metadata:
 +

--- a/guides/common/modules/proc_configuring-repositories-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-el.adoc
@@ -1,10 +1,10 @@
-[id="configuring-repositories-{distribution}-{distribution-major-version}-{package-manager}"]
+[id="configuring-repositories-{distribution}-{distribution-major-version}"]
 
 . Clear any metadata:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {package-manager} clean all
+# {project-package-clean} all
 ----
 ifdef::foreman-el,katello[]
 . Install the `foreman-release.rpm` package:

--- a/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
@@ -2,7 +2,6 @@
 
 :distribution: el
 :distribution-major-version: 9
-:package-manager: dnf
 
 include::proc_configuring-repositories-el.adoc[]
 

--- a/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
+++ b/guides/common/modules/proc_configuring-repositories-foreman-el.adoc
@@ -1,6 +1,5 @@
 .Procedure
 
-:distribution: el
 :distribution-major-version: 9
 
 include::proc_configuring-repositories-el.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?

This is always the same, so it doesn't have to be set as an attribute. If it were to change, the actual procedeure would need to use it too.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This was part of https://github.com/theforeman/foreman-documentation/pull/2936 but I'm splitting this off into its own change so it's easier to review.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.