### PR TITLE
Remove custom templates snippet

### DIFF
--- a/guides/common/modules/proc_customizing-the-registration-templates.adoc
+++ b/guides/common/modules/proc_customizing-the-registration-templates.adoc
@@ -7,11 +7,13 @@ You can customize the registration process by editing the provisioning templates
 Note that all default templates in {Project} are locked.
 If you want to customize the registration templates, you must clone the default templates and edit the clones.
 
+ifdef::satellite,orcharhino[]
 [NOTE]
 ====
 {Team} only provides support for the original unedited templates.
 Customized templates do not receive updates released by {Team}.
 ====
+endif::[]
 
 The registration process uses the following provisioning templates:
 

--- a/guides/common/modules/proc_customizing-the-registration-templates.adoc
+++ b/guides/common/modules/proc_customizing-the-registration-templates.adoc
@@ -7,7 +7,11 @@ You can customize the registration process by editing the provisioning templates
 Note that all default templates in {Project} are locked.
 If you want to customize the registration templates, you must clone the default templates and edit the clones.
 
-include::snip_note-custom-templates-unsupported.adoc[]
+[NOTE]
+====
+{Team} only provides support for the original unedited templates.
+Customized templates do not receive updates released by {Team}.
+====
 
 The registration process uses the following provisioning templates:
 

--- a/guides/common/modules/snip_note-custom-templates-unsupported.adoc
+++ b/guides/common/modules/snip_note-custom-templates-unsupported.adoc
@@ -1,5 +1,0 @@
-[NOTE]
-====
-{Team} only provides support for the original unedited templates.
-Customized templates do not receive updates released by {Team}.
-====


### PR DESCRIPTION
#### What changes are you introducing?

Removing `guides/common/modules/snip_note-custom-templates-unsupported.adoc`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Snippet is very short and used only once.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No tech review or testing required.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
