### PR TITLE
Use Ubuntu 26.04 as latest Ubuntu release

### DIFF
--- a/guides/common/assembly_preparing-client-platforms.adoc
+++ b/guides/common/assembly_preparing-client-platforms.adoc
@@ -22,15 +22,15 @@ include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :DL: Ubuntu
-:DL-codename: noble
-:DL-major: 24.04
-:DL-major-context: 24-04
+:DL-codename: resolute
+:DL-major: 26.04
+:DL-major-context: 26-04
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :DL: Ubuntu
-:DL-codename: jammy
-:DL-major: 22.04
-:DL-major-context: 22-04
+:DL-codename: noble
+:DL-major: 24.04
+:DL-major-context: 24-04
 include::modules/proc_creating-an-operating-system-for-debian.adoc[leveloffset=+1]
 
 :!DL-codename:

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -29,7 +29,7 @@ For official Debian repositories, set a _codename_ in the *Releases/Distribution
 Avoid using `stable` or `testing` because the codename they reference changes over time.
 This helps to avoid drastic changes once a new Debian version is released and the reference is changed.
 To keep things easy to manage and to avoid potential performance and network issues during synchronization, create one repository per release in {Project}.
-For official Ubuntu repositories, use the Ubuntu suite, for example `noble` or `noble-updates`.
+For official Ubuntu repositories, use the Ubuntu suite, for example `resolute` or `resolute-updates`.
 . Optional: In the *Components* field, enter a component.
 This indicates the licensing terms of the software packages.
 +

--- a/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
+++ b/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
@@ -13,6 +13,6 @@ endif::[]
 ifdef::katello,orcharhino[]
 ** Debian 13 "Trixie": Suite `trixie` and component `main`
 ** Debian 12 "Bookworm": Suite `bookworm` and component `main`
+** Ubuntu 26.04 "Resolute": Suite `resolute` and components `main universe`
 ** Ubuntu 24.04 "Noble": Suite `noble` and components `main universe`
-** Ubuntu 22.04 "Jammy": Suite `jammy` and components `main universe`
 endif::[]

--- a/guides/common/modules/snip_using-atix-debian-and-ubuntu-errata-service.adoc
+++ b/guides/common/modules/snip_using-atix-debian-and-ubuntu-errata-service.adoc
@@ -10,6 +10,6 @@ An erratum contains the information which packages have to be updated to fix a s
 Debian and Ubuntu errata are derived from the Debian security announcements (DSA) and the Ubuntu security notices (USN).
 
 You must add Debian and Ubuntu errata to the _security_ repository.
-For Debian, you need the `_My_Debian_Release_-security` repository, for example, `bookworm-security`.
-For Ubuntu, you need the `_My_Ubuntu_Release_-security` repository, for example, `noble-security`.
+For Debian, you need the `_My_Debian_Release_-security` repository, for example, `trixie-security`.
+For Ubuntu, you need the `_My_Ubuntu_Release_-security` repository, for example, `resolute-security`.
 ====


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that the docs show the last two major releases for Debian and Ubuntu.

`$ podman run --rm -it docker.io/library/ubuntu:resolute /bin/bash -c "apt-get update && apt-get install --yes openscap-scanner"`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

upstream docs always show the last two major version of Client operating systems. With Ubuntu 26.04 "Resolute", that will be Ubuntu 26.04 and Ubuntu 24.04. For Debian, it's Debian 13 "Trixie" and Debian 12 "Bookworm".

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs https://discourse.ubuntu.com/t/ubuntu-26-04-lts-the-roadmap/72740

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
