### PR TITLE
Remove note about leapp report

### DIFF
--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
@@ -60,7 +60,7 @@ From the *Job category* list, select *Leapp - Preupgrade*.
 Follow the job wizard to start the preupgrade check.
 . Review the results of the pre-upgrade check:
 .. Navigate to *Monitor* > *Jobs*.
-Click the *Upgradeability check for RHEL host* job.
+.. Click the *Upgradeability check for RHEL host* job.
 .. Click the *Leapp preupgrade report* tab to see if Leapp has found any issues on your hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
 Issues that have the *Has Remediation* flag contain remediation that can help you fix the issue.

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
@@ -60,8 +60,7 @@ From the *Job category* list, select *Leapp - Preupgrade*.
 Follow the job wizard to start the preupgrade check.
 . Review the results of the pre-upgrade check:
 .. Navigate to *Monitor* > *Jobs*.
-Click the pre-upgrade check job.
-.. From the *Rerun all* dropdown menu, click *Legacy UI*.
+Click the *Upgradeability check for RHEL host* job.
 .. Click the *Leapp preupgrade report* tab to see if Leapp has found any issues on your hosts.
 Issues that have the *Inhibitor* flag are considered crucial and are likely to break the upgrade procedure.
 Issues that have the *Has Remediation* flag contain remediation that can help you fix the issue.

--- a/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
+++ b/guides/common/modules/proc_upgrading-hosts-to-next-major-release.adoc
@@ -59,12 +59,6 @@ The *leap_preupgrade* and *leapp_upgrade* remote execution features now point to
 From the *Job category* list, select *Leapp - Preupgrade*.
 Follow the job wizard to start the preupgrade check.
 . Review the results of the pre-upgrade check:
-+
-[NOTE]
-====
-The results of the pre-upgrade check are only available in the legacy {ProjectWebUI} job invocation details page.
-====
-+
 .. Navigate to *Monitor* > *Jobs*.
 Click the pre-upgrade check job.
 .. From the *Rerun all* dropdown menu, click *Legacy UI*.


### PR DESCRIPTION
The pre-upgrade check reports are available on the new  job invocation page. Removing the note as it is no longer necessary.

JIRA:
https://redhat.atlassian.net/browse/SAT-36237
https://redhat.atlassian.net/browse/SAT-41334

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
