### PR TITLE
Add new skill: foremanctl documentation impact analysis

### DIFF
--- a/.claude/skills/foremanctl-analysis/SKILL.md
+++ b/.claude/skills/foremanctl-analysis/SKILL.md
@@ -77,7 +77,7 @@ For each affected file identified in Step 3a:
 
 ## Output format
 
-Present findings as:
+Save findings to a file named `foremanctl-analysis-YYYY-MM-DD.txt` in the root of the foreman-documentation repository.
 
 ### Summary
 - Total number of affected files


### PR DESCRIPTION
#### What changes are you introducing?

Adding a skill file for analysing the documentation impact of foremanctl.

1. You supply a list of components you want to evaluate.
2. AI searches the repo to identify the affected files (either files that directly reference foreman-installer or foreman-maintain or files that reference workflows which are affected by foremanctl and thus also need updating).
3. The resulting report summarizes the findings, with hints on how the docs will need to be updated.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Foremanctl is a new deployment tool that replaces the previously used foreman-installer and foreman-maintain utilities. As part of introducing foremanctl, we need to update all the documentation that either references foreman-installer and foreman-maintain directly, or is indirectly affected by the new foremanctl-based workflows without even mentioning the installer and maintain utilities.

Because our docs set is quite extensive, I'm experimenting with AI-based analysis of foremanctl's impact to see whether it can be helpful with setting us on the right track. The goal is not to have a detailed plan for how to update the docs; the goal is to get a summary of expected impact + have something to start the right conversations with our Engineering teams.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Alternative solution: An alternative approach would be to analyse foremanctl's impact on a single guide, and review one guide after another like this. However, because our teams own components, rather than guides, I chose a component-based approach. However, the resulting report still maps the identified files to guides in case there is a preference to track the follow-up work per guide.

Potential downside: Written like this, the skill does not include any details about what foremanctl actually is. It seems reliable when searching for direct foreman-installer and foreman-maintain references, but I wonder how reliable it is when identifying workflows that could potentially be broken by foremanctl without directly referencing these old tools.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
