### PR TITLE
Use commonName instead of CN

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
+++ b/guides/common/modules/proc_creating-a-custom-ssl-certificate.adoc
@@ -61,7 +61,7 @@ extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [ alt_names ]
-DNS.1 = _{ssl-common-name}_ 
+DNS.1 = _{ssl-common-name}_
 ----
 endif::[]
 
@@ -108,7 +108,7 @@ For more information about the `[ v3_req ]` parameters and their purpose, see li
 [options="nowrap", subs="+quotes,attributes"]
 ----
 [req_distinguished_name]
-CN = _{ssl-common-name}_
+commonName = _{ssl-common-name}_
 countryName = _My_Country_Name_
 stateOrProvinceName = _My_State_Or_Province_Name_
 localityName = _My_Locality_Name_


### PR DESCRIPTION
#### What changes are you introducing?

Make sure we use only full field names for certificate configuration

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To reduce confusion between the short version and full version of the field

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
