### PR TITLE
Remove major version repository references from LEAPP upgrade docs

### DIFF
--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,4 +1,3 @@
-:satellite:
 [id="upgrading-{project-context}-or-{smart-proxy-context}-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL-abbr} 9 in-place by using Leapp
 

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -19,13 +19,11 @@ Note that you can upgrade to {EL} 9 using LEAPP without updating to the latest {
 ifdef::satellite[]
 * If you are upgrading {SmartProxyServers}, enable and synchronize the following repositories to {ProjectServer}, and add them to the lifecycle environment and content view that is attached to your {SmartProxyServer}:
 ** *Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)*:
-*** `{RepoRHEL9BaseOS}` for the major version: `x86_64 9`.
 *** `{RepoRHEL9BaseOS}` for the latest supported minor version: `x86_64 9._Y_`, where _Y_ represents the minor version.
 ifndef::orcharhino[]
 For information about the latest supported minor version for in-place upgrades, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
 ** *Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)*:
-*** `{RepoRHEL9AppStream}` for the major version: `x86_64 9`.
 *** `{RepoRHEL9AppStream}` for the latest supported minor version: `x86_64 9._Y_`, where _Y_ represents the minor version.
 ifndef::orcharhino[]
 For information about the latest supported minor versions for in-place upgrades, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.

--- a/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
+++ b/guides/common/modules/proc_upgrading-project-or-proxy-in-place-using-leapp.adoc
@@ -1,3 +1,4 @@
+:satellite:
 [id="upgrading-{project-context}-or-{smart-proxy-context}-in-place-using-leapp_{context}"]
 = Upgrading {Project} or {SmartProxy} to {EL-abbr} 9 in-place by using Leapp
 
@@ -18,18 +19,18 @@ endif::[]
 Note that you can upgrade to {EL} 9 using LEAPP without updating to the latest {Project} {ProjectVersion} patch release version.
 ifdef::satellite[]
 * If you are upgrading {SmartProxyServers}, enable and synchronize the following repositories to {ProjectServer}, and add them to the lifecycle environment and content view that is attached to your {SmartProxyServer}:
-** *Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)*:
-*** `{RepoRHEL9BaseOS}` for the latest supported minor version: `x86_64 9._Y_`, where _Y_ represents the minor version.
+Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs):::
+`{RepoRHEL9BaseOS}` for the latest supported minor version: `x86_64 9._Y_`, where _Y_ represents the minor version.
 ifndef::orcharhino[]
 For information about the latest supported minor version for in-place upgrades, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
-** *Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)*:
-*** `{RepoRHEL9AppStream}` for the latest supported minor version: `x86_64 9._Y_`, where _Y_ represents the minor version.
+Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs):::
+`{RepoRHEL9AppStream}` for the latest supported minor version: `x86_64 9._Y_`, where _Y_ represents the minor version.
 ifndef::orcharhino[]
 For information about the latest supported minor versions for in-place upgrades, see {RHELDocsBaseURL}9/html-single/upgrading_from_rhel_8_to_rhel_9/index#con_supported-upgrade-paths_upgrading-from-rhel-8-to-rhel-9[Supported upgrade paths] in _Upgrading from RHEL 8 to RHEL 9_.
 endif::[]
-** *Red Hat Satellite Capsule {ProjectVersion} for RHEL 9 x86_64 RPMs*: `{RepoRHEL9ServerSatelliteCapsuleProjectVersion}`
-** *Red Hat Satellite Maintenance {ProjectVersion} for RHEL 9 x86_64 RPMs*: `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}`
+Red Hat Satellite Capsule {ProjectVersion} for RHEL 9 x86_64 RPMs*::: `{RepoRHEL9ServerSatelliteCapsuleProjectVersion}`
+Red Hat Satellite Maintenance {ProjectVersion} for RHEL 9 x86_64 RPMs::: `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}`
 endif::[]
 ifndef::satellite[]
 * Access to available repositories or a local mirror of repositories.


### PR DESCRIPTION
Only the latest supported minor version repositories should be enabled for in-place upgrades using LEAPP, not the major version repositories.

Fixes: SAT-43595

#### What changes are you introducing?
When upgrading a system, Leapp expects the minor version to be available in the repo baseurl

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
This is being reported repeatedly, for example https://redhat.atlassian.net/browse/SAT-43595

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
