### PR TITLE
Use "client-os" attribute where possible

### DIFF
--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -143,6 +143,7 @@ Possible values:
 | Needed security errata | Error | 3
 |===
 
+ifeval::["{client-os}" == "{RHEL}"]
 RHEL Lifecycle::
 Indicates the current state of the {RHEL} operating system installed on the host.
 +
@@ -159,6 +160,7 @@ Possible values:
 | Approaching end of support | Warning | 5
 | Support ended | Error | 6
 |===
+endif::[]
 
 Traces::
 Indicates if the host needs a reboot or a process restart.

--- a/guides/common/modules/con_resolving-package-dependencies.adoc
+++ b/guides/common/modules/con_resolving-package-dependencies.adoc
@@ -45,31 +45,31 @@ For example, if you create a filter for security purposes but enable dependency 
 To mitigate this problem, carefully test filtering rules to determine the required dependencies.
 If dependency solving includes unwanted packages, manually identify the core basic dependencies that the extra packages and errata need.
 
-ifeval::["{client-os-family}" == "Red Hat"]
+ifeval::["{client-os}" == "{RHEL}"]
 [id="Combining_exclusion_filters_with_dependency_solving_{context}"]
 .Combining exclusion filters with dependency solving
 ====
-For example, you can recreate {RHEL}{nbsp}8.3 by using content view filters and include selected errata from a later {RHEL}{nbsp}8 minor release.
-To achieve this, you create filters to exclude most of the errata after the {RHEL}{nbsp}8.3 release date, except a few that you need.
+For example, you can recreate {client-os}{nbsp}9.3 by using content view filters and include selected errata from a later {client-os}{nbsp}9 minor release.
+To achieve this, you create filters to exclude most of the errata after the {client-os}{nbsp}9.3 release date, except a few that you need.
 Then, you enable dependency solving.
 
 In this situation, dependency solving might include more packages than expected.
-As a result, the host diverges from {RHEL}{nbsp}8.3 machines.
+As a result, the host diverges from {client-os}{nbsp}9.3 machines.
 
 If you do not need the extra errata and packages, do not configure content view filtering.
-Instead, enable and use the {RHEL}{nbsp}8.3 repository on the *Content* > *Red Hat Repositories* page in the {ProjectWebUI}.
+Instead, enable and use the {client-os}{nbsp}9.3 repository on the *Content* > *Red Hat Repositories* page in the {ProjectWebUI}.
 ====
 endif::[]
 
-ifeval::["{client-os-family}" == "Red Hat"]
+ifeval::["{client-os}" == "{RHEL}"]
 [id="Excluding_packages_and_dependency_solving_with_DNF_{context}"]
 .Excluding packages sometimes makes dependency solving impossible for DNF
 ====
-If you create {RHEL}{nbsp}8.3 repositories with a few excluded packages, `dnf upgrade` can sometimes fail.
+If you create {client-os}{nbsp}9.3 repositories with a few excluded packages, `dnf upgrade` can sometimes fail.
 
 Do not enable dependency solving to resolve the problem.
 Instead, investigate the error from `dnf` and adjust the filters to stop excluding the missing dependency.
 
-Else, dependency solving might cause the repository to diverge from {RHEL}{nbsp}8.3.
+Else, dependency solving might cause the repository to diverge from {client-os}{nbsp}9.3.
 ====
 endif::[]

--- a/guides/common/modules/proc_configuring-ipxe-environment.adoc
+++ b/guides/common/modules/proc_configuring-ipxe-environment.adoc
@@ -9,7 +9,7 @@ Configure an iPXE environment on all {SmartProxies} that you want to use for iPX
 ifndef::foreman-deb[]
 [IMPORTANT]
 ====
-In {EL}, security-related features of iPXE are not supported and the iPXE binary is built without security features.
+In {install-on-os}, security-related features of iPXE are not supported and the iPXE binary is built without security features.
 For this reason, you can only use HTTP but not HTTPS.
 ifdef::satellite[]
 For more information, see https://access.redhat.com/solutions/3483601[{RHEL} HTTPS support in iPXE].

--- a/guides/common/modules/proc_preparing-an-image-to-use-the-cloud-init-template.adoc
+++ b/guides/common/modules/proc_preparing-an-image-to-use-the-cloud-init-template.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 To prepare an image, you must first configure the settings that you require on a virtual machine that you can then save as an image to use in {Project}.
 
-ifndef::satellite[]
+ifndef::orcharhino,satellite[]
 These instructions are for {EL} or Fedora, follow similar steps for other Linux distributions.
 endif::[]
 

--- a/guides/common/modules/proc_provisioning-from-a-builder-image-on-an-http-server.adoc
+++ b/guides/common/modules/proc_provisioning-from-a-builder-image-on-an-http-server.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 You can upload a {LoraxCompose} image to an HTTP server and use this image to provision hosts by using network boot.
 
-ifndef::satellite[]
+ifndef::orcharhino,satellite[]
 [NOTE]
 ====
 This feature is available for {EL} hosts only.

--- a/guides/common/modules/proc_provisioning-from-a-builder-image-on-smartproxy.adoc
+++ b/guides/common/modules/proc_provisioning-from-a-builder-image-on-smartproxy.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 You can upload a {LoraxCompose} image to {Project} and use this image to provision hosts by using network boot.
 
-ifndef::satellite[]
+ifndef::orcharhino,satellite[]
 [NOTE]
 ====
 This feature is available for {EL} hosts only.


### PR DESCRIPTION
#### What changes are you introducing?

Use `client-os` attribute in favor of `EL` where possible.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In downstream, the Client OS differs from the EL attribute.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Please review commit by commit.

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
