### PR TITLE
Add missing modular docs attributes

### DIFF
--- a/guides/common/assembly_configuring-scap-contents.adoc
+++ b/guides/common/assembly_configuring-scap-contents.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_configuring-scap-contents.adoc[]
 
 include::modules/proc_loading-the-default-scap-contents.adoc[leveloffset=+1]

--- a/guides/common/assembly_deploying-compliance-policies.adoc
+++ b/guides/common/assembly_deploying-compliance-policies.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_deploying-compliance-policies.adoc[]
 
 include::modules/ref_inclusion-of-remote-scap-resources.adoc[leveloffset=+1]

--- a/guides/common/assembly_installing-and-configuring-insights-iop.adoc
+++ b/guides/common/assembly_installing-and-configuring-insights-iop.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_installing-and-configuring-insights-iop.adoc[]
 
 ifdef::installing-satellite-server-connected[]

--- a/guides/common/assembly_managing-compliance-policies.adoc
+++ b/guides/common/assembly_managing-compliance-policies.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_managing-compliance-policies.adoc[]
 
 include::modules/proc_creating-a-compliance-policy.adoc[leveloffset=+1]

--- a/guides/common/assembly_monitoring-compliance.adoc
+++ b/guides/common/assembly_monitoring-compliance.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_monitoring-compliance.adoc[]
 
 include::modules/proc_searching-compliance-reports.adoc[leveloffset=+1]

--- a/guides/common/assembly_security-compliance-management-in-project.adoc
+++ b/guides/common/assembly_security-compliance-management-in-project.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::modules/con_security-compliance-management-in-project.adoc[]
 
 include::modules/con_security-content-automation-protocol.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Add missing attributes to assemblies.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

CI checks fail if assemblies do not set the attribute.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Follow-up PR to #4565.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
