### PR TITLE
Foreman 3.18.0 RC2 - release notes update

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman-3.18.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-3.18.0.adoc
@@ -73,6 +73,10 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 * pass:[Log file count can reach max int for `logs_id_seq`] - https://projects.theforeman.org/issues/38949[#38949]
 
+=== Notifications
+
+* pass:[Notifications title is cut by the header when instance title is set] - https://projects.theforeman.org/issues/39069[#39069]
+
 === Orchestration
 
 * pass:[Queue Orchestration::Templates only for Host::Managed class] - https://projects.theforeman.org/issues/38976[#38976]


### PR DESCRIPTION
#### What changes are you introducing?
Foreman 3.18.0 rc2 release notes update. This patch should be reviewed alongside with https://github.com/theforeman/theforeman.org/pull/2279
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
