### PR TITLE
Clarify PostgreSQL versions on Debian/Ubuntu

### DIFF
--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -16,9 +16,9 @@
 :project-package-update: apt upgrade
 :package-update: apt upgrade
 :postgresql-server-package: postgresql
-:postgresql-conf-dir: /etc/postgresql/13/main
+:postgresql-conf-dir: /etc/postgresql/14/main
 :postgresql-lib-dir: /var/lib/postgresql
-:postgresql-data-dir: {postgresql-lib-dir}/13/main
+:postgresql-data-dir: {postgresql-lib-dir}/14/main
 :postgresql-log-dir: /var/log/postgresql
 
 // Some documents are not ready for stable releases, but can be published on nightly

--- a/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
@@ -9,6 +9,7 @@ If you are using the default internal databases but want to start using external
 To confirm whether your {ProjectServer} has internal or external databases, you can query the status of your databases:
 
 For PostgreSQL, enter the following command:
+
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service status --only postgresql
@@ -23,6 +24,11 @@ endif::[]
 To migrate from the default internal databases to external databases, you must complete the following procedures:
 
 . xref:installing-postgresql_{context}[].
+ifdef::katello,orcharhino,satellite[]
 Prepare PostgreSQL with databases for Foreman, Pulp, and Candlepin with dedicated users owning them.
+endif::[]
+ifdef::foreman-el,foreman-deb[]
+Prepare PostgreSQL with a database for Foreman with a dedicated user owning it.
+endif::[]
 . xref:migrating-to-external-databases_{context}[].
 Edit the parameters of `{foreman-installer}` to point to the new databases, and run `{foreman-installer}`.

--- a/guides/common/modules/con_postgresql-as-an-external-database-considerations.adoc
+++ b/guides/common/modules/con_postgresql-as-an-external-database-considerations.adoc
@@ -10,7 +10,13 @@ ifndef::katello,orcharhino,satellite[]
 Foreman uses the PostgreSQL database.
 endif::[]
 If you want to use PostgreSQL as an external database, the following information can help you decide if this option is right for your {Project} configuration.
+ifdef::foreman-deb[]
+{Project} requires PostgreSQL version 13 or later.
+{Team} recommends that you use the PostgreSQL version that is part of the default operating system repositories.
+endif::[]
+ifndef::foreman-deb[]
 {Project} supports PostgreSQL version 13.
+endif::[]
 
 .Advantages of external PostgreSQL
 * Increase in free memory and free CPU on {Project}

--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -3,8 +3,15 @@
 [id="installing-postgresql_{context}"]
 = Installing PostgreSQL
 
-You can install only the same version of PostgreSQL that is installed with the `{foreman-installer}` tool during an internal database installation.
+ifdef::foreman-deb[]
+{Project} requires PostgreSQL version 13 or later.
+{Team} recommends that you use the PostgreSQL version that is part of the default operating system repositories.
+The examples below assume PostgreSQL 14 as used on Ubuntu 22.04.
+If you run {ProjectServer} on Debian 12, you have to adjust the paths of PostgreSQL config and data directories which depend on the PostgreSQL version.
+endif::[]
+ifndef::foreman-deb[]
 {Project} supports PostgreSQL version 13.
+endif::[]
 
 include::snip_firewalld.adoc[]
 

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -81,3 +81,7 @@ endif::[]
 ----
 # rm -fr {postgresql-data-dir}
 ----
+ifdef::foreman-deb[]
++
+If you run {ProjectServer} on Debian 12, you have to adjust the paths of PostgreSQL config and data directories which depend on the PostgreSQL version.
+endif::[]

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -27,7 +27,9 @@ Back up and transfer existing data, then use the `{foreman-installer}` command t
 ----
 # {foreman-maintain} backup online \
 --preserve-directory \
+ifndef::foreman-el,foreman-deb[]
 --skip-pulp-content \
+endif::[]
 /var/_My_Migration_Backup_Directory_
 ----
 . Transfer the data to the new external databases:

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -6,7 +6,7 @@
 Back up and transfer existing data, then use the `{foreman-installer}` command to configure {Project} to connect to an external PostgreSQL database server.
 
 .Prerequisites
-* You have installed and configured a PostgreSQL server on a {EL} server.
+* You have installed and configured a PostgreSQL server on an external server.
 
 .Procedure
 . On {ProjectServer}, stop all {Project} services except for PostgreSQL:


### PR DESCRIPTION
#### What changes are you introducing?

Explain that foreman-deb for Foreman on Debian 12 and Foreman on Ubuntu 22.04 relies on two different versions of PostgreSQL provided by the OS vendor.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* Debian 12 provides PostgreSQL 15
* Ubuntu 22.04 provides PostgreSQL 14

The examples use PostgreSQL 14, so on Debian 12, you have to adjust the paths in two procedures.

Fixes #3999

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I am quite unsure about my change:

* Should we really write that Foreman supports different versions of PostgreSQL depending on the flavour?

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
