### PR TITLE
Rename modules to import Katello CA to local host

### DIFF
--- a/guides/common/assembly_accessing-project-from-web-ui.adoc
+++ b/guides/common/assembly_accessing-project-from-web-ui.adoc
@@ -5,9 +5,9 @@ include::modules/con_accessing-project-from-web-ui.adoc[]
 include::modules/proc_logging-in-to-the-web-ui.adoc[leveloffset=+1]
 
 ifdef::katello,orcharhino,satellite[]
-include::modules/proc_importing-the-katello-root-ca-certificate-using-web-ui.adoc[leveloffset=+1]
+include::modules/proc_importing-the-katello-root-ca-certificate-by-using-browser.adoc[leveloffset=+1]
 
-include::modules/proc_importing-the-katello-root-ca-certificate-using-cli.adoc[leveloffset=+1]
+include::modules/proc_importing-the-katello-root-ca-certificate-by-using-command-line.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_resetting-the-administrative-user-password.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
+++ b/guides/common/modules/proc_adding-a-remote-console-connection-for-a-host-on-proxmox.adoc
@@ -60,7 +60,7 @@ ifndef::foreman-deb[]
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 . If you use a {customssl} certificate, import the SSL certificate from {ProjectServer} into your browser.
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-using-{project-context}-web-ui[Importing the Katello root CA certificate using {ProjectWebUI}] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-by-using-browser[Importing the Katello root CA certificate by using browser] in _{ConfiguringUserAuthenticationDocTitle}_.
 +
 The remote console connection to your host will fail if you choose to temporarily accept not checking the certificates in your browser.
 endif::[]

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-cli.adoc
@@ -12,7 +12,7 @@ For more information, see xref:creating-a-custom-file-type-repository-by-using-c
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 ** The `katello-server-ca.crt`.
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-using-{project-context}-cli[Importing the Katello root CA certificate using Hammer CLI] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-by-using-command-line[Importing the Katello root CA certificate by using command line] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-web-ui.adoc
@@ -12,7 +12,7 @@ For more information, see xref:creating-a-custom-file-type-repository-by-using-w
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 ** The `katello-server-ca.crt`.
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-using-{project-context}-web-ui[Importing the Katello root CA certificate using {ProjectWebUI}] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-by-using-browser[Importing the Katello root CA certificate by using browser] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 ifndef::satellite[]
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-python-type-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-python-type-repository-by-using-cli.adoc
@@ -11,7 +11,7 @@ You can use Hammer CLI to download files to a client over HTTPS using `curl -O`,
 * You know the name of the Python package you want to download to clients from the Python type repository.
 * To download the Python packages over HTTPS to your hosts, you require:
 ** The `katello-server-ca.crt`.
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-using-{project-context}-cli[Importing the Katello root CA certificate using Hammer CLI] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-by-using-command-line[Importing the Katello root CA certificate by using command line] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.
 

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-python-type-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-python-type-repository-by-using-web-ui.adoc
@@ -11,7 +11,7 @@ You can use {ProjectWebUI} to download files to a client over HTTPS using `curl 
 * You know the name of the Python package you want to download to clients from the Python type repository.
 * To download the Python packages over HTTPS to your hosts, you require:
 ** The `katello-server-ca.crt`.
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-using-{project-context}-web-ui[Importing the Katello root CA certificate using {ProjectWebUI}] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-by-using-browser[Importing the Katello root CA certificate by using browser] in _{ConfiguringUserAuthenticationDocTitle}_.
 ** An Organization Debug Certificate.
 For more information, see {ManagingOrganizationsLocationsDocURL}Creating_an_Organization_Debug_Certificate_managing-organizations-locations[Creating an Organization Debug Certificate] in _{ManagingOrganizationsLocationsDocTitle}_.
 

--- a/guides/common/modules/proc_importing-the-katello-root-ca-certificate-by-using-browser.adoc
+++ b/guides/common/modules/proc_importing-the-katello-root-ca-certificate-by-using-browser.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="importing-the-katello-root-ca-certificate-using-{project-context}-web-ui"]
-= Importing the Katello root CA certificate using {ProjectWebUI}
+[id="importing-the-katello-root-ca-certificate-by-using-browser"]
+= Importing the Katello root CA certificate by using browser
 
 [role="_abstract"]
 After the first login to {ProjectWebUI}, you might see a warning that you are using the default self-signed certificate.

--- a/guides/common/modules/proc_importing-the-katello-root-ca-certificate-by-using-command-line.adoc
+++ b/guides/common/modules/proc_importing-the-katello-root-ca-certificate-by-using-command-line.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="importing-the-katello-root-ca-certificate-using-cli"]
-= Importing the Katello root CA certificate using CLI
+[id="importing-the-katello-root-ca-certificate-by-using-command-line"]
+= Importing the Katello root CA certificate by using command line
 
 [role="_abstract"]
 After the first login to {ProjectWebUI}, you might see a warning that you are using the default self-signed certificate.

--- a/guides/common/modules/proc_logging-in-to-the-web-ui.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui.adoc
@@ -10,7 +10,7 @@ To access {ProjectWebUI}, use your web browser to navigate to the {ProjectWebUI}
 ifdef::katello,orcharhino,satellite[]
 .Prerequisites
 * Ensure that the Katello root CA certificate is installed in your browser.
-For more information, see xref:importing-the-katello-root-ca-certificate-using-{project-context}-web-ui[].
+For more information, see xref:importing-the-katello-root-ca-certificate-by-using-browser[].
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
+++ b/guides/common/modules/proc_using-novnc-to-access-virtual-machines.adoc
@@ -17,7 +17,7 @@ You can use your browser to access the VNC console of VMs created by {Project}.
 * You have imported the CA certificate used for {Project} into your browser.
 Adding a security exception in the browser is not enough for using noVNC.
 ifdef::katello,orcharhino,satellite[]
-For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-using-{project-context}-web-ui[Importing the Katello root CA certificate using {ProjectWebUI}] in _{ConfiguringUserAuthenticationDocTitle}_.
+For more information, see {ConfiguringUserAuthenticationDocURL}importing-the-katello-root-ca-certificate-by-using-browser[Importing the Katello root CA certificate by using browser] in _{ConfiguringUserAuthenticationDocTitle}_.
 endif::[]
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?

The modules to import the Katello CA to the local host do not use the Foreman+Katello Web UI or Hammer CLI. Instead, they use the browser or command line.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

By convention, we append "-by-using-web-ui" for modules that users accomplish via Foreman Web UI and "-by-using-cli" for modules that users accomplish via Hammer CLI.

This patch ensures that there is no naming clash.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
