### PR TITLE
Fix image headings

### DIFF
--- a/guides/common/modules/con_project-mcp-integration-overview.adoc
+++ b/guides/common/modules/con_project-mcp-integration-overview.adoc
@@ -20,8 +20,8 @@ Avoid deploying the MCP server on a system exposed to the network.
 
 ifndef::satellite[]
 //Source for the following image is in common/images/mcp-architecture.mmd.
-image::common/mcp-architecture.png[MCP integration with a single user]
 .Architecture of {Project} MCP integration with a single user
+image::common/mcp-architecture.png[MCP integration with a single user]
 endif::[]
 
 Each {Project} user deploys their own MCP server and uses their credentials to access the {Project} inventory data.
@@ -29,8 +29,8 @@ A user's MCP client cannot obtain data that the user does not have permission to
 
 ifndef::satellite[]
 //Source for the following image is in common/images/mcp-architecture-2.mmd.
-image::common/mcp-architecture-2.png[MCP integration with multiple users]
 .Architecture of {Project} MCP integration with multiple users
+image::common/mcp-architecture-2.png[MCP integration with multiple users]
 endif::[]
 
 When the connection is established, you query your AI application for data about your {Project} environment.


### PR DESCRIPTION
#### What changes are you introducing?

Switching lines to make sure image heading is placed correctly.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://docs.asciidoctor.org/asciidoc/latest/macros/images/

Right now, it's actually a block title, not a figure heading.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
