### PR TITLE
Add Katello 4.21.0 release notes and contributors

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -15,6 +15,10 @@ endif::[]
 // Start inserting specific x.y.z releases here
 include::topics/foreman-3.19.0.adoc[leveloffset=+1]
 
+ifdef::katello[]
+include::topics/katello-4.21.0.adoc[leveloffset=+1]
+endif::[]
+
 [appendix]
 [id="foreman-contributors"]
 = Foreman contributors

--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,9 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+ifdef::katello[]
+include::topics/katello-4.21.0.adoc[leveloffset=+1]
+endif::[]
 
 [appendix]
 [id="foreman-contributors"]

--- a/guides/doc-Release_Notes/topics/katello-4.21.0.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.21.0.adoc
@@ -1,0 +1,113 @@
+= Katello 4.21.0
+
+You can find the complete list of changes on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=2011[Redmine].
+
+== Katello
+
+* pass:[Fix typos and scan issues for rubygem-katello] - https://projects.theforeman.org/issues/39136[#39136]
+* pass:[Structured APT migration rake task not marked as applied if there are no deb repos during upgrade] - https://projects.theforeman.org/issues/39091[#39091]
+* pass:[Remove remainder of entitlement mode code] - https://projects.theforeman.org/issues/39078[#39078]
+* pass:[Add warning for Change Content Source] - https://projects.theforeman.org/issues/39072[#39072]
+
+=== Activation Key
+
+* pass:[API call to list the activation keys associated with a specific lifecycle environment returns all activation keys in the organization] - https://projects.theforeman.org/issues/39252[#39252]
+* pass:[Remove activation key in host group does not work in Web UI] - https://projects.theforeman.org/issues/38928[#38928]
+
+=== Alternate Content Sources
+
+* pass:[Add Alternate Content Source for Deb Repositories] - https://projects.theforeman.org/issues/38905[#38905]
+
+=== Bootable Containers
+
+* pass:[Sanitize order input bootc_images] - https://projects.theforeman.org/issues/39306[#39306]
+
+=== Container
+
+* pass:[Repository update ID parameter in hammer command in docker repos is failing] - https://projects.theforeman.org/issues/39186[#39186]
+
+=== Content Credentials
+
+* pass:[Missing validation to prevent CC deletion when used by ACS] - https://projects.theforeman.org/issues/39309[#39309]
+* pass:[Content credentials - new details page] - https://projects.theforeman.org/issues/39197[#39197]
+* pass:[New Content Credentials Page - Index page] - https://projects.theforeman.org/issues/39140[#39140]
+* pass:[Content Credentials - set up initial infrastructure in React] - https://projects.theforeman.org/issues/39139[#39139]
+
+=== Content Views
+
+* pass:[Issue when creating filter in content view using openssl package] - https://projects.theforeman.org/issues/39217[#39217]
+* pass:[Incremental update of content view version should throw error when no content is added] - https://projects.theforeman.org/issues/39214[#39214]
+* pass:[Unable to delete empty CCV] - https://projects.theforeman.org/issues/39155[#39155]
+* pass:[Replace DeleteLatestContentViewVersion with execution plan callback] - https://projects.theforeman.org/issues/39150[#39150]
+* pass:[CV create lacks useful information in task list view] - https://projects.theforeman.org/issues/39082[#39082]
+* pass:[Composite content view auto publish will be triggered while other component content views are still publishing] - https://projects.theforeman.org/issues/38856[#38856]
+
+=== Foreman Proxy Content
+
+* pass:[n-1/2 Smart Proxy syncs with publication-less Python-type repositories on Pulp 3.105+] - https://projects.theforeman.org/issues/39289[#39289]
+* pass:[Incorrect smart proxy Sync Status after failure] - https://projects.theforeman.org/issues/39203[#39203]
+* pass:[orphan cleanup triggers CapsuleContent::UpdateContentCounts regardless of automatic_content_count_updates setting] - https://projects.theforeman.org/issues/39112[#39112]
+
+=== Host Collections
+
+* pass:[Need to add flow for bulk-assigning Host Collections when there are no HCs in the system] - https://projects.theforeman.org/issues/38843[#38843]
+
+=== Hosts
+
+* pass:[Activation Keys tab is blank when creating/editing HostGroup] - https://projects.theforeman.org/issues/39284[#39284]
+* pass:[Applicable/Installable toggle is hidden for hosts assigned to rolling content views] - https://projects.theforeman.org/issues/39282[#39282]
+* pass:[Unable to save host configuration due to missing variant_repos method] - https://projects.theforeman.org/issues/39258[#39258]
+* pass:[Hosts end up with a nil content source when registered to a foremanctl setup] - https://projects.theforeman.org/issues/39257[#39257]
+* pass:[Hostgroup::ContentFacet should have 1:1 relationship to Content View Environment] - https://projects.theforeman.org/issues/39223[#39223]
+* pass:[As an external Smart Proxy user, the web UI allows me to change hosts' content source and preserve multi-environment hosts] - https://projects.theforeman.org/issues/39216[#39216]
+* pass:[Remove redundant Candlepin pre-flight check and cache /rhsm/status response] - https://projects.theforeman.org/issues/39204[#39204]
+* pass:[Installable updates column has no space between icon and number of updates] - https://projects.theforeman.org/issues/39170[#39170]
+* pass:[Replace JS snapshot tests – Registration Commands] - https://projects.theforeman.org/issues/39168[#39168]
+* pass:[Host links from Packages Details page open Legacy UI instead of new Web UI] - https://projects.theforeman.org/issues/39147[#39147]
+* pass:[Update import of useBulkModal in Katello] - https://projects.theforeman.org/issues/39138[#39138]
+* pass:[bootc information is nullified after Ansible facts upload] - https://projects.theforeman.org/issues/39135[#39135]
+* pass:[MultiCV will get reset after editing a host] - https://projects.theforeman.org/issues/39122[#39122]
+* pass:[Katello:clean_backend_object takes a long time to complete] - https://projects.theforeman.org/issues/38997[#38997]
+
+=== Orchestration
+
+* pass:[Integrate Katello recurring tasks with Foreman::Cron#11633] - https://projects.theforeman.org/issues/39114[#39114]
+
+=== Organizations and Locations
+
+* pass:[Migrate SetOrganization from pf3 to pf5] - https://projects.theforeman.org/issues/39307[#39307]
+* pass:[Organization delete fails with HasManyThroughNestedAssociationsAreReadonly on environment destroy] - https://projects.theforeman.org/issues/39280[#39280]
+* pass:[API docs for organizations still show taxonomy params] - https://projects.theforeman.org/issues/39084[#39084]
+
+=== Repositories
+
+* pass:[Some Pulp tasks not tracked due to change in Pulp update APIs] - https://projects.theforeman.org/issues/39305[#39305]
+* pass:[Replace JS snapshot tests - Misc components] - https://projects.theforeman.org/issues/39215[#39215]
+* pass:[Stop using Python publications with pulp_python 3.27] - https://projects.theforeman.org/issues/39205[#39205]
+* pass:[Replace JS snapshot tests - PF3 components] - https://projects.theforeman.org/issues/39201[#39201]
+* pass:[Replace JS snapshot tests – OrganizationProducts] - https://projects.theforeman.org/issues/39179[#39179]
+* pass:[Replace JS snapshot tests - Content Details] - https://projects.theforeman.org/issues/39178[#39178]
+* pass:[Custom repository sync does not work without the upstream password] - https://projects.theforeman.org/issues/39172[#39172]
+* pass:[Importing content from an URL generates repositories with download_policy on-demand] - https://projects.theforeman.org/issues/39162[#39162]
+* pass:[Add extensions repo to Recommended Repositories] - https://projects.theforeman.org/issues/39157[#39157]
+* pass:[Protected Content should be excluded from Orphan Cleanup] - https://projects.theforeman.org/issues/39116[#39116]
+* pass:[Bump pulp-deb bindings to 3.8] - https://projects.theforeman.org/issues/39032[#39032]
+* pass:[Migrate sync status page to React] - https://projects.theforeman.org/issues/38901[#38901]
+
+=== Subscriptions
+
+* pass:[Error on Subscriptions UI page] - https://projects.theforeman.org/issues/39295[#39295]
+* pass:[Refactor manifest import so Katello no longer consumes Candlepin events] - https://projects.theforeman.org/issues/38953[#38953]
+
+=== Tooling
+
+* pass:[Move theforeman-rubocop dependency to Gemfile] - https://projects.theforeman.org/issues/39270[#39270]
+
+=== Upgrades
+
+* pass:[Create upgrade job to remove publications for all Python repositories in Pulp database] - https://projects.theforeman.org/issues/39241[#39241]
+* pass:[Update gemspec for Pulp 3.105 bindings] - https://projects.theforeman.org/issues/39145[#39145]
+
+=== Web UI
+
+* pass:[Migrate Module Streams to Generic UI and update from PF3 to PF5] - https://projects.theforeman.org/issues/39267[#39267]

--- a/guides/doc-Release_Notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/katello-contributors.adoc
@@ -1,0 +1,21 @@
+Adam Lazik
+Aiden Fine
+Bernhard Suttner
+Eric Helms
+Ian Ballou
+Jeremy Lenz
+Jonathon Turel
+Ladislav Vašina
+Lucy Fu
+Lukáš Ježek
+Nofar Alfasi
+Oleh Fedorenko
+Pablo Méndez Hernández
+Pavan Soma Shekar
+Quinn James
+Samir Jha
+Samuel Bible
+Tobias Grigo
+Vijaykumar Sawant
+Vladimir Sedmik
+Zach Huntington-Meath

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -4,12 +4,43 @@
 [id="katello-headline-features"]
 == Headline features
 
-There are no headline features with Katello {KatelloVersion}.
+Content credentials page modernized::
+The content credentials page has been rewritten in React with modern Patternfly styling.
+The page functions the same as before.
+https://projects.theforeman.org/issues/39197
+
+Container image tagging restored in Hammer CLI::
+You can now tag container images by using Hammer CLI again.
+https://projects.theforeman.org/issues/39186
+
+Pulp 3.105 required::
+Katello now requires Pulp 3.105.
+If you interact directly with certain Pulp APIs, expect breaking changes, for example events switching from asynchronous to synchronous.
+Consult the https://pulpproject.org/pulpcore/changes/#3.105.7[Pulp 3.105 to 3.85 changelog] for more details.
+
+Expanded foreman-maintain reports::
+The `foreman-maintain` report now includes significantly more Katello-specific data about your environment:
++
+* Count of all content types
+* Rolling content view publication information
+* Counts of all host types: image-mode, smart-proxy assigned, and multi content view
 
 [id="katello-upgrade-warnings"]
 == Upgrade warnings
 
-There are no upgrade warnings with Katello {KatelloVersion}.
+Python content on {SmartProxies} requires a complete sync::
+If you have {SmartProxies} syncing Python content from {Project}, run a complete sync on those {SmartProxies} after the upgrade.
+This is required because of changes to Python distributions in Pulp 3.105.
+
+Host groups use a single content view environment::
+Host groups are now associated with a single content view environment, rather than separate content view and lifecycle environment fields.
+Before upgrading, ensure the following:
++
+* Host groups must either assign both the content view and lifecycle environment fields, or assign neither field.
+This avoids breaking host group inheritance.
+* Do not rely on host group inheritance to compose a content view environment from separate lifecycle environment and content view assignments.
+* The content views and lifecycle environments on your host groups must be coherent.
+The content view of the host group must be promoted to the lifecycle environment of the host group.
 
 [id="katello-deprecations"]
 == Deprecations


### PR DESCRIPTION
- Generated release notes from Redmine for Katello 4.21.0
- Added katello-4.21.0.adoc to master.adoc
- Updated katello-contributors.adoc with contributors since KATELLO-4.20 branching

Note: Headline features, upgrade warnings, and deprecations in katello.adoc still have placeholders — release owner should fill those in.