### PR TITLE
Add upgrade warning for Flatpak content

### DIFF
--- a/guides/common/modules/con_planning-project-upgrade.adoc
+++ b/guides/common/modules/con_planning-project-upgrade.adoc
@@ -8,6 +8,19 @@ Upgrading to {Project} {ProjectVersion} affects your entire {Project} infrastruc
 Plan carefully before proceeding.
 
 * Read the {ProjectName} {ProjectVersion} {ReleaseNotesDocURL}[{ReleaseNotesDocTitle}].
+ifdef::katello,orcharhino,satellite[]
++
+[IMPORTANT]
+====
+If you use Flatpak content in your environment, be aware that upgrading to {Project} {ProjectVersion} will prevent your hosts from consuming Flatpak content from {Project}.
+ifdef::katello[]
+For more information, see {ReleaseNotesDocURL}katello-upgrade-warnings[Katello upgrade warnings] in {ReleaseNotesDocTitle}.
+endif::[]
+ifdef::satellite[]
+For more information, see {ReleaseNotesDocURL}Jira-SAT-44554[SAT-44554] in {ReleaseNotesDocTitle}.
+endif::[]
+====
+endif::[]
 * Consider whether any of your integrations need updating.
 Some {Project} API endpoints, Hammer CLI commands, and modules from the {Project} Ansible Collection can differ between versions of {Project}.
 ifdef::satellite[]

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -84,12 +84,22 @@ You can now add the "Last checkin" column to the fields displayed by hammer host
 [id="katello-upgrade-warnings"]
 == Upgrade warnings
 
-To resolve https://github.com/pulp/pulp_rpm/issues/4073[Pulp RPM bug #4073], run the following after upgrading:
+Flatpak content becomes inaccessible after upgrading to Katello {KatelloVersion}::
++
+Upgrading to Katello {KatelloVersion} prevents hosts from consuming Flatpak content managed by your {ProjectServer}. The Flatpak registry static index endpoint located at `https://_{foreman-example-com}_/pulpcore_registry/index/static` returns a server error.
++
+This issue exists because the Pulp Core version included in Katello {KatelloVersion} implements response caching that requires JSON-serializable responses, while the pulp-container FlatpakIndex view returns a Python set in its response data.
++
+No known workaround is available.
 
+Pulp RPM data repair required after upgrading::
++
+To resolve https://github.com/pulp/pulp_rpm/issues/4073[Pulp RPM bug #4073], run the following after upgrading:
++
 ----
 # sudo -u pulp PULP_SETTINGS='/etc/pulp/settings.py' DJANGO_SETTINGS_MODULE='pulpcore.app.settings' pulpcore-manager rpm-datarepair 4073
 ----
-
++
 For more information, see https://projects.theforeman.org/issues/39108[#39108].
 
 [id="katello-deprecations"]


### PR DESCRIPTION
#### What changes are you introducing?

Adding an upgrade warning for a Flatpak consumption issue.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Warns users that upgrading breaks Flatpak content consumption due to a Pulp Core compatibility issue with no available workaround.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Normally I would say that a release note is enough but this particular known issue could preset a sever limitation to some users' workflow so IMO the duplication is worth it.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
