### PR TITLE
Rename attribute insights-iop-id

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -157,7 +157,7 @@
 :ansible-doc-base-url: https://docs.ansible.com/ansible/latest/collections/theforeman/foreman
 :ansible-doc-templates_import: {ansible-doc-base-url}/templates_import_module.html
 // Red Hat Insights
-:insights-iop-id: insights
+:insights-iop-context: insights
 :Insights: Insights
 :insights-iop: {Insights} in {Project}
 :advisorengine: {Insights} Advisor

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -139,7 +139,7 @@
 :ansible-doc-templates_import: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/content/module/templates_import/
 
 // Red Hat Insights rebranded to Red Hat Lightspeed
-:insights-iop-id: red-hat-lightspeed-in-satellite
+:insights-iop-context: red-hat-lightspeed-in-satellite
 :Insights: Red{nbsp}Hat Lightspeed
 :insights-iop: {Insights} in {Project}
 :advisorengine: {Insights} advisor service in {Project}

--- a/guides/common/modules/con_installing-and-configuring-insights-iop.adoc
+++ b/guides/common/modules/con_installing-and-configuring-insights-iop.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="installing-and-configuring-{insights-iop-id}"]
+[id="installing-and-configuring-{insights-iop-context}"]
 = Installing and configuring {insights-iop}
 
 {insights-iop} analyzes system health and configuration by applying predefined rules to a small set of local data, such as installed packages, running services, and configuration settings.

--- a/guides/common/modules/proc_configuring-synchronization-of-insights-recommendations-for-hosts.adoc
+++ b/guides/common/modules/proc_configuring-synchronization-of-insights-recommendations-for-hosts.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-synchronization-of-{insights-iop-id}-recommendations-for-hosts"]
+[id="configuring-synchronization-of-{insights-iop-context}-recommendations-for-hosts"]
 = Configuring synchronization of {Insights} recommendations for hosts
 
 [role="_abstract"]

--- a/guides/common/modules/proc_examining-vulnerability-of-systems.adoc
+++ b/guides/common/modules/proc_examining-vulnerability-of-systems.adoc
@@ -19,4 +19,4 @@ include::snip_technology-preview.adoc[]
 . In the *CVE ID* column, click the ID of the vulnerability to see details.
 
 .Additional resources
-* {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}]
+* {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-context}[Installing and configuring {insights-iop}]

--- a/guides/common/modules/proc_installing-insights-iop-by-using-export-and-import.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-by-using-export-and-import.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-{insights-iop-id}-by-using-export-and-import"]
+[id="installing-{insights-iop-context}-by-using-export-and-import"]
 = Installing {insights-iop} by using export and import
 
 You can transfer the container images from a connected system to a disconnected {ProjectServer}. 

--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 :FeatureName: The {vulnerabilityengine}
 
-[id="installing-{insights-iop-id}-on-a-connected-{project-context}-server"]
+[id="installing-{insights-iop-context}-on-a-connected-{project-context}-server"]
 = Installing {insights-iop} on a connected {ProjectServer}
 
 ifdef::satellite[]

--- a/guides/common/modules/proc_installing-insights-iop-with-the-project-context-iso-image.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-with-the-project-context-iso-image.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-{insights-iop-id}-with-the-{project-context}-iso-image"]
+[id="installing-{insights-iop-context}-with-the-{project-context}-iso-image"]
 = Installing {insights-iop} with the {Project} ISO image
 
 You can use the {Project} installation ISO image to access the required container content.  

--- a/guides/common/modules/proc_refreshing-clients-of-insights-iop.adoc
+++ b/guides/common/modules/proc_refreshing-clients-of-insights-iop.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="refreshing-clients-of-{insights-iop-id}"]
+[id="refreshing-clients-of-{insights-iop-context}"]
 = Refreshing clients of {insights-iop}
 
 [role="_abstract"]

--- a/guides/common/modules/proc_restoring-from-a-full-backup.adoc
+++ b/guides/common/modules/proc_restoring-from-a-full-backup.adoc
@@ -45,11 +45,11 @@ endif::[]
 ifdef::satellite[]
 +
 If you have used {insights-iop}, enable it.
-For more information, see {InstallingServerDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}].
+For more information, see {InstallingServerDocURL}installing-and-configuring-{insights-iop-context}[Installing and configuring {insights-iop}].
 ** To install {ProjectServer} from a disconnected network, follow the procedures in {InstallingServerDisconnectedDocURL}[{InstallingServerDisconnectedDocTitle}].
 +
 If you have used {insights-iop}, enable it.
-For more information, see {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}].
+For more information, see {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-context}[Installing and configuring {insights-iop}].
 endif::[]
 ** To install a {SmartProxyServer}, follow the procedures in {InstallingSmartProxyDocURL}[{InstallingSmartProxyDocTitle}].
 . Copy the backup data to the local file system on {ProjectServer}.

--- a/guides/common/modules/ref_access-to-information-from-insights-in-project.adoc
+++ b/guides/common/modules/ref_access-to-information-from-insights-in-project.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="access-to-information-from-{insights-iop-id}-in-{project-context}"]
+[id="access-to-information-from-{insights-iop-context}-in-{project-context}"]
 = Access to information from {Insights} in {Project}
 
 [role="_abstract"]


### PR DESCRIPTION
#### What changes are you introducing?

This patch renames the attribute "insights-iop-id" to "insights-iop-context". This does not cause a user-visible change but aligns the attribute to the current naming scheme (aka. "adding '-context' to any attribute in anchors"). The second command shows that there are no other attributes that need renaming.

````
$ fd . -e adoc -t f guides/common | xargs sed -i "s/insights-iop-id/insights-iop-context/g"
$ rg -- "-id" guides/common/attributes*
````

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To keep conventions up to simplify maintenance

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Suggested by Anet
Refs #4446 (Show RH Insights for orcharhino builds)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Rename "insights-iop-id" attribute to "insights-iop-context" across common guides to match current naming conventions.