### PR TITLE
Add katello repos to foremanctl installation doc

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -73,6 +73,14 @@ ifdef::foremanctl[]
 ----
 # {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
 ----
+ifdef::katello[]
+. Install the `katello-repos-latest.rpm` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
+----
+endif::[]
 . Enable the required additional repositories:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -89,8 +89,7 @@ endif::[]
 ----
 endif::[]
 
-ifndef::foremanctl[]
-ifdef::foreman-el,katello,satellite[]
+ifdef::foreman-el,katello,satellite,foremanctl[]
 .Verification
 * Verify that the required repositories are enabled:
 +
@@ -98,5 +97,4 @@ ifdef::foreman-el,katello,satellite[]
 ----
 # dnf repolist enabled
 ----
-endif::[]
 endif::[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -8,7 +8,6 @@
 Configure the required repositories.
 
 .Procedure
-ifndef::foremanctl[]
 ifdef::satellite[]
 . Disable all repositories:
 +
@@ -37,59 +36,15 @@ ifdef::foreman-el,katello[]
 ----
 # {project-package-clean} all
 ----
-ifdef::foreman-el,katello[]
-. Install the `foreman-release.rpm` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
-----
 endif::[]
-ifdef::katello[]
-. Install the `katello-repos-latest.rpm` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
-----
-endif::[]
-ifdef::foreman-el,katello[]
-. Install the `puppet-release` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} https://yum.puppet.com/puppet8-release-el-{distribution-major-version}.noarch.rpm
-----
-endif::[]
+ifdef::foreman-el,katello,foremanctl[]
+include::snip_configuring-repositories-foreman-rpm.adoc[]
 endif::[]
 ifdef::orcharhino[]
 * Ensure the repositories required to install {ProductName} are enabled on your {EL} host.
 endif::[]
-endif::[]
-ifdef::foremanctl[]
-. Install the `foreman-release.rpm` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
-----
-ifdef::katello[]
-. Install the `katello-repos-latest.rpm` package:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
-----
-endif::[]
-. Enable the required additional repositories:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# dnf copr enable @theforeman/foremanctl rhel-9-x86_64
-----
-endif::[]
 
-ifdef::foreman-el,katello,satellite,foremanctl[]
+ifndef::foreman-deb[]
 .Verification
 * Verify that the required repositories are enabled:
 +

--- a/guides/common/modules/snip_configuring-repositories-foreman-rpm.adoc
+++ b/guides/common/modules/snip_configuring-repositories-foreman-rpm.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: SNIPPET
+
+. Install the `foreman-release.rpm` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
+----
+ifdef::katello[]
+. Install the `katello-repos-latest.rpm` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
+----
+endif::[]
+ifdef::foremanctl[]
+. Enable the required additional repositories:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# dnf copr enable @theforeman/foremanctl rhel-9-x86_64
+----
+endif::[]
+ifndef::foremanctl[]
+. Install the `puppet-release` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} https://yum.puppet.com/puppet8-release-el-{distribution-major-version}.noarch.rpm
+----
+endif::[]


### PR DESCRIPTION


#### What changes are you introducing?
Add katello-repos package installation step
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
When running `foremanctl deploy --add-feature hammer`, the installation fails because it tries to install hammer_cli_katello package but cannot find it since the Katello repository is not enabled. Installing   
  katello-repos-latest.rpm first ensures the Katello repositories are configured before attempting to install Katello-specific packages.
#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
