### PR TITLE
Add style definition for abstracts

### DIFF
--- a/web/content/css/_site.scss
+++ b/web/content/css/_site.scss
@@ -13,3 +13,11 @@
     margin-top: 70px!important;
   }
 }
+
+._abstract {
+  background-color: #f7f7f7;
+  border-left: 4px solid #025d8c;
+  padding: 15px;
+  margin-bottom: 1.25em;
+  border-radius: 4px;
+}


### PR DESCRIPTION
#### What changes are you introducing?

Adding a CSS style definition for paragraphs annotated with [role=_abstract].

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In order to address the requirements for Red Hat's downstream DITA pre-migration checks (https://github.com/jhradilek/asciidoctor-dita-vale/), we are now required to add abstract metadata to introductory paragraphs (http://github.com/theforeman/foreman-documentation/pull/4221). I thought it might be nice to use this metadata to visually separate abstract paragraphs on the Foreman side.

<img width="1298" height="415" alt="Screenshot From 2025-09-30 20-13-19" src="https://github.com/user-attachments/assets/5d12a58f-ac3d-4637-99a9-29d8f9e9e476" />

IMO this sort of visual separation improves readability (users will immediately know which part of a module is an abstract and where the actual fun begins). But also, seeing the abstract highlighted like this in preview might help us all write abstract as summaries (authors and reviewers will immediately see that an abstract is something else than the rest of the introduction).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

For transparency: The CSS definition was generated by Gemini and I only made minor tweaks to it. (The prompt I used was to make the abstracts look similar to standard AsciiDoc [INFO] blocks.) Feel free to suggest different CSS attributes if you'd prefer something else.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
