### PR TITLE
Remove obsolete BZ2177730 reference from Puppet agent registration

### DIFF
--- a/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc
@@ -58,11 +58,6 @@ endif::[]
 * Optional: Add a host parameter named `puppet_ca_server`, select the *string* type, and set the value to the hostname of your Puppet CA server, such as `puppet-ca.example.com`.
 If `puppet_ca_server` is not set, the Puppet agent will use the same server as `puppet_server`.
 * Optional: Add a host parameter named `puppet_environment`, select the *string* type, and set the value to the Puppet environment you want the host to use.
-
-ifndef::orcharhino[]
-+
-Until the https://bugzilla.redhat.com/show_bug.cgi?id=2177730[BZ2177730] is resolved, you must use host parameters to specify the Puppet agent configuration even in integrated setups where the Puppet server is a {SmartProxyServer}.
-endif::[]
 ifdef::katello,orcharhino,satellite[]
 . Navigate to *Hosts* > *Register Host* and register your host using an appropriate activation key.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Removing a reference to an obsolete Bugzilla ticket

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It looks like the ticket will never get addressed, which makes the paragraph obsolete. The rest of the procedure already documents the required steps.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
