### PR TITLE
Include table definition in Ruby script

### DIFF
--- a/guides/common/modules/proc_creating-a-complete-permission-table.adoc
+++ b/guides/common/modules/proc_creating-a-complete-permission-table.adoc
@@ -33,21 +33,11 @@ result = Foreman::AccessControl.permissions {|a,b| a.security_block <=> b.securi
       "<tr><td>#{p.name}</td><td><ul>#{actions.join('')}</ul></td><td>#{p.resource_type}</td></tr>"
 end.join("\n")
 
+f.write("<table border=\"1\"><tr><td>Permission name</td><td>Actions</td><td>Resource type</td></tr>\n")
 f.write(result)
+f.write("</table>\n")
 ----
 +
 The above syntax creates a table of permissions and saves it to the `/tmp/table.html` file.
 . Press `*Ctrl*` + `*D*` to exit the {Project} console.
-. Insert the following text at the first line of `/tmp/table.html`:
-+
-[source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-<table border="1"><tr><td>Permission name</td><td>Actions</td><td>Resource type</td></tr>
-----
-. Append the following text at the end of `/tmp/table.html`:
-+
-[source, none, options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-</table>
-----
 . Open `/tmp/table.html` in a web browser to view the table.


### PR DESCRIPTION
#### What changes are you introducing?

It moves some steps from manual to a little bit longer script that's already copied verbatim anyway.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This reduces the number of steps a user needs to take.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The whole procedure is ugly and should be replaced with something else native to Foreman but that's out of scope for this PR.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Clarify the procedure for creating a complete permission table by expanding the Ruby script usage to cover additional manual steps.