### PR TITLE
Rebrand :advisorengine:

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -84,6 +84,7 @@
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy
 :Insights: Insights
+:insights-iop: {Insights} in {Project}
 :advisorengine: {Insights} Advisor
 :vulnerabilityengine: {Insights} Vulnerability
 :install-on-os: {EL}

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -42,7 +42,6 @@
 :SatelliteSub: Red Hat Satellite Infrastructure Subscription
 
 // Base attributes
-:advisorengine: advisor
 :apache-user: apache
 :apache-log-dir: httpd
 :ansible-collection-package: ansible-collection-theforeman-foreman
@@ -85,6 +84,7 @@
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy
 :Insights: Insights
+:advisorengine: advisor
 :install-on-os: {EL}
 :installer-log-file: /var/log/foreman-installer/foreman.log
 // this is foreman-installer or foreman-installer --scenario MyScenario if there are multiple

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -84,7 +84,8 @@
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy
 :Insights: Insights
-:advisorengine: advisor
+:advisorengine: {Insights} Advisor
+:vulnerabilityengine: {Insights} Vulnerability
 :install-on-os: {EL}
 :installer-log-file: /var/log/foreman-installer/foreman.log
 // this is foreman-installer or foreman-installer --scenario MyScenario if there are multiple

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -83,10 +83,6 @@
 :FreeIPA-context: {FreeIPA}
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy
-:Insights: Insights
-:insights-iop: {Insights} in {Project}
-:advisorengine: {Insights} Advisor
-:vulnerabilityengine: {Insights} Vulnerability
 :install-on-os: {EL}
 :installer-log-file: /var/log/foreman-installer/foreman.log
 // this is foreman-installer or foreman-installer --scenario MyScenario if there are multiple
@@ -153,6 +149,11 @@
 :SmartProxyServer: {SmartProxy}{nbsp}server
 :SmartProxyServers: {SmartProxyServer}s
 :Team: {Project} community
+// Red Hat Insights
+:Insights: Insights
+:insights-iop: {Insights} in {Project}
+:advisorengine: {Insights} Advisor
+:vulnerabilityengine: {Insights} Vulnerability
 :sectanchors:
 :client-content-dnf:
 // Hosts

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -81,6 +81,7 @@
 :freeipaserver-example-com: idm-server.example.com
 :hammer-smart-proxy: hammer capsule
 :Insights: Red{nbsp}Hat Lightspeed
+:insights-iop: {Insights} in Satellite
 :advisorengine: {Insights} Advisor in Satellite
 :vulnerabilityengine: {Insights} Vulnerability in Satellite
 :installer-log-file: /var/log/foreman-installer/satellite.log

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -80,10 +80,6 @@
 :FreeIPA-context: Identity_Management
 :freeipaserver-example-com: idm-server.example.com
 :hammer-smart-proxy: hammer capsule
-:Insights: Red{nbsp}Hat Lightspeed
-:insights-iop: {Insights} in Satellite
-:advisorengine: {Insights} Advisor in Satellite
-:vulnerabilityengine: {Insights} Vulnerability in Satellite
 :installer-log-file: /var/log/foreman-installer/satellite.log
 :installer-scenario-smartproxy: satellite-installer --scenario capsule
 :installer-scenario: satellite-installer --scenario satellite
@@ -134,6 +130,12 @@
 :SmartProxyServer: Capsule{nbsp}Server
 :SmartProxyServers: {SmartProxyServer}s
 :Team: Red{nbsp}Hat
+
+// Red Hat Insights rebranded to Red Hat Lightspeed
+:Insights: Red{nbsp}Hat Lightspeed
+:insights-iop: {Insights} in {Project}
+:advisorengine: {Insights} Advisor in {Project}
+:vulnerabilityengine: {Insights} Vulnerability in {Project}
 
 // Repositories and subscriptions (used in Satellite guides)
 

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -134,8 +134,8 @@
 // Red Hat Insights rebranded to Red Hat Lightspeed
 :Insights: Red{nbsp}Hat Lightspeed
 :insights-iop: {Insights} in {Project}
-:advisorengine: {Insights} Advisor in {Project}
-:vulnerabilityengine: {Insights} Vulnerability in {Project}
+:advisorengine: {Insights} advisor in {Project}
+:vulnerabilityengine: {Insights} vulnerability in {Project}
 
 // Repositories and subscriptions (used in Satellite guides)
 

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -81,7 +81,8 @@
 :freeipaserver-example-com: idm-server.example.com
 :hammer-smart-proxy: hammer capsule
 :Insights: Red{nbsp}Hat Lightspeed
-:advisorengine: {Insights} advisor in Satellite
+:advisorengine: {Insights} Advisor in Satellite
+:vulnerabilityengine: {Insights} Vulnerability in Satellite
 :installer-log-file: /var/log/foreman-installer/satellite.log
 :installer-scenario-smartproxy: satellite-installer --scenario capsule
 :installer-scenario: satellite-installer --scenario satellite

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -43,7 +43,6 @@
 :ReleaseNotesDocURL: {BaseURL}release_notes/index#
 
 // Overrides for satellite build
-:advisorengine: Insights advisor in Satellite
 :ansible-collection-package: ansible-collection-redhat-satellite
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
 :ansible-galaxy-name: Red{nbsp}Hat Ansible Automation Platform
@@ -82,6 +81,7 @@
 :freeipaserver-example-com: idm-server.example.com
 :hammer-smart-proxy: hammer capsule
 :Insights: Red{nbsp}Hat Lightspeed
+:advisorengine: {Insights} advisor in Satellite
 :installer-log-file: /var/log/foreman-installer/satellite.log
 :installer-scenario-smartproxy: satellite-installer --scenario capsule
 :installer-scenario: satellite-installer --scenario satellite


### PR DESCRIPTION
#### What changes are you introducing?

Rebrand "Insights advisor in Satellite -> "Red Hat Lightspeed advisor in Satellite" (do not capitalize "advisor" for Satellite)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Has been rebranded together with Insights https://github.com/theforeman/foreman-documentation/pull/4031

Branding for Satellite confirmed per [comment](https://issues.redhat.com/browse/SAT-34946?focusedId=27676681&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27676681) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Putting the attributes one after another so that attribute can be reused and for better findability in source code

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

#### Review checklists

N/A