### PR TITLE
Add deprecation warning for ACD plugin

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -70,3 +70,10 @@ GRUB version 1::
 GRUB Legacy, also known as GRUB version 1, is deprecated in provisioning and will be removed in a future release.
 GRUB 1 was used by end of life distributions such as SUSE Linux Enterprise Server 11, RHEL 6, Debian Lenny, and Ubuntu 9.04.
 Current distributions use GRUB 2 and are not affected by the deprecation.
+
+=== Plugins
+
+Application Centric Deployment (ACD) plugin::
+
+Foreman 3.17 does not support the `foreman_acd` and `smart_proxy_acd` plugins.
+Before upgrading from 3.16 to 3.17, uninstall the ACD plugin on your {ProjectServer} and {SmartProxyServers}.


### PR DESCRIPTION
#### What changes are you introducing?

Foreman 3.17 does not support foreman_acd and smart_proxy_acd.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

follow-up to #4359 (Remove docs for foreman_acd from nightly)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Note that the package is currently still present on https://yum.theforeman.org/plugins/nightly/el9/x86_64/.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
