### PR TITLE
Rework Hammer reference generation

### DIFF
--- a/guides/doc-Hammer_Reference/README.md
+++ b/guides/doc-Hammer_Reference/README.md
@@ -1,11 +1,12 @@
 # Creating Hammer reference
 
-## Generating the basic reference
+## Generating the reference
 
-Use the `generate-hammer-reference.sh` script to update the generated reference.
+Use the `generate-hammer-reference.sh` script to generate the reference.
 
-### Prerequisite
+### Prerequisites
 
+- Ensure all Foreman plugins are enabled on your Foreman instance.
 - You have got the full help output from Hammer CLI in MarkDown format:
   ```
      hammer full-help --md >hammer.full-help.md
@@ -19,17 +20,17 @@ Use the `generate-hammer-reference.sh` script to update the generated reference.
 
 ## Manual editing
 
-Move `content-view component` and `content-view filter` sections,
-which are level 3 and have level 4 sections, to **level 2**
-to decrease section nesting to 3 levels.
+Move `content-view component` and `content-view filter` sections, which are level 3 and have level 4 sections, to **level 2** to decrease section nesting to 3 levels.
 
-Initial structure:
+Generated structure:
 ```
 2.1 content-view
+   2.1.x content-view component
+   2.1.y content-view filter
 2.2 content-view-environment
 ```
 
-Suggested structure:
+Manually updated structure:
 ```
 2.1 content-view
 2.2 content-view component

--- a/guides/doc-Hammer_Reference/README.md
+++ b/guides/doc-Hammer_Reference/README.md
@@ -1,16 +1,38 @@
-# Generated Hammer reference
+# Creating Hammer reference
+
+## Generating the basic reference
 
 Use the `generate-hammer-reference.sh` script to update the generated reference.
 
-## Prerequisite
+### Prerequisite
 
 - You have got the full help output from Hammer CLI in MarkDown format:
   ```
      hammer full-help --md >hammer.full-help.md
   ```
 
-## Usage
+### Usage
 ```
    cd guides/
    scripts/generate-hammer-reference.sh hammer.full-help.md
+```
+
+## Manual editing
+
+Move `content-view component` and `content-view filter` sections,
+which are level 3 and have level 4 sections, to **level 2**
+to decrease section nesting to 3 levels.
+
+Initial structure:
+```
+2.1 content-view
+2.2 content-view-environment
+```
+
+Suggested structure:
+```
+2.1 content-view
+2.2 content-view component
+2.3 content-view-environment
+2.4 content-view filter
 ```

--- a/guides/doc-Hammer_Reference/README.md
+++ b/guides/doc-Hammer_Reference/README.md
@@ -15,6 +15,7 @@ Use the `generate-hammer-reference.sh` script to generate the reference.
 ### Usage
 ```
    cd guides/
+   mkdir common/hammer-reference
    scripts/generate-hammer-reference.sh hammer.full-help.md
 ```
 

--- a/guides/doc-Hammer_Reference/README.md
+++ b/guides/doc-Hammer_Reference/README.md
@@ -15,7 +15,7 @@ Use the `generate-hammer-reference.sh` script to generate the reference.
 ### Usage
 ```
    cd guides/
-   mkdir common/hammer-reference
+   mkdir --parents common/hammer-reference
    scripts/generate-hammer-reference.sh hammer.full-help.md
 ```
 

--- a/guides/scripts/generate-hammer-reference.sh
+++ b/guides/scripts/generate-hammer-reference.sh
@@ -437,7 +437,7 @@ echo -e "I: [End of input file]"
 echo
 
 # Process option details
-echo -e "Processing option details..."
+echo -e "Processing data representation module..."
 sort $details_tmp | uniq | \
     sed -E 's/^([A-Z\_]+)\s+/\n\1:: /' >>$details_file
 [ -n "$DEBUG" ] || rm $details_tmp # Delete tmp file

--- a/guides/scripts/generate-hammer-reference.sh
+++ b/guides/scripts/generate-hammer-reference.sh
@@ -10,7 +10,7 @@ DEBUG=
 
 print_help() {
     echo -e "Generate AsciiDoc reference from a Hammer full-help MarkDown file"
-    echo -e "Generates the master.adoc and one module per hammer subsubcommand (3 levels)."
+    echo -e "Generates $ASMB_FILENAME and one module per hammer subsubcommand (3 levels)."
     echo
     echo -e "Usage:"
     echo -e "    $0 [OPTIONS ...] SOURCE_FILE"


### PR DESCRIPTION
#### What changes are you introducing?

Updating the `generate-hammer-reference.sh` for the new Hammer reference

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Assembly moved to a new guide
- More granular modularization
- DITA compliance
- Decreased nesting

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- The subcommands are now split into multiple `ref_` modules. The generation results in over **800 modules** in addition to the existing ones! Are we sure we want them inside `common/modules`?
- The generation workflow now requires manual steps to decrease nesting of a small number of subcommands.
- I've tested it downstream thoroughly.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16
