### PR TITLE
Limit PR labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,10 @@
 Needs tech review:
 - changed-files:
-  - any-glob-to-any-file: ['**']
+  - any-glob-to-any-file: ['guides/**']
 
 Needs style review:
 - changed-files:
-  - any-glob-to-any-file: ['**']
+  - any-glob-to-any-file: ['guides/**']
 
 Needs testing:
 - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,4 +8,4 @@ Needs style review:
 
 Needs testing:
 - changed-files:
-  - any-glob-to-any-file: ['guides/**']
+  - any-glob-to-any-file: ['guides/common/assembly_*.adoc','guides/common/modules/proc_*.adoc']


### PR DESCRIPTION
#### What changes are you introducing?

- Limiting PRs that will be labeled as **Needs tech review** and **Needs style review** to changes under the `guides/` folder
- Limiting PRs that will be labeled as **Needs testing** to changes in procedure modules

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Changes outside the `guides/` folder don't really need formal tech/style reviews, just community agreement
- Testing is typically only needed for procedures

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **Not sure how far we label**

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
