### PR TITLE
Remove Pulp export destination filepath setting reference

### DIFF
--- a/guides/common/modules/ref_content-settings.adoc
+++ b/guides/common/modules/ref_content-settings.adoc
@@ -34,7 +34,6 @@ Either `immediate` or `on_demand`.
 Either `immediate` or `on_demand`.
 | *Default {SmartProxy} download policy* | `on_demand` | Default download policy for {SmartProxy} syncs.
 Either `inherit`, `immediate`, or `on_demand`.
-| *Pulp export destination filepath* | `/var/lib/pulp/katello-export` | On-disk location for exported repositories.
 | *Pulp 3 export destination filepath* | `/var/lib/pulp/exports` |On-disk location for Pulp 3 exported repositories.
 | *Pulp client key* | `/etc/pki/katello/private/pulp-client.key` |Path for SSL key used for Pulp server authentication.
 | *Pulp client cert* | `/etc/pki/katello/certs/pulp-client.crt` | Path for SSL certificate used for Pulp server authentication.


### PR DESCRIPTION
#### What changes are you introducing?

Removes "Pulp export destination filepath" which hasn't existed in Katello for a long time.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's an old setting that no longer exists. Here is the only remaining setting: https://github.com/Katello/katello/blob/d6c704d5dbaa2cb8fbc3babf60906bccf852cb1c/lib/katello/plugin.rb#L562

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
