### PR TITLE
Add procedure to promote content views using MCP

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -26,7 +26,7 @@ include::modules/proc_promoting-a-content-view-by-using-web-ui.adoc[leveloffset=
 
 include::modules/proc_promoting-a-content-view-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_promoting-a-content-view-by-using-mcp.adoc[leveloffset=+1]
+include::modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc[leveloffset=+1]
 
 include::modules/proc_promoting-a-content-view-to-all-environments-in-an-organization.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -26,6 +26,8 @@ include::modules/proc_promoting-a-content-view-by-using-web-ui.adoc[leveloffset=
 
 include::modules/proc_promoting-a-content-view-by-using-cli.adoc[leveloffset=+1]
 
+include::modules/proc_promoting-a-content-view-by-using-mcp.adoc[leveloffset=+1]
+
 include::modules/proc_promoting-a-content-view-to-all-environments-in-an-organization.adoc[leveloffset=+1]
 
 include::modules/con_rolling-content-views.adoc[leveloffset=+1]

--- a/guides/common/modules/con_project-mcp-integration-overview.adoc
+++ b/guides/common/modules/con_project-mcp-integration-overview.adoc
@@ -37,8 +37,5 @@ When the connection is established, you query your AI application for data about
 The MCP client within the AI application obtains the required data from your {Project} inventory and returns it to the AI application.
 The AI application processes the data to answer your queries.
 
-The MCP server runs in read-only mode.
-It extracts data from your {Project} inventory but cannot write, edit, or make any updates to the inventory.
-
 .Additional resources
 * link:https://modelcontextprotocol.io[Model Context Protocol]

--- a/guides/common/modules/proc_promoting-a-content-view-by-using-mcp.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view-by-using-mcp.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="promoting-a-content-view-by-using-mcp"]
+= Promoting a content view by using MCP
+
+[role="_abstract"]
+You can use your AI application to promote content views across different lifecycle environments.
+
+include::snip_warning-ai-output-review.adoc[]
+
+.Procedure
+. Allow the MCP server to trigger content view promote actions:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ podman run --interactive --tty --publish 127.0.0.1:8080:8080 \
+  --volume _Path_to_My_CA_Bundle_:/app/ca.pem:ro,Z \
+  {mcp-server-image} \
+  --foreman-url https://_{foreman-example-com}_ \
+  --allowed-cv-actions "promote"
+----
++
+For more information, see {ManagingHostsDocURL}deploying-the-mcp-server-for-{project-context}[Deploying the MCP server for {Project}] in _{ManagingHostsDocTitle}_.
+. Type a prompt in your AI application to list content views:
++
+[source, none, options="nowrap", subs="+quotes,attributes"]
+----
+Show a list of content views on my {Project}.
+----
+. The MCP server will return a list of content views to the AI application.
+Review the information.
+. Type a prompt in your AI application to promote the content view to an environment.
+Refer to the documentation of your AI application to find more about how to use MCP server prompts.
+Review all the steps that the AI application performs.

--- a/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
+++ b/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
@@ -30,5 +30,4 @@ Show a list of content views on my {Project}.
 . The MCP server will return a list of content views to the AI application.
 Review the information.
 . Type a prompt in your AI application to publish a new version of the content view or to promote the content view to an environment.
-Refer to the documentation of your AI application to find more about how to use MCP server prompts.
 Review all the steps that the AI application performs.

--- a/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
+++ b/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="promoting-a-content-view-by-using-mcp"]
-= Promoting a content view by using MCP
+[id="publishing-and-promoting-a-content-view-by-using-mcp"]
+= Publishing and Promoting a content view by using MCP
 
 [role="_abstract"]
-You can use your AI application to promote content views across different lifecycle environments.
+You can use your AI application to publish and promote content views across different lifecycle environments.
 
 include::snip_warning-ai-output-review.adoc[]
 
@@ -17,7 +17,7 @@ $ podman run --interactive --tty --publish 127.0.0.1:8080:8080 \
   --volume _Path_to_My_CA_Bundle_:/app/ca.pem:ro,Z \
   {mcp-server-image} \
   --foreman-url https://_{foreman-example-com}_ \
-  --allowed-cv-actions "promote"
+  --allowed-cv-actions "publish,promote"
 ----
 +
 For more information, see {ManagingHostsDocURL}deploying-the-mcp-server-for-{project-context}[Deploying the MCP server for {Project}] in _{ManagingHostsDocTitle}_.
@@ -29,6 +29,6 @@ Show a list of content views on my {Project}.
 ----
 . The MCP server will return a list of content views to the AI application.
 Review the information.
-. Type a prompt in your AI application to promote the content view to an environment.
+. Type a prompt in your AI application to publish a new version of the content view or to promote the content view to an environment.
 Refer to the documentation of your AI application to find more about how to use MCP server prompts.
 Review all the steps that the AI application performs.

--- a/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
+++ b/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
@@ -9,7 +9,7 @@ You can use your AI application to publish and promote content views across diff
 include::snip_warning-ai-output-review.adoc[]
 
 .Procedure
-. Allow the MCP server to trigger content view promote actions:
+. Allow the MCP server to trigger content view publish and promote actions:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
+++ b/guides/common/modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="publishing-and-promoting-a-content-view-by-using-mcp"]
-= Publishing and Promoting a content view by using MCP
+= Publishing and promoting a content view by using MCP
 
 [role="_abstract"]
 You can use your AI application to publish and promote content views across different lifecycle environments.


### PR DESCRIPTION
Users can now use their AI applications connected to the MCP server to promote incremental content views using natural language requests.

Similar to https://github.com/theforeman/foreman-documentation/pull/4691.

JIRA:
https://redhat.atlassian.net/browse/SAT-43610

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
