### PR TITLE
Remove extract-directory snippet

### DIFF
--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -4,7 +4,7 @@
 = Importing a content view version
 
 You can import an exported content view version to create a version with the same content in an organization on another {ProjectServer}.
-For more information about exporting a content view version, see xref:Exporting_a_Content_View_Version_{context}[].
+For more information about exporting a content view version, see xref:guides/common/modules/proc_exporting-a-content-view-version.adoc#Exporting_a_Content_View_Version_{context}[].
 
 ifdef::debian,ubuntu[]
 When you import a content view version, it has the same major and minor version numbers and contains the same repositories with the same packages.
@@ -23,7 +23,7 @@ endif::[]
 
 .Procedure
 . Copy the exported files to a subdirectory of `/var/lib/pulp/imports` on {ProjectServer} where you want to import.
-. Set the ownership of the import directory and its contents to `pulp:pulp`.
+. Set the ownership of the import directory and its contents to `pulp:pulp`:
 +
 [subs="+quotes"]
 ----
@@ -35,7 +35,7 @@ endif::[]
 ----
 # ls -lh /var/lib/pulp/imports/2021-02-25T21-15-22-00-00/
 ----
-. To import the content view version to {ProjectServer}, enter the following command:
+. Import the content view version to {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -44,13 +44,20 @@ $ hammer content-import version \
 --path=/var/lib/pulp/imports/2021-02-25T21-15-22-00-00/
 ----
 +
-Note that you must enter the full path `/var/lib/pulp/imports/_My_Exported_Version_Dir_`.
+You must specify the absolute path as in the example: `/var/lib/pulp/imports/2021-02-25T21-15-22-00-00/`.
 Relative paths do not work.
-. To verify that you imported the content view version successfully, list content view versions for your organization:
+. Verify that you imported the content view version successfully by listing the content view versions for your organization:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ hammer content-view version list \
 --organization-id=_My_Organization_ID_
 ----
-include::snip_extract-directory-imported-project-server.adoc[]
++
+The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`.
+. Delete the import files after a successful import:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# rm -fr /var/lib/pulp/imports/2021-02-25T21-15-22-00-00/
+----

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -19,7 +19,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# chown -R pulp:pulp /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+# chown -R pulp:pulp /var/lib/pulp/imports/2021-03-02T03-35-24-00-00/
 ----
 . Verify that the ownership is set correctly:
 +
@@ -38,7 +38,7 @@ total 68M
 ----
 $ hammer content-import repository \
 --organization="_My_Organization_" \
---path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+--path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00/
 ----
 +
 You must specify the absolute path as in the example: `/var/lib/pulp/imports/2021-03-02T03-35-24-00-00`.

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -4,7 +4,7 @@
 = Importing a repository
 
 You can import an exported repository into an organization on another {ProjectServer}.
-For more information about exporting content of a repository, see xref:Exporting_a_Repository_{context}[].
+For more information about exporting content of a repository, see xref:common/modules/proc_exporting-a-repository.adoc#Exporting_a_Repository_{context}[].
 
 .Prerequisites
 * The export files must be in a directory under `/var/lib/pulp/imports`.
@@ -15,7 +15,7 @@ endif::[]
 
 .Procedure
 . Copy the exported files to a subdirectory of `/var/lib/pulp/imports` on {ProjectServer} where you want to import.
-. Set the ownership of the import directory and its contents to `pulp:pulp`.
+. Set the ownership of the import directory and its contents to `pulp:pulp`:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -31,17 +31,23 @@ total 68M
 -rw-r--r--. 1 pulp pulp 333 Mar  2 04:29 export-1e25417c-6d09-49d4-b9a5-23df4db3d52a-20210302_0335-toc.json
 -rw-r--r--. 1 pulp pulp 443 Mar  2 04:29 metadata.json
 ----
-. Identify the Organization that you wish to import into.
-. To import the repository content to {ProjectServer}, enter the following command:
+. Identify the Organization that you want to import into.
+. Import the repository content into {ProjectServer}:
 +
 [subs="+quotes"]
 ----
 $ hammer content-import repository \
 --organization="_My_Organization_" \
---path=/var/lib/pulp/imports/_2021-03-02T03-35-24-00-00_
+--path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00
 ----
 +
-Note that you must enter the full path `/var/lib/pulp/imports/_My_Exported_Repo_Dir_`.
+You must specify the absolute path as in the example: `/var/lib/pulp/imports/2021-03-02T03-35-24-00-00`.
 Relative paths do not work.
-. To verify that you imported the repository, check the contents of the product and repository.
-include::snip_extract-directory-imported-project-server.adoc[]
+. Verify that you imported the repository by checking the contents of the product and repository.
+The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`.
+. Delete the import files after a successful import:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# rm -fr /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+----

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -49,5 +49,5 @@ The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# rm -fr /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+# rm -fr /var/lib/pulp/imports/2021-03-02T03-35-24-00-00/
 ----

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -19,7 +19,7 @@ endif::[]
 +
 [options="nowrap" subs="+quotes"]
 ----
-# chown -R pulp:pulp /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+# chown -R pulp:pulp /var/lib/pulp/imports/2021-03-02T03-35-24-00-00/
 ----
 . Verify that the ownership is set correctly:
 +
@@ -38,10 +38,10 @@ total 68M
 ----
 $ hammer content-import library \
 --organization="_My_Organization_" \
---path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+--path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00/
 ----
 +
-You must specify the absolute path as in the example: `/var/lib/pulp/imports/2021-03-02T03-35-24-00-00`.
+You must specify the absolute path as in the example: `/var/lib/pulp/imports/2021-03-02T03-35-24-00-00/`.
 Relative paths do not work.
 . Verify that you imported the Library content by checking the contents of the product and repositories.
 A new content view called `Import-Library` is created in the target organization.

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -56,5 +56,5 @@ The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to 
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# rm -fr /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+# rm -fr /var/lib/pulp/imports/2021-03-02T03-35-24-00-00/
 ----

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -4,7 +4,7 @@
 = Importing into the Library environment
 
 You can import exported Library content into the Library lifecycle environment of an organization on another {ProjectServer}.
-For more information about exporting contents from the Library environment, see xref:Exporting_the_Library_Environment_{context}[].
+For more information about exporting contents from the Library environment, see xref:common/modules/proc_exporting-the-library-environment.adoc#Exporting_the_Library_Environment_{context}[].
 
 .Prerequisites
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
@@ -31,8 +31,8 @@ total 68M
 -rw-r--r--. 1 pulp pulp 333 Mar  2 04:29 export-1e25417c-6d09-49d4-b9a5-23df4db3d52a-20210302_0335-toc.json
 -rw-r--r--. 1 pulp pulp 443 Mar  2 04:29 metadata.json
 ----
-. Identify the Organization that you wish to import into.
-. To import the Library content to {ProjectServer}, enter the following command:
+. Identify the Organization that you want to import into.
+. Import the Library content to {ProjectServer}:
 +
 [subs="+quotes"]
 ----
@@ -41,13 +41,20 @@ $ hammer content-import library \
 --path=/var/lib/pulp/imports/2021-03-02T03-35-24-00-00
 ----
 +
-Note you must enter the full path `/var/lib/pulp/imports/_My_Exported_Library_Dir_`.
+You must specify the absolute path as in the example: `/var/lib/pulp/imports/2021-03-02T03-35-24-00-00`.
 Relative paths do not work.
-. To verify that you imported the Library content, check the contents of the product and repositories.
+. Verify that you imported the Library content by checking the contents of the product and repositories.
 A new content view called `Import-Library` is created in the target organization.
 This content view is used to facilitate the Library content import.
 +
 By default, this content view is not shown in the {ProjectWebUI}.
 `Import-Library` is not meant to be assigned directly to hosts.
 Instead, assign your hosts to `Default Organization View` or another content view as you would normally.
-include::snip_extract-directory-imported-project-server.adoc[]
++
+The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`.
+. Delete the import files after a successful import:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# rm -fr /var/lib/pulp/imports/2021-03-02T03-35-24-00-00
+----

--- a/guides/common/modules/snip_extract-directory-imported-project-server.adoc
+++ b/guides/common/modules/snip_extract-directory-imported-project-server.adoc
@@ -1,2 +1,0 @@
-. The importing {ProjectServer} extracts the `/var/lib/pulp/imports` directory to `/var/lib/pulp/`.
-You can empty the `/var/lib/pulp/imports` directory after a successful import.


### PR DESCRIPTION
#### What changes are you introducing?

Removing extract directory snippet and converting it from a step to a list continuation in modules.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Snippet is very short and only used in 2 modules. Also, it is not a step, so I changed it to a list continuation.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No tech review required

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
