### PR TITLE
Add review requirements for time-sensitive release updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,10 @@ As a maintainer, I will:
 * Only merge PRs if the Github Actions are green.
 * Try to review PRs in a timely manner.
 * Keep non-trivial PRs open for at least 24 hours (72 hours if over the weekend) to allow for input from the community.
-Examples of trivial PRs: Fixing a typo, fixing markup, or fixing links.
+Examples of trivial PRs: Fixing a typo, fixing markup, fixing links, updating release version configuration files (e.g., `web/releases/*.json`).
+Time-critical release changes, such as release notes, can be merged without waiting 24 hours, but still require peer review and an ACK.
 Non-trivial PRs might not only benefit from additional review but they also represent an opportunity for community members to ask questions and learn.
+All PRs, including trivial ones, require peer review and an ACK before merging.
 
 ## Pull request checklists
 


### PR DESCRIPTION
#### What changes are you introducing?
Add release configuration files and fully generated release notes to the
list of trivial PRs that can be merged without the 24-hour waiting period.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Based on discussion in https://github.com/theforeman/foreman-documentation/pull/4707

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
