### PR TITLE
Add links to provisioning hosts chapters

### DIFF
--- a/guides/common/modules/ref_supported-virtualization-infrastructures.adoc
+++ b/guides/common/modules/ref_supported-virtualization-infrastructures.adoc
@@ -7,9 +7,19 @@ You can connect the following virtualization infrastructures as compute resource
 
 * KVM (libvirt)
 * VMware
+ifndef::satellite[]
+* Proxmox
+endif::[]
 ifndef::orcharhino[]
 * {KubeVirt}
 endif::[]
+
+.Additional resources
+* xref:Provisioning_Virtual_Machines_on_KVM_kvm-provisioning[]
+* xref:Provisioning_Virtual_Machines_in_VMware_vmware-provisioning[]
 ifndef::satellite[]
-* Proxmox
+* xref:Provisioning_Virtual_Machines_in_Proxmox_proxmox-provisioning[]
+endif::[]
+ifndef::orcharhino[]
+* xref:Provisioning_Virtual_Machines_Kubevirt_kubevirt-provisioning[]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

This patch adds links to the relevant chapters in the "Provisioning hosts" guide. It also sorts the list as they are included in "master.adoc".

Similar to "ref_supported-cloud-providers.adoc".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Fixes #4017

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
