### PR TITLE
Use long options for pg_isready and pg_restore

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -133,10 +133,10 @@ endif::[]
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# PGPASSWORD='_Foreman_Password_' pg_isready -h _postgres.example.com_ -p 5432 -U foreman -d foreman -c
+# PGPASSWORD='_Foreman_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=foreman --dbname=foreman --clean
 ifndef::foreman-el,foreman-deb[]
-# PGPASSWORD='_Candlepin_Password_' pg_isready -h _postgres.example.com_ -p 5432 -U candlepin -d candlepin -c
-# PGPASSWORD='_Pulpcore_Password_' pg_isready -h _postgres.example.com_ -p 5432 -U pulp -d pulpcore -c
+# PGPASSWORD='_Candlepin_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=candlepin --dbname=candlepin --clean
+# PGPASSWORD='_Pulpcore_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=pulp --dbname=pulpcore --clean
 endif::[]
 ----
 +

--- a/guides/common/modules/proc_migrating-to-external-databases.adoc
+++ b/guides/common/modules/proc_migrating-to-external-databases.adoc
@@ -36,10 +36,10 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-PGPASSWORD='_Foreman_Password_' pg_restore -h _postgres.example.com_ -U foreman -d foreman < /var/_My_Migration_Backup_Directory_/foreman.dump
+PGPASSWORD='_Foreman_Password_' pg_restore --host=_postgres.example.com_ --username=foreman --dbname=foreman < /var/_My_Migration_Backup_Directory_/foreman.dump
 ifndef::foreman-el,foreman-deb[]
-PGPASSWORD='_Candlepin_Password_' pg_restore -h _postgres.example.com_ -U candlepin -d candlepin < /var/_My_Migration_Backup_Directory_/candlepin.dump
-PGPASSWORD='_Pulpcore_Password_' pg_restore -h _postgres.example.com_ -U pulp -d pulpcore < /var/_My_Migration_Backup_Directory_/pulpcore.dump
+PGPASSWORD='_Candlepin_Password_' pg_restore --host=_postgres.example.com_ --username=candlepin --dbname=candlepin < /var/_My_Migration_Backup_Directory_/candlepin.dump
+PGPASSWORD='_Pulpcore_Password_' pg_restore --host=_postgres.example.com_ --username=pulp --dbname=pulpcore < /var/_My_Migration_Backup_Directory_/pulpcore.dump
 endif::[]
 ----
 . Use the `{foreman-installer}` command to update {Project} to point to the new 


### PR DESCRIPTION
#### What changes are you introducing?

Use long options for pg_isready and pg_restore

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Using long options improves readability.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

 Verified locally on EL 9.7:

````
$ pg_restore --help | grep -- "--dbname\|--host=\|--port=\|--username=\|--clean" | sort -u
  -c, --clean                  clean (drop) database objects before recreating
  -d, --dbname=NAME        connect to database name
  -h, --host=HOSTNAME      database server host or socket directory
  -p, --port=PORT          database server port number
  -U, --username=NAME      connect as specified database user
$ pg_isready --help | grep -- "--dbname\|--host=\|--port=\|--username=\|--clean" | sort -u
  -d, --dbname=DBNAME      database name
  -h, --host=HOSTNAME      database server host or socket directory
  -p, --port=PORT          database server port
  -U, --username=USERNAME  user name to connect as
````
#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Standardize PostgreSQL utility examples to use long option flags for improved readability.

Documentation:
- Update pg_isready usage examples to use long-form CLI options.
- Update pg_restore usage examples to use long-form CLI options in migration documentation.