### PR TITLE
Add initial organization and location values for foremanctl

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -88,7 +88,12 @@
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy
 :install-on-os: {EL}
+ifdef::foremanctl[]
+:installer-log-file: /var/log/foremanctl/foremanctl.log
+endif::[]
+ifndef::foremanctl[]
 :installer-log-file: /var/log/foreman-installer/foreman.log
+endif::[]
 // this is foreman-installer or foreman-installer --scenario MyScenario if there are multiple
 :installer-scenario: {foreman-installer}
 :installer-scenario-smartproxy: {foreman-installer} --no-enable-foreman --no-enable-foreman-plugin-puppet --no-enable-foreman-cli --no-enable-foreman-cli-puppet

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -84,8 +84,9 @@
 :FreeIPA-context: Identity_Management
 :freeipaserver-example-com: idm-server.example.com
 :hammer-smart-proxy: hammer capsule
+ifndef::foremanctl[]
 :installer-log-file: /var/log/foreman-installer/satellite.log
-:foremanctl-log-file: /var/log/foremanctl/foremanctl.log
+endif::[]
 :installer-scenario-smartproxy: {foreman-installer} --scenario capsule
 :installer-scenario: {foreman-installer} --scenario satellite
 :installer-smartproxy-log-file: /var/log/foreman-installer/capsule.log

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
@@ -6,14 +6,10 @@
 [role="_abstract"]
 By default, the {Project} deployment includes installing a PostgreSQL database on the same host as {ProjectServer}.
 However, in certain {Project} deployments, using external databases instead of the default local databases can help with the server load or have other benefits.
+
 To extend the default deployment, you can select one or more features or add one or more configuration options.
 
-[NOTE]
-====
-Any additional run of the `{foremanctl-installer} deploy` command overwrites the corresponding configuration options and records them in the {Project} answer file.
-This way, you can restore a broken system or add additional settings to your deployment.
-//For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
-====
+include::snip_foremanctl-deploy-overwrites-note.adoc[]
 
 .Prerequisites
 * You have considered whether using an external database is beneficial for your use case.
@@ -46,23 +42,23 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foremanctl-installer} deploy \
---foreman-initial-admin-username _My_admin_user_name_ \
---foreman-initial-admin-password _My_admin_password_ \
+--foreman-initial-admin-username _My_Admin_User_Name_ \
+--foreman-initial-admin-password _My_Admin_Password_ \
 --database-mode external \
---database-host _My_database_host_ \
---database-port _My_database_port_ \
+--database-host _My_Database_Host_ \
+--database-port _My_Database_Port_ \
 --database-ssl-mode {disable,allow,prefer,require,verify-ca,verify-full} \
---database-ssl-ca _My_database_ssl_ca_ \
---candlepin-database-name _My_candlepin_database_name_ \
---candlepin-database-password _My_candlepin_database_password_ \
---candlepin-database-user _My_candlepin_database_user_ \
---pulp-database-name _My_pulp_database_name_ \
---pulp-database-password _My_pulp_database_password_ \
---pulp-database-user _My_pulp_database_user_ \
---pulp-worker-count _My_pulp_worker_count_ \
---foreman-database-name _My_foreman_database_name_ \
---foreman-database-user _My_foreman_database_user_ \
---foreman-database-password _My_foreman_database_password_
+--database-ssl-ca _My_Database_SSL_CA_ \
+--candlepin-database-name _My_Candlepin_Database_Name_ \
+--candlepin-database-password _My_Candlepin_Database_Password_ \
+--candlepin-database-user _My_Candlepin_Database_User_ \
+--pulp-database-name _My_Pulp_Database_Name_ \
+--pulp-database-password _My_Pulp_Database_Password_ \
+--pulp-database-user _My_Pulp_Database_User_ \
+--pulp-worker-count _My_Pulp_Worker_Count_ \
+--foreman-database-name _My_Foreman_Database_Name_ \
+--foreman-database-user _My_Foreman_Database_User_ \
+--foreman-database-password _My_Foreman_Database_Password_
 ----
 +
 The script displays its progress and writes logs to `{installer-log-file}`.

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
@@ -44,6 +44,8 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 # {foremanctl-installer} deploy \
 --foreman-initial-admin-username _My_Admin_User_Name_ \
 --foreman-initial-admin-password _My_Admin_Password_ \
