### PR TITLE
Add deprecation warning for ACD plugin (#4420)

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -34,4 +34,6 @@ If you are still using Grub1 for provisioning, migrate to GRUB2 before upgrading
 [id="foreman-deprecations"]
 == Deprecations
 
-There are no deprecations with Foreman {ProjectVersion}.
+Application Centric Deployment (ACD) plugin::
+Foreman 3.18 does not support the `foreman_acd` and `smart_proxy_acd` plugins.
+Before upgrading from 3.17 to 3.18, uninstall the ACD plugin on your {ProjectServer} and {SmartProxyServers}.


### PR DESCRIPTION
Foreman 3.17 does not support foreman_acd and smart_proxy_acd.

Refs #4359 (Remove docs for foreman_acd from nightly)

(cherry picked from commit c2c42ca498cc282122ad7a14e04041bfdce93ab3)