### PR TITLE
Add IoP notes to backup and restore

### DIFF
--- a/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
+++ b/guides/common/modules/proc_estimating-the-size-of-a-backup.adoc
@@ -14,9 +14,9 @@ A full backup requires space to store the following data:
 
 ifdef::satellite[]
 [NOTE]
-----
-Backup does not include container images for {insights-iop}.
-----
+====
+Backups do not include container images for {insights-iop}.
+====
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -44,13 +44,11 @@ endif::[]
 ** To install {ProjectServer} from a connected network, follow the procedures in {InstallingServerDocURL}[{InstallingServerDocTitle}].
 ifdef::satellite[]
 +
-If you intend to use {insights-iop}, enable it.
+If you have used {insights-iop}, enable it.
 For more information, see {InstallingServerDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}].
-endif::[]
-ifdef::satellite[]
 ** To install {ProjectServer} from a disconnected network, follow the procedures in {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
 +
-If you intend to use {insights-iop}, enable it.
+If you have used {insights-iop}, enable it.
 For more information, see {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}].
 endif::[]
 ** To install a {SmartProxyServer}, follow the procedures in {InstallingSmartProxyDocURL}[{InstallingSmartProxyDocTitle}].


### PR DESCRIPTION
#### What changes are you introducing?

Updating the _Administering_ guide:

- Adding NOTE: backup doesn't include IoP container images
- Mentioning IoP needs to be enabled for restore

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Making users aware
- Required to ensure smooth restore

[SAT-38721](https://issues.redhat.com/browse/SAT-38721) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
