### PR TITLE
use `make html` from the main Makefile to build guides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,17 +32,14 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: guides
     steps:
       - name: Get branch name (merge)
         if: github.event_name != 'pull_request'
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-        working-directory: .
 
       - name: Get branch name (pull request)
         if: github.event_name == 'pull_request'
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-        working-directory: .
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -56,14 +53,7 @@ jobs:
       - name: Build HTML with real links
         run: |
           make clean
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-el
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb
-          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-katello
-          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-orcharhino
-          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-satellite
-          make -j ${{ env.MAKE_J }} html BUILD=katello
-          make -j ${{ env.MAKE_J }} html BUILD=satellite
-          make -j ${{ env.MAKE_J }} html BUILD=orcharhino
+          make -j ${{ env.MAKE_J }} html
 
       - name: Upload HTML
         uses: actions/upload-artifact@v6
@@ -102,7 +92,6 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: guides
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -118,14 +107,7 @@ jobs:
       - name: Build HTML base for comparison
         run: |
           make clean
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-el
-          make -j ${{ env.MAKE_J }} html BUILD=foreman-deb
-          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-katello
-          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-orcharhino
-          make -j ${{ env.MAKE_J }} html BUILD=foremanctl-satellite
-          make -j ${{ env.MAKE_J }} html BUILD=katello
-          make -j ${{ env.MAKE_J }} html BUILD=satellite
-          make -j ${{ env.MAKE_J }} html BUILD=orcharhino
+          make -j ${{ env.MAKE_J }} html
 
       - name: Upload HTML base for comparison
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
#### What changes are you introducing?

Use `make html` with the main `Makefile` instead of calling `make html BUILD=…` in the `guides/` subdirectory.
The result is the same, but that way we rely on the `html` target to know all builds instead of having to define them manually

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To avoid things like #4564

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
