### PR TITLE
Remove use of unrecognized --clean option of pg_isready command

### DIFF
--- a/guides/common/modules/proc_installing-postgresql.adoc
+++ b/guides/common/modules/proc_installing-postgresql.adoc
@@ -134,10 +134,10 @@ endif::[]
 +
 [options="nowrap" subs="verbatim,quotes"]
 ----
-# PGPASSWORD='_Foreman_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=foreman --dbname=foreman --clean
+# PGPASSWORD='_Foreman_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=foreman --dbname=foreman
 ifndef::foreman-el,foreman-deb[]
-# PGPASSWORD='_Candlepin_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=candlepin --dbname=candlepin --clean
-# PGPASSWORD='_Pulpcore_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=pulp --dbname=pulpcore --clean
+# PGPASSWORD='_Candlepin_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=candlepin --dbname=candlepin
+# PGPASSWORD='_Pulpcore_Password_' pg_isready --host=_postgres.example.com_ --port=5432 --username=pulp --dbname=pulpcore
 endif::[]
 ----
 +


### PR DESCRIPTION
#### What changes are you introducing?
Removing use of unrecognized --clean option of pg_isready command
```
# pg_isready --host=postgres.server.example.com --port=5432 --username=foreman --dbname=foreman --clean
pg_isready: unrecognized option '--clean'
Try "pg_isready --help" for more information.
```

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Based on https://redhat.atlassian.net/browse/SAT-43917

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
```
#  pg_isready --host=postgres.server.example.com --port=5432 --username=foreman --dbname=foreman
postgres.server.example.com - accepting connections
```
#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
