### PR TITLE
Ignore DITA styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ guides/common/default.css
 /web/output/
 /vendor
 .vale/styles/AsciiDoc/
+.vale/styles/AsciiDocDITA/
 .vale/styles/RedHat/
 .vscode/*


### PR DESCRIPTION
#### What changes are you introducing?

Adding `.vale/styles/AsciiDocDITA/` to `.gitignore`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To allow local Vale sync without having to commit the synced styles

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Follow-up on #4402 

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
