### PR TITLE
Include auxiliary IDs in TOC

### DIFF
--- a/guides/scripts/extract_links_toc
+++ b/guides/scripts/extract_links_toc
@@ -4,10 +4,28 @@
 # this json file will be used later to verify links to the documentation in the Foreman UI.
 
 require 'nokogiri'
+require 'optparse'
 require 'json'
 
-unless (f2l_file = ENV['F2L'])
-  STDERR.puts "Must specify folder to link file: F2L="
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: extract_links_toc [options] FILES..."
+
+  opts.on("--f2l F2L_FILE", "File containing filename to satellite guide name mappings") do |f2l|
+    options[:f2l] = f2l
+  end
+
+  opts.on("--output-toc-file FILE", "Write TOC output to FILE instead of stdout") do |f|
+    options[:toc_file] = f
+  end
+
+  opts.on("--output-aliases-file FILE", "Write aliases output (auxiliary id to canonical id mapping) to FILE (disabled by default)") do |f|
+    options[:aliases_file] = f
+  end
+end.parse!
+
+unless (f2l_file = options[:f2l] || ENV['F2L'])
+  STDERR.puts "Must specify folder to link file: F2L= or --f2l="
   exit 1
 end
 
@@ -55,5 +73,13 @@ files.each do |file|
   toc[link_name] = file_toc
 end
 
-toc['aliases'] = aliases
-$stdout << JSON.pretty_generate(toc)
+if options[:aliases_file]
+  File.write(options[:aliases_file], JSON.pretty_generate(aliases))
+end
+
+toc_json = JSON.pretty_generate(toc)
+if options[:toc_file]
+  File.write(options[:toc_file], toc_json)
+else
+  $stdout << toc_json
+end


### PR DESCRIPTION
#### What changes are you introducing?
Changing the TOC generating script to also include auxiliary IDs. The auxiliary IDs are included in the TOC under the `aliases` key as a dictionary where the keys are the auxiliary IDs and the values are the real ids.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Auxiliary IDs seem like a reasonable solution for maintaining anchor stability, it is a workaround for https://github.com/theforeman/foreman-documentation/issues/4607

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)


See [toc.json](https://github.com/user-attachments/files/25723197/toc.json) generated from master (as of 3b33297287)
See [toc-aux.json](https://github.com/user-attachments/files/26056393/toc-aux.json) 
generated from https://github.com/theforeman/foreman-documentation/pull/4687 which adds some auxiliary ids.

```
# diff -U 1 toc.json toc-aux.json
--- toc.json	2026-03-05 19:20:42
+++ toc-aux.json	2026-03-17 15:09:19
@@ -1663,2 +1663,19 @@
     ]
+  },
+  "aliases": {
+    "managing_configurations_by_using_puppet_integration/configuration-management-with-puppet-in-satellite": [
+      "managing_configurations_by_using_puppet_integration/introducing-configuration-management-by-using-puppet"
+    ],
+    "managing_configurations_by_using_puppet_integration/configuration-management-with-puppet-in-satellite#high-level-steps-for-configuration-management-with-puppet": [
+      "managing_configurations_by_using_puppet_integration/configuration-management-with-puppet-in-satellite#performing-configuration-management_managing-configurations-puppet"
+    ],
+    "managing_security_compliance/configuring-scap-contents-for-compliance-policies-in-satellite": [
+      "managing_security_compliance/Configuring_SCAP_Contents_security-compliance"
+    ],
+    "managing_security_compliance/configuring-scap-contents-for-compliance-policies-in-satellite#customizing-xccdf-profiles-with-tailoring-files": [
+      "managing_security_compliance/configuring-scap-contents-for-compliance-policies-in-satellite#tailoring-xccdf-profiles_security-compliance"
+    ],
+    "managing_security_compliance/Managing_Compliance_Policies_security-compliance": [
+      "managing_security_compliance/compliance-policy-deployment-options_security-compliance"
+    ]
   }
```

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
