### PR TITLE
Add Cursor command for prerequisite review

### DIFF
--- a/.cursor/skills/prerequisites/SKILL.md
+++ b/.cursor/skills/prerequisites/SKILL.md
@@ -22,7 +22,7 @@ Review prerequisites in this file to make sure they are labeled correctly and us
 2. If a section titled `.Prerequisites` exists in the file, ensure it contains information suitable for prerequisites:
     - Prerequisites are checks that are true, checks that the user must have completed before they begin a procedure, or items that the user must have ready before beginning a procedure. Prerequisites can also be actions that the user, another person, or piece of technology has completed before the user can begin the procedure.
     - Focus on relevant prerequisites that users might not otherwise be aware of. Do not list obvious prerequisites.
-    - Do not include steps in prerequisites. If `.Prerequisites` includes a step, move the step to the `.Procedure` section.
+    - Do not include procedure steps in prerequisites. If `.Prerequisites` includes a prerequisite that would be more suitable as a procedure step, move it to the `.Procedure` section.
     - Do not exceed 10 prerequisites. If `.Prerequisites` includes more than 10 list items, flag this as an issue for human review.
 3. If a procedure module does not include `.Prerequisites` section, scan the module to identify steps that meet criteria for prerequisites. If a step or steps like this exist, create a `.Prerequisites` section and rephrase the step or steps as prerequisites in this section.
 


### PR DESCRIPTION
#### What changes are you introducing?

Adding a Cursor command to review prerequisites.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I'm trying to find ways to speed up, automate, and standardize the current downstream quality initiative (Content Quality Assessment aka CQA).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The instructions for review are based on prerequisite guidelines from the Red Hat Supplementary Style Guide, the modular docs template for procedures, and downstream CQA requirements.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
