### PR TITLE
Revert "Remove grub1-based provisioning templates (#4467)"

### DIFF
--- a/guides/common/modules/con_boot-disk-types.adoc
+++ b/guides/common/modules/con_boot-disk-types.adoc
@@ -11,7 +11,7 @@ The boot loader on this image chain loads the installer directly from the image.
 This image is useful if the host fails to chain load from {ProjectServer} or {SmartProxyServer} correctly.
 The provisioning template still downloads from {ProjectServer}.
 +
-This image is based on SYSLINUX and GRUB2 and works with most network cards.
+This image is based on SYSLINUX and GRUB and works with most network cards.
 +
 This image contains a provisioning security token, therefore the generated image has a limited lifespan.
 For more information about configuring the security token, see xref:configuring-the-security-token-validity-duration[].

--- a/guides/common/modules/con_network-boot-provisioning-workflow.adoc
+++ b/guides/common/modules/con_network-boot-provisioning-workflow.adoc
@@ -13,7 +13,7 @@ When you complete all the options for the new host, submit the new host request.
 * A DHCP record on {SmartProxyServer} that is associated with the subnet.
 * A forward DNS record on {SmartProxyServer} that is associated with the domain.
 * A reverse DNS record on the DNS {SmartProxyServer} that is associated with the subnet.
-* PXELinux, Grub2, and iPXE configuration files for the host in the TFTP {SmartProxyServer} that is associated with the subnet.
+* PXELinux, Grub, Grub2, and iPXE configuration files for the host in the TFTP {SmartProxyServer} that is associated with the subnet.
 * A Puppet certificate on the associated Puppet server.
 * A realm on the associated identity server.
 . The host is configured to boot from the network as the first device and HDD as the second device.

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -88,6 +88,14 @@ endif::[]
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
 # chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi
 ----
+ifeval::["{client-pkg-ext}" == "deb"]
+. Link the `grub.cfg` file from the TFTP servers `grub2` folder to the legacy `grub` folder:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# ln --relative --symbolic /var/lib/tftpboot/grub2/grub.cfg /var/lib/tftpboot/grub/grub.cfg
+----
+endif::[]
 
 .Verification
 * Verify the contents of your boot loader directory:

--- a/guides/common/modules/proc_customizing-the-discovery-pxe-boot.adoc
+++ b/guides/common/modules/proc_customizing-the-discovery-pxe-boot.adoc
@@ -8,7 +8,7 @@
 {Project} builds PXE boot menus from the following global provisioning templates:
 
 * `PXELinux global default` for BIOS provisioning.
-* `PXEGrub2 global default` for UEFI provisioning.
+* `PXEGrub global default` and `PXEGrub2 global default` for UEFI provisioning.
 
 The PXE boot menus are available on {ProjectServer} and {SmartProxies} that have TFTP enabled.
 
@@ -20,6 +20,9 @@ You can customize the passed kernel parameters by changing the following snippet
 This snippet renders the Discovery boot menu option.
 The `KERNEL` and `APPEND` options boot the Discovery kernel and initial RAM disk.
 The `APPEND` option contains kernel parameters.
+
+* `pxegrub_discovery`: This snippet is included in the `PXEGrub global default` template.
+However, Discovery is http://projects.theforeman.org/issues/15997[not implemented for GRUB 1.x].
 
 * `pxegrub2_discovery`: This snippet is included in the `PXEGrub2 global default` template.
 +

--- a/guides/common/modules/ref_content-settings.adoc
+++ b/guides/common/modules/ref_content-settings.adoc
@@ -11,6 +11,7 @@
 | *Default synced OS finish template* | Kickstart default finish | Default finish template for new operating systems created from synced content.
 | *Default synced OS user-data* | Kickstart default user data |Default user data for new operating systems created from synced content.
 | *Default synced OS PXELinux template* | Kickstart default PXELinux | Default PXELinux template for new operating systems created from synced content.
+| *Default synced OS PXEGrub template* | Kickstart default PXEGrub | Default PXEGrub template for new operating systems created from synced content.
 | *Default synced OS PXEGrub2 template* | Kickstart default PXEGrub2 | Default PXEGrub2 template for new operating systems created from synced content.
 | *Default synced OS iPXE template* | Kickstart default iPXE | Default iPXE template for new operating systems created from synced content.
 | *Default synced OS partition table* | Kickstart default | Default partitioning table for new operating systems created from synced content.

