### PR TITLE
Mention image mode available for EL hosts only

### DIFF
--- a/guides/common/modules/con_package-mode-and-image-mode-hosts.adoc
+++ b/guides/common/modules/con_package-mode-and-image-mode-hosts.adoc
@@ -5,4 +5,9 @@
 
 [role="_abstract"]
 Image mode simplifies enterprise operations by enabling development, operations, and solution providers to use the same container-native tools and techniques to manage both applications and the underlying operating system.
+ifdef::satellite[]
 {Project} supports image mode for hosts in addition to package mode.
+endif::[]
+ifndef::satellite[]
+{Project} supports image mode for {EL} hosts in addition to package mode.
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Specifying for what host OS is image mode available in Foreman

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Info was missing for upstream

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **???**

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
