### PR TITLE
Merge MCP query examples into one

### DIFF
--- a/guides/common/modules/proc_querying-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/proc_querying-the-mcp-server-for-project.adoc
@@ -28,33 +28,33 @@ Show a list of hosts that require patching.
 The AI application interprets the query and asks the MCP client to retrieve the relevant data from {Project} inventory through the MCP server.
 The MCP client fetches the data and returns it to the AI application, which then processes it to provide an answer to the user.
 
-.Obtaining a list of hosts that require patching
+.Query examples
 ====
+Querying hosts::
++
 To obtain a list of hosts that require patching and refine it, you can use the following prompts:
-
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 Show a list of hosts that require patching on my {Project}.
 ----
-
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 Categorize the list into hosts that require security patches
 and hosts that require bug fix patches.
 ----
-====
-
-.Querying the MCP server for {Project} to generate a static report of all subnets in {Project} inventory
-====
-To obtain a report of all subnets, you can use the following prompts:
-
+Querying subnets::
++
+To obtain a report of all subnets in {Project} inventory, you can use the following prompts:
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 Generate a static report of all subnets on my {Project}.
 Read API documentation for each of the needed resources
 before doing any searches.
 ----
-
++
 [options="nowrap", subs="+quotes,attributes"]
 ----
 For each subnet, report its name, address, network mask,


### PR DESCRIPTION
#### What changes are you introducing?

Ensuring that the procedure contains only one example block.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/styles/AsciiDocDITA/TaskExample.yml

`message: "Examples are allowed only once in DITA tasks."`

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I'm open to other approaches on how to structure the example block. This is the best I could come up with.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
