### PR TITLE
Add auxiliary IDs for SAT-41410

### DIFF
--- a/guides/common/modules/con_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/modules/con_configuring-and-setting-up-remote-jobs.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="configuring-and-setting-up-remote-jobs"]
-= Configuring and setting up remote jobs
+= Configuring and setting up remote jobs[[configuring_and_setting_up_remote_jobs_managing-hosts]]
 
 [role="_abstract"]
 {ProjectName} supports remote execution of commands on hosts.

--- a/guides/common/modules/con_data-control-settings.adoc
+++ b/guides/common/modules/con_data-control-settings.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="data-control-settings"]
-= Data control settings
+= Data control settings[[setting-minimal-data-collection]]
 
 [role="_abstract"]
 You can configure how {Project} handles the data collected from hosts before uploading it to the {RHCloud} and how {Project} handles hosts in the {RHCloud} that are no longer managed by {Project}.

--- a/guides/common/modules/con_monitoring-hosts-by-using-insights-in-cloud.adoc
+++ b/guides/common/modules/con_monitoring-hosts-by-using-insights-in-cloud.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="monitoring-hosts-by-using-{insights-id}-in-cloud"]
-= Monitoring hosts by using {Insights} in {RHCloud}
+= Monitoring hosts by using {Insights} in {RHCloud}[[monitoring-hosts-by-using-insights]]
 
 [role="_abstract"]
 You can use the {Insights} advisor service in the {RHCloud} to assess system health on hosts running {RHEL}.

--- a/guides/common/modules/proc_adding-a-subnet-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-a-subnet-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="adding-a-subnet-to-server-by-using-web-ui"]
-= Adding a subnet to {ProjectServer} by using {ProjectWebUI}
+= Adding a subnet to {ProjectServer} by using {ProjectWebUI}[[Adding_a_Subnet_to_Server_provisioning]]
 
 [role="_abstract"]
 You must add information for each of your subnets to {ProjectServer} because {Project} configures interfaces for new hosts.

--- a/guides/common/modules/proc_adding-installation-media-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-installation-media-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="adding-installation-media-by-using-web-ui"]
-= Adding installation media to {Project} by using {ProjectWebUI}
+= Adding installation media to {Project} by using {ProjectWebUI}[[adding-installation-media_provisioning]]
 
 [role="_abstract"]
 Installation media are sources of packages that {ProjectServer} uses to install a base operating system on a machine from an external repository.

--- a/guides/common/modules/proc_creating-architectures-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-architectures-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="creating-architectures-by-using-web-ui"]
-= Creating architectures by using {ProjectWebUI}
+= Creating architectures by using {ProjectWebUI}[[creating-architectures_provisioning]]
 
 [role="_abstract"]
 An architecture in {Project} represents a logical grouping of hosts and operating systems.

--- a/guides/common/modules/proc_creating-compute-profiles-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-compute-profiles-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="creating-compute-profiles-by-using-web-ui"]
-= Creating compute profiles by using {ProjectWebUI}
+= Creating compute profiles by using {ProjectWebUI}[[creating-compute-profiles_provisioning]]
 
 [role="_abstract"]
 You can create custom compute profiles in addition to the default predefined profiles to bundle CPU cores, memory, and storage details.

--- a/guides/common/modules/proc_creating-operating-systems-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-operating-systems-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="creating-operating-systems-by-using-web-ui"]
-= Creating operating systems by using {ProjectWebUI}
+= Creating operating systems by using {ProjectWebUI}[[creating-operating-systems_provisioning]]
 
 [role="_abstract"]
 An operating system is a collection of resources that define how {ProjectServer} installs a base operating system on a host.

--- a/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="creating-partition-tables-by-using-web-ui"]
-= Creating partition tables by using {ProjectWebUI}
+= Creating partition tables by using {ProjectWebUI}[[creating-partition-tables_provisioning]]
 
 [role="_abstract"]
 A partition table is a type of template that defines the way {ProjectServer} configures the disks available on a new host.


### PR DESCRIPTION
#### What changes are you introducing?

Adding auxiliary IDs for compatibility. Namely addressing all the changes done in https://github.com/RedHatSatellite/foreman_theme_satellite/pull/302 with the intention of reverting that code change once this goes in.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The documentation structure changed after the release.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

There were some section renames, which will require setting up redirects in the Satellite documentation, but that has to be handled outside of this PR.

For the sake of completeness
| Redirect from | Redirect to |
|--------|--------|
| `/managing_hosts/configuring_and_setting_up_remote_jobs_managing-hosts` | `/managing_hosts/configuring-and-setting-up-remote-jobs` |
| `/managing_hosts/monitoring-hosts-by-using-insights` | `/managing_hosts/monitoring-hosts-by-using-red-hat-lightspeed-in-cloud` |

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
