### PR TITLE
Replace instances of "vertical ellipsis" with "options icon"

### DIFF
--- a/guides/common/modules/proc_adding-a-host-to-a-host-collection-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-a-host-to-a-host-collection-by-using-web-ui.adoc
@@ -15,6 +15,6 @@ For more information about registering hosts, see xref:registering-hosts-by-usin
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. In the *Host collections* card, click the vertical ellipsis and select *Add host to collections*.
+. In the *Host collections* card, open the options icon and select *Add host to collections*.
 . Select the host collection.
 . Click *Add*.

--- a/guides/common/modules/proc_adding-a-host-to-a-host-collection-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-a-host-to-a-host-collection-by-using-web-ui.adoc
@@ -15,6 +15,6 @@ For more information about registering hosts, see xref:registering-hosts-by-usin
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. In the *Host collections* card, open the options icon and select *Add host to collections*.
+. In the *Host collections* card, open the options menu and select *Add host to collections*.
 . Select the host collection.
 . Click *Add*.

--- a/guides/common/modules/proc_applying-errata-to-a-host.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host.adoc
@@ -12,5 +12,5 @@ To patch security vulnerabilities and bugs, you can apply errata to a host.
 . Click *Content* and select the *Errata* tab.
 . Select the errata you want to apply to the host, or select the checkbox at the top of the list to apply all installable errata.
 Click the checkbox next to any errata you want to remove from a full list.
-. Using the vertical ellipsis icon next to the errata you want to apply to the host, select *Apply via Remote Execution* to use Remote Execution, or select *Apply via customized remote execution* if you want to customize the remote execution.
+. Using the options icon next to the errata you want to apply to the host, select *Apply via Remote Execution* to use Remote Execution, or select *Apply via customized remote execution* if you want to customize the remote execution.
 . Click *Submit*.

--- a/guides/common/modules/proc_applying-errata-to-a-host.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host.adoc
@@ -12,5 +12,5 @@ To patch security vulnerabilities and bugs, you can apply errata to a host.
 . Click *Content* and select the *Errata* tab.
 . Select the errata you want to apply to the host, or select the checkbox at the top of the list to apply all installable errata.
 Click the checkbox next to any errata you want to remove from a full list.
-. Using the options icon next to the errata you want to apply to the host, select *Apply via Remote Execution* to use Remote Execution, or select *Apply via customized remote execution* if you want to customize the remote execution.
+. Open the options menu next to the errata you want to apply to the host, and select *Apply via Remote Execution* to use Remote Execution, or select *Apply via customized remote execution* if you want to customize the remote execution.
 . Click *Submit*.

--- a/guides/common/modules/proc_applying-errata-to-a-host.adoc
+++ b/guides/common/modules/proc_applying-errata-to-a-host.adoc
@@ -12,5 +12,5 @@ To patch security vulnerabilities and bugs, you can apply errata to a host.
 . Click *Content* and select the *Errata* tab.
 . Select the errata you want to apply to the host, or select the checkbox at the top of the list to apply all installable errata.
 Click the checkbox next to any errata you want to remove from a full list.
-. Open the options menu next to the errata you want to apply to the host, and select *Apply via Remote Execution* to use Remote Execution, or select *Apply via customized remote execution* if you want to customize the remote execution.
+. Open the options menu next to the errata you want to apply to the host, and select *Apply via Remote Execution* to use remote execution, or select *Apply via customized remote execution* if you want to customize the remote execution.
 . Click *Submit*.

--- a/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
@@ -10,7 +10,7 @@ This helps you balance load or point the host to a closer or preferred content s
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Click the options icon next to the *Edit* button and select *Change content source*.
+. Open the options menu next to the *Edit* button and select *Change content source*.
 . Select *Content Source*, *Lifecycle Content View*, and *Content Source* from the lists.
 . Click *Change content source*.
 +

--- a/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
@@ -10,7 +10,7 @@ This helps you balance load or point the host to a closer or preferred content s
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
-. Click the vertical ellipsis icon next to the *Edit* button and select *Change content source*.
+. Click the options icon next to the *Edit* button and select *Change content source*.
 . Select *Content Source*, *Lifecycle Content View*, and *Content Source* from the lists.
 . Click *Change content source*.
 +

--- a/guides/common/modules/proc_changing-the-module-stream-for-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-module-stream-for-a-host.adoc
@@ -11,5 +11,5 @@ You can enable, disable, install, update, and remove module streams from your ho
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
 . Click the *Content* tab, then click the *Module streams* tab.
