### PR TITLE
Publish cloud Lightspeed in Katello build

### DIFF
--- a/guides/doc-Managing_Hosts/master.adoc
+++ b/guides/doc-Managing_Hosts/master.adoc
@@ -32,7 +32,7 @@ endif::[]
 
 include::common/assembly_host-management-and-monitoring-using-cockpit.adoc[leveloffset=+1]
 
-ifdef::satellite,orcharhino[]
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_monitoring-hosts-by-using-insights-in-cloud.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Enabling the chapter "Monitoring hosts by using Lightspeed in RH Cloud" for Katello build

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Upstream users with a RHEL subscription can enable and use that plugin.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Is there a reason not to?

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: supported Foreman versions

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
