### PR TITLE
Reword procedure to schedule recurring Ansible jobs

### DIFF
--- a/guides/common/modules/proc_scheduling-a-recurring-ansible-job-for-a-host-group.adoc
+++ b/guides/common/modules/proc_scheduling-a-recurring-ansible-job-for-a-host-group.adoc
@@ -1,13 +1,19 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Scheduling_a_Recurring_Ansible_Job_for_a_Host_Group_{context}"]
+[id="scheduling-a-recurring-ansible-job-for-a-host-group"]
 = Scheduling a recurring Ansible job for a host group
 
 You can schedule a recurring job to run Ansible roles on host groups.
 
+.Prerequisite
+* Ensure that you have assigned at least one Ansible role to your host group.
+* Ensure that you have assigned at least one host assigned to your host group.
+
 .Procedure
-. In the {ProjectWebUI}, navigate to *Configure* > *Host groups*.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
 . In the *Actions* column, select *Configure Ansible Job* for the host group you want to schedule an Ansible roles run for.
 . Click *Schedule recurring job*.
-. Define the repetition frequency, start time, and date of the first run in the *Create New Recurring Ansible Run* window.
+. In the *Repeat* list, select the interval.
+. In the *Start time* field, enter the time of the recurring job.
+. In the *Start date* field, enter the start date of the recurring job.
 . Click *Submit*.

--- a/guides/common/modules/proc_scheduling-a-recurring-ansible-job-for-a-host.adoc
+++ b/guides/common/modules/proc_scheduling-a-recurring-ansible-job-for-a-host.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="scheduling-a-recurring-ansible-job-for-a-host_{context}"]
+[id="scheduling-a-recurring-ansible-job-for-a-host"]
 = Scheduling a recurring Ansible job for a host
 
 You can schedule a recurring job to run Ansible roles on hosts.
@@ -9,9 +9,11 @@ You can schedule a recurring job to run Ansible roles on hosts.
 * Ensure you have the `view_foreman_tasks`, `view_job_invocations`, and `view_recurring_logics` permissions.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the target host on which you want to execute a remote job.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select your host.
 . On the *Ansible* tab, select *Jobs*.
 . Click *Schedule recurring job*.
-. Define the repetition frequency, start time, and date of the first run in the *Create New Recurring Ansible Run* window.
+. In the *Repeat* list, select the interval.
+. In the *Start time* field, enter the time of the recurring job.
+. In the *Start date* field, enter the start date of the recurring job.
 . Click *Submit*.
-. Optional: View the scheduled Ansible job in host overview or by navigating to *Ansible* > *Jobs*.


### PR DESCRIPTION
#### What changes are you introducing?

slightly reword procedure to schedule recurring Ansible role runs on hosts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Tested on Foreman 3.16
* Found while testing: https://projects.theforeman.org/issues/38777

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
