### PR TITLE
Flatten assemblies for Security Settings

### DIFF
--- a/guides/common/assembly_provisioning-fips-compliant-hosts.adoc
+++ b/guides/common/assembly_provisioning-fips-compliant-hosts.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-
-include::modules/con_provisioning-fips-compliant-hosts.adoc[]
-
-include::modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc[leveloffset=+1]
-
-include::modules/proc_setting-the-fips-enabled-parameter.adoc[leveloffset=+1]
-
-include::modules/proc_verifying-fips-mode-is-enabled.adoc[leveloffset=+1]

--- a/guides/common/assembly_security-settings.adoc
+++ b/guides/common/assembly_security-settings.adoc
@@ -6,4 +6,10 @@ include::modules/proc_configuring-the-security-token-validity-duration.adoc[leve
 
 include::modules/proc_setting-a-default-encrypted-root-password.adoc[leveloffset=+1]
 
-include::assembly_provisioning-fips-compliant-hosts.adoc[leveloffset=+1]
+include::modules/con_provisioning-fips-compliant-hosts.adoc[leveloffset=+1]
+
+include::modules/proc_changing-the-provisioning-password-hashing-algorithm.adoc[leveloffset=+2]
+
+include::modules/proc_setting-the-fips-enabled-parameter.adoc[leveloffset=+2]
+
+include::modules/proc_verifying-fips-mode-is-enabled.adoc[leveloffset=+2]


### PR DESCRIPTION
#### What changes are you introducing?

This patch removes an assembly that was only used once and included in another assemblies. Flattening the assemblies helps downstream orcharhino.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #4342

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
