### PR TITLE
Add information on the algorithm choice - local

### DIFF
--- a/guides/common/modules/proc_enabling-the-installer-managed-dhcp-service.adoc
+++ b/guides/common/modules/proc_enabling-the-installer-managed-dhcp-service.adoc
@@ -50,13 +50,13 @@ The default algorithm is HMAC-SHA256.
 The default name is `tsig-key`.
 --
 +
-Example output:
+The command outputs key information in the following format:
 +
 [source, none, options="nowrap" subs="+quotes"]
 ----
-key "tsig-key" {
-	algorithm hmac-sha256;
-	secret "hJBge7QC5AaUkRVsZmFUlg==";
+key "_My_Key_Name_" {
+	algorithm _Algorithm_Name_;
+	secret "_Key_Secret_";
 };
 ----
 . Add the information about the key from the command output to the {SmartProxy} configuration:


### PR DESCRIPTION
#### What changes are you introducing?
Adding choice of algorithms to https://docs.theforeman.org/nightly/Integrating_Provisioning_Infrastructure_Services/index-katello.html#enabling-the-installer-managed-dhcp-service

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-37669
https://issues.redhat.com/browse/SAT-37909

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Also will revamp shortdesc, which is feature-centric.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
