### PR TITLE
Resolve snippet that only contains a single item

### DIFF
--- a/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-google-compute-engine.adoc
@@ -12,7 +12,8 @@ endif::[]
 
 Before you can provision cloud instances on Google Compute Engine, ensure that your environment meets the following requirements:
 
-include::snip_prerequisite-networking-for-provisioning.adoc[]
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:preparing-networking[].
 +
 include::snip_prerequisites-common-compute-resource.adoc[]
 * In your GCE project, configure a service account with the necessary IAM Compute role.

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -27,7 +27,7 @@ include::snip_prerequisites-common-compute-resource.adoc[]
 
 * A {SmartProxyServer} managing a network on the {Kubernetes} cluster.
 Ensure that no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information about network service configuration for {SmartProxyServers}, see {ProvisioningDocURL}preparing-networking[Preparing networking] in _{ProvisioningDocTitle}_.
+For more information about network service configuration for {SmartProxyServers}, see xref:preparing-networking-for-host-management[].
 * Ensure the provisioning user has the required permissions to provision hosts.
 
 include::snip_warning-destroy-vm-on-host-delete.adoc[]

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kvm.adoc
@@ -16,7 +16,7 @@ Before you provision virtual machines on KVM, ensure that your environment meets
 include::snip_prerequisites-common-compute-resource.adoc[]
 * A {SmartProxyServer} managing a network on the KVM server.
 Ensure no other DHCP services run on this network to avoid conflicts with {SmartProxyServer}.
-For more information about network service configuration for {SmartProxyServers}, see {ProvisioningDocURL}preparing-networking[Preparing networking] in _{ProvisioningDocTitle}_.
+For more information about network service configuration for {SmartProxyServers}, see xref:preparing-networking-for-host-management[].
 ifdef::satellite[]
 * A {RHEL} server running KVM virtualization tools (libvirt daemon).
 For more information, see the {RHELDocsBaseURL}8/html/configuring_and_managing_virtualization/index[_{RHEL}{nbsp}8 Configuring and managing virtualization_].

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-cli.adoc
@@ -8,7 +8,8 @@ Provisioning discovered hosts follows a provisioning process that is similar to 
 The main difference is that instead of manually entering the host's MAC address, you can select the host to provision from the list of discovered hosts.
 
 .Prerequisites
-include::snip_prerequisite-networking-for-provisioning.adoc[]
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:preparing-networking[].
 * You have one or more discovered hosts in your {Project} inventory.
 +
 include::snip_prerequisites-common-compute-resource.adoc[]

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-cli.adoc
@@ -8,7 +8,8 @@ Provisioning discovered hosts follows a provisioning process that is similar to 
 The main difference is that instead of manually entering the host's MAC address, you can select the host to provision from the list of discovered hosts.
 
 .Prerequisites
-include::snip_prerequisite-networking-for-provisioning.adoc[]
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:preparing-networking-for-host-management[].
 * You have one or more discovered hosts in your {Project} inventory.
 +
 include::snip_prerequisites-common-compute-resource.adoc[]

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-web-ui.adoc
@@ -8,7 +8,8 @@ Provisioning discovered hosts follows a provisioning process that is similar to 
 The main difference is that instead of manually entering the host's MAC address, you can select the host to provision from the list of discovered hosts.
 
 .Prerequisites
-include::snip_prerequisite-networking-for-provisioning.adoc[]
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:preparing-networking[].
 * You have one or more discovered hosts in your {Project} inventory.
 +
 include::snip_prerequisites-common-compute-resource.adoc[]

--- a/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-from-discovered-hosts-by-using-web-ui.adoc
@@ -8,7 +8,8 @@ Provisioning discovered hosts follows a provisioning process that is similar to 
 The main difference is that instead of manually entering the host's MAC address, you can select the host to provision from the list of discovered hosts.
 
 .Prerequisites
-include::snip_prerequisite-networking-for-provisioning.adoc[]
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:preparing-networking-for-host-management[].
 * You have one or more discovered hosts in your {Project} inventory.
 +
 include::snip_prerequisites-common-compute-resource.adoc[]

--- a/guides/common/modules/ref_prerequisites-for-google-compute-engine-provisioning.adoc
+++ b/guides/common/modules/ref_prerequisites-for-google-compute-engine-provisioning.adoc
@@ -6,7 +6,8 @@
 [role="_abstract"]
 Before you can provision cloud instances on Google Compute Engine (GCE), ensure that your environment meets the following requirements.
 
-include::snip_prerequisite-networking-for-provisioning.adoc[]
+* Configure a domain and subnet on {Project}.
+For more information about networking requirements, see xref:preparing-networking-for-host-management[].
 +
 include::snip_prerequisites-common-compute-resource.adoc[]
 * In your GCE project, configure a service account with the necessary IAM Compute role.

--- a/guides/common/modules/ref_prerequisites-for-openstack-provisioning.adoc
+++ b/guides/common/modules/ref_prerequisites-for-openstack-provisioning.adoc
@@ -8,7 +8,7 @@ Before you can provision cloud instances on {OpenStack}, ensure that your enviro
 
 include::snip_prerequisites-common-compute-resource.adoc[]
 * A {SmartProxyServer} managing a network in your {OpenStack} environment.
-For more information, see {ProvisioningDocURL}preparing-networking[Preparing networking] in _{ProvisioningDocTitle}_.
+For more information, see xref:preparing-networking-for-host-management[].
 * An image added to {OpenStack} Image Storage (glance) service for image-based provisioning.
 ifndef::orcharhino[]
 For more information, see the {RHDocsBaseURL}red_hat_openstack_platform/16.0/html/instances_and_images_guide/index[{OpenStack} _Instances and Images Guide_].

--- a/guides/common/modules/snip_prerequisite-networking-for-provisioning.adoc
+++ b/guides/common/modules/snip_prerequisite-networking-for-provisioning.adoc
@@ -1,4 +1,0 @@
-:_mod-docs-content-type: SNIPPET
-
-* Configure a domain and subnet on {Project}.
-For more information about networking requirements, see xref:preparing-networking[].

--- a/guides/common/modules/snip_prerequisite-networking-for-provisioning.adoc
+++ b/guides/common/modules/snip_prerequisite-networking-for-provisioning.adoc
@@ -1,4 +1,0 @@
-:_mod-docs-content-type: SNIPPET
-
-* Configure a domain and subnet on {Project}.
-For more information about networking requirements, see xref:preparing-networking-for-host-management[].


### PR DESCRIPTION
#### What changes are you introducing?

This patch drops a snippet that only contains a single unordered list item. Instead, the two lines are now part of the three modules that included the snippet before.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I think that we do not need a snippet for a single line.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
