### PR TITLE
Update host actions to the new UI

### DIFF
--- a/guides/common/modules/proc_assigning-a-host-to-a-specific-location.adoc
+++ b/guides/common/modules/proc_assigning-a-host-to-a-specific-location.adoc
@@ -13,19 +13,19 @@ You can assign a host to a different location so that the host is managed under 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the checkbox of the host you want to change.
-. From the *Select Action* list, select *Assign Location*.
+. From the options menu, select *Change associations* > *Location*.
 A new option window opens.
-. Navigate to the *Select Location* list and choose the location that you want for your host.
-Select the checkbox *Fix Location on Mismatch*.
+. Select the location that you want for your host.
+Select the checkbox *Fix on mismatch*.
 +
 [NOTE]
 ====
 A mismatch happens if there is a resource associated with a host, such as a domain or subnet, and at the same time not associated with the location you want to assign the host to.
-The option *Fix Location on Mismatch* will add such a resource to the location, and is therefore the recommended choice.
-The option *Fail on Mismatch* will always result in an error message.
+The option *Fix on mismatch* will add such a resource to the location, and is therefore the recommended choice.
+The option *Fail on mismatch* will always result in an error message.
 For example, reassigning a host from one location to another will fail, even if there is no actual mismatch in settings.
 ====
-. Click *Submit*.
+. Click *Change location*.
 
 .Additional resources
 ifdef::satellite[]

--- a/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
+++ b/guides/common/modules/proc_assigning-a-host-to-a-specific-organization.adoc
@@ -20,19 +20,19 @@ After you assign the host to a new organization, you can re-register the host.
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the checkbox of the host you want to change.
-. From the *Select Action* list, select *Assign Organization*.
+. From the options menu, select *Change associations* > *Organization*.
 A new option window opens.
-. From the *Select Organization* list, select the organization that you want to assign your host to.
-Select the checkbox *Fix Organization on Mismatch*.
+. Select the organization that you want to assign your host to.
+Select *Fix on mismatch*.
 +
 [NOTE]
 ====
 A mismatch happens if there is a resource associated with a host, such as a domain or subnet, and at the same time not associated with the organization you want to assign the host to.
-The option *Fix Organization on Mismatch* will add such a resource to the organization, and is therefore the recommended choice.
-The option *Fail on Mismatch* will always result in an error message.
+The option *Fix on mismatch* will add such a resource to the organization, and is therefore the recommended choice.
+The option *Fail on mismatch* will always result in an error message.
 For example, reassigning a host from one organization to another will fail, even if there is no actual mismatch in settings.
 ====
-. Click *Submit*.
+. Click *Change organization*.
 
 .Additional resources
 ifdef::satellite[]

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
@@ -27,6 +27,7 @@ This repository is required for installing the SCAP client.
 . Optional: On the *Parameters* tab, configure any Ansible variables of the role.
 . Click *Submit* to save your changes.
 . Click the *Hosts* breadcrumbs link to navigate back to the host index page.
+. From the top options menu, select *Legacy UI*.
 . Select the host or hosts to which you want to add the policy.
 . Click *Select Action*.
 . Select *Assign Compliance Policy* from the list.

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
@@ -27,6 +27,7 @@ This repository is required for installing the SCAP client.
 . On the *Puppet ENC* tab, add the `foreman_scap_client` Puppet class.
 . Optional: Configure any *Puppet Class Parameters*.
 . Click the *Hosts* breadcrumbs link to navigate back to the host index page.
+. From the top options menu, select *Legacy UI*.
 . Select the host or hosts to which you want to add the policy.
 . Click *Select Action*.
 . Select *Assign Compliance Policy* from the list.

--- a/guides/common/modules/proc_disassociating-a-vm-from-project-without-removing-it-from-a-hypervisor.adoc
+++ b/guides/common/modules/proc_disassociating-a-vm-from-project-without-removing-it-from-a-hypervisor.adoc
@@ -9,7 +9,6 @@ This does not delete the VM from its hypervisor.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
-. Select the checkbox to the left of the hosts that you want to disassociate.
-. From the *Select Action* list, click *Disassociate Hosts*.
-. Optional: Select the checkbox to keep the hosts for future action.
-. Click *Submit*.
+. Select the hosts that you want to disassociate.
+. From the options menu, select *Disassociate hosts*.
+. Click *Disassociate*.

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -28,7 +28,7 @@ endif::[]
 . Select the organization where you want to assign this {SmartProxy}.
 . Select *Fix on mismatch*.
 . Click *Change organization*.
