### PR TITLE
Add missing CSS for ribbons

### DIFF
--- a/web/content/css/_ribbon.scss
+++ b/web/content/css/_ribbon.scss
@@ -144,3 +144,17 @@ SOFTWARE.
   -o-transform: rotate(-45deg);
   transform: rotate(-45deg);
 }
+
+.release-ribbon {
+  @extend .github-fork-ribbon;
+  &:before {
+    background-color: #a00;
+  }
+}
+
+.issue-ribbon {
+  @extend .github-fork-ribbon;
+  &:before {
+    background-color: #025d8c;
+  }
+}


### PR DESCRIPTION
#### What changes are you introducing?

Adding a missing style definition for ribbons.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/4147 and its equivalents on the lower branches, I forgot to add a few lines of the CSS definitions for the ribbons. This currently manifests on 3.13-3.9 guides as the "Unsupported version" ribbon being displayed not as a ribbon, but as a plain link at the bottom of each guide:

<img width="858" height="213" alt="Screenshot From 2025-08-13 18-48-29" src="https://github.com/user-attachments/assets/fe60357d-7e82-4d3f-b715-3d37ae201e71" />

This PR should ensure that the style definitions are loaded correctly and the link is displayed as a ribbon again.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
