### PR TITLE
Add notice of deprecation of sendmail

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -6,7 +6,7 @@
 To send email messages from {ProjectServer}, you can use an SMTP server or the `sendmail` command.
 
 :FeatureName: The `sendmail` command
-:FeatureAlternative: SMTP service on {ProjectServer}
+:FeatureAlternative: the SMTP service on {ProjectServer}
 include::snip_deprecated-feature.adoc[]
 
 .Prerequisites


### PR DESCRIPTION
#### What changes are you introducing?
Add mentions that sendmail is deprecated.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Sendmail is deprecated in Satellite 6.18 and will be removed. To prevent users from relying on deprecated features, I want to update the docs so that it's clear which method is future-proof.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Also some minor style improvements in the procedure.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
