### PR TITLE
Replace sendmail with SMTP as default method

### DIFF
--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -7,7 +7,7 @@
 To send email messages from {ProjectServer}, you can use an SMTP server or the `sendmail` command.
 
 :FeatureName: The `sendmail` command
-:FeatureAlternative: the SMTP service on {ProjectServer}
+:FeatureAlternative: an SMTP service
 include::snip_deprecated-feature.adoc[]
 
 .Prerequisites

--- a/guides/common/modules/ref_email-settings.adoc
+++ b/guides/common/modules/ref_email-settings.adoc
@@ -7,7 +7,7 @@
 The email settings define how {Project} sends email notifications, including delivery method, SMTP configuration, reply addresses, and welcome email options.
 
 :FeatureName: The `sendmail` command
-:FeatureAlternative: the SMTP service on {ProjectServer}
+:FeatureAlternative: an SMTP service
 include::snip_deprecated-feature.adoc[]
 
 [cols="30%,30%,40%",options="header"]


### PR DESCRIPTION
#### What changes are you introducing?
Replace sendmail with SMTP as default method

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
sendmail is deprecated, SMTP is the new default method for emails
https://redhat.atlassian.net/browse/SAT-40450

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
