### PR TITLE
Align names to current convention

### DIFF
--- a/guides/common/assembly_accessing-project-from-web-ui.adoc
+++ b/guides/common/assembly_accessing-project-from-web-ui.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 
-include::modules/con_accessing-projectname-from-projectwebui.adoc[]
+include::modules/con_accessing-project-from-web-ui.adoc[]
 
-include::modules/proc_logging-in-to-the-projectwebui.adoc[leveloffset=+1]
+include::modules/proc_logging-in-to-the-web-ui.adoc[leveloffset=+1]
 
 ifdef::katello,orcharhino,satellite[]
 include::modules/proc_importing-the-katello-root-ca-certificate-using-web-ui.adoc[leveloffset=+1]
@@ -12,4 +12,4 @@ endif::[]
 
 include::modules/proc_resetting-the-administrative-user-password.adoc[leveloffset=+1]
 
-include::modules/proc_setting-a-custom-message-on-the-projectwebui-login-page.adoc[leveloffset=+1]
+include::modules/proc_setting-a-custom-message-on-the-web-ui-login-page.adoc[leveloffset=+1]

--- a/guides/common/assembly_administering-hosts.adoc
+++ b/guides/common/assembly_administering-hosts.adoc
@@ -2,7 +2,7 @@
 
 include::modules/con_administering-hosts.adoc[]
 
-include::modules/con_browsing-hosts-in-foreman-webui.adoc[leveloffset=+1]
+include::modules/con_browsing-hosts-in-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-host.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
@@ -12,8 +12,8 @@ include::modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc[
 
 include::modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc[leveloffset=+1]
 
-include::modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-mozilla-firefox.adoc[leveloffset=+1]
+include::modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-mozilla-firefox.adoc[leveloffset=+1]
 
-include::modules/proc_logging-in-to-the-projectwebui-with-freeipa-credentials-in-chrome.adoc[leveloffset=+1]
+include::modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-a-cross-forest-trust-between-freeipa-and-active-directory-for-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
@@ -8,7 +8,7 @@ include::modules/proc_registering-project-as-a-client-of-keycloak.adoc[leveloffs
 
 include::modules/proc_configuring-the-project-client-in-keycloak-quarkus.adoc[leveloffset=+1]
 
-include::modules/proc_configuring-a-project-client-to-provide-projectwebui-authentication-with-keycloak.adoc[leveloffset=+1]
+include::modules/proc_configuring-a-project-client-to-provide-web-ui-authentication-with-keycloak.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -8,7 +8,7 @@ include::modules/proc_registering-project-as-a-client-of-keycloak.adoc[leveloffs
 
 include::modules/proc_configuring-the-project-client-in-keycloak-wildfly.adoc[leveloffset=+1]
 
-include::modules/proc_configuring-a-project-client-to-provide-projectwebui-authentication-with-keycloak.adoc[leveloffset=+1]
+include::modules/proc_configuring-a-project-client-to-provide-web-ui-authentication-with-keycloak.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc[leveloffset=+1]
 

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -132,7 +132,6 @@
 :ProjectServerTitle: {Project}{nbsp}Server
 :ProjectServerID: {Project}-Server
 :ProjectWebUI: {Project} web UI
-:ProjectWebUI-context: {project-context}_web_UI
 :ProjectX: {Project}
 :ProjectXY: {Project}{nbsp}{ProjectVersion}
 :provision-script: OS installer recipe

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -14,7 +14,6 @@
 :ProjectServerTitle: {ProjectServer}
 :ProjectServerID: {Project}-Server
 :ProjectWebUI: {Project} management UI
-:ProjectWebUI-context: {project-context}_management_UI
 :ProjectX: {Project}
 :ProjectXY: {Project}{nbsp}{ProjectVersion}
 :SmartProxies: orcharhino{nbsp}Proxies

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -119,7 +119,6 @@
 :ProjectServerTitle: {ProjectServer}
 :ProjectServerID: {Project}-Server
 :ProjectWebUI: {Project} web UI
-:ProjectWebUI-context: {project-context}_web_UI
 :ProjectX: Satellite{nbsp}6
 :ProjectXY: Satellite{nbsp}{ProjectVersionRepoTitle}
 :provision-script: kickstart

--- a/guides/common/modules/con_accessing-project-from-web-ui.adoc
+++ b/guides/common/modules/con_accessing-project-from-web-ui.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="Accessing_Server_{context}"]
+[id="accessing-{project-context}-from-web-ui"]
 = Accessing {ProjectName} from {ProjectWebUI}
 
 [role="_abstract"]

--- a/guides/common/modules/con_browsing-hosts-in-web-ui.adoc
+++ b/guides/common/modules/con_browsing-hosts-in-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="Browsing-Hosts-in-{ProjectWebUI-context}_{context}"]
-= Browsing Hosts in {ProjectWebUI}
+[id="browsing-hosts-in-web-ui"]
+= Browsing hosts in {ProjectWebUI}
 
 In the {ProjectWebUI}, you can browse all hosts recognized by {Project}, grouped by type:
 

--- a/guides/common/modules/con_hammer-compared-to-web-ui.adoc
+++ b/guides/common/modules/con_hammer-compared-to-web-ui.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="hammer-compared-to-{ProjectWebUI-context}"]
+[id="hammer-compared-to-web-ui"]
 = Hammer compared to {ProjectWebUI}
 
 [role="_abstract"]

