### PR TITLE
Bump version of SLES OS entry example

### DIFF
--- a/guides/common/assembly_managing-suse-content.adoc
+++ b/guides/common/assembly_managing-suse-content.adoc
@@ -1,5 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 
+:parent-client-os-major: {client-os-major}
+:parent-client-os-minor: {client-os-minor}
+:client-os-major: 16
+:client-os-minor: 0
+:client-iso-sha256-checksum: 86dcdb8730622fab5d073a07610522bb10791a58f052eb304f88d653e1bb0d6a
+
 include::modules/con_managing-suse-content.adoc[]
 
 include::modules/proc_preparing-suse-installation-media.adoc[leveloffset=+1]
@@ -21,3 +27,9 @@ include::modules/proc_importing-suse-products.adoc[leveloffset=+1]
 include::modules/proc_synchronizing-suse-content.adoc[leveloffset=+1]
 
 include::modules/proc_removing-an-scc-account.adoc[leveloffset=+1]
+
+:client-os-major: {parent-client-os-major}
+:client-os-minor: {parent-client-os-minor}
+:!client-iso-sha256-checksum:
+:!parent-client-os-major:
+:!parent-client-os-minor:

--- a/guides/common/modules/proc_adding-an-scc-account-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account-by-using-web-ui.adoc
@@ -20,7 +20,7 @@ For more information, see xref:Installing_the_SCC_Manager_plugin_{context}[].
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Content Credentials* and click *Create Content Credential*.
 +
-Add the GPG public key for SLES 15 SP3 from https://www.suse.com/support/security/keys/[suse.com].
+Add the GPG public key for {SLES} from https://www.suse.com/support/security/keys/[suse.com].
 . In the {ProjectWebUI}, navigate to *Content* > *SUSE Subscriptions*.
 . Click *Add SCC account*.
 . In the *Name* field, enter a name for your SCC account in {Project}.

--- a/guides/common/modules/proc_creating-a-suse-operating-system.adoc
+++ b/guides/common/modules/proc_creating-a-suse-operating-system.adoc
@@ -3,7 +3,7 @@
 [id="Creating_a_SUSE_Operating_System_{context}"]
 = Creating a SUSE operating system
 
-Use this procedure to create an installation medium and operating system entry for SLES 15 SP3.
+Use this procedure to create an installation medium and operating system entry for {SLES} {client-os-major}.{client-os-minor}.
 For more information, see:
 
 * {ProvisioningDocURL}adding-installation-media-by-using-web-ui[Adding installation media to {Project} by using {ProjectWebUI}] in _{ProvisioningDocTitle}_
@@ -16,31 +16,31 @@ For more information, see xref:Preparing_SUSE_Installation_Media_{context}[].
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Setup* > *Installation Media*.
 . Click *Create Medium*.
-. Set a *Name* for the installation medium for SLES 15 SP3.
+. Set a *Name* for the installation medium for SLES {client-os-major}.{client-os-minor}.
 Add `local` to the name because the path of the extracted `.iso` image points to your {Project}.
 . Set the *Path* of the extracted `.iso` image.
 The content of `/var/www/html/pub/` is publicly available on `\http://{foreman-example-com}/pub/`.
-If you extract the `.iso` image to `/var/www/html/pub/installation_media/sles/15sp3/`, the path is `\http://{foreman-example-com}/pub/installation_media/sles/15sp3/`.
+If you extract the `.iso` image to `/var/www/html/pub/installation_media/sles/{client-os-major}.{client-os-minor}/`, the path is `\http://{foreman-example-com}/pub/installation_media/sles/{client-os-major}.{client-os-minor}/`.
 . Set the *Operating System Family* to `SUSE` for all SLES systems.
 . Set a location and organization context for the installation media.
-. On the *Parameters* tab, add the `sle-module-basesystem-url` parameter, select the *string* type, and enter the value `\http://{foreman-example-com}/pub/installation_media/sles/15sp3/`.
+. On the *Parameters* tab, add the `sle-module-basesystem-url` parameter, select the *string* type, and enter the value `\http://{foreman-example-com}/pub/installation_media/sles/{client-os-major}.{client-os-minor}/`.
 Note that the value depends on the path of the extracted `.iso` image.
 ifdef::orcharhino[]
 include::snip_host-parameters-for-orcharhino-clients.adoc[]
 endif::[]
 +
 (SLES 12 only) Add the parameter `additional_media`, select the *string* type, and enter the value `""`.
-. Click *Submit* to save the installation media entry for SLES 15 SP3.
+. Click *Submit* to save the installation media entry for SLES {client-os-major}.{client-os-minor}.
 . In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Setup* > *Operating Systems*.
 . Click *Create Operating System*.
 . Set the *Name* of the operating system.
 Choose a name as reported by Ansible, Puppet, or Salt as fact.
