### PR TITLE
Remove ansible roles with host parameters

### DIFF
--- a/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
@@ -47,3 +47,10 @@ If the hashes contain the same key, the value is overwritten by the value of the
 ** *Avoid Duplicates* {endash} Ensures that the values in the array or hash are unique.
 . Optional: Expand the *Specify Matchers* area and specify criteria for selecting hosts on which the variable overrides.
 . To save the override settings, click *Submit*.
+
+.Overriding variables for hosts
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select your host.
+. On the *Ansible* tab, select the *Variables* tab.
+. Click the pencil icon to edit the value of the variable.
+. Click the tick icon to accept the value of the changed variable or the cross icon to cancel the change.

--- a/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
@@ -47,24 +47,3 @@ If the hashes contain the same key, the value is overwritten by the value of the
 ** *Avoid Duplicates* {endash} Ensures that the values in the array or hash are unique.
 . Optional: Expand the *Specify Matchers* area and specify criteria for selecting hosts on which the variable overrides.
 . To save the override settings, click *Submit*.
-
-To use the Ansible variable, add the variable as a parameter to your host or host group, or add the variable as a global parameter.
-
-.Adding the variable to a host
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the host that you want to use.
-. Click the *Ansible* tab, and in the *Variables* area, click the pencil icon to edit the value of the variable.
-. Click the tick icon to accept the value of the changed variable or the cross icon to cancel the change.
-
-.Adding the variable to a host group
-. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*, and select the host group that you want to use.
-. Click the *Parameters* tab, and in the *Host Group Parameters* area, click *Add Parameter*.
-. In the *Name* field, add the Ansible variable name.
-. From the *Type* list, select the type of the variable for validation.
-. In the *Value* field, enter the value for the variable.
-
-.Adding the variable as a global parameter
-. In the {ProjectWebUI}, navigate to *Configure* > *Global Parameters*, and click *Create Parameter*.
-. In the *Name* field, add the Ansible variable name.
-. From the *Type* list, select the type of the variable for validation.
-. In the *Value* field, enter the value for the variable.
-. Optional: If you do not want to display the Ansible variable in plain text, select the *Hidden Values* checkbox to display the content of the variable as asterisks in the {ProjectWebUI}.


### PR DESCRIPTION
#### What changes are you introducing?

Remove docs on how to configure configuring hosts with foreman_ansible by overriding Ansible variables of imported Ansible roles with host parameters because it does not work.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I tried to reproduce this on Foreman 3.14 but could not get it to run.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

draft PR until reproduced by someone else

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
