### PR TITLE
Make "Configuring hosts by using Puppet" available for all builds

### DIFF
--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -35,7 +35,7 @@ You can also create multiple Puppet environments to control versions of configur
 .High-level integration steps
 Puppet integration with {Project} involves the following high-level steps:
 
-ifdef::katello,satellite[]
+ifdef::katello,orcharhino,satellite[]
 . xref:Enabling_Puppet_Integration_{context}[Enable Puppet integration].
 endif::[]
 ifdef::katello,satellite,orcharhino[]

--- a/guides/common/modules/proc_assigning-a-puppet-class-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-a-puppet-class-to-a-host-group.adoc
@@ -7,7 +7,8 @@ Use a host group to assign the _ntp_ Puppet class to multiple hosts at once.
 Every host you deploy based on this host group has this Puppet class installed.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Configure > Host Groups* to create a host group or edit an existing one.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
+. Create or edit a host group.
 . On the *Host Group* tab, set the following parameters:
 .. The *Lifecycle Environment* describes the stage in which certain versions of content are available to hosts.
 .. The *Content View* is comprised of products and allows for version control of content repositories.

--- a/guides/common/modules/proc_assigning-a-puppet-class-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-a-puppet-class-to-a-host-group.adoc
@@ -9,9 +9,11 @@ Every host you deploy based on this host group has this Puppet class installed.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
 . Create or edit a host group.
-. On the *Host Group* tab, set the following parameters:
+. On the *Host Group* tab, set the following:
+ifdef::katello,orcharhino,satellite[]
 .. The *Lifecycle Environment* describes the stage in which certain versions of content are available to hosts.
 .. The *Content View* is comprised of products and allows for version control of content repositories.
+endif::[]
 .. The *Environment* allows you to supply a group of hosts with their own dedicated configuration.
 . Navigate to the *Puppet ENC* tab.
 . Add the Puppet class to the _Included Classes_ or to the _Included Config Groups_ if a Puppet config group is configured.

--- a/guides/common/modules/proc_creating-a-custom-puppet-environment.adoc
+++ b/guides/common/modules/proc_creating-a-custom-puppet-environment.adoc
@@ -13,6 +13,4 @@ You can create a Puppet environment within your {Project}.
 . Optional: Set an organization context.
 . Click *Submit* to create the Puppet environment.
 
-ifndef::orcharhino[]
 Note that before you run an import of Puppet modules into {Project}, the environment must already exist as the folder `/etc/puppetlabs/code/environments/_example_environment_` on the Puppet server and contain installed Puppet modules.
-endif::[]

--- a/guides/common/modules/proc_creating-a-custom-puppet-environment.adoc
+++ b/guides/common/modules/proc_creating-a-custom-puppet-environment.adoc
@@ -6,7 +6,7 @@
 You can create a Puppet environment within your {Project}.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Configure > Puppet Environments*.
+. In the {ProjectWebUI}, navigate to *Configure* > *Puppet Environments*.
 . Click *Create Puppet Environment* to create a Puppet environment.
 . Enter a *Name*, alphanumeric characters and underscores are allowed, such as `example_environment`.
 . Optional: Set a location context.

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
@@ -6,25 +6,21 @@
 You can install and configure the Puppet agent on a host during the provisioning process.
 A configured Puppet agent is required on the host for Puppet integration with your {Project}.
 
-ifdef::satellite[]
 .Prerequisites
 * Puppet must be enabled in your {Project}.
 For more information, see xref:Enabling_Puppet_Integration_{context}[].
+ifdef::satellite[]
 include::snip_prerequisite-project-client-repository-ak.adoc[]
 * You have an activation key.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::katello[]
-.Prerequisites
 * You created a product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::orcharhino[]
-.Prerequisites
-* Puppet must be enabled in your {Project}.
-For more information, see xref:Enabling_Puppet_Integration_{context}[].
 * You created a product and repository containing the Puppet agent and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc
@@ -32,7 +32,7 @@ For more information, see {ContentManagementDocURL}Managing_Activation_Keys_cont
 endif::[]
 
 .Procedure
-. Navigate to *Hosts* > *Templates* > *Provisioning Templates*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
 . Select a provisioning template depending on your host provisioning method.
 For more information, see {ProvisioningDocURL}kinds-of-provisioning-templates[Kinds of Provisioning Templates] in _{ProvisioningDocTitle}_.
 ifndef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -9,7 +9,6 @@ ifndef::managing-configurations-puppet[]
 For more information about Puppet, see {ManagingConfigurationsPuppetDocURL}[_{ManagingConfigurationsPuppetDocTitle}_].
 endif::[]
 
-ifdef::satellite[]
 .Prerequisites
 * Puppet must be enabled in your {Project}.
 ifdef::managing-configurations-puppet[]
@@ -18,26 +17,18 @@ endif::[]
 ifndef::managing-configurations-puppet[]
 For more information, see {ManagingConfigurationsPuppetDocURL}Enabling_Puppet_Integration_managing-configurations-puppet[Enabling Puppet Integration with {Project}] in _{ManagingConfigurationsPuppetDocTitle}_.
 endif::[]
+ifdef::satellite[]
 include::snip_prerequisite-project-client-repository-ak.adoc[]
 * You have an activation key.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::katello[]
-.Prerequisites
 * You created a product and repository for the upstream Puppet agent, such as `\https://yum.puppet.com` or `\https://apt.puppet.com`, and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing Content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing Activation Keys] in _{ContentManagementDocTitle}_.
 endif::[]
 ifdef::orcharhino[]
