### PR TITLE
Turning starting and stopping into a reference appendix

### DIFF
--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="Starting_and_Stopping_Server_{context}"]
-= Starting and stopping {ProjectName}
+[id="starting-and-stopping-{project-context}-services"]
+= Starting and stopping {Project} services
 
 [role="_abstract"]
 {Project} provides the `{foreman-maintain} service` command to manage {Project} services from the command line.

--- a/guides/common/modules/ref_starting-and-stopping-server.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-server.adoc
@@ -5,8 +5,6 @@
 
 [role="_abstract"]
 {Project} provides the `{foreman-maintain} service` command to manage {Project} services from the command line.
-This is useful when creating a backup of {Project}.
-For more information on creating backups, see xref:backing-up-{project-context}-server-and-{smart-proxy-context}_{context}[].
 
 After installing {Project} with the `{foreman-installer}` command, all {Project} services are started and enabled automatically.
 View the list of these services by executing:

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -8,8 +8,6 @@ ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
-include::common/modules/ref_starting-and-stopping-server.adoc[leveloffset=+1]
-
 ifdef::satellite[]
 include::common/assembly_cloning-project-server.adoc[leveloffset=+1]
 endif::[]
@@ -83,6 +81,9 @@ endif::[]
 include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 
 include::common/assembly_searching-and-bookmarking.adoc[leveloffset=+1]
+
+[appendix]
+include::common/modules/ref_starting-and-stopping-server.adoc[leveloffset=+1]
 
 [appendix]
 include::common/assembly_logging-and-reporting-problems.adoc[leveloffset=+1]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -83,7 +83,7 @@ include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 include::common/assembly_searching-and-bookmarking.adoc[leveloffset=+1]
 
 [appendix]
-include::common/modules/ref_starting-and-stopping-server.adoc[leveloffset=+1]
+include::common/modules/ref_starting-and-stopping-project-services.adoc[leveloffset=+1]
 
 [appendix]
 include::common/assembly_logging-and-reporting-problems.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Moving the module on starting and stopping Foreman services to an appendix, while also dropping incorrect (or at the very least misleading) information from its abstract.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Starting and stopping Foreman services is not an everyday operation, and it's arguably not even a separate user story (because users don't suddenly decide to stop the services -- the action is always a part of a larger goal). Therefore, turning it into an appendix references seems more appropriate.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
