### PR TITLE
Add default OS repositories for Ubuntu 26.04

### DIFF
--- a/guides/common/modules/ref_default-operating-system-repositories.adoc
+++ b/guides/common/modules/ref_default-operating-system-repositories.adoc
@@ -255,6 +255,22 @@ endif::[]
 
 GPG key: https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-rockyofficial
 
+[id="ubuntu-26-04"]
+.Ubuntu 26.04
+[width="100%",cols="20%,34%,22%,12%,12%",options="header"]
+|===
+| Name | Upstream URL | Releases/Distributions | Components | Architectures
+| `Ubuntu 26.04 main` | `https://archive.ubuntu.com/ubuntu/` | `resolute` | `main` | `amd64`
+| `Ubuntu 26.04 updates` | `https://archive.ubuntu.com/ubuntu/` | `resolute-updates` | `main` | `amd64`
+| `Ubuntu 26.04 security` | `https://security.ubuntu.com/ubuntu/` | `resolute-security` | `main` | `amd64`
+ifdef::katello[]
+| `Ubuntu 26.04 Client` | `https://oss.atix.de/Ubuntu26LTS/` | `stable` | `main` | `amd64`
+endif::[]
+ifdef::orcharhino[]
+| `Ubuntu 26.04 Client` | see {atix-kb-clients} in the _ATIX Service Portal_ | `stable` | `main` | `amd64`
+endif::[]
+|===
+
 [id="ubuntu-24-04"]
 .Ubuntu 24.04
 [width="100%",cols="20%,34%,22%,12%,12%",options="header"]


### PR DESCRIPTION
#### What changes are you introducing?

Add default OS content for Ubuntu 26.04 based on current alpha release: `podman run --rm -it docker.io/library/ubuntu:resolute cat /etc/apt/sources.list.d/ubuntu.sources | rg -v "^#"`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Canonical currently plans to release Ubuntu 26.04 "Resolute" on April 23rd.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs https://discourse.ubuntu.com/t/ubuntu-26-04-lts-the-roadmap/72740
Refs https://community.theforeman.org/t/oss-atix-de-clients-for-ubuntu-26-04-resolute-raccoon/46044?u=maximilian

~~Note that the link to oss.atix.de is currently broken. The packaged `subscription-manager` will most likely be published as soon as there is a beta release.~~

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
