### PR TITLE
Add banner for unsupported and pre-release to 3.13

### DIFF
--- a/guides/common/header.adoc
+++ b/guides/common/header.adoc
@@ -10,6 +10,13 @@ endif::[]
 ifeval::["{DocState}" == "nightly"]
 :revnumber: Nightly
 :revdate: published {date_my}
+++++
+<!-- "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License -->
+<!-- https://github.com/simonwhitaker/github-fork-ribbon-css -->
+<a class="github-fork-ribbon right-top fixed" data-ribbon="Pre-release version" title="Pre-release version">
+Pre-release version
+</a>
+++++
 endif::[]
 ifeval::["{DocState}" == "stable"]
 :revnumber: {ProjectVersion}
@@ -18,4 +25,11 @@ endif::[]
 ifeval::["{DocState}" == "unsupported"]
 :revnumber: {ProjectVersion} (unsupported)
 :revdate: published {date_mdy}
+++++
+<!-- "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License -->
+<!-- https://github.com/simonwhitaker/github-fork-ribbon-css -->
+<a class="github-fork-ribbon right-top fixed" href="https://docs.theforeman.org" data-ribbon="Unsupported version" title="Unsupported version">
+Unsupported version
+</a>
+++++
 endif::[]

--- a/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
+++ b/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
@@ -7,9 +7,13 @@ include::common/header.adoc[]
 = {ConfiguringVMSubscriptionsDocTitle}
 
 ifdef::foreman-deb[]
+== Katello plugin required
+
 You cannot use the virt-who plugin because it requires the Katello plugin, which is not supported on Debian or Ubuntu.
 endif::[]
 ifdef::foreman-el[]
+== Katello plugin required
+
 You cannot use the virt-who plugin without the Katello plugin.
 endif::[]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -6,12 +6,16 @@ include::common/header.adoc[]
 = {ContentManagementDocTitle}
 
 ifdef::foreman-deb[]
+== Katello plugin required
+
 The Katello plugin required to manage content in Foreman is not supported for {Project} on {DL}.
 
 With {Project} and Katello on {EL}, you can provide content to hosts running {DL}.
 endif::[]
 
 ifdef::foreman-el,foreman-deb[]
+== Katello plugin required
+
 If you want to manage content using Foreman/Katello, you have to run Foreman/Katello on {EL}.
 Converting an existing Foreman installation on {EL} to Foreman/Katello is not supported.
 For more information, see {BaseURL}Installing_Server/index-katello.html[Installing Foreman Server with Katello plugin on {EL}].

--- a/guides/doc-Managing_Security_Compliance/master.adoc
+++ b/guides/doc-Managing_Security_Compliance/master.adoc
@@ -6,6 +6,8 @@ include::common/header.adoc[]
 = {ManagingSecurityDocTitle}
 
 ifdef::foreman-deb[]
+== Unavailable for Debian/Ubuntu
+
 This feature is not available for {Project} on {DL}.
 // Because we don't package foreman_openscap for Debian
 endif::[]

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -6,6 +6,8 @@ include::common/header.adoc[]
 
 // This guide is Katello specific, in particular the diagrams
 ifdef::foreman-el,foreman-deb[]
+== Katello plugin required
+
 include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 ifndef::foreman-el,foreman-deb[]
@@ -15,7 +17,7 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 endif::[]
 
 [id="Project_Overview_and_Concepts_{context}"]
-= {Project} overview and concepts
+== {Project} overview and concepts
 
 {ProjectName} is a centralized tool for provisioning, remote management, and monitoring of multiple {EL} deployments.
 With {Project}, you can deploy, configure, and maintain your systems across physical, virtual, and cloud environments.
@@ -33,7 +35,7 @@ include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1
 include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]
 
 [[part-Deployment_Planning]]
-= {Project} deployment planning
+== {Project} deployment planning
 
 include::topics/Deployment_Scenarios.adoc[]
 

--- a/web/content/css/_ribbon.scss
+++ b/web/content/css/_ribbon.scss
@@ -1,0 +1,146 @@
+/*!
+* "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License
+* https://github.com/simonwhitaker/github-fork-ribbon-css
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Simon Whitaker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+.github-fork-ribbon {
+  width: 12.1em;
+  height: 12.1em;
+  position: absolute;
+  overflow: hidden;
+  top: 70px;
+  right: 0;
+  z-index: 9999;
+  pointer-events: none;
+  font-size: 13px;
+  text-decoration: none;
+  text-indent: -999999px;
+}
+
+.github-fork-ribbon.fixed {
+  position: fixed;
+}
+
+.github-fork-ribbon:hover, .github-fork-ribbon:active {
+  background-color: rgba(0, 0, 0, 0.0);
+}
+
+.github-fork-ribbon:before, .github-fork-ribbon:after {
+  /* The right and left classes determine the side we attach our banner to */
+  position: absolute;
+  display: block;
+  width: 15.38em;
+  height: 1.54em;
+
+  top: 3.23em;
+  right: -3.23em;
+
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.github-fork-ribbon:before {
+  content: "";
+
+  /* Add a bit of padding to give some substance outside the "stitching" */
+  padding: .38em 0;
+
+  /* Set the base colour */
+  background-color: #a00;
+
+  /* Set a gradient: transparent black at the top to almost-transparent black at the bottom */
+  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.15)));
+  background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+
+  /* Add a drop shadow */
+  -webkit-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+
+  pointer-events: auto;
+}
+
+.github-fork-ribbon:after {
+  /* Set the text from the data-ribbon attribute */
+  content: attr(data-ribbon);
+
+  /* Set the text properties */
+  color: #fff;
+  font: 700 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.54em;
+  text-decoration: none;
+  text-shadow: 0 -.08em rgba(0, 0, 0, 0.5);
+  text-align: center;
+  text-indent: 0;
+
+  /* Set the layout properties */
+  padding: .15em 0;
+  margin: .15em 0;
+
+  /* Add "stitching" effect */
+  border-width: .08em 0;
+  border-style: dotted;
+  border-color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.github-fork-ribbon.left-top, .github-fork-ribbon.left-bottom {
+  right: auto;
+  left: 0;
+}
+
+.github-fork-ribbon.left-bottom, .github-fork-ribbon.right-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after {
+  right: auto;
+  left: -3.23em;
+}
+
+.github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  top: auto;
+  bottom: 3.23em;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}

--- a/web/content/css/_ribbon.scss
+++ b/web/content/css/_ribbon.scss
@@ -32,7 +32,7 @@ SOFTWARE.
   overflow: hidden;
   top: 70px;
   right: 0;
-  z-index: 9999;
+  z-index: 9998;
   pointer-events: none;
   font-size: 13px;
   text-decoration: none;

--- a/web/content/css/default.scss
+++ b/web/content/css/default.scss
@@ -1,3 +1,4 @@
 @import "asciidoc";
 @import "nav";
+@import "ribbon";
 @import "site";


### PR DESCRIPTION
#### What changes are you introducing?

Adding the banner for unsupported and pre-release versions to 3.13.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/3653

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
