### PR TITLE
POC: Add doc info to master.adoc

### DIFF
--- a/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
+++ b/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
@@ -7,28 +7,9 @@ include::common/header.adoc[]
 = {ConfiguringVMSubscriptionsDocTitle}
 
 ////
-DOC INFO POC
+Persona: Admin
 
-Category: Managing hosts
-
-Published: Satellite, Orcharhino
-
-Persona: System administrator (probably corresponds to 'Admin' in Contributing.md)
-
-Goal: Install and configure the "virt-who" plugin to enable accurate tracking of virtual machine subscriptions on supported hypervisors.
-"virt-who" maps virtual guests to physical hosts and reports the data to Project Server.
-
-Technical context:
-* Project Server
-* Proxy Server
-
-* Virtualization platforms:
-** RHEL Virtualization (KVM)
-** VMware vSphere
-** Nutanix AHV (Satellite)
-** Microsoft Hyper-V
-** Red Hat OpenStack Services on OpenShift (Satellite)
-** OpenShift Virtualization (Satellite)
+Goal: Enable accurate tracking of virtual machine subscriptions on the {RHCloud}.
 ////
 
 ifdef::foreman-deb[]

--- a/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
+++ b/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
@@ -6,6 +6,31 @@ include::common/header.adoc[]
 
 = {ConfiguringVMSubscriptionsDocTitle}
 
+////
+DOC INFO POC
+
+Category: Managing hosts
+
+Published: Satellite, Orcharhino
+
+Persona: System administrator (probably corresponds to 'Admin' in Contributing.md)
+
+Goal: Install and configure the "virt-who" plugin to enable accurate tracking of virtual machine subscriptions on supported hypervisors.
+"virt-who" maps virtual guests to physical hosts and reports the data to Project Server.
+
+Technical context:
+* Project Server
+* Proxy Server
+
+* Virtualization platforms:
+** RHEL Virtualization (KVM)
+** VMware vSphere
+** Nutanix AHV (Satellite)
+** Microsoft Hyper-V
+** Red Hat OpenStack Services on OpenShift (Satellite)
+** OpenShift Virtualization (Satellite)
+////
+
 ifdef::foreman-deb[]
 == Katello plugin required
 


### PR DESCRIPTION
#### What changes are you introducing?

Add persona and goal to master.adoc file of Virt-who guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/issues/4494

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is a POC. DO NOT MERGE.

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Document personas, user goals, and related metadata in the Virt-who VM Subscriptions guide entrypoint.