### PR TITLE
Remove 'Optional:' from heading

### DIFF
--- a/guides/common/modules/proc_configuring-group-mapping-for-keycloak-authentication.adoc
+++ b/guides/common/modules/proc_configuring-group-mapping-for-keycloak-authentication.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="configuring-group-mapping-for-keycloak-authentication_{context}"]
-= Optional: Configuring external group mapping for {keycloak} authentication
+= Configuring external group mapping for {keycloak} authentication
 
 [role="_abstract"]
-To implement the role-based access control (RBAC), create a group in {Project}, assign a role to this group, and then map an {keycloak} group to the {Project} group.
+Optionally, to implement the role-based access control (RBAC), create a group in {Project}, assign a role to this group, and then map an {keycloak} group to the {Project} group.
 As a result, anyone in the given group in {keycloak} will log in under the corresponding {Project} group.
 
 For example, you can configure users of the {Project}-admin user group defined in Active Directory to authenticate as users with administrator privileges on {Project}.


### PR DESCRIPTION
#### What changes are you introducing?

Removing the keyword "Optional:" from a heading and moving it to the abstract.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It seems that the element is causing an older downstream Satellite version. I'd like to change it in all versions for consistency.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
