### PR TITLE
Fix content readability issues for planning upgrade

### DIFF
--- a/guides/common/modules/con_planning-project-upgrade.adoc
+++ b/guides/common/modules/con_planning-project-upgrade.adoc
@@ -14,13 +14,12 @@ For information about changes in these tools, see the {ProjectName} {ProjectVers
 endif::[]
 ifdef::satellite[]
 * Optional: You can test the upgrade on a clone of your {ProjectServer}.
-After you successfully test the upgrade on the clone, you can repeat the upgrade on your primary {ProjectServer} and discard the clone, or you can promote the clone to your primary {ProjectServer} and discard the previous primary {ProjectServer}.
+After you successfully test the upgrade on the clone, you can repeat the upgrade on your primary {ProjectServer} and discard the clone.
+Alternately, you can promote the clone to your primary {ProjectServer} and discard the previous primary {ProjectServer}.
 For more information, see {AdministeringDocURL}cloning-{project-context}-server[Cloning {ProjectServer}] in _{AdministeringDocTitle}_.
 endif::[]
-
-{Project} services are shut down during the upgrade.
+* {Project} services are shut down during the upgrade.
 Ensure to plan for the required downtime.
 The upgrade process duration varies depending on your hardware configuration, network speed, and the amount of data that is stored on the server:
-
-* On average installations, upgrading {ProjectServer} takes up to 30 minutes and upgrading a single {SmartProxyServer} takes up to 10 minutes.
-* On very large installations, upgrading {ProjectServer} can take up to 1{range}2 hours and upgrading a single {SmartProxyServer} can take up to 15{range}30 minutes.
+** On average installations, upgrading {ProjectServer} takes up to 30 minutes and upgrading a single {SmartProxyServer} takes up to 10 minutes.
+** On very large installations, upgrading {ProjectServer} can take up to 1{range}2 hours and upgrading a single {SmartProxyServer} can take up to 15{range}30 minutes.


### PR DESCRIPTION
Fix content readability issues in the planning upgrade section of the connected upgrade guide.
- Split sentence with word count more than 22 words.
- Rearrange bullet points.

JIRA: https://issues.redhat.com/browse/SAT-35663

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
