### PR TITLE
Use Hammer CLI in favor of WebUI to change setting

### DIFF
--- a/guides/common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc
+++ b/guides/common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc
@@ -38,8 +38,13 @@ endif::[]
 include::snip_make-firewall-settings-persistent.adoc[]
 . In `pull-mqtt` mode, hosts subscribe for job notifications to either your {ProjectServer} or any {SmartProxyServer} through which they are registered.
 Ensure that {ProjectServer} sends remote execution jobs to that same {ProjectServer} or {SmartProxyServer}:
-.. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
-.. On the *Content* tab, set the value of *Prefer registered through {SmartProxy} for remote execution* to *Yes*.
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ hammer settings set \
+--name remote_execution_prefer_registered_through_proxy \
+--value true
+----
 
 .Next steps
 * Configure your hosts for the pull-based transport.


### PR DESCRIPTION
#### What changes are you introducing?

Replace step that uses Web UI with Hammer CLI command.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

All steps but one relies on using CLI, so we should not force the user to complete this single step via WebUI.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tested on Foreman 3.14/Katello 4.16.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
