### PR TITLE
Remove attribute additional-resources

### DIFF
--- a/guides/common/modules/con_content-views-in-project.adoc
+++ b/guides/common/modules/con_content-views-in-project.adoc
@@ -81,7 +81,6 @@ include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
 
 ifeval::["{context}" == "planning"]
-[role="_additional-resources"]
 .Additional resources
 * {ContentManagementDocURL}Managing_Content_Views_content-management[Managing content views in _{ContentManagementDocTitle}_]
 endif::[]

--- a/guides/common/modules/con_preparing-provisioning-content.adoc
+++ b/guides/common/modules/con_preparing-provisioning-content.adoc
@@ -7,7 +7,6 @@
 You have to configure provisioning content that will be used for installation of the operating system on the provisioned host.
 
 ifdef::katello,orcharhino,satellite[]
-[role="_additional-resources"]
 .Additional resources
 * {ContentManagementDocURL}[_{ContentManagementDocTitle}_]
 endif::[]

--- a/guides/common/modules/con_prerequisites-for-network-boot-provisioning.adoc
+++ b/guides/common/modules/con_prerequisites-for-network-boot-provisioning.adoc
@@ -24,7 +24,6 @@ You can also provision virtual machines from unintegrated infrastructure as you 
 +
 include::snip_prerequisites-common-compute-resource.adoc[]
 
-[role="_additional-resources"]
 .Additional resources
 * {IntegratingProvisioningInfrastructureServicesDocURL}[{IntegratingProvisioningInfrastructureServicesDocTitle}]
 * xref:preparing-networking[]

--- a/guides/common/modules/con_security-settings.adoc
+++ b/guides/common/modules/con_security-settings.adoc
@@ -7,6 +7,5 @@
 You can configure global security settings for provisioning to secure your host provisioning environment.
 For example, you can set a default encrypted root password for newly provisioned hosts, configure the validity duration of the security token used for authentication, or provision FIPS-compliant hosts that meet strict governmental or regulatory security standards for data processing.
 
-[role="_additional-resources"]
 .Additional resources
 * {AdministeringDocURL}provisioning_settings_admin[Provisioning settings in _{AdministeringDocTitle}_]

--- a/guides/common/modules/proc_configuring-smartproxy-for-uefi-http-booting.adoc
+++ b/guides/common/modules/proc_configuring-smartproxy-for-uefi-http-booting.adoc
@@ -36,6 +36,5 @@ In the {ProjectWebUI}, navigate to *Infrastructure* > *{SmartProxies}* and click
 Click *Refresh Features* if any of the features are missing.
 endif::[]
 
-[role="_additional-resources"]
 .Next steps
 * xref:creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui[]

--- a/guides/common/modules/proc_customizing-the-discovery-iso.adoc
+++ b/guides/common/modules/proc_customizing-the-discovery-iso.adoc
@@ -44,7 +44,6 @@ if=/usr/share/foreman-discovery-image/foreman-discovery-image-_version_.iso \
 of=/dev/sdb
 ----
 
-[role="_additional-resources"]
 .Next steps
 * Insert the Discovery boot medium into a bare metal host, start the host, and boot from the medium.
 +

--- a/guides/common/modules/proc_refreshing-clients-of-insights-iop.adoc
+++ b/guides/common/modules/proc_refreshing-clients-of-insights-iop.adoc
@@ -19,7 +19,6 @@ If you use {insights-iop}, you must refresh {insights-iop} registration of your 
 +
 You can use remote execution to run this command on your hosts.
 
-[role="_additional-resources"]
 .Additional resources
 * {ManagingHostsDocURL}executing-a-remote-job-by-using-web-ui[Executing a remote job by using {ProjectWebUI} in _{ManagingHostsDocTitle}_]
 * {ManagingHostsDocURL}executing-a-remote-job-by-using-cli[Executing a remote job by using Hammer CLI in _{ManagingHostsDocTitle}_]

--- a/guides/common/modules/proc_retrieving-metrics-in-the-web-ui.adoc
+++ b/guides/common/modules/proc_retrieving-metrics-in-the-web-ui.adoc
@@ -11,6 +11,5 @@ You can also select the time span displayed for each widget.
 .Procedure
 * Open the following URL in a browser: http://_{foreman-example-com}_:3000
 
-[role="_additional-resources"]
 .Additional resources
 * https://grafana.com/[Grafana Labs website]

--- a/guides/common/modules/ref_configuring-logging-levels-with-hammer-cli.adoc
+++ b/guides/common/modules/ref_configuring-logging-levels-with-hammer-cli.adoc
@@ -46,7 +46,6 @@ $ hammer admin logging --help
 ----
 
 ifdef::satellite[]
-[role="_additional-resources"]
 .Additional resources
 * {BaseURL}using_the_hammer_cli_tool/index#[Using the Hammer CLI tool]
 endif::[]

--- a/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
+++ b/guides/common/modules/ref_permissions-required-to-provision-hosts.adoc
@@ -126,7 +126,6 @@ endif::[]
 |
 |===
 
-[role="_additional-resources"]
 .Additional resources
 * {AdministeringDocURL}creating-a-role-by-using-web-ui[Creating a role by using {ProjectWebUI} in _{AdministeringDocTitle}_]
 * {AdministeringDocURL}adding-permissions-to-a-role-by-using-web-ui[Adding permissions to a role by using {ProjectWebUI} in _{AdministeringDocTitle}_]

--- a/guides/common/modules/ref_pxe-loaders.adoc
+++ b/guides/common/modules/ref_pxe-loaders.adoc
@@ -79,7 +79,6 @@ These workflows are not documented.
 endif::[]
 
 ifdef::satellite[]
-[role="_additional-resources"]
 .Additional resources
 * xref:configuring-{smart-proxy-context}-to-provision-rhel-on-Secure-Boot-enabled-hosts[]
 * https://access.redhat.com/solutions/2674001[Supported architectures and provisioning scenarios]


### PR DESCRIPTION
#### What changes are you introducing?

Remove unnecessary attribute.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This attribute is not required for any upstream or downstream builds. The following commands show that it was only added to select modules, but not all instances. This patch removes the attribute.

$ rg "^.Additional resources$"
$ rg "^\[role=\"_addi"

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Fixes #4546

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
