### PR TITLE
Use attribute in favor of HOST

### DIFF
--- a/guides/common/modules/ref_generic-project-specific-macros.adoc
+++ b/guides/common/modules/ref_generic-project-specific-macros.adoc
@@ -12,7 +12,7 @@ You can use the macros listed in the following table across all kinds of templat
 |Name |Description
 |indent(n) |Indents the block of code by n spaces, useful when using a snippet template that is not indented.
 |foreman_url(kind) |Returns the full URL to host-rendered templates of the given kind.
-For example, templates of the "provision" type usually reside at `\http://HOST/unattended/provision`.
+For example, templates of the "provision" type usually reside at `\http://{foreman-example-com}/unattended/provision`.
 |snippet(name) |Renders the specified snippet template.
 Useful for nesting provisioning templates.
 |snippets(file) |Renders the specified snippet found in the Foreman database, attempts to load it from the `unattended/snippets/` directory if it is not found in the database.


### PR DESCRIPTION
#### What changes are you introducing?

use attribute for Foreman Server URL instead of `HOST`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
