### PR TITLE
Update Allow multiple CVs default

### DIFF
--- a/guides/common/modules/con_content-view-environments-overview.adoc
+++ b/guides/common/modules/con_content-view-environments-overview.adoc
@@ -4,13 +4,11 @@
 = Content view environments overview
 
 [role="_abstract"]
-The *Allow multiple content views* setting controls whether hosts and activation keys can be assigned to multiple content view environments.
-By default, this feature is disabled, limiting assignments to a single content view environment.
-Enable this setting to assign multiple content view environments to hosts and activation keys.
-For more information on content settings, see {AdministeringDocURL}content_settings_admin[Content settings] in _{AdministeringDocTitle}_.
+By default, you can assign multiple content view environments to hosts and activation keys.
+This is controlled by the *Allow multiple content views* setting.
 
-Hosts registered with multiple activation keys handle content view environment assignments based on the key order and settings configuration.
-For more information about content view environment ordering and priority, see xref:content-view-environment-ordering-and-priority[].
+Hosts registered with multiple activation keys handle content view environment assignments based on the order of activation keys and content view environments.
+For more information, see xref:content-view-environment-ordering-and-priority[].
 
 When you disable *Allow multiple content views*, multi-environment hosts remain assigned to multiple content view environments and retain access to all their content.
 Existing multi-environment activation keys remain associated with multiple content view environments, and both multi-environment hosts and activation keys remain visible in the {ProjectWebUI} and accessible through the Hammer CLI.
@@ -20,4 +18,5 @@ Assigning multiple content view environments to a host or activation key results
 When you disable *Allow multiple content views*, you can still reassign a multi-environment host to a single content view environment.
 You can also reassign a multi-environment activation key to a single content view environment or remove all content view environments from the key.
 
-This setting provides flexibility in managing how content view environments are applied to hosts and activation keys while ensuring consistent behavior when disabled.
+.Additional resources
+* {AdministeringDocURL}content_settings_admin[Content settings in _{AdministeringDocTitle}_]


### PR DESCRIPTION
#### What changes are you introducing?

Updating the enablement of the capability to assign multiple CV Environments to AKs and hosts

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

*Allow multiple content views* setting enabled by default

Documents https://github.com/Katello/katello/pull/11576

[SAT-41539](https://issues.redhat.com/browse/SAT-41539)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I've dropped fluff.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **Expected in Foreman 3.18/Katello 4.20**
