### PR TITLE
Add custom server certs installation with foremanctl

### DIFF
--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -1,4 +1,5 @@
 :_mod-docs-content-type: PROCEDURE
+:foremanctl:
 
 [id="Deploying_a_Custom_SSL_Certificate_to_Server_{context}"]
 = Deploying a custom SSL certificate to {ProjectServer}
@@ -23,10 +24,10 @@ fails to execute while enabling features or upgrading {ProjectServer}.
 ifdef::foremanctl[]
 ----
 # {foremanctl-installer} deploy \
---certificate-source=custom_server
+--certificate-source=custom_server \
 --certificate-server-certificate "_/root/{project-context}_cert/{project-context}_cert.pem_" \
 --certificate-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
---certificate-server-ca-certificate "_/root/{project-context}_cert/ca_cert_bundle.pem_" \
+--certificate-server-ca-certificate "_/root/{project-context}_cert/ca_cert_bundle.pem_"
 //--certs-update-server --certs-update-server-ca
 //Are these^ just unnecessary now?
 ----

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -8,7 +8,7 @@ Use this procedure to configure your {ProjectServer} to use a custom SSL certifi
 
 [IMPORTANT]
 ====
-Do not store the SSL certificates or .tar bundles in `/tmp` or `/var/tmp` directory.
+Do not store the SSL certificates or `.tar` bundles in `/tmp` or `/var/tmp` directory.
 The operating system removes files from these directories periodically.
 As a result,
 ifdef::foremanctl[`{foremanctl-installer}`]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -27,13 +27,11 @@ ifdef::foremanctl[]
 --certificate-server-certificate "_/root/{project-context}_cert/{project-context}_cert.pem_" \
 --certificate-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
 --certificate-server-ca-certificate "_/root/{project-context}_cert/ca_cert_bundle.pem_"
-//--certs-update-server --certs-update-server-ca
-//Are these^ just unnecessary now?
 ----
 +
 The options used in the command include the following:
 +
-`--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user. Automatically generates an internal CA for client certificates and localhost. Server certificate, key, and CA bundle are copied to `/root/certificates/`.
+`--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user. Automatically generates an internal CA for client certificates and localhost.
 `--certs-server-cert`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
 `--certs-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
 `--certs-server-ca-cert`:: Path to the Certificate Authority bundle.

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -33,7 +33,7 @@ The options used in the command include the following:
 +
 `--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user.
 `--certificate-server-certificate`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
-`--certificate-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
+`--certificate-server-key`:: Path to the private key for the {ProjectServer} certificate.
 `--certificate-server-ca-certificate`:: Path to the Certificate Authority bundle.
 endif::[]
 ifndef::foremanctl[]
@@ -48,7 +48,7 @@ ifndef::foremanctl[]
 The options used in the command include the following:
 +
 `--certs-server-cert`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
-`--certs-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
+`--certs-server-key`:: Path to the private key for the {ProjectServer} certificate.
 `--certs-server-ca-cert`:: Path to the Certificate Authority bundle.
 endif::[]
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -10,13 +10,35 @@ Use this procedure to configure your {ProjectServer} to use a custom SSL certifi
 ====
 Do not store the SSL certificates or .tar bundles in `/tmp` or `/var/tmp` directory.
 The operating system removes files from these directories periodically.
-As a result, `{foreman-installer}` fails to execute while enabling features or upgrading {ProjectServer}.
+As a result,
+ifdef::foremanctl[`{foremanctl-installer}`]
+ifndef::foremanctl[`{foreman-installer}`]
+fails to execute while enabling features or upgrading {ProjectServer}.
 ====
 
 .Procedure
 * Update certificates on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]
+ifdef::foremanctl[]
+----
+# {foremanctl-installer} deploy \
+--certificate-source=custom_server
+--certificate-server-certificate "_/root/{project-context}_cert/{project-context}_cert.pem_" \
+--certificate-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
+--certificate-server-ca-certificate "_/root/{project-context}_cert/ca_cert_bundle.pem_" \
+//--certs-update-server --certs-update-server-ca
+//Are these^ just unnecessary now?
+----
++
+The options used in the command include the following:
++
+`--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user. Automatically generates an internal CA for client certificates and localhost. Server certificate, key, and CA bundle are copied to `/root/certificates/`.
+`--certs-server-cert`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
+`--certs-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
+`--certs-server-ca-cert`:: Path to the Certificate Authority bundle.
+endif::[]
+ifndef::foremanctl[]
 ----
 # {foreman-installer} \
 --certs-server-cert "_/root/{project-context}_cert/{project-context}_cert.pem_" \
