### PR TITLE
Add cursor commands for heading review

### DIFF
--- a/.cursor/skills/heading/SKILL.md
+++ b/.cursor/skills/heading/SKILL.md
@@ -21,9 +21,9 @@ Follow these general principles for all headings:
 Additional principles for specific heading types:
 
 * For concepts (con_*.adoc): Do not start the heading with a gerund or verb. Use a noun phrase and include nouns or noun phrases that appear in the body text.
-* For procedures (proc_*.adoc): When writing a new heading, start with a verb in imperative voice. When reviewing an existing heading that uses a gerund, keep the gerund; do not rewrite it in imperative voice.
+* For procedures (proc_*.adoc): Start the heading with a gerund.
 * For references (ref_*.adoc): Do not start the heading with a gerund or verb. Include nouns that appear in the body text.
-* For assemblies (the first con_*.adoc in an assembly_*.adoc) that contain at least one procedure: When writing a new heading, start with a verb in imperative voice. When reviewing an existing heading, keep the gerund; do not rewrite it in imperative voice.
+* For assemblies (the first con_*.adoc in an assembly_*.adoc) that contain at least one procedure: Start the heading with a gerund.
 * For assemblies (the first con_*.adoc in an assembly_*.adoc) that contain only concepts or references: Do not start the heading with a gerund or verb. Use a noun phrase.
 
 ## Post-command cleanup
@@ -40,9 +40,9 @@ Concept headings:
 
 Procedure headings:
 
-* Deploy SSH keys during provisioning
-* Open required ports
-* Configure pull-based transport for remote execution
+* Deploying SSH keys during provisioning
+* Opening required ports
+* Configuring pull-based transport for remote execution
 
 Reference headings:
 
@@ -52,6 +52,6 @@ Reference headings:
 
 Assembly headings:
 
-* Connect AI applications to the MCP server for {Project}
-* Configure {SmartProxy} and hosts to authenticate with SSH certificates during remote execution
+* Connecting AI applications to the MCP server for {Project}
+* Configuring {SmartProxy} and hosts to authenticate with SSH certificates during remote execution
 * Content and patch management with {Project}


### PR DESCRIPTION
#### What changes are you introducing?

~~Adding two Cursor commands: `headings.md`, which writes or reviews headings, and `recursive-includes.md`, which can be used along with another command (such as `headings.md`) to process also included file within an *.adoc file.~~

Adding a new Cursor command to review headings.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I'm trying to find ways to speed up, automate, and standardize the current downstream quality initiative (Content Quality Assessment aka CQA).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
