### PR TITLE
Fix Pulp manifest on 3.12-

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -8,18 +8,7 @@ Use this procedure to configure a repository in a directory on the base system w
 To create a file type repository in a directory on a remote server, see xref:Creating_a_Remote_Source_for_a_Custom_File_Type_Repository_{context}[].
 
 .Procedure
-ifdef::satellite[]
-. On your {ProjectServer}, enable the required repositories:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# subscription-manager repos \
---enable={RepoRHEL8AppStream} \
---enable={RepoRHEL8BaseOS} \
---enable={RepoRHEL8ServerSatelliteServerProjectVersion}
-----
-endif::[]
-. Install the Pulp Manifest package:
+. On your {ProjectServer}, install the Pulp Manifest package:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -38,7 +27,7 @@ Alternatively, to prevent downtime caused by stopping the service, you can use t
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} packages unlock
-# {project-package-install} pulp-manifest
+# {project-package-install} python3.11-pulp_manifest
 # {foreman-maintain} packages lock
 ----
 endif::[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -13,7 +13,7 @@ ifdef::katello,orcharhino[]
 endif::[]
 ifdef::satellite[]
 * You have a server running {EL} 8 registered to your {Project} or the Red{nbsp}Hat CDN.
-* Your server has an entitlement to the {RHELServer} and {ProjectName} Utils repositories.
+* Your server has an entitlement to the {RHELServer} and {ProjectName} repositories.
 endif::[]
 * You have installed an HTTP server.
 ifndef::orcharhino[]
@@ -47,10 +47,10 @@ endif::[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::satellite[]
-# {project-package-install} python3.11-pulp_manifest
+# {package-install} python3.11-pulp_manifest
 endif::[]
 ifndef::satellite[]
-# {project-package-install} pulp-manifest
+# {package-install} pulp-manifest
 endif::[]
 ----
 . Create a directory that you want to use as the file type repository in the HTTP server's public folder:


### PR DESCRIPTION
#### What changes are you introducing?

Fixing installation of `pulp_manifest` package in Sat 6.16 and older

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Package is in the main _Satellite_ repo, not in _Satellite Utils_ repo
- Package name was incorrect for Satellite

[SAT-31853](https://issues.redhat.com/browse/SAT-31853) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
