### PR TITLE
Adapt xref rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gem 'sass'
 
 # For TOC generation
 gem 'nokogiri'
+
+# For custom convertor templates
+gem 'tilt'

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gem 'nokogiri'
 
 # For custom convertor templates
 gem 'tilt'
+# Recommended when using the default template cache
+gem 'concurrent-ruby'

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -18,6 +18,8 @@ UNAME = $(shell uname)
 DATE_MDY = $(shell LC_ALL=C date "+%b %d %Y")
 DATE_MY = $(shell LC_ALL=C date "+%b %Y")
 CSS_STYLE = compressed
+TEMPLATE_PATH=$(realpath ../..)/templates
+TEMPLATE_ENGINE=erb
 
 ifeq ($(UNAME), Linux)
 BROWSER_OPEN = xdg-open
@@ -75,7 +77,7 @@ $(IMAGES_TS): $(IMAGES)
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/$(BUILD).css $(IMAGES_TS)
-	bundle exec asciidoctor -r asciidoctor-tabs -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -a attribute-missing=warn -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
+	bundle exec asciidoctor -T $(TEMPLATE_PATH) -E $(TEMPLATE_ENGINE) -r asciidoctor-tabs -a build=$(BUILD) $(BASEURL_ATTR) -a docinfo=shared -a docinfodir=common -a date_mdy="$(DATE_MDY)" -a date_my="$(DATE_MY)" -a docdatetime="$(DATE_MY)" -a stylesheet=$(DEST_DIR)/$(BUILD).css -a attribute-missing=warn -b html5 -d book --trace -o $@ $< 2>&1 | tee $@.log 1>&2
 	@echo CHECKING FOR ASCIIDOCTOR ERRORS AND WARNINGS
 	@! grep -Eq "^asciidoctor: (ERROR|WARNING)" $@.log
 	@echo CHECKING FOR ORPHAN XREFS HTML LINKS

--- a/guides/common/modules/con_content-flow-in-project.adoc
+++ b/guides/common/modules/con_content-flow-in-project.adoc
@@ -38,7 +38,7 @@ image::common/system-architecture-satellite.png[Content flow in {ProjectName}]
 endif::[]
 
 .Additional resources
-* See xref:Major-{Project}-Components_{context}[] for details.
+* See xref:con_major-project-components.adoc#Major-{Project}-Components_{context}[] for details.
 ifdef::satellite[]
 * See {ContentManagementDocURL}Managing_Red_Hat_Subscriptions_content-management[Managing Red Hat subscriptions] in _{ContentManagementDocTitle}_ for information about Content Delivery Network (CDN).
 endif::[]

