### PR TITLE
fdi.ssh accepts only the value '1'

### DIFF
--- a/guides/common/modules/ref_kernel-parameters-for-discovery-customization.adoc
+++ b/guides/common/modules/ref_kernel-parameters-for-discovery-customization.adoc
@@ -90,7 +90,7 @@ You can enter both clear and encrypted passwords.
 
 fdi.ssh::
 By default, the SSH service is disabled.
-Set this to `1` or `true` to enable SSH access.
+Set this to `1` to enable SSH access.
 
 fdi.uploadsleep::
 Duration in seconds between facter runs.


### PR DESCRIPTION
#### What changes are you introducing?
`fdi.ssh` accepts only the value '1'. The `true` value doesn't work.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://github.com/theforeman/foreman-discovery-image/pull/178

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
