### PR TITLE
Fix example URL for multiple CV envs

### DIFF
--- a/guides/common/assembly_managing-content-view-environments.adoc
+++ b/guides/common/assembly_managing-content-view-environments.adoc
@@ -6,20 +6,7 @@ include::modules/con_content-view-environments-overview.adoc[leveloffset=+1]
 
 include::modules/con_content-view-environment-categories.adoc[leveloffset=+1]
 
-ifdef::satellite[]
-:example-repo-id: satellite-client-6-for-rhel-9-x86_64-rpms
-:example-repo-name: Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs)
-:example-repo-url: https://{foreman-example-com}/pulp/content/_My_Organization_/Library/cv1/content/dist/layered/rhel9/x86_64/_My_Product_/_My_Repository_ID_/os
-endif::[]
-ifndef::satellite[]
-:example-repo-id: {project-context}-client
-:example-repo-name: {Project} Client
-:example-repo-url: https://{foreman-example-com}/pulp/content/_My_Organization_/Library/cv1/content/dist/layered/{project-context}-client/x86_64/_My_Product_/_My_Repository_ID_/os
-endif::[]
 include::modules/con_content-view-environment-ordering-and-priority.adoc[leveloffset=+1]
-:!example-repo-id:
-:!example-repo-name:
-:!example-repo-url:
 
 include::modules/proc_assigning-content-view-environments-to-hosts.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
+++ b/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
@@ -3,6 +3,15 @@
 [id="content-view-environment-ordering-and-priority"]
 = Content view environment ordering and priority
 
+ifdef::satellite[]
+:example-repo-id: satellite-client-6-for-rhel-9-x86_64-rpms
+:example-repo-name: Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs)
+endif::[]
+ifndef::satellite[]
+:example-repo-id: {project-context}-client
+:example-repo-name: {Project} Client
+endif::[]
+
 The order of content view environments assigned to a host or activation key determines content priority.
 During host registration, an activation key assigns content view environments in the order in which they are stored.
 
@@ -15,6 +24,7 @@ Content view environment order is critical when repository conflicts occur.
 A repository conflict occurs when multiple content view environments contain a repository with the same label.
 For example:
 A host assigned to the content view environments `Library/cv1, dev/cv1` uses the following configuration:
+
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ hammer host update \
@@ -22,15 +32,18 @@ $ hammer host update \
 --name "{server-example-com}" \
 --organization-id _My_Organization_ID_
 ----
+
 Both content view environments include the `{example-repo-id}` repository.
 Log in as a `root` user, then run `subscription-manager repos` to inspect the available repositories on the host. 
 The output reflects the `Library/cv1` content view environment:
+
 [options="nowrap" subs="+quotes"]
 ----
 # subscription-manager repos
 ----
 
 This results in the following output:
+
 [source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 +----------------------------------------------------------+
@@ -38,9 +51,15 @@ This results in the following output:
 +----------------------------------------------------------+
 Repo ID:   {example-repo-id}
 Repo Name: {example-repo-name}
-Repo URL:  {example-repo-url}
+ifdef::satellite[]
+Repo URL:  https://{foreman-example-com}/pulp/content/_My_Organization_/Library/cv1/content/dist/layered/rhel9/x86_64/_My_Product_/_My_Repository_ID_/os
+endif::[]
+ifndef::satellite[]
+Repo URL:  https://{foreman-example-com}/pulp/content/_My_Organization_/Library/cv1/content/dist/layered/{project-context}-client/x86_64/_My_Product_/_My_Repository_ID_/os
+endif::[]
 Enabled:   0
 ----
+
 [NOTE]
 ====
 The `Repo URL` reflects the `Library/cv1` content view environment, meaning the system uses content from `Library/cv1` and ignores `dev/cv1`.
@@ -49,6 +68,7 @@ The `Repo URL` reflects the `Library/cv1` content view environment, meaning the 
 .Reordering content view environments
 To change priority, reorder the content view environments.
 To prioritize `dev/cv1` over `Library/cv1`, update the host settings:
+
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ hammer host update \
@@ -56,13 +76,16 @@ $ hammer host update \
 --name "{server-example-com}" \
 --organization-id _My_Organization_ID_
 ----
+
 After reordering, inspecting the repositories again shows the `dev/cv1` content view environment:
+
 [options="nowrap" subs="+quotes"]
 ----
 # subscription-manager repos
 ----
 
 This results in the following output:
+
 [source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 +----------------------------------------------------------+
@@ -70,7 +93,16 @@ This results in the following output:
 +----------------------------------------------------------+
 Repo ID:   {example-repo-id}
 Repo Name: {example-repo-name}
-Repo URL:  {example-repo-url}
+ifdef::satellite[]
+Repo URL:  https://{foreman-example-com}/pulp/content/_My_Organization_/dev/cv1/content/dist/layered/rhel9/x86_64/_My_Product_/_My_Repository_ID_/os
+endif::[]
+ifndef::satellite[]
+Repo URL:  https://{foreman-example-com}/pulp/content/_My_Organization_/dev/cv1/content/dist/layered/{project-context}-client/x86_64/_My_Product_/_My_Repository_ID_/os
+endif::[]
 Enabled:   0
 ----
+
 The `Repo URL` now reflects the `dev/cv1` content view environment, meaning the system uses content from `dev/cv1` and ignores `Library/cv1`.
+
+:!example-repo-id:
+:!example-repo-name:


### PR DESCRIPTION
#### What changes are you introducing?

This patch moves the attributes for the examples in "Content view environment ordering and priority" from the assembly to the module. This is required to show the correct example URL for the second example that reorderes the content view environments on a host.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Refs PR #3609

See https://docs.theforeman.org/nightly/Managing_Content/index-katello.html#content-view-environment-ordering-and-priority -> the code blocks do not match the note/explanations that follow.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Relates to #4099

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
