### PR TITLE
Add DITA Vale lint to GitHub workflows

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -7,19 +7,83 @@ on:
       - '.github/workflows/vale.yml'
       - '.vale/**'
       - .vale.ini
+      - .vale-dita.ini
 
 jobs:
-  vale:
-    name: linter
+  lint-style:
+    name: lint style
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - name: Install Asciidoctor
-        run: sudo apt-get install -y asciidoctor
-      - uses: errata-ai/vale-action@v2
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
         with:
+          files: |
+            guides/common/*.adoc
+            guides/common/modules/*.adoc
+          files_ignore: |
+            guides/common/attributes*.adoc
+            guides/common/header.adoc
+            guides/common/ribbons.adoc
+
+      - name: List changed files
+        run: |
+          echo "Any files changed? ${{ steps.changed-files.outputs.any_changed }}"
+          echo "Changed files list: ${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "Count: ${{ steps.changed-files.outputs.all_changed_files_count }}"
+
+      - name: Install Asciidoctor
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: sudo apt-get install -y asciidoctor
+
+      - name: Vale style lint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: errata-ai/vale-action@v2
+        with:
+          files: ${{ steps.changed-files.outputs.all_changed_files }}
           filter_mode: diff_context
           vale_flags: "--no-exit --minAlertLevel=error"
           reporter: github-pr-review
           fail_on_error: true
-          files: guides/common/
+
+  lint-dita:
+    name: lint DITA
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            guides/common/*.adoc
+            guides/common/modules/*.adoc
+          files_ignore: |
+            guides/common/attributes*.adoc
+            guides/common/header.adoc
+            guides/common/ribbons.adoc
+
+      - name: List changed files
+        run: |
+          echo "Any files changed? ${{ steps.changed-files.outputs.any_changed }}"
+          echo "Changed files list: ${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "Count: ${{ steps.changed-files.outputs.all_changed_files_count }}"
+
+      - name: Install Asciidoctor
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: sudo apt-get install -y asciidoctor
+
+      - name: Vale DITA lint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: errata-ai/vale-action@v2
+        with:
+          files: ${{ steps.changed-files.outputs.all_changed_files }}
+          filter_mode: diff_context
+          vale_flags: "--no-exit --minAlertLevel=warning --config=.vale-dita.ini"
+          reporter: github-pr-review
+          fail_on_error: true


### PR DESCRIPTION
#### What changes are you introducing?

Adding DITA Vale linter to PR checks

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To ensure DITA compliance of future changes

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- We should enable the check on all branches that we need DITA-compliant (3.16+).
- Not sure if branches 3.17 and older contain the `.vale-dita.ini` file - I might have to cherry pick it before merging.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
