### PR TITLE
Add EL 9 to the cloning prerequisites

### DIFF
--- a/guides/common/modules/proc_cloning-satellite-server.adoc
+++ b/guides/common/modules/proc_cloning-satellite-server.adoc
@@ -32,7 +32,7 @@ Ensure that you understand the following terms:
 
 To clone {ProjectServer}, ensure that you have the following resources available:
 
-* A minimal install of {EL} to become the target server.
+* A minimal install of {EL} 8 or 9 to become the target server.
 Do not install {EL} 8 or 9 software groups or third-party applications.
 Ensure that your server complies with all the required specifications.
 For more information, see {InstallingServerDocURL}Preparing_your_Environment_for_Installation_{project-context}[Preparing your Environment for Installation] in _{InstallingServerDocTitle}_.


### PR DESCRIPTION
Since 3.12 can be installed on both EL versions, adding EL9 to the prerequisites.

JIRA:
https://issues.redhat.com/browse/SAT-39806

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Documentation:
- Document EL9 as a supported environment in the Satellite server cloning prerequisites.