### PR TITLE
Fix content attribute - "Using free text search"

### DIFF
--- a/guides/common/assembly_searching-and-bookmarking.adoc
+++ b/guides/common/assembly_searching-and-bookmarking.adoc
@@ -10,7 +10,7 @@ include::modules/ref_query-operators.adoc[leveloffset=+2]
 
 include::modules/ref_query-values.adoc[leveloffset=+2]
 
-include::modules/proc_using-free-text-search.adoc[leveloffset=+1]
+include::modules/con_using-free-text-search.adoc[leveloffset=+1]
 
 include::modules/con_managing-bookmarks.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_using-free-text-search.adoc
+++ b/guides/common/modules/con_using-free-text-search.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 
 [id="Using_Free_Text_Search_{context}"]
 = Using free text search


### PR DESCRIPTION
#### What changes are you introducing?

Change content attribute to "concept".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

"Using free text search" is not a procedure.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
