### PR TITLE
Split off Ansible procedures into separate modules

### DIFF
--- a/guides/common/assembly_building-cloud-images.adoc
+++ b/guides/common/assembly_building-cloud-images.adoc
@@ -10,6 +10,8 @@ include::modules/proc_configuring-a-host-for-registration.adoc[leveloffset=+1]
 
 include::modules/proc_registering-a-host.adoc[leveloffset=+1]
 
+include::modules/proc_registering-a-host-using-ansible.adoc[leveloffset=+1]
+
 include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]
 
 ifdef::satellite[]

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -17,6 +17,8 @@ include::modules/proc_configuring-a-host-for-registration.adoc[leveloffset=+2]
 
 include::modules/proc_registering-a-host.adoc[leveloffset=+2]
 
+include::modules/proc_registering-a-host-using-ansible.adoc[leveloffset=+2]
+
 include::modules/proc_customizing-host-registration-by-using-snippets.adoc[leveloffset=+2]
 
 include::modules/proc_customizing-the-registration-templates.adoc[leveloffset=+2]

--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -12,6 +12,8 @@ include::modules/proc_synchronizing-templates-with-a-local-directory.adoc[levelo
 
 include::modules/proc_importing-templates.adoc[leveloffset=+1]
 
+include::modules/proc_importing-templates-using-ansible.adoc[leveloffset=+1]
+
 include::modules/proc_exporting-templates.adoc[leveloffset=+1]
 
 ifndef::satellite[]

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -46,6 +46,7 @@
 :apache-log-dir: httpd
 :ansible-collection-package: ansible-collection-theforeman-foreman
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
+:ansible-galaxy-doc: https://docs.ansible.com/ansible/latest/collections/theforeman/foreman
 :ansible-docs-url: https://theforeman.github.io/foreman-ansible-modules/develop/index.html
 :ansible-galaxy-name: Ansible Galaxy
 :ansible-namespace: theforeman.foreman

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -46,7 +46,6 @@
 :apache-log-dir: httpd
 :ansible-collection-package: ansible-collection-theforeman-foreman
 :ansible-galaxy: https://galaxy.ansible.com/theforeman/foreman
-:ansible-galaxy-doc: https://docs.ansible.com/ansible/latest/collections/theforeman/foreman
 :ansible-docs-url: https://theforeman.github.io/foreman-ansible-modules/develop/index.html
 :ansible-galaxy-name: Ansible Galaxy
 :ansible-namespace: theforeman.foreman
@@ -150,6 +149,9 @@
 :SmartProxyServer: {SmartProxy}{nbsp}server
 :SmartProxyServers: {SmartProxyServer}s
 :Team: {Project} community
+// Ansible documentation
+:ansible-doc-base-url: https://docs.ansible.com/ansible/latest/collections/theforeman/foreman
+:ansible-doc-templates_import: {ansible-doc-base-url}/templates_import_module.html
 // Red Hat Insights
 :insights-iop-id: insights
 :Insights: Insights

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -45,7 +45,6 @@
 // Overrides for satellite build
 :ansible-collection-package: ansible-collection-redhat-satellite
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
-:ansible-galaxy-doc: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/content/module
 :ansible-galaxy-name: Red{nbsp}Hat Ansible Automation Platform
 :ansible-namespace: redhat.satellite
 :ansible-module-defaults-group: {ansible-namespace}.satellite
@@ -131,6 +130,9 @@
 :SmartProxyServer: Capsule{nbsp}Server
 :SmartProxyServers: {SmartProxyServer}s
 :Team: Red{nbsp}Hat
+
+// Ansible documentation
+:ansible-doc-templates_import: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/content/module/templates_import/
 
 // Red Hat Insights rebranded to Red Hat Lightspeed
 :insights-iop-id: red-hat-lightspeed-in-satellite

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -45,6 +45,7 @@
 // Overrides for satellite build
 :ansible-collection-package: ansible-collection-redhat-satellite
 :ansible-galaxy: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/docs
+:ansible-galaxy-doc: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/content/module
 :ansible-galaxy-name: Red{nbsp}Hat Ansible Automation Platform
 :ansible-namespace: redhat.satellite
 :ansible-module-defaults-group: {ansible-namespace}.satellite

--- a/guides/common/modules/proc_importing-templates-using-ansible.adoc
+++ b/guides/common/modules/proc_importing-templates-using-ansible.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="importing-templates-using-ansible"]
+= Importing templates using Ansible
+
+You can import templates from a repository of your choice.
+You can use different protocols to point to your repository, for example `/tmp/dir`, `git://example.com`, `\https://example.com`, and `ssh://example.com`.
+
+.Procedure
+* Use the `{ansible-namespace}.templates_import` module.
+
+.Additional resources
+* For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.templates_import`.

--- a/guides/common/modules/proc_importing-templates-using-ansible.adoc
+++ b/guides/common/modules/proc_importing-templates-using-ansible.adoc
@@ -10,4 +10,9 @@ You can use different protocols to point to your repository, for example `/tmp/d
 * Use the `{ansible-namespace}.templates_import` module.
 
 .Additional resources
