### PR TITLE
wip: TOC checking CI

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -47,3 +47,53 @@ jobs:
       - name: Check HTML links of all builds
         run: |
           make linkchecker-tryer
+
+  theme-link-check:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: guides
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Build satellite docs
+        run: |
+          bundle exec make -j ${{ env.MAKE_J }} html BUILD=satellite LINKS=local
+
+      - name: Extract TOC
+        run: |
+          mkdir -p build/ci-toc
+          bundle exec ruby scripts/extract_links_toc \
+              --f2l upstream_filename_to_satellite_link.json \
+              --output-toc-file build/ci-toc/toc.json \
+              --output-aliases-file build/ci-toc/aliases.json \
+              build/**/index-satellite.html
+
+      - name: Stage documentation TOC for CI artifact
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/toc-artifact"
+          cp build/ci-toc/toc.json build/ci-toc/aliases.json "${GITHUB_WORKSPACE}/toc-artifact/"
+
+      - name: Upload documentation TOC
+        uses: actions/upload-artifact@v7
+        with:
+          name: documentation-toc
+          path: toc-artifact
+          if-no-files-found: error
+
+  foreman-theme-satellite-plugin:
+    needs: theme-link-check
+    # TODO
+    # uses: theforeman/foreman_theme_satellite/.github/workflows/toc-check.yml@develop
+    uses: adamruzicka/foreman_theme_satellite/.github/workflows/toc-check.yml@ci
+    secrets: inherit
+    with:
+      documentation_toc_artifact: documentation-toc

--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -66,6 +66,9 @@ jobs:
 
       - name: Build satellite docs
         run: |
+          # Undo the "satellite is always containerized" overrides
+          sed -e '/:containerized:/d' -e '/include::attributes-containerized/d' -i common/attributes-satellite.adoc
+
           bundle exec make -j ${{ env.MAKE_J }} html BUILD=satellite LINKS=local
 
       - name: Extract TOC


### PR DESCRIPTION
TODOs:
- [x] properly fill in the description template
- [ ] rename the individual jobs to something more sensible

#### What changes are you introducing?
Adding a CI check that verifies that all the headings that the satellite branding plugin links to remain in place. It does so by:
- building the satellite flavour of the docs
- extracting TOC and aliases from the built html
- runs the TOC checking rake from foreman_theme_satellite

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Every now and then seemingly innocent changes break the documentation link, leading to unnecessary back and forth. This change moves the check closer to the source.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
For the time being, this is just a proof of concept. We may eventually find out it is too heavy handed.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.

This should go all the way back to 3.16 probably, but there will be some changes needed to get the branches right.
