### PR TITLE
Comply DITA - Using Hammer - role abstract

### DIFF
--- a/guides/common/modules/con_hammer-authentication.adoc
+++ b/guides/common/modules/con_hammer-authentication.adoc
@@ -3,6 +3,7 @@
 [id="hammer-authentication"]
 = Hammer authentication
 
+[role="_abstract"]
 A {Project} user must prove their identity to {ProjectName} when entering hammer commands.
 Hammer commands can be run manually or automatically.
 In either case, hammer requires {Project} credentials for authentication.

--- a/guides/common/modules/con_hammer-cheat-sheet.adoc
+++ b/guides/common/modules/con_hammer-cheat-sheet.adoc
@@ -3,6 +3,7 @@
 [id="hammer-cheat-sheet"]
 = Hammer cheat sheet
 
+[role="_abstract"]
 Hammer is a command-line tool provided with {ProjectNameX}.
 You can use Hammer to configure and manage a {ProjectServer} by using either CLI commands or shell script automation.
 Run `hammer full-help` on {Project} to view the complete Hammer CLI help.

--- a/guides/common/modules/con_hammer-compared-to-project-api.adoc
+++ b/guides/common/modules/con_hammer-compared-to-project-api.adoc
@@ -3,6 +3,7 @@
 [id="hammer-compared-to-{project-context}-api"]
 = Hammer compared to {Project} API
 
+[role="_abstract"]
 For many tasks, both Hammer and {Project} API are equally applicable.
 Hammer can be used as a human friendly interface to {Project} API, for example to test responses to API calls before applying them in a script (use the `-d` option to inspect API calls issued by Hammer, for example `hammer -d organization list`).
 Changes in the API are automatically reflected in Hammer, while scripts using the API directly have to be updated manually.

--- a/guides/common/modules/con_hammer-compared-to-project-webui.adoc
+++ b/guides/common/modules/con_hammer-compared-to-project-webui.adoc
@@ -3,6 +3,7 @@
 [id="hammer-compared-to-{ProjectWebUI-context}"]
 = Hammer compared to {ProjectWebUI}
 
+[role="_abstract"]
 Compared to navigating the {ProjectWebUI}, using Hammer can result in much faster interaction with the {ProjectServer}, as common shell features such as environment variables and aliases are at your disposal.
 You can also incorporate Hammer commands into reusable scripts for automating tasks of various complexity.
 Output from Hammer commands can be redirected to other tools, which allows for integration with your existing environment.

--- a/guides/common/modules/con_introduction-to-hammer.adoc
+++ b/guides/common/modules/con_introduction-to-hammer.adoc
@@ -3,6 +3,7 @@
 [id="introduction-to-hammer"]
 = Introduction to Hammer
 
+[role="_abstract"]
 Hammer is a powerful command-line tool provided with {ProjectNameX}.
 You can use Hammer to configure and manage a {ProjectServer} either through CLI commands or automation in shell scripts.
 Hammer also provides an interactive shell.

--- a/guides/common/modules/proc_authenticating-hammer-using-a-configuration-file.adoc
+++ b/guides/common/modules/proc_authenticating-hammer-using-a-configuration-file.adoc
@@ -3,6 +3,7 @@
 [id="authenticating-hammer-using-a-configuration-file"]
 = Authenticating Hammer using a configuration file
 
+[role="_abstract"]
 If you ran the {Project} installation with `--foreman-initial-admin-username` and `--foreman-initial-admin-password` options, credentials you entered are stored in the `~/.hammer/cli.modules.d/foreman.yml` configuration file, and hammer does not prompt for your credentials.
 
 You can also add your credentials to the `~/.hammer/cli.modules.d/foreman.yml` configuration file manually:

--- a/guides/common/modules/proc_authenticating-hammer-using-cli-options.adoc
+++ b/guides/common/modules/proc_authenticating-hammer-using-cli-options.adoc
@@ -3,6 +3,7 @@
 [id="authenticating-hammer-using-cli-options"]
 = Authenticating Hammer using CLI options
 
+[role="_abstract"]
 If you do not have your {Project} credentials saved in the `~/.hammer/cli.modules.d/foreman.yml` configuration file, hammer prompts you for them each time you enter a command.
 You can specify your credentials when executing a command as follows:
 

--- a/guides/common/modules/proc_authenticating-hammer-using-sessions.adoc
+++ b/guides/common/modules/proc_authenticating-hammer-using-sessions.adoc
@@ -3,6 +3,7 @@
 [id="authenticating-hammer-using-sessions"]
 = Authenticating Hammer using sessions
 
+[role="_abstract"]
 The hammer authentication session is a cache that stores your credentials, and you have to provide them only once, at the beginning of the session.
 This method is suited to running several hammer commands in succession, for example a script containing hammer commands.
 In this scenario, you enter your {Project} credentials once, and the script runs as expected.

