### PR TITLE
Add default OS content for SLES 16.0

### DIFF
--- a/guides/common/modules/snip_registering-a-host-prerequisites.adoc
+++ b/guides/common/modules/snip_registering-a-host-prerequisites.adoc
@@ -97,6 +97,11 @@ a|* `SUSE Linux Enterprise Server 15 SP7 x86_64` including `Basesystem Module 15
 a|
 * `Basesystem Module 15 SP7 x86_64` > `SLE-Module-Basesystem15-SP7-Pool for sle-15-x86_64`
 * `SUSE Linux Enterprise Server 15 SP7 x86_64` > `SLE-Product-SLES15-SP7-Pool for sle-15-x86_64`
+
+|SUSE Linux Enterprise Server 16.0
+a|* `SUSE Linux Enterprise Server 16.0 x86_64` including `SLE-Product-SLES-16.0 for sle-16-x86_64`
+a|
+* `SUSE Linux Enterprise Server 16.0 x86_64` > `SLE-Product-SLES-16.0 for sle-16-x86_64`
 |===
 +
 You can use the SCC Manager plugin to import SUSE products and repositories.


### PR DESCRIPTION
#### What changes are you introducing?

Add default OS content for SLES 16.0

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

SLES 16.0 was released Nov 2025.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

content is hidden for upstream; in downstream http://demo-docs.infra.dev.atix/or_documentation/main/or_docs_website/or/docs/sources/guides/suse_linux_enterprise_server/managing_hosts/registering_hosts.html#registering-a-host_managing-hosts which should suffice as TECH ack.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
