### PR TITLE
Add rpm repair tip for Katello upgrade

### DIFF
--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -84,7 +84,13 @@ You can now add the "Last checkin" column to the fields displayed by hammer host
 [id="katello-upgrade-warnings"]
 == Upgrade warnings
 
-There are no upgrade warnings with Katello {KatelloVersion}.
+To resolve https://github.com/pulp/pulp_rpm/issues/4073[Pulp RPM bug #4073], run the following after upgrading:
+
+----
+# sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' DJANGO_SETTINGS_MODULE='pulpcore.app.settings' pulpcore-manager rpm-datarepair 4073
+----
+
+For more information, see https://projects.theforeman.org/issues/39108[#39108].
 
 [id="katello-deprecations"]
 == Deprecations


### PR DESCRIPTION
#### What changes are you introducing?

Tells users to run a Pulp data repair command on the Foreman 3.18 upgrade.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It is required to fully resolve https://github.com/pulp/pulp_rpm/issues/4073

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
