### PR TITLE
Fix ifdef in tech preview snippet

### DIFF
--- a/guides/common/modules/snip_technology-preview.adoc
+++ b/guides/common/modules/snip_technology-preview.adoc
@@ -4,8 +4,8 @@
 [IMPORTANT]
 ====
 [subs="attributes+"]
-ifdef::satellite[]
 {FeatureName} is a Technology Preview feature only.
+ifdef::satellite[]
 Technology Preview features are not supported with {Team} production service level agreements (SLAs) and might not be functionally complete.
 endif::[]
 ifndef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Moving the beginning of an ifdef statement in the tech preview snippet.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Currently, the name of the feature is only shown for non-satellite builds, which doesn't seem right.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

To be cherry-picked into the same branches as https://github.com/theforeman/foreman-documentation/pull/3996

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
