### PR TITLE
Add Cursor skill to review assemblies for single user story

### DIFF
--- a/.cursor/skills/review-assembly-user-story/SKILL.md
+++ b/.cursor/skills/review-assembly-user-story/SKILL.md
@@ -70,9 +70,6 @@ Provide a summary that includes:
 - **One user story per assembly** - Each assembly should answer "What does the user want to accomplish?"
 - **User-centric organization** - Think from the user's perspective, not the product's features
 - **Cohesive modules** - All modules in an assembly should support the same goal
-- **Inverse operations stay together** - Creating/deleting or enabling/disabling are part of the same user story
-- **Clear boundaries** - If a user might want to do X without doing Y (excluding inverse operations), they should be separate assemblies
-- **Meaningful names** - Assembly names should clearly indicate the user story
 
 ## Examples
 

--- a/.cursor/skills/review-assembly-user-story/SKILL.md
+++ b/.cursor/skills/review-assembly-user-story/SKILL.md
@@ -59,7 +59,7 @@ For each identified user story:
 2. **Add the assembly header** - Include `:_mod-docs-content-type: ASSEMBLY`
 3. **Include relevant modules** - Copy the appropriate module includes for this user story
 4. **Create or update the introductory concept module** - Write a focused concept module with an abstract for this specific user story if needed
-5. **Update parent files** - Replace the original assembly include with includes for all new assemblies
+5. **Update parent files** - Replace the original assembly include with includes for all new assemblies in the `master.adoc` file
 6. **Delete the original assembly** - Once all content is split and includes are updated
 
 ### Step 4: Report findings

--- a/.cursor/skills/review-assembly-user-story/SKILL.md
+++ b/.cursor/skills/review-assembly-user-story/SKILL.md
@@ -6,7 +6,7 @@ description: Review assembly to ensure it follows the one-user-story principle
 
 ## Overview
 
-Review an assembly file to ensure it describes one and only one user story.
+Review an assembly file to ensure it describes a single user story.
 If the assembly contains multiple user stories, split it into separate assembly files.
 
 Usage:
@@ -15,10 +15,15 @@ Usage:
 /review-assembly-user-story @assembly_example.adoc
 ```
 
+## Reasoning
+
+An assembly must cover a single user story (what the user wants to accomplish).
+When an assembly attempts to describe multiple user stories, it often loses its focus, becomes too long, and can be confusing to follow.
+
 ## Instructions
 
 Review the assembly file to determine if it follows the one-user-story principle.
-Each assembly should describe a single user story (what the user wants to accomplish).
+Each assembly must describe a single user story.
 
 ### Step 1: Analyze the assembly
 

--- a/.cursor/skills/review-assembly-user-story/SKILL.md
+++ b/.cursor/skills/review-assembly-user-story/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: review-assembly-user-story
+description: Review assembly to ensure it follows the one-user-story principle
+---
+# Review assembly for single user story
+
+## Overview
+
+Review an assembly file to ensure it describes one and only one user story.
+If the assembly contains multiple user stories, split it into separate assembly files.
+
+Usage:
+
+```
+/review-assembly-user-story @assembly_example.adoc
+```
+
+## Instructions
+
+Review the assembly file to determine if it follows the one-user-story principle.
+Each assembly should describe a single user story (what the user wants to accomplish).
+
+### Step 1: Analyze the assembly
+
+Read the assembly file and:
+
+1. **Identify the primary user story** - What is the main goal or task the user wants to accomplish?
+2. **Check the introductory concept module** (the first include in the assembly) - Does it describe a single focused topic?
+3. **Review included modules** - Do they all support the same user story, or do they describe separate independent tasks?
+4. **Look for clear boundaries** - Are there sections that could stand alone as separate user stories?
+
+### Step 2: Determine if splitting is needed
+
+The assembly needs splitting if:
+
+- It contains procedures for multiple independent tasks that users might want to do separately
+- The concept module describes multiple distinct use cases or workflows
+- Different sections serve different user goals (e.g., "creating/deleting" vs "configuring" vs "monitoring")
+- Modules could be logically grouped into 2 or more cohesive assemblies
+
+Note: Inverse operations (creating/deleting, enabling/disabling) belong together in the same assembly.
+
+The assembly is fine if:
+
+- All procedures work toward a single user goal
+- Procedures are sequential steps or alternative approaches for the same task
+- Modules provide context, reference, or examples for one user story
+
+### Step 3: If splitting is needed
+
+For each identified user story:
+
+1. **Create a new assembly file** - Name it `assembly_<descriptive-name>.adoc`
+2. **Add the assembly header** - Include `:_mod-docs-content-type: ASSEMBLY`
+3. **Include relevant modules** - Copy the appropriate module includes for this user story
+4. **Create or update the introductory concept module** - Write a focused concept module with an abstract for this specific user story if needed
+5. **Update parent files** - Replace the original assembly include with includes for all new assemblies
+6. **Delete the original assembly** - Once all content is split and includes are updated
+
+### Step 4: Report findings
+
+Provide a summary that includes:
+
+- Whether the assembly follows the one-user-story principle
+- If splitting occurred, list the new assembly files created and their user stories
+- Any recommendations for improving the assembly structure
+
+## Principles
+
+- **One user story per assembly** - Each assembly should answer "What does the user want to accomplish?"
+- **User-centric organization** - Think from the user's perspective, not the product's features
+- **Cohesive modules** - All modules in an assembly should support the same goal
+- **Inverse operations stay together** - Creating/deleting or enabling/disabling are part of the same user story
+- **Clear boundaries** - If a user might want to do X without doing Y (excluding inverse operations), they should be separate assemblies
+- **Meaningful names** - Assembly names should clearly indicate the user story
+
+## Examples
+
+### Good examples (single user story):
+- `assembly_backing-up-server-and-proxy.adoc` - User wants to back up their system
+- `assembly_configuring-email-notifications.adoc` - User wants to set up email notifications
+
+### Important considerations:
+- **Inverse operations belong together** - Creating and deleting (e.g., organizations), or enabling and disabling (e.g., external authentication) are part of the same user story, as users may want to revert their actions
+- **Alternative methods belong together** - Multiple procedures for the same task (web UI, CLI, API) belong in the same assembly
+- **Sequential workflows belong together** - If steps must be done in order for one goal, they belong in the same assembly


### PR DESCRIPTION
#### What changes are you introducing?

Add a new Cursor skill that reviews assembly files to ensure they follow the one-user-story principle. The skill analyzes assemblies and can split them into multiple files if they contain multiple independent user stories.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The requirement that each assembly is a single user story is part of the downstream Content Quality Assessment checklist.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
