### PR TITLE
Fix Vale checks for multiple files

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -28,6 +28,8 @@ jobs:
             guides/common/attributes*.adoc
             guides/common/header.adoc
             guides/common/ribbons.adoc
+          json: true
+          escape_json: false
 
       - name: List changed files
         run: |
@@ -67,6 +69,8 @@ jobs:
             guides/common/attributes*.adoc
             guides/common/header.adoc
             guides/common/ribbons.adoc
+          json: true
+          escape_json: false
 
       - name: List changed files
         run: |


### PR DESCRIPTION
#### What changes are you introducing?

Using JSON for the list of changed files

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Vale action refuses to accept space-separated file lists. As a consequence, Vale ends up checking all files in the repo instead of the changed files only.

Forgot to test it with multiple changed files in #4672 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I tried adding space as the separator and it didn't work. Therefore, JSON.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