--- a/guides/common/modules/con_web-ui-overview.adoc
+++ b/guides/common/modules/con_web-ui-overview.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="{ProjectWebUI-context}-overview"]
+[id="web-ui-overview"]
 = {ProjectWebUI} overview
 
 You can manage and monitor your {Project} infrastructure from a browser with the {ProjectWebUI}.

--- a/guides/common/modules/proc_configuring-a-project-client-to-provide-web-ui-authentication-with-keycloak.adoc
+++ b/guides/common/modules/proc_configuring-a-project-client-to-provide-web-ui-authentication-with-keycloak.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-a-{project-context}-client-to-provide-{ProjectWebUI-context}-authentication-with-keycloak_{context}"]
+[id="configuring-a-{project-context}-client-to-provide-web-ui-authentication-with-keycloak_{context}"]
 = Configuring a {Project} client to provide {ProjectWebUI} authentication with {keycloak}
 
 [role="_abstract"]

--- a/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="logging-in-to-the-webui-with-{FreeIPA-context}-credentials-in-chrome"]
+[id="logging-in-to-the-web-ui-with-{FreeIPA-context}-credentials-in-chrome"]
 = Logging in to the {ProjectWebUI} with {FreeIPA} credentials in Chrome
 
 [role="_abstract"]

--- a/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-mozilla-firefox.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-mozilla-firefox.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="logging-in-to-the-webui-with-{FreeIPA-context}-credentials-in-mozilla-firefox"]
+[id="logging-in-to-the-web-ui-with-{FreeIPA-context}-credentials-in-mozilla-firefox"]
 = Logging in to the {ProjectWebUI} with {FreeIPA} credentials in Mozilla Firefox
 
 [role="_abstract"]

--- a/guides/common/modules/proc_logging-in-to-the-web-ui.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="logging-in-to-the-{ProjectWebUI-context}_{context}"]
+[id="logging-in-to-the-web-ui"]
 = Logging in to the {ProjectWebUI}
 
 [role="_abstract"]

--- a/guides/common/modules/proc_setting-a-custom-message-on-the-web-ui-login-page.adoc
+++ b/guides/common/modules/proc_setting-a-custom-message-on-the-web-ui-login-page.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="setting-a-custom-message-on-the-{ProjectWebUI-context}-login-page_{context}"]
+[id="setting-a-custom-message-on-the-web-ui-login-page"]
 = Setting a custom message on the {ProjectWebUI} login page
 
 [role="_abstract"]
@@ -8,7 +8,8 @@ You can change the default text on the login page to a custom message you want y
 For example, your custom message might be a warning required by your company.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *General* tab.
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
+. Select the *General* tab.
 . Enter your custom message in the *Login page footer text* field.
 . Click *Submit*.
 

--- a/guides/doc-Configuring_User_Authentication/master.adoc
+++ b/guides/doc-Configuring_User_Authentication/master.adoc
@@ -10,7 +10,7 @@ endif::[]
 
 include::common/modules/ref_overview-of-authentication-methods-in-foreman.adoc[leveloffset=+1]
 
-include::common/assembly_accessing-projectname-from-projectwebui.adoc[leveloffset=+1]
+include::common/assembly_accessing-project-from-web-ui.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc[leveloffset=+1]
 

--- a/guides/doc-Hammer_CLI/master.adoc
+++ b/guides/doc-Hammer_CLI/master.adoc
@@ -11,7 +11,7 @@ endif::[]
 
 include::common/modules/con_introduction-to-hammer.adoc[leveloffset=+1]
 
-include::common/modules/con_hammer-compared-to-project-webui.adoc[leveloffset=+2]
+include::common/modules/con_hammer-compared-to-web-ui.adoc[leveloffset=+2]
 
 include::common/modules/con_hammer-compared-to-project-api.adoc[leveloffset=+2]
 


### PR DESCRIPTION
#### What changes are you introducing?

We have accepted to use "web-ui" in anchors, so there's no need for a separate attribute anymore.
This patch also ensures that we do not use "webui" in modules or module names.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Extends PR #4340

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
