### PR TITLE
Move tuning after install

### DIFF
--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -25,11 +25,11 @@ include::common/assembly_planning-project-server-installation.adoc[leveloffset=+
 
 include::common/assembly_preparing-environment-for-project-server-installation.adoc[leveloffset=+1]
 
+include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
+
 ifdef::katello,orcharhino,satellite[]
 include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
 endif::[]
-
-include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -26,9 +26,9 @@ include::common/assembly_planning-project-server-installation.adoc[leveloffset=+
 
 include::common/assembly_preparing-environment-for-project-server-installation.adoc[leveloffset=+1]
 
-include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
-
 include::common/assembly_installing-satellite-server-disconnected.adoc[leveloffset=+1]
+
+include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
 
 [id="performing-additional-configuration"]
 == Performing Additional Configuration on {ProjectServer}


### PR DESCRIPTION
#### What changes are you introducing?

Moving _Tuning Foreman server_ after Foreman server is installed

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Problem of running the command before the user has installed the `foreman-installer` tool

[SAT-31102](https://issues.redhat.com/browse/SAT-31102) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Avital's suggestion was to move it to _Performing additional configuration_, but IMO it doesn't quite fit, so I've just switched the chapters.
- How far do we want to cherry pick this?

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **???**

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Move the Foreman server tuning section to follow the installation steps in both master and disconnected installation guides