### PR TITLE
Add set_passwords to cloud_config_modules

### DIFF
--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -109,6 +109,7 @@ cloud_init_modules:
  - ssh
 
 cloud_config_modules:
+ - set_passwords
  - runcmd
 
 cloud_final_modules:


### PR DESCRIPTION
#### What changes are you introducing?

Adding `set_passwords` to the `/etc/cloud/cloud.cfg` file so that the root password set on the deployed system is the same as the root password of the VM template.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- JIRA:
https://issues.redhat.com/browse/SAT-20584
- PR comment:
https://github.com/theforeman/foreman/pull/10343#issuecomment-2462808433

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Documentation:
- Update VMware cloud-init and userdata provisioning documentation to cover configuring set_passwords in cloud.cfg so deployed systems inherit the template root password.