### PR TITLE
Hide KubeVirt for orcharhino

### DIFF
--- a/guides/common/modules/ref_supported-virtualization-infrastructures.adoc
+++ b/guides/common/modules/ref_supported-virtualization-infrastructures.adoc
@@ -7,7 +7,9 @@ You can connect the following virtualization infrastructures as compute resource
 
 * KVM (libvirt)
 * VMware
+ifndef::orcharhino[]
 * {KubeVirt}
+endif::[]
 ifndef::satellite[]
 * Proxmox
 endif::[]

--- a/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
+++ b/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
@@ -30,7 +30,9 @@ include::common/assembly_configuring-virt-who-hyperv.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-virt-who-openstack.adoc[leveloffset=+1]
 
+ifndef::orcharhino[]
 include::common/assembly_configuring-virt-who-kubevirt.adoc[leveloffset=+1]
+endif::[]
 
 include::common/modules/proc_editing-a-virt-who-configuration.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

orcharhino does not support compute resource KubeVirt.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Follow-up to #3995

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Prerequisite to #4017

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
