### PR TITLE
Address asciidoctor-dita-vale issues for refreshing certs

### DIFF
--- a/guides/common/modules/con_refreshing-the-self-signed-ca-certificate-on-hosts.adoc
+++ b/guides/common/modules/con_refreshing-the-self-signed-ca-certificate-on-hosts.adoc
@@ -3,6 +3,7 @@
 [id="refreshing-the-self-signed-ca-certificate-on-hosts"]
 = Refreshing the self-signed CA certificate on hosts
 
+[role="_abstract"]
 When you change the CA certificate on your {ProjectServer}, you must refresh the CA certificate on your hosts.
 
 Ensure that you use a temporary dual CA certificate file for uninterrupted operation.

--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-ansible-rex.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-ansible-rex.adoc
@@ -3,6 +3,7 @@
 [id="deploying-the-ca-certificate-on-a-host-by-using-ansible-rex"]
 = Deploying the CA certificate on a host by using Ansible REX
 
+[role="_abstract"]
 You can use remote execution (REX) with the Ansible provider to deploy the CA certificate.
 
 include::snip_prerequisites-deploying-ca-cert-rex.adoc[]
@@ -25,8 +26,8 @@ You can use HTTP when the CA certificate is expired.
 . Optional: Click *Next* and configure advanced fields and scheduling as you require.
 . Click *Run on selected hosts*.
 
+.Verification
 include::snip_verification-ca-set-correctly.adoc[]
 
-[role="_additional-resources"]
 .Additional resources
 * xref:executing-a-remote-job_managing-hosts[]

--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-script-rex.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-script-rex.adoc
@@ -3,6 +3,7 @@
 [id="deploying-the-ca-certificate-on-a-host-by-using-script-rex"]
 = Deploying the CA certificate on a host by using Script REX
 
+[role="_abstract"]
 You can use remote execution (REX) with the Script provider to deploy the CA certificate.
 
 include::snip_prerequisites-deploying-ca-cert-rex.adoc[]
@@ -25,8 +26,8 @@ You can use HTTP when the CA certificate is expired.
 . Optional: Click *Next* and configure advanced fields and scheduling as you require.
 . Click *Run on selected hosts*.
 
+.Verification
 include::snip_verification-ca-set-correctly.adoc[]
 
-[role="_additional-resources"]
 .Additional resources
 * xref:executing-a-remote-job_managing-hosts[]

--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-manually.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-manually.adoc
@@ -3,6 +3,7 @@
 [id="deploying-the-ca-certificate-on-a-host-manually"]
 = Deploying the CA certificate on a host manually
 
+[role="_abstract"]
 You can deploy the CA certificate on the host manually by rendering a public provisioning template, which provides the CA certificate.
 
 .Prerequisites
@@ -62,4 +63,5 @@ ifdef::client-content-apt[]
 ----
 endif::[]
 
+.Verification
 include::snip_verification-ca-set-correctly.adoc[]

--- a/guides/common/modules/snip_verification-ca-set-correctly.adoc
+++ b/guides/common/modules/snip_verification-ca-set-correctly.adoc
@@ -1,4 +1,3 @@
-.Verification
 * If the host can access {ProjectServer}, the following command succeeds on your host:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

* Adding the abstract role and creating basic abstracts
* Removing the additional resources role (not related to asciidoctor-dita-vale but a relict from a previous version of the modular templates)
* Moving `.Verification` heading from a snippet to the parent module

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To ensure a clean https://github.com/jhradilek/asciidoctor-dita-vale/ check for the assembly.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
