### PR TITLE
Remove pull step from IoP installation - SAT-38722

### DIFF
--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -22,12 +22,6 @@ endif::[]
 ----
 # podman login --authfile /etc/foreman/registry-auth.json registry.redhat.io
 ----
-. Pull the container image:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-$ podman pull registry.redhat.io/satellite/iop-advisor-engine-rhel9:{ProjectVersion}
-----
 . Enable the plugin:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

Remove the podman pull command from Installing {insights-iop} on a connected {ProjectServer}

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

When installing IoP on 6.18, there is no need to run podman pull manually for any images. The installation guide at [1] has a step to pull a (non-existent) image. This step should be removed, so that the only commands required are the podman login and satellite-installer commands.
https://issues.redhat.com/browse/SAT-38722

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