-. Set the *Major Version* of SLES, for example `15`.
-. Set the *Minor Version* of SLES, for example `3` for SLES 15 SP3.
+. Set the *Major Version* of SLES, for example, `{client-os-major}`.
+. Set the *Minor Version* of SLES, for example, `{client-os-minor}`.
 . Optional: Add an arbitrary *Description*.
-. Set the *Family* to `SUSE` for all SLES systems.
-. Set the *Root Password Hash* to `SHA256` for SLES 15 SP3.
-. Assign the *Architectures* to SLES 15 SP3.
+. Set the *Family* to `SUSE` for all SLES hosts.
+. Set the *Root Password Hash* to `SHA512` for SLES {client-os-major}.{client-os-minor}.
+. Assign the *Architectures* to SLES {client-os-major}.{client-os-minor}.
 . Click *Submit* to save the operating system entry.
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Partition Tables* and click *Create Partition Table*.
 The partition tables are stored in the `/usr/share/foreman/app/views/unattended/partition_tables_templates/` directory on your {ProjectServer}.

--- a/guides/common/modules/proc_preparing-suse-installation-media.adoc
+++ b/guides/common/modules/proc_preparing-suse-installation-media.adoc
@@ -4,39 +4,39 @@
 = Preparing SUSE installation media
 
 Use this procedure to extract the SUSE installation medium on your {ProjectServer} to provision hosts in a disconnected environment.
-This example prepares the installation medium for SUSE Linux Enterprise Server 15 SP3.
+This example prepares the installation medium for {SLES} {client-os-major}.{client-os-minor}.
 
 .Procedure
-. Download the `SLES 15 SP3` installation medium from https://www.suse.com/download/sles/[suse.com/download/sles].
+. Download the `SLES {client-os-major}.{client-os-minor}` installation medium from https://www.suse.com/download/sles/[suse.com/download/sles].
 . Download the signature and checksum from https://www.suse.com/support/security/download-verification/[suse.com].
 . Transfer the `.iso` image, the signature, and the checksum from your local machine to {ProjectServer} using `scp`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# scp SLE-15-SP3-Full-x86_64-GM-Media1.iso root@{foreman-example-com}:/tmp/
-# scp SLE-15-SP3-Full-x86_64-GM-Media1.iso.sha256 root@{foreman-example-com}:/tmp/
-# scp sles_15_sp3.signature root@{foreman-example-com}:/tmp/
+# scp SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso root@{foreman-example-com}:/tmp/
+# scp SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso.sha256 root@{foreman-example-com}:/tmp/
+# scp SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso.sha256.asc root@{foreman-example-com}:/tmp/
 ----
 . On your {ProjectServer}, verify the integrity and authenticity of the `.iso` image using GPG public keys:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # cd /tmp
-# gpg --verify sles_15_sp3.signature SLE-15-SP3-Full-x86_64-GM-Media1.iso.sha256
-# echo '2a6259fc849fef6ce6701b8505f64f89de0d2882857def1c9e4379d26e74fa56 SLE-15-SP3-Full-x86_64-GM-Media1.iso' | sha256sum --check
+# gpg --verify SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso.sha256.asc SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso.sha256
+# echo '{client-iso-sha256-checksum} SLES-{client-os-major}-{client-os-minor}-Full-x86_64-GM.install.iso' | sha256sum --check
 ----
 . Mount the `.iso` image:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# mount SLE-15-SP3-Full-x86_64-GM-Media1.iso /mnt
+# mount SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso /mnt
 ----
 . Copy the content of the mounted installation medium to the `pub` directory:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# mkdir -p /var/www/html/pub/installation_media/sles/15sp3
-# cp -a /mnt/* /var/www/html/pub/installation_media/sles/15sp3/
+# mkdir -p /var/www/html/pub/installation_media/sles/{client-os-major}.{client-os-minor}
+# cp -a /mnt/* /var/www/html/pub/installation_media/sles/{client-os-major}.{client-os-minor}/
 ----
 . Unmount and delete the `.iso` image:
 +
@@ -44,10 +44,10 @@ This example prepares the installation medium for SUSE Linux Enterprise Server 1
 ----
 # cd
 # umount /mnt
-# rm -f /tmp/SLE-15-SP3-Full-x86_64-GM-Media1.iso
-# rm -f /tmp/SLE-15-SP3-Full-x86_64-GM-Media1.iso.sha256
-# rm -f /tmp/sles_15_sp3.signature
+# rm -f /tmp/SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso
+# rm -f /tmp/SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso.sha256
+# rm -f /tmp/SLES-{client-os-major}.{client-os-minor}-Full-x86_64-GM.install.iso.sha256.asc
 ----
 