--- a/guides/common/modules/ref_discovery-settings.adoc
+++ b/guides/common/modules/ref_discovery-settings.adoc
@@ -25,6 +25,7 @@ Must start with a letter.
 | *IPMI facts* | | Regex to organize facts for the _Intelligent Platform Management Interface_ (IPMI) section.
 | *Lock PXE* | No | Automatically generate a _Preboot Execution Environment_ (PXE) configuration to pin a newly discovered host to discovery.
 | *Locked PXELinux template name* | pxelinux_discovery | PXELinux template to be used when pinning a host to discovery.
+| *Locked PXEGrub template name* | pxegrub_discovery | PXEGrub template to be used when pinning a host to discovery.
 | *Locked PXEGrub2 template name* | pxegrub2_discovery | PXEGrub2 template to be used when pinning a host to discovery.
 | *Force DNS* | Yes | Force the creation of DNS entries when provisioning a discovered host.
 | *Error on existing NIC* | No | Do not permit to discover an existing host matching the MAC of a provisioning _Network Interface Card_ (NIC) (errors out early).

--- a/guides/common/modules/ref_kinds-of-provisioning-templates.adoc
+++ b/guides/common/modules/ref_kinds-of-provisioning-templates.adoc
@@ -16,7 +16,7 @@ For more information about Kickstart syntax and commands, see the following reso
 * {RHELDocsBaseURL}7/html/installation_guide/sect-kickstart-syntax[Kickstart Syntax Reference] in the _{RHEL}{nbsp}7 Installation Guide_
 endif::[]
 
-PXELinux and PXEGrub2::
+PXELinux, PXEGrub, PXEGrub2::
 PXE-based templates that deploy to the template {SmartProxy} associated with a subnet to ensure that the host uses the installer with the correct kernel options.
 For BIOS provisioning, select *PXELinux* template.
 For UEFI provisioning, select *PXEGrub2*.

--- a/guides/common/modules/ref_provisioning-settings.adoc
+++ b/guides/common/modules/ref_provisioning-settings.adoc
@@ -56,11 +56,15 @@ It is not affected by upgrades.
 | *Global default PXELinux template* | PXELinux global default | Global default PXELinux template.
 This template is deployed to all configured TFTP servers.
 It is not affected by upgrades.
+| *Global default PXEGrub template* | PXEGrub global default | Global default PXEGrub template.
+This template is deployed to all configured TFTP servers.
+It is not affected by upgrades.
 | *Global default iPXE template* | iPXE global default | Global default iPXE template.
 This template is deployed to all configured TFTP servers.
 It is not affected by upgrades.
 | *Local boot PXEGrub2 template* | PXEGrub2 default local boot | Template that is selected as PXEGrub2 default for local boot.
 | *Local boot PXELinux template* | PXELinux default local boot | Template that is selected as PXELinux default for local boot.
+| *Local boot PXEGrub template* | PXEGrub default local boot | Template that is selected as PXEGrub default for local boot.
 | *Local boot iPXE template* | iPXE default local boot | Template that is selected as iPXE default for local boot.
 | *Manage PuppetCA* | Yes | {Project} automates certificate signing upon provision of a new host.
 | *Use UUID for certificates* | No | {Project} uses random UUIDs for certificate signing instead of hostnames.

--- a/guides/common/modules/ref_troubleshooting-discovery.adoc
+++ b/guides/common/modules/ref_troubleshooting-discovery.adoc
@@ -17,7 +17,7 @@ For more information, see xref:setting-discovery-as-the-default-PXE-boot-option_
 ** `/var/lib/tftpboot/pxelinux.cfg/default`
 ** `/var/lib/tftpboot/grub2/grub.cfg`
 * Verify that the values of the `proxy.url` and `proxy.type` options in the PXE Discovery snippet you are using.
-The default snippets are named `pxelinux_discovery` or `pxegrub2_discovery`.
+The default snippets are named `pxelinux_discovery`, `pxegrub_discovery`, or `pxegrub2_discovery`.
 
 .Inspecting problems with networking
 * Ensure adequate network connectivity between hosts, {SmartProxyServer}, and {ProjectServer}.


### PR DESCRIPTION
#### What changes are you introducing?

This reverts commit 7bd463e0f943621fdc08763321db2aa3af7bc2a8.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This commit has not been cherry-picked to "3.16-stable" in foreman. Therefore, we need to revert it to bring back grub-based provisioning templates.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #4467
Refs Redmine 38768

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

No cherry-pick