### PR TITLE
Add file-type repository for Ubuntu 26.04 Clients

### DIFF
--- a/guides/common/modules/snip_file-type-repositories-for-installation-media-for-debian-and-ubuntu.adoc
+++ b/guides/common/modules/snip_file-type-repositories-for-installation-media-for-debian-and-ubuntu.adoc
@@ -12,6 +12,7 @@ For a list of upstream URLs, see {atix-kb-debian-ubuntu-installation-media} in t
 * Debian 12
 * Debian 11
 * Debian 10
+* Ubuntu 26.04
 * Ubuntu 24.04
 * Ubuntu 22.04
 * Ubuntu 20.04


### PR DESCRIPTION
#### What changes are you introducing?

orcharhino 7.8 supports Ubuntu 26.04 Clients, so we need to list the offline installation media.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

orcharhino users can synchronize a file-type repository to their orcharhino Server/orcharhino Proxy Servers to provision Ubuntu 26.04 hosts in a disconnected environment.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs https://orcharhino.com/ressourcen/release-notes/orcharhino-7-8/

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