-* For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.templates_import`.
+ifdef::satellite[]
+* {ansible-galaxy-doc}/templates_import/[{ansible-namespace}.templates_import module – Sync Templates from a repository]
+endif::[]
+ifndef::satellite[]
+* {ansible-galaxy-doc}/templates_import_module.html[{ansible-namespace}.templates_import module – Sync Templates from a repository]
+endif::[]

--- a/guides/common/modules/proc_importing-templates-using-ansible.adoc
+++ b/guides/common/modules/proc_importing-templates-using-ansible.adoc
@@ -10,9 +10,4 @@ You can use different protocols to point to your repository, for example `/tmp/d
 * Use the `{ansible-namespace}.templates_import` module.
 
 .Additional resources
-ifdef::satellite[]
-* {ansible-galaxy-doc}/templates_import/[{ansible-namespace}.templates_import module – Sync Templates from a repository]
-endif::[]
-ifndef::satellite[]
-* {ansible-galaxy-doc}/templates_import_module.html[{ansible-namespace}.templates_import module – Sync Templates from a repository]
-endif::[]
+* {ansible-doc-templates_import}[{ansible-namespace}.templates_import module – Sync Templates from a repository]

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -38,7 +38,7 @@ To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templat
 
 To use the API, see the xref:api_Importing_Templates_{context}[].
 
-To use Ansible, see the xref:ansible_Importing_Templates_{context}[].
+To use Ansible, see xref:importing-templates-using-ansible[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.
@@ -84,9 +84,3 @@ For example `--filter '.*Ansible Default$'` imports various Ansible Default temp
 ----
 +
 If the import is successful, you receive `{"message":"Success"}`.
-
-[id="ansible_Importing_Templates_{context}"]
-.Ansible procedure
-* Use the `{ansible-namespace}.templates_import` module.
-
-For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.templates_import`.

--- a/guides/common/modules/proc_importing-templates.adoc
+++ b/guides/common/modules/proc_importing-templates.adoc
@@ -12,6 +12,12 @@ The templates provided by {Project} are locked and you cannot import them by def
 To overwrite this behavior, change the `Force import` setting in the *Template Sync* menu to `yes` or add the `force` parameter `-d '{ "force": "true" }'` to the import command.
 ====
 
+To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[].
+
+To use the API, see the xref:api_Importing_Templates_{context}[].
+
+To use Ansible, see xref:importing-templates-using-ansible[].
+
 .Prerequisites
 * Each template must contain the location and organization that the template belongs to.
 This applies to all template types.
@@ -33,12 +39,6 @@ organizations:
 - _My_second_Organization_
 %>
 ----
-
-To use the CLI instead of the {ProjectWebUI}, see the xref:cli_Importing_Templates_{context}[].
-
-To use the API, see the xref:api_Importing_Templates_{context}[].
-
-To use Ansible, see xref:importing-templates-using-ansible[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Sync Templates*.

--- a/guides/common/modules/proc_registering-a-host-using-ansible.adoc
+++ b/guides/common/modules/proc_registering-a-host-using-ansible.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="registering-a-host-using-ansible"]
+= Registering a host using Ansible
+
+You can register a host by using registration templates and set up various integration features and host tools during the registration process.
+
+.Procedure
+* Use the `{ansible-namespace}.registration_command` module.
+
+.Additional resources
+* For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.registration_command`.

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -183,11 +183,6 @@ The parameter values must be URL encoded.
 
 For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.
 
-.Ansible procedure
-* Use the `{ansible-namespace}.registration_command` module.
-
-For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.registration_command`.
-
 .API procedure
 * Use the `POST /api/registration_commands` resource.
 


### PR DESCRIPTION
#### What changes are you introducing?

How to split off modules:
* Search for applicable modules: $ rg "^.Ansible procedure"
* Delete the block in the source modules
* Move content to separate procedure $ git diff > _original_module-using-X.adoc # with "X" as "ansible", "cli", or "api"
* Copy over missing header
  * modular docs attribute
  * anchor > add "using-X": Do not use attributes if at all possible
  * title > add "using X"
  * shortest introduction possible (TODO: discuss and reach consensus)
* If you deleted any anchors: search and replace them
* Add module below original procedure to any affected assembly with the same leveloffset (TODO: discuss and reach consensus)
* In your commit message, reference #4083

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Part of #4083

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

**Needs appreciated**, specifically on the two items above.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
