### PR TITLE
Drop KubeVirt deprecation

### DIFF
--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -9,9 +9,6 @@ These capabilities support rapid application modernization across the open hybri
 
 You can create a compute resource for {KubeVirt} so that you can provision and manage virtual machines in {Kubernetes} by using {Project}.
 
-:FeatureName: {KubeVirt} compute resource
-include::snip_deprecated-feature.adoc[]
-
 ifdef::satellite[]
 Note that template provisioning is not supported for this release.
 


### PR DESCRIPTION
#### What changes are you introducing?

Dropping deprecation notice for the KubeVirt compute resource

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Feature removal has been reconsidered.

Discussion in [SAT-33355](https://issues.redhat.com/browse/SAT-33355) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] **?** Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
