### PR TITLE
Fix result of remote DB backup

### DIFF
--- a/guides/common/modules/proc_performing-a-full-backup.adoc
+++ b/guides/common/modules/proc_performing-a-full-backup.adoc
@@ -44,12 +44,8 @@ If you want to set a custom directory name, add the `--preserve-directory` optio
 The backup is then stored in the directory you provide in the command line.
 If you use the `--preserve-directory` option, no data is removed if the backup fails.
 
-Note that if you use a local PostgreSQL database, the `postgres` user requires write access to the backup directory.
-
 .Remote databases
 You can use the `{foreman-maintain} backup` command to back up remote databases.
-
-You can use both online and offline methods to back up remote databases, but if you use offline method, the `{foreman-maintain} backup` command performs a database dump.
 
 .Backing up to a remote NFS share
 To enable {Project} to save the backup to an NFS share, ensure that the `root` user of your {ProjectServer} or {SmartProxyServer} can write to the NFS share.


### PR DESCRIPTION
#### What changes are you introducing?

If you create a backup on Foreman+Katello Server or Smart Proxy Servers by using `foreman-maintain backup [online|offline]`, `foreman-maintain` creates a dump of the database.

Regardless of the method (online or offline), the backup contains a dump of the database.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Tested on Foreman 3.14/Katello 4.16: Create an online/offline backup on Foreman Server; migrate to external DB as documented; recreate an online/offline backup on Foreman Server:

````
$ du -ksh /my-backup*
4.0G /my-backup-offline
4.0G /my-backup-online
5.2G /my-backup-post-migration-offline
5.2G /my-backup-post-migration-online
$ find /my-backup* -name "*.dump"
/my-backup-offline/foreman-backup-2025-09-10-07-36-30/candlepin.dump
/my-backup-offline/foreman-backup-2025-09-10-07-36-30/foreman.dump
/my-backup-offline/foreman-backup-2025-09-10-07-36-30/pulpcore.dump
/my-backup-online/foreman-backup-2025-09-10-07-48-17/candlepin.dump
/my-backup-online/foreman-backup-2025-09-10-07-48-17/foreman.dump
/my-backup-online/foreman-backup-2025-09-10-07-48-17/pulpcore.dump
/my-backup-post-migration-offline/foreman-backup-2025-09-10-11-45-19/candlepin.dump
/my-backup-post-migration-offline/foreman-backup-2025-09-10-11-45-19/foreman.dump
/my-backup-post-migration-offline/foreman-backup-2025-09-10-11-45-19/pulpcore.dump
/my-backup-post-migration-online/foreman-backup-2025-09-10-11-39-36/candlepin.dump
/my-backup-post-migration-online/foreman-backup-2025-09-10-11-39-36/foreman.dump
/my-backup-post-migration-online/foreman-backup-2025-09-10-11-39-36/pulpcore.dump
````

Note that the diff in size results to Foreman+Katello usage.

On Smart Proxy Server:

````
$ du -ksh /my-backup*
1.1G /my-backup-offline
1.1G /my-backup-online
$ find /my-backup* -name "*.dump"
/my-backup-online/foreman-proxy-backup-2025-09-10-07-42-49/pulpcore.dump
/my-backup-offline/foreman-proxy-backup-2025-09-10-07-48-45/pulpcore.dump
````

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

[Refs PR 893 in foreman_maintain](https://github.com/theforeman/foreman_maintain/pull/893)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
