### PR TITLE
Add virt-who guide to navigation

### DIFF
--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -24,6 +24,7 @@
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],
           ["Configuring_User_Authentication", "Configuring user authentication"],
+          ["Configuring_virt_who_VM_Subscriptions", "Configuring virt-who for virtual machine subscriptions"],
           ["Integrating_Provisioning_Infrastructure_Services", "Integrating provisioning infrastructure services"],
           ["Managing_Content", "Managing content"],
           ["Managing_Organizations_and_Locations", "Managing organizations and locations in Foreman"],


### PR DESCRIPTION
#### What changes are you introducing?

Adding the _Configuring virt-who for virtual machine subscriptions_ guide to navigation in Foreman docs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It was missing

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I'm assuming it's Katello-only

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **Not sure**, probably none

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
