### PR TITLE
Delete satellite-maintain packages remove

### DIFF
--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -105,7 +105,6 @@ endif::[]
 :OpenStack: Red{nbsp}Hat OpenStack Services on OpenShift
 :project-package-check-update: satellite-maintain packages check-update
 :project-package-install: satellite-maintain packages install
-:project-package-remove: satellite-maintain packages remove
 :project-package-update: satellite-maintain packages update
 :package-install: dnf install
 :package-upgrade: dnf upgrade


### PR DESCRIPTION
#### What changes are you introducing?
Delete the attribute value for `satellite-maintain packages remove` so that satellite always uses the `dnf remove` command.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
The command never existed in satellite.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
https://redhat.atlassian.net/browse/SAT-44436

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6 and 7.7)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
