### PR TITLE
Fix content type attribute in "Using content views"

### DIFF
--- a/guides/common/assembly_basic-content-management-workflow.adoc
+++ b/guides/common/assembly_basic-content-management-workflow.adoc
@@ -12,7 +12,7 @@ include::modules/con_registering-a-centos-stream-host.adoc[leveloffset=+1]
 
 include::modules/snip_host-registration-steps.adoc[]
 
-include::modules/proc_using-content-views.adoc[leveloffset=+1]
+include::modules/con_using-content-views.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-content-view-short.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_using-content-views.adoc
+++ b/guides/common/modules/con_using-content-views.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 
 [id="Using_Content_Views_{context}"]
 = Using content views


### PR DESCRIPTION
#### What changes are you introducing?

Change content type attribute from "procedure" to "concept".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

"Using content views" is not a procedure.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
