### PR TITLE
Emphasize prerequisite SmartProxy in trusted proxies

### DIFF
--- a/guides/common/modules/snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
+++ b/guides/common/modules/snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
@@ -1,2 +1,8 @@
 * If you want to use {SmartProxyServers} instead of your {ProjectServer}, ensure that you have configured your {SmartProxyServers} accordingly.
++
+[IMPORTANT]
+====
+It is essential to add your {SmartProxyServer} to the list of trusted proxies on {ProjectServer}!
+====
++
 For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for Host Registration and Provisioning] in _{InstallingSmartProxyDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

Adding an admonition to the prerequisite about configuring SmartProxies for use instead of ProjectServer in registration and provisioning

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To emphasize the prerequisite.
Users tend to overlook it, which has resulted in an escalation by our customer.

[SAT-35859](https://issues.redhat.com/browse/SAT-35859)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: as far as possible

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
