### PR TITLE
Add missing endif

### DIFF
--- a/guides/doc-Tuning_Performance/master.adoc
+++ b/guides/doc-Tuning_Performance/master.adoc
@@ -71,6 +71,7 @@ include::common/modules/con_smart-proxy-configuration-tuning.adoc[leveloffset=+2
 include::common/modules/con_smartproxy-performance-tests.adoc[leveloffset=+3]
 endif::[]
 endif::[]
+endif::[]
 
 ifndef::orcharhino,satellite[]
 include::common/ribbons.adoc[]


### PR DESCRIPTION
This PR fixes the build for 3.13 and should get cherry-picked as part of cherry-picking https://github.com/theforeman/foreman-documentation/pull/4360

Note: GHA to build the merge base (aka. current HEAD of 3.13) is expected to fail.