### PR TITLE
Use retain version only with additive mirroring

### DIFF
--- a/guides/common/modules/proc_adding-custom-rpm-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-custom-rpm-repositories-by-using-web-ui.adoc
@@ -50,7 +50,8 @@ Leave this field empty if the repository does not require authentication.
 For more information, see xref:Download_Policies_Overview_{context}[].
 . From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
 For more information, see xref:Mirroring_Policies_Overview_{context}[].
-. Optional: In the *Retain package versions* field, enter the number of versions you want to retain per package if you using the additive download policy.
+. Optional: In the *Retain package versions* field, enter the number of versions you want to retain per package.
+This field is available only if you are using the additive download policy.
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.
 . From the *Checksum* list, select the checksum type for the repository.
 . Optional: You can clear the *Unprotected* checkbox to require a subscription entitlement certificate for accessing this repository.


### PR DESCRIPTION
#### What changes are you introducing?

Adds a note that the retain versions field is only to be used with the additive download policy.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The retain versions feature is only possible if using the additive mirroring policy.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I wasn't sure if it was worth explicitly mentioning that the retain versions field disappears in the UI if the additive mirroring policy is not selected.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
