### PR TITLE
Improve discovery plugin installation

### DIFF
--- a/guides/common/modules/proc_installing-the-discovery-service.adoc
+++ b/guides/common/modules/proc_installing-the-discovery-service.adoc
@@ -65,7 +65,7 @@ ifdef::satellite[]
 . Install `{fdi-package-name}` on {ProjectServer}:
 endif::[]
 ifdef::orcharhino[]
-. For Discovery in PXE mode, install `{fdi-package-name}` on {ProjectServer}:
+. If you want to use {ProjectServer} as Discovery Proxy for Discovery in PXE mode, install `{fdi-package-name}`:
 endif::[]
 ifdef::satellite,orcharhino[]
 +
@@ -90,8 +90,14 @@ The package extracts the PXE boot image to the `/var/lib/tftpboot/boot/fdi-image
 +
 The `{fdi-package-name}-iso` package installs the Discovery ISO to the `/usr/share/foreman-discovery-image/` directory.
 endif::[]
-. If you want to use {SmartProxyServer}, install the Discovery plugin on {SmartProxyServer}:
+ifdef::satellite[]
+. On every {SmartProxyServer} you want to use as Discovery {SmartProxy}, install the Discovery plugin:
 +
+endif::[]
+ifndef::satellite[]
+. On every {SmartProxyServer} you want to use as Discovery Proxy, install the Discovery plugin:
++
+endif::[]
 ifdef::satellite,orcharhino[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -116,10 +122,10 @@ If you require another version, add the following argument:
 ----
 endif::[]
 ifdef::satellite[]
-. If you want to use {SmartProxyServer}, install `{fdi-package-name}` on {SmartProxyServer}:
+. On every {SmartProxyServer} you want to use as Discovery {SmartProxy}, install `{fdi-package-name}` on {SmartProxyServer}:
 endif::[]
 ifdef::orcharhino[]
-. If you want to use {SmartProxyServer} for Discovery in PXE mode, install `{fdi-package-name}` on {SmartProxyServer}:
+. On every {SmartProxyServer} you want to use as Discovery Proxy for Discovery in PXE mode, install `{fdi-package-name}` on {SmartProxyServer}:
 endif::[]
 ifdef::satellite,orcharhino[]
 +


### PR DESCRIPTION
#### What changes are you introducing?

There are differences in installing the Discovery plugin for the different flavors that are currently not covered by the documentation. Second, the documentation misses information on when to install the plugin on a proxy.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
