### PR TITLE
Do not emphasize arrows

### DIFF
--- a/guides/common/modules/con_provisioning-templates.adoc
+++ b/guides/common/modules/con_provisioning-templates.adoc
@@ -21,7 +21,7 @@ endif::[]
 ifdef::satellite[]
 Templates supported by {Team} are indicated by a {Team} icon.
 
-To hide unsupported templates, in the {ProjectWebUI} navigate to *Administer > Settings*.
+To hide unsupported templates, in the {ProjectWebUI} navigate to *Administer* > *Settings*.
 On the *Provisioning* tab, set the value of *Show unsupported provisioning templates* to `false` and click *Submit*.
 You can also filter out the supported templates by making the following query "supported = true".
 endif::[]

--- a/guides/common/modules/proc_adding-an-scc-account-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-an-scc-account-by-using-web-ui.adoc
@@ -39,7 +39,7 @@ Note that this does not refer to synchronizing content to {Project}.
 ====
 You can also set the GPG public key for repositories from SUSE at a later stage.
 However, changing it does not affect already synchronized products.
-If you already have synchronized products in {Project}, navigate to *Content > Products* and replace the GPG key in each respective product.
+If you already have synchronized products in {Project}, navigate to *Content* > *Products* and replace the GPG key in each respective product.
 ====
 . Optional: From the *Download Policy* list, select a download policy for your SUSE products.
 For more information, see xref:Download_Policies_Overview_{context}[].

--- a/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
+++ b/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
@@ -10,7 +10,7 @@ You can use Ansible roles for remote management of {Project} clients.
 * Ensure that you have configured and imported Ansible roles.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the host and click *Edit*.
 . On the *Ansible Roles* tab, select the role that you want to add from the *Available Ansible Roles* list.
 . Click the *+* icon to add the role to the host.

--- a/guides/common/modules/proc_changing-the-order-of-ansible-roles.adoc
+++ b/guides/common/modules/proc_changing-the-order-of-ansible-roles.adoc
@@ -7,7 +7,7 @@
 Use the following procedure to change the order of Ansible roles applied to a host.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select a host.
 . Select the *Ansible Roles* tab.
 . In the *Assigned Ansible Roles* area, you can change the order of the roles by dragging and dropping the roles into the preferred position.

--- a/guides/common/modules/proc_cloning-hosts-in-project.adoc
+++ b/guides/common/modules/proc_cloning-hosts-in-project.adoc
@@ -14,7 +14,7 @@ For more information, see {ProvisioningDocURL}[_{ProvisioningDocTitle}_].
 ====
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . In the *Actions* menu, click *Clone*.
 . On the *Host* tab, ensure to provide a *Name* different from the original host.
 . On the *Interfaces* tab, ensure to provide a different IP address.

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-web-ui.adoc
@@ -8,7 +8,7 @@ The procedure for creating a {customfiletype} repository is the same as the proc
 You must create a product and then add a {customrepo}.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content > Products*.
+. In the {ProjectWebUI}, navigate to *Content* > *Products*.
 . Select a product that you want to create a repository for.
 . On the *Repositories* tab, click *New Repository*.
 . In the *Name* field, enter a name for the repository.

--- a/guides/common/modules/proc_creating-an-api-only-user.adoc
+++ b/guides/common/modules/proc_creating-an-api-only-user.adoc
@@ -13,7 +13,7 @@ For more information, see xref:Managing_Users_and_Roles_{context}[].
 
 .Procedure
 . Log in to your {Project} as admin.
-. Navigate to *Administer > Users* and select a user.
+. Navigate to *Administer* > *Users* and select a user.
 . On the *User* tab, set a password.
 Do not save or communicate this password with others.
 You can create pseudo-random strings on your console:

