### PR TITLE
enable foreman repos when deploying with foremanctl

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: PROCEDURE
+:distribution-major-version: 9
 
 [id="configuring-repositories_{context}"]
 = Configuring repositories
@@ -30,7 +31,6 @@ ifdef::foreman-deb[]
 include::snip_configuring-repositories-foreman-deb.adoc[]
 endif::[]
 ifdef::foreman-el,katello[]
-:distribution-major-version: 9
 . Clear any metadata:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -61,14 +61,19 @@ ifdef::foreman-el,katello[]
 # {package-install} https://yum.puppet.com/puppet8-release-el-{distribution-major-version}.noarch.rpm
 ----
 endif::[]
-:!distribution-major-version:
 endif::[]
 ifdef::orcharhino[]
 * Ensure the repositories required to install {ProductName} are enabled on your {EL} host.
 endif::[]
 endif::[]
 ifdef::foremanctl[]
-* Enable the required repositories:
+. Install the `foreman-release.rpm` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
+----
+. Enable the required additional repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

enable foreman repos in foremanctl scenario

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

the latest builds of foremanctl require ansible from our plugins repo

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
