### PR TITLE
Add missing backslash to Hammer cmd

### DIFF
--- a/guides/common/modules/proc_adding-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_adding-lifecycle-environments.adoc
@@ -24,7 +24,7 @@ For definitions of each synchronization type, see {ContentManagementDocURL}Recov
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} list
+$ {hammer-smart-proxy} list
 ----
 +
 Note the {SmartProxy} ID of the {SmartProxy} to which you want to add a lifecycle.
@@ -32,23 +32,23 @@ Note the {SmartProxy} ID of the {SmartProxy} to which you want to add a lifecycl
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} info \
+$ {hammer-smart-proxy} info \
 --id __My_{smart-proxy-context-titlecase}_ID__
 ----
 . To view the lifecycle environments available for your {SmartProxyServer}, enter the following command and note the ID and the organization name:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} content available-lifecycle-environments \
+$ {hammer-smart-proxy} content available-lifecycle-environments \
 --id __My_{smart-proxy-context-titlecase}_ID__
 ----
 . Add the lifecycle environment to your {SmartProxyServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} content add-lifecycle-environment \
+$ {hammer-smart-proxy} content add-lifecycle-environment \
 --id __My_{smart-proxy-context-titlecase}_ID__ \
---lifecycle-environment-id _My_Lifecycle_Environment_ID_
+--lifecycle-environment-id _My_Lifecycle_Environment_ID_ \
 --organization "_My_Organization_"
 ----
 +
@@ -59,7 +59,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} content synchronize \
+$ {hammer-smart-proxy} content synchronize \
 --id __My_{smart-proxy-context-titlecase}_ID__
 ----
 +
@@ -67,7 +67,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} content synchronize \
+$ {hammer-smart-proxy} content synchronize \
 --id __My_{smart-proxy-context-titlecase}_ID__ \
 --lifecycle-environment-id _My_Lifecycle_Environment_ID_
 ----
@@ -76,7 +76,7 @@ Repeat for each lifecycle environment you want to add to {SmartProxyServer}.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {hammer-smart-proxy} content synchronize \
+$ {hammer-smart-proxy} content synchronize \
 --id __My_{smart-proxy-context-titlecase}_ID__ \
 --skip-metadata-check true
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Add missing backslash to list of command arguments split by newlines.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Found while reviewing another PR.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This patch also uses dollar signs as command prefix because you can (almost) always run Hammer CLI as normal user.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
