### PR TITLE
Add a step to manually remove python-38 packages

### DIFF
--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -38,6 +38,12 @@ include::snip_warning-maintain-config-noop.adoc[]
 On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
+. Remove the `python-38` packages:
++
+[options="nowrap" subs="attributes"]
+----
+# {project-package-remove} python38-pytz python38-cffi python38-babel
+----
 ifdef::satellite[]
 . Ensure that the {Project} Maintenance repository is enabled:
 +

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -39,7 +39,7 @@ On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
 ifdef::satellite[]
-. If your {ProjectServer} was originally installed with {Project} version 6.11 or below, and subsequently upgraded to {ProjectVersionPrevious}, remove the `python38` packages:
+. If your {ProjectServer} was originally installed with {Project} version 6.11 or earlier, and subsequently upgraded to {ProjectVersionPrevious}, remove the `python38` packages:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-connected-project-server.adoc
@@ -38,13 +38,13 @@ include::snip_warning-maintain-config-noop.adoc[]
 On the Discovered Hosts page, power off and then delete the discovered hosts.
 From the *Select an Organization* menu, select each organization in turn and repeat the process to power off and delete the discovered hosts.
 Make a note to reboot these hosts when the upgrade is complete.
-. Remove the `python-38` packages:
+ifdef::satellite[]
+. If your {ProjectServer} was originally installed with {Project} version 6.11 or below, and subsequently upgraded to {ProjectVersionPrevious}, remove the `python38` packages:
 +
 [options="nowrap" subs="attributes"]
 ----
 # {project-package-remove} python38-pytz python38-cffi python38-babel
 ----
-ifdef::satellite[]
 . Ensure that the {Project} Maintenance repository is enabled:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -66,6 +66,13 @@ If there are discovered hosts available, turn them off and then delete all entri
 Select all other organizations in turn using the organization setting menu and repeat this action as required.
 Reboot these hosts after the upgrade has completed.
 
+. Remove the `python-38` packages:
++
+[options="nowrap" subs="attributes"]
+----
+# {project-package-remove} python38-pytz python38-cffi python38-babel
+----
+
 . Remove old repositories:
 +
 [options="nowrap" subs="attributes"]

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -66,7 +66,7 @@ If there are discovered hosts available, turn them off and then delete all entri
 Select all other organizations in turn using the organization setting menu and repeat this action as required.
 Reboot these hosts after the upgrade has completed.
 
-. If your {ProjectServer} was originally installed with {Project} version 6.11 or below, and subsequently upgraded to {ProjectVersionPrevious}, remove the `python38` packages:
+. If your {ProjectServer} was originally installed with {Project} version 6.11 or earlier, and subsequently upgraded to {ProjectVersionPrevious}, remove the `python38` packages:
 +
 [options="nowrap" subs="attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -66,7 +66,7 @@ If there are discovered hosts available, turn them off and then delete all entri
 Select all other organizations in turn using the organization setting menu and repeat this action as required.
 Reboot these hosts after the upgrade has completed.
 
-. Remove the `python-38` packages:
+. If your {ProjectServer} was originally installed with {Project} version 6.11 or below, and subsequently upgraded to {ProjectVersionPrevious}, remove the `python38` packages:
 +
 [options="nowrap" subs="attributes"]
 ----


### PR DESCRIPTION
Upgrade fails as the python38-pytz, python38-cffi, and python38-babel legacy packages are not automatically removed. These packages need to be manually removed.

JIRA:
https://redhat.atlassian.net/browse/SAT-44811

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