@@ -27,9 +49,10 @@ As a result, `{foreman-installer}` fails to execute while enabling features or u
 +
 The options used in the command include the following:
 +
-`--certs-server-cert`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority
-`--certs-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate
-`--certs-server-ca-cert`:: Path to the Certificate Authority bundle
+`--certs-server-cert`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
+`--certs-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
+`--certs-server-ca-cert`:: Path to the Certificate Authority bundle.
+endif::[]
 
 .Verification
 . On a computer with network access to {ProjectServer}, navigate to the following URL: `\https://{foreman-example-com}`.

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -32,9 +32,9 @@ ifdef::foremanctl[]
 The options used in the command include the following:
 +
 `--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user. Automatically generates an internal CA for client certificates and localhost.
-`--certs-server-cert`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
-`--certs-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
-`--certs-server-ca-cert`:: Path to the Certificate Authority bundle.
+`--certificate-server-certificate`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
+`--certificate-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
+`--certificate-server-ca-certificate`:: Path to the Certificate Authority bundle.
 endif::[]
 ifndef::foremanctl[]
 ----

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -1,5 +1,4 @@
 :_mod-docs-content-type: PROCEDURE
-:foremanctl:
 
 [id="Deploying_a_Custom_SSL_Certificate_to_Server_{context}"]
 = Deploying a custom SSL certificate to {ProjectServer}

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -23,7 +23,7 @@ fails to execute while enabling features or upgrading {ProjectServer}.
 ifdef::foremanctl[]
 ----
 # {foremanctl-installer} deploy \
---certificate-source=custom_server \
+--certificate-source custom_server \
 --certificate-server-certificate "_/root/{project-context}_cert/{project-context}_cert.pem_" \
 --certificate-server-key "_/root/{project-context}_cert/{project-context}_cert_key.pem_" \
 --certificate-server-ca-certificate "_/root/{project-context}_cert/ca_cert_bundle.pem_"

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -31,7 +31,7 @@ ifdef::foremanctl[]
 +
 The options used in the command include the following:
 +
-`--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user. Automatically generates an internal CA for client certificates and localhost.
+`--certificate-source=custom_server`:: Sets the certificate source to custom server certificates provided by the user.
 `--certificate-server-certificate`:: Path to {ProjectServer} certificate file that is signed by a Certificate Authority.
 `--certificate-server-key`:: Path to the private key that was used to sign {ProjectServer} certificate.
 `--certificate-server-ca-certificate`:: Path to the Certificate Authority bundle.

--- a/guides/common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc
+++ b/guides/common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc
@@ -10,9 +10,16 @@ If you want to revert to the default configuration, you can reset a custom SSL c
 * Reset the {customssl} certificate to default self-signed certificate:
 +
 [options="nowrap" subs="+quotes,attributes"]
+ifdef::foremanctl[]
+----
+# {foremanctl-installer} deploy --certificate-source=default
+----
+endif::[]
+ifndef::foremanctl[]
 ----
 # {foreman-installer} --certs-reset
 ----
+endif::[]
 
 .Verification
 ifndef::orcharhino[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -82,11 +82,9 @@ ifdef::katello,orcharhino,satellite[]
 
 include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 
-ifndef::foremanctl[]
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc[leveloffset=+2]
-endif::[]
 endif::[]
 
 ifndef::foremanctl[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -85,7 +85,6 @@ include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc[leveloffset=+2]
-endif::[]
 
 ifndef::foremanctl[]
 :numbered!:

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -85,6 +85,7 @@ include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc[leveloffset=+2]
+endif::[]
 
 ifndef::foremanctl[]
 :numbered!:


### PR DESCRIPTION
#### What changes are you introducing?
Add installation with custom server certs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-43472

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
