### PR TITLE
Add ConfigReport events for webhooks

### DIFF
--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -46,6 +46,7 @@ endif::[]
 |Actions Remote Execution Run Host Job Leapp Upgrade Succeeded |Run Leapp upgrade job for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
 |Build Entered |A host entered the build mode.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
 |Build Exited |A host build mode was canceled, either it was successfully provisioned or the user canceled the build manually.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
+|Config Report Created/Updated/Destroyed |Common database operations on a configuration report.|ConfigReport
 ifdef::katello,orcharhino,satellite[]
 |Content View Created/Updated/Destroyed |Common database operations on a content view.|Katello::ContentView
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

CRUD events for configuration report a webhook can subscribe to.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

These new events were introduced by https://github.com/theforeman/foreman/pull/10787.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I don't think so.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Documentation:
- Describe CRUD webhook events for configuration reports in the available events reference.