### PR TITLE
Hide MCP modules for orcharhino

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -28,7 +28,9 @@ include::modules/proc_promoting-a-content-view-by-using-web-ui.adoc[leveloffset=
 
 include::modules/proc_promoting-a-content-view-by-using-cli.adoc[leveloffset=+1]
 
+ifndef::orcharhino[]
 include::modules/proc_publishing-and-promoting-a-content-view-by-using-mcp.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_promoting-a-content-view-to-all-environments-in-an-organization.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_managing-errata.adoc
+++ b/guides/common/assembly_managing-errata.adoc
@@ -28,7 +28,9 @@ include::modules/proc_adding-errata-to-an-incremental-content-view-by-using-web-
 
 include::modules/proc_adding-errata-to-an-incremental-content-view-by-using-cli.adoc[leveloffset=+1]
 
+ifndef::orcharhino[]
 include::modules/proc_adding-errata-to-an-incremental-content-view-by-using-mcp.adoc[leveloffset=+1]
+endif::[]
 
 ifndef::satellite[]
 include::modules/proc_creating-an-incremental-content-view-version-by-adding-deb-packages.adoc[leveloffset=+1]
@@ -42,4 +44,6 @@ include::modules/proc_applying-errata-to-hosts-by-using-web-ui.adoc[leveloffset=
 
 include::modules/proc_applying-errata-to-hosts-by-using-cli.adoc[leveloffset=+2]
 
+ifndef::orcharhino[]
 include::modules/proc_applying-errata-to-hosts-by-using-mcp.adoc[leveloffset=+2]
+endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

orcharhino builds do not include the assembly to set up MCP servers. Therefore, this patch removes three other modules about MCP to avoid broken links.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

$ rg -C 1 assembly_connecting-ai-applications-to-the-mcp-server-for-project.adoc

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs 81bdd623d950f18e8af7806b106c6ab1c65b09a9 (includes ACK)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
