### PR TITLE
Comply with DITA - Mng content - role abstract

### DIFF
--- a/guides/common/modules/con_applying-errata-to-hosts.adoc
+++ b/guides/common/modules/con_applying-errata-to-hosts.adoc
@@ -3,6 +3,7 @@
 [id="applying-errata-to-hosts"]
 = Applying errata to hosts
 
+[role="_abstract"]
 Use these procedures to review and apply errata to hosts.
 
 .Prerequisites

--- a/guides/common/modules/con_basic-content-management-workflow.adoc
+++ b/guides/common/modules/con_basic-content-management-workflow.adoc
@@ -3,6 +3,7 @@
 [id="Basic_Content_Management_Workflow_{context}"]
 = Basic content management workflow
 
+[role="_abstract"]
 This is a quick overview of the tasks involved in the basic content management workflow in {Project}.
 If you have installed {Project} with Katello and want to synchronize and manage Enterprise Linux content on your hosts, follow the steps in this chapter.
 

--- a/guides/common/modules/con_clearing-the-search-filter.adoc
+++ b/guides/common/modules/con_clearing-the-search-filter.adoc
@@ -3,6 +3,7 @@
 [id="Clearing_the_Search_Filter_{context}"]
 = Clearing the search filter
 
+[role="_abstract"]
 If you search for specific content types by using keywords in the *Search* text box and the search returns no results, click *Clear search* to clear all the search queries and reset the *Search* text box.
 
 If you use a filter to search for specific repositories in the *Type* text box and the search returns no results, click *Clear filters* to clear all active filters and reset the *Type* text box.

--- a/guides/common/modules/con_comparison-of-content-view-environments-and-composite-content-views.adoc
+++ b/guides/common/modules/con_comparison-of-content-view-environments-and-composite-content-views.adoc
@@ -3,6 +3,7 @@
 [id="comparison-of-content-view-environments-and-composite-content-views"]
 = Comparison of content view environments and composite content views
 
+[role="_abstract"]
 Composite content views provide an alternative method for granting hosts access to content from multiple content views.
 You can use composite content views, multiple content view environments, or a combination of both.
 The key differences between these methods include the following:

--- a/guides/common/modules/con_composite-content-views-overview.adoc
+++ b/guides/common/modules/con_composite-content-views-overview.adoc
@@ -3,6 +3,7 @@
 [id="Composite_Content_Views_Overview_{context}"]
 = Composite content views overview
 
+[role="_abstract"]
 A composite content view combines the content from several content views.
 For example, you might have separate content views to manage an operating system and an application individually.
 You can use a composite content view to merge the contents of both content views into a new repository.

--- a/guides/common/modules/con_configuring-inter-server-synchronization.adoc
+++ b/guides/common/modules/con_configuring-inter-server-synchronization.adoc
@@ -3,6 +3,7 @@
 [id="Configuring-ISS_{context}"]
 = Configuring {ISS} (ISS)
 
+[role="_abstract"]
 ifdef::satellite[]
 Configure {ISS} on your disconnected {ProjectServer} to provide content in your disconnected network.
 endif::[]

--- a/guides/common/modules/con_content-delivery-network-structure.adoc
+++ b/guides/common/modules/con_content-delivery-network-structure.adoc
@@ -3,6 +3,7 @@
 [id="Content_Delivery_Network_Structure_{context}"]
 = Content Delivery Network structure
 
+[role="_abstract"]
 ifdef::katello,orcharhino[]
 [NOTE]
 ====

--- a/guides/common/modules/con_content-filter-examples.adoc
+++ b/guides/common/modules/con_content-filter-examples.adoc
@@ -3,6 +3,7 @@
 [id="Content_Filter_Examples_{context}"]
 = Content filter examples
 
+[role="_abstract"]
 Use any of the following examples with the procedure that follows to build custom content filters.
 
 [NOTE]

--- a/guides/common/modules/con_content-filter-overview.adoc
+++ b/guides/common/modules/con_content-filter-overview.adoc
@@ -3,6 +3,7 @@
 [id="Content_Filter_Overview_{context}"]
 = Content filter overview
 
+[role="_abstract"]
 ifdef::satellite[]
 Content views also use filters to include or restrict certain Yum content.
 endif::[]

--- a/guides/common/modules/con_content-promotion-across-the-application-lifecycle.adoc
+++ b/guides/common/modules/con_content-promotion-across-the-application-lifecycle.adoc
@@ -3,6 +3,7 @@
 [id="Content_Promotion_across_the_Application_Lifecycle_{context}"]
 = Content promotion across the application lifecycle
 
+[role="_abstract"]
 In the application lifecycle chain, when content moves from one environment to the next, this is called _promotion_.
 
 .Example: Content promotion across {Project} lifecycle environments

--- a/guides/common/modules/con_content-synchronization-by-using-export-and-import.adoc
+++ b/guides/common/modules/con_content-synchronization-by-using-export-and-import.adoc
@@ -3,6 +3,7 @@
 [id="content-synchronization-by-using-export-and-import_{context}"]
 = Content synchronization by using export and import
 
+[role="_abstract"]
 There are multiple approaches for synchronizing content by using the export and import workflow:
 
 * You employ the upstream {ProjectServer} as a content store, which means that you sync the whole Library rather than content view versions.

--- a/guides/common/modules/con_content-types-in-project.adoc
+++ b/guides/common/modules/con_content-types-in-project.adoc
@@ -3,6 +3,7 @@
 [id="Content_Types_in_{ProjectNameID}_{context}"]
 = Content types in {ProjectName}
 
+[role="_abstract"]
 With {ProjectName}, you can import and manage many content types.
 ifdef::satellite[]
 You can use Red{nbsp}Hat content as well as custom content and organize it into {Project} products.

--- a/guides/common/modules/con_content-view-environment-categories.adoc
+++ b/guides/common/modules/con_content-view-environment-categories.adoc
@@ -3,6 +3,7 @@
 [id="content-view-environment-categories"]
 = Content view environment categories
 
+[role="_abstract"]
 The content view environments available in your organization fall into the following categories:
 
 Library environment::

--- a/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
+++ b/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
@@ -3,6 +3,7 @@
 [id="content-view-environment-ordering-and-priority"]
 = Content view environment ordering and priority
 
+[role="_abstract"]
 ifdef::satellite[]
 :example-repo-id: satellite-client-6-for-rhel-9-x86_64-rpms
 :example-repo-name: Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs)

--- a/guides/common/modules/con_content-view-environments-overview.adoc
+++ b/guides/common/modules/con_content-view-environments-overview.adoc
@@ -3,6 +3,7 @@
 [id="content-view-environments-overview"]
 = Content view environments overview
 
+[role="_abstract"]
 The *Allow multiple content views* setting controls whether hosts and activation keys can be assigned to multiple content view environments.
 By default, this feature is disabled, limiting assignments to a single content view environment.
 Enable this setting to assign multiple content view environments to hosts and activation keys.

--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -3,6 +3,7 @@
 [id="Content-Views-in-{ProjectNameID}_{context}"]
 = Content views in {ProjectName}
 
+[role="_abstract"]
 A content view is a deliberately curated subset of content that your hosts can access.
 By creating a content view, you can define the software versions used by a particular environment or {SmartProxyServer}.
 

--- a/guides/common/modules/con_download-policies-overview.adoc
+++ b/guides/common/modules/con_download-policies-overview.adoc
@@ -3,6 +3,7 @@
 [id="Download_Policies_Overview_{context}"]
 = Download policies overview
 
+[role="_abstract"]
 ifdef::satellite[]
 {ProjectName} provides multiple download policies for synchronizing RPM content.
 endif::[]

--- a/guides/common/modules/con_importing-content.adoc
+++ b/guides/common/modules/con_importing-content.adoc
@@ -3,6 +3,7 @@
 [id="Importing_Content_{context}"]
 = Importing content
 
+[role="_abstract"]
 This chapter outlines how you can import different types of {customcontent} to {Project}.
 For example, you can use the following chapters for information on specific types of {customcontent} but the underlying procedures are the same:
 

--- a/guides/common/modules/con_introduction-to-application-lifecycle.adoc
+++ b/guides/common/modules/con_introduction-to-application-lifecycle.adoc
@@ -3,6 +3,7 @@
 [id="introduction_to_application_lifecycle_{context}"]
 = Introduction to application lifecycle
 
+[role="_abstract"]
 The _application lifecycle_ is a concept central to {Project}'s content management functions.
 The application lifecycle defines how a particular system and its software look at a particular stage.
 For example, an application lifecycle might be simple; you might only have a development stage and production stage.

--- a/guides/common/modules/con_introduction-to-content-management.adoc
+++ b/guides/common/modules/con_introduction-to-content-management.adoc
@@ -3,6 +3,7 @@
 [id="Introduction_to_Content_Management_{context}"]
 = Introduction to content management
 
+[role="_abstract"]
 In the context of {Project}, _content_ is defined as the software installed on systems.
 This includes, but is not limited to, the base operating system, middleware services, and end-user applications.
 ifdef::satellite[]

--- a/guides/common/modules/con_limitations-to-repository-dependency-resolution.adoc
+++ b/guides/common/modules/con_limitations-to-repository-dependency-resolution.adoc
@@ -3,6 +3,7 @@
 [id="Limitations_to_Repository_Dependency_Resolution_{context}"]
 = Limitations to repository dependency resolution
 
+[role="_abstract"]
 With {Project}, using incremental updates to your content views solves some repository dependency problems.
 However, dependency resolution at a repository level still remains problematic on occasion.
 

--- a/guides/common/modules/con_managing-activation-keys.adoc
+++ b/guides/common/modules/con_managing-activation-keys.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Activation_Keys_{context}"]
 = Managing activation keys
 
+[role="_abstract"]
 Activation keys provide a method to automate system registration.
 You can create multiple keys and associate them with different environments and content views.
 For example, you might create a basic activation key that enables certain Red Hat repositories and associate it with the appropriate content view.

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Alternate_Content_Sources_{context}"]
 = Managing alternate content sources
 
+[role="_abstract"]
 Alternate content sources define alternate paths to download content during synchronization.
 The content itself is downloaded from the alternate content source, while the metadata is downloaded from the {ProjectServer} or the upstream URL, depending on the configuration.
 You can use alternate content source to speed up synchronization if the content is located on the local filesystem or on a nearby network.

--- a/guides/common/modules/con_managing-ansible-content.adoc
+++ b/guides/common/modules/con_managing-ansible-content.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Ansible_Content_{context}"]
 = Managing Ansible content
 
+[role="_abstract"]
 You can import Ansible collections from several sources to {ProjectServer}.
 
 For more information about Ansible integration in {Project}, see {ManagingConfigurationsAnsibleDocURL}[_{ManagingConfigurationsAnsibleDocTitle}_].

--- a/guides/common/modules/con_managing-application-lifecycles.adoc
+++ b/guides/common/modules/con_managing-application-lifecycles.adoc
@@ -3,4 +3,5 @@
 [id="Managing_Application_Lifecycles_{context}"]
 = Managing application lifecycles
 
+[role="_abstract"]
 This chapter outlines the application lifecycle in {Project} and how to create and remove application lifecycles for {Project} and {SmartProxy}.

--- a/guides/common/modules/con_managing-container-images.adoc
+++ b/guides/common/modules/con_managing-container-images.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Container_Images_{context}"]
 = Managing container images
 
+[role="_abstract"]
 With {Project}, you can import container images from various sources and distribute them to external containers by using content views.
 
 ifndef::orcharhino[]

--- a/guides/common/modules/con_managing-content-view-environments.adoc
+++ b/guides/common/modules/con_managing-content-view-environments.adoc
@@ -3,6 +3,7 @@
 [id="managing-content-view-environments"]
 = Managing content view environments
 
+[role="_abstract"]
 A content view environment combines a specific lifecycle environment with a content view and describes which version of the content view to use.
 You can assign hosts and activation keys to one or more content view environments instead of assigning lifecycle environments and content views separately.
 When you assign a host to multiple content view environments, the host gains access to the combined repositories from all its associated content view environments.

