### PR TITLE
Ensure attribute links get picked up by ConceptLink

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -31,7 +31,7 @@
 :UpgradingDisconnectedDocURL: {BaseURL}Upgrading_Project_Disconnected/{BaseFilenameURL}#
 
 // Red Hat specific URLs
-:RHDocsBaseURL: https://docs.redhat.com/en/documentation/
+:RHDocsBaseURL: docs.redhat.com/en/documentation/
 :RHELDocsBaseURL: {RHDocsBaseURL}red_hat_enterprise_linux/
 
 // Repositories and subscriptions (used both upstream and Satellite guides)

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -2,7 +2,7 @@
 
 :upstream-ProjectVersion: {ProjectVersion}
 // Overrides for orcharhino build
-:BaseURL: https://docs.orcharhino.com/
+:BaseURL: docs.orcharhino.com/
 :ProjectVersion: 7.9
 :ProjectVersionPrevious: 7.8
 :ProjectVersionPrevious-Previous: 7.7

--- a/guides/common/attributes.adoc
+++ b/guides/common/attributes.adoc
@@ -65,7 +65,7 @@ ifeval::["{build}" == "orcharhino"]
 endif::[]
 
 // Load base attributes
-:SiteURL: https://docs.theforeman.org
+:SiteURL: docs.theforeman.org
 :BaseURL: {SiteURL}/{ProjectVersion}/
 include::attributes-base.adoc[]
 include::attributes-typography.adoc[]

--- a/guides/common/modules/con_user-groups.adoc
+++ b/guides/common/modules/con_user-groups.adoc
@@ -6,6 +6,6 @@
 [role="_abstract"]
 With {Project}, you can assign permissions to groups of users.
 You can also create user groups as collections of other user groups.
-If you use an external authentication source, you can map {Project} user groups to external user groups as described in {ConfiguringUserAuthenticationDocURL}Configuring_External_User_Groups_authentication[Configuring external user groups] in _{ConfiguringUserAuthenticationDocTitle}_.
+If you use an external authentication source, you can map {Project} user groups to external user groups as described in https://{ConfiguringUserAuthenticationDocURL}Configuring_External_User_Groups_authentication[Configuring external user groups] in _{ConfiguringUserAuthenticationDocTitle}_.
 
 User groups are defined in an organizational context, meaning that you must select an organization before you can access user groups.


### PR DESCRIPTION
#### What changes are you introducing?

Moving `https://` out of link attributes and into the modules.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/jhradilek/asciidoctor-dita-vale/issues/186

Per asciidoctor-dita-vale rules, links and cross-references are not allowed in concept modules. Right now, we often include links as attributes (such as `{ManagingContentDocURL}`) and these don't get picked up by the ConceptLink rule. Moving the `https://` URI from attributes to the text ensures that the links get picked up by Vale.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