-. Click the vertical ellipsis next to the module and select the action you want to perform.
+. Click the options icon next to the module and select the action you want to perform.
 You get a REX job notification once the remote execution job is complete.

--- a/guides/common/modules/proc_changing-the-module-stream-for-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-module-stream-for-a-host.adoc
@@ -11,5 +11,5 @@ You can enable, disable, install, update, and remove module streams from your ho
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
 . Click the *Content* tab, then click the *Module streams* tab.
-. Click the options icon next to the module and select the action you want to perform.
+. Open the options menu next to the module and select the action you want to perform.
 You get a REX job notification once the remote execution job is complete.

--- a/guides/common/modules/proc_copying-a-content-view-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_copying-a-content-view-by-using-web-ui.adoc
@@ -16,7 +16,7 @@ As a result, you cannot promote an older version of a content view from the copi
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select the content view you want to copy.
-. Click the options icon and click *Copy*.
+. Open the options menu and click *Copy*.
 . In the *Name* field, enter a name for the new content view and click *Copy content view*.
 
 .Verification

--- a/guides/common/modules/proc_copying-a-content-view-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_copying-a-content-view-by-using-web-ui.adoc
@@ -16,7 +16,7 @@ As a result, you cannot promote an older version of a content view from the copi
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select the content view you want to copy.
-. Click the vertical ellipsis icon and click *Copy*.
+. Click the options icon and click *Copy*.
 . In the *Name* field, enter a name for the new content view and click *Copy content view*.
 
 .Verification

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
@@ -27,7 +27,7 @@ For example, if your base URL is `\https://{server-example-com}` and your subpat
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*.
-. Click the vertical ellipsis next to the newly created alternate content source and click *Refresh*.
+. Click the options icon next to the newly created alternate content source and click *Refresh*.
 
 .Verification
 . In the {ProjectWebUI}, navigate to *Monitor* > *{Project} Tasks* > *Tasks*.

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
@@ -27,7 +27,7 @@ For example, if your base URL is `\https://{server-example-com}` and your subpat
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*.
-. Click the options icon next to the newly created alternate content source and click *Refresh*.
+. Open the options menu next to the newly created alternate content source and click *Refresh*.
 
 .Verification
 . In the {ProjectWebUI}, navigate to *Monitor* > *{Project} Tasks* > *Tasks*.

--- a/guides/common/modules/proc_creating-a-simplified-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-simplified-alternate-content-source-by-using-web-ui.adoc
@@ -22,7 +22,7 @@ This accelerates synchronization by downloading content directly from the upstre
 . Select the products that should use the alternate content source.
 . Click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*.
-. Click the vertical ellipsis next to the newly created alternate content source and click *Refresh*.
+. Click the options icon next to the newly created alternate content source and click *Refresh*.
 
 .Verification
 . In the {ProjectWebUI}, navigate to *Monitor* > *{Project} Tasks* > *Tasks*.

--- a/guides/common/modules/proc_creating-a-simplified-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-simplified-alternate-content-source-by-using-web-ui.adoc
@@ -22,7 +22,7 @@ This accelerates synchronization by downloading content directly from the upstre
 . Select the products that should use the alternate content source.
 . Click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*.
-. Click the options icon next to the newly created alternate content source and click *Refresh*.
+. Open the options menu next to the newly created alternate content source and click *Refresh*.
 
 .Verification
 . In the {ProjectWebUI}, navigate to *Monitor* > *{Project} Tasks* > *Tasks*.

--- a/guides/common/modules/proc_creating-an-rhui-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-an-rhui-alternate-content-source-by-using-web-ui.adoc
@@ -41,4 +41,4 @@ Ensure that you pass the repo labels of the desired repositories.
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*.
-. Click the options icon next to the newly created alternate content source and click *Refresh*.
+. Open the options menu next to the newly created alternate content source and click *Refresh*.

--- a/guides/common/modules/proc_creating-an-rhui-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-an-rhui-alternate-content-source-by-using-web-ui.adoc
@@ -41,4 +41,4 @@ Ensure that you pass the repo labels of the desired repositories.
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Click *Add*.
 . Navigate to *Content* > *Alternate Content Sources*.
-. Click the vertical ellipsis next to the newly created alternate content source and click *Refresh*.
+. Click the options icon next to the newly created alternate content source and click *Refresh*.

