### PR TITLE
correct installer option to connect to libvirt for dns/dhcp

### DIFF
--- a/guides/common/modules/proc_integrating-the-libvirt-api-to-manage-dhcp-leases.adoc
+++ b/guides/common/modules/proc_integrating-the-libvirt-api-to-manage-dhcp-leases.adoc
@@ -17,7 +17,7 @@ With this type of integration, {Project} uses a local or remote `libvirt` API to
 --foreman-proxy-dhcp true \
 --foreman-proxy-dhcp-provider libvirt \
 --foreman-proxy-libvirt-network default \
---foreman-proxy-libvirt-url qemu:///system
+--foreman-proxy-libvirt-connection qemu:///system
 ----
 +
 Note that you can only use one network and URL for both the `dns_libvirt` and `dhcp_libvirt` providers.

--- a/guides/common/modules/proc_integrating-the-libvirt-api-to-manage-dns-records.adoc
+++ b/guides/common/modules/proc_integrating-the-libvirt-api-to-manage-dns-records.adoc
@@ -15,7 +15,7 @@ The integration enables you to continue using `dnsmasq` in `libvirt`, and {Proje
 --foreman-proxy-dns true \
 --foreman-proxy-dns-provider libvirt \
 --foreman-proxy-libvirt-network default \
---foreman-proxy-libvirt-url qemu:///system
+--foreman-proxy-libvirt-connection qemu:///system
 ----
 +
 Note that you can only use one network and URL for both the `dns_libvirt` and `dhcp_libvirt` providers.


### PR DESCRIPTION

#### What changes are you introducing?
correction to foreman-installer option example command replacing obsolete option

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
the foreman-installer option --foreman-proxy-libvirt-url no longers exists making the guide incorrect

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