--- a/guides/common/modules/con_managing-content-views.adoc
+++ b/guides/common/modules/con_managing-content-views.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Content_Views_{context}"]
 = Managing content views
 
+[role="_abstract"]
 {ProjectName} uses content views to allow your hosts access to a deliberately curated subset of content.
 To do this, you must define which repositories to use and then apply certain filters to the content.
 

--- a/guides/common/modules/con_managing-custom-file-type-content.adoc
+++ b/guides/common/modules/con_managing-custom-file-type-content.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Custom_File_Type_Content_{context}"]
 = Managing {customfiletype} content
 
+[role="_abstract"]
 In {Project}, you might require methods of managing and distributing SSH keys and source code files or larger files such as virtual machine images and ISO files.
 To achieve this, {customproduct}s in {ProjectName} include repositories for {customfiletype}s.
 This provides a generic method to incorporate arbitrary files in a product.

--- a/guides/common/modules/con_managing-errata.adoc
+++ b/guides/common/modules/con_managing-errata.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Errata_{context}"]
 = Managing errata
 
+[role="_abstract"]
 ifdef::satellite[]
 As a part of Red Hat's quality control and release process, we provide customers with updates for each release of official Red Hat RPMs.
 Red Hat compiles groups of related packages into an *erratum* along with an advisory that provides a description of the update.

--- a/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
@@ -3,6 +3,7 @@
 [id="managing-flatpak-repositories-in-project"]
 = Managing Flatpak repositories in {Project}
 
+[role="_abstract"]
 Flatpak allows users to install, manage, and run portable applications on {Project}, primarily for desktop environments.
 In {Project}, you can integrate Flatpak repositories to distribute and control Flatpak applications across managed hosts. 
 By configuring Flatpak repositories, you ensure that systems have access to the necessary application packages while maintaining centralized control over application deployment.

--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -3,5 +3,6 @@
 [id="Managing_ISO_Images_{context}"]
 = Managing ISO images
 
+[role="_abstract"]
 You can use {Project} to store ISO images, either from Red{nbsp}Hat's Content Delivery Network or other sources.
 You can also upload other files, such as virtual machine images, and publish them in repositories.

--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -3,6 +3,7 @@
 [id="managing-ostree-content"]
 = Managing OSTree content
 
+[role="_abstract"]
 You can use OSTree to manage bootable, immutable, versioned file system trees.
 
 OSTree makes it easy to install and update Linux-based operating systems on hosts and to switch between versions of operating systems on hosts.

--- a/guides/common/modules/con_managing-python-type-content.adoc
+++ b/guides/common/modules/con_managing-python-type-content.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Python_Type_Content_{context}"]
 = Managing Python type content
 
+[role="_abstract"]
 You can use {Project} to manage Python type repositories.
 To achieve this, {customproduct}s in {ProjectName} include repositories for Python type content.
 This provides a generic method to incorporate Python packages in a product.

--- a/guides/common/modules/con_managing-red-hat-subscriptions.adoc
+++ b/guides/common/modules/con_managing-red-hat-subscriptions.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Red_Hat_Subscriptions_{context}"]
 = Managing Red Hat subscriptions
 
+[role="_abstract"]
 {ProjectName} can import content from the Red{nbsp}Hat Content Delivery Network (CDN).
 {Project} requires a Red{nbsp}Hat subscription manifest to find, access, and download content from the corresponding repositories.
 You must have a Red{nbsp}Hat subscription manifest containing a subscription allocation for each organization on {ProjectServer}.

--- a/guides/common/modules/con_managing-suse-content.adoc
+++ b/guides/common/modules/con_managing-suse-content.adoc
@@ -3,4 +3,5 @@
 [id="Managing_SUSE_Content_{context}"]
 = Managing SUSE content
 
+[role="_abstract"]
 You can use the SCC Manager plugin to manage content from SUSE on your {Project}.

--- a/guides/common/modules/con_mirroring-policies-overview.adoc
+++ b/guides/common/modules/con_mirroring-policies-overview.adoc
@@ -3,6 +3,7 @@
 [id="Mirroring_Policies_Overview_{context}"]
 = Mirroring policies overview
 
+[role="_abstract"]
 Mirroring keeps the local repository exactly in synchronization with the upstream repository.
 If any content is removed from the upstream repository since the last synchronization, with the next synchronization, it will be removed from the local repository as well.
 

--- a/guides/common/modules/con_multiple-activation-keys-and-content-view-environments.adoc
+++ b/guides/common/modules/con_multiple-activation-keys-and-content-view-environments.adoc
@@ -3,6 +3,7 @@
 [id="multiple-activation-keys-and-content-view-environments"]
 = Multiple activation keys and content view environments
 
+[role="_abstract"]
 Registering a host with multiple activation keys assigns different attributes from each key, and their combined settings determine the configuration of the host.
 Note that multiple activation keys and multiple content view environments are not the same.
 Activation keys assign specific attributes to hosts during registration.

--- a/guides/common/modules/con_products-and-repositories.adoc
+++ b/guides/common/modules/con_products-and-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Products_and_Repositories_{context}"]
 = Products and repositories in {Project}
 
+[role="_abstract"]
 ifdef::satellite[]
 Both Red Hat content and custom content in {Project} have similarities:
 endif::[]

--- a/guides/common/modules/con_registering-a-centos-stream-host.adoc
+++ b/guides/common/modules/con_registering-a-centos-stream-host.adoc
@@ -3,4 +3,5 @@
 [id="Registering_a_CentOS_Stream_Host_{context}"]
 = Registering a CentOS Stream host to {Project}
 
+[role="_abstract"]
 Use the following procedure to register an existing CentOS Stream host to {Project}.

--- a/guides/common/modules/con_resolving-package-dependencies.adoc
+++ b/guides/common/modules/con_resolving-package-dependencies.adoc
@@ -3,6 +3,7 @@
 [id="Resolving_Package_Dependencies_{context}"]
 = Resolving package dependencies
 
+[role="_abstract"]
 {Project} can add dependencies of packages in a content view to the dependent repository when publishing the content view.
 To configure this, you can enable _dependency solving_.
 

--- a/guides/common/modules/con_restricting-hosts-access-to-content.adoc
+++ b/guides/common/modules/con_restricting-hosts-access-to-content.adoc
@@ -3,6 +3,7 @@
 [id="Restricting_Hosts_Access_to_Content_{context}"]
 = Restricting hosts' access to content
 
+[role="_abstract"]
 {Project} offers multiple options for restricting host access to content.
 To give hosts access to a specific subset of the content managed by {Project}, you can use the following strategies.
 {Team} recommends to consider implementing the strategies in the order listed here:

--- a/guides/common/modules/con_rolling-content-views.adoc
+++ b/guides/common/modules/con_rolling-content-views.adoc
@@ -3,6 +3,7 @@
 [id="rolling-content-views"]
 = Rolling content views
 
+[role="_abstract"]
 A rolling content view is a curated subset of content that your hosts can access.
 It is a subset of the Library environment and contains the latest synchronized content from one or multiple repositories.
 You can use a rolling content view to provide a continuous stream of synchronized content to hosts.

--- a/guides/common/modules/con_standardizing-content-view-empty-states.adoc
+++ b/guides/common/modules/con_standardizing-content-view-empty-states.adoc
@@ -3,6 +3,7 @@
 [id="Standardizing_Content_View_Empty_States_{context}"]
 = Standardizing content view empty states
 
+[role="_abstract"]
 If there are no filters listed for a content view, click *Create filter*.
 A modal opens to show you the next steps to create a filter.
 Follow these steps to add a new filter to create new content types.

--- a/guides/common/modules/con_structured-apt-content.adoc
+++ b/guides/common/modules/con_structured-apt-content.adoc
@@ -3,6 +3,7 @@
 [id="Structured-apt-content"]
 = Structured APT content
 
+[role="_abstract"]
 With structured APT content, Deb repositories on {Project} use the same structure as the upstream Deb repository.
 This allows features that attach to the repository structure to work the same way as they would with the upstream repository, for example:
 

--- a/guides/common/modules/con_subscribing-to-errata-notifications.adoc
+++ b/guides/common/modules/con_subscribing-to-errata-notifications.adoc
@@ -3,6 +3,7 @@
 [id="Subscribing_to_Errata_Notifications_{context}"]
 = Subscribing to errata notifications
 
+[role="_abstract"]
 You can configure email notifications for {Project} users.
 Users receive a summary of applicable and installable errata, notifications on content view promotion or after synchronizing a repository.
 For more information, see {AdministeringDocURL}Configuring_Email_Notification_Preferences_admin[Configuring Email Notification Preferences] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/con_synchronizing-content-between-servers.adoc
+++ b/guides/common/modules/con_synchronizing-content-between-servers.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_Content_Between_Servers_{context}"]
 = Synchronizing content between {ProjectServer}s
 
+[role="_abstract"]
 In a {Project} setup with multiple {ProjectServer}s, you can use {ISS} (ISS) to synchronize content from one upstream server to one or more downstream servers.
 
 There are two possible ISS configurations of {Project}, depending on how you deployed your infrastructure:

--- a/guides/common/modules/con_using-activation-keys-for-host-registration.adoc
+++ b/guides/common/modules/con_using-activation-keys-for-host-registration.adoc
@@ -3,6 +3,7 @@
 [id="Using_Activation_Keys_for_Host_Registration_{context}"]
 = Using activation keys for host registration
 
+[role="_abstract"]
 You can use activation keys to complete the following tasks:
 
 * Registering new hosts during provisioning through {ProjectName}.

--- a/guides/common/modules/con_using-content-views.adoc
+++ b/guides/common/modules/con_using-content-views.adoc
@@ -3,6 +3,7 @@
 [id="Using_Content_Views_{context}"]
 = Using content views
 
+[role="_abstract"]
 {Project} uses the concept of content views to create snapshots of a set of repositories and make them available to hosts registered to it.
 For example, if you want a group of hosts to have access to a specific version of a set of repositories, add those repositories to a content view, publish and promote to a lifecycle environment.
 You can then register hosts to this content view.

--- a/guides/common/modules/proc_adding-an-http-proxy.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy.adoc
@@ -3,6 +3,7 @@
 [id="Adding_an_HTTP_Proxy_{context}"]
 = Adding an HTTP proxy
 
+[role="_abstract"]
 Use this procedure to add HTTP proxies to {Project}.
 You can then specify which HTTP proxy to use for products, repositories, and supported compute resources.
 

--- a/guides/common/modules/proc_adding-an-scc-account.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account.adoc
@@ -3,6 +3,7 @@
 [id="Adding_an_SCC_Account_to_Server_{context}"]
 = Adding an SCC account to {Project}
 
