### PR TITLE
Republish metadata via Hammer CLI

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -68,9 +68,9 @@ include::modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-us
 
 include::modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_republishing-repository-metadata.adoc[leveloffset=+1]
+include::modules/proc_republishing-repository-metadata-by-using-web-ui.adoc[leveloffset=+1]
 
-include::modules/proc_republishing-content-view-metadata.adoc[leveloffset=+1]
+include::modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_adding-an-http-proxy.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -70,7 +70,11 @@ include::modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-us
 
 include::modules/proc_republishing-repository-metadata-by-using-web-ui.adoc[leveloffset=+1]
 
+include::modules/proc_republishing-repository-metadata-by-using-cli.adoc[leveloffset=+1]
+
 include::modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc[leveloffset=+1]
+
+include::modules/proc_republishing-content-view-metadata-by-using-cli.adoc[leveloffset=+1]
 
 include::modules/proc_adding-an-http-proxy.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_republishing-content-view-metadata-by-using-cli.adoc
+++ b/guides/common/modules/proc_republishing-content-view-metadata-by-using-cli.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="republishing-content-view-metadata-by-using-cli"]
+= Republishing content view metadata by using CLI
+
+You can use Hammer CLI to republish metadata of content view versions.
+
+.Procedure
+* Republish metadata for your content view version:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer content-view version verify-checksum --id _My_Content_View_Version_ID_
+----
+
+.Verification
+. Search for the {Project} task:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer task list --search "Verify checksum of repositories in"
+----
++
+Note the UUID of the task.
+. Verify that the task completed successfully:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer task info --id "_My_Task_ID_"
+----

--- a/guides/common/modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Republishing_Content_View_Metadata_{context}"]
-= Republishing content view metadata
+[id="republishing-content-view-metadata-by-using-web-ui"]
+= Republishing content view metadata by using {ProjectWebUI}
 
-Use this procedure to republish content view metadata.
+You can use {ProjectWebUI} to republish content view metadata.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.

--- a/guides/common/modules/proc_republishing-repository-metadata-by-using-cli.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata-by-using-cli.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="republishing-repository-metadata-by-using-cli"]
+= Republishing repository metadata by using CLI
+
+You can republish repository metadata when a repository distribution does not have the content that should be distributed based on the contents of the repository.
+
+Use this procedure with caution.
+{Team} recommends a complete repository sync or publishing a new content view version to repair broken metadata.
+
+.Prerequisites
+* Ensure that the mirroring policy of your repository is not set to *Complete Mirroring*:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer repository info \
+--fields "Name,Mirroring policy" \
+--name "_My_Repository_Name_" \
+--organization-id _My_Organization_ID_ \
+--product "_My_Product_Name_"
+----
+
+.Procedure
+* Republish metadata for your repository:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer repository verify-checksum \
+--name "_My_Repository_Name_" \
+--organization-id _My_Organization_ID_ \
+--product "_My_Product_Name_"
+----
+
+.Verification
+. Search for the {Project} task:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer task list --search "Metadata generate repository"
+----
++
+Note the UUID of the task.
+. Verify that the task completed successfully:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+$ hammer task info --id "_My_Task_ID_"
+----

--- a/guides/common/modules/proc_republishing-repository-metadata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Republishing_Repository_Metadata_{context}"]
-= Republishing repository metadata
+[id="republishing-repository-metadata-by-using-web-ui"]
+= Republishing repository metadata by using {ProjectWebUI}
 
 You can republish repository metadata when a repository distribution does not have the content that should be distributed based on the contents of the repository.
 


### PR DESCRIPTION
#### What changes are you introducing?

* Rename existing modules
* Add module to republish metadata by using Hammer CLI

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

CLI procedures were missing.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Republishing the metadata felt a bit weird to me. I would appreciate it if someone would rerun the commands on Foreman nightly or latest too.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
