### PR TITLE
build foremanctl guide base to have something to compare against

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,9 @@ jobs:
           make clean
           make -j ${{ env.MAKE_J }} html BUILD=foreman-el
           make -j ${{ env.MAKE_J }} html BUILD=foreman-deb
+          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-katello
+          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-orcharhino
+          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-satellite
           make -j ${{ env.MAKE_J }} html BUILD=katello
           make -j ${{ env.MAKE_J }} html BUILD=satellite
           make -j ${{ env.MAKE_J }} html BUILD=orcharhino


### PR DESCRIPTION
Fixes: b27cba41ddd48ba957a9e4a67b7a4a10f10f1227

#### What changes are you introducing?

Enable building `foremanctl` guides when building the "base" a PR is diffed against

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

So that the diff doesn't show all of `foremanctl` as new all the time.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
