### PR TITLE
Remove note about cloning and editing templates

### DIFF
--- a/guides/common/modules/proc_booting-virtual-machines.adoc
+++ b/guides/common/modules/proc_booting-virtual-machines.adoc
@@ -18,13 +18,6 @@ endif::[]
 * You have configured your iPXE environment.
 For more information, see xref:Configuring_iPXE_Environment_{context}[].
 
-[NOTE]
-====
-You can use the original templates shipped in {Project} as described below.
-If you require modification to an original template, clone the template, edit the clone, and associate the clone instead of the original template.
-For more information, see xref:running-custom-code-during-host-provisioning-by-using-web-ui[].
-====
-
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
 ifdef::satellite[]
@@ -60,3 +53,6 @@ endif::[]
 . Select the *Templates* tab.
 . In *Provisioning Templates*, click *Resolve* and verify that the *iPXE template* resolves to the required template.
 . Click *Submit* to save host settings.
+
+.Additional resources
+* xref:running-custom-code-during-host-provisioning-by-using-web-ui[]

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -15,13 +15,6 @@ To use HTTP with iPXE, use the iPXE build with built-in drivers (`ipxe.lkrn`).
 * You have configured your iPXE environment.
 For more information, see xref:Configuring_iPXE_Environment_{context}[].
 
-[NOTE]
-====
-You can use the original templates shipped in {Project} as described below.
-If you require modification to an original template, clone the template, edit the clone, and associate the clone instead of the original template.
-For more information, see xref:running-custom-code-during-host-provisioning-by-using-web-ui[].
-====
-
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
 . Search for the required PXELinux template:
@@ -65,3 +58,6 @@ endif::[]
 . Set the *PXE Loader*:
 * Select `PXELinux BIOS` to chainboot iPXE (`ipxe.lkrn`) from PXELinux.
 * Select `iPXE Chain BIOS` to load `undionly-ipxe.0` directly.
+
+.Additional resources
+* xref:running-custom-code-during-host-provisioning-by-using-web-ui[]


### PR DESCRIPTION
#### What changes are you introducing?

Users should never clone and edit templates. Instead, if they really need to run custom code before or after registration or provisioning workflows, they should use "custom pre" and "custom post" snippets as documented. This way they do not lose support by the community/vendor.

Also, there's configuration management.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #4256

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Should we also drop the hint about cloning and editing in `guides/common/modules/proc_setting-up-job-templates.adoc`?
#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
