### PR TITLE
Fix content-label to create activation key via CLI

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -183,6 +183,7 @@
 :client-os-family: Red Hat
 :client-os: {EL}
 :client-os-context: enterprise-linux
+:client-os-label: Enterprise_Linux
 :client-os-major: 9
 :client-os-minor: 5
 :client-os-minor-bumped: 6

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -59,6 +59,7 @@
 :certs-proxy-context: capsule
 :client-os: {RHEL}
 :client-os-context: red-hat-enterprise-linux
+:client-os-label: Red_Hat_Enterprise_Linux
 :Cockpit: RHEL web console
 :the-Cockpit: the {Cockpit}
 :customcontent: custom content

--- a/guides/common/modules/proc_creating-an-activation-key-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-by-using-cli.adoc
@@ -46,9 +46,14 @@ $ hammer activation-key product-content \
 ----
 $ hammer activation-key content-override \
 --name "_My_Activation_Key_" \
---content-label "{project-client-name}" \
+--content-label "_My_Content_Label_" \
 --value 1 \
 --organization "_My_Organization_"
 ----
++
+For a {customrepo}, the content label consists of your organization label, product label, and repository label split by underscores.
+For example, `Example_{Project}_Client_{client-os-label}_{client-os-major}`.
+For content from Red{nbsp}Hat, the content label is taken from the Red{nbsp}Hat manifest.
+For example, `rhel-10-for-x86_64-baseos-rpms`.
 +
 The default status is set to disabled.


### PR DESCRIPTION
#### What changes are you introducing?

Fix/explain example value for "content label" which is organization + product + repository.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The example is not in a valid structure, at least, for upstream F+K.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
