### PR TITLE
Provide links to subscription central guide rather than sections

### DIFF
--- a/guides/common/modules/con_subscriptions-usage-data.adoc
+++ b/guides/common/modules/con_subscriptions-usage-data.adoc
@@ -28,4 +28,4 @@ This data tells you: How much of my capacity is being used?
 For example: I am using 42 of my 52 RH00001, leaving 10 free for additional use.
 
 .Additional resources
-* {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/con-how-does-subscriptionwatch-show-data_assembly-viewing-understanding-subscriptionwatch-data#how_to_use_the_subscription_data_in_the_views[How to use the subscription data in the views in _Getting Started with the Subscriptions Service_]
+* {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_the_subscriptions_service[How to use the subscription data in the views in _Getting Started with the Subscriptions Service_]

--- a/guides/common/modules/con_troubleshooting-virt-who.adoc
+++ b/guides/common/modules/con_troubleshooting-virt-who.adoc
@@ -6,4 +6,5 @@
 [role="_abstract"]
 You can troubleshoot virt-who by checking the service status, logs, and by identifying configuration issues.
 
-For more information, see link:{RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-config-vm-sub_#virt-who-troubleshooting-methods_[Virt-who troubleshooting methods] and link:{RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/adv-reg-rhel-config-vm-sub_#virt-who-troubleshooting-scenarios_[Virt-who troubleshooting scenarios] in _Getting Started with RHEL System Registration_ in the Subscription Central documentation.
+For more information, see link:{RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration[Getting Started with RHEL System Registration] in the Subscription Central documentation on virt-who troubleshooting
+methods and scenarios.

--- a/guides/common/modules/con_troubleshooting-virt-who.adoc
+++ b/guides/common/modules/con_troubleshooting-virt-who.adoc
@@ -5,6 +5,3 @@
 
 [role="_abstract"]
 You can troubleshoot virt-who by checking the service status, logs, and by identifying configuration issues.
-
-For more information, see link:{RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration[Getting Started with RHEL System Registration] in the Subscription Central documentation on virt-who troubleshooting
-methods and scenarios.

--- a/guides/common/modules/ref_subscriptions-tracking-configuration.adoc
+++ b/guides/common/modules/ref_subscriptions-tracking-configuration.adoc
@@ -18,7 +18,7 @@ For more information, see {ConfiguringVMSubscriptionsDocURL}[_{ConfiguringVMSubs
 * Configure inventory upload in {Project} and install the Insights client on hosts.
 For more information, see {ManagingHostsDocURL}monitoring-hosts-by-using-red-hat-lightspeed-in-cloud[Monitoring hosts by using {Insights} in {RHCloud}] in _{ManagingHostsDocTitle}_.
 * Activate the Subscriptions service in the {RHCloud} if needed.
-For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/assembly-activating-opening-subscriptionwatch[Activating and opening the subscriptions service] in _Getting Started with the Subscriptions Service_.
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_the_subscriptions_service[Activating and opening the subscriptions service] in _Getting Started with the Subscriptions Service_.
 
 .Additional resources
 * xref:expense-management-for-red-hat-subscriptions[]

--- a/guides/common/modules/ref_troubleshooting-virt-who.adoc
+++ b/guides/common/modules/ref_troubleshooting-virt-who.adoc
@@ -99,3 +99,6 @@ Enter the following commands to check the number of virtual machines that virt-w
 # cat /tmp/virt-who.json | json_reformat | grep "guestId" | sort | uniq -c | wc -l
 ----
 --
+
+.Additional resources
+* link:{RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_rhel_system_registration/[Troubleshooting documentation in _Getting Started with RHEL System Registration_]

--- a/guides/common/modules/ref_virt-who-configuration-overview.adoc
+++ b/guides/common/modules/ref_virt-who-configuration-overview.adoc
@@ -24,7 +24,7 @@ You can set the system purpose attributes when you configure activation keys for
 For more information, see {ContentManagementDocURL}Managing_Activation_Keys_content-management[Managing activation keys] in _{ContentManagementDocTitle}_.
 ifdef::satellite[]
 * In a connected environment, configure the {Project} inventory upload plugin to upload your inventory to {RHCloud}.
-For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_the_subscriptions_service/proc-installing-satellite-inventory-upload-plugin_assembly-setting-up-subscriptionwatch[Installing the Satellite inventory upload plugin] in _Getting Started with the Subscriptions Service_.
+For more information, see {RHDocsBaseURL}subscription_central/1-latest/html/getting_started_with_the_subscriptions_service[Getting Started with the Subscriptions Service].
 endif::[]
 * Associate the virtual machines with {Project}.
 For more information, see {ManagingHostsDocURL}Associating_a_Virtual_Machine_from_a_Hypervisor_managing-hosts[Associating a virtual machine with {Project} from a hypervisor] in _{ManagingHostsDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

Updating links to Subscription Central documentation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

linkchecker failures

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Right now, we link to specific sections in the guides. However, the guides are small enough that I think just providing a hint on what users should search for is enough. Considering how often the guide's URL structure is changing, this will also help us prevent linkchecker failures.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

Everywhere