### PR TITLE
Add consuming collections to Ansible guide

### DIFF
--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -20,6 +20,8 @@ endif::[]
 
 include::modules/proc_synchronizing-ansible-collections.adoc[leveloffset=+1]
 
+include::modules/proc_consuming-content-from-an-ansible-collection-repository.adoc[leveloffset=+1]
+
 include::modules/ref_customizing-ansible-configuration.adoc[leveloffset=+1]
 
 include::modules/proc_using-ansible-vault-with-project.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Re-using the procedure to consume Ansible Collections in the _Configuring hosts by using Ansible_ guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* To make it findable in that guide as well 
* The bug report requests it for that guide specifically
* I forgot to add it in #4636 

[SAT-22414](https://issues.redhat.com/browse/SAT-22414)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
