### PR TITLE
Add steps for specifying target version for leapp

### DIFF
--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
@@ -53,8 +53,9 @@ The *leap_preupgrade* and *leapp_upgrade* remote execution features now point to
 . Run a pre-upgrade check:
 .. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 .. Select the hosts that you want to upgrade.
-.. If you want to upgrade to the latest available release, from the *Schedule a Job* drop-down menu, select *Preupgrade check with Leapp*.
-.. If you want to upgrade to a specific release version, click *Schedule a job*, and select *Leapp - Preupgrade* from the *Job category* list.
+.. If you want to upgrade to the latest available release, expand the *Schedule a Job* drop-down menu and select *Preupgrade check with Leapp*.
+.. If you want to upgrade to a specific release version, click *Schedule a job*.
+From the *Job category* list, select *Leapp - Preupgrade*.
 Follow the job wizard to start the preupgrade check.
 . Review the results of the pre-upgrade check:
 +
@@ -83,6 +84,7 @@ Repeat this step for other issues.
 . Start the upgrade:
 .. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 .. Select the hosts that you want to upgrade.
-.. If you want to upgrade to the latest available release version, select *Upgrade with Leapp* from the *Schedule a Job* drop-down menu.
-.. If you want to upgrade to a specific release version, click *Schedule a job*, and select *Leapp - Upgrade* from the *Job category* list.
+.. If you want to upgrade to the latest available release version, expand the *Schedule a Job* drop-down menu and select *Upgrade with Leapp*.
+.. If you want to upgrade to a specific release version, click *Schedule a job*.
+From the *Job category* list, select *Leapp - Upgrade*.
 Follow the job wizard to start the upgrade.


### PR DESCRIPTION
#### What changes are you introducing?

Leapp pre-upgrade and upgrade now supports specifying which version to upgrade to. This PR includes:

* Adding new steps to describe how to specify the target version
* Updating steps for modifying upgrade and pre-upgrade templates (for consistency with the new steps)
* Clarifying that the pre-upgrade check results are currently only available from the legacy UI job page

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman_leapp/pull/159/

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Documentation:
- Add instructions for selecting a specific target version in Leapp pre-upgrade and upgrade procedures.