### PR TITLE
Explain URL structure of uploaded packages

### DIFF
--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc
@@ -25,9 +25,16 @@ $ hammer repository upload-content \
 --path __/path/to/example-package.src.rpm__
 ----
 
-ifdef::orcharhino[]
-include::snip_important-consuming-content-requires-a-subscription.adoc[]
-endif::[]
-
 .Verification
 * After the upload is complete, you can view information about a source RPM by using the commands `hammer srpm list` and `hammer srpm info --id _srpm_ID_`.
+
+.Next steps
+* Add your {customrpm} repository to a content view.
+For more information, see xref:creating-a-content-view-by-using-cli[].
+* If your {customrpm} is unprotected, hosts can consume its content by using the *Published At* URL.
++
+In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.
+ifdef::orcharhino[]
++
+include::snip_important-consuming-content-requires-a-subscription.adoc[]
+endif::[]

--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc
@@ -19,6 +19,13 @@ For more information, see xref:uploading-content-to-custom-rpm-repositories-by-u
 .Verification
 * To view all RPMs in this repository, click the number next to *Packages* under *Content Counts*.
 
+.Next steps
+* Add your {customrpm} repository to a content view.
+For more information, see xref:creating-a-content-view-by-using-web-ui[].
+* If your {customrpm} is unprotected, hosts can consume its content by using the *Published At* URL.
++
+In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.
 ifdef::orcharhino[]
++
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
@@ -26,6 +26,14 @@ $ hammer repository upload-content \
 $ hammer deb list --repository-id _My_Repository_ID_
 ----
 
+.Next steps
+* Add your Deb repository to a content view.
+For more information, see xref:creating-a-content-view-by-using-cli[].
+* If your Deb repository is unprotected, hosts can consume its content by using the *Published At* URL.
++
+In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.
+Use `katello` as the distribution to set up the repository on your host.
 ifdef::orcharhino[]
++
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
@@ -17,6 +17,14 @@ Do not upload packages to a repository if you have set the *Upstream URL*.
 .Verification
 * To view all Deb packages in this repository, click the number next to *Packages* under *Content Counts*.
 
+.Next steps
+* Add your Deb repository to a content view.
+For more information, see xref:creating-a-content-view-by-using-web-ui[].
+* If your Deb repository is unprotected, hosts can consume its content by using the *Published At* URL.
++
+In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.
+Use `katello` as the distribution to set up the repository on your host.
 ifdef::orcharhino[]
++
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Explain how to consume unprotected content via *Published At* URL.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

`katello` as distribution/release was not yet documented, so it was unclear how to consume content from Deb repositories that only contain uploaded packages.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Relates to and should be merged before #4600.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
