### PR TITLE
Add details about repositories to Smart Proxy upgrade prerequisites

### DIFF
--- a/guides/common/modules/proc_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/proc_upgrading-smartproxy-server.adoc
@@ -27,7 +27,6 @@ ifdef::satellite[]
 * Ensure that you synchronize the required repositories on {ProjectServer}.
 For more information, see xref:synchronizing_the_new_repositories_{context}[].
 * If the {SmartProxyServer} is registered to a content view, add the {SmartProxy} {ProjectVersion} repositories to the content view.
-For more information, see xref:synchronizing_the_new_repositories_{context}[].
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 Publish and promote a new version of the content view.


### PR DESCRIPTION
Since the smart proxies can be upgraded separately, some users might miss out on the information about which repos are to be synced. Adding a prerequisite to ensure this information is not skipped.

JIRA:
https://issues.redhat.com/browse/SAT-37314
Specifically this comment:
https://issues.redhat.com/browse/SAT-37314?focusedId=27987597&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27987597

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
