### PR TITLE
Fix build errors in Planning

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -35,22 +35,22 @@ include::common/assembly_deployment-path.adoc[leveloffset=+2]
 
 include::common/assembly_common-deployment-scenarios.adoc[leveloffset=+2]
 
-include::common/modules/con_provisioning-requirements.adoc[leveloffset=+1]
+include::common/modules/con_provisioning-requirements.adoc[leveloffset=+2]
 
-include::common/modules/con_pxe-booting.adoc[leveloffset=+2]
+include::common/modules/con_pxe-booting.adoc[leveloffset=+3]
 
-include::common/modules/con_pxe-sequence.adoc[leveloffset=+3]
+include::common/modules/con_pxe-sequence.adoc[leveloffset=+4]
 
-include::common/modules/con_pxe-booting-requirements.adoc[leveloffset=+3]
+include::common/modules/con_pxe-booting-requirements.adoc[leveloffset=+4]
 
-include::common/modules/con_http-booting.adoc[leveloffset=+2]
+include::common/modules/con_http-booting.adoc[leveloffset=+3]
 
-include::common/modules/con_http-booting-requirements-with-managed-dhcp.adoc[leveloffset=+3]
+include::common/modules/con_http-booting-requirements-with-managed-dhcp.adoc[leveloffset=+4]
 
-include::common/modules/con_http-booting-requirements-with-unmanaged-dhcp.adoc[leveloffset=+3]
+include::common/modules/con_http-booting-requirements-with-unmanaged-dhcp.adoc[leveloffset=+4]
 
 ifdef::foreman-el,katello,orcharhino[]
-include::common/modules/con_secure-boot.adoc[leveloffset=+2]
+include::common/modules/con_secure-boot.adoc[leveloffset=+3]
 endif::[]
 
 :!numbered:

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -15,25 +15,25 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/modules/con_foreman-overview-and-concepts.adoc[]
+include::common/modules/con_foreman-overview-and-concepts.adoc[leveloffset=+1]
 
-include::common/assembly_content-and-patch-management-with-project.adoc[leveloffset=+1]
+include::common/assembly_content-and-patch-management-with-project.adoc[leveloffset=+2]
 
-include::common/assembly_provisioning-management-with-project.adoc[leveloffset=+1]
+include::common/assembly_provisioning-management-with-project.adoc[leveloffset=+2]
 
-include::common/assembly_major-project-components.adoc[leveloffset=+1]
+include::common/assembly_major-project-components.adoc[leveloffset=+2]
 
-include::common/assembly_project-infrastructure-organization-concepts.adoc[leveloffset=+1]
+include::common/assembly_project-infrastructure-organization-concepts.adoc[leveloffset=+2]
 
-include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1]
+include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+2]
 
-include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]
+include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+2]
 
-include::common/modules/con_foreman-deployment-planning.adoc[]
+include::common/modules/con_foreman-deployment-planning.adoc[leveloffset=+1]
 
-include::common/assembly_deployment-path.adoc[leveloffset=+1]
+include::common/assembly_deployment-path.adoc[leveloffset=+2]
 
-include::common/assembly_common-deployment-scenarios.adoc[leveloffset=+1]
+include::common/assembly_common-deployment-scenarios.adoc[leveloffset=+2]
 
 include::common/modules/con_provisioning-requirements.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

Adjusting leveloffset values in master.adoc for Planning.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Cherry-picking https://github.com/theforeman/foreman-documentation/pull/4098 to 3.14 broke the build because in order for a ribbon to be displayed, all content needs to have a heading of the appropriate level. On 3.14, there are currently multiple 0-level headings.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