--- a/guides/common/modules/proc_deleting-multiple-content-view-versions.adoc
+++ b/guides/common/modules/proc_deleting-multiple-content-view-versions.adoc
@@ -10,7 +10,7 @@ You can delete multiple content view versions simultaneously.
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select the content view you want to delete versions of.
 . On the *Versions* tab, select the checkbox of the version or versions you want to delete.
-. Click the options icon at the top of the list of content views.
+. Open the options menu at the top of the list of content views.
 . Click *Delete* to open the deletion wizard that shows any affected environments.
 . If there are no affected environments, review the details and click *Delete*.
 . If there are any affected environments, reassign any hosts or activation keys before deletion.

--- a/guides/common/modules/proc_deleting-multiple-content-view-versions.adoc
+++ b/guides/common/modules/proc_deleting-multiple-content-view-versions.adoc
@@ -10,7 +10,7 @@ You can delete multiple content view versions simultaneously.
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select the content view you want to delete versions of.
 . On the *Versions* tab, select the checkbox of the version or versions you want to delete.
-. Click the vertical ellipsis icon at the top of the list of content views.
+. Click the options icon at the top of the list of content views.
 . Click *Delete* to open the deletion wizard that shows any affected environments.
 . If there are no affected environments, review the details and click *Delete*.
 . If there are any affected environments, reassign any hosts or activation keys before deletion.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
@@ -11,4 +11,4 @@ This affects which packages are available for installation or upgrade on the hos
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*,
 . Select a host.
 . On the *Content* tab, click the *Repository sets* tab.
-. Click the vertical ellipsis to choose *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.
+. Click the options icon to choose *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
@@ -11,4 +11,4 @@ This affects which packages are available for installation or upgrade on the hos
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*,
 . Select a host.
 . On the *Content* tab, click the *Repository sets* tab.
-. Click the options icon to choose *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.
+. Click the options icon and select *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.

--- a/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-and-disabling-repositories-on-hosts.adoc
@@ -11,4 +11,4 @@ This affects which packages are available for installation or upgrade on the hos
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*,
 . Select a host.
 . On the *Content* tab, click the *Repository sets* tab.
-. Click the options icon and select *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.
+. Open the options menu and select *Override to disabled* or *Override to enabled* to disable or enable repositories on hosts.

--- a/guides/common/modules/proc_enabling-custom-repositories-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-custom-repositories-on-hosts.adoc
@@ -11,4 +11,5 @@ This allows the host to install packages or consume other content from repositor
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select a host.
 . Select the *Content* tab, then select *Repository sets*.
 . From the dropdown, you can filter the *Repository type* column to *Custom*.
-. Select the desired number of repositories or click the *Select All* checkbox to select all repositories, then click the options icon, and select *Override to Enabled*.
+. Select the desired number of repositories or click the *Select All* checkbox to select all repositories.
+. Open the options menu, and select *Override to Enabled*.

--- a/guides/common/modules/proc_enabling-custom-repositories-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-custom-repositories-on-hosts.adoc
@@ -11,4 +11,4 @@ This allows the host to install packages or consume other content from repositor
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select a host.
 . Select the *Content* tab, then select *Repository sets*.
 . From the dropdown, you can filter the *Repository type* column to *Custom*.
-. Select the desired number of repositories or click the *Select All* checkbox to select all repositories, then click the vertical ellipsis, and select *Override to Enabled*.
+. Select the desired number of repositories or click the *Select All* checkbox to select all repositories, then click the options icon, and select *Override to Enabled*.

--- a/guides/common/modules/proc_generating-a-full-host-boot-disk-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_generating-a-full-host-boot-disk-by-using-web-ui.adoc
@@ -35,4 +35,4 @@ endif::[]
 . Click *Submit* to save the host details.
 This creates a host entry and the host details page appears.
 . Download the boot disk from {ProjectServer}.
-On the host details page, click the vertical ellipsis and select *Full host '_My_Host_Name_' image*.
+On the host details page, click the options icon and select *Full host '_My_Host_Name_' image*.

--- a/guides/common/modules/proc_generating-a-full-host-boot-disk-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_generating-a-full-host-boot-disk-by-using-web-ui.adoc
@@ -35,4 +35,4 @@ endif::[]
 . Click *Submit* to save the host details.
 This creates a host entry and the host details page appears.
 . Download the boot disk from {ProjectServer}.
-On the host details page, click the options icon and select *Full host '_My_Host_Name_' image*.
+On the host details page, open the options menu and select *Full host '_My_Host_Name_' image*.

