### PR TITLE
Shorten CLI procedure to verify task

### DIFF
--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-cli.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-cli.adoc
@@ -52,17 +52,9 @@ $ {hammer-smart-proxy} content verify-checksum \
 ----
 
 .Verification
-. Search for the {Project} task:
+* Verify that the task completed successfully:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 $ hammer task list --search "Verify checksum for content"
-----
-+
-Note the UUID of the task.
-. Verify that the task completed successfully:
-+
-[options="nowrap", subs="+quotes,attributes"]
-----
-$ hammer task info --id "_My_Task_ID_"
 ----


### PR DESCRIPTION
#### What changes are you introducing?

shorter verification is better.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

One command is enough to list the tasks and to view their state. The Hammer CLI stdout contains columns for both the state and result.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
