### PR TITLE
Remove trailing whitespace from attribute definition

### DIFF
--- a/guides/common/modules/con_configuring-project-for-performance.adoc
+++ b/guides/common/modules/con_configuring-project-for-performance.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: CONCEPT 
+:_mod-docs-content-type: CONCEPT
 
 [id="Configuring_Project_for_Performance_{context}"]
 = Configuring {Project} for performance

--- a/guides/common/modules/con_disable-transparent-hugepage.adoc
+++ b/guides/common/modules/con_disable-transparent-hugepage.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: CONCEPT 
+:_mod-docs-content-type: CONCEPT
 
 [id="Disable_Transparent_Hugepage_{context}"]
 = Disable Transparent Hugepage

--- a/guides/common/modules/con_manually-tuning-puma-workers-and-threads-count.adoc
+++ b/guides/common/modules/con_manually-tuning-puma-workers-and-threads-count.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: CONCEPT 
+:_mod-docs-content-type: CONCEPT
 
 [id="Manually_tuning_Puma_workers_and_threads_count_{context}"]
 = Manually tuning Puma workers and threads count


### PR DESCRIPTION
#### What changes are you introducing?

Remove trailing whitespace.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This patch ensures that downstream CI works.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

check: `find guides/common/modules -type f -name "con_*" | xargs grep --files-without-match "^:_mod-docs-content-type: CONCEPT$"`

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
