### PR TITLE
Document UEFI for VMs on Proxmox

### DIFF
--- a/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-proxmox.adoc
@@ -32,6 +32,11 @@ include::snip_steps-create-a-host-tab-interfaces.adoc[]
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.
 Modify these settings to suit your requirements.
++
+You can set UEFI instead of legacy BIOS for your virtual machine:
+
+.. On the *Advanced Options* tab, set *BIOS* to `OVMF (UEFI)`.
+.. On the *Storage* tab, click *Add Efi Disk*.
 ifdef::katello,orcharhino[]
 +
 include::snip_step-parameter-ak.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?

* Remove unnecessary macro
* Mention option to use UEFI in favor of BIOS

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Documentation for https://github.com/theforeman/foreman_fog_proxmox/pull/437

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
