### PR TITLE
Hide various lines for orcharhino builds

### DIFF
--- a/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -9,7 +9,6 @@ As well as providing access to {ProjectServer}, hosts provisioned with {Project}
 Use this section to configure {ProjectServer} or {SmartProxyServer} for {FreeIPA} realm support, then add hosts to the {FreeIPA} realm group.
 
 .Prerequisites
-* {ProjectServer} that is registered to the Content Delivery Network or your {SmartProxyServer} that is registered to {ProjectServer}.
 * A deployed realm or domain provider such as {FreeIPA}.
 
 .To install and configure {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}:

--- a/guides/common/modules/con_package-mode-and-image-mode-hosts.adoc
+++ b/guides/common/modules/con_package-mode-and-image-mode-hosts.adoc
@@ -27,5 +27,7 @@ These fields track the container images used in various scenarios:
 * *Available Image & Digest*: Represents the container image cached by running `bootc upgrade --check`.
 * *Rollback Image & Digest*: Represents the container image the host reverts to after the next reboot if `Bootc rollback` is applied.
 
+ifndef::orcharhino[]
 .Additional resources
 * For more information on image mode, see the https://www.redhat.com/en/blog/image-mode-red-hat-enterprise-linux-quick-start-guide[RHEL Image Mode quick start guide].
+endif::[]

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -11,12 +11,12 @@ This does not use SSH and hosts do not require opening up any incoming firewall 
 * The {SmartProxy} through which the host is registered is configured to use `pull-mqtt` mode.
 For more information, see {InstallingSmartProxyDocURL}configuring-pull-based-transport-for-remote-execution_{smart-proxy-context}[Configuring pull-based transport for remote execution] in _{InstallingSmartProxyDocTitle}_.
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
-ifdef::foreman-el[]
-* The AppStream repository is available for the host.
-endif::[]
-ifndef::foreman-el[]
+ifdef::satellite[]
 * The AppStream repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
+endif::[]
+ifndef::satellite[]
+* Your host has access to the default operating system repositories.
 endif::[]
 * The host can communicate with its {SmartProxy} over MQTT using port `1883`.
 * The host can communicate with its {SmartProxy} over HTTPS using port `{smartproxy_port}`.

--- a/guides/common/modules/ref_registration-methods.adoc
+++ b/guides/common/modules/ref_registration-methods.adoc
@@ -3,7 +3,14 @@
 [id="registration-methods_{context}"]
 = Registration methods
 
-You can use the following methods to register hosts to {Project}:
+You can use the following
+ifdef::orcharhino[]
+method
+endif::[]
+ifndef::orcharhino[]
+methods
+endif::[]
+to register hosts to {Project}:
 
 Global registration::
 You generate a registration command from {Project} and run this command on an unlimited number of hosts to register them by using provisioning templates over the {Project} API.
@@ -24,8 +31,8 @@ endif::[]
 ifndef::orcharhino[]
 *(Deprecated)* Katello CA Consumer::
 You download and install the consumer RPM from `_{foreman-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm` on the host and then run `subscription-manager`.
-endif::[]
 
 *(Deprecated)* Bootstrap script::
 You download the bootstrap script from `_{foreman-example-com}_/pub/bootstrap.py` on the host and then run the script.
 For more information, see xref:Registering_Hosts_by_Using_the_Bootstrap_Script_{context}[].
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Hide links to redhat.com for orcharhino builds
* Reword "AppStream" as required Yum repo on Clients because not all Clients are EL Clients
* Hide bootstrap.py for orcharhino

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
