### PR TITLE
Improve disconnected Upgrade

### DIFF
--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -8,7 +8,7 @@ Upgrading a {ProjectServer} that is not connected to the Red{nbsp}Hat Content De
 include::snip_warning-maintain-config-noop.adoc[]
 
 .Prerequisites
-* If you synchronize content between your {ProjectServer}s by using exports, ensure that all your {ProjectServer}s are on the same {Project} version.
+* Ensure that all your {ProjectServer}s are on the same {Project} version.
 * If you have made manual edits to you DNS or DHCP configuration in the `/etc/zones.conf` or `/etc/dhcp/dhcpd.conf` files, ensure DNS and DHCP configuration management is disabled:
 +
 [options="nowrap" subs="attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

- Removing the step to stop services
- Improving stuff

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Stopping services is an unwanted step because foreman-maintain requires they are running:
```
# satellite-maintain upgrade check --whitelist="repositories-validate,repositories-setup"
Checking for new version of satellite-maintain, rubygem-foreman_maintain...
Nothing to update, can't find new version of satellite-maintain, rubygem-foreman_maintain.
Running preparation steps required to run the next scenarios
================================================================================
Check whether all services are running:                               [FAIL]
```

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Discovered during additional testing

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
