### PR TITLE
Document Salt authentication version on Smart Proxies

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -155,6 +155,7 @@ endif::[]
 :RHEL: Red{nbsp}Hat Enterprise Linux
 :RHELServer: {RHEL} Server
 :SLES: openSUSE/SUSE Linux Enterprise Server
+:salt-version: 3006
 :server-example-com: server.example.com
 :smart-proxy-context: smart-proxy
 :smart-proxy-context-titlecase: Smart_Proxy

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -55,6 +55,7 @@
 :atix-kb-clients: https://atixservice.zendesk.com/hc/en-001/articles/19430263501468[{Project} Clients gen3]
 :atix-kb-debian-ubuntu-installation-media: https://atixservice.zendesk.com/hc/en-001/articles/7044086506908[Using file repositories for installation media for Debian/Ubuntu]
 :atix-kb-register-to-occ: https://atixservice.zendesk.com/hc/en-001/articles/9464966748444[Registering {ProjectServer} to OCC]
+:atix-kb-salt-authentication-version: https://atixservice.zendesk.com/hc/en-001/articles/24283411290908[Salt Master Authentication Version]
 :atix-kb-tech-previews: https://atixservice.zendesk.com/hc/en-001/articles/16772654610844[Technical Previews]
 // Client attributes; overwritten in downstream for docs.orcharhino.com for all supported Client OS
 :ubuntu:

--- a/guides/common/modules/con_introduction-to-salt.adoc
+++ b/guides/common/modules/con_introduction-to-salt.adoc
@@ -20,7 +20,7 @@ endif::[]
 ====
 
 ifdef::orcharhino[]
-{Project} supports Salt 3006.
+{Project} supports Salt {salt-version}.
 endif::[]
 
 .Additional resources

--- a/guides/common/modules/proc_using-older-salt-minions.adoc
+++ b/guides/common/modules/proc_using-older-salt-minions.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="using-older-salt-minions"]
+= Using older Salt Minions
+
+[role="_abstract"]
+If you use older Salt Minions on your hosts with Salt Master {salt-version}, you must configure your Salt {SmartProxies} to acccept a lower authentication version.
+{Team} recommends using the Salt Master {salt-version} on your {SmartProxies} and Salt Minions {salt-version} on your hosts.
+
+If you do not use the latest supported Salt Minions on your hosts, you might see an error when trying to authenticate with {SmartProxies} as follows:
+
+[source, none, options="nowrap", subs="+quotes,attributes"]
+----
+"Version 3 Requirement: A warning [WARNING ] Rejected authentication attempt using protocol version 2 (minimum required: 3) indicates an outdated minion is trying to connect to a secure, updated master."
+----
+
+You can resolve this issue by setting a lower authentication version for Salt.
+
+.Procedure
+* On your Salt {SmartProxies}, lower the Salt minimum authentication version:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --foreman-proxy-plugin-salt-minimum-auth-version 2
+----
++
+By default, the Salt minimum authentication version is set to `3`.
+
+ifdef::orcharhino[]
+.Additional resources
+* {atix-kb-salt-authentication-version} in the _ATIX Service Portal_
+endif::[]

--- a/guides/doc-Managing_Configurations_Salt/master.adoc
+++ b/guides/doc-Managing_Configurations_Salt/master.adoc
@@ -44,6 +44,8 @@ include::common/modules/proc_deploying-salt-minion-hosts.adoc[leveloffset=+2]
 
 include::common/modules/proc_verifying-the-connection-between-salt-master-and-salt-minions.adoc[leveloffset=+2]
 
+include::common/modules/proc_using-older-salt-minions.adoc[leveloffset=+2]
+
 include::common/modules/con_using-salt.adoc[leveloffset=+1]
 
 include::common/modules/ref_using-the-salt-hammer-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
#### What changes are you introducing?

Document setting for Salt minimum authentication version for Salt Smart Proxies.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Users might not be able to upgrade their Salt Minions on hosts.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

* Refs [baa29e869ce2402a5f984b1b9f0193615fd42c23](https://github.com/theforeman/puppet-foreman_proxy/commit/baa29e869ce2402a5f984b1b9f0193615fd42c23) in puppet-foreman_proxy
* Refs issue [38964](https://projects.theforeman.org/issues/38964) (Add salt minimum auth version)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
