### PR TITLE
Removing backup-note snippet

### DIFF
--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -6,7 +6,11 @@
 You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.
 
-include::snip_backup-usecase-note.adoc[]
+[NOTE]
+====
+If you create a new instance of the {ProjectServer}, decommission the old instances after restoring the backup.
+Cloned instances are not supposed to run in parallel in a production environment.
+====
 
 To create a backup of your {ProjectServer} or {SmartProxyServer} and all associated data, use the `{foreman-maintain} backup` command.
 Backing up to a separate storage device on a separate system is highly recommended.

--- a/guides/common/modules/con_backing-up-server-and-proxy.adoc
+++ b/guides/common/modules/con_backing-up-server-and-proxy.adoc
@@ -3,7 +3,7 @@
 [id="backing-up-{project-context}-server-and-{smart-proxy-context}_{context}"]
 = Backing up {ProjectServer} and {SmartProxyServer}
 
-You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in the event of a disaster.
+You can back up your {Project} deployment to ensure the continuity of your {ProjectName} deployment and associated data in case a disaster occurs.
 If your deployment uses custom configurations, you must consider how to handle these custom configurations when you plan your backup and disaster recovery policy.
 
 [NOTE]

--- a/guides/common/modules/snip_backup-usecase-note.adoc
+++ b/guides/common/modules/snip_backup-usecase-note.adoc
@@ -1,5 +1,0 @@
-[NOTE]
-====
-If you create a new instance of the {ProjectServer}, decommission the old instances after restoring the backup.
-Cloned instances are not supposed to run in parallel in a production environment.
-====


### PR DESCRIPTION
#### What changes are you introducing?

Removing backup-usecase-note snippet

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Snippet is very short and used in only one module.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tech review and testing not required.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
