### PR TITLE
Add Katello 4.18 documentation

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,9 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+ifdef::katello[]
+include::topics/katello-4.18.0.adoc[leveloffset=+1]
+endif::[]
 
 [appendix]
 [id="foreman-contributors"]

--- a/guides/doc-Release_Notes/topics/katello-4.18.0.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.18.0.adoc
@@ -1,0 +1,94 @@
+= Katello 4.18.0
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=1943[Redmine]
+
+== Katello
+
+* pass:[Remove foreman settings from Katello tests] - https://projects.theforeman.org/issues/38548[#38548]
+* pass:[Async Repository::CapsuleSync tasks that don't find any relevant proxies to sync sometimes end up in failing state] - https://projects.theforeman.org/issues/38546[#38546]
+* pass:[IPv6 addresses in HTTP proxy URL breaks CDN content retrieval] - https://projects.theforeman.org/issues/38545[#38545]
+* pass:[Remove settingActions from Katello] - https://projects.theforeman.org/issues/38490[#38490]
+* pass:[Remove @theforeman/vendor-dev] - https://projects.theforeman.org/issues/38431[#38431]
+
+=== Container
+
+* pass:[Flatpak - Install REX job run hangs for 10 minutes] - https://projects.theforeman.org/issues/38638[#38638]
+* pass:[Handle permissions correctly on flatpak UI + UX feedback] - https://projects.theforeman.org/issues/38621[#38621]
+* pass:[Remove "seeded" and "organization_id" from Flatpak remote search bar proposals] - https://projects.theforeman.org/issues/38617[#38617]
+* pass:[Add mirror action with a small form that selects product to mirror into] - https://projects.theforeman.org/issues/38537[#38537]
+* pass:[Add a Remote details page with a table for scanned remote repositories] - https://projects.theforeman.org/issues/38489[#38489]
+* pass:[Second container push set manifest size fields to -1, which breaks bootc] - https://projects.theforeman.org/issues/38488[#38488]
+* pass:[REX job template: As a user, I can easily setup certs in the /etc/containers/certs.d/hostname/ directory] - https://projects.theforeman.org/issues/38457[#38457]
+* pass:[Global Registration: As a user, I can easily setup certs in the /etc/containers/certs.d/hostname/ directory] - https://projects.theforeman.org/issues/38455[#38455]
+* pass:[Implement cert auth for flatpak index] - https://projects.theforeman.org/issues/38421[#38421]
+* pass:[Organization-label can break container image sync] - https://projects.theforeman.org/issues/38269[#38269]
+
+=== Content uploads
+
+* pass:[When importing content in disconnected Satellite in syncable format via hammer, hammer content-import list is empty] - https://projects.theforeman.org/issues/38494[#38494]
+* pass:[Accept "real" file uploads to /katello/api/repositories/:repository_id/content_uploads/:id] - https://projects.theforeman.org/issues/38482[#38482]
+
+=== Content views
+
+* pass:[Incremental CCV updates all CV versions] - https://projects.theforeman.org/issues/38484[#38484]
+* pass:[When creating a rolling content view with repository_ids no rolling repo clones are created] - https://projects.theforeman.org/issues/38413[#38413]
+* pass:[Disallow pushing containers to rolling content views] - https://projects.theforeman.org/issues/38285[#38285]
+
+=== Errata management
+
+* pass:[Web UI shows incorrect host count when applying an erratum] - https://projects.theforeman.org/issues/38550[#38550]
+* pass:['Install Selected via remote execution – customize first' installs all available errata for the host collection] - https://projects.theforeman.org/issues/38483[#38483]
+* pass:[Allow for scoped search of 'other' errata types] - https://projects.theforeman.org/issues/38135[#38135]
+
+=== {SmartProxy} content
+
+* pass:[Code is not reloadable] - https://projects.theforeman.org/issues/38578[#38578]
+* pass:[Cert auth for capsule - Maintain host-repo mapping on capsule] - https://projects.theforeman.org/issues/38514[#38514]
+* pass:[Silent failure when triggering a CapsuleSync using a user without the manage_capsule_content permission] - https://projects.theforeman.org/issues/38406[#38406]
+* pass:[Point to main RHSM URL when rhsm_url is empty on Pulp Smart Proxies] - https://projects.theforeman.org/issues/38364[#38364]
+
+=== Hosts
+
+* pass:[Post 4.15 upgrade katello is affected with high CPU usage and Actions::Katello::Applicability::Hosts::BulkGenerate tasks getting stuck] - https://projects.theforeman.org/issues/38576[#38576]
+* pass:[After installing a package via the --transient flag on an image mode host, any template that uses bootc usr-overlay will fail to perform package actions] - https://projects.theforeman.org/issues/38508[#38508]
+* pass:[Katello 4.16 upgrade fails with ERROR:  duplicate key value violates unique constraint "index_katello_installed_packages_on_nvrea"] - https://projects.theforeman.org/issues/38504[#38504]
+* pass:[subscription-manager environments --set raises Forbidden error until the user is Admin] - https://projects.theforeman.org/issues/38448[#38448]
+* pass:[As a user I want to be able to change the location and organization of multiple hosts] - https://projects.theforeman.org/issues/38436[#38436]
+* pass:[Add bulk Repository Sets wizard to new All Hosts page] - https://projects.theforeman.org/issues/38353[#38353]
+
+=== Localization
+
+* pass:[Drop redundant gettext_i18n_rails dependency] - https://projects.theforeman.org/issues/38430[#38430]
+
+=== Repositories
+
+* pass:[HTTP should be allowed on Flatpak remote creation and application name should be displayed for remote repository] - https://projects.theforeman.org/issues/38634[#38634]
+* pass:[Add flatpak remote actions to Remote details page] - https://projects.theforeman.org/issues/38596[#38596]
+* pass:[Add a scan action on the flatpak remote table] - https://projects.theforeman.org/issues/38595[#38595]
+* pass:[Prevent unintentional password updates in empty edit forms] - https://projects.theforeman.org/issues/38593[#38593]
+* pass:[Add edit action to flatpak remotes page] - https://projects.theforeman.org/issues/38590[#38590]
+* pass:[ERROR:  nextval: reached maximum value of sequence "katello_erratum_packages_id_seq"  during concurrent repository sync plan executions] - https://projects.theforeman.org/issues/38497[#38497]
+* pass:[Do not delete candlepin content when deleting a rolling repo clone of a structured apt deb repository] - https://projects.theforeman.org/issues/38440[#38440]
+* pass:[Create option for default repository mirroring behavior] - https://projects.theforeman.org/issues/38433[#38433]
+
+=== Subscriptions
+
+* pass:[ remove react-ellipsis-with-tooltip in katello] - https://projects.theforeman.org/issues/38602[#38602]
+
+=== Tests
+
+* pass:[Update CP VCR's for 4.6.3-1] - https://projects.theforeman.org/issues/38618[#38618]
+* pass:[Make the new host overview page default] - https://projects.theforeman.org/issues/38555[#38555]
+
+=== Tooling
+
+* pass:[Fix JS snapshots after scalprum addition in Foreman] - https://projects.theforeman.org/issues/38577[#38577]
+
+=== Web UI
+
+* pass:[Support delete action on the remote table row] - https://projects.theforeman.org/issues/38588[#38588]
+* pass:[Fix plurality of React UI elements on the new Host details -> Content page] - https://projects.theforeman.org/issues/38476[#38476]
+* pass:[Errata page displays 'Apply Errata' even when one erratum is selected] - https://projects.theforeman.org/issues/38466[#38466]
+* pass:[Create a page with a table listing flatpak remotes in an organization.] - https://projects.theforeman.org/issues/38385[#38385]
+* pass:[move css import from vendor to foreman] - https://projects.theforeman.org/issues/37910[#37910]
+* pass:[Change content source JS console error: Cannot update a component ('ConnectFunction') while rendering a different component ('Context.Consumer')] - https://projects.theforeman.org/issues/37256[#37256]

--- a/guides/doc-Release_Notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/katello-contributors.adoc
@@ -1,0 +1,17 @@
+We’d like to thank the following people who contributed to the Katello 4.18 release:
+
+Chyenne Ross,
+Ewoud Kohl van Wijngaarden,
+Hao Chang Yu,
+Ian Ballou,
+Jeremy Lenz,
+Jonathon Turel,
+Lucy Fu,
+Lukas Jezek,
+Maria,
+Pavan Soma Shekar,
+Quinn James,
+Quirin Pamp,
+and Samir Jha.
+
+As well as all users who helped test releases, report bugs and provide feedback on the project.


### PR DESCRIPTION
#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Add Katello 4.18 documentation to Foreman 3.16 branch

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Working on Headline features for 4.18 documentation.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
