### PR TITLE
Add docs for TPM in libvirt

### DIFF
--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -5,6 +5,7 @@
 
 [role="_abstract"]
 {Project} can connect to the `libvirt` API on the hypervisor to provision hosts and control certain virtualization functions.
+Optional Trusted Platform Module (TPM) support is available for libvirt virtual machines.
 
 Only Virtual Machines created through {Project} can be managed.
 Virtual Machines with other than directory storage pool types are unsupported.

--- a/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile-by-using-cli.adoc
@@ -19,9 +19,11 @@ $ hammer compute-profile create --name "_My_Libvirt_Compute_Profile_"
 [options="nowrap" subs="+quotes"]
 ----
 $ hammer compute-profile values create \
---compute-attributes "cpus=1,memory=1073741824" \
+--compute-attributes "cpus=1,memory=1073741824,tpm=true" \
 --compute-profile "_My_Libvirt_Compute_Profile_" \
 --compute-resource "_My_KVM_Server_" \
 --interface "compute_type=network,compute_model=virtio,compute_network=_examplenetwork_" \
 --volume "pool_name=default,capacity=20G,format_type=qcow2"
 ----
++
+To enable a virtual Trusted Platform Module (TPM) for the profile, add `tpm=true` to the `--compute-attributes` option.

--- a/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-kvm-details-to-a-compute-profile-by-using-web-ui.adoc
@@ -19,4 +19,5 @@ You can create multiple network interfaces.
 However, at least one interface must point to a {SmartProxy}-managed network.
 . In the *Storage* area, enter the storage parameters for the host.
 You can create multiple volumes for the host.
+. Optional: Select *Trusted Platform Module (TPM)* to add a virtual TPM device for enhanced security.
 . Click *Submit* to save the settings to the compute profile.

--- a/guides/common/modules/proc_creating-network-or-image-based-hosts-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-network-or-image-based-hosts-by-using-cli.adoc
@@ -29,7 +29,7 @@ ifeval::["{context}" == "kvm-provisioning"]
 ----
 $ hammer host create \
 --build true \
---compute-attributes="cpus=1,memory=1073741824" \
+--compute-attributes="cpus=1,memory=1073741824,tpm=true" \
 --compute-resource "_My_KVM_Server_" \
 --enabled true \
 --hostgroup "_My_Host_Group_" \
@@ -51,7 +51,7 @@ ifeval::["{context}" == "kvm-provisioning"]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 $ hammer host create \
---compute-attributes="cpus=1,memory=1073741824" \
+--compute-attributes="cpus=1,memory=1073741824,tpm=true" \
 --compute-resource "_My_KVM_Server_" \
 --enabled true \
 --hostgroup "_My_Host_Group_" \
@@ -64,4 +64,6 @@ $ hammer host create \
 --provision-method "image" \
 --volume="pool_name=default,capacity=20G,format_type=qcow2"
 ----
++
+For KVM (libvirt), you can add `tpm=true` to `--compute-attributes` to attach a virtual Trusted Platform Module (TPM). Omit it if you do not need TPM.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding documentation for TPM in libvirt compute resource provisioning

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Documents
- https://github.com/theforeman/foreman/pull/10824

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Currently just edits by an AI tool to test https://github.com/theforeman/foreman-documentation/pull/4558
- Might need (human) editing

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
