### PR TITLE
Improve wording for LCE paths 3.15

### DIFF
--- a/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
+++ b/guides/common/modules/proc_creating-a-lifecycle-environment-path.adoc
@@ -13,7 +13,7 @@ Then optionally add additional environments to the environment paths.
 . Optional: To add an environment to the environment path, click *Add New Environment*, complete the *Name* and *Description* fields, and select the prior environment from the *Prior Environment* list.
 
 .CLI procedure
-. To create an environment path, enter the `hammer lifecycle-environment create` command and specify the Library environment with the `--prior` option:
+. Create a lifecycle environment path by tying your first environment to Library:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -23,7 +23,7 @@ $ hammer lifecycle-environment create \
 --prior "Library" \
 --organization "_My_Organization_"
 ----
-. Optional: To add an environment to the environment path, enter the `hammer lifecycle-environment create` command and specify the parent environment with the `--prior` option:
+. Optional: Add another environment to the environment path by tying it to the prior environment:
 +
 [options="nowrap" subs="+quotes"]
 ----
@@ -33,7 +33,7 @@ $ hammer lifecycle-environment create \
 --prior "_My First Lifecycle Environment_" \
 --organization "_My_Organization_"
 ----
-. To view the chain of the lifecycle environment path, enter the following command:
+. View the chain of the lifecycle environment path:
 +
 [options="nowrap" subs="+quotes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Follow-up on #4485 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [x] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [x] Foreman 3.10/Katello 4.12
* [x] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Improve the clarity and phrasing of the lifecycle environment path creation guide for Foreman 3.15.

Enhancements:
- Refine wording and instructions in the proc_creating-a-lifecycle-environment-path.adoc document

Documentation:
- Clarify terminology and improve readability in the lifecycle environment path documentation