### PR TITLE
Fix modules to enable OSTree content

### DIFF
--- a/guides/common/assembly_managing-ostree-content.adoc
+++ b/guides/common/assembly_managing-ostree-content.adoc
@@ -2,6 +2,8 @@
 
 include::modules/con_managing-ostree-content.adoc[]
 
+include::modules/proc_enabling-os-tree-content.adoc[leveloffset=+1]
+
 include::modules/proc_importing-ostree-content.adoc[leveloffset=+1]
 
 ifndef::satellite[]

--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="con_managing-ostree-content_{context}"]
+[id="managing-ostree-content"]
 = Managing OSTree content
 
 You can use OSTree to manage bootable, immutable, versioned file system trees.
@@ -10,14 +10,3 @@ If a host update fails, you can easily revert the operating system on the host t
 
 You can create an OSTree image by using an image builder and expose it in an OSTree repository on an HTTP server.
 Then you can use your {Project} to synchronize and manage OSTree branches from the exposed OSTree repository.
-
-.Prerequisites
-* OSTree content is supported only when running {Project} on {EL} 8 or {EL} 9.
-* In {ProjectServer}, OSTree management tools are not enabled by default.
-To enable OSTree, enter the following command:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-installer} --foreman-proxy-content-enable-ostree true
-----
-* If you want to use Hammer CLI, you must enable the `hammer-cli-katello` plugin on {ProjectServer}.

--- a/guides/common/modules/proc_enabling-os-tree-content.adoc
+++ b/guides/common/modules/proc_enabling-os-tree-content.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="enabling-ostree-content"]
+= Enabling OSTree content
+
+You can enable OSTree on your {Project} to synchronize and manage OSTree branches from the exposed OSTree repository.
+
+.Procedure
+* On your {ProjectServer}, enable OSTree content:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-installer} --foreman-proxy-content-enable-ostree true
+----


### PR DESCRIPTION
#### What changes are you introducing?

* Drop unnecessary prerequisite about OS platform
* Drop note about Katello plugin for Hammer CLI which _should_ be installed on Foreman/Katello Server anyway
* Fix anchor

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I stumbled over the wording as part of https://github.com/theforeman/foreman-documentation/issues/3672 & the limitation to EL8/9 caught my eye which must be bogus because Foreman+Katello nightly only runs on EL9.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Untested anything else than enabling the feature.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
