### PR TITLE
Add conditional step for http proxy for iop vulnerability

### DIFF
--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -29,14 +29,21 @@ endif::[]
 ----
 # {foreman-installer} --enable-iop
 ----
-. To use the {vulnerabilityengine}, and if your {ProjectServer} connects to `\https://security.access.redhat.com` through an HTTP proxy, configure the `iop-cvemap-download` service for the same HTTP proxy.
-To do so, enter the `systemctl edit iop-cvemap-download.service` command and input the following content:
+. If you want to use the {vulnerabilityengine} and your {ProjectServer} connects to `\https://security.access.redhat.com` through an HTTP proxy, configure the `iop-cvemap-download` service to use the same HTTP proxy:
+.. Edit the `iop-cvemap-download` service:
++
+[source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl edit iop-cvemap-download.service
+----
+.. Input the following content:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 [Service]
-Environment = HTTPS_PROXY=https://_http-proxy.example.com:port_
+Environment = HTTPS_PROXY=http://_http-proxy.example.com:port_
 Environment = NO_PROXY=localhost
 ----
+
 +
 include::snip_technology-preview.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?
Add a conditional step for IoP Vulnerability service if the server needs http proxy to access redhat.com

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://issues.redhat.com/browse/SAT-39459

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
