### PR TITLE
Add ACL requirements for ReX

### DIFF
--- a/guides/common/modules/proc_altering-the-privilege-elevation-method.adoc
+++ b/guides/common/modules/proc_altering-the-privilege-elevation-method.adoc
@@ -7,9 +7,10 @@
 By default, push-based remote execution uses `sudo` to switch from the SSH user to the effective user that executes the script on your host.
 In some situations, you might require to use another method, such as `su` or `dzdo`.
 You can globally configure an alternative method in your {Project} settings.
+
 [NOTE]
 ====
-If the SSH user and effective user are non-root users, ensure the `acl` package is installed on the host and the remote execution working directory is mounted on a filesystem that supports ACLs.
+If the SSH user and effective user for push-based transport are non-root users, ensure the `acl` package is installed on the host and the remote execution working directory is mounted on a filesystem that supports ACLs.
 ====
 
 .Prerequisites


### PR DESCRIPTION
For remote execution that uses non-root SSH and effective users, the acl package should be installed on the host otherwise the REX job fails. The working directory too should be mounted on a filesystem that supports ACLs.

JIRA:
https://redhat.atlassian.net/browse/SAT-39761

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
