### PR TITLE
Hide CentOS Linux as CentOS Linux 7 is EoL

### DIFF
--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -162,13 +162,12 @@ ifndef::satellite[]
 Enterprise Linux:: An umbrella term for the following {RHEL}-like operating systems:
 
 * AlmaLinux
-* CentOS Linux
 * CentOS Stream
 * Oracle Linux
 * {RHEL}
 * Rocky Linux
 
-ifndef::satellite,orcharhino[]
+ifndef::orcharhino[]
 +
 {Project} is tested on AlmaLinux and CentOS Stream.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

There is no Community-supported version of CentOS Linux anymore. This patch also simplifies the "ifndef" macros.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

"CentOS Linux is dead; long live CentOS Stream" or something similar.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
