### PR TITLE
Fix 'Image mode details' card title

### DIFF
--- a/guides/common/modules/proc_viewing-booted-container-images-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_viewing-booted-container-images-by-using-web-ui.adoc
@@ -11,6 +11,6 @@ These actions streamline the management of image mode hosts, providing flexibili
 This page displays the spread of digests under specific image paths.
 More digests under an image path indicate greater drift in the host ecosystem, ideally minimized by ensuring all hosts run the most up-to-date image version.
 . Click the host count to navigate to the *All Hosts* page, which identifies the hosts associated with each specific image and displays the number of hosts using each digest.
-. Select a host and on the *Details* tab, use the image mode *Details* card to see the current `bootc` status.
+. Select a host and on the *Details* tab, locate the *Image mode details* card to see the current `bootc` status.
 . Click the link to the *Bootc Action - Script Default* remote execution job in this card to perform a Bootc action on the host.
 For pull-mode remote execution, the `foreman_ygg_worker` package must be included in the container image of the image mode hosts.


### PR DESCRIPTION
#### What changes are you introducing?

Fixing the card title for **Image mode details**

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

<img width="530" height="127" alt="image" src="https://github.com/user-attachments/assets/571cccec-a395-407a-a643-52e26281432e" />

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Correct the Image mode details card title in the web UI documentation for viewing booted container images.