### PR TITLE
Make "Provisioning Hosts" fit for all build flavours

### DIFF
--- a/guides/common/modules/con_preparing-networking.adoc
+++ b/guides/common/modules/con_preparing-networking.adoc
@@ -22,6 +22,6 @@ endif::[]
 . Defining network resource data in {ProjectServer} to help configure network interfaces on new hosts.
 
 The following instructions have similar applications to configuring {SmartProxyServers} managing a specific network.
-ifndef::orcharhino[]
-To configure {Project} to use external DHCP, DNS, and TFTP services, see {InstallingServerDocURL}configuring-external-services[Configuring External Services] in _{InstallingServerDocTitle}_.
-endif::[]
+
+.Additional resources
+* {IntegratingProvisioningInfrastructureServicesDocURL}[{IntegratingProvisioningInfrastructureServicesDocTitle}]

--- a/guides/common/modules/con_preparing-networking.adoc
+++ b/guides/common/modules/con_preparing-networking.adoc
@@ -14,7 +14,9 @@ Configuring {SmartProxies} has two basic requirements:
 
 . Configuring network services.
 This includes:
+ifdef::katello,orcharhino,satellite[]
 ** Content delivery services
+endif::[]
 ** Network services (DHCP, DNS, and TFTP)
 ** Puppet configuration
 . Defining network resource data in {ProjectServer} to help configure network interfaces on new hosts.

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -3,8 +3,7 @@
 [id="Provisioning_Virtual_Machines_on_KVM_{context}"]
 = Provisioning virtual machines on KVM (libvirt)
 
-Kernel-based Virtual Machines (KVMs) use an open source virtualization daemon and API called `libvirt` running on {RHEL}.
-{Project} can connect to the `libvirt` API on a KVM server, provision hosts on the hypervisor, and control certain virtualization functions.
+{Project} can connect to the `libvirt` API on the hypervisor to provision hosts and control certain virtualization functions.
 
 Only Virtual Machines created through {Project} can be managed.
 Virtual Machines with other than directory storage pool types are unsupported.

--- a/guides/common/modules/proc_adding-openstack-connection.adoc
+++ b/guides/common/modules/proc_adding-openstack-connection.adoc
@@ -7,11 +7,15 @@ You can add {OpenStack} as a compute resource in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-openstack-connection_{context}[].
 
 .Procedure
-
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
 . Click *Create Compute Resource*.
 . In the *Name* field, enter a name for the new compute resource.
+ifdef::satellite[]
 . From the *Provider* list, select *RHEL OpenStack Platform*.
+endif::[]
+ifndef::satellite[]
+. From the *Provider* list, select *OpenStack*.
+endif::[]
 . Optional: In the *Description* field, enter a description for the compute resource.
 . In the *URL* field, enter the URL for the OpenStack Authentication keystone service's API at the `tokens` resource, such as `\http://openstack.example.com:5000/v2.0/tokens` or `\http://openstack.example.com:5000/v3/auth/tokens`.
 . In the *Username* and *Password* fields, enter the user authentication for {Project} to access the environment.

--- a/guides/common/modules/proc_cloning-satellite-server.adoc
+++ b/guides/common/modules/proc_cloning-satellite-server.adoc
@@ -174,7 +174,7 @@ After you install the `satellite-clone` tool, you can adjust any configuration t
 . Reconfigure DHCP, DNS, TFTP, and remote execution services.
 The cloning process disables these services on the target {ProjectServer} to avoid conflict with the source {ProjectServer}.
 . Reconfigure and enable DHCP, DNS, and TFTP in the {ProjectWebUI}.
-For more information, see {InstallingServerDocURL}configuring-external-services[Configuring External Services on {ProjectServer}] in _{InstallingServerDocTitle}_.
+For more information, see {IntegratingProvisioningInfrastructureServicesDocURL}[{IntegratingProvisioningInfrastructureServicesDocTitle}].
 . Log in to the {ProjectWebUI}, with the username `admin` and the password `changeme`.
 Immediately update the admin password to secure credentials.
 . Ensure that the correct organization is selected.

