### PR TITLE
Use ISS export sync for disconnected Upgrade 3.14

### DIFF
--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -138,7 +138,7 @@ Keep the `{RepoRHEL9ServerSatelliteServerProjectVersion}` repository disabled.
 . Optional: Because of the lengthy upgrade time, use a utility such as `tmux` to suspend and reattach a communication session.
 You can then check the upgrade progress without staying connected to the command shell continuously.
 +
-If you lose connection to the command shell where the upgrade command is running, you can see the logs in `/var/log/foreman-installer/satellite.log` to check if the process completed successfully.
+If you lose connection to the command shell where the upgrade command is running, you can see the logs in `{installer-log-file}` to check if the process completed successfully.
 
 . Upgrade the `{foreman-maintain}` utility to its latest version:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Replacing ISOs with ISS export sync in disconnected Upgrading

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Recommended method to obtain content
[SAT-24753](https://issues.redhat.com/browse/SAT-24753) (private)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Similar to https://github.com/theforeman/foreman-documentation/pull/4164 + https://github.com/theforeman/foreman-documentation/pull/4450
- Sat 6.17 only

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
