### PR TITLE
Fix xref to import GPG pub key for SUSE content

### DIFF
--- a/guides/common/modules/proc_adding-an-scc-account-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account-by-using-cli.adoc
@@ -6,9 +6,9 @@
 Add your SCC account to {Project} by using Hammer CLI.
 
 .Procedure
-. Optional: Import the public GPG key from SUSE into {Project}.
+. Import the public GPG key from SUSE into {Project}.
 +
-For more information, see {ContentManagementDocURL}cli-importing-a-gpg-key[Importing a GPG Key] in _{ContentManagementDocTitle}_.
+For more information, see xref:importing-a-custom-gpg-key-by-using-cli[].
 . Add your SCC account to {Project}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_adding-an-scc-account-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account-by-using-web-ui.adoc
@@ -18,7 +18,7 @@ If you need to use additional SCC accounts, add them to other organizations.
 For more information, see xref:Installing_the_SCC_Manager_plugin_{context}[].
 
 .Procedure
-. Optional: In the {ProjectWebUI}, navigate to *Content* > *Content Credentials* and click *Create Content Credential*.
+. In the {ProjectWebUI}, navigate to *Content* > *Content Credentials* and click *Create Content Credential*.
 +
 Add the GPG public key for SLES 15 SP3 from https://www.suse.com/support/security/keys/[suse.com].
 . In the {ProjectWebUI}, navigate to *Content* > *SUSE Subscriptions*.


### PR DESCRIPTION
#### What changes are you introducing?

* Fix broken xref
* This patch also drops "Optional:" to avoid telling users that security is optional.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Error was introduced via #4404 or earlier

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
