### PR TITLE
param --organization-id is required for hammer flatpak-remote list cmd

### DIFF
--- a/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-hammer-cli.adoc
+++ b/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-hammer-cli.adoc
@@ -45,7 +45,7 @@ $ hammer flatpak-remote update \
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ hammer flatpak-remote list
+$ hammer flatpak-remote list --organization-id <org-id>
 $ hammer flatpak-remote info --id _My_Flatpak_Remote_ID_
 ----
 . Scan the Flatpak remote:


### PR DESCRIPTION
#### What changes are you introducing?
Add missing param --organization-id to the docs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-37075
```
Actual behavior:

$ hammer flatpak-remote list
Error: Could not find organization. Some search options were missing, please see --help.

Expected behavior:

Command needs to be corrected as:
$ hammer flatpak-remote list --organization-id <org-id>
```

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
