### PR TITLE
Reword EL8 and above due to lack of EL7

### DIFF
--- a/guides/common/modules/proc_configuring-openvox-agent-on-a-host-manually.adoc
+++ b/guides/common/modules/proc_configuring-openvox-agent-on-a-host-manually.adoc
@@ -40,13 +40,13 @@ endif::[]
 endif::[]
 ifndef::orcharhino,satellite[]
 . Install the OpenVox agent package:
-* On hosts running {EL} 8 and above:
+* On hosts running {EL}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {client-package-install-el8} openvox-agent
 ----
-* On hosts running Debian:
+* On hosts running Debian/Ubuntu:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Remove "and above" if there's no above

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's only EL8+ Clients; so "EL8 and above" is always true.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs 45b956c62dd6521a96825adecc0916e6d55b8ae9
Refs PR 4766

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
