### PR TITLE
Clarify required OS content of remote web servers

### DIFF
--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -21,10 +21,13 @@ endif::[]
 ifndef::orcharhino[]
 For more information about configuring a web server, see {RHELDocsBaseURL}9/html/deploying_web_servers_and_reverse_proxies/setting-apache-http-server_deploying-web-servers-and-reverse-proxies[Setting up the Apache HTTP web server] in {RHEL}{nbsp}9 _Deploying web servers and reverse proxies_.
 endif::[]
+ifdef::orcharhino[]
+* Your HTTP server consumes the same content as {SmartProxies}.
+endif::[]
 
 .Procedure
 ifdef::katello[]
-. On your server, enable the required repositories:
+. On your HTTP server, enable the required repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -34,7 +37,7 @@ ifdef::katello[]
 ----
 endif::[]
 ifdef::satellite[]
-. On your server, enable the required repositories:
+. On your HTTP server, enable the required repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Rephrase "server" to "HTTP server" to help differentiate between Foreman Server, hosts (sometimes also called "servers" by users) and the required HTTP server.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To install "pulp-manifest" on EL9, you need to consume the same content that orcharhino Proxy Servers consume.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Alternative wording: "web server".

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
