### PR TITLE
Fix 'internet' capitalization

### DIFF
--- a/guides/common/modules/con_content-synchronization-by-using-export-and-import.adoc
+++ b/guides/common/modules/con_content-synchronization-by-using-export-and-import.adoc
@@ -23,5 +23,5 @@ Synchronizing content by using export and import requires the same major version
 When you are unable to match upstream and downstream {Project} versions, you can use:
 
 * Syncable exports and imports.
-* {ISS} (ISS) with your upstream {Project} connected to the Internet and your downstream {Project} connected to the upstream {Project}.
+* {ISS} (ISS) with your upstream {Project} connected to the internet and your downstream {Project} connected to the upstream {Project}.
 ====

--- a/guides/common/modules/con_deploying-project-on-aws.adoc
+++ b/guides/common/modules/con_deploying-project-on-aws.adoc
@@ -56,7 +56,7 @@ If you do not establish a site-to-site VPN connection, use the external DNS host
 [NOTE]
 ====
 Most public cloud providers do not charge for data being transferred into a region or between availability zones within a single region.
-However, they charge for data leaving the region to the Internet.
+However, they charge for data leaving the region to the internet.
 ====
 
 *Site-to-site VPN connection between AWS regions*

--- a/guides/common/modules/con_installing-a-project-server.adoc
+++ b/guides/common/modules/con_installing-a-project-server.adoc
@@ -8,7 +8,7 @@ ifdef::satellite[]
 You can install a {ProjectServer} in a connected or disconnected setup:
 
 * Connected deployment is suitable for networked environments where your {ProjectServer} is connected to the Red{nbsp}Hat CDN.
-* Disconnected deployment is suitable for high-security environments where direct Internet access is restricted or prohibited.
+* Disconnected deployment is suitable for high-security environments where direct internet access is restricted or prohibited.
 
 A disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN but you can still provision systems with the latest security updates, errata, packages, and other content.
 You can use the following methods to import content to a disconnected {ProjectServer}:

--- a/guides/common/modules/con_iss-scenarios.adoc
+++ b/guides/common/modules/con_iss-scenarios.adoc
@@ -27,7 +27,7 @@ The way you can use depends on your multi-server setup that can fall to one of t
 == ISS network sync in a disconnected scenario
 In a disconnected scenario, there is the following setup:
 
-* The upstream {ProjectServer} is connected to the Internet.
+* The upstream {ProjectServer} is connected to the internet.
 This server consumes content from the Red Hat Content Delivery Network (CDN) or custom sources.
 * The downstream {ProjectServer} is completely isolated from all external networks.
 * The downstream {ProjectServer} can communicate with a connected upstream {ProjectServer} over an internal network.
@@ -47,7 +47,7 @@ You can configure your downstream {ProjectServer} to synchronize content from th
 == ISS export sync in an air-gapped scenario
 In an air-gapped scenario, there is the following setup:
 
-* The upstream {ProjectServer} is connected to the Internet.
+* The upstream {ProjectServer} is connected to the internet.
 This server consumes content from the Red Hat CDN or custom sources.
 * The downstream {ProjectServer} is completely isolated from all external networks.
 * The downstream {ProjectServer} does not have a network connection to a connected upstream {ProjectServer}.

--- a/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
@@ -8,5 +8,5 @@
 [role="_abstract"]
 You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the Red{nbsp}Hat Knowledgebase offline in a restricted or secure network environment.
 
-By installing the Red{nbsp}Hat Offline Knowledge Portal, you can gain access to content from the Red{nbsp}Hat Customer Portal and Knowledgebase in environments with limited or no Internet connectivity. 
+By installing the Red{nbsp}Hat Offline Knowledge Portal, you can gain access to content from the Red{nbsp}Hat Customer Portal and Knowledgebase in environments with limited or no internet connectivity.
 For more information, see {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation].

--- a/guides/common/modules/con_repository-synchronization.adoc
+++ b/guides/common/modules/con_repository-synchronization.adoc
@@ -14,7 +14,7 @@ Create a sync plan to ensure updates on a regular basis.
 For more information, see xref:creating-a-sync-plan-by-using-web-ui[].
 
 The synchronization duration depends on the size of each repository and the speed of your network connection.
-The following table provides estimates of how long it would take to synchronize content, depending on the available Internet bandwidth:
+The following table provides estimates of how long it would take to synchronize content, depending on the available internet bandwidth:
 
 |===
 | |Single Package (10Mb)|Minor Release (750Mb)|Major Release (6Gb)

--- a/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
@@ -55,7 +55,7 @@ endif::[]
 | 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
 | 22 | TCP | SSH | Target host | Remote execution | Run jobs
 | 22, 16514 | TCP | SSH SSH/TLS | Compute Resource | {Project} originated communications, for compute resources in libvirt |
-| 53 | TCP and UDP | DNS | DNS Servers on the Internet | DNS Server | Resolve DNS records (optional)
+| 53 | TCP and UDP | DNS | DNS Servers on the internet | DNS Server | Resolve DNS records (optional)
 | 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} DNS | Validation of DNS conflicts (optional)
 | 53 | TCP and UDP | DNS | DNS Server | Orchestration | Validation of DNS conflicts
 | 68 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -54,7 +54,7 @@ endif::[]
 | | ICMP | ping  | Client | DHCP | Free IP checking (optional)
 | 7 | TCP | echo | Client | DHCP |Free IP checking (optional)
 | 22 | TCP | SSH | Target host | Remote execution | Run jobs
-| 53 | TCP and UDP | DNS | DNS Servers on the Internet | DNS Server | Resolve DNS records (optional)
+| 53 | TCP and UDP | DNS | DNS Servers on the internet | DNS Server | Resolve DNS records (optional)
 | 53 | TCP and UDP | DNS | DNS Server | {SmartProxy} DNS | Validation of DNS conflicts (optional)
 | 68 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 443 | TCP | HTTPS | {Project} | {SmartProxy} | {SmartProxy}


### PR DESCRIPTION
#### What changes are you introducing?

Fixing capitalization of the term "internet"

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

According to the IBM Style Guide, it's supposed to be lower case in most cases.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: We can try

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
