### PR TITLE
Fix spelling of behavior in anchor

### DIFF
--- a/guides/common/modules/con_webhooks-behavior-and-integration.adoc
+++ b/guides/common/modules/con_webhooks-behavior-and-integration.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="webhook-behaviour-and-integration"]
+[id="webhook-behavior-and-integration"]
 = Webhook behavior and integration
 
 [role="_abstract"]


### PR DESCRIPTION
#### What changes are you introducing?

Fix spelling

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

downstream CI reports spelling error

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

'rg -i "webhook-behaviour-and-integration"' does not return any results, so this anchor is not in use.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
