### PR TITLE
Add information about upgrading from any z-stream

### DIFF
--- a/guides/common/modules/con_planning-project-upgrade.adoc
+++ b/guides/common/modules/con_planning-project-upgrade.adoc
@@ -18,6 +18,7 @@ ifdef::satellite[]
 After you successfully test the upgrade on the clone, you can repeat the upgrade on your primary {ProjectServer} and discard the clone.
 Alternately, you can promote the clone to your primary {ProjectServer} and discard the previous primary {ProjectServer}.
 For more information, see {AdministeringDocURL}cloning-{project-context}-server[Cloning {ProjectServer}] in _{AdministeringDocTitle}_.
+* Note that you can upgrade to {Project} {ProjectVersion} from any {Project} {ProjectVersionPrevious} z-stream.
 endif::[]
 * {Project} services are shut down during the upgrade.
 Ensure to plan for the required downtime.

--- a/guides/common/modules/con_planning-project-upgrade.adoc
+++ b/guides/common/modules/con_planning-project-upgrade.adoc
@@ -18,8 +18,8 @@ ifdef::satellite[]
 After you successfully test the upgrade on the clone, you can repeat the upgrade on your primary {ProjectServer} and discard the clone.
 Alternately, you can promote the clone to your primary {ProjectServer} and discard the previous primary {ProjectServer}.
 For more information, see {AdministeringDocURL}cloning-{project-context}-server[Cloning {ProjectServer}] in _{AdministeringDocTitle}_.
-* Note that you can upgrade to {Project} {ProjectVersion} from any {Project} {ProjectVersionPrevious} z-stream.
 endif::[]
+* You can upgrade to {Project} {ProjectVersion} from any {Project} {ProjectVersionPrevious} patch version.
 * {Project} services are shut down during the upgrade.
 Ensure to plan for the required downtime.
 The upgrade process duration varies depending on your hardware configuration, network speed, and the amount of data that is stored on the server:


### PR DESCRIPTION
Earlier users were required to update to the latest z-stream of the previous version before upgrading, this is no longer required. However, this has to be explicitly called out as users spend time updating to latest z-stream.

JIRA:
https://redhat.atlassian.net/browse/SAT-43692

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
