### PR TITLE
Show updating Foreman guide for all builds

### DIFF
--- a/guides/common/assembly_updating-foreman.adoc
+++ b/guides/common/assembly_updating-foreman.adoc
@@ -1,0 +1,5 @@
+include::modules/con_updating-project.adoc[]
+
+include::modules/proc_updating-foreman-server.adoc[leveloffset=+1]
+
+include::modules/proc_updating-smart-proxy-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_updating-satellite.adoc
+++ b/guides/common/assembly_updating-satellite.adoc
@@ -1,0 +1,9 @@
+include::modules/con_updating-project-to-next-patch-version.adoc[]
+
+include::modules/proc_updating-server.adoc[]
+
+include::modules/proc_updating-disconnected-server.adoc[]
+
+include::modules/proc_updating-disconnected-server-on-EL9.adoc[leveloffset=+1]
+
+include::modules/proc_updating-smart-proxy.adoc[]

--- a/guides/common/modules/con_updating-project.adoc
+++ b/guides/common/modules/con_updating-project.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="updating-{project-context}"]
+= Updating {Project}
+
+ifdef::orcharhino[]
+{Team} provides updates for your base operating system and backported bugfixes for {Project}.
+You can use this procedure to apply those updates.
+
+If you want to upgrade {Project} to the next version, see xref:sources/installation_and_maintenance/upgrading_orcharhino_server.adoc[Upgrading {ProjectServer}] or xref:sources/installation_and_maintenance/upgrading_orcharhino_proxy_server.adoc[Upgrading {SmartProxyServer}].
+endif::[]
+
+ifndef::orcharhino[]
+{Team} recommends that you perform updates regularly to resolve security vulnerabilities and other issues.
+endif::[]

--- a/guides/common/modules/proc_updating-foreman-server.adoc
+++ b/guides/common/modules/proc_updating-foreman-server.adoc
@@ -1,0 +1,44 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="updating-{project-context}-server"]
+= Updating {ProjectServer}
+
+You can update your {ProjectServer} to the latest packages published by {Team}.
+
+.Procedure
+. On your {ProjectServer}, start {Project} maintenance mode:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} maintenance-mode start
+----
+. Upgrade all packages:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {project-package-update}
+----
+. Reconfigure {ProjectServer}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer}
+----
+. Stop {Project} maintenance mode:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} maintenance-mode stop
+----
+
+.Verification
+* On your {ProjectServer}, verify that all {Project} services are running:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-maintain} service status -b
+----
+
+.Next steps
+* Update your {SmartProxyServers}.
+For more information, see xref:updating-{smart-proxy-context}-server[]

--- a/guides/common/modules/proc_updating-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_updating-smart-proxy-server.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="updating-{smart-proxy-context}-server"]
+= Updating {SmartProxyServer}
+
+You can update your {SmartProxyServer} to the latest packages published by {Team}.
+
+ifdef::orcharhino[]
+.Prerequisites
+* Ensure that you have synchronized the `{SmartProxy}` product to {ProjectServer}.
+endif::[]
+
+.Procedure
+. On your {SmartProxyServer}, upgrade all packages:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {project-package-update}
+----
+. Reconfigure {SmartProxyServer}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer}
+----

--- a/guides/doc-Updating_Project/master.adoc
+++ b/guides/doc-Updating_Project/master.adoc
@@ -5,28 +5,14 @@ include::common/header.adoc[]
 
 = {UpdatingDocTitle}
 
-// This guide is not ready because it uses foreman-maintain to update to .z
-// releases but that is not implemented upstream
-ifdef::foreman-el,foreman-deb,katello[]
-include::common/modules/con_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-ifndef::foreman-el,foreman-deb,katello[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
+
+include::common/assembly_updating-satellite.adoc[leveloffset=+1]
 endif::[]
 
-include::common/modules/con_updating-project-to-next-patch-version.adoc[leveloffset=+1]
-
-include::common/modules/proc_updating-server.adoc[leveloffset=+1]
-
-ifdef::satellite[]
-include::common/modules/proc_updating-disconnected-server.adoc[leveloffset=+1]
-
-include::common/modules/proc_updating-disconnected-server-on-EL9.adoc[leveloffset=+2]
-endif::[]
-
-include::common/modules/proc_updating-smart-proxy.adoc[leveloffset=+1]
+ifndef::satellite[]
+include::common/assembly_updating-foreman.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::orcharhino,satellite[]

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -18,6 +18,7 @@
           ["Planning_for_Project", "Planning for Foreman with Katello"],
           ["Installing_Server", "Installing Katello Server"],
           ["Installing_Proxy", "Installing Smart Proxy Server with content"],
+          ["Updating_Project", "Updating Foreman with Katello"],
           ["Configuring_Load_Balancer", "Configuring Smart Proxies with a load balancer"]
         ],
         "Administering Foreman server": [
@@ -61,7 +62,8 @@
         "Deploying Foreman": [
           ["Planning_for_Project", "Planning for Foreman"],
           ["Installing_Server", "Installing Foreman Server"],
-          ["Installing_Proxy", "Installing Smart Proxy Server"]
+          ["Installing_Proxy", "Installing Smart Proxy Server"],
+          ["Updating_Project", "Updating Foreman"]
         ],
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],
@@ -103,7 +105,8 @@
         "Deploying Foreman": [
           ["Planning_for_Project", "Planning for Foreman"],
           ["Installing_Server", "Installing Foreman Server"],
-          ["Installing_Proxy", "Installing Smart Proxy Server"]
+          ["Installing_Proxy", "Installing Smart Proxy Server"],
+          ["Updating_Project", "Updating Foreman"]
         ],
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],


### PR DESCRIPTION
#### What changes are you introducing?

This patch assumes that upstream does not publish Z-releases for Foreman/Katello that are upgraded to by using `foreman-maintain`.

Parts of the introduction to orcharhino updates come from https://docs.orcharhino.com/or/docs/sources/installation_and_maintenance/updating_orcharhino.html.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #2280

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Untested on Foreman Server nightly & Smart Proxy Servers nightly. Tested on Katello-like product :upside_down_face: 
* I decided to leave https://docs.theforeman.org/nightly/Updating_Project/index-satellite.html as is, because upstream and orcharhino do not use Z-releases. The last orcharhino X.Y.Z release is from [July 2022](https://orcharhino.com/en/resources/release-notes/orcharhino-6-0-1/); but [intro to Updating orcharhino](https://docs.orcharhino.com/or/docs/sources/installation_and_maintenance/updating_orcharhino.html) still holds true!

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
