### PR TITLE
Fix Podman proxy configuration leaking into containers

### DIFF
--- a/guides/common/modules/proc_configuring-podman-to-use-an-http-proxy.adoc
+++ b/guides/common/modules/proc_configuring-podman-to-use-an-http-proxy.adoc
@@ -16,10 +16,13 @@ For more information, see https://podman.io/docs/installation#installing-on-linu
 endif::[]
 
 .Procedure
-* Edit the `/etc/containers/containers.conf` file to include the following directive:
+* Edit the `/etc/containers/containers.conf` file to include the following directives:
 +
 [source, ini, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 [engine]
-env = ["http_proxy=http://_http-proxy.example.com:port_", "https_proxy=https://_http-proxy.example.com:port_"]
+env = ["https_proxy=https://_http-proxy.example.com:port_"]
+
+[containers]
+http_proxy=false
 ----


### PR DESCRIPTION
Only set https_proxy in the engine env, which is sufficient for container pulls, and disable http_proxy passthrough to containers to prevent them from routing inter-container traffic through the proxy.

#### What changes are you introducing?
* Update the Podman HTTP proxy configuration procedure to only set https_proxy in the [engine] env (removing http_proxy), and add a [containers] section with http_proxy=false to prevent proxy environment variables from leaking into containers.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
* Current [Jira](https://issues.redhat.com/browse/SAT-40216) 
* The current documentation sets both http_proxy and https_proxy in the Podman engine env. Due to a Podman bug [RHEL-127541](https://issues.redhat.com/browse/RHEL-127541), these proxy settings are passed through to containers, causing inter-container communication to be routed through the proxy. 
* Setting https_proxy alone is sufficient for Podman to pull container images, and http_proxy=false under [containers] prevents the proxy settings from leaking into the container environment.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Even with http_proxy=false, the https_proxy variable may still leak into containers but setting http_proxy=false mitigates the most disruptive behavior (inter-container traffic being blocked by the proxy).
* This aligns with the documented workaround from the bug report.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)