### PR TITLE
Move attribute definitions from module to assembly

### DIFF
--- a/guides/common/assembly_managing-content-view-environments.adoc
+++ b/guides/common/assembly_managing-content-view-environments.adoc
@@ -6,7 +6,17 @@ include::modules/con_content-view-environments-overview.adoc[leveloffset=+1]
 
 include::modules/con_content-view-environment-categories.adoc[leveloffset=+1]
 
+ifdef::satellite[]
+:example-repo-id: satellite-client-6-for-rhel-9-x86_64-rpms
+:example-repo-name: Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs)
+endif::[]
+ifndef::satellite[]
+:example-repo-id: {project-context}-client
+:example-repo-name: {Project} Client
+endif::[]
 include::modules/con_content-view-environment-ordering-and-priority.adoc[leveloffset=+1]
+:!example-repo-id:
+:!example-repo-name:
 
 include::modules/proc_assigning-content-view-environments-to-hosts-in-bulk.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
+++ b/guides/common/modules/con_content-view-environment-ordering-and-priority.adoc
@@ -1,14 +1,5 @@
 :_mod-docs-content-type: CONCEPT
 
-ifdef::satellite[]
-:example-repo-id: satellite-client-6-for-rhel-9-x86_64-rpms
-:example-repo-name: Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs)
-endif::[]
-ifndef::satellite[]
-:example-repo-id: {project-context}-client
-:example-repo-name: {Project} Client
-endif::[]
-
 [id="content-view-environment-ordering-and-priority"]
 = Content view environment ordering and priority
 
@@ -101,6 +92,3 @@ Enabled:   0
 ----
 
 The `Repo URL` now reflects the `dev/cv1` content view environment, meaning the system uses content from `dev/cv1` and ignores `Library/cv1`.
-
-:!example-repo-id:
-:!example-repo-name:


### PR DESCRIPTION
#### What changes are you introducing?

Move attribute definitions from module to assembly. Alternative idea: move to `attribute-*.adoc` files.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In downstream, builds break if the attribute is defined in the module. Therefore, this patch moves the attribute to the assembly that includes this module.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

No diff in rendered HTML expected.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
