### PR TITLE
Fix ribbon layering

### DIFF
--- a/web/content/css/_ribbon.scss
+++ b/web/content/css/_ribbon.scss
@@ -32,7 +32,7 @@ SOFTWARE.
   overflow: hidden;
   top: 70px;
   right: 0;
-  z-index: 9999;
+  z-index: 9998;
   pointer-events: none;
   font-size: 13px;
   text-decoration: none;


### PR DESCRIPTION
#### What changes are you introducing?

Decreasing z-index for the "pre-release" and "unsuppored release" diagonal ribbon

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The default z-index puts the ribbon in front of the expanded menu, which shouldn't happen

<img width="499" height="324" alt="image" src="https://github.com/user-attachments/assets/d35e4092-ee63-4b8d-92fa-c183122f0f0c" />

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Follows up on #3653 
- The z-index of the navigation menu is 9999, therefore 9998 for the ribbon should suffice.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **Not sure**

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
