### PR TITLE
Remove disaster recovery hostname snippet

### DIFF
--- a/guides/common/modules/proc_recovering-from-disaster-by-restoring-a-vm-snapshot-of-projectserver.adoc
+++ b/guides/common/modules/proc_recovering-from-disaster-by-restoring-a-vm-snapshot-of-projectserver.adoc
@@ -5,7 +5,11 @@
 
 In case of a disaster, use a virtual machine (VM) snapshot of your {ProjectServer} to restore {Project} services.
 
-include::snip_disaster-recovery-hostname-cannot-change.adoc[]
+[IMPORTANT]
+====
+Ensure that the hostname of your {ProjectServer} does not change during recovery.
+The IP address can change.
+====
 
 .Procedure
 . Identify the snapshot from which you want to recover.

--- a/guides/common/modules/snip_disaster-recovery-hostname-cannot-change.adoc
+++ b/guides/common/modules/snip_disaster-recovery-hostname-cannot-change.adoc
@@ -1,5 +1,0 @@
-[IMPORTANT]
-====
-Ensure that the hostname of your {ProjectServer} does not change during recovery.
-The IP address can change.
-====


### PR DESCRIPTION
#### What changes are you introducing?

Removing guides/common/modules/snip_disaster-recovery-hostname-cannot-change.adoc

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Snippet is used in only one file. Unlikely to be reused.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No tech review or testing needed.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