--- a/guides/common/modules/proc_deleting-a-vm-on-gce.adoc
+++ b/guides/common/modules/proc_deleting-a-vm-on-gce.adoc
@@ -9,8 +9,8 @@ You can delete VMs running on Google Compute Engine (GCE) on your {ProjectServer
 include::snip_warning-destroy-vm-on-host-delete.adoc[]
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Infrastructure > Compute Resources*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
 . Select your GCE provider.
 . On the *Virtual Machines* tab, click *Delete* from the *Actions* menu.
 This deletes the virtual machine from the GCE compute resource while retaining any associated hosts within {Project}.
-If you want to delete the orphaned host, navigate to *Hosts > All Hosts* and delete the host manually.
+If you want to delete the orphaned host, navigate to *Hosts* > *All Hosts* and delete the host manually.

--- a/guides/common/modules/proc_deleting-a-vm-on-microsoft-azure.adoc
+++ b/guides/common/modules/proc_deleting-a-vm-on-microsoft-azure.adoc
@@ -9,8 +9,8 @@ You can delete VMs running on Microsoft Azure from within {Project}.
 include::snip_warning-destroy-vm-on-host-delete.adoc[]
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Infrastructure > Compute Resources*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
 . Select your Microsoft Azure provider.
 . On the *Virtual Machines* tab, click *Delete* from the *Actions* menu.
 This deletes the virtual machine from the Microsoft Azure compute resource while retaining any associated hosts within {Project}.
-If you want to delete the orphaned host, navigate to *Hosts > All Hosts* and delete the host manually.
+If you want to delete the orphaned host, navigate to *Hosts* > *All Hosts* and delete the host manually.

--- a/guides/common/modules/proc_deleting-a-vm-on-vmware.adoc
+++ b/guides/common/modules/proc_deleting-a-vm-on-vmware.adoc
@@ -9,8 +9,8 @@ You can delete VMs running on VMware from within {Project}.
 include::snip_warning-destroy-vm-on-host-delete.adoc[]
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Infrastructure > Compute Resources*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
 . Select your VMware provider.
 . On the *Virtual Machines* tab, click *Delete* from the *Actions* menu.
 This deletes the virtual machine from the VMware compute resource while retaining any associated hosts within {Project}.
-If you want to delete the orphaned host, navigate to *Hosts > All Hosts* and delete the host manually.
+If you want to delete the orphaned host, navigate to *Hosts* > *All Hosts* and delete the host manually.

--- a/guides/common/modules/proc_filter-errata-by-type-severity.adoc
+++ b/guides/common/modules/proc_filter-errata-by-type-severity.adoc
@@ -7,7 +7,8 @@
 You can filter errata by type or severity to focus on security updates, bug fixes, or enhancements when planning or applying errata.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and click the name of the host.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select your host.
 . On the *Contents* tab, *Errata* lists the errata associated with the selected host.
 . Click *Type* to filter errata by type.
 . You can filter to display errata of type Security, Bugfix, or Enhancement

--- a/guides/common/modules/proc_importing-suse-products-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-suse-products-by-using-web-ui.adoc
@@ -11,7 +11,7 @@ Use this procedure to import products from SUSE into {Project} by using {Project
 For more information, see xref:adding-an-scc-account-to-{project-context}-by-using-web-ui[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*.
+. In the {ProjectWebUI}, navigate to *Content* > *SUSE Subscriptions*.
 . Click *Select products* on your previously synchronized SCC account.
 . Use the *Select Product*, *Select Version*, and *Select Architecture* lists to filter all available SUSE products.
 +

--- a/guides/common/modules/proc_installing-gce-plugin.adoc
+++ b/guides/common/modules/proc_installing-gce-plugin.adoc
@@ -16,4 +16,4 @@ This allows you to manage and deploy hosts to GCE.
 --enable-foreman-cli-google \
 --enable-foreman-plugin-google
 ----
-. Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the *Compute Resources* tab to verify the installation of the GCE plugin.
+. Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the *Compute Resources* tab to verify the installation of the GCE plugin.

--- a/guides/common/modules/proc_installing-microsoft-azure-plugin.adoc
+++ b/guides/common/modules/proc_installing-microsoft-azure-plugin.adoc
@@ -14,4 +14,4 @@ This allows you to manage and deploy hosts to Azure.
 ----
 # {foreman-installer} --enable-foreman-plugin-azure
 ----
-. Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the _compute resources_ tab to verify the installation of the Microsoft Azure plugin.
+. Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the _compute resources_ tab to verify the installation of the Microsoft Azure plugin.

--- a/guides/common/modules/proc_installing-red-hat-cloud-plugin.adoc
+++ b/guides/common/modules/proc_installing-red-hat-cloud-plugin.adoc
@@ -13,4 +13,4 @@ Install the Red Hat Cloud plugin to generate and upload reports from {Project} t
 ----
 # {foreman-installer} --enable-foreman-plugin-rh-cloud
 ----
-. Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the _Plugins_ tab to verify the installation of the Red Hat Cloud plugin.
+. Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the _Plugins_ tab to verify the installation of the Red Hat Cloud plugin.

--- a/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
+++ b/guides/common/modules/proc_overriding-ansible-variables-in-project.adoc
@@ -52,7 +52,7 @@ If the hashes contain the same key, the value is overwritten by the value of the
 . To save the override settings, click *Submit*.
 . To use the Ansible variable, add the variable as a parameter to your host or host group, or add the variable as a global parameter:
 .. To add the variable to a host:
-... In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the host that you want to use.
+... In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts* and select the host that you want to use.
 ... Click the *Ansible* tab, and in the *Variables* area, click the pencil icon to edit the value of the variable.
 ... Click the tick icon to accept the value of the changed variable or the cross icon to cancel the change.
 .. To add the variable to a host group:

--- a/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
+++ b/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
@@ -20,5 +20,5 @@ For more information, see xref:creating-an-installation-medium-for-ubuntu-22-04[
 Set the *Path* to the extracted ISO image on your {SmartProxyServer}.
 . In the {ProjectWebUI}, navigate to *Hosts* > *Provisioning Setup* > *Operating Systems*.
 . Assign the installation medium to your operating system entry for Ubuntu 22.04.
-. In the {ProjectWebUI}, navigate to *Configure > Host Groups*.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
 . Select the host group that you use to deploy Ubuntu 22.04 through a {SmartProxyServer} and set the installation medium entry accordingly.

--- a/guides/common/modules/proc_removing-a-package-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-a-package-from-a-host.adoc
@@ -7,7 +7,8 @@
 To uninstall software or resolve dependency issues, you can remove a package from a host.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the host containing the package you want to remove.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select the host containing the package you want to remove.
 . On the *Content* tab, select *Packages*.
 . Click the vertical ellipsis icon at the end of the line for the package you want to remove, and choose the *Remove* option.
 . Click *Submit*.

--- a/guides/common/modules/proc_removing-ansible-roles-from-a-host.adoc
+++ b/guides/common/modules/proc_removing-ansible-roles-from-a-host.adoc
@@ -7,7 +7,7 @@
 Use the following procedure to remove Ansible roles from a host.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts*.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the host and click *Edit*.
 . Select the *Ansible Roles* tab.
 . In the *Assigned Ansible Roles* area, click the *-* icon to remove the role from the host.

--- a/guides/common/modules/proc_switching-scc-accounts.adoc
+++ b/guides/common/modules/proc_switching-scc-accounts.adoc
@@ -22,7 +22,7 @@ If you delete your old SCC account, you cannot reuse existing repositories, prod
 For more information, see xref:adding-an-scc-account-to-{project-context}-by-using-web-ui[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content > SUSE Subscriptions*.
+. In the {ProjectWebUI}, navigate to *Content* > *SUSE Subscriptions*.
 . Select your SCC account.
 . Enter a new *Login* and *Password*.
 . Click *Submit* to change your SCC account.

--- a/guides/common/modules/proc_synchronizing-suse-content.adoc
+++ b/guides/common/modules/proc_synchronizing-suse-content.adoc
@@ -11,7 +11,7 @@ Use this procedure to synchronize SUSE content to your {Project} to deploy, regi
 For more information, see xref:importing-suse-products-by-using-web-ui[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content > Products*.
+. In the {ProjectWebUI}, navigate to *Content* > *Products*.
 . Select the `{SLES} {client-os-major}.{client-os-minor} x86_64` product and click *Sync Now* to synchronize the SUSE repositories for SLES {client-os-major}.{client-os-minor} to {Project}.
 ifdef::orcharhino[]
 +

--- a/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
+++ b/guides/common/modules/proc_uninstalling-microsoft-azure-plugin.adoc
@@ -14,4 +14,4 @@ If you previously installed the Microsoft Azure plugin but do not use it anymore
 # {project-package-remove} rubygem-foreman_azure_rm rubygem-ms_rest_azure
 # {foreman-installer} --no-enable-foreman-plugin-azure
 ----
-. Optional: In the {ProjectWebUI}, navigate to *Administer > About* and select the *Available Providers* tab to verify the removal of the Microsoft Azure plugin.
+. Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the *Available Providers* tab to verify the removal of the Microsoft Azure plugin.

--- a/guides/common/modules/proc_viewing-installed-packages.adoc
+++ b/guides/common/modules/proc_viewing-installed-packages.adoc
@@ -7,7 +7,8 @@
 You can view the installed packages on a host to see what is present or to plan package or errata actions.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Hosts > All Hosts* and select the name of the host.
+. In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
+. Select the name of the host.
 . On the *Content* tab, *Packages* displays a list of installed packages.
 . To see details of a package, select that package.
 * The *Details* tab displays details of the selected package.

--- a/guides/common/modules/ref_general-settings-information.adoc
+++ b/guides/common/modules/ref_general-settings-information.adoc
@@ -9,9 +9,9 @@ The general settings define system-wide configuration options for {Project}, inc
 [cols="30%,30%,40%",options="header"]
 |====
 | Setting | Default Value | Description
-| *Administrator email address*	|  |The default administrator email address
+| *Administrator email address* | |The default administrator email address
 | *{Project} URL* | | URL where your {Project} instance is reachable.
-See also *Provisioning > Unattended URL*.
+See also *Provisioning* > *Unattended URL*.
 | *Entries per page* | 20 | Number of records shown per page in {Project}
 | *Fix DB cache* | No | {Project} maintains a cache of permissions and roles.
 When set to `Yes`, {Project} recreates this cache on the next restart.
@@ -25,7 +25,7 @@ Requests to the local host are excluded by default.
 | *Show Experimental Labs* | No | Whether or not to show a menu to access experimental lab features (requires reload of page).
 | *Display FQDN for hosts* | Yes | If set to `Yes`, {Project} displays names of hosts as fully qualified domain names (FQDNs).
 | *Out of sync interval* | 30 | Hosts report periodically, and if the time between reports exceeds this duration in minutes, hosts are considered out of sync.
-You can override this on your hosts by adding the `outofsync_interval` parameter, per host, at *Hosts > All hosts > $host > Edit > Parameters > Add Parameter*.
+You can override this on your hosts by adding the `outofsync_interval` parameter, per host, at *Hosts* > *All Hosts* > *$host* > *Edit* > *Parameters* > *Add Parameter*.
 | *{Project} UUID* | | {Project} instance ID.
 Uniquely identifies a {Project} instance.
 | *Default language* | | The UI for new users uses this language.


### PR DESCRIPTION
#### What changes are you introducing?

Change from "\*X > Y\*" to "\*X\* > \*Y\*".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This patch ensures that we only emphasize the labels from Foreman+Katello Web UI, but not the arrows.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Found via `$ fd -e adoc | xargs rg " > " | rg -v "\* > \*"`.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
