### PR TITLE
Move tuning after install 3.15

### DIFF
--- a/guides/common/assembly_preparing-environment-for-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-installation.adoc
@@ -29,10 +29,6 @@ include::modules/proc_enabling-client-connections-to-project-server.adoc[levelof
 
 include::modules/proc_verifying-dns-resolution.adoc[leveloffset=+1]
 
-ifdef::katello,orcharhino,satellite[]
-include::modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
-endif::[]
-
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]
 

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -23,6 +23,10 @@ include::common/assembly_preparing-environment-for-installation-in-ipv6-network.
 
 include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
+include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
+endif::[]
+
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 
 ifdef::satellite[]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -21,6 +21,8 @@ include::common/assembly_preparing-environment-for-installation.adoc[leveloffset
 
 include::common/assembly_installing-satellite-server-disconnected.adoc[leveloffset=+1]
 
+include::common/modules/proc_tuning-with-predefined-profiles.adoc[leveloffset=+1]
+
 [id="performing-additional-configuration"]
 == Performing Additional Configuration on {ProjectServer}
 


### PR DESCRIPTION
#### What changes are you introducing?

Follow-up on #4490 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Adjust installation guides to present tuning instructions after the core installation procedure in both connected and disconnected server installation documents and the shared environment preparation guide.