### PR TITLE
Describe "Set up container registry certs" option

### DIFF
--- a/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
@@ -78,7 +78,7 @@ Operating system:: URL fragment example: `operatingsystem=My%20Operating%20Syste
 The parameter values must be URL encoded.
 ====
 * On the *Advanced* tab, you can enable container and Flatpak registry access without a username or password by selecting the *Set up container registry certs* checkbox.
-Using certificate-based authentication also enforces lifecycle management of container and flatpak content for the host.
+Using certificate-based authentication also enforces lifecycle management of container and Flatpak content for the host.
 . Click *Generate* to generate a `curl` command.
 . Run the `curl` command as `root` on the host that you want to register.
 After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.


### PR DESCRIPTION
#### What changes are you introducing?
Add description for the Set up container registry certs option

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Description was missing, https://issues.redhat.com/browse/SAT-43078

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