--- a/guides/common/modules/proc_generating-a-host-boot-disk-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_generating-a-host-boot-disk-by-using-web-ui.adoc
@@ -31,4 +31,4 @@ endif::[]
 . Click *Submit* to save the host details.
 This creates a host entry and the host details page appears.
 . Download the boot disk from {ProjectServer}.
-On the host details page, click the vertical ellipsis and select *Host '_My_Host_Name_' image*.
+On the host details page, click the options icon and select *Host '_My_Host_Name_' image*.

--- a/guides/common/modules/proc_generating-a-host-boot-disk-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_generating-a-host-boot-disk-by-using-web-ui.adoc
@@ -31,4 +31,4 @@ endif::[]
 . Click *Submit* to save the host details.
 This creates a host entry and the host details page appears.
 . Download the boot disk from {ProjectServer}.
-On the host details page, click the options icon and select *Host '_My_Host_Name_' image*.
+On the host details page, open the options menu and select *Host '_My_Host_Name_' image*.

--- a/guides/common/modules/proc_installing-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_installing-packages-on-a-host.adoc
@@ -14,7 +14,7 @@ Available packages depend on the content view environments assigned to the host.
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select a host.
 . On the *Content* tab, click the *Packages* tab.
-. On the vertical ellipsis icon next to the upgrade button, click *Install packages*.
+. From the options icon next to the upgrade button, click *Install packages*.
 . In the *Install packages* window, select the package or packages that you want to install on the host.
 . Click *Install*.
 The {ProjectWebUI} shows a notification for the remote execution job.

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -18,7 +18,7 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {the-Cockpit}.
-. In the upper right of the host window, click the options icon and select *Web Console*.
+. In the upper right of the host window, open the options menu and select *Web Console*.
 +
 You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {the-Cockpit}.
 

