### PR TITLE
Add 'RC' DocState

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When a commit is pushed into `X.Y`:
 * On `master`, pull the latest changes and create a new `X.Y` branch.
 * On the `X.Y` branch:
   * Update `guides/common/attributes.adoc`.
-    * Set `DocState` to `unsupported`.
+    * Set `DocState` to `RC`.
     * Set `ProjectVersion` to `X.Y` and set the matching `KatelloVersion`.
   * Push into the `X.Y` branch.
   * Notify the Doc team on the [TheForeman Doc chat](https://matrix.to/#/#theforeman-doc:matrix.org) Matrix channel.

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,5 +1,8 @@
-// Document state: "nightly" for master, "stable" for last two releases,
-// "unsupported" for the rest and "satellite" for satellite build
+// Document state: "nightly" for master,
+// "RC" for release candidate,
+// "stable" for the last two (supported) releases,
+// "unsupported" for the rest,
+// "satellite" for satellite build
 :DocState: nightly
 
 // Version numbers

--- a/guides/common/header.adoc
+++ b/guides/common/header.adoc
@@ -11,6 +11,10 @@ ifeval::["{DocState}" == "nightly"]
 :revnumber: Nightly
 :revdate: published {date_my}
 endif::[]
+ifeval::["{DocState}" == "RC"]
+:revnumber: {ProjectVersion} (release candidate)
+:revdate: published {date_my}
+endif::[]
 ifeval::["{DocState}" == "stable"]
 :revnumber: {ProjectVersion}
 :revdate: published {date_mdy}

--- a/guides/common/ribbons.adoc
+++ b/guides/common/ribbons.adoc
@@ -10,6 +10,18 @@ Report issue
 </a>
 ++++
 endif::[]
+ifeval::["{DocState}" == "RC"]
+++++
+<!-- "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License -->
+<!-- https://github.com/simonwhitaker/github-fork-ribbon-css -->
+<a class="release-ribbon right-top fixed" data-ribbon="Release candidate" title="Release candidate">
+Pre-release version
+</a>
+<a class="issue-ribbon right-bottom fixed" href="https://github.com/theforeman/foreman-documentation/issues/new" data-ribbon="Report issue" title="Report issue">
+Report issue
+</a>
+++++
+endif::[]
 ifeval::["{DocState}" == "stable"]
 ++++
 <!-- "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License -->


### PR DESCRIPTION
#### What changes are you introducing?

Introducing the 'RC' document state, in addition to the existing 'nightly', 'supported', and 'unsupported' states.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The https://docs.theforeman.org/ website lists:

* "Supported releases"
* "Pre-release versions"

and it also mentions:

* "Unsupported releases", from which users are recommended to update to a supported release.

Based on this, we shouldn't label release candidate documentation as "unsupported" because the website lists it as "pre-release" and also, users can't update to a supported version from a release candidate.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

https://github.com/theforeman/foreman-documentation/pull/4157 is there to make the change on 3.16, the current release candidate.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
