### PR TITLE
Fix incorrect instruction for kubevirt

### DIFF
--- a/guides/common/modules/proc_adding-kubevirt-connection.adoc
+++ b/guides/common/modules/proc_adding-kubevirt-connection.adoc
@@ -39,6 +39,6 @@ $ {kubevirt-command} get secrets _MY_SECRET_ -o jsonpath='{.data.token}' | base6
 . In the *Description* field, enter a description for the compute resource.
 . In the *Hostname* field, enter the FQDN, hostname, or IP address of the {Kubernetes} cluster.
 . In the *API Port* field, enter the port number that you want to use for provisioning requests from {Project} to {KubeVirt}.
-. In the *Namespace* field, enter the user name of the {Kubernetes} cluster.
+. In the *Namespace* field, enter the namespace of the {Kubernetes} cluster.
 . In the *Token* field, enter the bearer token for HTTP and HTTPs authentication.
 . Optional: In the *X509 Certification Authorities* field, enter a certificate to enable client certificate authentication for API server calls.


### PR DESCRIPTION
#### What changes are you introducing?
https://docs.theforeman.org/3.16/Provisioning_Hosts/index-foreman-el.html says:-

```In the Namespace field, enter the user name of the Kubernetes cluster.``` and thats incorrect we should use namspace instead user name

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