+--initial-organization _"My_Organization"_ \
+--initial-location _"My_Location"_ \
 --database-mode external \
 --database-host _My_Database_Host_ \
 --database-port _My_Database_Port_ \
@@ -60,6 +62,8 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 --foreman-database-user _My_Foreman_Database_User_ \
 --foreman-database-password _My_Foreman_Database_Password_
 ----
++
+include::snip_initial-organization-note.adoc[]
 +
 The script displays its progress and writes logs to `{installer-log-file}`.
 

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
@@ -5,16 +5,12 @@
 
 [role="_abstract"]
 You can deploy a {ProjectServer} in a default configuration by using the `{foremanctl-installer} deploy` command.
+
 To extend the default deployment, you can select one or more features or add one or more configuration options.
 
 The initial deployment also installs PostgreSQL databases on the same server.
 
-[NOTE]
-====
-Any additional run of the `{foremanctl-installer} deploy` command overwrites the corresponding configuration options and records them in the `parameters.yaml` file.
-This way, you can restore a broken system or add additional settings to your deployment.
-//For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
-====
+include::snip_foremanctl-deploy-overwrites-note.adoc[]
 
 .Prerequisites
 * Your system conforms with the requirements.
@@ -43,8 +39,8 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foremanctl-installer} deploy \
---foreman-initial-admin-username _My_admin_user_name_ \
---foreman-initial-admin-password _My_admin_password_
+--foreman-initial-admin-username _My_Admin_User_Name_ \
+--foreman-initial-admin-password _My_Admin_Password_
 ----
 +
 The script displays its progress and writes logs to `{installer-log-file}`.

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
@@ -40,8 +40,12 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 ----
 # {foremanctl-installer} deploy \
 --foreman-initial-admin-username _My_Admin_User_Name_ \
---foreman-initial-admin-password _My_Admin_Password_
+--foreman-initial-admin-password _My_Admin_Password_ \
+--initial-organization _"My_Organization"_ \
+--initial-location _"My_Location"_
 ----
++
+include::snip_initial-organization-note.adoc[]
 +
 The script displays its progress and writes logs to `{installer-log-file}`.
 

--- a/guides/common/modules/snip_foremanctl-deploy-overwrites-note.adoc
+++ b/guides/common/modules/snip_foremanctl-deploy-overwrites-note.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 [NOTE]
 ====
 Any additional run of the `{foremanctl-installer} deploy` command overwrites the corresponding configuration options and records them in the `parameters.yaml` file.

--- a/guides/common/modules/snip_foremanctl-deploy-overwrites-note.adoc
+++ b/guides/common/modules/snip_foremanctl-deploy-overwrites-note.adoc
@@ -1,0 +1,6 @@
+[NOTE]
+====
+Any additional run of the `{foremanctl-installer} deploy` command overwrites the corresponding configuration options and records them in the `parameters.yaml` file.
+This way, you can restore a broken system or add additional settings to your deployment.
+//For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
+====

--- a/guides/common/modules/snip_initial-organization-note.adoc
+++ b/guides/common/modules/snip_initial-organization-note.adoc
@@ -1,0 +1,14 @@
+[NOTE]
+====
+Specify a meaningful value for the `--initial-organization` option.
+This can be your company name.
+ifdef::katello,satellite,orcharhino[]
+The `{foremanctl-installer}` tool creates an internal label that matches the value, and you cannot change it later.
+If you do not specify a value, an organization called *Default Organization* with the label *Default_Organization* is created.
+You can rename the organization name but not the label.
+endif::[]
+ifndef::katello,satellite,orcharhino[]
+If you do not specify a value, an organization called *Default Organization* is created.
+You can change the organization name later.
+endif::[]
+====

--- a/guides/common/modules/snip_initial-organization-note.adoc
+++ b/guides/common/modules/snip_initial-organization-note.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 [NOTE]
 ====
 Specify a meaningful value for the `--initial-organization` option.


### PR DESCRIPTION
#### What changes are you introducing?
Add the --inital-organization and --initial-location parameters to foremanctl docs, including the note about not being able to change the label.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-44441

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Also split the abstracts to comply with the CQA rule of max. 2 sentences per abstract.

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
