### PR TITLE
Do not use link: prefix for DocURL

### DIFF
--- a/guides/common/modules/proc_configuring-a-bmc-interface.adoc
+++ b/guides/common/modules/proc_configuring-a-bmc-interface.adoc
@@ -7,9 +7,9 @@ To control the power status of bare-metal hosts from {Project}, you can configur
 
 .Prerequisites
 * Power management is enabled on {ProjectServer}.
-For more information, see link:{InstallingServerDocURL}enabling-power-management-on-hosts_{project-context}[Enabling power management on hosts] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}enabling-power-management-on-hosts_{project-context}[Enabling power management on hosts] in _{InstallingServerDocTitle}_.
 * If you want to use {SmartProxyServer} instead of {ProjectServer}, ensure that power management is enabled on your {SmartProxyServer}.
-For more information, see link:{InstallingSmartProxyDocURL}enabling-power-management-on-hosts_{project-context}[Enabling power management on hosts] in _{InstallingSmartProxyDocTitle}_.
+For more information, see {InstallingSmartProxyDocURL}enabling-power-management-on-hosts_{project-context}[Enabling power management on hosts] in _{InstallingSmartProxyDocTitle}_.
 * You know the MAC address, IP address, and other details of the BMC interface on the host, and authentication credentials for that interface.
 +
 [NOTE]


### PR DESCRIPTION
#### What changes are you introducing?

Remove "link:" prefix for internal links that use `*DocURL` attributes.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This is not necessary for any DocURL attributes & breaks downstream builds.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #4308

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
