### PR TITLE
Also include H4s when generating TOC

### DIFF
--- a/guides/scripts/extract_links_toc
+++ b/guides/scripts/extract_links_toc
@@ -25,7 +25,7 @@ files.each do |file|
   file_toc = document.css('h2').to_h do |chapter|
     [
       chapter['id'].downcase,
-      (chapter.parent.css('h3') + chapter.parent.css('div[id]')).map {|subchapter| subchapter['id']}
+      (chapter.parent.css('h4') + chapter.parent.css('h3') + chapter.parent.css('div[id]')).map {|subchapter| subchapter['id']}
     ]
   end
 


### PR DESCRIPTION
#### What changes are you introducing?
Change the toc extractor to also look at level 4 headings

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Some headings got pushed one level lower and weren't getting picked up when the TOC was being generated.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
The goal is to make https://github.com/RedHatSatellite/foreman_theme_satellite/pull/227 turn green.

We've seen the failure only for 3.14/sat-6.17, but I'd expect to see it all the way until 3.9/sat-6.15. We can either have this in master and cherry-pick it all the way back, or have me reopen this against 3.14 directly and run quite possibly run into the same problem once we start adding the banner to later 3.16.

Related to:
- https://github.com/theforeman/foreman-documentation/pull/4118
- https://github.com/theforeman/foreman-documentation/pull/4115
- https://github.com/theforeman/foreman-documentation/pull/4125

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