-. Select {SmartProxyServer}. From the options menu, select *Change associations* > *Location*.
+. From the options menu, select *Change associations* > *Location*.
 . Select the location where you want to assign this {SmartProxy}.
 . Select *Fix on mismatch*.
 . Click *Change location*.

--- a/guides/common/modules/proc_enabling-capsule-in-UI.adoc
+++ b/guides/common/modules/proc_enabling-capsule-in-UI.adoc
@@ -24,14 +24,14 @@ endif::[]
 . From the *Organization* list in the upper-left of the screen, select *Any Organization*.
 . From the *Location* list in the upper-left of the screen, select *Any Location*.
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select {SmartProxyServer}.
-. From the *Select Actions* list, select *Assign Organization*.
-. From the *Organization* list, select the organization where you want to assign this {SmartProxy}.
-. Click *Fix Organization on Mismatch*.
-. Click *Submit*.
-. Select {SmartProxyServer}. From the *Select Actions* list, select *Assign Location*.
-. From the *Location* list, select the location where you want to assign this {SmartProxy}.
-. Click *Fix Location on Mismatch*.
-. Click *Submit*.
+. From the options menu, select *Change associations* > *Organization*.
+. Select the organization where you want to assign this {SmartProxy}.
+. Select *Fix on mismatch*.
+. Click *Change organization*.
+. Select {SmartProxyServer}. From the options menu, select *Change associations* > *Location*.
+. Select the location where you want to assign this {SmartProxy}.
+. Select *Fix on mismatch*.
+. Click *Change location*.
 . In the {ProjectWebUI}, navigate to *Administer* > *Organizations* and click the organization to which you have assigned {SmartProxy}.
 . Click *{SmartProxies}* tab and ensure that {SmartProxyServer} is listed under the *Selected items* list, then click *Submit*.
 . In the {ProjectWebUI}, navigate to *Administer* > *Locations* and click the location to which you have assigned {SmartProxy}.

--- a/guides/common/modules/proc_removing-a-host-from-server-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_removing-a-host-from-server-by-using-web-ui.adoc
@@ -12,5 +12,6 @@ include::snip_warning-destroy-vm-on-host-delete.adoc[]
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the hosts that you want to remove.
-. From the *Select Action* list, select *Delete Hosts*.
-. Click *Submit* to remove the host from {Project} permanently.
+. From the options menu, select *Delete*.
+. Select the checkbox *I understand that this action cannot be undone*.
+. Click *Delete* to remove the host from {Project} permanently.

--- a/guides/common/modules/proc_running-ansible-roles-on-a-host.adoc
+++ b/guides/common/modules/proc_running-ansible-roles-on-a-host.adoc
@@ -13,7 +13,8 @@ For more information, see xref:Configuring_Your_{project-context}_to_Run_Ansible
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
-. Select the checkbox of the host that contains the Ansible role you want to run.
-. From the *Select Action* list, select *Run all Ansible roles*.
-. You can view the status of your Ansible job on the *Run Ansible roles* page.
-To rerun a job, click *Rerun*.
+. Select the host on which you want to run the assigned Ansible roles.
+. From the *Schedule a job* menu, select *Run Ansible roles*.
+
+.Verification
+* You can view the status of your Ansible job by navigating to *Monitor* > *Jobs*.


### PR DESCRIPTION
#### What changes are you introducing?

Updating procedure steps to navigate the new host actions menu on the new hosts overview page

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The new hosts overview page has beed redesigned and made the default in 3.16.

[SAT-44566](https://redhat.atlassian.net/browse/SAT-44566)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I've looked up all modules containing "Select Action" and "All Hosts". I hope that's all.
- This shouldn't need testing - I've followed the UI rigorously.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
