### PR TITLE
Switch to English Service Portal for orcharhino

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -52,10 +52,10 @@
 // Overwrite to avoid "Insights on Foreman"
 :insights-iop: {Insights} in {Project}
 // KB articles
-:atix-kb-clients: https://atixservice.zendesk.com/hc/de/articles/19430263501468[{Project} Clients gen3]
-:atix-kb-debian-ubuntu-installation-media: https://atixservice.zendesk.com/hc/de/articles/7044086506908[Using file repositories for installation media for Debian/Ubuntu]
-:atix-kb-register-to-occ: https://atixservice.zendesk.com/hc/de/articles/9464966748444[Registering {ProjectServer} to OCC]
-:atix-kb-tech-previews: https://atixservice.zendesk.com/hc/de/articles/16772654610844[Technical Previews]
+:atix-kb-clients: https://atixservice.zendesk.com/hc/en-001/articles/19430263501468[{Project} Clients gen3]
+:atix-kb-debian-ubuntu-installation-media: https://atixservice.zendesk.com/hc/en-001/articles/7044086506908[Using file repositories for installation media for Debian/Ubuntu]
+:atix-kb-register-to-occ: https://atixservice.zendesk.com/hc/en-001/articles/9464966748444[Registering {ProjectServer} to OCC]
+:atix-kb-tech-previews: https://atixservice.zendesk.com/hc/en-001/articles/16772654610844[Technical Previews]
 // Overwritten in downstream for docs.orcharhino.com
 :client-package-install: dnf install
 :client-package-remove: dnf remove

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -19,6 +19,6 @@ ignore=example.com
   forge.puppetlabs.com
   sources/
   tuxcare.com/enterprise-live-patching-services
-  atixservice.zendesk.com
+  atixservice.zendesk.com/hc/en-001/articles/
   # 6.19 docs are not yet published
   docs.redhat.com/en/documentation/red_hat_satellite/6.19


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that all links for orcharhino builds to Zendesk are in English. The longer URL in the linkcheck exceptions ensures that old links would case the linkchecker to fail.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

ATIX Service Portal switches from German to English.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

````
$ sed --in-place "s@/hc/de/articles/@/hc/en-001/articles/@g" guides/common/attributes-orcharhino.adoc
````

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
