### PR TITLE
Remove port 80 from global registration

### DIFF
--- a/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
@@ -14,7 +14,7 @@ The following tables indicate the destination port and the direction of incoming
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
-| 443 | TCP | HTTPS, HTTP | Client | Global Registration | Registering hosts to {Project}
+| 443 | TCP | HTTPS | Client | Global Registration | Registering hosts to {Project}
 
 Port 443 is required for
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_project-server-port-and-firewall-requirements.adoc
@@ -14,15 +14,13 @@ The following tables indicate the destination port and the direction of incoming
 | 67 | UDP | DHCP | Client | Dynamic IP | DHCP (optional)
 | 69 | UDP | TFTP | Client | TFTP Server (optional) |
 | 443 | TCP | HTTPS | {SmartProxy} | {ProjectName} API | Communication from {SmartProxy}
-| 443, 80 | TCP | HTTPS, HTTP | Client | Global Registration | Registering hosts to {Project}
+| 443 | TCP | HTTPS, HTTP | Client | Global Registration | Registering hosts to {Project}
 
 Port 443 is required for
 ifdef::katello,orcharhino,satellite[]
 sending installed packages and traces,
 endif::[]
 registration initiation, and uploading facts.
-
-Port 80 notifies {Project} on the `/unattended/built` endpoint that registration has finished
 ifdef::katello,satellite,orcharhino[]
 | 443 | TCP | HTTPS | {ProjectName} | Content Mirroring | Management
 | 443 | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality


### PR DESCRIPTION
#### What changes are you introducing?
Remove port 80 from global registration

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Global registration no longer uses port 80 https://redhat.atlassian.net/browse/SAT-45432

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