--- a/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
+++ b/guides/common/modules/proc_managing-and-monitoring-hosts-using-cockpit.adoc
@@ -18,7 +18,7 @@ For more information, see xref:Distributing_SSH_Keys_for_Remote_Execution_{conte
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to manage and monitor with {the-Cockpit}.
-. In the upper right of the host window, click the vertical ellipsis and select *Web Console*.
+. In the upper right of the host window, click the options icon and select *Web Console*.
 +
 You can now access the full range of features available for host monitoring and management, for example, {LoraxCompose}, through {the-Cockpit}.
 

--- a/guides/common/modules/proc_promoting-a-content-view-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_promoting-a-content-view-by-using-web-ui.adoc
@@ -12,7 +12,7 @@ Use this procedure to promote content views across different lifecycle environme
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select the content view that you want to promote.
-. Select the version that you want to promote, click the vertical ellipsis icon, and click *Promote*.
+. Select the version that you want to promote, click the options icon, and click *Promote*.
 . Select the environment where you want to promote the content view and click *Promote*.
 
 .Next steps

--- a/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
+++ b/guides/common/modules/proc_refreshing-content-counts-on-smart-proxy.adoc
@@ -17,4 +17,4 @@ You can then expand the content view to view the repositories associated with th
 . Expand the content view by clicking *>* to view repositories available to the content view and the specific version for the environment.
 . View the number of content counts under *Packages* specific to {client-content-type} repositories.
 . View the number of errata, package groups, files, container tags, container manifests, and Ansible collections under *Additional content*.
-. Click the vertical ellipsis in the column to the right next to the environment and click *Refresh counts* to refresh the content counts synchronized on the {SmartProxy} under *Packages*.
+. Click the options icon in the column to the right next to the environment and click *Refresh counts* to refresh the content counts synchronized on the {SmartProxy} under *Packages*.

--- a/guides/common/modules/proc_removing-a-package-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-a-package-from-a-host.adoc
@@ -9,5 +9,5 @@ To uninstall software or resolve dependency issues, you can remove a package fro
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the host containing the package you want to remove.
 . On the *Content* tab, select *Packages*.
-. Click the vertical ellipsis icon at the end of the line for the package you want to remove, and choose the *Remove* option.
+. Click the options icon at the end of the line for the package you want to remove, and choose the *Remove* option.
 . Click *Submit*.

--- a/guides/common/modules/proc_removing-a-package-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-a-package-from-a-host.adoc
@@ -9,5 +9,5 @@ To uninstall software or resolve dependency issues, you can remove a package fro
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the host containing the package you want to remove.
 . On the *Content* tab, select *Packages*.
-. Click the options icon at the end of the line for the package you want to remove, and choose the *Remove* option.
+. Click the options icon at the end of the line for the package you want to remove, and click *Remove*.
 . Click *Submit*.

--- a/guides/common/modules/proc_removing-packages-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-packages-from-a-host.adoc
@@ -10,6 +10,6 @@ You can remove packages from a host from the {ProjectWebUI} to uninstall softwar
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select a host.
 . On the *Content* tab, click the *Packages* tab.
-. Click the vertical ellipsis for the package you want to remove.
+. Click the options icon for the package you want to remove.
 . Select *Remove*.
 The {ProjectWebUI} shows a notification for the remote execution job.

--- a/guides/common/modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_republishing-content-view-metadata-by-using-web-ui.adoc
@@ -13,4 +13,4 @@ Republishing repository metadata will regenerate metadata for all repositories i
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
 . Select a content view.
 . On the *Versions* tab, select a content view version.
-. To republish metadata for the content view version, click *Republish repository metadata* from the vertical ellipsis icon.
+. To republish metadata for the content view version, click *Republish repository metadata* from the options icon.

--- a/guides/common/modules/proc_synchronizing-insights-recommendations-for-hosts.adoc
+++ b/guides/common/modules/proc_synchronizing-insights-recommendations-for-hosts.adoc
@@ -16,4 +16,4 @@ If you leave the setting disabled, you can synchronize the recommendations manua
 * To get the recommendations manually:
 +
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Recommendations*.
-. From the options icon, click *Sync Recommendations*.
+. From the options menu, select *Sync Recommendations*.

--- a/guides/common/modules/proc_synchronizing-insights-recommendations-for-hosts.adoc
+++ b/guides/common/modules/proc_synchronizing-insights-recommendations-for-hosts.adoc
@@ -16,4 +16,4 @@ If you leave the setting disabled, you can synchronize the recommendations manua
 * To get the recommendations manually:
 +
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Recommendations*.
-. On the vertical ellipsis, click *Sync Recommendations*.
+. From the options icon, click *Sync Recommendations*.

--- a/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_synchronizing-smart-proxy-directly-from-red-hat-cdn-by-using-web-ui.adoc
@@ -20,4 +20,4 @@ You can configure your {SmartProxyServers} to sync Red{nbsp}Hat content directly
 . If you require synchronizing content through the HTTP proxy of your {SmartProxies}, select *Use HTTP proxies*.
 . Select the Red{nbsp}Hat products that should be synced to the {SmartProxy} from Red{nbsp}Hat CDN.
 . Review details and click *Add*.
-. Navigate to *Content* > *Alternate Content Sources*, click the vertical ellipsis next to the newly created alternate content source, and select *Refresh*.
+. Navigate to *Content* > *Alternate Content Sources*, click the options icon next to the newly created alternate content source, and select *Refresh*.

--- a/guides/common/modules/proc_upgrading-a-package.adoc
+++ b/guides/common/modules/proc_upgrading-a-package.adoc
@@ -12,6 +12,6 @@ You can upgrade an installed package on a host to a newer version from the {Proj
 +
 The *Status* column displays whether the package is upgradable or Up-to date.
 You cannot update an up-to-date package.
-. From the list of packages, choose the package you want to upgrade and click the vertical ellipsis icon at the end of the line.
+. From the list of packages, choose the package you want to upgrade and click the options icon at the end of the line.
 . Choose the *Apply via Remote Execution* to use Remote Execution, or *Apply via customized remote execution* if you want to customize the remote execution, for example, to set a time when it should be applied.
 . Click *Submit* to upgrade the package.

--- a/guides/common/modules/proc_upgrading-a-package.adoc
+++ b/guides/common/modules/proc_upgrading-a-package.adoc
@@ -10,7 +10,7 @@ You can upgrade an installed package on a host to a newer version from the {Proj
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the name of the host that contains the package you want to upgrade.
 . On the *Content* tab, select *Packages*.
 +
-The *Status* column displays whether the package is upgradable or Up-to date.
+The *Status* column displays whether the package is upgradeable or Up-to date.
 You cannot update an up-to-date package.
 . From the list of packages, choose the package you want to upgrade and click the options icon at the end of the line.
 . Choose the *Apply via Remote Execution* to use Remote Execution, or *Apply via customized remote execution* if you want to customize the remote execution, for example, to set a time when it should be applied.


### PR DESCRIPTION
As per discussion at https://community.theforeman.org/t/how-to-refer-to-kebab-menus/45994?u=maximilian Implemented Maxmilian's and Lena's feedback.

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
