### PR TITLE
Update procedure for TLS for secure LDAP connection

### DIFF
--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -6,7 +6,7 @@
 If {Project} uses TLS to establish a secure LDAP connection (LDAPS), you must obtain the CA certificates of your LDAP server and add them to the trusted CA list on the base operating system of your {ProjectServer}.
 
 .Prerequisite
-* If your LDAP server uses a certificate chain with intermediate certificate authorities, the trusted CA list contains all root and intermediate certificates.
+* If your LDAP server uses a certificate chain with intermediate certificate authorities, the trusted CA list must contain all root and intermediate certificates.
 
 .Procedure
 . Obtain the CA certificate from the LDAP Server:

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -32,7 +32,7 @@ ifdef::foreman-deb[]
 # cp /tmp/_example.crt_ /usr/local/share/ca-certificates
 endif::[]
 ifndef::foreman-deb[]
-# cp /tmp/_example.crt_ /etc/pki/tls/source/anchors
+# cp /tmp/_example.crt_ /etc/pki/ca-trust/source/anchors
 endif::[]
 ----
 .. Update the certificate authority truststore:

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -47,6 +47,12 @@ ifndef::foreman-deb[]
 endif::[]
 ----
 . Delete the downloaded LDAP certificate from the temporary location on your {ProjectServer}.
+. Restart {Project} services:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service restart
+----
 
 ifndef::orcharhino,foreman-deb[]
 .Additional resources

--- a/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
+++ b/guides/common/modules/proc_configuring-tls-for-secure-ldap.adoc
@@ -5,7 +5,8 @@
 
 If {Project} uses TLS to establish a secure LDAP connection (LDAPS), you must obtain the CA certificates of your LDAP server and add them to the trusted CA list on the base operating system of your {ProjectServer}.
 
-If your LDAP server uses a certificate chain with intermediate certificate authorities, you must obtain all root and intermediate certificates and add them to the trusted CA list.
+.Prerequisite
+* If your LDAP server uses a certificate chain with intermediate certificate authorities, the trusted CA list contains all root and intermediate certificates.
 
 .Procedure
 . Obtain the CA certificate from the LDAP Server:


### PR DESCRIPTION
#### What changes are you introducing?

* Highlighting an existing prerequisite as an actual prerequisite so it's harder to miss
* Adding a step to restart services
* EDIT: Updating cert location

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-32048

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Somewhat related to https://github.com/theforeman/foreman-documentation/pull/3941 which also adds a step to restart services after updating certs.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
