### PR TITLE
Use attribute in favor of hardcoded provisioning template

### DIFF
--- a/guides/common/modules/con_using-activation-keys-for-host-registration.adoc
+++ b/guides/common/modules/con_using-activation-keys-for-host-registration.adoc
@@ -8,7 +8,12 @@ You can use activation keys to register new hosts during provisioning through {P
 
 [NOTE]
 ====
-The Kickstart provisioning templates in {ProjectName} contain commands to register the host using an activation key that is defined when creating a host.
+ifdef::orcharhino,satellite[]
+The {client-provisioning-template-type} provisioning templates in {ProjectName} contain commands to register the host using an activation key that is defined when creating a host.
+endif::[]
+ifdef::katello[]
+The Agama, Kickstart, and Preseed provisioning templates in {ProjectName} contain commands to register the host using an activation key that is defined when creating a host.
+endif::[]
 ====
 
 You can use multiple activation keys when registering a host.


### PR DESCRIPTION
#### What changes are you introducing?

Use attribute in favor of hardcoded template type.

EL: uses Kickstart templates
SLES 16: uses Agama templates
Deb: uses Preseed templates

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #4624

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
