### PR TITLE
Add permission prerequisites for Lightspeed IoP

### DIFF
--- a/guides/common/modules/proc_examining-recommendations-for-hosts.adoc
+++ b/guides/common/modules/proc_examining-recommendations-for-hosts.adoc
@@ -9,6 +9,7 @@ You can view the recommendations for RHEL hosts in the {ProjectWebUI}.
 ifdef::insights-in-project[]
 .Prerequisites
 * Your {Project} account has a role that grants the `view_foreman_rh_cloud`, `view_insights_hits`, and `view_advisor` permissions.
+You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
+++ b/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
@@ -13,6 +13,7 @@ include::snip_technology-preview.adoc[]
 .Prerequisites
 * You have installed {insights-iop}.
 * Your {Project} account has a role that grants the `view_foreman_rh_cloud`, `view_insights_hits`, and `view_vulnerability` permissions.
+You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Vulnerability*.


### PR DESCRIPTION
#### What changes are you introducing?

Adding permission prerequisites to Lightspeed IoP procedures

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Documents:
- https://github.com/theforeman/foreman_rh_cloud/pull/1135
- https://github.com/theforeman/foreman_rh_cloud/pull/1136
- https://github.com/theforeman/foreman_rh_cloud/pull/1137

[SAT-40633](https://issues.redhat.com/browse/SAT-40633)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Expected in Foreman 3.18 (I guess)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A

## Summary by Sourcery

Document permission prerequisites for accessing Lightspeed IoP features and related Insights information.

Documentation:
- Add permission prerequisites to the Lightspeed IoP vulnerability examination procedure documentation.
- Update Insights-in-project access reference to describe required permissions for Lightspeed IoP usage.