### PR TITLE
Remove overview of hosts from Managing hosts

### DIFF
--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -2,6 +2,8 @@
 
 include::modules/con_administering-hosts.adoc[]
 
+include::modules/con_browsing-hosts-in-foreman-webui.adoc[leveloffset=+1]
+
 include::modules/proc_creating-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_cloning-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-hosts.adoc
+++ b/guides/common/assembly_overview-of-hosts.adoc
@@ -1,5 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-
-include::modules/con_overview-of-hosts-in-project.adoc[]
-
-include::modules/con_browsing-hosts-in-foreman-webui.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -9,8 +9,6 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/assembly_overview-of-hosts.adoc[leveloffset=+1]
-
 include::common/assembly_administering-hosts.adoc[leveloffset=+1]
 
 include::common/assembly_working-with-host-groups.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

* Removing overview of hosts from Managing hosts
* Moving browsing hosts to another assembly

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The existing assembly `assembly_overview-of-hosts-in-project.adoc` looks somewhat out of place in the guide. The module with an overview of hosts is already part of Planning. Because there isn't more content to be included in the assembly, I think it would be reasonable to simply drop it.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I have it on my to-do list (and Jira backlog) to review `assembly_administering-hosts.adoc` and split it into smaller assemblies.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
