### PR TITLE
Use ISS export sync for disconnected Updating 3.14

### DIFF
--- a/guides/common/modules/proc_updating-disconnected-server-on-EL9.adoc
+++ b/guides/common/modules/proc_updating-disconnected-server-on-EL9.adoc
@@ -12,7 +12,7 @@ You can update your disconnected {Project} on {EL} 9 by synchronizing the requir
 * `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}`
 
 +
-Ensure to set the download policy to *Immediate* for each repository.
+Ensure that the download policy is set to *Immediate* for each repository.
 . List the repositories to identify their IDs:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

Replace reposync with ISS export sync in updating disconnected ProjectServer

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's the recommended method

[SAT-24752](https://issues.redhat.com/browse/SAT-24752) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Cherry pick for Sat 6.17
- Follow-up on https://github.com/theforeman/foreman-documentation/pull/4293

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
