### PR TITLE
Add example to access global host parameters via Ansible

### DIFF
--- a/guides/common/modules/proc_running-an-ansible-playbook.adoc
+++ b/guides/common/modules/proc_running-an-ansible-playbook.adoc
@@ -36,3 +36,4 @@ For more information, see xref:executing-a-remote-job_{context}[].
 For more information, see the following resources:
 ** xref:importing-an-ansible-playbook-by-name_{context}[]
 ** xref:importing-all-available-ansible-playbooks_{context}[]
+* xref:host-parameters-in-ansible-playbooks[]

--- a/guides/common/modules/ref_host-parameters-in-ansible-playbooks.adoc
+++ b/guides/common/modules/ref_host-parameters-in-ansible-playbooks.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="host-parameters-in-ansible-playbooks"]
+= Host parameters in Ansible Playbooks
+
+You can use host parameters from {Project} in Ansible Playbooks.
+
+.Example Ansible Playbook to access host parameters
+[source, yaml, options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+---
+- name: "Ansible Playbook to access host parameters"
+  hosts: all
+  tasks:
+    - name: "View a host parameter"
+      ansible.builtin.debug:
+        msg: "{{ hostvars[inventory_hostname]['_My_Host_Parameter_'] }}"
+...
+----
+
+Ansible will access the host parameter and show its value.
+If you set the host parameter to an ERB template, for example, `<%= @host.capabilities.include?(:snapshots) %>`, {Project} will render it and provide the result to Ansible.
+Ansible receives only the rendered value, not the ERB template itself.
+
+.Additional resources
+* xref:Host_Parameter_Hierarchy_{context}[]

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -15,6 +15,8 @@ include::common/assembly_using-ansible-roles.adoc[leveloffset=+1]
 
 include::common/modules/proc_running-an-ansible-playbook.adoc[leveloffset=+1]
 
+include::common/modules/ref_host-parameters-in-ansible-playbooks.adoc[leveloffset=+2]
+
 include::common/assembly_configuring-and-setting-up-remote-jobs.adoc[leveloffset=+1]
 
 include::common/assembly_integrating-awx.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Add example on how to use global parameters in Ansible Playbooks.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* This is a workaround for this limitation: https://docs.theforeman.org/nightly/Managing_Configurations_Ansible/index-katello.html#running-an-ansible-playbook-from-foreman_ansible
* It's not documented anywhere yet how to access host parameters in Ansible.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tested on Foreman/Katello 3.14/4.16:

<img width="1864" height="1008" alt="custom-playbook" src="https://github.com/user-attachments/assets/8be8ad4b-0e32-4919-be37-e17a2f3e793c" />

<img width="1864" height="526" alt="global-parameter" src="https://github.com/user-attachments/assets/71bb9961-1980-4f41-90e9-361868ea061e" />

<img width="1864" height="1230" alt="rex-output" src="https://github.com/user-attachments/assets/b63ef960-1165-4b04-924e-b5e3bd7472ea" />

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
