### PR TITLE
Consume content without subscription-manager for orcharhino builds

### DIFF
--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -76,6 +76,8 @@ endif::[]
 
 ifdef::orcharhino[]
 You can use these URLs to provide versioned {project-client-name}s during host registration.
+
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
 
 ifeval::["{context}" == "planning"]

--- a/guides/common/modules/con_managing-container-images.adoc
+++ b/guides/common/modules/con_managing-container-images.adoc
@@ -6,6 +6,9 @@
 [role="_abstract"]
 With {Project}, you can import container images from various sources and distribute them to external containers by using content views.
 
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
 ifndef::orcharhino[]
 .Additional resources
 * {RHELDocsBaseURL}10/html-single/building_running_and_managing_containers/index[_{RHEL}{nbsp}10 Building, running, and managing containers_]

--- a/guides/common/modules/con_managing-custom-file-type-content.adoc
+++ b/guides/common/modules/con_managing-custom-file-type-content.adoc
@@ -15,3 +15,7 @@ You must download the files on clients over HTTP or HTTPS by using `curl -O`.
 You can create a file type repository in {ProjectServer} only in a {customproduct}, but there is flexibility in how you create the repository source.
 You can create an independent repository source in a directory on {ProjectServer}, or on a remote HTTP server, and then synchronize the contents of that directory into {Project}.
 This method is useful when you have multiple files to add to a {Project} repository.
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
@@ -13,3 +13,7 @@ You can synchronize, manage access permissions, and assign repositories to speci
 You can also use Hammer CLI to manage Flatpak repositories.
 
 For more information, see {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment[Installing applications using Flatpak].
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/con_managing-ostree-content.adoc
+++ b/guides/common/modules/con_managing-ostree-content.adoc
@@ -11,3 +11,7 @@ If a host update fails, you can easily revert the operating system on the host t
 
 You can create an OSTree image by using an image builder and expose it in an OSTree repository on an HTTP server.
 Then you can use your {Project} to synchronize and manage OSTree branches from the exposed OSTree repository.
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/con_managing-python-type-content.adoc
+++ b/guides/common/modules/con_managing-python-type-content.adoc
@@ -14,3 +14,7 @@ You must download the files on clients over HTTP or HTTPS by using `curl -O`.
 
 You can create an independent repository source in a directory on {ProjectServer}, or on a remote HTTP server, and then synchronize the contents of that directory into {Project}.
 This method is useful when you have multiple Python packages to add to a {customrepo}.
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-by-using-cli.adoc
@@ -37,6 +37,10 @@ $ hammer repository create \
 --publish-via-http true \
 --url _My_Upstream_URL_
 ----
+ifdef::orcharhino[]
++
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
 
 .Next steps
 * xref:repository-synchronization[]

--- a/guides/common/modules/proc_adding-custom-rpm-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-by-using-web-ui.adoc
@@ -55,6 +55,10 @@ For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . From the *Checksum* list, select the checksum type for the repository.
 . Optional: You can clear the *Unprotected* checkbox to require a subscription entitlement certificate for accessing this repository.
 By default, the repository is published through HTTP.
+ifdef::orcharhino[]
++
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
 . Optional: From the *GPG Key* list, select the GPG key for the product.
 . Optional: In the *SSL CA Cert* field, select the SSL CA Certificate for the repository.
 . Optional: In the *SSL Client cert* field, select the SSL Client Certificate for the repository.

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-cli.adoc
@@ -27,6 +27,10 @@ $ hammer repository create \
 --publish-via-http true \
 --url _My_Upstream_URL_
 ----
+ifdef::orcharhino[]
++
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
 
 .Next steps
 * xref:repository-synchronization[]

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -62,6 +62,10 @@ For more information, see xref:Mirroring_Policies_Overview_{context}[].
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.
 . Optional: You can clear the *Unprotected* checkbox to require a subscription entitlement certificate for accessing this repository.
 By default, the repository is published through HTTP.
+ifdef::orcharhino[]
++
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
 . Optional: From the *GPG Key* list, select the GPG key if you want to verify the signatures of the `Release` files associated with the Debian repository.
 . Optional: In the *SSL CA Cert* field, select the SSL CA Certificate for the repository.
 . Optional: In the *SSL Client cert* field, select the SSL Client Certificate for the repository.

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -13,6 +13,10 @@ For more information, see xref:importing-suse-products-by-using-web-ui[].
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content > Products*.
 . Select the `{SLES} {client-os-major}.{client-os-minor} x86_64` product and click *Sync Now* to synchronize the SUSE repositories for SLES {client-os-major}.{client-os-minor} to {Project}.
+ifdef::orcharhino[]
++
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Create a content view called `SLES {client-os-major}.{client-os-minor}` comprising the SLES repositories created in the `SLES {client-os-major}.{client-os-minor}` product and a content view called `SLES {client-os-major}.{client-os-minor} {Project} client` comprising the {project-client-name} repository created in the `SLES {client-os-major}.{client-os-minor} {Project} client` product.
 +

--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc
@@ -25,5 +25,9 @@ $ hammer repository upload-content \
 --path __/path/to/example-package.src.rpm__
 ----
 
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]
+
 .Verification
 * After the upload is complete, you can view information about a source RPM by using the commands `hammer srpm list` and `hammer srpm info --id _srpm_ID_`.

--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc
@@ -18,3 +18,7 @@ For more information, see xref:uploading-content-to-custom-rpm-repositories-by-u
 
 .Verification
 * To view all RPMs in this repository, click the number next to *Packages* under *Content Counts*.
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
@@ -25,3 +25,7 @@ $ hammer repository upload-content \
 ----
 $ hammer deb list --repository-id _My_Repository_ID_
 ----
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
@@ -16,3 +16,7 @@ Do not upload packages to a repository if you have set the *Upstream URL*.
 
 .Verification
 * To view all Deb packages in this repository, click the number next to *Packages* under *Content Counts*.
+
+ifdef::orcharhino[]
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/snip_important-consuming-content-requires-a-subscription.adoc
+++ b/guides/common/modules/snip_important-consuming-content-requires-a-subscription.adoc
@@ -1,0 +1,5 @@
+[IMPORTANT]
+====
+You can consume content from {Project} without registering your hosts to {Project} and/or without using `subscription-manager` to consume content, for example, in containerized build pipelines.
+Any host that consumes content from {ProjectServer} or {SmartProxyServers} is considered a managed host that requires a valid {Project} subscription.
+====


### PR DESCRIPTION
#### What changes are you introducing?

Adding an admonition about consuming content without using `subscription-manager` for orcharhino builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

All content in Foreman+Katello that is considered "unprotected" can be consumed via HTTP/HTTPS/apt/dnf/zypper/pip/curl without "subscription-manager".

However, even if users do not register their host to Foreman+Katello, ATIX still considers it a managed host and therefore part of the orcharhino Subscription.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
