### PR TITLE
Add step to enable maintenance repo

### DIFF
--- a/guides/common/modules/snip_upgrading-smartproxy-server.adoc
+++ b/guides/common/modules/snip_upgrading-smartproxy-server.adoc
@@ -6,8 +6,8 @@ ifdef::satellite[]
 +
 [options="nowrap" subs="attributes"]
 ----
-# subscription-manager repos --enable \
-{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+# subscription-manager repos \
+ --enable {RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
 endif::[]
 ifdef::foreman-el,katello[]


### PR DESCRIPTION
The step to enable the maintenance repo before self-upgrade is missing.

JIRA:
http://issues.redhat.com/browse/SAT-41326

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