-You can use the path to the local installation media files when creating an installation medium, for example `\http://{foreman-example-com}/pub/installation_media/sles/15sp3/`.
+You can use the path to the local installation media files when creating an installation medium, for example `\http://{foreman-example-com}/pub/installation_media/sles/{client-os-major}.{client-os-minor}/`.
 For more information, see {ProvisioningDocURL}adding-installation-media-by-using-web-ui[Adding installation media to {Project} by using {ProjectWebUI}] in _{ProvisioningDocTitle}_.

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -11,24 +11,24 @@ For more information, see xref:Importing_SUSE_Products_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > Products*.
-. Select the `SUSE Linux Enterprise Server 15 SP3 x86_64` product and click *Sync Now* to synchronize the SUSE repositories for SLES 15 SP3 to {Project}.
+. Select the `{SLES} {client-os-major}.{client-os-minor} x86_64` product and click *Sync Now* to synchronize the SUSE repositories for SLES {client-os-major}.{client-os-minor} to {Project}.
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
-. Create a content view called `SLES 15 SP3` comprising the SLES repositories created in the `SLES 15 SP3` product and a content view called `SLES 15 SP3 {Project} client` comprising the {Project} client repository created in the `SLES 15 SP3 {Project} client` product.
+. Create a content view called `SLES {client-os-major}.{client-os-minor}` comprising the SLES repositories created in the `SLES {client-os-major}.{client-os-minor}` product and a content view called `SLES {client-os-major}.{client-os-minor} {Project} client` comprising the {project-client-name} repository created in the `SLES {client-os-major}.{client-os-minor} {Project} client` product.
 +
 For more information, see xref:Creating_a_Content_View_{context}[].
 . Publish a new version of both content views.
 +
 For more information, see xref:Promoting_a_Content_View_{context}[].
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
-. Click *Create Content View* to create a composite content view called `Composite SLES 15 SP3` comprising the previously published `SLES 15 SP3` content view, the `SLES 15 SP3 {Project} client` content view, and optionally further content views of your choice, for example a content view containing Puppet.
+. Click *Create Content View* to create a composite content view called `Composite SLES {client-os-major}.{client-os-minor}` comprising the previously published `SLES {client-os-major}.{client-os-minor}` content view, the `SLES {client-os-major}.{client-os-minor} {Project} client` content view, and optionally further content views of your choice, for example a content view containing Puppet.
 ifdef::orcharhino[]
 For more information, see {atix-kb-clients} in the _ATIX Service Portal_.
 endif::[]
 For more information, see xref:Creating_a_Composite_Content_View_{context}[].
 . Publish a new version and promote this version to the lifecycle environment of your choice.
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.
-. Click *Create Activation Key* to create an Activation Key called `sles-15-sp3`.
+. Click *Create Activation Key* to create an activation key called `sles-{client-os-major}-{client-os-minor}`.
 +
 For more information, see xref:Creating_an_Activation_Key_{context}[].
 . On the *Details* tab, select a lifecycle environment and composite content view.
-. On the *Subscriptions* tab, select the necessary subscriptions, for example `SLES 15 SP3`, `SLES 15 SP3 {Project} client`, and `Puppet`.
+. On the *Subscriptions* tab, select the necessary subscriptions, for example `SLES {client-os-major}.{client-os-minor}`, `SLES {client-os-major}.{client-os-minor} {Project} client`, and `Puppet`.


### PR DESCRIPTION
#### What changes are you introducing?

This patch introduces attributes for the major and minor version of SLES. It also bumps the version to SLES 16.0.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Docs should use the latest OS version in examples. It's already part of [Managing SUSE content](https://docs.orcharhino.com/or/docs/sources/guides/suse_linux_enterprise_server/managing_content/managing_suse_content.html) in orcharhino docs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

SLES 16 does not use Service Packs anymore to indicate minor releases:

````
$ podman run --rm -it registry.suse.com/bci/bci-base:16.0 cat /etc/os-release | rg "^VERSION=|^VERSION_ID=|^PRETTY_NAME=" | sort -u PRETTY_NAME="SUSE Linux Enterprise Server 16.0"
VERSION="16.0"
VERSION_ID="16.0"
$ podman run --rm -it registry.suse.com/bci/bci-base:15.7 cat /etc/os-release | rg "^VERSION=|^VERSION_ID=|^PRETTY_NAME=" | sort -u PRETTY_NAME="SUSE Linux Enterprise Server 15 SP7"
VERSION="15-SP7"
VERSION_ID="15.7"
````

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
