### PR TITLE
Remove broken URL

### DIFF
--- a/guides/common/modules/ref_kernel-parameters-for-discovery-customization.adoc
+++ b/guides/common/modules/ref_kernel-parameters-for-discovery-customization.adoc
@@ -72,7 +72,7 @@ Manually configures IP address (`fdi.pxip`), the gateway (`fdi.pxgw`), and the D
 If you omit these parameters, the image uses DHCP to configure the network interface.
 You can add multiple DNS entries in a comma-separated
 footnote:[NetworkManager expects `;` as a list separator but currently also accepts `,`.
-For more information, see `man nm-settings-keyfile` and https://www.gnu.org/software/grub/manual/grub/grub.html#Shell_002dlike-scripting[Shell-like scripting in GRUB]]
+For more information, see `man nm-settings-keyfile`]
 list, for example `fdi.pxdns=192.168.1.1,192.168.200.1`.
 
 fdi.pxmac::


### PR DESCRIPTION
#### What changes are you introducing?

Remove URL

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Either the URL is broken on a regular basis or gnu just doesn't like the GHA checking the URL. Either way, I've had enough of it.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

#### Review checklists

Tech review (performed by an Engineer who did not author the PR; can be skipped if tech review is unnecessary):

* [ ] The PR documents a recommended, user-friendly path.
* [ ] The PR removes steps that have been made unnecessary or obsolete.
* [ ] Any steps introduced or updated in the PR have been tested to confirm that they lead to the documented end result.

Style review (by a Technical Writer who did not author the PR):

* [ ] The PR conforms with the team's style guidelines.
* [ ] The PR introduces documentation that describes a user story rather than a product feature.
