### PR TITLE
Fix installation of IoP for STIG compliant systems

### DIFF
--- a/guides/common/modules/proc_installing-insights-iop-by-using-export-and-import.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-by-using-export-and-import.adoc
@@ -7,7 +7,9 @@
 You can transfer the container images from a connected system to a disconnected {ProjectServer}. 
 
 .Prerequisites
-* Ensure that Podman is installed.
+* You have a connected system with access to the container registry.
+* You have prepared a disconnected {ProjectServer}.
+* Ensure that Podman is installed on both systems.
 ifdef::satellite[]
 For more information, see {RHELDocsBaseURL}9/html/building_running_and_managing_containers/assembly_starting-with-containers_building-running-and-managing-containers#proc_getting-container-tools_assembly_starting-with-containers[Getting container tools] in _{RHEL}{nbsp}9 Building, running, and managing containers_.
 endif::[]
@@ -18,7 +20,6 @@ ifndef::satellite[]
 # {project-package-install} podman
 ----
 endif::[]
-* You have prepared a disconnected {ProjectServer}.
 
 .Procedure
 . On the connected system, log in to the container registry:


### PR DESCRIPTION
#### What changes are you introducing?

Fixing export/import of images for IoP installation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Users were experiencing problems, especially on STIG compliant systems

[SAT-38792](https://issues.redhat.com/browse/SAT-38792) and [SAT-41866](https://issues.redhat.com/browse/SAT-41866)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5) -- **needs another PR**
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
