### PR TITLE
Add a note to inform user about LEAPP z-stream neutrality

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -15,7 +15,7 @@ ifdef::foreman-el,foreman-deb,katello[]
 For more information, see {ReleaseNotesDocURL}[Release notes].
 endif::[]
 * {Project} {ProjectVersion} or {SmartProxy} {ProjectVersion} running on {EL} 8.
-Note that you can upgrade to {EL} 9 using LEAPP without updating to the latest {Project} {ProjectVersion} minor version.
+Note that you can upgrade to {EL} 9 using LEAPP without updating to the latest {Project} {ProjectVersion} patch release version.
 ifdef::satellite[]
 * If you are upgrading {SmartProxyServers}, enable and synchronize the following repositories to {ProjectServer}, and add them to the lifecycle environment and content view that is attached to your {SmartProxyServer}:
 ** *Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)*:


### PR DESCRIPTION
#### What changes are you introducing?
Inform users that they can upgrade to EL 9 without having to update to the latest Foreman release.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Users can upgrade from EL 8 to EL 9 without having to upgrade to the latest Foreman z-stream. 

JIRA:
https://issues.redhat.com/browse/SAT-38348

Specifically this comment:
https://issues.redhat.com/browse/SAT-38348?focusedId=28411930&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28411930

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* [ ] Foreman 3.11/Katello 4.13 (orcharhino 6.11 on EL8 only; orcharhino 7.0 on EL8+EL9; orcharhino 7.1 with Leapp)
* [ ] Foreman 3.10/Katello 4.12
* [ ] Foreman 3.9/Katello 4.11 (Satellite 6.15; orcharhino 6.8/6.9/6.10)
* We do not accept PRs for Foreman older than 3.9.

## Summary by Sourcery

Documentation:
- Add explanatory note that upgrading from EL 8 to EL 9 with LEAPP does not require updating to the latest Foreman z-stream release.