### PR TITLE
Add sendmail deprecation to 3.16

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -41,11 +41,13 @@ For more information, see {AdministeringDocURL}limiting-host-resources[Limiting 
 
 [id="foreman-deprecations"]
 == Deprecations
+
 === Preparing {Project} for operation in containerized environments
-- *`sendmail` is deprecated for delivering email* - Delivering email by calling the `sendmail` binary on the system is problematic in many cases.
+
+* *`sendmail` is deprecated for delivering email* - Delivering email by calling the `sendmail` binary on the system is problematic in many cases.
 Therefore, it is deprecated and will be removed in a future version.
 As an alternative, use the SMTP mail delivery method.
-For more information, see link:https://docs.theforeman.org/3.16/Installing_Server/index-katello.html#Configuring_Server_for_Outgoing_Emails_foreman[Configuring Foreman server for outgoing emails].
+For more information, see {InstallingServerDocURL}Configuring_Server_for_Outgoing_Emails_foreman[Configuring {ProjectServer} for outgoing emails].
 
 === UI component phase-outs
 - *Legacy AngularJS Pages* - Continued elimination of AngularJS-based UI components as part of All Hosts page redesign


### PR DESCRIPTION
#### What changes are you introducing?
Add sendmail deprecation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Sendmail is deprecated in Satellite 6.18 and will be removed in a future release.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
