### PR TITLE
Change command for Lifecycle Environment Path on 3.13

### DIFF
--- a/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
+++ b/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
@@ -17,8 +17,8 @@ Then optionally add additional environments to the environment paths.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment create \
---name "_Environment Path Name_" \
+$ hammer lifecycle-environment create \
+--name "_My First Lifecycle Environment_" \
 --description "_Environment Path Description_" \
 --prior "Library" \
 --organization "_My_Organization_"
@@ -27,15 +27,15 @@ Then optionally add additional environments to the environment paths.
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment create \
---name "_Environment Name_" \
+$ hammer lifecycle-environment create \
+--name "_My Second Lifecycle Environment_" \
 --description "_Environment Description_" \
---prior "_Prior Environment Name_" \
+--prior "_My First Lifecycle Environment_" \
 --organization "_My_Organization_"
 ----
-. To view the chain of the lifecycle environment, enter the following command:
+. To view the chain of the lifecycle environment path, enter the following command:
 +
 [options="nowrap" subs="+quotes"]
 ----
-# hammer lifecycle-environment paths --organization "_My_Organization_"
+$ hammer lifecycle-environment paths --organization "_My_Organization_"
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Cherry pick of #3533

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Revise the 'Creating a lifecycle environment path' guide to use the correct installer command on Foreman 3.13