### PR TITLE
Review PR checklist in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ Non-trivial PRs might not only benefit from additional review but they also repr
 
 ## Pull request checklists
 
+Checklist for documentation contributions:
+
 * [ ] My contribution is my own work and I agree to the license of the project.
 See [LICENSE](LICENSE).
 * [ ] My commits include meaningful commit messages.
@@ -32,6 +34,9 @@ See [One sentence per line](https://jeffkreeftmeijer.com/one-sentence-per-line/)
 Some editors can help with this.
 For example, VS Code has multiple settings related to handling whitespaces.
 * [ ] My change does not worsen the state of any build target.
+
+Checklist for raising PRs:
+
 * [ ] I re-read my work carefully before raising a PR or before marking a draft PR as ready for review.
 This can include using `git show`, viewing the diff against master or the target branch, running a local Vale check, and other methods.
 * [ ] My PR description includes a meaningful description of the changes for the community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ As a contributor, I will:
 
 * Familiarize myself with the [Pull Request Checklist](#Pull-Request-Checklist) and [Foreman documentation minimalist style guide](#Foreman-documentation-minimalist-style-guide).
 * Open additional issues if my contribution is incomplete.
+* Put in my best effort to ensure that my contribution does not worsen the state of any build target.
+For example, this might include reviewing how my changes affect upstream build targets even when working on behalf of a downstream product.
 
 ## Maintainer's pledge
 
@@ -33,7 +35,6 @@ See [One sentence per line](https://jeffkreeftmeijer.com/one-sentence-per-line/)
 * [ ] My change does not add trailing whitespaces.
 Some editors can help with this.
 For example, VS Code has multiple settings related to handling whitespaces.
-* [ ] My change does not worsen the state of any build target.
 
 Checklist for raising PRs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,14 +40,6 @@ If unsure, I let reviewers know so that they can assist.
 * [ ] Before pinging others about my PR, I await the GitHub Actions checks to see if my branch builds.
 If a GitHub check fails and I'm unsure how to proceed, I let reviewers know so that they can assist.
 
-* [ ] If I add text that applies only to a specific downstream product, I notify others and give them a chance to request extending the `ifdef::[]` or `ifndef::[]` directive.
-* [ ] My change does not contain `Foreman`, `Satellite`, or `orcharhino`.
-Instead, I use attributes.
-* [ ] If I make more than one change on my branch, I create more than one commit and rebase my branch to master.
-* [ ] I am familiar to proper capitalization for project-specific terminology.
-See [Capitalization](#Capitalization).
-* [ ] The first line of the file contains the modular docs content type attribute, for example, `:_mod-docs-content-type: ASSEMBLY` for assemblies.
-
 Each PR should undergo tech review.
 (Tech review is performed by an Engineer who did not author the PR. It can be skipped if the PR does not significantly change description of product behavior.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,28 +20,33 @@ As a maintainer, I will:
 Examples of trivial PRs: Fixing a typo, fixing markup, or fixing links.
 Non-trivial PRs might not only benefit from additional review but they also represent an opportunity for community members to ask questions and learn.
 
-## Pull request checklist
+## Pull request checklists
 
-* [ ] Before pushing, I view my diff against master or the target branch and check for spelling mistakes, failed conflict resolutions, etc.
-* [ ] Before pinging others about my PR, I await the Github Actions to see if my branch builds.
+* [ ] My contribution is my own work and I agree to the license of the project.
+See [LICENSE](LICENSE).
+* [ ] My commits include meaningful commit messages.
+See [seven rules for git commit messages](https://cbea.ms/git-commit/#seven-rules).
+* [ ] I write one sentence per line.
+See [One sentence per line](https://jeffkreeftmeijer.com/one-sentence-per-line/).
+* [ ] My change does not add trailing whitespaces.
+Some editors can help with this.
+For example, VS Code has multiple settings related to handling whitespaces.
+* [ ] My change does not worsen the state of any build target.
+* [ ] I re-read my work carefully before raising a PR or before marking a draft PR as ready for review.
+This can include using `git show`, viewing the diff against master or the target branch, running a local Vale check, and other methods.
+* [ ] My PR description includes a meaningful description of the changes for the community.
+* [ ] I fill out the cherry-picking list in the PR description to the best of my abilities to signify which versions my update applies to.
+If unsure, I let reviewers know so that they can assist.
+* [ ] Before pinging others about my PR, I await the GitHub Actions checks to see if my branch builds.
+If a GitHub check fails and I'm unsure how to proceed, I let reviewers know so that they can assist.
+
 * [ ] If I add text that applies only to a specific downstream product, I notify others and give them a chance to request extending the `ifdef::[]` or `ifndef::[]` directive.
 * [ ] My change does not contain `Foreman`, `Satellite`, or `orcharhino`.
 Instead, I use attributes.
-* [ ] I don't add useless or trailing white space.
-* [ ] I put each sentence to its own line.
-* [ ] I write a meaningful commit message.
-See [seven rules for git commit messages](https://cbea.ms/git-commit/#seven-rules).
-* [ ] My change does not worsen the state of any build target.
-* [ ] My contribution is my own work and I agree to the license of the project.
-See [LICENSE](LICENSE).
 * [ ] If I make more than one change on my branch, I create more than one commit and rebase my branch to master.
-* [ ] My PR does not solely rely on internal resources to answer the _why_, but instead contains at least a basic description for the community.
-* [ ] When creating my PR, I select all branches I want my change to get cherry-picked to.
 * [ ] I am familiar to proper capitalization for project-specific terminology.
 See [Capitalization](#Capitalization).
 * [ ] The first line of the file contains the modular docs content type attribute, for example, `:_mod-docs-content-type: ASSEMBLY` for assemblies.
-* [ ] I fill out the cherry-picking list in the PR template to the best of my abilities to signify which versions my update applies to.
-If unsure, I let reviewers know so that they can assist.
 
 Each PR should undergo tech review.
 (Tech review is performed by an Engineer who did not author the PR. It can be skipped if the PR does not significantly change description of product behavior.)


### PR DESCRIPTION
#### What changes are you introducing?

* Review PR checklist in the contribution doc for simplicity and clarity
* Drop a few items from the PR checklist that are obsolete or duplicate other parts of the contribution doc
* Splitting the PR checklist into two smaller checklist to make it a bit less overwhelming

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Follow-up on https://github.com/theforeman/foreman-documentation/pull/4281

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
