### PR TITLE
use foremanctl from main repos, not copr

### DIFF
--- a/guides/common/modules/snip_configuring-repositories-foreman-rpm.adoc
+++ b/guides/common/modules/snip_configuring-repositories-foreman-rpm.adoc
@@ -14,14 +14,6 @@ ifdef::katello[]
 # {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
-ifdef::foremanctl[]
-. Enable the required additional repositories:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# dnf copr enable @theforeman/foremanctl rhel-9-x86_64
-----
-endif::[]
 ifndef::foremanctl[]
 . Install the `puppet-release` package:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Dropping the use of the foremanctl copr, now that we have recent releases properly packaged in our repos.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

See above

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
