### PR TITLE
Add firewall host required to pull IoP containers

### DIFF
--- a/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
@@ -65,6 +65,7 @@ endif::[]
 The port can be customized if `LDAPAuthSource` is defined
 | 443 | TCP | HTTPS | Amazon EC2, Azure, Google Compute Engine | Compute resources | Virtual machine interactions (query/create/destroy) (optional)
 ifdef::satellite[]
+| 443 | TCP | HTTPS | *.akamaiedge.net | CDN for the Red{nbsp}Hat Container Registry | Pulling container images to install {insights-iop} (optional)
 ifeval::["{mode}" == "connected"]
 | 443 | TCP | HTTPS | console.redhat.com | Red{nbsp}Hat Cloud plugin API calls |
 | 443 | TCP | HTTPS | cdn.redhat.com | Content Sync | https://access.redhat.com/articles/1525183[Red{nbsp}Hat CDN]

--- a/guides/common/modules/snip_host-names-for-http-proxy.adoc
+++ b/guides/common/modules/snip_host-names-for-http-proxy.adoc
@@ -11,6 +11,7 @@ ifdef::satellite[]
 | cert-api.access.redhat.com (if using {Insights}) | 443 | HTTPS
 | console.redhat.com (if using {Insights}) | 443 | HTTPS
 | connect.cloud.redhat.com (if using {Insights}) | 443 | HTTPS
+| *.akamaiedge.net (if using {Insights-iop}) | 443 | HTTPS
 endif::[]
 |====
 


### PR DESCRIPTION
#### What changes are you introducing?

Adding a hostname+port that needs to be accessible to Project Server to successfully pull container images for IoP installation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Info was missing and users were facing an error when pulling IoP images for installation

[SAT-41427](https://issues.redhat.com/browse/SAT-41427)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I'm not sure it belongs to _Port and firewall requirements_ as well.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5) -- **needs another PR**
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
