### PR TITLE
Insights IoP does not support an external database

### DIFF
--- a/guides/common/modules/con_installing-and-configuring-insights-iop.adoc
+++ b/guides/common/modules/con_installing-and-configuring-insights-iop.adoc
@@ -8,8 +8,6 @@ When you install {insights-iop} locally, you can generate {Insights} recommendat
 
 [IMPORTANT]
 ====
-{insights-iop} has the following limitations:
-
 * With {insights-iop} enabled, you cannot use the hosted {Insights} services for hosts registered to your {Project}.
 Enabling {insights-iop} prevents you from using any {RHCloud} services on hosts registered to {Project}.
 * If you install {Project} with external databases, you cannot enable {insights-iop}.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a limitation of Insights IoP - it does not support an external database

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To make the limitation known

[SAT-38702](https://issues.redhat.com/browse/SAT-38702) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I think this is too late for users to get to know about these limitations and we should make this a snippet and include it in the Planning guide as well. WDYT?

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
