### PR TITLE
Fix leftover markup

### DIFF
--- a/guides/common/modules/proc_configuring-project-server.adoc
+++ b/guides/common/modules/proc_configuring-project-server.adoc
@@ -112,7 +112,7 @@ endif::[]
 --foreman-db-host _postgres.example.com_ \
 --foreman-db-database _foreman_ \
 --foreman-db-username _foreman_ \
---foreman-db-password _Foreman_Password_
+--foreman-db-password _Foreman_Password_ \
 --foreman-db-root-cert _My_CA_Certificate_ \
 --foreman-db-sslmode verify-full
 ----


### PR DESCRIPTION
#### What changes are you introducing?
There is extra markup >* in https://docs.theforeman.org/nightly/Installing_Server/index-katello.html#configuring-foreman-server

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
It should not be there, it is a leftover from fixing replaceable markup

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
