### PR TITLE
Tweak Vale rule for Subscription Manager

### DIFF
--- a/.vale/styles/foreman-documentation/Capitalization.yml
+++ b/.vale/styles/foreman-documentation/Capitalization.yml
@@ -27,5 +27,5 @@ swap:
   Lifecycle Environment: lifecycle environment
   Manifest: manifest
   Remote Execution: remote execution
-  Subscription: subscription
+  '(?<=\s)Subscription(?! Manager)': subscription
   Red Hat network: Red{nbsp}Hat Network


### PR DESCRIPTION
#### What changes are you introducing?

Tweaking Vale capitalization rules to allow "Subscription Manager" and capitalized "Subscription" at the beginning of a sentence (line) *)

*) Expects a preceding space to require lower case

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Closes https://github.com/theforeman/foreman-documentation/issues/4489 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
