### PR TITLE
Add modules to upload content to Deb repositories

### DIFF
--- a/guides/common/assembly_importing-content.adoc
+++ b/guides/common/assembly_importing-content.adoc
@@ -78,6 +78,12 @@ include::modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-
 
 include::modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc[leveloffset=+1]
 
+ifndef::satellite[]
+include::modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc[leveloffset=+1]
+
+include::modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc[leveloffset=+1]
+endif::[]
+
 include::modules/proc_refreshing-content-counts-on-smart-proxy.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-selinux-to-permit-content-synchronization-on-custom-ports.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="uploading-content-to-deb-repositories-by-using-cli"]
+= Uploading content to Deb repositories by using Hammer CLI
+
+[role="_abstract"]
+You can upload individual Deb packages to Deb repositories by using Hammer CLI.
+Do not upload packages to a repository if you have set the *Upstream URL*.
+
+.Procedure
+* Upload a Deb package:
++
+[options="nowrap" subs="+quotes,verbatim"]
+----
+$ hammer repository upload-content \
+--content-type deb \
+--id _My_Repository_ID_ \
+--path _/path/to/example-package.deb_
+----
+
+.Verification
+* Verify that your Deb repository contains the Deb package that you have uploaded:
++
+[options="nowrap" subs="+quotes,verbatim"]
+----
+$ hammer deb list --repository-id _My_Repository_ID_
+----

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="uploading-content-to-deb-repositories-by-using-web-ui"]
+= Uploading content to Deb repositories by using {ProjectWebUI}
+
+[role="_abstract"]
+You can upload individual Deb packages to Deb repositories by using {ProjectWebUI}.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *Content* > *Products*.
+. Select your {customproduct}.
+. Select the Deb repository that you want to upload packages to.
+Do not upload packages to a repository if you have set the *Upstream URL*.
+. Under *Upload Package*, click *Browse...* and select the Deb package that you want to upload.
+. Click *Upload*.
+
+.Verification
+* To view all Deb packages in this repository, click the number next to *Packages* under *Content Counts*.


### PR DESCRIPTION
#### What changes are you introducing?

Add two modules to upload Deb packages to Deb repositories.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We have prodedures to RPM packages but not Deb packages.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tested on Foreman 3.16+Katello 4.18.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Document uploading content to Deb repositories via both CLI and web UI.

Documentation:
- Add procedures for uploading content to Deb repositories using the CLI.
- Add procedures for uploading content to Deb repositories using the web UI.
- Integrate Deb upload procedures into the common content importing guide.