### PR TITLE
Add release notes for Foreman 3.16.2

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/foreman-3.16.2.adoc[leveloffset=+1]
 include::topics/foreman-3.16.1.adoc[leveloffset=+1]
 ifdef::katello[]
 include::topics/katello-4.18.1.adoc[leveloffset=+1]

--- a/guides/doc-Release_Notes/topics/foreman-3.16.2.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.16.2.adoc
@@ -1,0 +1,15 @@
+= Foreman 3.16.2
+
+A full list of changes is available on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=2007[Redmine]
+
+== Foreman
+
+=== Security
+
+* pass:[CVE-2025-9572: GraphQL API permission bypass leads to information disclosure] - https://projects.theforeman.org/issues/38913[#38913]
+
+== Installer
+
+=== Foreman modules
+
+* pass:[Add support for foreman_ovirt plugin] - https://projects.theforeman.org/issues/38921[#38921]


### PR DESCRIPTION
#### What changes are you introducing?
Release notes for Foreman 3.16.2 - all autogenerated.
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Introduce a new release notes page for Foreman 3.16.2 and reference it from the main release notes index.