### PR TITLE
Update external links to RH Lightspeed

### DIFF
--- a/guides/common/modules/con_additional-deployment-tasks.adoc
+++ b/guides/common/modules/con_additional-deployment-tasks.adoc
@@ -46,5 +46,5 @@ ifdef::satellite,orcharhino[]
 Incident management with {Insights}::
 With {Insights} enabled on your {ProjectServer}, you can identify key risks to stability, security, and performance.
 +
-For more information, see {InstallingServerDocURL}[Using Red{nbsp}Hat Insights with {ProjectServer}] in _{InstallingServerDocTitle}_.
+For more information, see {InstallingServerDocURL}performing-additional-configuration-on-server_{project-context}[Performing additional configuration on {ProjectServer}] in _{InstallingServerDocTitle}_.
 endif::[]

--- a/guides/common/modules/con_monitoring-hosts-by-using-insights.adoc
+++ b/guides/common/modules/con_monitoring-hosts-by-using-insights.adoc
@@ -16,7 +16,7 @@ For more information, see xref:Registering_Hosts_by_Using_Global_Registration_{c
 For more information, see xref:deploying-insights-by-using-the-ansible-role[].
 ifdef::satellite[]
 * If you register your host to a new {ProjectServer}, reregister the host to {Insights} to avoid creating duplicate entries.
-For more information, see {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights_with_fedramp/assembly-client-configuring-insights-client#proc-reregistering-system-insights_insights-cg-configuring-client[Re-registering your system with Red Hat Insights].
+For more information, see {RHDocsBaseURL}red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed/assembly-client-configuring-insights-client#proc-reregistering-system-insights_insights-cg-configuring-client[Re-registering your system with Red Hat Lightspeed].
 endif::[]
 
 To view the logs for all plugins, go to `/var/log/foreman/production.log`.
@@ -26,5 +26,5 @@ Refresh your subscription manifest to update your certificates.
 
 You can change the default schedule for running `insights-client` by configuring `insights-client.timer` on a host.
 ifdef::satellite[]
-For more information, see {RHDocsBaseURL}/red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Insights_.
+For more information, see {RHDocsBaseURL}red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed/assembly-client-changing-schedule[Changing the insights-client schedule] in the _Client Configuration Guide for Red Hat Lightspeed_.
 endif::[]

--- a/guides/common/modules/proc_configuring-project-server-as-insights-client.adoc
+++ b/guides/common/modules/proc_configuring-project-server-as-insights-client.adoc
@@ -37,8 +37,8 @@ To maintain your {ProjectServer}, and improve your ability to monitor and diagno
 ----
 
 .Additional resources
-* https://access.redhat.com/products/red-hat-insights/[Red Hat Insights]
-* {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-configuring-insights-client#proc-registering-system-insights_insights-cg-configuring-client[Registering your system with Red Hat Insights]
-* {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-changing-schedule[Changing the insights-client schedule]
-* {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-configuring-insights-client#proc-unregistering-system-insights_insights-cg-configuring-client[Unregistering your system with Red Hat Insights]
-* {RHDocsBaseURL}red_hat_insights/1-latest/html/client_configuration_guide_for_red_hat_insights/assembly-client-configuring-insights-client[Configuring insights-client]
+* https://access.redhat.com/products/red-hat-lightspeed[Red Hat Lightspeed]
+* {RHDocsBaseURL}red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed/assembly-client-configuring-insights-client#proc-registering-system-insights_insights-cg-configuring-client[Registering your system with Red Hat Lightspeed]
+* {RHDocsBaseURL}red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed/assembly-client-changing-schedule[Changing the insights-client schedule]
+* {RHDocsBaseURL}red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed/assembly-client-configuring-insights-client#proc-unregistering-system-insights_insights-cg-configuring-client[Unregistering your system with Red Hat Lightspeed]
+* {RHDocsBaseURL}red_hat_lightspeed/1-latest/html/client_configuration_guide_for_red_hat_lightspeed/assembly-client-configuring-insights-client[Configuring insights-client]


### PR DESCRIPTION
#### What changes are you introducing?

Updating external links to RH Lightspeed

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Insights service has been rebranded to [Lightspeed service](https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest)

[SAT-36001](https://issues.redhat.com/browse/SAT-36001)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Linkchecker must pass.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Update documentation to use RH Lightspeed service links instead of the rebranded Insights service

Documentation:
- Replace external Insights service URLs with the new RH Lightspeed service links in the additional deployment tasks guide
- Update the monitoring hosts guide to reference RH Lightspeed documentation
- Change project server client configuration instructions to link to RH Lightspeed service docs