-.Prerequisites
-* Puppet must be enabled in your {Project}.
-ifdef::managing-configurations-puppet[]
-For more information, see xref:Enabling_Puppet_Integration_{context}[].
-endif::[]
-ifndef::managing-configurations-puppet[]
-For more information, see {ManagingConfigurationsPuppetDocURL}Enabling_Puppet_Integration_managing-configurations-puppet[Enabling Puppet integration with {Project}] in _{ManagingConfigurationsPuppetDocTitle}_.
-endif::[]
 * You created a product and repository containing the Puppet agent and synchronized the repository to {Project}.
 For more information, see {ContentManagementDocURL}Importing_Content_content-management[Importing content] in _{ContentManagementDocTitle}_.
 * You created an activation key that enables the Puppet agent repository for hosts.

--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-manually.adoc
@@ -10,14 +10,12 @@ For more information about Puppet, see {ManagingConfigurationsPuppetDocURL}[_{Ma
 endif::[]
 
 .Prerequisites
-ifdef::orcharhino,satellite[]
 * Puppet must be enabled in your {Project}.
 ifdef::managing-configurations-puppet[]
 For more information, see xref:Enabling_Puppet_Integration_{context}[].
 endif::[]
 ifndef::managing-configurations-puppet[]
 For more information, see {ManagingConfigurationsPuppetDocURL}Enabling_Puppet_Integration_managing-configurations-puppet[Enabling Puppet Integration with {Project}] in _{ManagingConfigurationsPuppetDocTitle}_.
-endif::[]
 endif::[]
 * The host must have a Puppet environment assigned to it.
 ifdef::satellite[]

--- a/guides/common/modules/proc_overriding-a-smart-class-parameter-on-an-individual-host.adoc
+++ b/guides/common/modules/proc_overriding-a-smart-class-parameter-on-an-individual-host.adoc
@@ -7,7 +7,7 @@ You can override parameters on individual hosts.
 This is recommended if you have multiple hosts and only want to make changes to a single one.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click a host name to select a host.
 . Click *Edit*.
 . On the *Host* tab, select a Puppet *Environment*.

--- a/guides/common/modules/proc_overriding-out-of-sync-interval-for-a-host-group.adoc
+++ b/guides/common/modules/proc_overriding-out-of-sync-interval-for-a-host-group.adoc
@@ -4,7 +4,7 @@
 = Overriding out-of-sync interval for a host group
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Configure > Host Groups*.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
 . Select a host group.
 . On the *Parameters* tab, click *Add Parameter*.
 . In the *Name* field, enter `outofsync_interval`.

--- a/guides/common/modules/proc_overriding-out-of-sync-interval-for-an-individual-host.adoc
+++ b/guides/common/modules/proc_overriding-out-of-sync-interval-for-an-individual-host.adoc
@@ -4,7 +4,7 @@
 = Overriding out-of-sync interval for an individual host
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click *Edit* for a selected host.
 . On the *Parameters* tab, click *Add Parameter*.
 . In the *Name* field, enter `outofsync_interval`.

--- a/guides/common/modules/proc_setting-the-global-out-of-sync-interval.adoc
+++ b/guides/common/modules/proc_setting-the-global-out-of-sync-interval.adoc
@@ -4,7 +4,7 @@
 = Setting the global out-of-sync interval
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Administer > Settings*.
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
 . On the *General* tab, edit *Out of sync interval*.
 Set a duration, in minutes, after which hosts are considered to be out of sync.
 +

--- a/guides/common/modules/proc_setting-the-puppet-out-of-sync-interval.adoc
+++ b/guides/common/modules/proc_setting-the-puppet-out-of-sync-interval.adoc
@@ -4,5 +4,6 @@
 = Setting the Puppet out-of-sync interval
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Administer > Settings*, and click the *Config Management* tab.
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
+. Select the *Config Management* tab.
 . In the *Puppet interval* field, set the value to the duration, in minutes, after which hosts reporting using Puppet are considered to be out of sync.

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -21,9 +21,7 @@ include::common/modules/con_how-puppet-integrates-with-project.adoc[leveloffset=
 
 include::common/modules/ref_supported-puppet-versions-and-system-requirements.adoc[leveloffset=+2]
 
-ifdef::katello,satellite,orcharhino[]
 include::common/modules/proc_enabling-puppet.adoc[leveloffset=+2]
-endif::[]
 
 include::common/modules/proc_installing-and-configuring-puppet-agent-during-host-provisioning.adoc[leveloffset=+2]
 
@@ -33,9 +31,7 @@ include::common/modules/proc_installing-and-configuring-puppet-agent-manually.ad
 
 include::common/modules/ref_performing-configuration-management.adoc[leveloffset=+2]
 
-ifdef::katello,satellite,orcharhino[]
 include::common/modules/proc_disabling-puppet.adoc[leveloffset=+2]
-endif::[]
 
 include::common/modules/con_managing-puppet-modules.adoc[leveloffset=+1]
 

--- a/guides/doc-Managing_Configurations_Puppet/master.adoc
+++ b/guides/doc-Managing_Configurations_Puppet/master.adoc
@@ -5,12 +5,6 @@ include::common/header.adoc[]
 
 = {ManagingConfigurationsPuppetDocTitle}
 
-// This guide is not ready for stable releases
-ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-ifndef::HideDocumentOnStable[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -80,4 +74,3 @@ include::common/modules/proc_setting-the-puppet-out-of-sync-interval.adoc[levelo
 include::common/modules/proc_overriding-out-of-sync-interval-for-a-host-group.adoc[leveloffset=+2]
 
 include::common/modules/proc_overriding-out-of-sync-interval-for-an-individual-host.adoc[leveloffset=+2]
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Make "Configuring hosts by using Puppet" available for all builds

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

part of https://github.com/theforeman/foreman-documentation/issues/396

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tech ack needed for two assumptions:

* You can enable foreman_puppet on all builds equally
* You can disable foreman_puppet on all builds equally

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
