### PR TITLE
Add cmd to verify if private key requires password

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -24,17 +24,23 @@ endif::[]
 # mkdir /root/{cert-name}_cert
 ----
 . Create a private key with which to sign the certificate signing request (CSR).
-+
-Note that the private key must be unencrypted.
-If you use a password-protected private key, remove the private key password.
-+
-If you already have a private key for this {ProductName}, skip this step.
+The private key must be unencrypted:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# openssl genrsa -out `/root/{cert-name}_cert/{cert-name}_cert_key.pem` 4096
+# openssl genrsa -out /root/{cert-name}_cert/{cert-name}_cert_key.pem 4096
 ----
-
++
+If you already have a private key, skip this step.
+. Optional: Verify that the key is unencrypted:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# openssl pkey -noout -in /root/{cert-name}_cert/{cert-name}_cert_key.pem
+----
++
+If the command does not ask for a password, the key is unencrypted.
+If your private key is password-protected, remove the password.
 ifndef::load-balancing[]
 . Create the `/root/{cert-name}_cert/openssl.cnf` configuration file for the CSR and include the following content:
 +


### PR DESCRIPTION
#### What changes are you introducing?

If you use a custom SSL cerificate with Foreman server, your private key must not be password protected. This patch adds a command so that users can verify this.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Untested.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
