### PR TITLE
--add-feature only takes a single feature per invocation

### DIFF
--- a/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
@@ -35,7 +35,7 @@ For more information, see {AdministeringDocURL}installing-postgresql_admin[Insta
 # {foremanctl-installer} features
 ----
 +
-You can enable one or more features by adding the `--add-feature _Feature-1_ _Feature-2_` option to the `{foremanctl-installer} deploy` command.
+You can enable one or more features by adding the `--add-feature _Feature-1_ --add-feature _Feature-2_` option to the `{foremanctl-installer} deploy` command.
 
 . Deploy the configuration on the server:
 +

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
@@ -33,7 +33,7 @@ For more information, see xref:{InstallingServerDocURL}preparing-environment-for
 # {foremanctl-installer} features
 ----
 +
-You can enable one or more features by adding the `--add-feature _Feature-1_ _Feature-2_` option to the `{foremanctl-installer} deploy` command.
+You can enable one or more features by adding the `--add-feature _Feature-1_ --add-feature _Feature-2_` option to the `{foremanctl-installer} deploy` command.
 . Deploy the configuration on the server:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION

#### What changes are you introducing?

Correcting how `--add-feature` should be used in `foremanctl`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It's wrong otherwise ;)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Fixes: e98367c39ca7f04e21e3a5a9425083ec47652e9e

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
