### PR TITLE
Rename initial foremanctl params

### DIFF
--- a/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
@@ -42,8 +42,8 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foremanctl-installer} deploy \
---foreman-initial-admin-username _My_Admin_User_Name_ \
---foreman-initial-admin-password _My_Admin_Password_ \
+--initial-admin-username _My_Admin_User_Name_ \
+--initial-admin-password _My_Admin_Password_ \
 --initial-organization _"My_Organization"_ \
 --initial-location _"My_Location"_ \
 --database-mode external \

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
@@ -39,8 +39,8 @@ You can enable one or more features by adding the `--add-feature _Feature-1_ _Fe
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foremanctl-installer} deploy \
---foreman-initial-admin-username _My_Admin_User_Name_ \
---foreman-initial-admin-password _My_Admin_Password_ \
+--initial-admin-username _My_Admin_User_Name_ \
+--initial-admin-password _My_Admin_Password_ \
 --initial-organization _"My_Organization"_ \
 --initial-location _"My_Location"_
 ----


### PR DESCRIPTION
#### What changes are you introducing?
Rename initial foremanctl parameters

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-44508

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
