### PR TITLE
Simplify Client OS attributes

### DIFF
--- a/guides/common/assembly_adding-content-to-foreman.adoc
+++ b/guides/common/assembly_adding-content-to-foreman.adoc
@@ -18,11 +18,11 @@ include::modules/proc_importing-custom-ssl-certificates-by-using-web-ui.adoc[lev
 
 include::modules/proc_importing-custom-ssl-certificates-by-using-cli.adoc[leveloffset=+2]
 
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 include::modules/proc_extracting-gpg-keys-from-rpm-packages.adoc[leveloffset=+2]
 endif::[]
 
-ifndef::satellite[]
+ifdef::katello,debian,ubuntu[]
 include::modules/proc_extracting-gpg-public-key-fingerprints-from-release-files.adoc[leveloffset=+2]
 endif::[]
 

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -154,7 +154,7 @@ endif::[]
 :RHCloud: Red{nbsp}Hat Hybrid Cloud Console
 :RHEL: Red{nbsp}Hat Enterprise Linux
 :RHELServer: {RHEL} Server
-:SLES: SUSE Linux Enterprise Server
+:SLES: openSUSE/SUSE Linux Enterprise Server
 :server-example-com: server.example.com
 :smart-proxy-context: smart-proxy
 :smart-proxy-context-titlecase: Smart_Proxy
@@ -180,16 +180,14 @@ endif::[]
 :advisorengine: {Insights} Advisor
 :vulnerabilityengine: {Insights} Vulnerability
 :sectanchors:
-:client-content-dnf:
 // Hosts
-:client-installation-medium: centos
 :client-content-type: yum
 :client-container-image-name: rhel7
 :client-container-product-name: Red Hat Container Catalog
 :client-container-repository-name: RHEL7
 :client-container-url: http://registry.access.redhat.com/
 :client-debian-installation-medium-path: http://deb.debian.org/debian/
-:client-installation-medium-path: download.example.com/{client-installation-medium}/$version/Server/$arch/os/
+:client-installation-medium-path: download.example.com/centos/$version/Server/$arch/os/
 :client-clevis-repository: AppStream
 :client-cv-filter: RPM
 :client-os-family-hammer: Redhat

--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -1,8 +1,6 @@
 :_mod-docs-content-type: ATTRIBUTES
 
 // Overrides for katello build
-:client-content-apt:
-:client-content-zypper:
 :installer-log-file: /var/log/foreman-installer/katello.log
 :installer-scenario-smartproxy: foreman-installer --scenario foreman-proxy-content
 :installer-scenario: foreman-installer --scenario katello

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -56,9 +56,43 @@
 :atix-kb-debian-ubuntu-installation-media: https://atixservice.zendesk.com/hc/en-001/articles/7044086506908[Using file repositories for installation media for Debian/Ubuntu]
 :atix-kb-register-to-occ: https://atixservice.zendesk.com/hc/en-001/articles/9464966748444[Registering {ProjectServer} to OCC]
 :atix-kb-tech-previews: https://atixservice.zendesk.com/hc/en-001/articles/16772654610844[Technical Previews]
-// Overwritten in downstream for docs.orcharhino.com
-:client-package-install: dnf install
-:client-package-remove: dnf remove
-:client-repo-url: {foreman-example-com}/pulp/content/My_Organization/Library/custom/{client-os-context}_Client/{client-os-context}_Client_{client-os-major}/
+// Client attributes; overwritten in downstream for docs.orcharhino.com for all supported Client OS
+:ubuntu:
+:client-os-codename: Resolute
+:client-os-context: ubuntu
+:client-os-major: 26.04
+:client-os-minor: 0
+:client-os: Ubuntu
+// Client attributes in alphabetical order that use other attributes
+:client-ca-certificates-path: /usr/local/share/ca-certificates/
+:client-clevis-repository: universe
+:client-container-image-name: ubuntu
+:client-container-product-name: Ubuntu Container Images
+:client-container-repository-name: {client-os}
+:client-container-url: https://registry-1.docker.io
+:client-content-content-view-label: {client-os}_{client-os-major}
+:client-content-product-label: {client-os}_{client-os-major}
+:client-content-repository-label: {client-os-codename}-main
+:client-content-type: Deb
+:client-cv-filter: Deb
+:client-debian-installation-medium-path: http://ftp.ubuntu.com/ubuntu/
+:client-enable-chrony-service: systemctl enable --now chrony
+:client-extracted-gpg-key-extracted-path: ~/_My_GPG_Public_Key_
+:client-extracted-gpg-key-target-path: ~/_My_GPG_Public_Key_
+:client-install-yggdrasil-package: apt-get install foreman-ygg-migration
+:client-installation-medium-path: download.example.com/{client-os-context}/{client-os-major}.{client-os-minor}/
+:client-os-family-hammer: Debian
+:client-os-family: Debian
+:client-os-label: {client-os}
+:client-os-minor-bumped: 1
+:client-package-install: apt-get install
+:client-package-remove: apt-get remove
+:client-pkg-arch: all
+:client-pkg-ext: deb
+:client-provisioning-template-type: Preseed
 :client-puppet-repo-url: http://_{foreman-example-com}_/pulp/content/_My_Organization_/Library/custom/Puppet_Agent/Puppet_Agent_{client-os}_{client-os-major}/
-:client-yggdrasil-query-command: rpm --query yggdrasil
+:client-query-yggdrasil-package: dpkg-query --show yggdrasil-mqtt
+:client-redhat-repo-path: /etc/apt/sources.list.d/rhsm.sources
+:client-repo-url: {foreman-example-com}/pulp/content/My_Organization/Library/custom/{client-os-context}_Client/{client-os-context}_Client_{client-os-major}/
+:client-salt-minion-repository-url: https://packages.broadcom.com/artifactory/saltproject-deb/
+:client-update-certificates-command: update-ca-certificates

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -141,6 +141,15 @@ endif::[]
 :SmartProxyServer: Capsule{nbsp}Server
 :SmartProxyServers: {SmartProxyServer}s
 :Team: Red{nbsp}Hat
+// Clients
+:client-ca-certificates-path: /etc/pki/ca-trust/source/anchors/
+:client-enable-chrony-service: systemctl enable --now chronyd
+:client-extracted-gpg-key-extracted-path: ~/etc/pki/rpm-gpg/RPM-GPG-KEY-EXAMPLE-95
+:client-extracted-gpg-key-target-path: ~/RPM-GPG-KEY-EXAMPLE-95
+:client-install-yggdrasil-package: dnf install foreman_ygg_migration
+:client-query-yggdrasil-package: rpm --query yggdrasil
+:client-redhat-repo-path: /etc/yum.repos.d/redhat.repo
+:client-update-certificates-command: update-ca-trust
 
 // Ansible documentation
 :ansible-doc-templates_import: https://console.redhat.com/ansible/automation-hub/repo/published/redhat/satellite/content/module/templates_import/

--- a/guides/common/modules/con_content-filter-examples.adoc
+++ b/guides/common/modules/con_content-filter-examples.adoc
@@ -62,7 +62,7 @@ Set the *Start Date* to the date you want to restrict errata.
 Leave the *End Date* blank to ensure any new non-security errata is filtered.
 ====
 
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 .Include a module stream
 ====
 Filter a specific module stream in a content view.
@@ -83,7 +83,7 @@ Add a rule to exclude all `*` packages, or specify the package names that you wa
 ====
 endif::[]
 
-ifndef::orcharhino[]
+ifdef::satellite[]
 .Additional resources
 * https://access.redhat.com/solutions/1564953["How do content filters work in Satellite 6"]
 endif::[]

--- a/guides/common/modules/con_content-filter-overview.adoc
+++ b/guides/common/modules/con_content-filter-overview.adoc
@@ -39,12 +39,12 @@ You can filter content based on the following content types:
 |===
 | Content Type | Description
 
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 |*RPM* | Filter packages based on their name and version number.
 The *RPM* option filters non-modular RPM packages and errata.
 Source RPMs are not affected by this filter and will still be available in the content view.
 endif::[]
-ifdef::client-content-apt[]
+ifdef::katello,debian,ubuntu[]
 |*Deb* | Filter packages based on their name.
 The *Deb* option filters Deb packages.
 endif::[]
@@ -53,7 +53,7 @@ The list of package groups is based on the repositories added to the content vie
 | *Erratum (by ID)* | Select which specific errata to add to the filter.
 The list of Errata is based on the repositories added to the content view.
 | *Erratum (by Date and Type)* | Select a issued or updated date range and errata type (Bugfix, Enhancement, or Security) to add to the filter.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 | *Module Streams* | Select whether to include or exclude specific module streams.
 The *Module Streams* option filters modular RPMs and errata, but does not filter non-modular content that is associated with the selected module stream.
 endif::[]

--- a/guides/common/modules/proc_adding-installation-media-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-installation-media-by-using-web-ui.adoc
@@ -42,7 +42,7 @@ If you want to improve download performance when using installation media to ins
 . Click *Create Medium*.
 . In the *Name* field, enter a name to represent the installation media entry.
 . In the *Path* enter the URL that contains the installation tree.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 You can use following variables in the path to represent multiple different system architectures and versions:
   * `$arch` {endash} The system architecture.
   * `$version` {endash} The operating system version.

--- a/guides/common/modules/proc_altering-the-privilege-elevation-method.adoc
+++ b/guides/common/modules/proc_altering-the-privilege-elevation-method.adoc
@@ -19,7 +19,7 @@ This collection contains the required *dzdo* become plugin.
 For more information, see https://docs.ansible.com/ansible/latest/collections_guide/collections_installing.html[Installing collections] in _Ansible documentation_.
 
 .Procedure
-. Navigate to *Administer* > *Settings*.
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
 . Select the *Remote Execution* tab.
 . Click the value of the *Effective User Method* setting.
 . Select the new value.

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -20,11 +20,29 @@ endif::[]
 ifdef::satellite,orcharhino,katello[]
 . Enable and start a time-synchronization tool on your host.
 The host must be synchronized with the same NTP server as {ProjectServer} and any {SmartProxyServers}.
-ifdef::client-content-dnf[]
-ifndef::satellite[]
-* On {EL}:
-endif::[]
+ifdef::orcharhino,satellite[]
 +
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {client-enable-chrony-service}
+----
+endif::[]
+ifdef::foreman-el,foreman-deb,katello[]
+* On {EL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# systemctl enable --now chronyd
+----
+* On {DL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# systemctl enable --now chrony
+----
+* On {SLES}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # systemctl enable --now chronyd
 ----
@@ -35,37 +53,55 @@ endif::[]
 .. Transfer the SSL CA file to your host securely, for example by using `scp`.
 .. Login to your host by using SSH.
 .. Copy the certificate to the truststore:
-ifdef::client-content-dnf[]
-ifndef::satellite[]
-* On {EL}:
-endif::[]
+ifdef::orcharhino,satellite[]
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-# cp _My_SSL_CA_file_.pem /etc/pki/ca-trust/source/anchors
+# cp _My_SSL_CA_file_.pem {client-ca-certificates-path}
 ----
 endif::[]
-ifdef::client-content-apt[]
+ifdef::foreman-el,foreman-deb,katello[]
+* On {EL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp _My_SSL_CA_file_.pem /etc/pki/ca-trust/source/anchors/
+----
 * On {DL}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # cp _My_SSL_CA_file_.pem /usr/local/share/ca-certificates/
 ----
+* On {SLES}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp _My_SSL_CA_file_.pem /etc/pki/trust/anchors/
+----
 endif::[]
 .. Update the truststore:
-ifdef::client-content-dnf[]
-ifndef::satellite[]
-* On {EL}:
+ifdef::orcharhino,satellite[]
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# {client-update-certificates-command}
+----
 endif::[]
+ifdef::foreman-el,foreman-deb,katello[]
+* On {EL}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # update-ca-trust
 ----
-endif::[]
-ifdef::client-content-apt[]
 * On {DL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# update-ca-certificates
+----
+* On {SLES}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
+++ b/guides/common/modules/proc_configuring-a-host-to-use-the-pull-client.adoc
@@ -41,7 +41,7 @@ ifdef::satellite[]
 ----
 endif::[]
 endif::[]
-ifdef::katello[]
+ifdef::foreman-el,foreman-deb,katello[]
 ** On {DL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -65,21 +65,15 @@ endif::[]
 
 .Verification
 . Determine which version of the `yggdrasil` package is installed on the host:
+ifdef::orcharhino,satellite[]
 +
-ifdef::satellite[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ rpm --query yggdrasil
+$ {client-query-yggdrasil-package}
 ----
 endif::[]
-ifdef::orcharhino[]
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-$ {client-yggdrasil-query-command}
-----
-endif::[]
-ifdef::katello[]
-** On {EL} and {SLES} hosts:
+ifdef::foreman-el,foreman-deb,katello[]
+** On {EL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -90,6 +84,12 @@ $ rpm --query yggdrasil
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ dpkg-query --show yggdrasil-mqtt
+----
+** On {SLES} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
 ----
 endif::[]
 . Check the status of the Yggdrasil services:

--- a/guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc
+++ b/guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc
@@ -27,42 +27,30 @@ If you want users to authenticate with {PIV} cards, configure {Keycloak} for aut
 . On each system from which you want users to log in to with {PIV} cards:
 .. Install the `opensc` package:
 +
-ifdef::satellite[]
+ifdef::orcharhino,satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {client-package-install-el8} opensc
 ----
 endif::[]
-ifndef::orcharhino,satellite[]
-** On Debian or Ubuntu:
+ifdef::foreman-el,foreman-deb,katello[]
+** On {EL}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {client-package-install-el8} opensc
+----
+** On {DL}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {client-package-install-deb} opensc
 ----
-** On {EL} 8+:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {client-package-install-el8} opensc
-----
-** On {EL} 7:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {client-package-install-el7} opensc
-----
-** On OpenSUSE and {SLES}:
+** On {SLES}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {client-package-install-sles} opensc
-----
-endif::[]
-ifdef::orcharhino[]
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {client-package-install} opensc
 ----
 endif::[]
 .. Ensure Mozilla Firefox is installed.

--- a/guides/common/modules/proc_consuming-content-from-an-ansible-collection-repository.adoc
+++ b/guides/common/modules/proc_consuming-content-from-an-ansible-collection-repository.adoc
@@ -10,7 +10,7 @@ Configure the Ansible Galaxy client to use your {ProjectServer} or {SmartProxySe
 .Prerequisites
 * You have synchronized an Ansible Collection to a {Project} repository.
 * The `ansible-core` package is installed on the host.
-ifdef::client-content-dnf[]
+ifndef::debian,ubuntu[]
 This package is available in AppStream repositories.
 endif::[]
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -15,8 +15,14 @@ ifdef::satellite[]
 # {client-package-install-el8} http://_{common-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
 ----
 endif::[]
-ifndef::satellite,orcharhino[]
-** On Debian and Ubuntu:
+ifdef::foreman-el,foreman-deb,katello[]
+** On {EL}:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {client-package-install-el8} http://_{common-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
+----
+** On {DL}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
@@ -24,13 +30,7 @@ ifndef::satellite,orcharhino[]
 # chmod +x katello-rhsm-consumer
 # ./katello-rhsm-consumer
 ----
-** On {EL} 8+:
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {client-package-install-el8} http://_{common-example-com}_/pub/katello-ca-consumer-latest.noarch.rpm
-----
-** On OpenSUSE and {SLES}:
+** On {SLES}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----

--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-manually.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-manually.adoc
@@ -25,37 +25,55 @@ You can deploy the CA certificate on the host manually by rendering a public pro
 # cp -u {project-context}_ca_cert.crt /etc/rhsm/ca/katello-server-ca.pem
 ----
 . Copy the certificate to the truststore:
-ifdef::client-content-dnf[]
-ifndef::satellite[]
-* On {EL}:
+ifdef::orcharhino,satellite[]
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp {project-context}_ca_cert.crt {client-ca-certificates-path}
+----
 endif::[]
+ifdef::foreman-el,foreman-deb,katello[]
+* On {EL}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # cp {project-context}_ca_cert.crt /etc/pki/ca-trust/source/anchors
 ----
-endif::[]
-ifdef::client-content-apt[]
 * On {DL}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # cp {project-context}_ca_cert.crt /usr/local/share/ca-certificates/
 ----
+* On {SLES}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# cp {project-context}_ca_cert.crt /etc/pki/trust/anchors/
+----
 endif::[]
 . Update the truststore:
-ifdef::client-content-dnf[]
-ifndef::satellite[]
-* On {EL}:
-endif::[]
+ifdef::orcharhino,satellite[]
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
 # update-ca-trust
 ----
 endif::[]
-ifdef::client-content-apt[]
+ifdef::foreman-el,foreman-deb,katello[]
+* On {EL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# update-ca-trust
+----
 * On {DL}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# update-ca-certificates
+----
+* On {SLES}:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version-from-a-web-server.adoc
@@ -18,7 +18,7 @@ Custom repositories, products, and content views are automatically created if th
 .Prerequisites
 * The exported files must be in a syncable format.
 * The exported files must be accessible through HTTP/HTTPS.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ role.

--- a/guides/common/modules/proc_importing-a-content-view-version.adoc
+++ b/guides/common/modules/proc_importing-a-content-view-version.adoc
@@ -24,7 +24,7 @@ endif::[]
 ifndef::satellite[]
 For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
 endif::[]
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ Role.

--- a/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-cli.adoc
@@ -12,41 +12,71 @@ Red{nbsp}Hat content is already configured with the appropriate GPG key and thus
 endif::[]
 
 .Prerequisites
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * Ensure that you have a copy of the GPG key used to sign the RPM content that you want to use and manage in {Project}.
 Most RPM distribution vendors provide their GPG Key on their website.
 You can also extract GPG key files from an RPM package.
 For more information, see xref:extracting-gpg-keys-from-rpm-packages[].
 endif::[]
-ifndef::client-content-dnf[]
+ifdef::katello,debian,ubuntu[]
 * Extract the GPG public key fingerprints from a signed `Release` file for Deb content.
 For more information, see xref:Extracting_GPG_Public_Key_Fingerprints_from_Release_Files_{context}[].
 endif::[]
 
 .Procedure
 . Copy the GPG key to your {ProjectServer}:
+ifdef::orcharhino,satellite[]
 +
-[options="nowrap" subs="+quotes,attributes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-ifdef::client-content-dnf[]
-$ scp ~/etc/pki/rpm-gpg/RPM-GPG-KEY-_EXAMPLE-95_ root@{foreman-example-com}:~/.
+$ scp _{client-extracted-gpg-key-extracted-path}_ root@{foreman-example-com}:~/.
+----
 endif::[]
-ifndef::client-content-dnf[]
+ifdef::katello[]
+* For Deb content:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
 $ scp ~/_My_GPG_Public_Key_ root@{foreman-example-com}:~/.
-endif::[]
 ----
-. Upload the GPG key to {Project}:
+* For Yum content:
 +
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ scp ~/_etc/pki/rpm-gpg/RPM-GPG-KEY-EXAMPLE-95_ root@{foreman-example-com}:~/.
+----
+endif::[]
+. Upload the GPG key to {Project}:
+ifdef::orcharhino,satellite[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ hammer content-credentials create \
 --content-type gpg_key \
 --name "_My_GPG_Key_" \
 --organization "_My_Organization_" \
-ifdef::client-content-dnf[]
---path ~/RPM-GPG-KEY-_EXAMPLE-95_
-endif::[]
-ifndef::client-content-dnf[]
---path ~/_My_GPG_Public_Key_
-endif::[]
+--path _{client-extracted-gpg-key-target-path}_
 ----
+endif::[]
+ifdef::katello[]
+* For Deb content:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ hammer content-credentials create \
+--content-type gpg_key \
+--name "_My_GPG_Key_" \
+--organization "_My_Organization_" \
+--path ~/_My_GPG_Public_Key_
+----
+* For Yum content:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ hammer content-credentials create \
+--content-type gpg_key \
+--name "_My_GPG_Key_" \
+--organization "_My_Organization_" \
+--path ~/_RPM-GPG-KEY-EXAMPLE-95_
+----
+endif::[]

--- a/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-web-ui.adoc
@@ -12,13 +12,13 @@ Red{nbsp}Hat content is already configured with the appropriate GPG key and thus
 endif::[]
 
 .Prerequisites
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * Ensure that you have a copy of the GPG key used to sign the RPM content that you want to use and manage in {Project}.
 Most RPM distribution vendors provide their GPG Key on their website.
 You can also extract GPG key files from an RPM package.
 For more information, see xref:extracting-gpg-keys-from-rpm-packages[].
 endif::[]
-ifndef::client-content-dnf[]
+ifdef::katello,debian,ubuntu[]
 * Extract the GPG public key fingerprints from a signed `Release` file for Deb content.
 For more information, see xref:Extracting_GPG_Public_Key_Fingerprints_from_Release_Files_{context}[].
 endif::[]

--- a/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-a-repository-from-a-web-server.adoc
@@ -10,7 +10,7 @@ For more information about exporting the content of a repository, see xref:Expor
 .Prerequisites
 * The exported files must be in a syncable format.
 * The exported files must be accessible through HTTP/HTTPS.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 * If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ Role.

--- a/guides/common/modules/proc_importing-a-repository.adoc
+++ b/guides/common/modules/proc_importing-a-repository.adoc
@@ -16,7 +16,7 @@ endif::[]
 ifndef::satellite[]
 For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
 endif::[]
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 * If the export contains any Red Hat repositories, the manifest of the importing organization must contain subscriptions for the products contained within the export.
 endif::[]
 * The user importing the content must have the _Content Importer_ Role.

--- a/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment-from-a-web-server.adoc
@@ -10,7 +10,7 @@ For more information about exporting contents from the Library environment, see 
 .Prerequisites
 * The exported files must be in a syncable format.
 * The exported files must be accessible through HTTP/HTTPS.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
 endif::[]
 * The user importing the content view version must have the _Content Importer_ role.

--- a/guides/common/modules/proc_importing-into-the-library-environment.adoc
+++ b/guides/common/modules/proc_importing-into-the-library-environment.adoc
@@ -16,7 +16,7 @@ endif::[]
 ifndef::satellite[]
 For more information, see xref:configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[].
 endif::[]
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 * If there are any Red Hat repositories in the exported content, the importing organization's manifest must contain subscriptions for the products contained within the export.
 endif::[]
 * The user importing the content must have the _Content Importer_ Role.

--- a/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
+++ b/guides/common/modules/proc_providing-the-salt-client-to-salt-minions.adoc
@@ -12,20 +12,10 @@ ifdef::suse_linux_enterprise_server[]
 endif::[]
 ifndef::suse_linux_enterprise_server[]
 . Create a product called `Salt`.
-ifndef::orcharhino[]
-For more information, see {ContentManagementDocURL}creating-a-custom-product-by-using-web-ui[Creating a {customproduct} by using {ProjectWebUI}].
-endif::[]
 . Create a repository within the _Salt_ product for each operating system supported by {Project} that you want to install the Salt Minion client software on.
-ifdef::client-content-apt[]
-For more information, see {ContentManagementDocURL}adding-deb-repositories-by-using-web-ui[Adding Deb repositories].
-endif::[]
-ifdef::client-content-dnf[]
-For more information, see {ContentManagementDocURL}adding-custom-rpm-repositories-by-using-web-ui[Adding RPM repositories].
-endif::[]
-+
 Add the operating system to the name of the repository, for example `Salt for {client-os} {client-os-major}`.
 +
-The URL depends on both the Salt version and the operating system, for example `{client-salt-minion-repository-url}`.
+The URL depends on both the Salt version and the operating system, for example, `{client-salt-minion-repository-url}`.
 ifdef::katello[]
 For hosts running {DL}, use `https://packages.broadcom.com/artifactory/saltproject-deb` as upstream URL.
 endif::[]
@@ -40,4 +30,11 @@ For more information, see {ContentManagementDocURL}creating-a-composite-content-
 . Promote the content view from the previous step to your lifecycle environments as appropriate.
 For more information, see {ContentManagementDocURL}promoting-a-content-view-by-using-web-ui[Promoting a content view by using {ProjectWebUI}].
 . Optional: Create activation keys for your composite content view and lifecycle environment combinations.
+endif::[]
+
+ifdef::katello[]
+.Additional resources
+* {ContentManagementDocURL}creating-a-custom-product-by-using-web-ui[Creating a {customproduct} by using {ProjectWebUI}]
+* {ContentManagementDocURL}adding-deb-repositories-by-using-web-ui[Adding Deb repositories by using {ProjectWebUI}]
+* {ContentManagementDocURL}adding-custom-rpm-repositories-by-using-web-ui[Adding {customrpm} repositories by using {ProjectWebUI}]
 endif::[]

--- a/guides/common/modules/proc_registering-a-host-to-project-by-using-api.adoc
+++ b/guides/common/modules/proc_registering-a-host-to-project-by-using-api.adoc
@@ -56,16 +56,13 @@ Keep in mind this can save the password in the shell history.
 Alternatively, you can use a temporary personal access token instead of a password.
 To generate a token in the {ProjectWebUI}, navigate to *My Account* > *Personal Access Tokens*.
 . Connect to your host using SSH and run the registration command.
-ifdef::satellite[]
-. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+ifdef::orcharhino,satellite[]
+. Check the `{client-redhat-repo-path}` file and ensure that the appropriate repositories have been enabled.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Ensure that the appropriate repositories have been enabled:
 +
-ifdef::client-content-dnf[]
 * On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::client-content-apt[]
-* On Debian: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-endif::[]
+* On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+* On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
 endif::[]

--- a/guides/common/modules/proc_registering-a-host-to-project-by-using-cli.adoc
+++ b/guides/common/modules/proc_registering-a-host-to-project-by-using-cli.adoc
@@ -41,16 +41,13 @@ $ hammer host-registration generate-command \
 ----
 endif::[]
 . Connect to your host using SSH and run the registration command.
-ifdef::satellite[]
-. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+ifdef::orcharhino,satellite[]
+. Check the `{client-redhat-repo-path}` file and ensure that the appropriate repositories have been enabled.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Ensure that the appropriate repositories have been enabled:
 +
-ifdef::client-content-dnf[]
 * On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::client-content-apt[]
-* On Debian: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-endif::[]
+* On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+* On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
 endif::[]

--- a/guides/common/modules/proc_registering-a-host-to-project-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-to-project-by-using-web-ui.adoc
@@ -13,16 +13,12 @@ For more information, see {ManagingHostsDocURL}registering-hosts-to-{project-con
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Connect to your host using SSH and run the registration command.
-ifdef::satellite[]
-. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+ifdef::orcharhino,satellite[]
+. Check the `{client-redhat-repo-path}` file and ensure that the appropriate repositories have been enabled.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Ensure that the appropriate repositories have been enabled:
-+
-ifdef::client-content-dnf[]
 * On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::client-content-apt[]
-* On Debian: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-endif::[]
+* On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+* On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
 endif::[]

--- a/guides/common/modules/proc_registering-a-host-to-the-load-balancer-using-api.adoc
+++ b/guides/common/modules/proc_registering-a-host-to-the-load-balancer-using-api.adoc
@@ -46,19 +46,13 @@ Keep in mind this can save the password in the shell history.
 Alternatively, you can use a temporary personal access token instead of a password.
 To generate a token in the {ProjectWebUI}, navigate to *My Account* > *Personal Access Tokens*.
 . Connect to your host using SSH and run the registration command.
-ifdef::satellite[]
-. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+ifdef::orcharhino,satellite[]
+. Check the `{client-redhat-repo-path}` file and ensure that the appropriate repositories have been enabled.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Ensure that the appropriate repositories have been enabled:
 +
-ifdef::client-content-dnf[]
 * On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::client-content-apt[]
-* On Debian: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-endif::[]
 * On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-* On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 * On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
 endif::[]

--- a/guides/common/modules/proc_registering-a-host-to-the-load-balancer-using-cli.adoc
+++ b/guides/common/modules/proc_registering-a-host-to-the-load-balancer-using-cli.adoc
@@ -30,21 +30,12 @@ You can use the ID of any {SmartProxyServer} that you configured for host regist
 +
 Include the `--force` option to register a host that has been previously registered to a {SmartProxyServer}.
 . Connect to your host using SSH and run the registration command.
-ifdef::satellite[]
-. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+ifdef::orcharhino,satellite[]
+. Check the `{client-redhat-repo-path}` file and ensure that the appropriate repositories have been enabled.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Ensure that the appropriate repositories have been enabled:
-+
-ifdef::client-content-dnf[]
 * On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::client-content-apt[]
-* On Debian: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::load-balancing[]
 * On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-* On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 * On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
-endif::[]
 endif::[]

--- a/guides/common/modules/proc_registering-a-host-to-the-load-balancer-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-to-the-load-balancer-using-web-ui.adoc
@@ -14,21 +14,12 @@ After setting the load balancer for host registration, you can register a host t
 . Click *Generate* to create the registration command.
 . Click on the _files_ icon to copy the command to your clipboard.
 . Connect to your host using SSH and run the registration command.
-ifdef::satellite[]
-. Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+ifdef::orcharhino,satellite[]
+. Check the `{client-redhat-repo-path}` file and ensure that the appropriate repositories have been enabled.
 endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Ensure that the appropriate repositories have been enabled:
-+
-ifdef::client-content-dnf[]
 * On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::client-content-apt[]
-* On Debian: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-endif::[]
-ifdef::load-balancing[]
 * On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-* On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
 * On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
-endif::[]
 endif::[]

--- a/guides/common/modules/proc_restricting-customrepoid-to-a-specific-operating-system-version-or-architecture-in-project.adoc
+++ b/guides/common/modules/proc_restricting-customrepoid-to-a-specific-operating-system-version-or-architecture-in-project.adoc
@@ -5,9 +5,7 @@
 
 [role="_abstract"]
 You can configure {Project} to make a {customrepo} available only on hosts with a specific operating system version or architecture.
-ifdef::client-content-dnf[]
 For example, you can restrict a {customrepo} only to {client-os}{nbsp}{client-os-major} hosts.
-endif::[]
 
 ifdef::satellite[]
 [NOTE]

--- a/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-pull-mode.adoc
+++ b/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-pull-mode.adoc
@@ -11,27 +11,31 @@ If the `/run/` directory on your host is mounted with the `noexec` flag, {Projec
 
 .Prerequisite
 * Determine which version of the `yggdrasil` package is installed on the host:
-ifdef::satellite[]
+ifdef::orcharhino,satellite[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ {client-query-yggdrasil-package}
+----
+endif::[]
+ifdef::foreman-el,foreman-deb,katello[]
+** On {EL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ rpm --query yggdrasil
 ----
-endif::[]
-ifndef::satellite[]
-** On {EL} and {SLES} hosts:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-$ rpm --query yggdrasil
-----
-endif::[]
-ifdef::client-content-apt[]
 ** On {DL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ dpkg-query --show yggdrasil-mqtt
+----
+** On {SLES} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
 ----
 endif::[]
 

--- a/guides/common/modules/proc_synchronizing-a-single-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-a-single-repository.adoc
@@ -10,17 +10,17 @@ In this scenario, you export and import a single repository.
 . On the upstream {ProjectServer}, perform the following steps:
 .. Ensure that the repository is using the *Immediate* download policy in one of the following ways:
 ... For existing repositories using *On Demand*, change their download policy on the repository details page to *Immediate*.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 ... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
-ifndef::client-content-dnf[]
+ifdef::almalinux,amazon_linux,centos,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[]
 ... Ensure that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
 
 +
 For more information, see xref:Download_Policies_Overview_{context}[].
 .. Enable the content that you want to synchronize.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For more information, see xref:enabling-red-hat-repositories-by-using-web-ui[].
 endif::[]
 +

--- a/guides/common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc
+++ b/guides/common/modules/proc_troubleshooting-remote-jobs-timing-out-after-yggdrasil-update.adoc
@@ -18,11 +18,33 @@ On hosts with weak dependencies disabled, you must install the `foreman_ygg_migr
 
 .Procedure
 . Determine which version of the `yggdrasil` package is installed on the host:
+ifdef::orcharhino,satellite[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ {client-query-yggdrasil-package}
+----
+endif::[]
+ifdef::foreman-el,foreman-deb,katello[]
+** On {EL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ rpm --query yggdrasil
 ----
+** On {DL} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ dpkg-query --show yggdrasil-mqtt
+----
+** On {SLES} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ rpm --query yggdrasil
+----
+endif::[]
 . If your host has `yggdrasil` version 0.4.z or later installed, the `yggdrasil` and `com.redhat.Yggdrasil1.Worker1.foreman` services are expected to be running.
 Check the status of these services:
 +
@@ -33,11 +55,33 @@ Check the status of these services:
 +
 If the above services are not running, it means that Yggdrasil might not be configured correctly.
 . Install the `foreman_ygg_migration` package manually:
+ifdef::orcharhino,satellite[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {client-install-yggdrasil-package}
+----
+endif::[]
+ifdef::foreman-el,foreman-deb,katello[]
+** On {EL} hosts:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # dnf install foreman_ygg_migration
 ----
+** On {DL} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# apt-get install foreman-ygg-migration
+----
+** On {SLES} hosts:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# zypper install foreman_ygg_migration
+----
+endif::[]
 +
 Installing `foreman_ygg_migration` ensures that {Project} applies the required Yggdrasil configuration changes and enables remote execution in pull mode to work as expected.
 

--- a/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
+++ b/guides/common/modules/proc_using-upstream-server-as-a-content-store.adoc
@@ -12,17 +12,17 @@ You export the Library content from the upstream {ProjectServer} and import it i
 . On the upstream {ProjectServer}, perform the following steps:
 .. Ensure that repositories are using the *Immediate* download policy in one of the following ways:
 ... For existing repositories using *On Demand*, change their download policy on the repository details page to *Immediate*.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 ... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
-ifndef::client-content-dnf[]
+ifdef::almalinux,amazon_linux,centos,debian,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[]
 ... Ensure that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
 
 +
 For more information, see xref:Download_Policies_Overview_{context}[].
 .. Enable the content that you want to synchronize.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For more information, see xref:enabling-red-hat-repositories-by-using-web-ui[].
 endif::[]
 +

--- a/guides/common/modules/proc_using-upstream-server-to-sync-content-view-versions.adoc
+++ b/guides/common/modules/proc_using-upstream-server-to-sync-content-view-versions.adoc
@@ -12,17 +12,17 @@ Once you promote content to a designated lifecycle environment, you can export t
 . On the upstream {ProjectServer}, perform the following steps:
 .. Ensure that repositories are using the *Immediate* download policy in one of the following ways:
 ... For existing repositories using *On Demand*, change their download policy on the repository details page to *Immediate*.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 ... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
-ifndef::client-content-dnf[]
+ifdef::katello,almalinux,amazon_linux,centos,debian,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[]
 ... Ensure that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
 
 +
 For more information, see xref:Download_Policies_Overview_{context}[].
 .. Enable the content that you want to synchronize.
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For more information, see xref:enabling-red-hat-repositories-by-using-web-ui[].
 endif::[]
 +

--- a/guides/common/modules/ref_advanced-synchronization-options.adoc
+++ b/guides/common/modules/ref_advanced-synchronization-options.adoc
@@ -15,7 +15,7 @@ Complete Sync::
 Synchronizes all packages regardless of detected changes.
 Use this option if specific packages could not be downloaded to the local repository even though they exist in the upstream repository.
 
-ifdef::client-content-dnf[]
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 Verify Content Checksum::
 Synchronizes all packages and then verifies the checksum of all packages locally.
 If the checksum of an RPM differs from the upstream, it re-downloads the RPM.

--- a/guides/common/modules/ref_workflow-for-creating-content-views.adoc
+++ b/guides/common/modules/ref_workflow-for-creating-content-views.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="workflows-for-creating-content-views"]
+[id="workflow-for-creating-content-views"]
 = Workflow for creating content views
 
 [role="_abstract"]
@@ -18,12 +18,14 @@ For more information, see xref:Resolving_Package_Dependencies_{context}[].
 . Optional: Promote the content view to another environment.
 For more information, see xref:promoting-a-content-view-by-using-web-ui[].
 . Attach the host to the content view.
-
-ifdef::client-content-dnf[]
-If a repository is not associated with the content view, the file `/etc/yum.repos.d/redhat.repo` remains empty and systems registered to it cannot receive updates.
++
+ifdef::orcharhino,satellite[]
+If a repository is not associated with the content view, the file `{client-redhat-repo-path}` remains empty and hosts registered to it cannot receive updates.
 endif::[]
-ifdef::client-content-apt[]
-If a repository is not associated with the content view, the file `/etc/apt/sources.list.d/rhsm.sources` remains empty and systems registered to it cannot receive updates.
+ifdef::katello[]
+* On {EL} hosts: If a repository is not associated with the content view, the file `/etc/yum.repos.d/redhat.repo` remains empty and hosts registered to it cannot receive updates.
+* On {DL} hosts: If a repository is not associated with the content view, the file `/etc/apt/sources.list.d/rhsm.sources` remains empty and hosts registered to it cannot receive updates.
+* On {SLES} hosts: If a repository is not associated with the content view, the directory `/etc/zypp/repos.d/` remains empty and hosts registered to it cannot receive updates.
 endif::[]
 
 Hosts can only be associated with a single content view.

--- a/guides/common/modules/snip_supported-client-operating-systems.adoc
+++ b/guides/common/modules/snip_supported-client-operating-systems.adoc
@@ -17,7 +17,6 @@ endif::[]
 endif::[]
 ifndef::orcharhino,satellite[]
 * Fedora
-* OpenSUSE
 * {SLES}
 * Ubuntu
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Add guidelines
* Add missing attributes
* Convert client-content-* attribute to Client OS
* For Satellite, use RHEL as default Client OS
* For orcharhino, use Ubuntu as default Client OS
* Remove attribute client-content-apt
* Remove attribute client-content-dnf
* Remove attribute client-content-zypper

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This massively simplifies maintenance for both upstream and downstream and enhances the docs for upstream.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

````
$ rg -i "client-content-apt"
$ rg -i "client-content-dnf"
$ rg -i "client-content-zypper"
````
#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
