### PR TITLE
Add prerequisite for ISS import

### DIFF
--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -17,6 +17,13 @@ Custom repositories, products and content views are automatically created if the
 
 .Prerequisites
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
+* The importing organization must be configured to synchronize content through exports.
+ifdef::satellite[]
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+endif::[]
+ifndef::satellite[]
+For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+endif::[]
 ifdef::client-content-dnf[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
 endif::[]

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -9,6 +9,13 @@ For more information about exporting content of a repository, see xref:Exporting
 
 .Prerequisites
 * The export files must be in a directory under `/var/lib/pulp/imports`.
+* The importing organization must be configured to synchronize content through exports.
+ifdef::satellite[]
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+endif::[]
+ifndef::satellite[]
+For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+endif::[]
 ifdef::client-content-dnf[]
 * If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the products contained within the export.
 endif::[]

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -9,6 +9,13 @@ For more information about exporting contents from the Library environment, see 
 
 .Prerequisites
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
+* The importing organization must be configured to synchronize content through exports.
+ifdef::satellite[]
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+endif::[]
+ifndef::satellite[]
+For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+endif::[]
 ifdef::client-content-dnf[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
 endif::[]

--- a/guides/common/modules/proc_importing-syncable-exports.adoc
+++ b/guides/common/modules/proc_importing-syncable-exports.adoc
@@ -9,6 +9,13 @@ You can import syncable exports into the Library environment of an organization.
 .Prerequisites
 * The syncable exports must be located in one of your `ALLOWED_IMPORT_PATHS` as specified in `/etc/pulp/settings.py`.
 By default, this includes `/var/lib/pulp/imports/`.
+* The importing organization must be configured to synchronize content through exports.
+ifdef::satellite[]
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+endif::[]
+ifndef::satellite[]
+For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+endif::[]
 
 .Procedure
 * Import the syncable exports into the Library environment of your organization:


### PR DESCRIPTION
#### What changes are you introducing?

Adding a prerequisite for ISS import

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The importing Foreman server must be configured for "export sync" except for imports from a web server

[SAT-32660](https://issues.redhat.com/browse/SAT-32660) (public)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
