### PR TITLE
Clarify authentication for Ansible collection syncing

### DIFF
--- a/guides/common/modules/proc_synchronizing-ansible-collections.adoc
+++ b/guides/common/modules/proc_synchronizing-ansible-collections.adoc
@@ -64,5 +64,4 @@ ifdef::satellite[]
 
 .Additional resources
 * https://console.redhat.com/ansible/automation-hub/token[Connect to Hub]
-* {RHDocsBaseURL}red_hat_ansible_automation_platform/2.3/html/getting_started_with_automation_hub/[_Getting started with automation hub_]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Documenting the exact location of the auth token and SSO URL for syncing Ansible content from console.redhat.com
* Distributing the new and existing information on authentication among prerequisites and additional resources

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://issues.redhat.com/browse/SAT-40367

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
