### PR TITLE
Use Agama provisioning templates for SLES 16

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -54,7 +54,7 @@ include::modules/proc_using-the-api-to-obtain-ssh-keys-for-remote-execution.adoc
 
 ifndef::orcharhino,satellite[]
 :parent-client-provisioning-template-type: {client-provisioning-template-type}
-:client-provisioning-template-type: AutoYaST
+:client-provisioning-template-type: Agama
 include::modules/proc_configuring-a-template-to-distribute-ssh-keys-during-provisioning.adoc[leveloffset=+1]
 :client-provisioning-template-type: {parent-client-provisioning-template-type}
 :!parent-client-provisioning-template-type:

--- a/guides/common/modules/con_content-types-in-project.adoc
+++ b/guides/common/modules/con_content-types-in-project.adoc
@@ -47,7 +47,7 @@ endif::[]
 ifndef::satellite[]
 Provisioning templates::
 Templates to provision hosts running EL based on synchronized content and Debian, Ubuntu, or SUSE Linux Enterprise Server based on local installation media.
-{Project} contains predefined AutoYaST, Kickstart, and Preseed templates as well as the ability to create your own, which are used to provision systems and customize the installation.
+{Project} contains predefined Agama, Kickstart, and Preseed templates as well as the ability to create your own, which are used to provision systems and customize the installation.
 ifdef::almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 You can provision hosts running {client-os} based on synchronized content.
 endif::[]

--- a/guides/common/modules/con_provisioning-methods-in-project.adoc
+++ b/guides/common/modules/con_provisioning-methods-in-project.adoc
@@ -16,7 +16,7 @@ ifdef::satellite[]
 This method uses the Anaconda operating system installer and template-generated Kickstart script for installation automation downloaded from {Project}.
 endif::[]
 ifndef::satellite[]
-This method uses an operating system installer, such as Anaconda, Debian Installer, or YaST, and template-generated file with installation options downloaded from {Project}, such as Kickstart, Preseed, or AutoYaST.
+This method uses an operating system installer, such as Anaconda, Debian Installer, or Agama, and template-generated file with installation options downloaded from {Project}, such as Kickstart, Preseed, or Agama.
 endif::[]
 
 Network based with PXE Discovery:::

--- a/guides/common/modules/proc_booting-virtual-machines.adoc
+++ b/guides/common/modules/proc_booting-virtual-machines.adoc
@@ -25,7 +25,7 @@ ifdef::satellite[]
 endif::[]
 ifndef::satellite[]
 . Search for the required template:
-* The `AutoYaST default iPXE` template for {SLES} hosts.
+* The `Agama default iPXE` template for {SLES} hosts.
 * The `Kickstart default iPXE` template for {EL} hosts.
 * The `Preseed default iPXE` template for {DL} hosts.
 endif::[]
@@ -41,7 +41,7 @@ ifdef::satellite[]
 endif::[]
 ifndef::satellite[]
 . From the *iPXE template* list, select the required template:
-* The `AutoYaST default iPXE` template for {SLES} hosts.
+* The `Agama default iPXE` template for {SLES} hosts.
 * The `Kickstart default iPXE` template for {EL} hosts.
 * The `Preseed default iPXE` template for {DL} hosts.
 endif::[]

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -30,7 +30,7 @@ ifdef::satellite[]
 endif::[]
 ifndef::satellite[]
 . On the *Provisioning Templates* page, search for the required template:
-* The `AutoYaST default iPXE` template for {SLES} hosts.
+* The `Agama default iPXE` template for {SLES} hosts.
 * The `Kickstart default iPXE` template for {EL} hosts.
 * The `Preseed default iPXE` template for {DL} hosts.
 endif::[]
@@ -47,7 +47,7 @@ ifdef::satellite[]
 endif::[]
 ifndef::satellite[]
 . From the *iPXE template* list, select the required template:
-* The `AutoYaST default iPXE` template for {SLES} hosts.
+* The `Agama default iPXE` template for {SLES} hosts.
 * The `Kickstart default iPXE` template for {EL} hosts.
 * The `Preseed default iPXE` template for {DL} hosts.
 endif::[]

--- a/guides/common/modules/ref_custom-provisioning-snippet-example-for-sles.adoc
+++ b/guides/common/modules/ref_custom-provisioning-snippet-example-for-sles.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 You can use `Custom Post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
 
-.`AutoYaST default custom post` Example for {SLES}
+.`Agama default custom post` Example for {SLES}
 ====
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -390,7 +390,7 @@ endif::[]
 ifndef::satellite[]
 {Project} contains provisioning templates for all supported host operating system families:
 
-* AutoYaST for SUSE Linux Enterprise Server
+* Agama for SUSE Linux Enterprise Server
 * Kickstart for AlmaLinux, Amazon Linux, CentOS, Oracle Linux, Red Hat Enterprise Linux, and Rocky Linux
 * Preseed files for Debian and Ubuntu
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that the default major OS version for SUSE Linux Enterprise Server (=16) and provisioning template type (=Agama) matches.

$ rg -i "AutoYaST"

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because SLES 16 uses Agama templates.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
