### PR TITLE
Add step to enable the Redis PMDA in the performance monitoring guide

### DIFF
--- a/guides/common/modules/proc_configuring-pcp-data-collection.adoc
+++ b/guides/common/modules/proc_configuring-pcp-data-collection.adoc
@@ -49,6 +49,12 @@ endif::[]
 # cd /var/lib/pcp/pmdas/postgresql
 # ./Install
 ----
+. Configure PCP to collect metrics from Redis:
++
+----
+# cd /var/lib/pcp/pmdas/redis
+# ./Install
+----
 . Enable the telemetry feature in {Project}:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

I am adding a step in the "Monitoring Foreman performance" guide to enable the Redis PMDA.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current state of the guide mentions that detailed metrics about Redis (among other processes) are going to be enabled (see the [code](https://github.com/theforeman/foreman-documentation/blob/master/guides/common/modules/proc_configuring-pcp-data-collection.adoc?plain=1#L16-L20)).

Furthermore, the example output of the `pcp` command shows the Redis PMDA as enabled (see the [code](https://github.com/theforeman/foreman-documentation/blob/444e7029b7d474ad1a414c2839028afd4c598174/guides/common/modules/proc_verifying-pcp-configuration.adoc?plain=1#L26)).

However, the actual enabling of the Redis PMDA is never described, i.e. if one were to follow the documentation step by step the Redis PMDA would never be enabled and would not appear in the `pcp` output.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This PR assumes that the documentation should indeed include the enabling of the Redis PMDA.

If the Redis PMDA should better not be enabled, I would suggest to remove references to Redis in the above mentioned lines instead.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.