### PR TITLE
add subs=attributes

### DIFF
--- a/guides/common/modules/snip_deprecated-feature.adoc
+++ b/guides/common/modules/snip_deprecated-feature.adoc
@@ -3,6 +3,7 @@
 
 [IMPORTANT]
 ====
+[subs="attributes+"]
 {FeatureName} is a deprecated feature.
 Deprecated functionality is still included in {Project} and continues to be supported.
 However, it will be removed in a future release of this product and is not recommended for new deployments.


### PR DESCRIPTION
#### What changes are you introducing?

Add the [subs="attributes+"] line to the deprecation snippets

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This enables correctly parsing markup, such as monospace, in the attribute.

Without this line, "The `shmommand` command" is not rendered in monospace but shows the backtick characters in the published docs.

The line is correctly implemented in the Technology Preview snippet.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
