### PR TITLE
Add Cursor command for recursive processing of adoc files

### DIFF
--- a/.cursor/skills/recursive-includes/SKILL.md
+++ b/.cursor/skills/recursive-includes/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: recursive-includes
+description: Process command recursively for all included files
+disable-model-invocation: true
+---
 # Process command recursively for all included files
 
 ## Overview


### PR DESCRIPTION
#### What changes are you introducing?

Adding a Cursor command that can take instructions from another command and apply them recursively in order to process also other files included in an *.adoc file (designed to search through master.adoc and assembly_*.adoc files and review all the nested files in them).

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I'm trying to find ways to speed up, automate, and standardize the current downstream quality initiative (Content Quality Assessment aka CQA).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
