### PR TITLE
Change instructions on importing syncable exports

### DIFF
--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -1,7 +1,8 @@
 ifdef::satellite[]
-You can then serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization.
+You can import Syncable Format exports directly by using the `hammer content-import` command.  
+This is the recommended method for consuming syncable exports.
 
-You cannot directly import Syncable Format exports.
+Alternatively, you can serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization. 
 Instead, on the importing {ProjectServer} you must:
 
 * Copy the generated content to an HTTP/HTTPS web server that is accessible to importing {ProjectServer}.

--- a/guides/common/modules/snip_generating-content.adoc
+++ b/guides/common/modules/snip_generating-content.adoc
@@ -1,9 +1,8 @@
 ifdef::satellite[]
-You can import Syncable Format exports directly by using the `hammer content-import` command.  
+You can import Syncable Format exports directly by using the `hammer content-import` command.
 This is the recommended method for consuming syncable exports.
 
-Alternatively, you can serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization. 
-Instead, on the importing {ProjectServer} you must:
+Alternatively, you can serve the generated content using a local web server on the importing {ProjectServer} or in another {ProjectServer} organization:
 
 * Copy the generated content to an HTTP/HTTPS web server that is accessible to importing {ProjectServer}.
 * Update your CDN configuration to *Custom CDN*.


### PR DESCRIPTION
#### What changes are you introducing?
The documentation says 
"You cannot directly import Syncable Format exports". 
But the user has been able to use `hammer content-import` 
as a syncable-format export since 6.12. Changed the `snip_generating-content.adoc`
to reflect that change. 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-27625

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
