### PR TITLE
Release Foreman 3.17.0, deprecate 3.15

### DIFF
--- a/web/releases/3.15.json
+++ b/web/releases/3.15.json
@@ -1,6 +1,6 @@
 {
     "katello": "4.17",
-    "state": "supported",
+    "state": "unsupported",
     "builds": [
         {
             "title": "Katello on EL",

--- a/web/releases/3.17.json
+++ b/web/releases/3.17.json
@@ -1,6 +1,6 @@
 {
   "katello": "4.19",
-  "state": "RC",
+  "state": "supported",
   "builds": [
     {
       "title": "Katello on EL",


### PR DESCRIPTION
## Summary by Sourcery

Update release metadata to add Foreman 3.17.0 and mark Foreman 3.15 as deprecated.

New Features:
- Add release descriptor for Foreman 3.17.0.

Enhancements:
- Update Foreman 3.15 release metadata to reflect its deprecation status.