### PR TITLE
Update information about read-only MCP server

### DIFF
--- a/guides/common/modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc
@@ -6,7 +6,6 @@
 [role="_abstract"]
 {Project} provides a Model Context Protocol (MCP) server to enable integration with your MCP-compatible AI applications.
 By connecting your MCP client to the MCP server, you can obtain comprehensive AI-generated reports and data analysis of your {Project} inventory.
-You can also start the MCP server with permissions to manage content views on your {Project} and trigger remote execution jobs.
 
 :FeatureName: MCP server for {Project}
 include::snip_technology-preview.adoc[]

--- a/guides/common/modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc
@@ -5,7 +5,8 @@
 
 [role="_abstract"]
 {Project} provides a Model Context Protocol (MCP) server to enable integration with your MCP-compatible AI applications.
-By connecting your MCP client to the MCP server, you can obtain comprehensive AI-generated reports and data analysis of your {Project} inventory.
+You can obtain comprehensive AI-generated reports and data analysis of your {Project} inventory.
+Optionally, you can start the MCP server with permissions to edit the inventory.
 
 :FeatureName: MCP server for {Project}
 include::snip_technology-preview.adoc[]

--- a/guides/common/modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc
@@ -6,6 +6,7 @@
 [role="_abstract"]
 {Project} provides a Model Context Protocol (MCP) server to enable integration with your MCP-compatible AI applications.
 By connecting your MCP client to the MCP server, you can obtain comprehensive AI-generated reports and data analysis of your {Project} inventory.
+You can also start the MCP server with permissions to manage content views on your {Project} and trigger remote execution jobs.
 
 :FeatureName: MCP server for {Project}
 include::snip_technology-preview.adoc[]

--- a/guides/common/modules/con_project-mcp-integration-overview.adoc
+++ b/guides/common/modules/con_project-mcp-integration-overview.adoc
@@ -37,5 +37,9 @@ When the connection is established, you query your AI application for data about
 The MCP client within the AI application obtains the required data from your {Project} inventory and returns it to the AI application.
 The AI application processes the data to answer your queries.
 
+The MCP server runs in read-only mode by default.
+It extracts data from your {Project} inventory but cannot write, edit, or make any updates to the inventory.
+Note that the MCP server can edit the inventory, if you enable the MCP server to trigger remote execution jobs or content view actions. 
+
 .Additional resources
 * link:https://modelcontextprotocol.io[Model Context Protocol]

--- a/guides/common/modules/con_project-mcp-integration-overview.adoc
+++ b/guides/common/modules/con_project-mcp-integration-overview.adoc
@@ -39,7 +39,7 @@ The AI application processes the data to answer your queries.
 
 The MCP server runs in read-only mode by default.
 It extracts data from your {Project} inventory but cannot write, edit, or make any updates to the inventory.
-Note that the MCP server can edit the inventory, if you enable the MCP server to trigger remote execution jobs or content view actions. 
+If you enable the MCP server to trigger remote execution jobs or content view actions, the MCP server can edit the inventory.
 
 .Additional resources
 * link:https://modelcontextprotocol.io[Model Context Protocol]

--- a/guides/common/modules/con_project-mcp-integration-overview.adoc
+++ b/guides/common/modules/con_project-mcp-integration-overview.adoc
@@ -39,7 +39,7 @@ The AI application processes the data to answer your queries.
 
 The MCP server runs in read-only mode by default.
 It extracts data from your {Project} inventory but cannot write, edit, or make any updates to the inventory.
-If you start the MCP server with additional permissions, for example, to allow it to start remote execution jobs or publish and promote content views, it can make changes to the inventory.
+You can start the MCP server with permissions to make changes to the inventory, for example, to start remote execution jobs or publish and promote content views.
 
 .Additional resources
 * link:https://modelcontextprotocol.io[Model Context Protocol]

--- a/guides/common/modules/con_project-mcp-integration-overview.adoc
+++ b/guides/common/modules/con_project-mcp-integration-overview.adoc
@@ -39,7 +39,7 @@ The AI application processes the data to answer your queries.
 
 The MCP server runs in read-only mode by default.
 It extracts data from your {Project} inventory but cannot write, edit, or make any updates to the inventory.
-If you enable the MCP server to trigger remote execution jobs or content view actions, the MCP server can edit the inventory.
+If you start the MCP server with additional permissions, for example, to allow it to start remote execution jobs or publish and promote content views, it can make changes to the inventory.
 
 .Additional resources
 * link:https://modelcontextprotocol.io[Model Context Protocol]


### PR DESCRIPTION
If the MCP server is allowed to perform REx jobs or CV actions, it ceases to function in read-only mode. Editing the earlier information regarding this.

JIRA:
https://redhat.atlassian.net/browse/SAT-44151

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
