### PR TITLE
Add Katello 4.19 structured APT for deb content upgrade docs

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -23,12 +23,11 @@ The new page will eventually merge with the Booted Container Images page.
 To view it, enable the "Experimental Labs" setting, refresh the page, and navigate to Lab Features -> Container Images (/labs/container_images).
 https://projects.theforeman.org/issues/38812
 
-=== Structured APT for deb content
+=== Structured APT for Deb content
 
-With Katello 4.19, all deb content will start using "structured APT" mode.
-This means that deb content published in APT repos on Katello, will no longer publish Release files u
-nder the `dists/default/` path.
-Instead, all APT repository publications will exclusively use the same repository structure (releases/distributions and components) as the remote upstream repositories they are synced from.
+With Katello 4.19, all Deb content will start using "structured APT" mode.
+This means that Deb content published in APT repositories on Katello will no longer publish metadata under the `dists/default/` path.
+Instead, all APT repository publications will exclusively use the same repository structure (releases/distributions and components), that are synchronized from the upstream URL.
 https://projects.theforeman.org/issues/38741
 
 === New bulk actions have been added to the host overview page
@@ -39,13 +38,14 @@ https://projects.theforeman.org/issues/38829
 [id="katello-upgrade-warnings"]
 == Upgrade warnings
 
-=== Structured APT migration for deb content
+=== Structured APT migration for Deb content
 
-For users with deb type content, it is recommended to migrate to "structured APT" enabled mode *before* upgrading. Instructions for migrating on Katello <= 4.18 can be found here: https://docs.theforeman.org/3.16/Managing_Content/index-katello.html#enabling-structured-apt-content
-If you do not migrate your deb content before upgrading, it will be automatically migrated by the foreman-installer run after upgrading.
-However, if this automatic migration run is omitted, or fails, some of your deb type content may be left in an inconsistent state.
+For users with Deb type content, {Team} recommends that you migrate to "structured APT" enabled mode before upgrading to Katello 4.19.
+If you do not migrate your Deb content before upgrading, it will be automatically migrated during the upgrade.
+However, if this automatic migration run is omitted or fails, your Deb type content may be left in an inconsistent state.
 You will also need to perform a complete sync of your smart proxies after the upgrade.
-This is why we recommend migrating before the upgrade, at which point you can easily re-run the migration or get help in case there is an issue.
+Detailed instructions for how to migrate before upgrading to Katello 4.19 can be found here:
+https://docs.theforeman.org/3.16/Managing_Content/index-katello.html#enabling-structured-apt-content
 
 [id="katello-deprecations"]
 == Deprecations
@@ -54,6 +54,6 @@ This is why we recommend migrating before the upgrade, at which point you can ea
 
 These options are no longer relevant because all organizations are SCA-only, and attaching subscriptions to hosts and activation keys is obsolete.
 
-=== With the switch to structured APT for deb content, new publications for deb content will no longer add metadata under the `dists/default/` path.
+=== With the switch to structured APT for Deb content, new publications for Deb content will no longer add metadata under the `dists/default/` path.
 
-Use the metadata published under the paths used by the remote repository being synced from instead.
+You must configure hosts to use the same releases/distributions and components that were synchronized from the relevant upstream repository.


### PR DESCRIPTION
#### What changes are you introducing?

Upgrade notes regarding the deb content migration that will run when upgrading to Katello 4.19.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

With Katello 4.19, all deb type content will be migrated to use "structured APT" mode, see: https://github.com/Katello/katello/pull/11487

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is an early draft. These upgrade notes will only be needed on the Katello 4.19 (Foreman 3.16) branch.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Add upgrade notes describing the automatic migration of deb content to structured APT mode when upgrading to Katello 4.19.