### PR TITLE
Update UI navigation for booted container images

### DIFF
--- a/guides/common/modules/proc_viewing-booted-container-images-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_viewing-booted-container-images-by-using-web-ui.adoc
@@ -7,8 +7,9 @@
 These actions streamline the management of image mode hosts, providing flexibility and control over host operations through {Project}.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Booted Container Images* to view all images used by image mode hosts.
-This page displays the spread of digests under specific image paths.
+. In the {ProjectWebUI}, navigate to *Content* > *Container Images*.
+. Select the *Booted* tab to view all images used by image mode hosts.
+This tab displays the spread of digests under specific image paths.
 More digests under an image path indicate greater drift in the host ecosystem, ideally minimized by ensuring all hosts run the most up-to-date image version.
 . Click the host count to navigate to the *All Hosts* page, which identifies the hosts associated with each specific image and displays the number of hosts using each digest.
 . Select a host and on the *Details* tab, use the image mode *Details* card to see the current `bootc` status.


### PR DESCRIPTION
#### What changes are you introducing?

Updating UI navigation for viewing booted container images

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- New page
- Refs https://github.com/Katello/katello/pull/11521
- Refs https://github.com/Katello/katello/pull/11592
- [SAT-40396](https://issues.redhat.com/browse/SAT-40396) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Expected in Katello 4.20

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: None

## Summary by Sourcery

Documentation:
- Revise the booted container images web UI guide to match the updated navigation path.