### PR TITLE
Use ISS export sync for disconnected Updating

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server-on-EL9.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server-on-EL9.adoc
@@ -3,7 +3,7 @@
 [id="Updating-Disconnected-{project-context}-on-EL9_{context}"]
 = Updating a disconnected {ProjectServer} on {EL} 9
 
-You can update your disconnected {Project} on {EL} 9 by synchronizing the required repositories on the connected {Project} and syncing the content to the disconnected {Project} by using `syncable` exports.
+You can update your disconnected {Project} on {EL} 9 by synchronizing the required repositories on the connected {Project} and syncing the content to the disconnected {Project} by using syncable exports.
 
 .Procedure on the connected {ProjectServer}
 . Synchronize the following repositories on your connected {ProjectServer}:
@@ -17,7 +17,8 @@ You can update your disconnected {Project} on {EL} 9 by synchronizing the requir
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 $ hammer content-export complete repository \
---id=_Repo_ID_ --format=syncable
+--format syncable \
+--id _My_Repository_ID_ 
 ----
 . Copy the exported directories to the disconnected {ProjectServer}.
 


### PR DESCRIPTION
#### What changes are you introducing?
Updates the instructions to upgrade 'in-place' for disconnected environments.
Related to closed PR #3770 but only addresses Updating a disconnected {ProjectServer} on {EL} 9

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-24752

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
