### PR TITLE
Update documentation for foreman-rake permissions:reset

### DIFF
--- a/guides/common/modules/proc_resetting-the-administrative-user-password.adoc
+++ b/guides/common/modules/proc_resetting-the-administrative-user-password.adoc
@@ -45,4 +45,3 @@ Be aware of the following behaviors:
 
 .Verification
 * Use the new password to log in to the {ProjectWebUI}.
-


### PR DESCRIPTION
#### What changes are you introducing?

The `foreman-rake permissions:reset` rake task in foreman is used to reset administer users.

Currently the documentation only says that the task is used to update the password of existing administer users but actually it also creates new administer users. Therefore, we need to update the documentation so users know what the task is actually doing.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-36570
https://issues.redhat.com/browse/SAT-34243

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
