### PR TITLE
Drop wrong reference to old installer

### DIFF
--- a/guides/common/modules/proc_enrolling-projectserver-in-your-freeipa-domain.adoc
+++ b/guides/common/modules/proc_enrolling-projectserver-in-your-freeipa-domain.adoc
@@ -29,11 +29,6 @@ ifndef::orcharhino[]
 +
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux//9/html-single/installing_identity_management/index#assembly_installing-an-idm-client_installing-identity-management[{RHEL}{nbsp}9 Installing Identity Management].
 endif::[]
-+
-[NOTE]
-====
-To install packages on your {ProjectServer}, use the `{foreman-installer}` utility.
-====
 ifdef::foreman-deb[]
 +
 . Ensure that the hostname is set to the fully qualified domain name (FQDN); the short name is not sufficient:


### PR DESCRIPTION
#### What changes are you introducing?

Removing a note that advises users to use the installer to install a package.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The note should say `maintain` not `installer`. And it's applicable only to Satellite. Furthermore, the need to use `installer` is documented in the example at the end of the module, so there is no need to have it here in the first place.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

## Summary by Sourcery

Documentation:
- Remove an incorrect note about using the installer from the FreeIPA domain enrollment guide, as the requirement is documented elsewhere and only applies to Satellite.