--- a/guides/common/modules/proc_configuring-hammer.adoc
+++ b/guides/common/modules/proc_configuring-hammer.adoc
@@ -3,6 +3,7 @@
 [id="configuring-hammer"]
 = Configuring Hammer
 
+[role="_abstract"]
 The default location for global `hammer` configuration is:
 
 * */etc/hammer/cli_config.yml* for general `hammer` settings

--- a/guides/common/modules/proc_formatting-hammer-output.adoc
+++ b/guides/common/modules/proc_formatting-hammer-output.adoc
@@ -3,6 +3,7 @@
 [id="formatting-hammer-output"]
 = Formatting Hammer output
 
+[role="_abstract"]
 You can modify the default formatting of the output of `hammer` commands to simplify the processing of this output by other command line tools and applications.
 For example, you can list organizations in a CSV format with a custom separator, for example, a semicolon:
 

--- a/guides/common/modules/proc_hiding-header-output-from-hammer-commands.adoc
+++ b/guides/common/modules/proc_hiding-header-output-from-hammer-commands.adoc
@@ -3,6 +3,7 @@
 [id="hiding-header-output-from-hammer-commands"]
 = Hiding header output from Hammer commands
 
+[role="_abstract"]
 When you use any hammer command, you have the option of hiding headers from the output.
 If you want to pipe or use the output in custom scripts, hiding the output is useful.
 

--- a/guides/common/modules/proc_increasing-the-logging-level-for-hammer.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-level-for-hammer.adoc
@@ -3,6 +3,7 @@
 [id="increasing-the-logging-level-for-hammer"]
 = Increasing the logging level for Hammer
 
+[role="_abstract"]
 You can find the log in `~/.hammer/log/hammer.log`.
 
 .Procedure

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -3,6 +3,7 @@
 [id="installing-standalone-hammer"]
 = Installing standalone Hammer
 
+[role="_abstract"]
 You can install Hammer on a host running {install-on-os} that has no {ProjectServer} installed, and use it to connect from the host to a remote {Project}.
 
 .Prerequisites

--- a/guides/common/modules/proc_setting-a-default-organization-and-location-context.adoc
+++ b/guides/common/modules/proc_setting-a-default-organization-and-location-context.adoc
@@ -3,6 +3,7 @@
 [id="setting-a-default-organization-and-location-context"]
 = Setting a default organization and location context
 
+[role="_abstract"]
 Many `hammer` commands are organization specific.
 You can set a default organization and location for `hammer` commands so that you do not have to specify them every time with the `--organization` and `--location` options.
 

--- a/guides/common/modules/proc_using-interactive-hammer-shell.adoc
+++ b/guides/common/modules/proc_using-interactive-hammer-shell.adoc
@@ -3,6 +3,7 @@
 [id="using-interactive-hammer-shell"]
 = Using interactive Hammer shell
 
+[role="_abstract"]
 You can issue `hammer` commands through an interactive shell.
 Start the shell:
 

--- a/guides/common/modules/ref_getting-help-with-hammer-cli.adoc
+++ b/guides/common/modules/ref_getting-help-with-hammer-cli.adoc
@@ -3,6 +3,7 @@
 [id="getting-help-with-hammer-cli"]
 = Getting help with Hammer CLI
 
+[role="_abstract"]
 View the full list of `hammer` options and subcommands by executing:
 
 [options="nowrap", subs="verbatim,quotes,attributes"]

--- a/guides/common/modules/ref_troubleshooting-project-by-using-hammer.adoc
+++ b/guides/common/modules/ref_troubleshooting-project-by-using-hammer.adoc
@@ -3,6 +3,7 @@
 [id="troubleshooting-{project-context}-by-using-hammer"]
 = Troubleshooting {Project} by using Hammer
 
+[role="_abstract"]
 You can use the `hammer ping` command to check the status of core {Project} services.
 Together with the `{foreman-maintain} service status` command, this can help you to diagnose and troubleshoot {Project} issues.
 If all services are running as expected, the output looks as follows:

--- a/guides/common/modules/ref_using-json-for-complex-parameters.adoc
+++ b/guides/common/modules/ref_using-json-for-complex-parameters.adoc
@@ -3,6 +3,7 @@
 [id="using-json-for-complex-parameters"]
 = Using JSON for complex parameters
 
+[role="_abstract"]
 JSON is the preferred way to describe complex parameters.
 
 An example of JSON formatted content appears below:


### PR DESCRIPTION
#### What changes are you introducing?

Add `[role="_abstract"]` to modules in the _Hammer CLI_ guide

Resolves this DITA Vale rule warnings:

```
warning  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription 
         to a paragraph to use it as                                   
         <shortdesc> in DITA.   
```

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

DITA compliance

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.) 

- Short descriptions (abstracts) will be rewritten later.
- **Please, stay within the scope of changes when reviewing.**

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
