### PR TITLE
Remove Proxmox 7 due to EoL

### DIFF
--- a/guides/common/modules/con_provisioning-virtual-machines-in-proxmox.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-in-proxmox.adoc
@@ -7,6 +7,6 @@ Proxmox Virtual Environment is an open-source server management platform for ent
 Proxmox tightly integrates the KVM hypervisor and Linux Containers (LXC).
 {Project} can interact with Proxmox, including creating virtual machines and controlling their power management states.
 
-{Project} supports Proxmox 7, 8, and 9.
+{Project} supports Proxmox 8 and 9.
 
 include::snip_warning-destroy-vm-on-host-delete.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?

Remove Proxmox 7

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Proxmox 7 is end of life since July 2024.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs https://forum.proxmox.com/threads/proxmox-ve-support-lifecycle.35755/

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
