### PR TITLE
Rename hammer-cli to cli in file names

### DIFF
--- a/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
@@ -10,7 +10,7 @@ include::modules/proc_viewing-flatpak-remote-details.adoc[leveloffset=+1]
 
 include::modules/proc_mirroring-remote-flatpak-repositories-to-project-products.adoc[leveloffset=+1]
 
-include::modules/proc_enabling-the-flatpak-remote-by-using-hammer-cli.adoc[leveloffset=+1]
+include::modules/proc_enabling-the-flatpak-remote-by-using-cli.adoc[leveloffset=+1]
 
 include::modules/proc_installing-flatpak-applications-on-project-hosts.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_managing-ostree-content.adoc
+++ b/guides/common/assembly_managing-ostree-content.adoc
@@ -7,7 +7,7 @@ include::modules/proc_enabling-os-tree-content.adoc[leveloffset=+1]
 include::modules/proc_importing-ostree-content.adoc[leveloffset=+1]
 
 ifndef::satellite[]
-include::modules/proc_uploading-ostree-content-with-hammer-cli.adoc[leveloffset=+1]
+include::modules/proc_uploading-ostree-content-by-using-cli.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_managing-ostree-content-with-content-views.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-cli.adoc
+++ b/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-cli.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="enabling-the-flatpak-remote-by-using-hammer-cli"]
+[id="enabling-the-flatpak-remote-by-using-cli"]
 = Enabling the Flatpak remote by using Hammer CLI
 
 This procedure configures and manages Flatpak repositories by using Hammer CLI.
@@ -15,7 +15,7 @@ For more information, see {RHELDocsBaseURL}9/html/administering_the_system_using
 For example, `rhel9/firefox-flatpak` depends on `rhel9/flatpak-runtime`. 
 * Ensure that runtime repositories are available to clients alongside application repositories for installations to work.
 
-.CLI procedure
+.Procedure
 . Enable a Flatpak remote on the {ProjectServer} by using standalone {EL} systems or {ProjectName}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
+++ b/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
@@ -7,7 +7,7 @@ Use Hammer CLI to transfer Flatpak content to {ProjectServer} in environments wi
 
 .Prerequisites
 * Enable the Flatpak remote.
-For more information about enabling the Flatpak remote, see xref:enabling-the-flatpak-remote-by-using-hammer-cli[].
+For more information about enabling the Flatpak remote, see xref:enabling-the-flatpak-remote-by-using-cli[].
 * Use download policy *Immediate* to synchronize Flatpak content to {ProjectServer}.
 For more information, see xref:changing_the_download_policy_for_a_repository_{context}[].
 

--- a/guides/common/modules/proc_installing-ostree-content-from-server.adoc
+++ b/guides/common/modules/proc_installing-ostree-content-from-server.adoc
@@ -7,7 +7,7 @@ OSTree content from {Project} on hosts is managed by Subscription Manager and ca
 
 .Prerequisites
 * You have synchronized or uploaded an OSTree head to {Project}.
-For more information, see xref:importing-ostree-content_{context}[] and xref:uploading-ostree-content-with-hammer-cli_{context}[].
+For more information, see xref:importing-ostree-content_{context}[] and xref:uploading-ostree-content-by-using-cli[].
 
 .Procedure
 . On your hosts, view the available heads:

--- a/guides/common/modules/proc_uploading-ostree-content-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-ostree-content-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-ostree-content-with-hammer-cli_{context}"]
-= Uploading OSTree content with Hammer CLI
+[id="uploading-ostree-content-by-using-cli"]
+= Uploading OSTree content by using Hammer CLI
 
 In deployments in which the {ProjectServer} does not have internet access, you can upload OSTree image archives using Hammer CLI.
 
@@ -11,23 +11,23 @@ You can also create an OSTree image archive by downloading a repository from an 
 
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# wget --no-parent -r _https://repos.example.com/ostree/repo_name/_
-# tar --exclude="index.html" -cvf "_example_archive_repo_.tar" -C _repos.example.com/ostree_ "_repo_name_"
+$ wget --no-parent -r _https://repos.example.com/ostree/repo_name/_
+$ tar --exclude="index.html" -cvf "_example_archive_repo_.tar" -C _repos.example.com/ostree_ "_repo_name_"
 ----
 
 .Prerequisites
 * You have an OSTree image archive ready and present on your file system.
 
 .Procedure
-. Connect to your {ProjectServer} using SSH.
-. Upload your OSTree archive with the `hammer` command:
+* On your {ProjectServer}, upload your OSTree archive:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-$ hammer repository upload-content --id _repository_id_ \
+$ hammer repository upload-content \
 --content-type ostree_ref \
---path _/path/to/image/file.tar_ \
---ostree-repository-name _example_repo_name_
+--id _My_Repository_id_ \
+--ostree-repository-name _My_Repository_Name_ \
+--path _/path/to/image/file.tar_
 ----
 +
 The value of `--ostree-repository-name` must match the name of the OSTree repository in the archive.


### PR DESCRIPTION
#### What changes are you introducing?

We have a convention to use "by-using-cli" or "by-using-web-ui" in anchors. Therefore, it makes maintenance easier if we also apply this to module names that document procedures for Hammer CLI in constrast to WebUI or API.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The main benefit is that you can search for the anchor and also find the assembly that includes the modules.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Fixes #4350
* Note that I did not touch/rename all files that the command from the issue returns. Some are IMO ok to stay as they are because I wanted to limit this convention to procedures that document ways for Hammer CLI. Some module, like "setting up Hammer CLI" can still be called "proc_setting-up-hammer-cli.adoc".

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
