### PR TITLE
Add Fedora Flatpak index for non-Satellite builds

### DIFF
--- a/guides/common/modules/proc_creating-a-flatpak-remote.adoc
+++ b/guides/common/modules/proc_creating-a-flatpak-remote.adoc
@@ -13,7 +13,10 @@ You can create a Flatpak remote to access and manage Flatpak repositories in {Pr
 . Click *Create new*.
 . In the *Name* field, enter a name for the Flatpak remote.
 . In the *URL* field, enter the URL of the Flatpak remote.
-  For example, to use the Red{nbsp}Hat Flatpak index, enter: `https://flatpaks.redhat.io/rhel/`.
+For example, to use the Red{nbsp}Hat Flatpak index, enter: `https://flatpaks.redhat.io/rhel/`.
+ifndef::satellite[]
+To use the Fedora Flatpak index, enter: `https://registry.fedoraproject.org/`.
+endif::[]
 . If the Flatpak remote requires authentication, enter the required credentials.
 For example, synchronizing Red{nbsp}Hat Flatpaks from `registry.redhat.io` requires authentication.
 For more information, see https://access.redhat.com/articles/RegistryAuthentication#creating-registry-service-accounts-6[Creating Registry Service Accounts].


### PR DESCRIPTION
#### What changes are you introducing?

This patch adds an example that users can use without authentication. 

Note that "https://quay.io/organization/fedora/" does not work. Pulp returns an "308 Permanent Redirect" error.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This helps users to use Foreman+Katello and maintainers to test the docs :)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

URL comes from Samir via https://community.theforeman.org/t/rfc-flatpak-support-in-katello/39768

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
