### PR TITLE
Fix installation of IoP for STIG compliant systems 3.14

### DIFF
--- a/guides/common/modules/proc_installing-advisor-engine-using-import-and-export.adoc
+++ b/guides/common/modules/proc_installing-advisor-engine-using-import-and-export.adoc
@@ -19,7 +19,13 @@ ifndef::satellite[]
 endif::[]
 
 .Procedure
-. On the connected system, pull the container image:
+. On the connected system, log in to the container registry:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ podman login --username _My_Username_ --password _My_Password_ registry.redhat.io
+----
+. Pull the container image:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Same as #4702 for Sat 6.17

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
