### PR TITLE
Fix pre-DITA links 3.15

### DIFF
--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -16,10 +16,10 @@ Custom repositories, products and content views are automatically created if the
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
 * The importing organization must be configured to synchronize content through exports.
 ifdef::satellite[]
-For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-by-using-exports_{project-context}[Configuring {ProjectServer} to synchronize content by using exports] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]
 ifndef::satellite[]
-For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+For more information, see xref:configuring-projectserver-to-synchronize-content-by-using-exports_{context}[].
 endif::[]
 ifdef::client-content-dnf[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -8,10 +8,10 @@ For more information about exporting content of a repository, see xref:Exporting
 * The export files must be in a directory under `/var/lib/pulp/imports`.
 * The importing organization must be configured to synchronize content through exports.
 ifdef::satellite[]
-For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-by-using-exports_{project-context}[Configuring {ProjectServer} to synchronize content by using exports] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]
 ifndef::satellite[]
-For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+For more information, see xref:configuring-projectserver-to-synchronize-content-by-using-exports_{context}[].
 endif::[]
 ifdef::client-content-dnf[]
 * If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the products contained within the export.

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -8,10 +8,10 @@ For more information about exporting contents from the Library environment, see 
 * The exported files must be in a directory under `/var/lib/pulp/imports`.
 * The importing organization must be configured to synchronize content through exports.
 ifdef::satellite[]
-For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-by-using-exports_{project-context}[Configuring {ProjectServer} to synchronize content by using exports] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]
 ifndef::satellite[]
-For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+For more information, see xref:configuring-projectserver-to-synchronize-content-by-using-exports_{context}[].
 endif::[]
 ifdef::client-content-dnf[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.

--- a/guides/common/modules/proc_importing-syncable-exports.adoc
+++ b/guides/common/modules/proc_importing-syncable-exports.adoc
@@ -9,10 +9,10 @@ You can import syncable exports into the Library environment of an organization.
 By default, this includes `/var/lib/pulp/imports/`.
 * The importing organization must be configured to synchronize content through exports.
 ifdef::satellite[]
-For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-by-using-exports_{project-context}[Configuring {ProjectServer} to synchronize content by using exports] in _{InstallingServerDisconnectedDocTitle}_.
 endif::[]
 ifndef::satellite[]
-For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
+For more information, see xref:configuring-projectserver-to-synchronize-content-by-using-exports_{context}[].
 endif::[]
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

Fixing links in ISS import prerequisites

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Different anchor in 3.15 and earlier

Follow-up on https://github.com/theforeman/foreman-documentation/pull/4642

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
