### PR TITLE
Update link in 'Report issue' ribbon

### DIFF
--- a/guides/common/ribbons.adoc
+++ b/guides/common/ribbons.adoc
@@ -5,7 +5,7 @@ ifeval::["{DocState}" == "nightly"]
 <a class="release-ribbon right-top fixed" data-ribbon="Pre-release version" title="Pre-release version">
 Pre-release version
 </a>
-<a class="issue-ribbon right-bottom fixed" href="https://github.com/theforeman/foreman-documentation/issues/new" data-ribbon="Report issue" title="Report issue">
+<a class="issue-ribbon right-bottom fixed" href="https://github.com/theforeman/foreman-documentation/issues/new?template=report-issue.md" data-ribbon="Report issue" title="Report issue">
 Report issue
 </a>
 ++++
@@ -14,7 +14,7 @@ ifeval::["{DocState}" == "stable"]
 ++++
 <!-- "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License -->
 <!-- https://github.com/simonwhitaker/github-fork-ribbon-css -->
-<a class="issue-ribbon right-bottom fixed" href="https://github.com/theforeman/foreman-documentation/issues/new" data-ribbon="Report issue" title="Report issue">
+<a class="issue-ribbon right-bottom fixed" href="https://github.com/theforeman/foreman-documentation/issues/new?template=report-issue.md" data-ribbon="Report issue" title="Report issue">
 Report issue
 </a>
 ++++


### PR DESCRIPTION
#### What changes are you introducing?

Changing the link in the 'Report issue' ribbon from a link to open a blank issue to a link to open a pre-filled issue template.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To help ensure that when a user reports an issue when reading the documentation, they know what information the docs team needs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
