### PR TITLE
Add 'attribute' content type

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // URLs
 :BaseFilenameURL: index-{build}.html
 :AdministeringDocURL: {BaseURL}Administering_Project/{BaseFilenameURL}#

--- a/guides/common/attributes-foreman-deb.adoc
+++ b/guides/common/attributes-foreman-deb.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Attributes only for foreman-deb build
 :install-on-os: Debian/Ubuntu
 

--- a/guides/common/attributes-foreman-el.adoc
+++ b/guides/common/attributes-foreman-el.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Some documents are not ready for stable releases, but can be published on nightly
 ifeval::["{DocState}" != "nightly"]
 :HideDocumentOnStable:

--- a/guides/common/attributes-foremanctl-katello.adoc
+++ b/guides/common/attributes-foremanctl-katello.adoc
@@ -1,1 +1,3 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 include::attributes-katello.adoc[]

--- a/guides/common/attributes-foremanctl-orcharhino.adoc
+++ b/guides/common/attributes-foremanctl-orcharhino.adoc
@@ -1,1 +1,3 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 include::attributes-orcharhino.adoc[]

--- a/guides/common/attributes-foremanctl-satellite.adoc
+++ b/guides/common/attributes-foremanctl-satellite.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 include::attributes-satellite.adoc[]
 
 :project-package-install: {package-install}

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Overrides for katello build
 :client-content-apt:
 :client-content-zypper:

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 :upstream-ProjectVersion: {ProjectVersion}
 // Overrides for orcharhino build
 :BaseURL: https://docs.orcharhino.com/

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Attributes only for satellite build
 :install-on-os: RHEL
 :ProjectVersion: 6.19

--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Base for titles
 
 :AdministeringDocTitle: Administering {ProjectName}

--- a/guides/common/attributes-typography.adoc
+++ b/guides/common/attributes-typography.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Extra attributes for typography
 // See also: https://docs.asciidoctor.org/asciidoc/latest/attributes/character-replacement-ref/
 

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+
 // Document state: "nightly" for master,
 // "RC" for release candidate,
 // "stable" for the last two (supported) releases,


### PR DESCRIPTION
#### What changes are you introducing?

Adding the attribute content type to all attribute files.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

asciidoctor-dita-vale relies on the attribute to recognize attribute files

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
