### PR TITLE
Remove mention of -certs.tar in non-katello builds

### DIFF
--- a/guides/common/modules/con_backup-and-restore-smartproxyserver-by-using-a-virtual-machine-snapshot.adoc
+++ b/guides/common/modules/con_backup-and-restore-smartproxyserver-by-using-a-virtual-machine-snapshot.adoc
@@ -13,7 +13,12 @@ In the event of failure, you can install or configure a new {SmartProxyServer}.
 endif::[]
 
 If required, deploy a new {SmartProxyServer}, ensuring the host name is the same as before, and then install the {SmartProxy} certificates.
+ifdef::katello,orcharhino,satellite[]
 You may still have them on {ProjectServer}, the package name ends in -certs.tar, alternately create new ones.
+endif::[]
+ifndef::katello,orcharhino,satellite[]
+You may still have them, alternately create new ones.
+endif::[]
 Follow the procedures in {InstallingSmartProxyDocURL}[Installing {SmartProxyServer}] until you can confirm, in the {ProjectWebUI}, that {SmartProxyServer} is connected to {ProjectServer}.
 ifdef::katello,orcharhino,satellite[]
 Then use the procedure xref:Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_{context}[] to synchronize from {Project}.


### PR DESCRIPTION
#### What changes are you introducing?

The `-certs.tar` files are Katello specific. This drops a mention of them.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes https://github.com/theforeman/foreman-documentation/issues/1874

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The `package name` bit in the Katello version isn't correct either and should probably be updated as well. In general I don't like the sentence with its commas, but I'd like to close out my old issues. If someone else wants to provide a better version then by all means.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.