### PR TITLE
Fix fedora required packages

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -12,8 +12,8 @@ Install the required tools.
 
 * In Fedora perform:
 
-      dnf -y groupinstall development-tools
-      dnf -y install ruby ruby-devel rubygem-bundler linkchecker
+      dnf -y group install development-tools
+      dnf -y install ruby ruby-devel rubygem-bundler linkchecker c++
 
 * In RHEL perform:
 


### PR DESCRIPTION
#### What changes are you introducing?

Update the required packages for Fedora in https://github.com/theforeman/foreman-documentation/blob/master/guides/README.md#building-locally

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

[Issue #4321 🚀](https://github.com/theforeman/foreman-documentation/issues/4321), TLDR:
With Fedora 41+ using DNF5, `groupinstall` changed to `group install`
the `c++` package is a dependency for `eventmachine` but is not installed with the listed packages, and is missing from clean Fedora installs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
