### PR TITLE
Do not hardcode Foreman version for orcharhino builds

### DIFF
--- a/guides/common/assembly_discovering-hosts-on-a-network.adoc
+++ b/guides/common/assembly_discovering-hosts-on-a-network.adoc
@@ -44,7 +44,7 @@ ifdef::orcharhino[]
 :parent-EL: {EL}
 :parent-ProjectVersion: {ProjectVersion}
 :EL: CentOS Stream
-:ProjectVersion: 3.16
+:ProjectVersion: {upstream-ProjectVersion}
 endif::[]
 include::modules/proc_building-a-custom-discovery-image.adoc[leveloffset=+1]
 ifdef::orcharhino[]

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,3 +1,4 @@
+:upstream-ProjectVersion: {ProjectVersion}
 // Overrides for orcharhino build
 :BaseURL: https://docs.orcharhino.com/
 :ProjectVersion: 7.6


### PR DESCRIPTION
#### What changes are you introducing?

Use variable from upstream instead of hardcoding upstream version in downstream builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Found this solution while cherry-picking. This should require less maintenance.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs #4578 (Adjust assemblies for orcharhino builds)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
