### PR TITLE
Add troubleshooting for pkg upload timeouts

### DIFF
--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc
@@ -46,3 +46,6 @@ ifdef::orcharhino[]
 +
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
+
+.Additional resources
+* {AdministeringDocURL}tasks-settings[*Sync task timeout* description in _{AdministeringDocTitle}_]

--- a/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc
@@ -34,3 +34,6 @@ ifdef::orcharhino[]
 +
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
+
+.Additional resources
+* {AdministeringDocURL}tasks-settings[*Sync task timeout* description in _{AdministeringDocTitle}_]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc
@@ -45,3 +45,6 @@ ifdef::orcharhino[]
 +
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
+
+.Additional resources
+* {AdministeringDocURL}tasks-settings[*Sync task timeout* description in _{AdministeringDocTitle}_]

--- a/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc
@@ -33,3 +33,6 @@ ifdef::orcharhino[]
 +
 include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
+
+.Additional resources
+* {AdministeringDocURL}tasks-settings[*Sync task timeout* description in _{AdministeringDocTitle}_]


### PR DESCRIPTION
#### What changes are you introducing?

* Adding a hint on how to deal with package upload timeouts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-35291 mentions the issue and the solution

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
