### PR TITLE
Clean up deprecation and upgrade warnings

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -18,28 +18,6 @@
 //+
 //Optional second paragraph of description
 
-Foreman recurring tasks use standardized rake tasks and systemd timers::
-+
---
-In this release, recurring Foreman maintenance tasks are no longer managed by ad‑hoc cron jobs.
-Instead, they now run through a standardized set of rake tasks, managed in `/etc/cron.d/foreman`.
-This change provides a more container‑native approach and enables plugins to register their tasks by using the `Foreman::Cron` framework.
-
-Foreman core provides the following rake tasks:
-
-* `foreman-rake cron:hourly`
-* `foreman-rake cron:daily`
-* `foreman-rake cron:weekly`
-* `foreman-rake cron:monthly`
-
-Users can no longer freely customize arbitrary schedules for these core recurring jobs. This is an intentional limitation to keep behavior more predictable and maintainable.
-
-[IMPORTANT]
-====
-During upgrade, existing cron schedules are not automatically detected or preserved. After upgrading, recurring jobs run on the new standardized schedules. If you previously relied on custom timings, review the new behavior and adjust any custom automation.
-====
---
-
 [id="infrastructure-and-platform-updates"]
 === Infrastructure & platform updates
 
@@ -101,11 +79,7 @@ There are no upgrade warnings with Foreman {ProjectVersion}.
 == Deprecations
 
 //If there are deprecations, comment out the following line.
-//There are no deprecations with Foreman {ProjectVersion}.
-
-Hammer CLI plugin Admin is deprecated::
-As an alternative, you can use the `{foreman-installer}` to manage your {ProjectServer} or {SmartProxyServer}.
-
+There are no deprecations with Foreman {ProjectVersion}.
 
 //To add a headline feature, use AsciiDoc's description list: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
 //Summary::


### PR DESCRIPTION
#### What changes are you introducing?
Based on 
> Clean up deprecation and upgrade warnings from nightly manual for in both foreman.adoc and katello.adoc.

in https://community.theforeman.org/t/foreman-3-19-branching-process/46290, I'm cleaning the Foreman RN up.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Foreman 3.19 branching

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
