### PR TITLE
Revert "Add deprecation warning for ACD plugin (#4420)"

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -70,10 +70,3 @@ GRUB version 1::
 GRUB Legacy, also known as GRUB version 1, is deprecated in provisioning and will be removed in a future release.
 GRUB 1 was used by end of life distributions such as SUSE Linux Enterprise Server 11, RHEL 6, Debian Lenny, and Ubuntu 9.04.
 Current distributions use GRUB 2 and are not affected by the deprecation.
-
-=== Plugins
-
-Application Centric Deployment (ACD) plugin::
-
-Foreman 3.17 does not support the `foreman_acd` and `smart_proxy_acd` plugins.
-Before upgrading from 3.16 to 3.17, uninstall the ACD plugin on your {ProjectServer} and {SmartProxyServers}.


### PR DESCRIPTION
This reverts commit c2c42ca498cc282122ad7a14e04041bfdce93ab3.

ACD plugins are still available for Foreman 3.17. They are gone for Foreman 3.18.