### PR TITLE
Edit 3.16 RN formatting

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -5,35 +5,44 @@
 == Headline features
 
 === User interface & experience
-- *All Hosts Page Redesign* - Continued modernization of the All Hosts page with enhanced functionality, including changing owner, location/organization, disassociating VMs, and other improvements.
+
+All Hosts Page Redesign::
+Continued modernization of the All Hosts page with enhanced functionality, including changing owner, location/organization, disassociating VMs, and other improvements.
 
 === Infrastructure & platform updates
-- *NodeJS 22 Upgrade* - Updated UI build stack to NodeJS 22, extending lifecycle support to April 2027
-- *PatternFly 5 Migration* - Modernization of UI components by upgrading our PatternFly 4 UI components to PatternFly 5.
+
+NodeJS 22 Upgrade::
+Updated UI build stack to NodeJS 22, extending lifecycle support to April 2027
+
+PatternFly 5 Migration::
+Modernization of UI components by upgrading our PatternFly 4 UI components to PatternFly 5.
+
 ifdef::katello[]
-- *Containerized installation (Tech Preview)* - The *foremanctl* utility is available for a containerized {Project} installation with the Katello plugin.
+Containerized installation (Tech Preview)::
+The *foremanctl* utility is available for a containerized {Project} installation with the Katello plugin.
 For installation steps, see https://docs.theforeman.org/3.16/Quickstart/index-katello.html[_{QuickStartDocTitle}_].
 endif::[]
 
-=== Networking & connectivity
-- *Dual-Stack IPv4/IPv6 Registration Support* - Full support for client registration in dual-stack environments, enabling seamless registration over both IPv4 and IPv6 networks.
-
-=== Documentation & tooling
-- *Provisioning Documentation Improvements* - Enhanced documentation for provisioning workflows and best practices.
-
-[id="resource-quota-plugin"]
-=== Resource Quota plugin
-
+Resource Quota plugin::
 If you use the Resource Quota plugin on {Project} {ProjectVersionPrevious}, {Project} will automatically assign all existing hosts to the `Unassigned` resource quota during the upgrade to {Project} {ProjectVersion}.
 For more information, see {AdministeringDocURL}limiting-host-resources[Limiting host resources] in _{AdministeringDocTitle}_.
+
+=== Networking & connectivity
+
+Dual-Stack IPv4/IPv6 Registration Support::
+Full support for client registration in dual-stack environments, enabling seamless registration over both IPv4 and IPv6 networks.
+
+=== Documentation & tooling
+
+Provisioning Documentation Improvements::
+Enhanced documentation for provisioning workflows and best practices.
 
 [id="foreman-upgrade-warnings"]
 == Upgrade warnings
 
-=== RHV/oVirt support removal
-
-*RHV/oVirt Support Completely Removed* - Red Hat Virtualization (RHV) and oVirt compute resource support has been fully removed in {Project} {ProjectVersion}.
-
+RHV/oVirt Support Completely Removed::
+Red Hat Virtualization (RHV) and oVirt compute resource support has been fully removed in {Project} {ProjectVersion}.
++
 * *Previous Deprecation:* Feature was deprecated in {Project} {ProjectVersionPrevious}
 * *Impact:* Users with RHV/oVirt compute resources will lose this functionality unless they install the new https://github.com/markt-de/foreman_ovirt[ForemanOvirt plugin]
 * *Alternative Solution:* Install the new https://github.com/markt-de/foreman_ovirt[ForemanOvirt plugin] (maintained by a third party) to maintain oVirt functionality. This plugin contains the oVirt functionality that was previously part of Foreman core.
@@ -44,16 +53,20 @@ For more information, see {AdministeringDocURL}limiting-host-resources[Limiting 
 
 === Preparing {Project} for operation in containerized environments
 
-* *`sendmail` is deprecated for delivering email* - Delivering email by calling the `sendmail` binary on the system is problematic in many cases.
+`sendmail` is deprecated for delivering email::
+Delivering email by calling the `sendmail` binary on the system is problematic in many cases.
 Therefore, it is deprecated and will be removed in a future version.
 As an alternative, use the SMTP mail delivery method.
 For more information, see {InstallingServerDocURL}Configuring_Server_for_Outgoing_Emails_foreman[Configuring {ProjectServer} for outgoing emails].
 
 === UI component phase-outs
-- *Legacy AngularJS Pages* - Continued elimination of AngularJS-based UI components as part of All Hosts page redesign
+
+Legacy AngularJS Pages::
+Continued elimination of AngularJS-based UI components as part of All Hosts page redesign
 
 === Provisioning
 
-* GRUB Legacy, also known as GRUB version 1, is deprecated in provisioning and will be removed in a future release.
+GRUB version 1::
+GRUB Legacy, also known as GRUB version 1, is deprecated in provisioning and will be removed in a future release.
 GRUB 1 was used by end of life distributions such as SUSE Linux Enterprise Server 11, RHEL 6, Debian Lenny, and Ubuntu 9.04.
 Current distributions use GRUB 2 and are not affected by the deprecation.


### PR DESCRIPTION
#### What changes are you introducing?

Updating the formatting in 3.16 Foreman release notes.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current formatting is slightly inconsistent.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Standardize formatting in the Foreman 3.16 release notes to ensure consistency across headings, lists, and punctuation

Documentation:
- Reformatted headings for uniform style in the 3.16 release notes
- Adjusted list formatting and indentation to align with documentation standards
- Fixed punctuation and whitespace inconsistencies throughout the 3.16 release notes