### PR TITLE
Fix: Use smartproxy-example-com for podman login in Flatpak remote setup

### DIFF
--- a/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
+++ b/guides/common/modules/proc_setting-up-flatpak-remote-for-smartproxy.adoc
@@ -33,7 +33,7 @@ Set *Set up certificate authentication* to `true` and enter the URL of your {Sma
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ podman login _{foreman-example-com}_
+$ podman login _{smartproxy-example-com}_
 ----
 For more information about logging in using Podman, see xref:configuring-podman-to-trust-the-certificate-authority[].
 +


### PR DESCRIPTION
## Summary

- Fix incorrect hostname in the `podman login` example in the Flatpak remote setup procedure
- The container registry is hosted on the Smart Proxy, not on the main Foreman server, so `{smartproxy-example-com}` is the correct attribute to use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cherry picks: Foreman 3.14 and newer