+[role="_abstract"]
 Use the following procedure to add your SCC account to {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Adding_an_SCC_Account_to_Server_{context}[].
 

--- a/guides/common/modules/proc_adding-custom-deb-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-deb-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Adding_Custom_Deb_Repositories_{context}"]
 = Adding Deb repositories
 
+[role="_abstract"]
 Use this procedure to add Deb repositories in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-custom-deb-repositories[].
 

--- a/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Adding_Custom_RPM_Repositories_{context}"]
 = Adding {customrpm} repositories
 
+[role="_abstract"]
 Use this procedure to add {customrpm} repositories in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-adding-custom-rpm-repositories[].
 

--- a/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
+++ b/guides/common/modules/proc_adding-errata-to-an-incremental-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Adding_Errata_To_An_Incremental_Content_View_{context}"]
 = Adding errata to an incremental content view
 
+[role="_abstract"]
 If errata are available but not installable, you can create an incremental content view version to add the errata to your content hosts.
 For example, if the content view is version 1.0, it becomes content view version 1.1, and when you publish, it becomes content view version 2.0.
 

--- a/guides/common/modules/proc_adding-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_adding-lifecycle-environments.adoc
@@ -3,6 +3,7 @@
 [id="Adding_Lifecycle_Environments_{context}"]
 = Adding lifecycle environments to {SmartProxyServers}
 
+[role="_abstract"]
 If your {SmartProxyServer} has the content functionality enabled, you must add an environment so that {SmartProxy} can synchronize content from {ProjectServer} and provide content to host systems.
 
 Do not assign the _Library_ lifecycle environment to your {SmartProxyServer} because it triggers an automated {SmartProxy} sync every time the CDN updates a repository.

--- a/guides/common/modules/proc_adding-red-hat-subscriptions-to-subscription-manifests.adoc
+++ b/guides/common/modules/proc_adding-red-hat-subscriptions-to-subscription-manifests.adoc
@@ -3,6 +3,7 @@
 [id="Adding_Red_Hat_Subscriptions_to_Subscription_Manifests_{context}"]
 = Adding Red Hat subscriptions to subscription manifests
 
+[role="_abstract"]
 Use the following procedure to add Red Hat subscriptions to a subscription manifest in the {ProjectWebUI}.
 
 .Prerequisites

--- a/guides/common/modules/proc_adding-repositories.adoc
+++ b/guides/common/modules/proc_adding-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Adding_Repositories_{context}"]
 = Adding repositories
 
+[role="_abstract"]
 Use the following procedure to add the upstream CentOS repositories to your Content view.
 
 .Procedure

--- a/guides/common/modules/proc_applying-errata-to-hosts-by-using-cli.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts-by-using-cli.adoc
@@ -3,6 +3,7 @@
 [id="applying-errata-to-hosts-by-using-cli"]
 = Applying errata to hosts by using CLI
 
+[role="_abstract"]
 You can use Hammer CLI to review and apply errata to hosts.
 
 .Procedure

--- a/guides/common/modules/proc_applying-errata-to-hosts-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_applying-errata-to-hosts-by-using-web-ui.adoc
@@ -3,6 +3,7 @@
 [id="applying-errata-to-hosts-by-using-web-ui"]
 = Applying errata to hosts by using {ProjectWebUI}
 
+[role="_abstract"]
 You can use {ProjectWebUI} to review and apply errata to hosts.
 
 .Prerequisites

--- a/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments.adoc
@@ -3,6 +3,7 @@
 [id="assigning-a-rolling-content-view-to-lifecycle-environments"]
 = Assigning a rolling content view to lifecycle environments
 
+[role="_abstract"]
 You can assign your rolling content view to lifecycle environments to limit content synchronized to {SmartProxyServers}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-assigning-a-rolling-content-view-to-lifecycle-environments[].
 

--- a/guides/common/modules/proc_assigning-a-sync-plan-to-a-product.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-a-product.adoc
@@ -3,6 +3,7 @@
 [id="Assigning_a_Sync_Plan_to_a_Product_{context}"]
 = Assigning a sync plan to a product
 
+[role="_abstract"]
 A sync plan checks and updates the content at a scheduled date and time.
 In {Project}, you can assign a sync plan to products to update content regularly.
 

--- a/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
+++ b/guides/common/modules/proc_assigning-a-sync-plan-to-multiple-products.adoc
@@ -3,6 +3,7 @@
 [id="Assigning_a_Sync_Plan_to_Multiple_Products_{context}"]
 = Assigning a sync plan to multiple products
 
+[role="_abstract"]
 Use this procedure to assign a sync plan to the products in an organization that have been synchronized at least once and contain at least one repository.
 
 .Procedure

--- a/guides/common/modules/proc_assigning-content-view-environments-to-activation-keys.adoc
+++ b/guides/common/modules/proc_assigning-content-view-environments-to-activation-keys.adoc
@@ -3,6 +3,7 @@
 [id="assigning-content-view-environments-to-activation-keys"]
 = Assigning content view environments to activation keys
 
+[role="_abstract"]
 You can assign multiple content view environments to an activation key to provide hosts with access to content from each assigned environment.
 Hosts registered with the activation key receive the environments in the order they are stored.
 For more information, see xref:content-view-environment-ordering-and-priority[].

--- a/guides/common/modules/proc_assigning-content-view-environments-to-hosts-by-using-subscription-manager.adoc
+++ b/guides/common/modules/proc_assigning-content-view-environments-to-hosts-by-using-subscription-manager.adoc
@@ -3,6 +3,7 @@
 [id="assigning-content-view-environments-to-hosts-by-using-subscription-manager"]
 = Assigning content view environments to hosts by using Subscription Manager
 
+[role="_abstract"]
 You can assign content view environments to hosts by using Subscription Manager.
 
 .CLI procedure

--- a/guides/common/modules/proc_assigning-content-view-environments-to-hosts.adoc
+++ b/guides/common/modules/proc_assigning-content-view-environments-to-hosts.adoc
@@ -3,6 +3,7 @@
 [id="assigning-content-view-environments-to-hosts"]
 = Assigning content view environments to hosts
 
+[role="_abstract"]
 To assign content view environments to a host, specify the entire list in order.
 There is no interface in Hammer or the API to add, remove, or insert individual content view environments.
 The current content view environments on the host are replaced with the new list you provide.

--- a/guides/common/modules/proc_changing-the-default-download-policy.adoc
+++ b/guides/common/modules/proc_changing-the-default-download-policy.adoc
@@ -3,6 +3,7 @@
 [id="changing-the-default-download-policy"]
 = Changing the default download policy
 
+[role="_abstract"]
 You can set the default download policy that {Project} applies to repositories that you create in all organizations.
 
 ifdef::satellite[]

--- a/guides/common/modules/proc_changing-the-default-mirroring-policy.adoc
+++ b/guides/common/modules/proc_changing-the-default-mirroring-policy.adoc
@@ -3,6 +3,7 @@
 [id="changing-the-default-mirroring-policy"]
 = Changing the default mirroring policy
 
+[role="_abstract"]
 You can set the default mirroring policy that {Project} applies to your {customrepo} that you create in all organizations.
 
 Depending on whether it is a Yum or non-Yum {customrepo}, {Project} uses separate settings.

--- a/guides/common/modules/proc_changing-the-download-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-download-policy-for-a-repository.adoc
@@ -3,6 +3,7 @@
 [id="changing_the_download_policy_for_a_repository_{context}"]
 = Changing the download policy for a repository
 
+[role="_abstract"]
 You can set the download policy for a repository.
 
 .Procedure

--- a/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-product.adoc
+++ b/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-product.adoc
@@ -3,6 +3,7 @@
 [id="Changing_the_HTTP_Proxy_Policy_for_a_Product_{context}"]
 = Changing the HTTP proxy policy for a product
 
+[role="_abstract"]
 For granular control over network traffic, you can set an HTTP proxy policy for each product.
 A product's HTTP proxy policy applies to all repositories in the product, unless you set a different policy for individual repositories.
 

--- a/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-http-proxy-policy-for-a-repository.adoc
@@ -3,6 +3,7 @@
 [id="Changing_the_HTTP_Proxy_Policy_for_a_Repository_{context}"]
 = Changing the HTTP proxy policy for a repository
 
+[role="_abstract"]
 For granular control over network traffic, you can set an HTTP proxy policy for each repository.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Changing_the_HTTP_Proxy_Policy_for_a_Repository_{context}[].
 

--- a/guides/common/modules/proc_changing-the-mirroring-policy-for-a-repository.adoc
+++ b/guides/common/modules/proc_changing-the-mirroring-policy-for-a-repository.adoc
@@ -3,6 +3,7 @@
 [id="Changing_the_Mirroring_Policy_for_a_Repository_{context}"]
 = Changing the mirroring policy for a repository
 
+[role="_abstract"]
 You can set the mirroring policy for a repository.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Changing_the_Mirroring_Policy_for_a_Repository_{context}[].

--- a/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
+++ b/guides/common/modules/proc_changing-the-repository-sets-status-for-a-host-in-project.adoc
@@ -3,6 +3,7 @@
 [id="Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_{context}"]
 = Changing the repository sets status for a host in {Project}
 
+[role="_abstract"]
 Repository sets show repositories available to each host.
 A host will be able to access content from a given repository if that repository is enabled.
 

--- a/guides/common/modules/proc_comparing-content-view-versions.adoc
+++ b/guides/common/modules/proc_comparing-content-view-versions.adoc
@@ -3,6 +3,7 @@
 [id="Comparing_Content_View_Versions_{context}"]
 = Comparing content view versions
 
+[role="_abstract"]
 Use this procedure to compare content view version functionality for {Project}.
 
 .Procedure

--- a/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-custom-alternate-content-sources.adoc
@@ -3,6 +3,7 @@
 [id="Configuring_Custom_Alternate_Content_Sources_{context}"]
 = Configuring custom alternate content sources
 
+[role="_abstract"]
 .Prerequisites
 * If the repository requires SSL authentication, import the SSL certificate and key to the {Project}.
 For more information, see {ContentManagementDocURL}Importing_Custom_SSL_Certificates_content-management[Importing Custom SSL Certificates] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-trust-the-ca.adoc
@@ -3,6 +3,7 @@
 [id="Configuring_podman_to_trust_the_CA_{context}"]
 = Configuring Podman and Docker to trust the certificate authority
 
+[role="_abstract"]
 Podman uses two paths to locate the CA file, namely, `/etc/containers/certs.d/` and `/etc/docker/certs.d/`.
 
 Copy the root CA file to one of these locations, with the exact path determined by the server hostname, and naming the file `ca.crt`

--- a/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-by-using-exports.adoc
+++ b/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-by-using-exports.adoc
@@ -3,6 +3,7 @@
 [id="configuring-projectserver-to-synchronize-content-by-using-exports_{context}"]
 = Configuring {ProjectServer} to synchronize content by using exports
 
+[role="_abstract"]
 If you deployed your downstream {ProjectServer} as air gapped, configure your {ProjectServer} as such to avoid attempts to consume content from a network.
 
 .Procedure

--- a/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network.adoc
+++ b/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network.adoc
@@ -3,6 +3,7 @@
 [id="configuring-server-to-synchronize-content-over-a-network_{context}"]
 = Configuring {ProjectServer} to synchronize content over a network
 
+[role="_abstract"]
 Configure a downstream {ProjectServer} to synchronize repositories from a connected upstream {ProjectServer} over HTTPS.
 
 .Prerequisites

--- a/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-rhui-alternate-content-sources.adoc
@@ -3,6 +3,7 @@
 [id="Configuring_RHUI_Alternate_Content_Sources_{context}"]
 = Configuring RHUI alternate content sources
 
+[role="_abstract"]
 .Prerequisites
 * Generate the client entitlement certificates for the required repos on the RHUA node as described in {RHDocsBaseURL}red_hat_update_infrastructure/4/html/configuring_and_managing_red_hat_update_infrastructure/assembly_cmg-creating-client-ent-cert-config-rpm_configuring-and-managing-red-hat-update-infrastructure#proc_cmg-creating-client-entitlement-certificate_assembly_cmg-creating-client-ent-cert-config-rpm[Creating a client entitlement certificate with the Red Hat Update Infrastructure Management Tool] in _Configuring and Managing Red Hat Update Infrastructure_.
 * Import the client entitlement certificates into {Project}.

--- a/guides/common/modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc
+++ b/guides/common/modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc
@@ -3,6 +3,7 @@
 [id="configuring-selinux-to-permit-content-synchronization-on-custom-ports_{context}"]
 = Configuring SELinux to permit content synchronization on custom ports
 
+[role="_abstract"]
 SELinux permits access of {Project} for content synchronization only on specific ports.
 By default, connecting to web servers running on the following ports is permitted: 80, 81, 443, 488, 8008, 8009, 8443, and 9000.
 

--- a/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
+++ b/guides/common/modules/proc_configuring-simplified-alternate-content-sources.adoc
@@ -3,6 +3,7 @@
 [id="Configuring_Simplified_Alternate_Content_Sources_{context}"]
 = Configuring simplified alternate content sources
 
+[role="_abstract"]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
 . Click *Add Source* and set the *Source type* as *Simplified*.

--- a/guides/common/modules/proc_copying-a-content-view.adoc
+++ b/guides/common/modules/proc_copying-a-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Copying_a_Content_View_{context}"]
 = Copying a content view
 
+[role="_abstract"]
 You can copy an existing content view into a new content view.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-copying-a-content-view_{context}[].
 

--- a/guides/common/modules/proc_creating-a-composite-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-composite-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Composite_Content_View_{context}"]
 = Creating a composite content view
 
+[role="_abstract"]
 Use this procedure to create a composite content view.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-composite-content-view_{context}[].
 

--- a/guides/common/modules/proc_creating-a-content-view-filter-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-filter-by-using-cli.adoc
@@ -3,6 +3,7 @@
 [id="creating-a-content-view-filter-by-using-cli"]
 = Creating a content view filter by using CLI
 
+[role="_abstract"]
 You can use Hammer CLI to create content view filters to include or exclude specific content units like packages, errata, or container image tags.
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-content-view-filter-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-filter-by-using-web-ui.adoc
@@ -3,6 +3,7 @@
 [id="creating-a-content-view-filter-by-using-web-ui"]
 = Creating a content view filter by using {ProjectWebUI}
 
+[role="_abstract"]
 You can filter content views containing {client-content-type} content to include or exclude specific packages or errata.
 Package filters are based on a combination of the _name_, _version_, and _architecture_.
 For examples of how to build a filter, see xref:Content_Filter_Examples_{context}[].

--- a/guides/common/modules/proc_creating-a-content-view-filter-for-errata-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-filter-for-errata-by-using-cli.adoc
@@ -3,6 +3,7 @@
 [id="creating-a-content-view-filter-for-errata-by-using-cli"]
 = Creating a content view filter for errata by using CLI
 
+[role="_abstract"]
 You can use Hammer CLI to create content view filters to limit errata.
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-content-view-filter-for-errata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-filter-for-errata-by-using-web-ui.adoc
@@ -3,6 +3,7 @@
 [id="creating-a-content-view-filter-for-errata-by-using-web-ui"]
 = Creating a content view filter for errata by using {ProjectWebUI}
 
+[role="_abstract"]
 You can use content filters to limit errata.
 Such filters include:
 

--- a/guides/common/modules/proc_creating-a-content-view-short.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-short.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Content_View_short_{context}"]
 = Creating a content view
 
+[role="_abstract"]
 Use the following procedure to create a content view.
 
 .Procedure

--- a/guides/common/modules/proc_creating-a-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Content_View_{context}"]
 = Creating a content view
 
+[role="_abstract"]
 Use this procedure to create a simple content view.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-content-view_{context}[].
 

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Custom_File_Type_Repository_{context}"]
 = Creating a {customfiletype} repository
 
+[role="_abstract"]
 The procedure for creating a {customfiletype} repository is the same as the procedure for creating any {customcontent}, except that when you create the repository, you select the *file* type.
 You must create a product and then add a {customrepo}.
 

--- a/guides/common/modules/proc_creating-a-custom-product.adoc
+++ b/guides/common/modules/proc_creating-a-custom-product.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Custom_Product_{context}"]
 = Creating a {customproduct}
 
+[role="_abstract"]
 Create a {customproduct} so that you can add repositories to the {customproduct}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-custom-product[].
 

--- a/guides/common/modules/proc_creating-a-flatpak-remote.adoc
+++ b/guides/common/modules/proc_creating-a-flatpak-remote.adoc
@@ -3,6 +3,7 @@
 [id="creating-a-flatpak-remote"]
 = Creating a Flatpak remote
 
+[role="_abstract"]
 You can create a Flatpak remote to access and manage Flatpak repositories in {Project}.
 
 .Prerequisites

--- a/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
+++ b/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Lifecycle_Environment_Path_{context}"]
 = Creating a lifecycle environment path
 
+[role="_abstract"]
 To create an application lifecycle for developing and releasing software, use the _Library_ environment as the initial environment to create environment paths.
 Then optionally add additional environments to the environment paths.
 

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Local_Source_for_a_Custom_File_Type_Repository_{context}"]
 = Creating a local source for a {customfiletype} repository
 
+[role="_abstract"]
 You can create a {customfiletype} repository source, from a directory of files, on the base system where {Project} is installed using *Pulp Manifest*.
 You can then synchronize the files into a repository and manage the {customfiletype} content like any other content type.
 

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Remote_Source_for_a_Custom_File_Type_Repository_{context}"]
 = Creating a remote source for a {customfiletype} repository
 
+[role="_abstract"]
 You can create a {customfiletype} repository source from a directory of files that is external to {ProjectServer} using *Pulp Manifest*.
 You can then synchronize the files into a repository on {ProjectServer} over HTTP or HTTPS and manage the {customfiletype} content like any other content type.
 

--- a/guides/common/modules/proc_creating-a-rolling-content-view.adoc
+++ b/guides/common/modules/proc_creating-a-rolling-content-view.adoc
@@ -3,6 +3,7 @@
 [id="creating-a-rolling-content-view"]
 = Creating a rolling content view
 
+[role="_abstract"]
 You can create a rolling content view in the {ProjectWebUI}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-a-rolling-content-view[].
 

--- a/guides/common/modules/proc_creating-a-suse-operating-system.adoc
+++ b/guides/common/modules/proc_creating-a-suse-operating-system.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_SUSE_Operating_System_{context}"]
 = Creating a SUSE operating system
 
+[role="_abstract"]
 Use this procedure to create an installation medium and operating system entry for SLES 15 SP3.
 For more information, see:
 

--- a/guides/common/modules/proc_creating-a-sync-plan.adoc
+++ b/guides/common/modules/proc_creating-a-sync-plan.adoc
@@ -3,6 +3,7 @@
 [id="Creating_a_Sync_Plan_{context}"]
 = Creating a sync plan
 
+[role="_abstract"]
 A sync plan checks and updates the content at a scheduled date and time.
 In {Project}, you can create a sync plan and assign products to the plan.
 

--- a/guides/common/modules/proc_creating-an-activation-key-short.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-short.adoc
@@ -3,6 +3,7 @@
 [id="Creating_an_Activation_Key_short_{context}"]
 = Creating an activation key
 
+[role="_abstract"]
 Use the following procedure to create an activation key that you can use to subscribe your hosts to content managed by {Project}.
 
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.

--- a/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-to-consume-the-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Creating_an_Activation_Key_to_Consume_the_Content_View_{context}"]
 = Creating an activation key to consume the content view
 
+[role="_abstract"]
 Create another activation key to assign hosts to the content view you created in xref:Creating_a_Content_View_{context}[]. 
 
 .Procedure

--- a/guides/common/modules/proc_creating-an-activation-key.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key.adoc
@@ -3,6 +3,7 @@
 [id="Creating_an_Activation_Key_{context}"]
 = Creating an activation key
 
+[role="_abstract"]
 Create an activation key to assign various attributes to hosts during registration.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-creating-an-activation-key_{context}[].

--- a/guides/common/modules/proc_creating-an-incremental-content-view-version-by-adding-deb-packages.adoc
+++ b/guides/common/modules/proc_creating-an-incremental-content-view-version-by-adding-deb-packages.adoc
@@ -3,6 +3,7 @@
 [id="creating-an-incremental-content-view-version-by-adding-deb-packages"]
 = Creating an incremental content view version by adding Deb packages
 
+[role="_abstract"]
 You can use Hammer CLI to add packages to a content view version.
 If you want to add errata to a content view version, see xref:Adding_Errata_To_An_Incremental_Content_View_{context}[].
 

--- a/guides/common/modules/proc_creating-repositories-to-synchronize.adoc
+++ b/guides/common/modules/proc_creating-repositories-to-synchronize.adoc
@@ -3,6 +3,7 @@
 [id="Creating_Repositories_to_Synchronize_{context}"]
 = Creating repositories to synchronize
 
+[role="_abstract"]
 Use this procedure to discover available repositories in the CentOS Stream, then select the repositories to mirror into a {customproduct}.
 
 .Procedure

--- a/guides/common/modules/proc_creating-uln-repositories.adoc
+++ b/guides/common/modules/proc_creating-uln-repositories.adoc
@@ -3,6 +3,7 @@
 [id="creating-uln-repositories"]
 = Creating ULN repositories
 
+[role="_abstract"]
 You can synchronize content from Oracle Unbreakable Linux Network (ULN) to {Project}.
 There are two main differences compared to generic Yum content:
 

--- a/guides/common/modules/proc_deleting-multiple-content-view-versions.adoc
+++ b/guides/common/modules/proc_deleting-multiple-content-view-versions.adoc
@@ -3,6 +3,7 @@
 [id="Deleting_Multiple_Content_View_Versions_{context}"]
 = Deleting multiple content view versions
 
+[role="_abstract"]
 You can delete multiple content view versions simultaneously.
 
 .Procedure

--- a/guides/common/modules/proc_distributing-archived-content-view-versions.adoc
+++ b/guides/common/modules/proc_distributing-archived-content-view-versions.adoc
@@ -3,6 +3,7 @@
 [id="Distributing_Archived_Content_View_Versions_{context}"]
 = Distributing archived content view versions
 
+[role="_abstract"]
 The setting *Distribute archived content view versions* enables hosting of non-promoted content view version repositories in the {Project} content web application along with other repositories.
 This is useful while debugging to see what content is present in your content view versions.
 

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository.adoc
@@ -3,6 +3,7 @@
 [id="Downloading_Files_to_a_Host_from_a_Custom_File_Type_Repository_{context}"]
 = Downloading files to a host from a {customfiletype} repository
 
+[role="_abstract"]
 You can download files to a client over HTTPS using `curl -O`, and optionally over HTTP if the *Unprotected* option for repositories is selected.
 
 .Prerequisites

--- a/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
+++ b/guides/common/modules/proc_downloading-python-packages-to-a-host-from-a-python-repository.adoc
@@ -3,6 +3,7 @@
 [id="Downloading_Files_to_a_Host_from_a_Python_Type_Repository_{context}"]
 = Downloading files to a host from a Python type repository
 
+[role="_abstract"]
 You can download files to a client over HTTPS using `curl -O`, and optionally over HTTP if the *Unprotected* option for repositories is selected.
 
 .Prerequisites

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc
@@ -3,6 +3,7 @@
 [id="enabling-and-disabling-repositories-on-activation-key_{context}"]
 = Enabling and disabling repositories on activation key
 
+[role="_abstract"]
 You can enable or disable repositories on an activation key in the {ProjectWebUI}.
 
 .Procedure

--- a/guides/common/modules/proc_enabling-dependency-solving-for-a-content-view.adoc
+++ b/guides/common/modules/proc_enabling-dependency-solving-for-a-content-view.adoc
@@ -3,6 +3,7 @@
 [id="enabling-dependency-solving-for-a-content-view_{context}"]
 = Enabling dependency solving for a content view
 
+[role="_abstract"]
 Use this procedure to enable dependency solving for a content view.
 
 .Prerequisites

--- a/guides/common/modules/proc_enabling-os-tree-content.adoc
+++ b/guides/common/modules/proc_enabling-os-tree-content.adoc
@@ -3,6 +3,7 @@
 [id="enabling-ostree-content"]
 = Enabling OSTree content
 
+[role="_abstract"]
 You can enable OSTree on your {Project} to synchronize and manage OSTree branches from the exposed OSTree repository.
 
 .Procedure

--- a/guides/common/modules/proc_enabling-red-hat-repositories.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Enabling_Red_Hat_Repositories_{context}"]
 = Enabling Red{nbsp}Hat repositories
 
+[role="_abstract"]
 If outside network access requires usage of an HTTP proxy, configure a default HTTP proxy for your server.
 For more information, see {InstallingServerDocURL}adding-a-default-http-proxy_{project-context}[Adding a default HTTP proxy to {Project}].
 

--- a/guides/common/modules/proc_enabling-structured-apt-content.adoc
+++ b/guides/common/modules/proc_enabling-structured-apt-content.adoc
@@ -3,6 +3,7 @@
 [id="enabling-structured-apt-content"]
 = Enabling structured APT content
 
+[role="_abstract"]
 You can enable structured APT content on your {Project} to use the same Deb repository structure as the remote repositories they are synchronized from.
 
 .Procedure

--- a/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-hammer-cli.adoc
+++ b/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-hammer-cli.adoc
@@ -3,6 +3,7 @@
 [id="enabling-the-flatpak-remote-by-using-hammer-cli"]
 = Enabling the Flatpak remote by using Hammer CLI
 
+[role="_abstract"]
 This procedure configures and manages Flatpak repositories by using Hammer CLI.
 
 .Prerequisites

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-a-syncable-format.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_a_Content_View_Version_in_a_Syncable_Format_{context}"]
 = Exporting a content view version in a syncable format
 
+[role="_abstract"]
 You can export a version of a content view to a syncable format that you can use to create your custom CDN.
 After you have exported the content view, you can do either of the following:
 

--- a/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-incrementally.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_a_Content_View_Version_Incrementally_{context}"]
 = Exporting a content view version incrementally
 
+[role="_abstract"]
 Exporting complete content view versions can be a very expensive operation in terms of system resources.
 ifdef::orcharhino[]
 The size of the exported content view versions depends on the number of products.

--- a/guides/common/modules/proc_exporting-a-content-view-version.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_a_Content_View_Version_{context}"]
 = Exporting a content view version
 
+[role="_abstract"]
 You can export a version of a content view to an archive file from {ProjectServer} and use this archive file to create the same content view version on another {ProjectServer} or on another {ProjectServer} organization.
 {Project} exports composite content views as normal content views.
 The composite nature is not retained.

--- a/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-in-a-syncable-format.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_a_Repository_in_a_Syncable_Format_{context}"]
 = Exporting a repository in a syncable format
 
+[role="_abstract"]
 You can export the content of a repository in the Library environment of an organization to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
 
 include::snip_generating-content.adoc[]

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-a-syncable-format.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_a_Repository_Incrementally_in_a_Syncable_Format_{context}"]
 = Exporting a repository incrementally in a syncable format
 
+[role="_abstract"]
 Exporting a repository can be a very expensive operation in terms of system resources.
 A typical {client-os} tree may occupy several gigabytes of space on {ProjectServer}.
 

--- a/guides/common/modules/proc_exporting-a-repository-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally.adoc
@@ -3,6 +3,7 @@
 [id="exporting-a-repository-incrementally"]
 = Exporting a repository incrementally
 
+[role="_abstract"]
 Exporting a repository can be a very expensive operation in terms of system resources.
 A typical {client-os} tree may occupy several gigabytes of space on {ProjectServer}.
 

--- a/guides/common/modules/proc_exporting-a-repository.adoc
+++ b/guides/common/modules/proc_exporting-a-repository.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_a_Repository_{context}"]
 = Exporting a repository
 
+[role="_abstract"]
 You can export the content of a repository in the Library environment of an organization from {ProjectServer}.
 You can use this archive file to create the same repository in another {ProjectServer} or in another {ProjectServer} organization.
 

--- a/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-a-syncable-format.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_the_Library_Environment_in_a_Syncable_Format_{context}"]
 = Exporting the library environment in a syncable format
 
+[role="_abstract"]
 You can export content in the Library environment of an organization to a syncable format that you can use to create your custom CDN and synchronize the content from the custom CDN over HTTP/HTTPS.
 
 ifdef::satellite[]

--- a/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-incrementally.adoc
@@ -3,6 +3,7 @@
 [id="exporting-the-library-environment-incrementally_{context}"]
 = Exporting the Library environment incrementally
 
+[role="_abstract"]
 Exporting Library content can be a very expensive operation in terms of system resources.
 ifdef::orcharhino[]
 The size of the exported Library depends on the number of products.

--- a/guides/common/modules/proc_exporting-the-library-environment.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_the_Library_Environment_{context}"]
 = Exporting the Library environment
 
+[role="_abstract"]
 You can export content in the Library environment of an organization to an archive file from {ProjectServer} and use this archive file to create the same repositories in another {ProjectServer} or in another {ProjectServer} organization.
 The exported archive file contains the following data:
 

--- a/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
+++ b/guides/common/modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc
@@ -3,6 +3,7 @@
 [id="Extracting_GPG_Public_Key_Fingerprints_from_Release_Files_{context}"]
 = Extracting GPG public key fingerprints from Release files
 
+[role="_abstract"]
 You can use GPG public keys to verify the authenticity of Deb repositories by verifying the signature of the `Release` file.
 This example verifies the signature for the `Release` file from Debian 11.
 

--- a/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
@@ -3,6 +3,7 @@
 [id="Importing_a_Content_View_Version_from_a_web_server{context}"]
 = Importing a content view version from a web server
 
+[role="_abstract"]
 You can import an exported content view version directly from a web server to create a version with the same content in an organization on another {ProjectServer}.
 For more information about exporting a content view version, see xref:Exporting_a_Content_View_Version_{context}[].
 

--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -3,6 +3,7 @@
 [id="Importing_a_Content_View_Version_{context}"]
 = Importing a content view version
 
+[role="_abstract"]
 You can import an exported content view version to create a version with the same content in an organization on another {ProjectServer}.
 For more information about exporting a content view version, see xref:Exporting_a_Content_View_Version_{context}[].
 

--- a/guides/common/modules/proc_importing-a-custom-gpg-key.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key.adoc
@@ -3,6 +3,7 @@
 [id="Importing_a_Custom_GPG_Key_{context}"]
 = Importing a {customgpg} key
 
+[role="_abstract"]
 When clients are consuming signed {customcontent}, ensure that the clients are configured to validate the installation of packages with the appropriate GPG Key.
 This helps to ensure that only packages from authorized sources can be installed.
 

--- a/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
@@ -3,6 +3,7 @@
 [id="Importing_a_Repository_from_a_web_server_{context}"]
 = Importing a repository from a web server
 
+[role="_abstract"]
 You can import an exported repository directly from a web server into an organization on another {ProjectServer}.
 For more information about exporting the content of a repository, see xref:Exporting_a_Repository_{context}[].
 

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -3,6 +3,7 @@
 [id="Importing_a_Repository_{context}"]
 = Importing a repository
 
+[role="_abstract"]
 You can import an exported repository into an organization on another {ProjectServer}.
 For more information about exporting content of a repository, see xref:Exporting_a_Repository_{context}[].
 

--- a/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
+++ b/guides/common/modules/proc_importing-a-subscription-manifest-into-foreman-server.adoc
@@ -3,6 +3,7 @@
 [id="Importing_a_Red_Hat_Subscription_Manifest_into_Server_{context}"]
 = Importing a Red{nbsp}Hat subscription manifest into {ProjectServer}
 
+[role="_abstract"]
 Use the following procedure to import a Red{nbsp}Hat subscription manifest into {ProjectServer}.
 
 [NOTE]

--- a/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
+++ b/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
@@ -3,6 +3,7 @@
 [id="importing-and-exporting-content-to-{project-context}-server-for-flatpak"]
 = Importing and exporting content to {ProjectServer} for Flatpak 
 
+[role="_abstract"]
 Use Hammer CLI to transfer Flatpak content to {ProjectServer} in environments with disconnected {ProjectServer} instances.
 
 .Prerequisites

--- a/guides/common/modules/proc_importing-container-images.adoc
+++ b/guides/common/modules/proc_importing-container-images.adoc
@@ -3,6 +3,7 @@
 [id="Importing_Container_Images_{context}"]
 = Importing container images
 
+[role="_abstract"]
 ifndef::orcharhino[]
 You can import container image repositories from Red Hat Registry or from other image registries.
 endif::[]

--- a/guides/common/modules/proc_importing-custom-ssl-certificates.adoc
+++ b/guides/common/modules/proc_importing-custom-ssl-certificates.adoc
@@ -3,6 +3,7 @@
 [id="Importing_Custom_SSL_Certificates_{context}"]
 = Importing {customssl} certificates
 
+[role="_abstract"]
 Before you synchronize {customcontent} from an external source, you might need to import SSL certificates into your {customproduct}.
 This might include client certs and keys or CA certificates for the upstream repositories you want to synchronize.
 

--- a/guides/common/modules/proc_importing-individual-iso-images-and-files.adoc
+++ b/guides/common/modules/proc_importing-individual-iso-images-and-files.adoc
@@ -3,6 +3,7 @@
 [id="Importing_Individual_ISO_Images_and_Files_{context}"]
 = Importing individual ISO images and files
 
+[role="_abstract"]
 Use this procedure to manually import ISO content and other files to {ProjectServer}.
 To import files, you can complete the following steps in the {ProjectWebUI} or using the Hammer CLI.
 However, if the size of the file that you want to upload is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.

--- a/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
@@ -3,6 +3,7 @@
 [id="Importing_into_the_Library_Environment_from_a_web_server_{context}"]
 = Importing into the Library environment from a web server
 
+[role="_abstract"]
 You can import exported Library content directly from a web server into the Library lifecycle environment of an organization on another {ProjectServer}.
 For more information about exporting contents from the Library environment, see xref:Exporting_the_Library_Environment_{context}[].
 

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -3,6 +3,7 @@
 [id="Importing_into_the_Library_Environment_{context}"]
 = Importing into the Library environment
 
+[role="_abstract"]
 You can import exported Library content into the Library lifecycle environment of an organization on another {ProjectServer}.
 For more information about exporting contents from the Library environment, see xref:Exporting_the_Library_Environment_{context}[].
 

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat.adoc
@@ -3,6 +3,7 @@
 [id="Importing_ISO_Images_from_Red_Hat_{context}"]
 = Importing ISO images from Red Hat
 
+[role="_abstract"]
 The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
 The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
 

--- a/guides/common/modules/proc_importing-ostree-content.adoc
+++ b/guides/common/modules/proc_importing-ostree-content.adoc
@@ -3,6 +3,7 @@
 [id="importing-ostree-content_{context}"]
 = Importing OSTree content
 
+[role="_abstract"]
 You can import and synchronize OSTree content from custom online sources over HTTPS.
 
 .Prerequisites

--- a/guides/common/modules/proc_importing-suse-products.adoc
+++ b/guides/common/modules/proc_importing-suse-products.adoc
@@ -3,6 +3,7 @@
 [id="Importing_SUSE_Products_{context}"]
 = Importing SUSE products
 
+[role="_abstract"]
 Use this procedure to import products from SUSE into {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Importing_SUSE_Products_{context}[].
 

--- a/guides/common/modules/proc_importing-syncable-exports.adoc
+++ b/guides/common/modules/proc_importing-syncable-exports.adoc
@@ -3,6 +3,7 @@
 [id="Importing_Syncable_Exports_{context}"]
 = Importing syncable exports
 
+[role="_abstract"]
 .Procedure
 * Use the organization name or ID to import syncable exports:
 +

--- a/guides/common/modules/proc_inspecting-available-errata.adoc
+++ b/guides/common/modules/proc_inspecting-available-errata.adoc
@@ -3,6 +3,7 @@
 [id="Inspecting_Available_Errata_{context}"]
 = Inspecting available errata
 
+[role="_abstract"]
 The following procedure describes how to view and filter the available errata and how to display metadata of the selected advisory.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-inspecting-available-errata[].
 

--- a/guides/common/modules/proc_installing-flatpak-applications-on-project-hosts.adoc
+++ b/guides/common/modules/proc_installing-flatpak-applications-on-project-hosts.adoc
@@ -3,6 +3,7 @@
 [id="installing-flatpak-applications-on-{project-context}-hosts"]
 = Installing Flatpak applications on {Project} hosts
 
+[role="_abstract"]
 Use the command line to install selected applications from the enabled Flatpak remotes.
 
 .Prerequisites

--- a/guides/common/modules/proc_installing-ostree-content-from-server.adoc
+++ b/guides/common/modules/proc_installing-ostree-content-from-server.adoc
@@ -3,6 +3,7 @@
 [id="Installing_OSTree_Content_from_{project-context}_Server_{context}"]
 = Installing OSTree content from {ProjectServer} on hosts
 
+[role="_abstract"]
 OSTree content from {Project} on hosts is managed by Subscription Manager and can be accessed by using `rpm-ostree`.
 
 .Prerequisites

--- a/guides/common/modules/proc_installing-python-packages-from-server.adoc
+++ b/guides/common/modules/proc_installing-python-packages-from-server.adoc
@@ -3,6 +3,7 @@
 [id="Installing_Python_Packages_from_{project-context}_Server_{context}"]
 = Installing Python packages from {ProjectServer}
 
+[role="_abstract"]
 You can install Python packages from {Project} on hosts using `pip`.
 
 .Prerequisites

--- a/guides/common/modules/proc_installing-the-scc-manager.adoc
+++ b/guides/common/modules/proc_installing-the-scc-manager.adoc
@@ -3,6 +3,7 @@
 [id="Installing_the_SCC_Manager_plugin_{context}"]
 = Installing the SCC Manager plugin
 
+[role="_abstract"]
 Use this procedure to install the SCC Manager plugin on your {Project}.
 
 .Procedure

--- a/guides/common/modules/proc_keeping-track-of-your-exports.adoc
+++ b/guides/common/modules/proc_keeping-track-of-your-exports.adoc
@@ -3,6 +3,7 @@
 [id="Keeping_Track_of_Your_Exports_{context}"]
 = Keeping track of your exports
 
+[role="_abstract"]
 {Project} keeps records of all exports.
 Each time you export content on the upstream {ProjectServer}, the export is recorded and maintained for future querying.
 You can use the records to organize and manage your exports, which is useful especially when exporting incrementally.

--- a/guides/common/modules/proc_limiting-synchronization-concurrency.adoc
+++ b/guides/common/modules/proc_limiting-synchronization-concurrency.adoc
@@ -3,6 +3,7 @@
 [id="Limiting_Synchronization_Concurrency_{context}"]
 = Limiting synchronization concurrency
 
+[role="_abstract"]
 By default, each Repository Synchronization job can fetch up to ten files at a time.
 This can be adjusted on a per repository basis.
 

--- a/guides/common/modules/proc_locating-a-red-hat-subscription.adoc
+++ b/guides/common/modules/proc_locating-a-red-hat-subscription.adoc
@@ -3,6 +3,7 @@
 [id="Locating_a_Red_Hat_Subscription_{context}"]
 = Locating a Red Hat subscription
 
+[role="_abstract"]
 When you import a Red{nbsp}Hat subscription manifest into {ProjectServer}, the subscriptions from your manifest are listed in the Subscriptions window.
 If you have a high volume of subscriptions, you can filter the results to find a specific subscription.
 

--- a/guides/common/modules/proc_managing-container-name-patterns.adoc
+++ b/guides/common/modules/proc_managing-container-name-patterns.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Container_Name_Patterns_{context}"]
 = Managing container name patterns
 
+[role="_abstract"]
 When you use {Project} to create and manage your containers, as the container moves through content view versions and different stages of the {Project} lifecycle environment, the container name changes at each stage.
 For example, if you synchronize a container image with the name `ssh` from an upstream repository, when you add it to a {Project} product and organization and then publish as part of a content view, the container image can have the following name: `my_organization_production-custom_spin-my_product-custom_ssh`.
 This can create problems when you want to pull a container image because container registries can contain only one instance of a container name.

--- a/guides/common/modules/proc_managing-container-registry-authentication.adoc
+++ b/guides/common/modules/proc_managing-container-registry-authentication.adoc
@@ -3,6 +3,7 @@
 [id="Managing_Container_Registry_Authentication_{context}"]
 = Managing container registry authentication
 
+[role="_abstract"]
 You can manage the authentication settings for accessing containers images from {Project}.
 By default, users must authenticate to access containers images in {Project}.
 

--- a/guides/common/modules/proc_managing-ostree-content-with-content-views.adoc
+++ b/guides/common/modules/proc_managing-ostree-content-with-content-views.adoc
@@ -3,6 +3,7 @@
 [id="managing-ostree-content-with-content-views_{context}"]
 = Managing OSTree content with content views
 
+[role="_abstract"]
 Use content views to manage OSTree branches across the application lifecycle.
 This process uses the same publication and promotion method as RPMs or Puppet modules.
 

--- a/guides/common/modules/proc_managing-the-lifecycle-of-the-content-view.adoc
+++ b/guides/common/modules/proc_managing-the-lifecycle-of-the-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Managing_the_Lifecycle_of_the_Content_View_{context}"]
 = Managing the lifecycle of the content view
 
+[role="_abstract"]
 The default location of any new content view is in the Library environment.
 Optionally, you can add a new environment and promote your content view to it.
 Use the following procedure to create a lifecycle environment.

--- a/guides/common/modules/proc_mirroring-remote-flatpak-repositories-to-project-products.adoc
+++ b/guides/common/modules/proc_mirroring-remote-flatpak-repositories-to-project-products.adoc
@@ -3,6 +3,7 @@
 [id="mirroring-remote-flatpak-repositories-to-{Project}-products"]
 = Mirroring remote Flatpak repositories to {Project} products
 
+[role="_abstract"]
 You can mirror a Flatpak repository from a Flatpak remote into an existing product in {Project} to make it available for content management and distribution.
 
 This action creates a new repository inside the product you selected.

--- a/guides/common/modules/proc_preparing-suse-installation-media.adoc
+++ b/guides/common/modules/proc_preparing-suse-installation-media.adoc
@@ -3,6 +3,7 @@
 [id="Preparing_SUSE_Installation_Media_{context}"]
 = Preparing SUSE installation media
 
+[role="_abstract"]
 Use this procedure to extract the SUSE installation medium on your {ProjectServer} to provision hosts in a disconnected environment.
 This example prepares the installation medium for SUSE Linux Enterprise Server 15 SP3.
 

--- a/guides/common/modules/proc_promoting-a-content-view.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Promoting_a_Content_View_{context}"]
 = Promoting a content view
 
+[role="_abstract"]
 Use this procedure to promote content views across different lifecycle environments.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-promoting-a-content-view_{context}[].
 

--- a/guides/common/modules/proc_promoting-your-content-view-to-the-new-lifecycle-environment.adoc
+++ b/guides/common/modules/proc_promoting-your-content-view-to-the-new-lifecycle-environment.adoc
@@ -3,6 +3,7 @@
 [id="Promoting_your_Content_View_to_the_New_Lifecycle_Environment_{context}"]
 = Promoting your content view to the new lifecycle environment
 
+[role="_abstract"]
 You can now promote your new content view to the *Production* environment using the following procedure.
 
 .Procedure

--- a/guides/common/modules/proc_publishing-the-content-view.adoc
+++ b/guides/common/modules/proc_publishing-the-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Publishing_the_Content_View_{context}"]
 = Publishing the content view
 
+[role="_abstract"]
 Use the following procedure to publish the content view.
 
 .Procedure

--- a/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
+++ b/guides/common/modules/proc_recovering-a-corrupted-repository.adoc
@@ -3,6 +3,7 @@
 [id="Recovering_a_Corrupted_Repository_{context}"]
 = Recovering a corrupted repository
 
+[role="_abstract"]
 In case of repository corruption, you can recover it by using an advanced synchronization, which has three options:
 
 Optimized Sync::

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-cli.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-cli.adoc
@@ -3,6 +3,7 @@
 [id="recovering-corrupted-content-on-a-{smart-proxy-context}-server-by-using-cli"]
 = Recovering corrupted content on a {SmartProxyServer} by using CLI
 
+[role="_abstract"]
 If hosts can no longer consume content from {SmartProxyServers}, the content has been corrupted and needs to be repaired.
 Depending on the amount of content on your {SmartProxyServer}, this task might take some time.
 

--- a/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_recovering-corrupted-content-on-a-smart-proxy-server-by-using-web-ui.adoc
@@ -3,6 +3,7 @@
 [id="recovering-corrupted-content-on-a-{smart-proxy-context}-server-by-using-web-ui"]
 = Recovering corrupted content on a {SmartProxyServer} by using {ProjectWebUI}
 
+[role="_abstract"]
 If hosts can no longer consume content from {SmartProxyServers}, the content has been corrupted and needs to be repaired.
 Depending on the amount of content on your {SmartProxyServer}, this task might take some time.
 

--- a/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
@@ -3,6 +3,7 @@
 [id="Refreshing_Content_Counts_on_{smart-proxy-context-titlecase}_{context}"]
 = Refreshing content counts on {SmartProxy}
 
+[role="_abstract"]
 If your {SmartProxies} have synchronized content enabled, you can refresh the number of content counts available to the environments associated with the {SmartProxy}.
 This displays the content views inside those environments available to the {SmartProxy}.
 You can then expand the content view to view the repositories associated with that content view version.

--- a/guides/common/modules/proc_registering-a-centos-stream-host-to-consume-content-from-a-promoted-content-view-in-the-production-environment.adoc
+++ b/guides/common/modules/proc_registering-a-centos-stream-host-to-consume-content-from-a-promoted-content-view-in-the-production-environment.adoc
@@ -3,6 +3,7 @@
 [id="Registering_a_CentOS_Stream_host_to_consume_content_from_a_promoted_Content_View_in_the_production_environment_{context}"]
 = Registering a CentOS Stream host to consume content from a promoted content view in the production environment
 
+[role="_abstract"]
 To register a host to consume content from the content view in the Production lifecycle environment, enter the following command:
 
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_registering-a-centos-stream-host-to-consume-content-from-a-published-content-view.adoc
+++ b/guides/common/modules/proc_registering-a-centos-stream-host-to-consume-content-from-a-published-content-view.adoc
@@ -3,6 +3,7 @@
 [id="Registering_a_CentOS_Stream_host_to_consume_content_from_a_published_content_view_{context}"]
 = Registering a CentOS Stream host to consume content from a published content view
 
+[role="_abstract"]
 You can also register the host to the published content view without an activation key using the following command:
 
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_removing-all-content-view-environments-from-an-activation-key.adoc
+++ b/guides/common/modules/proc_removing-all-content-view-environments-from-an-activation-key.adoc
@@ -3,6 +3,7 @@
 [id="removing-all-content-view-environments-from-an-activation-key"]
 = Removing all content view environments from an activation key
 
+[role="_abstract"]
 You can remove all content view environments from an activation key by doing either of the following:
 
 .CLI procedure

--- a/guides/common/modules/proc_removing-an-scc-account.adoc
+++ b/guides/common/modules/proc_removing-an-scc-account.adoc
@@ -3,6 +3,7 @@
 [id="Removing_an_SCC_Account_from_{project-context}_{context}"]
 = Removing an SCC account from {Project}
 
+[role="_abstract"]
 Use the following procedure to remove your SCC account from {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Removing_an_SCC_Account_from_{project-context}_{context}[].
 

--- a/guides/common/modules/proc_removing-lifecycle-environments-from-foreman.adoc
+++ b/guides/common/modules/proc_removing-lifecycle-environments-from-foreman.adoc
@@ -3,6 +3,7 @@
 [id="Removing_Lifecycle_Environments_from_Server_{context}"]
 = Removing lifecycle environments from {ProjectServer}
 
+[role="_abstract"]
 Use this procedure to remove a lifecycle environment.
 
 .Procedure

--- a/guides/common/modules/proc_removing-lifecycle-environments-from-smart-proxy.adoc
+++ b/guides/common/modules/proc_removing-lifecycle-environments-from-smart-proxy.adoc
@@ -3,6 +3,7 @@
 [id="Removing_Lifecycle_Environments_from_{smart-proxy-context-titlecase}_{context}"]
 = Removing lifecycle environments from {SmartProxyServer}
 
+[role="_abstract"]
 When lifecycle environments are no longer relevant to the host system or environments are added incorrectly to {SmartProxyServer}, you can remove the lifecycle environments from {SmartProxyServer}.
 
 You can use both the {ProjectWebUI} and the Hammer CLI to remove lifecycle environments from {SmartProxy}.

--- a/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-manifests.adoc
+++ b/guides/common/modules/proc_removing-red-hat-subscriptions-and-subscription-manifests.adoc
@@ -3,6 +3,7 @@
 [id="Removing_Red_Hat_Subscriptions_from_Subscription_Manifests_{context}"]
 = Removing Red Hat subscriptions from subscription manifests
 
+[role="_abstract"]
 Use the following procedure to remove Red Hat subscriptions from a subscription manifest in the {ProjectWebUI}.
 
 [WARNING]

--- a/guides/common/modules/proc_republishing-content-view-metadata-by-using-cli.adoc
+++ b/guides/common/modules/proc_republishing-content-view-metadata-by-using-cli.adoc
@@ -3,6 +3,7 @@
 [id="republishing-content-view-metadata-by-using-cli"]
 = Republishing content view metadata by using CLI
 
+[role="_abstract"]
 Republish metadata of content view versions if hosts report package checksum mismatches.
 You can use Hammer CLI to republish metadata of content view versions.
 

--- a/guides/common/modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc
@@ -3,6 +3,7 @@
 [id="republishing-content-view-metadata-by-using-web-ui"]
 = Republishing content view metadata by using {ProjectWebUI}
 
+[role="_abstract"]
 Republish metadata of content view versions if hosts report package checksum mismatches.
 You can use {ProjectWebUI} to republish content view metadata.
 

--- a/guides/common/modules/proc_republishing-repository-metadata-by-using-cli.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata-by-using-cli.adoc
@@ -3,6 +3,7 @@
 [id="republishing-repository-metadata-by-using-cli"]
 = Republishing repository metadata by using CLI
 
+[role="_abstract"]
 You can republish repository metadata when a repository distribution does not have the content that should be distributed based on the contents of the repository.
 
 Use this procedure with caution.

--- a/guides/common/modules/proc_republishing-repository-metadata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata-by-using-web-ui.adoc
@@ -3,6 +3,7 @@
 [id="republishing-repository-metadata-by-using-web-ui"]
 = Republishing repository metadata by using {ProjectWebUI}
 
+[role="_abstract"]
 You can republish repository metadata when a repository distribution does not have the content that should be distributed based on the contents of the repository.
 
 Use this procedure with caution.

--- a/guides/common/modules/proc_restricting-customrepoid-to-a-specific-operating-system-version-or-architecture-in-project.adoc
+++ b/guides/common/modules/proc_restricting-customrepoid-to-a-specific-operating-system-version-or-architecture-in-project.adoc
@@ -3,6 +3,7 @@
 [id="Restricting_a_{customrepoid}_to_a_Specific_operating_system_Version_or_Architecture_in_Project_{context}"]
 = Restricting a {customrepo} to a specific operating system or architecture in {Project}
 
+[role="_abstract"]
 You can configure {Project} to make a {customrepo} available only on hosts with a specific operating system version or architecture.
 ifdef::client-content-dnf[]
 For example, you can restrict a {customrepo} only to {client-os}{nbsp}{client-os-major} hosts.

--- a/guides/common/modules/proc_running-custom-code-while-applying-errata.adoc
+++ b/guides/common/modules/proc_running-custom-code-while-applying-errata.adoc
@@ -3,6 +3,7 @@
 [id="running-custom-code-while-applying-errata_{context}"]
 = Running custom code while applying errata
 
+[role="_abstract"]
 You can use custom snippets to run code before and/or after applying errata on hosts.
 
 .Prerequisites

--- a/guides/common/modules/proc_scanning-a-flatpak-remote.adoc
+++ b/guides/common/modules/proc_scanning-a-flatpak-remote.adoc
@@ -3,6 +3,7 @@
 [id="scanning-a-flatpak-remote"]
 = Scanning a Flatpak remote
 
+[role="_abstract"]
 You can scan a Flatpak remote to fetch metadata about the repositories it provides.
 Scanning a Flatpak remote creates remote repository artifacts for the repositories hosted by the Flatpak remote.
 If new repositories are added to the Flatpak remote, scan it again to pull in the changes.

--- a/guides/common/modules/proc_setting-the-service-level.adoc
+++ b/guides/common/modules/proc_setting-the-service-level.adoc
@@ -3,6 +3,7 @@
 [id="Setting_the_Service_Level_{context}"]
 = Setting the service level
 
+[role="_abstract"]
 You can configure an activation key to define a default service level for the new host created with the activation key.
 
 .Procedure

--- a/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
+++ b/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
@@ -3,6 +3,7 @@
 [id="setting-up-flatpak-remote-for-{smart-proxy-context}"]
 = Setting up Flatpak remote for {SmartProxy}
 
+[role="_abstract"]
 Configure {SmartProxyServers} to synchronize and distribute Flatpak repositories to managed hosts.
 
 [NOTE]

--- a/guides/common/modules/proc_switching-scc-accounts.adoc
+++ b/guides/common/modules/proc_switching-scc-accounts.adoc
@@ -3,6 +3,7 @@
 [id="Switching_SCC_Accounts_{context}"]
 = Switching SCC accounts
 
+[role="_abstract"]
 You can switch your SCC account by changing the SCC credentials saved on {Project}.
 
 [WARNING]

--- a/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_synchronizing-a-content-view-to-a-smart-proxy-server.adoc
@@ -3,6 +3,7 @@
 [id="synchronizing-a-content-view-to-a-{smart-proxy-context}-server"]
 = Synchronizing a content view to a {SmartProxyServer}
 
+[role="_abstract"]
 In the {ProjectWebUI}, you can only synchronize all selected lifecycle environments simultaneously.
 If you need to synchronize smaller items, such as individual lifecycle environments, single content views, and single repositories, use the Hammer CLI.
 

--- a/guides/common/modules/proc_synchronizing-a-custom-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-a-custom-repository.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_a_Custom_Repository_{context}"]
 = Synchronizing a custom repository
 
+[role="_abstract"]
 When using {ISS} Network Sync, Red Hat repositories are configured automatically, but custom repositories are not.
 Use this procedure to synchronize content from a custom repository on a connected {ProjectServer} to a disconnected {ProjectServer} through {ISS} (ISS) Network Sync.
 

--- a/guides/common/modules/proc_synchronizing-a-single-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-a-single-repository.adoc
@@ -3,6 +3,7 @@
 [id="synchronizing-a-single-repository_{context}"]
 = Synchronizing a single repository
 
+[role="_abstract"]
 In this scenario, you export and import a single repository.
 
 .On the upstream {ProjectServer}

--- a/guides/common/modules/proc_synchronizing-all-repositories-in-an-organization.adoc
+++ b/guides/common/modules/proc_synchronizing-all-repositories-in-an-organization.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_All_Repositories_in_an_Organization_{context}"]
 = Synchronizing all repositories in an organization
 
+[role="_abstract"]
 Use this procedure to synchronize all repositories within an organization.
 
 .Procedure

--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -3,6 +3,7 @@
 [id="synchronizing-ansible-collections_{context}"]
 = Synchronizing Ansible Collections
 
+[role="_abstract"]
 ifdef::satellite[]
 On {Project}, you can synchronize your Ansible Collections from Private Automation Hub, `console.redhat.com`, and other {Project} instances.
 endif::[]

--- a/guides/common/modules/proc_synchronizing-content-from-an-upstream-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-content-from-an-upstream-repository.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_Content_from_an_Upstream_Repository_{context}"]
 = Synchronizing content from an upstream repository
 
+[role="_abstract"]
 Use the following procedure to mirror the contents of the upstream CentOS repositories.
 
 .Procedure

--- a/guides/common/modules/proc_synchronizing-python-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-python-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_Python_Repositories_{context}"]
 = Synchronizing Python repositories
 
+[role="_abstract"]
 On {Project}, you can synchronize your Python repositories from any mirror and other {Project} instances.
 You can view the Python packages in the {ProjectWebUI} at *Content* > *Content Types* > *Other Content Types*.
 

--- a/guides/common/modules/proc_synchronizing-repositories.adoc
+++ b/guides/common/modules/proc_synchronizing-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_Repositories_{context}"]
 = Synchronizing repositories
 
+[role="_abstract"]
 You must synchronize repositories to download content into {Project}.
 You can use this procedure for an initial synchronization of repositories or to synchronize repositories manually as you need.
 

--- a/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
+++ b/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_{smart-proxy-context}_Directly_From_Red_Hat_CDN_{context}"]
 = Synchronizing {SmartProxy} directly from Red Hat CDN
 
+[role="_abstract"]
 You can use simplified alternate content sources to configure your {SmartProxy} to sync content directly from Red Hat CDN.
 
 .Procedure

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing_SUSE_Content_{context}"]
 = Synchronizing SUSE content
 
+[role="_abstract"]
 Use this procedure to synchronize SUSE content to your {Project} to deploy, register, and serve content to hosts.
 
 .Prerequisites

--- a/guides/common/modules/proc_synchronizing-ubuntu-expanded-security-maintenance-content.adoc
+++ b/guides/common/modules/proc_synchronizing-ubuntu-expanded-security-maintenance-content.adoc
@@ -3,6 +3,7 @@
 [id="Synchronizing-Ubuntu-Expanded-Security-Maintenance-content_{context}"]
 = Synchronizing Ubuntu Expanded Security Maintenance content
 
+[role="_abstract"]
 Canonical provides Ubuntu https://ubuntu.com/security/esm[Expanded Security Maintenance] (ESM) repositories to their paying customers.
 In {Project}, synchronize ESM repositories from Canonical to distribute content to your hosts running Ubuntu 14.04 and Ubuntu 16.04.
 

--- a/guides/common/modules/proc_tracking-subscription-usage-by-using-the-subscriptions-service.adoc
+++ b/guides/common/modules/proc_tracking-subscription-usage-by-using-the-subscriptions-service.adoc
@@ -3,6 +3,7 @@
 [id="tracking-subscription-usage-by-using-the-subscriptions-service"]
 = Tracking subscription usage by using the Subscriptions service
 
+[role="_abstract"]
 You can configure your {ProjectServer} to report usage data to the {RHCloud} by using the `foreman_rh_cloud` plugin.
 
 ifndef::satellite[]

--- a/guides/common/modules/proc_updating-an-scc-account.adoc
+++ b/guides/common/modules/proc_updating-an-scc-account.adoc
@@ -3,6 +3,7 @@
 [id="Updating_an_SCC_Account_{context}"]
 = Updating an SCC account
 
+[role="_abstract"]
 Use the following procedure to update your SCC account in {Project}.
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Updating_an_SCC_Account_{context}[].
 

--- a/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
+++ b/guides/common/modules/proc_updating-and-refreshing-red-hat-subscription-manifests.adoc
@@ -3,6 +3,7 @@
 [id="Updating_and_Refreshing_Red_Hat_Subscription_Manifests_{context}"]
 = Updating and refreshing Red Hat subscription manifests
 
+[role="_abstract"]
 Every time that you change a subscription allocation, you must refresh the manifest to reflect these changes.
 For example, you must refresh the manifest if you take any of the following actions:
 

--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories.adoc
@@ -3,6 +3,7 @@
 [id="Uploading_Content_to_custom_rpm_Repositories_{context}"]
 = Uploading content to {customrpm} repositories
 
+[role="_abstract"]
 You can upload individual RPMs and source RPMs to {customrpm} repositories.
 You can upload RPMs using the {ProjectWebUI} or the Hammer CLI.
 You must use the Hammer CLI to upload source RPMs.

--- a/guides/common/modules/proc_uploading-files-to-a-custom-file-repository.adoc
+++ b/guides/common/modules/proc_uploading-files-to-a-custom-file-repository.adoc
@@ -3,6 +3,7 @@
 [id="Uploading_Files_To_a_Custom_File_Type_Repository_{context}"]
 = Uploading files to a {customfiletype} repository
 
+[role="_abstract"]
 Use this procedure to upload files to a {customfiletype} repository.
 
 .Procedure

--- a/guides/common/modules/proc_uploading-files-to-a-python-repository.adoc
+++ b/guides/common/modules/proc_uploading-files-to-a-python-repository.adoc
@@ -3,6 +3,7 @@
 [id="Uploading_Files_To_a_Python_Type_Repository_{context}"]
 = Uploading files to a Python type repository
 
+[role="_abstract"]
 You can upload files from your local machine to a Python type repository.
 
 .Procedure

--- a/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
+++ b/guides/common/modules/proc_uploading-ostree-content-with-hammer-cli.adoc
@@ -3,6 +3,7 @@
 [id="uploading-ostree-content-with-hammer-cli_{context}"]
 = Uploading OSTree content with Hammer CLI
 
+[role="_abstract"]
 In deployments in which the {ProjectServer} does not have internet access, you can upload OSTree image archives using Hammer CLI.
 
 You can create images using the Image Builder or OSBuild tool.

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -3,6 +3,7 @@
 [id="Using_an_NFS_Share_for_Content_Storage_{context}"]
 = Using an NFS share for content storage
 
+[role="_abstract"]
 Your environment requires adequate hard disk space to fulfill content storage.
 In some situations, it is useful to use an NFS share to store this content.
 This appendix shows how to mount the NFS share on your {ProjectServer}'s content management component.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -3,6 +3,7 @@
 [id="Using_Container_Registries_{context}"]
 = Using container registries
 
+[role="_abstract"]
 You can use Podman and Docker to fetch content from container registries and push the content to the {Project} container registry.
 The {Project} registry follows the Open Containers Initiative (OCI) specification, so you can push content to {Project} by using the same methods that apply to other registries.
 For more information about OCI, see link:https://opencontainers.org/[Open Container Initiative Distribution Specification].

--- a/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
+++ b/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
@@ -3,6 +3,7 @@
 [id="Using_Upstream_Server_as_a_Content_Store_{context}"]
 = Using an upstream {ProjectServer} as a content store
 
+[role="_abstract"]
 In this scenario, you use the upstream {ProjectServer} as a content store for updates rather than to manage content.
 You use the downstream {ProjectServer} to manage content for all infrastructure behind the isolated network.
 You export the Library content from the upstream {ProjectServer} and import it into the downstream {ProjectServer}.

--- a/guides/common/modules/proc_using-upstream-server-to-sync-content-view-versions.adoc
+++ b/guides/common/modules/proc_using-upstream-server-to-sync-content-view-versions.adoc
@@ -3,6 +3,7 @@
 [id="Using_Upstream_Server_to_Synchronize_Content_View_Versions_{context}"]
 = Using an upstream {ProjectServer} to synchronize content view versions
 
+[role="_abstract"]
 In this scenario, you use the upstream {ProjectServer} not only as a content store, but also to synchronize content for all infrastructure behind the isolated network.
 You curate updates coming from the CDN into content views and lifecycle environments.
 Once you promote content to a designated lifecycle environment, you can export the content from the upstream {ProjectServer} and import it into the downstream {ProjectServer}.

--- a/guides/common/modules/proc_viewing-flatpak-remote-details.adoc
+++ b/guides/common/modules/proc_viewing-flatpak-remote-details.adoc
@@ -3,6 +3,7 @@
 [id="viewing-flatpak-remote-details"]
 = Viewing Flatpak remote details
 
+[role="_abstract"]
 You can view a list of the repositories a scanned Flatpak remote provides.
 
 .Prerequisites

--- a/guides/common/modules/proc_viewing-module-streams.adoc
+++ b/guides/common/modules/proc_viewing-module-streams.adoc
@@ -3,6 +3,7 @@
 [id="Viewing_Module_Streams_{context}"]
 = Viewing module streams
 
+[role="_abstract"]
 In {Project}, you can view the module streams of the repositories in your content views.
 
 To use the CLI instead of the {ProjectWebUI}, see the xref:cli-Viewing_Module_Streams_{context}[].

--- a/guides/common/modules/ref_best-practices-for-activation-keys.adoc
+++ b/guides/common/modules/ref_best-practices-for-activation-keys.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-activation-keys_{context}"]
 = Best practices for activation keys
 
+[role="_abstract"]
 * Create an activation key for each use case.
 This structures, modularizes, and simplifies content management on hosts.
 * Use a naming convention for activation keys to indicate the content and lifecycle environment, for example, `{client-os-context}-webserver`.

--- a/guides/common/modules/ref_best-practices-for-content-views.adoc
+++ b/guides/common/modules/ref_best-practices-for-content-views.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-content-views_{context}"]
 = Best practices for content views
 
+[role="_abstract"]
 * Content views that bundle content, such as {client-os} and additional software like `Apache-2.4` or `PostgreSQL-16.2`, are easier to maintain.
 Content views that are too small require more maintenance.
 * If you require daily updated content, use the content view `Default Organization View`, which contains the latest synchronized content from all repositories and is available in the Library lifecycle environment.

--- a/guides/common/modules/ref_best-practices-for-errata.adoc
+++ b/guides/common/modules/ref_best-practices-for-errata.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-errata_{context}"]
 = Best practices for errata
 
+[role="_abstract"]
 * Use errata to add patches for security issues to a frozen set of content without unnecessarily updating other unaffected packages.
 * Automate errata management by using a Hammer script or an {ansible-docs-url}[Ansible Playbook].
 * View errata on the content hosts page and compare the errata of the current content view environment to the Library lifecycle environment, which contains the latest synchronized packages.

--- a/guides/common/modules/ref_best-practices-for-lifecycle-environments.adoc
+++ b/guides/common/modules/ref_best-practices-for-lifecycle-environments.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-lifecycle-environments_{context}"]
 = Best practices for lifecycle environments
 
+[role="_abstract"]
 * Use multiple lifecycle environment paths to implement multiple sequential stages of content consumption.
 Each stage contains a defined set of content, for example in the _Production_ lifecycle environment.
 * Automate the creation of lifecycle environments by using a Hammer script or an {ansible-docs-url}[Ansible Playbook].

--- a/guides/common/modules/ref_best-practices-for-patching-content-hosts.adoc
+++ b/guides/common/modules/ref_best-practices-for-patching-content-hosts.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-patching-content-hosts_{context}"]
 = Best practices for patching content hosts
 
+[role="_abstract"]
 * Registering hosts to {Project} requires {project-client-name}, which contains the `katello-host-tools` package and its dependencies.
 For more information, see {ManagingHostsDocURL}Registering_Hosts_by_Using_Global_Registration_managing-hosts[Registering hosts by using global registration] in _{ManagingHostsDocTitle}_.
 * Use the {ProjectWebUI} to install, upgrade, and remove packages from hosts.

--- a/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
+++ b/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-products-and-repositories_{context}"]
 = Best practices for products and repositories
 
+[role="_abstract"]
 * Use one content type per product and content view, for example, {client-content-type} content only.
 ifdef::orcharhino[]
 * Use file repositories for installation media.

--- a/guides/common/modules/ref_best-practices-for-sync-plans.adoc
+++ b/guides/common/modules/ref_best-practices-for-sync-plans.adoc
@@ -3,6 +3,7 @@
 [id="best-practices-for-sync-plans_{context}"]
 = Best practices for sync plans
 
+[role="_abstract"]
 * Add sync plans to products and regularly synchronize content to keep the load on {Project} low during synchronization.
 Synchronize content rather more often than less often.
 For example, setup a sync plan to synchronize content every day rather than only once a month.

--- a/guides/common/modules/ref_default-operating-system-repositories.adoc
+++ b/guides/common/modules/ref_default-operating-system-repositories.adoc
@@ -3,6 +3,7 @@
 [id="default-operating-system-repositories"]
 = Default operating system repositories
 
+[role="_abstract"]
 The following tables list default operating system repositories of various supported Client operating systems.
 Each table corresponds to a product name and each row corresponds to a repository name.
 

--- a/guides/common/modules/ref_iss-export-import-cheat-sheet.adoc
+++ b/guides/common/modules/ref_iss-export-import-cheat-sheet.adoc
@@ -3,6 +3,7 @@
 [id="Exporting_and_Importing_Content_Using_Hammer_CLI_Cheat_Sheet_{context}"]
 = Exporting and importing content using Hammer CLI cheat sheet
 
+[role="_abstract"]
 .Export
 [width="100%",cols="4, 10",options="header"]
 |=========================================================

--- a/guides/common/modules/ref_parameters-available-for-errata-search.adoc
+++ b/guides/common/modules/ref_parameters-available-for-errata-search.adoc
@@ -3,6 +3,7 @@
 [id="Parameters_Available_for_Errata_Search_{context}"]
 = Parameters available for errata search
 
+[role="_abstract"]
 [options="header"]
 |====
 |Parameter|Description|Example

--- a/guides/common/modules/ref_required-red-hat-repositories.adoc
+++ b/guides/common/modules/ref_required-red-hat-repositories.adoc
@@ -3,6 +3,7 @@
 [id="required-red-hat-repositories"]
 = Required Red Hat repositories
 
+[role="_abstract"]
 You need the following repositories to manage hosts with {RHEL}.
 
 For {RHEL} 10 hosts::

--- a/guides/common/modules/ref_troubleshooting-synchronization-errors.adoc
+++ b/guides/common/modules/ref_troubleshooting-synchronization-errors.adoc
@@ -3,6 +3,7 @@
 [id="troubleshooting-synchronization-errors"]
 = Troubleshooting synchronization errors
 
+[role="_abstract"]
 "[Errno 1] Operation not permitted: ..." during repository syncing::
 
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/ref_uln-repositories-for-oracle-linux-10.adoc
+++ b/guides/common/modules/ref_uln-repositories-for-oracle-linux-10.adoc
@@ -3,6 +3,7 @@
 [id="uln-repositories-for-oracle-linux-10"]
 = ULN repositories for Oracle Linux 10
 
+[role="_abstract"]
 * Addons ULN: `uln://ol10_x86_64_addons`
 * AppStream ULN: `uln://ol10_x86_64_appstream`
 * BaseOS latest ULN: `uln://ol10_x86_64_baseos_latest`

--- a/guides/common/modules/ref_uln-repositories-for-oracle-linux-8.adoc
+++ b/guides/common/modules/ref_uln-repositories-for-oracle-linux-8.adoc
@@ -3,6 +3,7 @@
 [id="uln-repositories-for-oracle-linux-8"]
 = ULN repositories for Oracle Linux 8
 
+[role="_abstract"]
 * Addons ULN: `uln://ol8_x86_64_addons`
 * AppStream ULN: `uln://ol8_x86_64_appstream`
 * BaseOS latest ULN: `uln://ol8_x86_64_baseos_latest`

--- a/guides/common/modules/ref_uln-repositories-for-oracle-linux-9.adoc
+++ b/guides/common/modules/ref_uln-repositories-for-oracle-linux-9.adoc
@@ -3,6 +3,7 @@
 [id="uln-repositories-for-oracle-linux-9"]
 = ULN repositories for Oracle Linux 9
 
+[role="_abstract"]
 * Addons ULN: `uln://ol9_x86_64_addons`
 * AppStream ULN: `uln://ol9_x86_64_appstream`
 * BaseOS latest ULN: `uln://ol9_x86_64_baseos_latest`


### PR DESCRIPTION
#### What changes are you introducing?

Adding `[role="_abstract"]` to modules in the _Managing content_ guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

DITA compliance

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I'm sorry this PR is so big! But at least it's focused :)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