--- a/guides/common/modules/proc_creating-image-only-hosts.adoc
+++ b/guides/common/modules/proc_creating-image-only-hosts.adoc
@@ -12,7 +12,9 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-image-on
 include::snip_steps-create-a-host-tab-host.adoc[]
 . From the *Deploy on* list, select the {CRname} connection.
 . From the *Compute Profile* list, select a profile to use to automatically populate virtual machine settings.
+ifdef::katello,orcharhino,satellite[]
 . From the *Lifecycle Environment* list, select the environment.
+endif::[]
 include::snip_steps-create-a-host-tab-interfaces.adoc[]
 . Click the *Operating System* tab, and confirm that all fields automatically contain values.
 ifdef::openstack-provisioning[. If you want to change the image that populates automatically from your compute profile, from the *Images* list, select a different image to base the new host's root volume on.]

--- a/guides/common/modules/proc_installing-vmware-plugin.adoc
+++ b/guides/common/modules/proc_installing-vmware-plugin.adoc
@@ -7,7 +7,7 @@ Install the VMware plugin to attach the VMware compute resource provider to {Pro
 You can use the VMware provider to manage and deploy hosts to VMware.
 
 .Procedure
-. Install the VMware compute resource provider on your {ProjectServer}:
+* Install the VMware compute resource provider on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
+++ b/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
@@ -7,7 +7,9 @@ Perform these steps to provision hosts running Ubuntu 20.04.3+ or Ubuntu 22.04.
 
 .Prerequisites
 * Ensure you have configured your {SmartProxyServers} for provisioning.
-For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for Host Registration and Provisioning] in _{InstallingSmartProxyDocTitle}_.
+ifdef::katello,orcharhino,satellite[]
+For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for host registration and provisioning] in _{InstallingSmartProxyDocTitle}_.
+endif::[]
 
 .Procedure
 . Provide the extracted ISO and ISO image itself on each {SmartProxyServer}.

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -11,11 +11,13 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 * Libvirt
 
 .Prerequisites
-* You must have a virtual machine created by {Project}.
+* You have a virtual machine created by {Project}.
 * For existing virtual machines, ensure that the *Display type* in the *Compute Resource* settings is *VNC*.
-* You must import the Katello root CA certificate into your {ProjectServer}.
+* You have imported the CA certificate used for {Project} into your browser.
 Adding a security exception in the browser is not enough for using noVNC.
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate[Installing the Katello root CA certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
+ifdef::katello,orcharhino,satellite[]
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate[Importing the Katello root CA certificate] in _{ConfiguringUserAuthenticationDocTitle}_.
+endif::[]
 
 .Procedure
 . On your {ProjectServer}, configure the firewall to allow VNC service on ports 5900 to 5930.

--- a/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
+++ b/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
@@ -9,9 +9,11 @@ The following list provides an overview of the permissions a non-admin user requ
 |===
 |Resource name|Permissions|Additional details
 
+ifdef::katello,orcharhino,satellite[]
 |Activation Keys
 |view_activation_keys
 |
+endif::[]
 
 |Ansible role
 |view_ansible_roles

--- a/guides/common/modules/snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
+++ b/guides/common/modules/snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
@@ -4,5 +4,7 @@
 ====
 It is essential to add your {SmartProxyServer} to the list of trusted proxies on {ProjectServer}!
 ====
+ifdef::katello,orcharhino,satellite[]
 +
-For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for Host Registration and Provisioning] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-for-host-registration-and-provisioning_{smart-proxy-context}[Configuring {SmartProxy} for host registration and provisioning] in _{InstallingSmartProxyDocTitle}_.
+endif::[]

--- a/guides/doc-Provisioning_Hosts/master.adoc
+++ b/guides/doc-Provisioning_Hosts/master.adoc
@@ -5,12 +5,6 @@ include::common/header.adoc[]
 
 = {ProvisioningDocTitle}
 
-// This guide is not ready for stable releases
-ifdef::HideDocumentOnStable[]
-include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-ifndef::HideDocumentOnStable[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
@@ -70,4 +64,3 @@ include::common/modules/ref_host-parameter-hierarchy.adoc[leveloffset=+1]
 
 [appendix]
 include::common/modules/ref_permissions-required-to-provision-hosts.adoc[leveloffset=+1]
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Make "Provisioning Hosts" fit for all build flavours

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The guide was not officially ready yet for Foreman on Debian/Ubuntu and Foreman on EL.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
