### PR TITLE
Clarify where to obtain the CA bundle for MCP server

### DIFF
--- a/guides/common/modules/proc_configuring-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/proc_configuring-the-mcp-server-for-project.adoc
@@ -13,9 +13,7 @@ ifdef::satellite[]
 * You are logged in to the registry.redhat.io container registry.
 endif::[]
 * The CA bundle for your {Project} is available on your system.
-If you are using the default self-signed {Project} certificate, the CA bundle is located at `_{foreman-example-com}_/pub/katello-server-ca.crt`.
-+
-If the MCP client runs on a system other than the {ProjectServer}, your {Project} administrator can download the CA bundle from the {ProjectServer} and transfer it to your system.
+You can download it from `https://_{foreman-example-com}_/unattended/public/foreman_raw_ca`.
 
 .Procedure
 . Optional: Pull the latest version of the MCP container image from the registry:
@@ -41,6 +39,7 @@ The options used in the command include the following:
 * `ro` makes the read-only mode inside the container
 * `Z` relabels the file with a private, unshared label
 `--_Path_to_My_CA_Bundle_`:: Specifies the location of the {Project} CA bundle on the system.
+This is required to verify the connection to {Project}.
 
 .Additional resources
 ifdef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding details on how to obtain the CA bundle for MCP server.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-39417#

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
