### PR TITLE
Add TCP port 8443 to prerequisites for discovery

### DIFF
--- a/guides/common/modules/con_prerequisites-for-using-discovery.adoc
+++ b/guides/common/modules/con_prerequisites-for-using-discovery.adoc
@@ -15,5 +15,11 @@ For example, in the 10.1.0.0/16 network range, you can allocate the following IP
 
 ** 10.1.0.0 to 10.1.127.255 for leases.
 ** 10.1.128.0 to 10.1.255.254 for reservations.
+ifdef::satellite[]
+* For provisioning of discovered hosts using `kexec` or automatic reboot as well as reboot of discovered hosts through {ProjectWebUI}, ensure that the host and network-based firewalls are configured to allow communication from your Discovery {SmartProxy} to the discovered host on TCP port 8443.
+endif::[]
+ifndef::satellite[]
+* For provisioning of discovered hosts using `kexec` or automatic reboot as well as reboot of discovered hosts through {ProjectWebUI}, ensure that the host and network-based firewalls are configured to allow communication from your Discovery Proxy to the discovered host on TCP port 8443.
+endif::[]
 * Ensure the host or virtual machine being discovered has at least 1200 MB of memory.
 Insufficient memory can cause various random kernel panic errors because the Discovery image is extracted in memory.


### PR DESCRIPTION
#### What changes are you introducing?

Extend the prerequisites for discovery to cover network connections from Discovery Proxies to discovered hosts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

For sending reboot or kexec commands to discovered hosts, a TCP connection is established from the Discovery Proxy to the discovered host on port 8443. We should document this in a similar way as it is documented for [connections to compute resources like VMware](https://github.com/theforeman/foreman-documentation/blob/af2c94fec597a5379c5bda806bb2ccded6205705/guides/common/modules/proc_adding-a-vmware-connection-to-server-by-using-web-ui.adoc?plain=1#L10).

Refs: https://github.com/theforeman/foreman-discovery-image/blob/9bb40867bba5c3c97dd6c76e4adc483f1babc8fa/README.md?plain=1#L28-L29
Refs: https://github.com/theforeman/smart_proxy_discovery/blob/3dc2193050f67f3a644775749aa3fa32c73b487f/settings.d/discovery.yml.example#L6

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