--- a/guides/common/modules/con_defining-content-access-strategies-for-hosts.adoc
+++ b/guides/common/modules/con_defining-content-access-strategies-for-hosts.adoc
@@ -19,4 +19,4 @@ In smaller deployments or when you do not require content versioning and environ
 
 .Additional resources
 * For more information, see {ContentManagementDocURL}Managing_Application_Lifecycles_content-management[Managing application lifecycles], {ContentManagementDocURL}Managing_Content_Views_content-management[Managing content views], and {ContentManagementDocURL}Restricting_Hosts_Access_to_Content_content-management[Restricting hosts' access to content] in _{ContentManagementDocTitle}_.
-* For examples of content view deployments, see xref:common-deployment-scenarios[].
+* For examples of content view deployments, see xref:con_common-deployment-scenarios.adoc#common-deployment-scenarios[].

--- a/guides/common/modules/con_http-booting-requirements-with-managed-dhcp.adoc
+++ b/guides/common/modules/con_http-booting-requirements-with-managed-dhcp.adoc
@@ -9,7 +9,7 @@ To provision machines through HTTP booting ensure that you meet the following re
 For HTTP booting to work, ensure that your environment has the following client-side configurations:
 
 * All the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{smart-proxy-context}-networking_{context}[].
+For more information, see xref:con_smartproxy-networking.adoc#{smart-proxy-context}-networking_{context}[].
 * Your client has access to the DHCP and DNS servers.
 * Your client has access to the HTTP UEFI Boot {SmartProxy}.
 

--- a/guides/common/modules/con_http-booting-requirements-with-unmanaged-dhcp.adoc
+++ b/guides/common/modules/con_http-booting-requirements-with-unmanaged-dhcp.adoc
@@ -12,7 +12,7 @@ To provision machines through HTTP booting without managed DHCP ensure that you 
 * Ensure that your client has access to the DHCP and DNS servers.
 * Ensure that your client has access to the HTTP UEFI Boot {SmartProxy}.
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{smart-proxy-context}-networking_{context}[].
+For more information, see xref:con_smartproxy-networking.adoc#{smart-proxy-context}-networking_{context}[].
 
 .Network requirements
 * An unmanaged DHCP server available for clients.

--- a/guides/common/modules/con_planning-organization-and-location-context.adoc
+++ b/guides/common/modules/con_planning-organization-and-location-context.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 ifeval::["{context}" == "planning"]
 .Additional resources
-* For examples of deployment scenarios, see xref:common-deployment-scenarios[].
+* For examples of deployment scenarios, see xref:con_common-deployment-scenarios.adoc#common-deployment-scenarios[].
 ifdef::katello[]
 * For information about managing organizations and locations, see {ManagingOrganizationsLocationsDocURL}[_{ManagingOrganizationsLocationsDocTitle}_].
 endif::[]

--- a/guides/common/modules/con_pxe-booting-requirements.adoc
+++ b/guides/common/modules/con_pxe-booting-requirements.adoc
@@ -10,7 +10,7 @@ To provision machines using PXE booting, ensure that you meet the following requ
 
 .Client requirements
 * Ensure that all the network-based firewalls are configured to allow clients on the subnet to access the {SmartProxy}.
-For more information, see xref:{smart-proxy-context}-networking_{context}[].
+For more information, see xref:con_smartproxy-networking.adoc#{smart-proxy-context}-networking_{context}[].
 
 * Ensure that your client has access to the DHCP and TFTP servers.
 

--- a/guides/common/modules/con_smartproxy-overview.adoc
+++ b/guides/common/modules/con_smartproxy-overview.adoc
@@ -12,5 +12,5 @@ ifdef::katello,orcharhino,satellite[]
 By registering a host to a {SmartProxyServer}, you can configure this host to receive content and configuration from the {SmartProxy} in their location instead of from the central {ProjectServer}.
 
 By using content views, you can specify the exact subset of content that {SmartProxyServer} makes available to hosts.
-For more information, see xref:content-and-patch-management-with-{project-context}[].
+For more information, see xref:con_content-and-patch-management-with-project.adoc#content-and-patch-management-with-{project-context}[].
 endif::[]

--- a/guides/common/modules/ref_additional-resources-project-infrastructure-organization-concepts.adoc
+++ b/guides/common/modules/ref_additional-resources-project-infrastructure-organization-concepts.adoc
@@ -3,4 +3,4 @@
 [id="additional-resources-project-infrastructure-organization-concepts_{context}"]
 = Additional resources
 
-* For examples of {Project} deployment, see xref:{project-context}-deployment-planning[].
+* For examples of {Project} deployment, see xref:con_foreman-deployment-planning.adoc#{project-context}-deployment-planning[].

--- a/templates/html5/inline_anchor.html.erb
+++ b/templates/html5/inline_anchor.html.erb
@@ -1,0 +1,8 @@
+<% if node.type == :xref  && !node.attr('path') %>
+  anchor_id_for_href = node.target.sub(/^.*#/, '')
+  link_text = node.text || node.reftext
+  <a href="#<%= anchor_id_for_href %>" class="xref"><%= link_text %></a>
+<% else %>
+  <%# Fallback to default rendering for other inline anchors (e.g., normal links, external links) %>
+  <%= super %>
+<% end %>

--- a/templates/html5/inline_anchor.html.erb
+++ b/templates/html5/inline_anchor.html.erb
@@ -1,8 +1,11 @@
-<% if node.type == :xref  && !node.attr('path') %>
+<% if node.type == :xref && node.attr('path') %>
+  <% puts "", "------------------------------ Path -------------------------------", ""
+  # Extract anchor ID from the xref target
   anchor_id_for_href = node.target.sub(/^.*#/, '')
-  link_text = node.text || node.reftext
+  link_text = node.text || node.reftext || anchor_id_for_href %>
   <a href="#<%= anchor_id_for_href %>" class="xref"><%= link_text %></a>
 <% else %>
-  <%# Fallback to default rendering for other inline anchors (e.g., normal links, external links) %>
+  <%# Fallback to default rendering for other inline anchors %>
+  <% puts "", "~~~~~~~~~~~~~ Fallback ~~~~~~~~~~~~~", "" %>
   <%= super %>
 <% end %>


### PR DESCRIPTION
#### What changes are you introducing?

Adapting upstream HTML5 rendering for path-based xrefs to point to the ID in the same document

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Closes #4011 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- ADoctor assumes that path-based xrefs should point to another document, that these links are so-called _inter-document_ links. This solution enforces handling of path-based xrefs as any other xrefs (=local or _intra-document_ links in a single HTML document). This is a non-standard adaptation.
- I don't know about any other solution.
- Includes a commit from #3988 for testing

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
