### PR TITLE
Users cannot push containers to docker type repositories with upstream URL synced to Foreman+Katello (SAT-44672)

### DIFF
--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -16,8 +16,8 @@ The Container Gateway is available by default on {SmartProxies} with content.
 endif::[]
 
 Considerations for pushing content to the {Project} container registry::
-* You can only push content to the {ProjectServer} itself.
 * Containers cannot be pushed to synced repositories.
+* You can only push content to the {ProjectServer} itself.
 If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
 * The pushed container registry name must contain only lowercase characters.
 * Unless pushed repositories are published in a content view version, they do not follow the registry name pattern.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -17,6 +17,7 @@ endif::[]
 
 Considerations for pushing content to the {Project} container registry::
 * You can only push content to the {ProjectServer} itself.
+* Containers cannot be pushed to synced repositories.
 If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
 * The pushed container registry name must contain only lowercase characters.
 * Unless pushed repositories are published in a content view version, they do not follow the registry name pattern.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -16,7 +16,7 @@ The Container Gateway is available by default on {SmartProxies} with content.
 endif::[]
 
 Considerations for pushing content to the {Project} container registry::
-* You cannot push containers to repositories that are synchronized from an upstream URL.
+* You cannot push to repositories created by the general repositories endpoints, only to repositories created by the container push workflow.
 * You can only push content to the {ProjectServer} itself.
 If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
 * The pushed container registry name must contain only lowercase characters.

--- a/guides/common/modules/proc_using-container-registries.adoc
+++ b/guides/common/modules/proc_using-container-registries.adoc
@@ -16,7 +16,7 @@ The Container Gateway is available by default on {SmartProxies} with content.
 endif::[]
 
 Considerations for pushing content to the {Project} container registry::
-* Containers cannot be pushed to synced repositories.
+* You cannot push containers to repositories that are synchronized from an upstream URL.
 * You can only push content to the {ProjectServer} itself.
 If you need pushed content on {SmartProxyServers} as well, use {SmartProxy} syncing.
 * The pushed container registry name must contain only lowercase characters.


### PR DESCRIPTION
Implementing feedback from issue https://github.com/theforeman/foreman-documentation/issues/4776. 

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
