### PR TITLE
Update tag for downstream MCP server image

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -95,7 +95,7 @@
 :a-KubeVirt: an OpenShift Virtualization
 :kubevirt-command: oc
 :LoraxCompose: Red{nbsp}Hat Image Builder
-:mcp-server-image: registry.redhat.io/satellite/foreman-mcp-server-rhel9:latest
+:mcp-server-image: registry.redhat.io/satellite/foreman-mcp-server-rhel9:6.18
 :OpenStack: Red{nbsp}Hat OpenStack Services on OpenShift
 :project-package-check-update: satellite-maintain packages check-update
 :project-package-install: satellite-maintain packages install


### PR DESCRIPTION
#### What changes are you introducing?

Changing the tag for the MCP server image for downstream from `latest` to `6.18`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We don't publish latest for production images

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.
