### PR TITLE
Fix power management sections per persona

### DIFF
--- a/guides/common/modules/proc_configuring-a-bmc-interface.adoc
+++ b/guides/common/modules/proc_configuring-a-bmc-interface.adoc
@@ -18,10 +18,9 @@ You only need the MAC address for the BMC interface if the BMC interface is mana
 ====
 
 .Procedure
-. In the {ProjectWebUI}, navigate to the *Add Interface* form:
-.. Navigate to *Hosts* > *All Hosts*.
-.. Click *Edit* next to the host you want to edit.
-.. On the *Interfaces* tab, click *Add Interface*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Edit your host.
+. On the *Interfaces* tab, click *Add Interface*.
 . Select *BMC* from the *Type* list.
 . Specify the general interface settings:
 .. If the BMC is managed, specify a *MAC address*.

--- a/guides/common/modules/proc_configuring-a-bmc-interface.adoc
+++ b/guides/common/modules/proc_configuring-a-bmc-interface.adoc
@@ -6,6 +6,10 @@
 To control the power status of bare-metal hosts from {Project}, you can configure a baseboard management controller (BMC) interface for hosts that support this feature. 
 
 .Prerequisites
+* Power management is enabled on {ProjectServer}.
+For more information, see link:{InstallingServerDocURL}enabling-power-management-on-hosts_{project-context}[Enabling power management on hosts] in _{InstallingServerDocTitle}_.
+* If you want to use {SmartProxyServer} instead of {ProjectServer}, ensure that power management is enabled on your {SmartProxyServer}.
+For more information, see link:{InstallingSmartProxyDocURL}enabling-power-management-on-hosts_{project-context}[Enabling power management on hosts] in _{InstallingSmartProxyDocTitle}_.
 * You know the MAC address, IP address, and other details of the BMC interface on the host, and authentication credentials for that interface.
 +
 [NOTE]
@@ -14,37 +18,16 @@ You only need the MAC address for the BMC interface if the BMC interface is mana
 ====
 
 .Procedure
-. Enable BMC power management on your {SmartProxy}:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-installer} \
---foreman-proxy-bmc-default-provider ipmitool \
---foreman-proxy-bmc true
-----
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
-. Select the subnet of your host.
-ifdef::satellite[]
-. On the *{SmartProxies}* tab, select your {SmartProxy} as *BMC {SmartProxy}*.
-endif::[]
-ifndef::satellite[]
-. On the *Proxies* tab, select your {SmartProxy} as *BMC Proxy*.
-endif::[]
-. Click *Submit*.
-. Navigate to the *Add Interface* form:
+. In the {ProjectWebUI}, navigate to the *Add Interface* form:
 .. Navigate to *Hosts* > *All Hosts*.
 .. Click *Edit* next to the host you want to edit.
 .. On the *Interfaces* tab, click *Add Interface*.
-
 . Select *BMC* from the *Type* list.
-
 . Specify the general interface settings:
 .. If the BMC is managed, specify a *MAC address*.
 .. Specify the *Device Identifier*.
-
 . Specify the configuration options specific to BMC interfaces:
 .. *Username* and *Password*: Specify any authentication credentials required by BMC.
 .. *Provider*: Specify the BMC provider.
-
 . Click *OK* to save the interface configuration.
 . Click *Submit* to apply the changes to the host.

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -5,7 +5,7 @@
 
 To perform power management tasks on hosts using the intelligent platform management interface (IPMI) or a similar protocol, you must enable the baseboard management controller (BMC) module on {ProductName}.
 
-{ProjectName} includes the following BMC providers:
+{ProjectName} supports the following BMC providers:
 
 * `freeipmi`
 * `ipmitool`

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -5,17 +5,35 @@
 
 To perform power management tasks on hosts using the intelligent platform management interface (IPMI) or a similar protocol, you must enable the baseboard management controller (BMC) module on {ProductName}.
 
+{ProjectName} includes the following BMC providers:
+
+* `freeipmi`
+* `ipmitool`
+* `redfish`
+
 .Prerequisites
-* All hosts must have a network interface of BMC type.
-{ProductName} uses this NIC to pass the appropriate credentials to the host.
-For more information, see {ManagingHostsDocURL}configuring-a-baseboard-management-controller-interface[Configuring a baseboard management controller (BMC) interface] in _{ManagingHostsDocTitle}_.
+* Your host has a network interface of the BMC type.
+{ProductName} uses this NIC to pass credentials to the host.
 
 .Procedure
-* To enable BMC, enter the following command:
+. Enable the BMC module and select the default provider:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {foreman-installer} \
 --foreman-proxy-bmc "true" \
---foreman-proxy-bmc-default-provider "freeipmi"
+--foreman-proxy-bmc-default-provider "_freeipmi_"
 ----
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
+. Select the subnet of your host.
+ifdef::satellite[]
+. On the *{SmartProxies}* tab, select your {ProductName} as *BMC {SmartProxy}*.
+endif::[]
+ifndef::satellite[]
+. On the *Proxies* tab, select your {ProductName} as *BMC Proxy*.
+endif::[]
+. Click *Submit*.
+
+.Next steps
+* Configure a BMC interface on your host.
+For more information, see {ManagingHostsDocURL}configuring-a-baseboard-management-controller-interface[Configuring a baseboard management controller (BMC) interface] in _{ManagingHostsDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

Moving installer stuff about power management (BMC) from _Managing hosts_ to _Installing X_

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To align the procedures with personas: admin vs. non-admin users

[SAT-30833](https://issues.redhat.com/browse/SAT-30833) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Adding usage of power operations as such is out of scope.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
