### PR TITLE
Move FreeIPA realm section to Integrating Provisioning guide

### DIFF
--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -75,8 +75,6 @@ include::common/modules/proc_enabling-power-management-on-hosts.adoc[leveloffset
 
 include::common/modules/proc_configuring-satellite-for-outgoing-emails.adoc[leveloffset=+2]
 
-include::common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+2]
-
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -51,8 +51,6 @@ include::common/modules/proc_enabling-power-management-on-hosts.adoc[leveloffset
 
 include::common/modules/proc_configuring-satellite-for-outgoing-emails.adoc[leveloffset=+2]
 
-include::common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+2]
-
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 :!numbered:

--- a/guides/doc-Integrating_Provisioning_Infrastructure_Services/master.adoc
+++ b/guides/doc-Integrating_Provisioning_Infrastructure_Services/master.adoc
@@ -16,6 +16,8 @@ include::common/assembly_configuring-dhcp-integration.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-tftp-integration.adoc[leveloffset=+1]
 
+include::common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[leveloffset=+1]
+
 ifndef::orcharhino,satellite[]
 include::common/ribbons.adoc[]
 endif::[]


### PR DESCRIPTION
The `Configuring Project to manage the lifecycle of a host registered to a FreeIPA realm` section is better suited for the `Integrating provisioning infrastructure services` guide.

JIRA:
https://redhat.atlassian.net/browse/SAT-36280

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
