### PR TITLE
enable foreman repos when deploying with foremanctl

### DIFF
--- a/guides/common/modules/snip_configuring-repositories-el.adoc
+++ b/guides/common/modules/snip_configuring-repositories-el.adoc
@@ -45,7 +45,13 @@ endif::[]
 
 ifdef::foremanctl[]
 Containerized installation::
-* Enable the required repositories:
+. Install the `foreman-release.rpm` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
+----
+. Enable the required additional repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----


### PR DESCRIPTION
the latest builds of foremanctl require ansible from our plugins repo

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
