### PR TITLE
Rename module on policy deployment options

### DIFF
--- a/guides/common/assembly_configuring-compliance-policy-deployment-methods.adoc
+++ b/guides/common/assembly_configuring-compliance-policy-deployment-methods.adoc
@@ -2,7 +2,7 @@
 
 include::modules/con_configuring-compliance-policy-deployment-methods.adoc[]
 
-include::modules/ref_compliance-policy-deployment-options.adoc[leveloffset=+1]
+include::modules/ref_deployment-options-for-compliance-policies.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-project-for-ansible-compliance-policy-deployment.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_creating-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_creating-a-compliance-policy.adoc
@@ -7,7 +7,7 @@
 By creating a compliance policy, you can define and plan your security compliance requirements, and ensure that your hosts remain compliant to your security policies.
 
 .Prerequisites
-* You have configured {Project} for your selected xref:compliance-policy-deployment-options_{context}[compliance policy deployment method].
+* You have configured {Project} for your selected xref:deployment-options-for-compliance-policies_{context}[compliance policy deployment method].
 * You have available SCAP contents, and eventually tailoring files, in {Project}.
 ** To verify what SCAP contents are available by using {ProjectWebUI}, see xref:listing-available-scap-contents-using-web-ui[].
 ** To verify what SCAP contents are available by using CLI, see xref:listing-available-scap-contents-using-cli[].

--- a/guides/common/modules/ref_deployment-options-for-compliance-policies.adoc
+++ b/guides/common/modules/ref_deployment-options-for-compliance-policies.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="compliance-policy-deployment-options_{context}"]
-= Compliance policy deployment options
+[id="deployment-options-for-compliance-policies_{context}"]
+= Deployment options for compliance policies
 
 [role="_abstract"]
 With {Project}, multiple methods are available for compliance policy deployment.


### PR DESCRIPTION
#### What changes are you introducing?

Renaming a section on compliance policy deployment options.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/4687/, the rename was required to keep links in the web UI working (https://github.com/theforeman/foreman-documentation/pull/4687/changes#r2877623255). That PR introduces auxiliary IDs, which is not needed on master, but what we do need on master is the part that renames the module -- in order to keep using the new name in future versions as well.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
