### PR TITLE
Fix DITA warnings in Tuning Performance guide

### DIFF
--- a/guides/common/assembly_determining-hardware-and-operating-system-configuration.adoc
+++ b/guides/common/assembly_determining-hardware-and-operating-system-configuration.adoc
@@ -4,4 +4,4 @@ include::modules/con_hardware-and-operating-system-configuration.adoc[]
 
 include::modules/proc_enabling-tuned-profiles.adoc[leveloffset=+1]
 
-include::modules/con_disable-transparent-hugepage.adoc[leveloffset=+1]
+include::modules/con_transparent-hugepage-and-database-performance.adoc[leveloffset=+1]

--- a/guides/common/modules/con_apache-httpd-performance-tuning.adoc
+++ b/guides/common/modules/con_apache-httpd-performance-tuning.adoc
@@ -4,5 +4,6 @@
 = Apache HTTPD performance tuning
 
 [role="_abstract"]
-Apache httpd forms a core part of the {Project} and acts as a web server for handling the requests that are being made through the {ProjectWebUI} or exposed APIs.
-To increase the concurrency of the operations, httpd forms the first point where tuning can help to boost the performance of your {Project}.
+Tune Apache httpd to improve {Project} performance and increase concurrency for {ProjectWebUI} and API requests.
+
+Apache httpd forms a core part of the {Project} and acts as a web server for handling the requests sent through the {ProjectWebUI} or exposed APIs.

--- a/guides/common/modules/con_considerations-for-performance-tuning.adoc
+++ b/guides/common/modules/con_considerations-for-performance-tuning.adoc
@@ -4,10 +4,11 @@
 = Considerations for performance tuning
 
 [role="_abstract"]
-In following sections we suggest various tunables and how to apply them.
-Always test changing tunables in non production environment first, with valid backup and with proper outage window because most cases require {Project} restart.
+You can optimize {Project} performance by adjusting various tunables to suit your workload. 
 
-It is also a good practice to setup a monitoring before applying any change as it will allow you to evaluate effect of the change.
+Performance tuning requires careful testing in non-production environments with valid backups because most configuration changes require a {Project} restart. 
+Setting up monitoring before applying changes helps you evaluate their effectiveness in your specific environment.
+
 Our testing environment might be too far from what you will see although we are trying hard to mimic real world environment.
 
 Optional: After any change, run this quick {Project} health check:

--- a/guides/common/modules/con_disable-transparent-hugepage.adoc
+++ b/guides/common/modules/con_disable-transparent-hugepage.adoc
@@ -4,7 +4,8 @@
 = Disabling Transparent Hugepage
 
 [role="_abstract"]
-Disable Transparent Hugepage to improve database performance in {Project}. This optimization is essential for PostgreSQL and Redis workloads, which perform poorly when Transparent Hugepage is enabled.
+Disable Transparent Hugepage to improve database performance in {Project}.
+This optimization is essential for PostgreSQL and Redis workloads, which perform poorly when Transparent Hugepage is enabled.
 
 Transparent Hugepage is a memory management technique used by the Linux kernel to reduce the overhead of using the Translation Lookaside Buffer (TLB) by using larger sized memory pages.
 Due to databases having Sparse Memory Access patterns instead of Contiguous Memory access patterns, database workloads often perform poorly when Transparent Hugepage is enabled.

--- a/guides/common/modules/con_disable-transparent-hugepage.adoc
+++ b/guides/common/modules/con_disable-transparent-hugepage.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
 [id="Disable_Transparent_Hugepage_{context}"]
-= Disable Transparent Hugepage
+= Disabling Transparent Hugepage
 
 [role="_abstract"]
 Transparent Hugepage is a memory management technique used by the Linux kernel to reduce the overhead of using the Translation Lookaside Buffer (TLB) by using larger sized memory pages.

--- a/guides/common/modules/con_disable-transparent-hugepage.adoc
+++ b/guides/common/modules/con_disable-transparent-hugepage.adoc
@@ -4,10 +4,12 @@
 = Disabling Transparent Hugepage
 
 [role="_abstract"]
+Disable Transparent Hugepage to improve database performance in {Project}. This optimization is essential for PostgreSQL and Redis workloads, which perform poorly when Transparent Hugepage is enabled.
+
 Transparent Hugepage is a memory management technique used by the Linux kernel to reduce the overhead of using the Translation Lookaside Buffer (TLB) by using larger sized memory pages.
 Due to databases having Sparse Memory Access patterns instead of Contiguous Memory access patterns, database workloads often perform poorly when Transparent Hugepage is enabled.
-To improve PostgreSQL and Redis performance, disable Transparent Hugepage.
-In deployments with databases running on separate servers, the benefit of using Transparent Hugepage on the {ProjectServer} might be only small.
+
+In deployments with databases running on separate servers, the benefit of using Transparent Hugepage on the {ProjectServer} might be limited.
 
 ifndef::orcharhino[]
 .Additional resources

--- a/guides/common/modules/con_disable-transparent-hugepage.adoc
+++ b/guides/common/modules/con_disable-transparent-hugepage.adoc
@@ -7,7 +7,7 @@
 Transparent Hugepage is a memory management technique used by the Linux kernel to reduce the overhead of using the Translation Lookaside Buffer (TLB) by using larger sized memory pages.
 Due to databases having Sparse Memory Access patterns instead of Contiguous Memory access patterns, database workloads often perform poorly when Transparent Hugepage is enabled.
 To improve PostgreSQL and Redis performance, disable Transparent Hugepage.
-In deployments where the databases are running on separate servers, there may be a small benefit to using Transparent Hugepage on the {ProjectServer} only.
+In deployments with databases running on separate servers, the benefit of using Transparent Hugepage on the {ProjectServer} might be only small.
 
 ifndef::orcharhino[]
 .Additional resources

--- a/guides/common/modules/con_hardware-and-operating-system-configuration.adoc
+++ b/guides/common/modules/con_hardware-and-operating-system-configuration.adoc
@@ -21,7 +21,7 @@ Components such as PostgreSQL benefit from using SSDs due to their lower latency
 Network::
 The communication between the {ProjectServer} and {SmartProxies} is impacted by the network performance.
 A decent network with a minimum jitter and low latency is required to enable hassle free operations such as {ProjectServer} and {SmartProxies} synchronization.
-At the very leas, ensure it is not causing connection resets and similar problems.
+At the very least, ensure it is not causing connection resets and similar problems.
 
 Server Power Management::
 Your server by default is likely to be configured to conserve power.

--- a/guides/common/modules/con_hardware-and-operating-system-configuration.adoc
+++ b/guides/common/modules/con_hardware-and-operating-system-configuration.adoc
@@ -20,7 +20,8 @@ Components such as PostgreSQL benefit from using SSDs due to their lower latency
 
 Network::
 The communication between the {ProjectServer} and {SmartProxies} is impacted by the network performance.
-A decent network with a minimum jitter and low latency is required to enable hassle free operations such as {ProjectServer} and {SmartProxies} synchronization (at least ensure it is not causing connection resets, and so on).
+A decent network with a minimum jitter and low latency is required to enable hassle free operations such as {ProjectServer} and {SmartProxies} synchronization.
+At the very leas, ensure it is not causing connection resets and similar problems.
 
 Server Power Management::
 Your server by default is likely to be configured to conserve power.

--- a/guides/common/modules/con_hardware-and-operating-system-configuration.adoc
+++ b/guides/common/modules/con_hardware-and-operating-system-configuration.adoc
@@ -20,9 +20,9 @@ Components such as PostgreSQL benefit from using SSDs due to their lower latency
 
 Network::
 The communication between the {ProjectServer} and {SmartProxies} is impacted by the network performance.
-A decent network with a minimum jitter and low latency is required to enable hassle free operations such as {ProjectServer} and {SmartProxies} synchronization (at least ensure it is not causing connection resets, etc).
+A decent network with a minimum jitter and low latency is required to enable hassle free operations such as {ProjectServer} and {SmartProxies} synchronization (at least ensure it is not causing connection resets, and so on).
 
 Server Power Management::
 Your server by default is likely to be configured to conserve power.
-While this is a good approach to keep the max power consumption in check, it also has a side effect of lowering the performance that {Project} may be able to achieve.
+While this is a good approach to keep the max power consumption in check, it also has a side effect of lowering the performance that {Project} can achieve.
 For a server running {Project}, it is recommended to set the BIOS to enable the system to be run in performance mode to boost the maximum performance levels that {Project} can achieve.

--- a/guides/common/modules/con_introduction-to-performance-tuning.adoc
+++ b/guides/common/modules/con_introduction-to-performance-tuning.adoc
@@ -4,7 +4,8 @@
 = Introduction to performance tuning
 
 [role="_abstract"]
-Tune {Project} to improve system response times and handle larger numbers of managed hosts. Performance tuning helps optimize resource usage and ensures smooth operations as your infrastructure scales.
+Tune {Project} to improve system response times and handle larger numbers of managed hosts.
+Performance tuning helps optimize resource usage and ensures smooth operations as your infrastructure scales.
 
 ifdef::satellite[]
 While these guidelines cover many situations, contact Red Hat support if you have a specific use case that is not included.

--- a/guides/common/modules/con_introduction-to-performance-tuning.adoc
+++ b/guides/common/modules/con_introduction-to-performance-tuning.adoc
@@ -4,7 +4,8 @@
 = Introduction to performance tuning
 
 [role="_abstract"]
-This document provides guidelines for tuning {ProjectName} for performance and scalability.
+Learn how to tune {ProjectName} for optimal performance and scalability.
+
 ifdef::satellite[]
-Although much care has been given to make the content applicable to cover a wide set of use cases, if there is some use case which has not been covered, please feel free to reach out to Red Hat for support for the undocumented use case.
+While these guidelines cover many situations, contact Red Hat support if you have a specific use case that is not included.
 endif::[]

--- a/guides/common/modules/con_introduction-to-performance-tuning.adoc
+++ b/guides/common/modules/con_introduction-to-performance-tuning.adoc
@@ -4,7 +4,7 @@
 = Introduction to performance tuning
 
 [role="_abstract"]
-Learn how to tune {ProjectName} for optimal performance and scalability.
+Tune {Project} to improve system response times and handle larger numbers of managed hosts. Performance tuning helps optimize resource usage and ensures smooth operations as your infrastructure scales.
 
 ifdef::satellite[]
 While these guidelines cover many situations, contact Red Hat support if you have a specific use case that is not included.

--- a/guides/common/modules/con_manually-tuning-puma-workers-and-threads-count.adoc
+++ b/guides/common/modules/con_manually-tuning-puma-workers-and-threads-count.adoc
@@ -4,8 +4,9 @@
 = Manually tuning Puma workers and threads count
 
 [role="_abstract"]
-If you decide not to rely on Puma workers and threads auto-tuning, you can apply custom numbers for these tunables.
-In the example below we are using 2 workers and 5 threads:
+Manually configure Puma workers and threads count to optimize {Project} performance for your specific hardware and workload requirements when auto-tuning does not meet your needs.
+
+For example, the following configuration uses two workers and five threads:
 
 [options="nowrap", subs="+attributes"]
 ----

--- a/guides/common/modules/con_pull-based-rex-transport-tuning.adoc
+++ b/guides/common/modules/con_pull-based-rex-transport-tuning.adoc
@@ -4,6 +4,6 @@
 = Pull-based REX transport tuning
 
 [role="_abstract"]
-You can adjust MQTT broker settings and client polling intervals to optimize pull-based remote execution performance for your environment's scale and network conditions.
+You can adjust MQTT broker settings and client polling intervals to optimize pull-based remote execution performance for the scale and network conditions of your environment.
 
 For more information, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport modes for remote execution] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/con_pull-based-rex-transport-tuning.adoc
+++ b/guides/common/modules/con_pull-based-rex-transport-tuning.adoc
@@ -4,6 +4,6 @@
 = Pull-based REX transport tuning
 
 [role="_abstract"]
-{Project} has a pull-based transport mode for remote execution.
-This transport mode uses MQTT as its messaging protocol and includes an MQTT client running on each host.
+You can adjust MQTT broker settings and client polling intervals to optimize pull-based remote execution performance for your environment's scale and network conditions.
+
 For more information, see {ManagingHostsDocURL}transport-modes-for-remote-execution_managing-hosts[Transport modes for remote execution] in _{ManagingHostsDocTitle}_.

--- a/guides/common/modules/con_puma-threads-configuration.adoc
+++ b/guides/common/modules/con_puma-threads-configuration.adoc
@@ -4,8 +4,7 @@
 = Puma threads configuration
 
 [role="_abstract"]
-Understand how Puma thread configuration affects concurrent host operations in {Project}.
-Adjusting thread count improves parallel host registration performance and optimizes resource utilization per worker process.
+Configure Puma threads to improve parallel host registration performance and optimize resource utilization per worker process in {Project}.
 
 For example, we have compared these two setups:
 

--- a/guides/common/modules/con_puma-threads-configuration.adoc
+++ b/guides/common/modules/con_puma-threads-configuration.adoc
@@ -4,7 +4,8 @@
 = Puma threads configuration
 
 [role="_abstract"]
-More threads allow for lower time to register hosts in parallel.
+Understand how Puma thread configuration affects concurrent host operations in {Project}. Adjusting thread count improves parallel host registration performance and optimizes resource utilization per worker process.
+
 For example, we have compared these two setups:
 
 [width="100%",cols="50%,50%",options="header",]

--- a/guides/common/modules/con_puma-threads-configuration.adoc
+++ b/guides/common/modules/con_puma-threads-configuration.adoc
@@ -4,7 +4,8 @@
 = Puma threads configuration
 
 [role="_abstract"]
-Understand how Puma thread configuration affects concurrent host operations in {Project}. Adjusting thread count improves parallel host registration performance and optimizes resource utilization per worker process.
+Understand how Puma thread configuration affects concurrent host operations in {Project}.
+Adjusting thread count improves parallel host registration performance and optimizes resource utilization per worker process.
 
 For example, we have compared these two setups:
 

--- a/guides/common/modules/con_puma-tunings.adoc
+++ b/guides/common/modules/con_puma-tunings.adoc
@@ -4,5 +4,4 @@
 = Puma tunings
 
 [role="_abstract"]
-Puma is a ruby application server which is used for serving all Foreman related requests to hosts.
-For any {Project} configuration that is supposed to handle a large number of hosts or frequent operations, it is important for the Puma to be tuned appropriately.
+Tune Puma to optimize {Project} performance for handling concurrent host operations and API requests. Proper Puma configuration is essential for deployments managing large numbers of hosts or frequent operations.

--- a/guides/common/modules/con_puma-tunings.adoc
+++ b/guides/common/modules/con_puma-tunings.adoc
@@ -4,4 +4,5 @@
 = Puma tunings
 
 [role="_abstract"]
-Tune Puma to optimize {Project} performance for handling concurrent host operations and API requests. Proper Puma configuration is essential for deployments managing large numbers of hosts or frequent operations.
+Tune Puma to optimize {Project} performance for handling concurrent host operations and API requests.
+Proper Puma configuration is essential for deployments managing large numbers of hosts or frequent operations.

--- a/guides/common/modules/con_puma-workers-and-threads-autotuning.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-autotuning.adoc
@@ -4,6 +4,9 @@
 = Puma workers and threads auto-tuning
 
 [role="_abstract"]
+Auto-tuning configures Puma workers and threads based on available CPU and memory to optimize {Project} performance.
+Understanding this default behavior helps you determine when manual tuning is necessary for your environment.
+
 If you do not provide any Puma workers and thread values with `{foreman-installer}` or they are not present in your {Project} configuration, the `{foreman-installer}` configures a balanced number of workers.
 It follows this formula:
 

--- a/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
@@ -4,7 +4,7 @@
 = Puma workers and threads recommendations
 
 [role="_abstract"]
-In order to recommend thread and worker configurations for the different tuning profiles, we conducted Puma tuning testing on {Project} with different tuning profiles.
+We conducted Puma tuning testing on {Project} with different tuning profiles to determine the optimal thread and worker configurations.
 The main test used in this testing was concurrent registration with the following combinations along with different number of workers and threads.
 Our recommendation is based purely on concurrent registration performance, so it might not reflect your exact use-case.
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
@@ -4,7 +4,8 @@
 = Puma workers and threads recommendations
 
 [role="_abstract"]
-Optimize {Project} performance by configuring Puma workers and threads according to your deployment size. Use these recommendations to improve concurrent registration performance and balance resource usage across different infrastructure scales.
+Optimize {Project} performance by configuring Puma workers and threads according to your deployment size.
+Use these recommendations to improve concurrent registration performance and balance resource usage across different infrastructure scales.
 
 The main test used in this testing was concurrent registration with the following combinations along with different number of workers and threads.
 Our recommendation is based purely on concurrent registration performance, so it might not reflect your exact use-case.

--- a/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
@@ -4,7 +4,8 @@
 = Puma workers and threads recommendations
 
 [role="_abstract"]
-We conducted Puma tuning testing on {Project} with different tuning profiles to determine the optimal thread and worker configurations.
+Optimize {Project} performance by configuring Puma workers and threads according to your deployment size. Use these recommendations to improve concurrent registration performance and balance resource usage across different infrastructure scales.
+
 The main test used in this testing was concurrent registration with the following combinations along with different number of workers and threads.
 Our recommendation is based purely on concurrent registration performance, so it might not reflect your exact use-case.
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
+++ b/guides/common/modules/con_puma-workers-and-threads-recommendations.adoc
@@ -4,8 +4,7 @@
 = Puma workers and threads recommendations
 
 [role="_abstract"]
-Optimize {Project} performance by configuring Puma workers and threads according to your deployment size.
-Use these recommendations to improve concurrent registration performance and balance resource usage across different infrastructure scales.
+Configure Puma workers and threads based on your deployment size and hardware to optimize {Project} performance, especially for concurrent host registration workloads.
 
 The main test used in this testing was concurrent registration with the following combinations along with different number of workers and threads.
 Our recommendation is based purely on concurrent registration performance, so it might not reflect your exact use-case.

--- a/guides/common/modules/con_puma-workers-configuration.adoc
+++ b/guides/common/modules/con_puma-workers-configuration.adoc
@@ -4,6 +4,8 @@
 = Puma workers configuration
 
 [role="_abstract"]
+Configure Puma workers to scale {Project} performance based on available CPU resources. Adding more workers increases concurrent request capacity, improving registration times and overall system responsiveness.
+
 If you have enough CPUs, adding more workers adds more performance.
 For example, we have compared {Project} setups with 8 and 16 CPUs:
 

--- a/guides/common/modules/con_puma-workers-configuration.adoc
+++ b/guides/common/modules/con_puma-workers-configuration.adoc
@@ -4,7 +4,8 @@
 = Puma workers configuration
 
 [role="_abstract"]
-Configure Puma workers to scale {Project} performance based on available CPU resources. Adding more workers increases concurrent request capacity, improving registration times and overall system responsiveness.
+Configure Puma workers to scale {Project} performance based on available CPU resources.
+Adding more workers increases concurrent request capacity, improving registration times and overall system responsiveness.
 
 If you have enough CPUs, adding more workers adds more performance.
 For example, we have compared {Project} setups with 8 and 16 CPUs:

--- a/guides/common/modules/con_puma-workers-configuration.adoc
+++ b/guides/common/modules/con_puma-workers-configuration.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 Configure Puma workers to scale {Project} performance based on available CPU resources.
-Adding more workers increases concurrent request capacity, improving registration times and overall system responsiveness.
+Adding more workers increases concurrent request capacity, improving registration times, and overall system responsiveness.
 
 If you have enough CPUs, adding more workers adds more performance.
 For example, we have compared {Project} setups with 8 and 16 CPUs:

--- a/guides/common/modules/con_redis-tuning.adoc
+++ b/guides/common/modules/con_redis-tuning.adoc
@@ -4,6 +4,8 @@
 = Redis tuning
 
 [role="_abstract"]
+Understanding Redis tuning in {Project} helps you optimize caching and task tracking performance. Properly configured Redis ensures stable memory consumption and improves responsiveness of {Project} operations.
+
 Redis is an in-memory data store.
 ifdef::katello,orcharhino,satellite[]
 Foreman and Pulp use Redis for caching and Dynflow uses Redis to track its tasks.

--- a/guides/common/modules/con_redis-tuning.adoc
+++ b/guides/common/modules/con_redis-tuning.adoc
@@ -4,7 +4,8 @@
 = Redis tuning
 
 [role="_abstract"]
-Understanding Redis tuning in {Project} helps you optimize caching and task tracking performance. Properly configured Redis ensures stable memory consumption and improves responsiveness of {Project} operations.
+Understanding Redis tuning in {Project} helps you optimize caching and task tracking performance.
+Properly configured Redis ensures stable memory consumption and improves responsiveness of {Project} operations.
 
 Redis is an in-memory data store.
 ifdef::katello,orcharhino,satellite[]
@@ -18,4 +19,4 @@ Given the way {Project} uses Redis, its memory consumption should be stable.
 The Redis authors recommend disabling Transparent Hugepage on servers running Redis.
 
 .Additional resources
-* xref:transparent-hugepage-and-database-performance_{context}[]
+* xref:transparent-hugepage-and-database-performance[]

--- a/guides/common/modules/con_redis-tuning.adoc
+++ b/guides/common/modules/con_redis-tuning.adoc
@@ -16,4 +16,4 @@ Given the way {Project} uses Redis, its memory consumption should be stable.
 The Redis authors recommend disabling Transparent Hugepage on servers running Redis.
 
 .Additional resources
-* xref:Disable_Transparent_Hugepage_{context}[]
+* xref:Transparent_Hugepage_and_database_performance_{context}[]

--- a/guides/common/modules/con_redis-tuning.adoc
+++ b/guides/common/modules/con_redis-tuning.adoc
@@ -16,4 +16,4 @@ Given the way {Project} uses Redis, its memory consumption should be stable.
 The Redis authors recommend disabling Transparent Hugepage on servers running Redis.
 
 .Additional resources
-* xref:Transparent_Hugepage_and_database_performance_{context}[]
+* xref:transparent-hugepage-and-database-performance_{context}[]

--- a/guides/common/modules/con_smart-proxy-configuration-tuning.adoc
+++ b/guides/common/modules/con_smart-proxy-configuration-tuning.adoc
@@ -4,8 +4,10 @@
 = {SmartProxy} configuration tuning
 
 [role="_abstract"]
-{SmartProxies} are meant to offload part of {Project} load and provide access to different networks related to distributing content to clients but they can also be used to execute remote execution jobs.
-What they cannot help with is anything which extensively uses {Project} API,
+Understanding {SmartProxy} tuning helps you optimize load distribution and content delivery across different networks in your {Project} environment.
+Properly configured {SmartProxies} reduce load on your {Project} server and improve performance for remote execution and content distribution tasks.
+
+What {SmartProxies} cannot help with is anything which extensively uses {Project} API,
 ifdef::katello,orcharhino,satellite[]
 such as host registration or package profile update.
 endif::[]

--- a/guides/common/modules/con_smart-proxy-configuration-tuning.adoc
+++ b/guides/common/modules/con_smart-proxy-configuration-tuning.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 Understanding {SmartProxy} tuning helps you optimize load distribution and content delivery across different networks in your {Project} environment.
-Properly configured {SmartProxies} reduce load on your {Project} server and improve performance for remote execution and content distribution tasks.
+Properly configured {SmartProxies} reduce load on your {ProjectServer} and improve performance for remote execution and content distribution tasks.
 
 What {SmartProxies} cannot help with is anything which extensively uses {Project} API,
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/con_smartproxy-performance-tests.adoc
+++ b/guides/common/modules/con_smartproxy-performance-tests.adoc
@@ -4,7 +4,8 @@
 = {SmartProxy} performance tests
 
 [role="_abstract"]
-Review performance test results for different {SmartProxy} hardware configurations to determine the optimal sizing for your deployment. Understanding these benchmarks helps you choose the right resources based on your expected workload for content delivery, host registration, and remote execution tasks.
+Review performance test results for different {SmartProxy} hardware configurations to determine the optimal sizing for your deployment.
+Understanding these benchmarks helps you choose the right resources based on your expected workload for content delivery, host registration, and remote execution tasks.
 
 The following configurations were tested:
 

--- a/guides/common/modules/con_smartproxy-performance-tests.adoc
+++ b/guides/common/modules/con_smartproxy-performance-tests.adoc
@@ -4,7 +4,9 @@
 = {SmartProxy} performance tests
 
 [role="_abstract"]
-We have measured multiple test cases on multiple {SmartProxy} configurations:
+Review performance test results for different {SmartProxy} hardware configurations to determine the optimal sizing for your deployment. Understanding these benchmarks helps you choose the right resources based on your expected workload for content delivery, host registration, and remote execution tasks.
+
+The following configurations were tested:
 
 [width="79%",cols="48%,19%,33%",options="header",]
 |===

--- a/guides/common/modules/con_smartproxy-performance-tests.adoc
+++ b/guides/common/modules/con_smartproxy-performance-tests.adoc
@@ -42,5 +42,5 @@ apache::mod::proxy::proxy_timeout: 600
 endif::[]
 
 Remote execution use case::
-We have tested executing remote execution jobs using both SSH and Ansible backend on 500, 2000 and 4000 hosts.
+We have tested executing remote execution jobs by using both SSH and Ansible backend on 500, 2000 and 4000 hosts.
 All configurations were able to handle all of the tests without errors, except for the smallest configuration (4 CPUs and 12 GiB memory) which failed to finish on all 4000 hosts.

--- a/guides/common/modules/con_smartproxy-performance-tests.adoc
+++ b/guides/common/modules/con_smartproxy-performance-tests.adoc
@@ -7,7 +7,7 @@
 Review performance test results for different {SmartProxy} hardware configurations to determine the optimal sizing for your deployment.
 Understanding these benchmarks helps you choose the right resources based on your expected workload for content delivery, host registration, and remote execution tasks.
 
-The following configurations were tested:
+{Team} tested the following configurations:
 
 [width="79%",cols="48%,19%,33%",options="header",]
 |===

--- a/guides/common/modules/con_transparent-hugepage-and-database-performance.adoc
+++ b/guides/common/modules/con_transparent-hugepage-and-database-performance.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="Transparent_Hugepage_and_database_performance_{context}"]
+[id="transparent-hugepage-and-database-performance"]
 = Transparent Hugepage and database performance
 
 [role="_abstract"]

--- a/guides/common/modules/con_transparent-hugepage-and-database-performance.adoc
+++ b/guides/common/modules/con_transparent-hugepage-and-database-performance.adoc
@@ -1,11 +1,10 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="Disable_Transparent_Hugepage_{context}"]
-= Disabling Transparent Hugepage
+[id="Transparent_Hugepage_and_database_performance_{context}"]
+= Transparent Hugepage and database performance
 
 [role="_abstract"]
-Disable Transparent Hugepage to improve database performance in {Project}.
-This optimization is essential for PostgreSQL and Redis workloads, which perform poorly when Transparent Hugepage is enabled.
+Disable Transparent Hugepage to improve database performance in {Project}, especially for PostgreSQL and Redis workloads that perform poorly with this memory management feature enabled.
 
 Transparent Hugepage is a memory management technique used by the Linux kernel to reduce the overhead of using the Translation Lookaside Buffer (TLB) by using larger sized memory pages.
 Due to databases having Sparse Memory Access patterns instead of Contiguous Memory access patterns, database workloads often perform poorly when Transparent Hugepage is enabled.

--- a/guides/common/modules/proc_benchmarking-raw-database-performance.adoc
+++ b/guides/common/modules/proc_benchmarking-raw-database-performance.adoc
@@ -4,7 +4,7 @@
 = Benchmarking raw database performance
 
 [role="_abstract"]
-Use `pgbench` to measure raw PostgreSQL performance and validate storage behavior on your {Project} system.
+Use `pgbench` to measure raw PostgreSQL performance and validate storage behavior on your {Project} environment.
 Benchmarking helps you establish baseline performance metrics and verify that tuning changes improve database responsiveness.
 
 .Prerequisites

--- a/guides/common/modules/proc_benchmarking-raw-database-performance.adoc
+++ b/guides/common/modules/proc_benchmarking-raw-database-performance.adoc
@@ -4,7 +4,8 @@
 = Benchmarking raw database performance
 
 [role="_abstract"]
-Use `pgbench` to measure raw PostgreSQL performance and validate storage behavior on your {Project} system. Benchmarking helps you establish baseline performance metrics and verify that tuning changes improve database responsiveness.
+Use `pgbench` to measure raw PostgreSQL performance and validate storage behavior on your {Project} system.
+Benchmarking helps you establish baseline performance metrics and verify that tuning changes improve database responsiveness.
 
 .Prerequisites
 * A non-production system with a valid backup.

--- a/guides/common/modules/proc_benchmarking-raw-database-performance.adoc
+++ b/guides/common/modules/proc_benchmarking-raw-database-performance.adoc
@@ -4,8 +4,7 @@
 = Benchmarking raw database performance
 
 [role="_abstract"]
-You can use `pgbench` to measure raw PostgreSQL performance on your system and validate storage behavior before or after tuning.
-Interpreting benchmark results requires a database large enough relative to memory to avoid measuring only cached workloads.
+Use `pgbench` to measure raw PostgreSQL performance and validate storage behavior on your {Project} system. Benchmarking helps you establish baseline performance metrics and verify that tuning changes improve database responsiveness.
 
 .Prerequisites
 * A non-production system with a valid backup.

--- a/guides/common/modules/proc_decreasing-performance-impact-of-the-pull-based-rex-transport.adoc
+++ b/guides/common/modules/proc_decreasing-performance-impact-of-the-pull-based-rex-transport.adoc
@@ -4,6 +4,8 @@
 = Decreasing performance impact of the pull-based REX transport
 
 [role="_abstract"]
+Configure MQTT rate limiting and timing parameters to prevent connection exhaustion on {SmartProxyServer} when running high-concurrency remote execution jobs in pull-based mode.
+
 When {ProjectServer} is configured with the pull-based transport mode for remote execution jobs by using the Script provider, {SmartProxyServer} sends notifications about new jobs to hosts through MQTT.
 This notification does not include the actual workload that the host is supposed to execute.
 After a host receives a notification about a new remote execution job, it queries {SmartProxyServer} for its actual workload.

--- a/guides/common/modules/proc_decreasing-performance-impact-of-the-pull-based-rex-transport.adoc
+++ b/guides/common/modules/proc_decreasing-performance-impact-of-the-pull-based-rex-transport.adoc
@@ -4,7 +4,7 @@
 = Decreasing performance impact of the pull-based REX transport
 
 [role="_abstract"]
-When {ProjectServer} is configured with the pull-based transport mode for remote execution jobs using the Script provider, {SmartProxyServer} sends notifications about new jobs to hosts through MQTT.
+When {ProjectServer} is configured with the pull-based transport mode for remote execution jobs by using the Script provider, {SmartProxyServer} sends notifications about new jobs to hosts through MQTT.
 This notification does not include the actual workload that the host is supposed to execute.
 After a host receives a notification about a new remote execution job, it queries {SmartProxyServer} for its actual workload.
 During the job, the host periodically sends outputs of the job to {SmartProxyServer}, further increasing the number of requests to {SmartProxyServer}.

--- a/guides/common/modules/proc_enabling-tuned-profiles.adoc
+++ b/guides/common/modules/proc_enabling-tuned-profiles.adoc
@@ -4,8 +4,7 @@
 = Enabling tuned profiles
 
 [role="_abstract"]
-On bare metal, {Team} recommends to run the `throughput-performance` tuned profile on {ProjectServer} and {SmartProxyServers}.
-On virtual machines, {Team} recommends to run the `virtual-guest` profile.
+Enable tuned profiles to automatically optimize your system's performance settings for {Project} workloads. This improves overall system performance by applying configuration optimizations tailored to your deployment type.
 
 .Procedure
 . Install `tuned` on your {SmartProxy}:

--- a/guides/common/modules/proc_enabling-tuned-profiles.adoc
+++ b/guides/common/modules/proc_enabling-tuned-profiles.adoc
@@ -4,7 +4,8 @@
 = Enabling tuned profiles
 
 [role="_abstract"]
-Enable tuned profiles to automatically optimize your system's performance settings for {Project} workloads. This improves overall system performance by applying configuration optimizations tailored to your deployment type.
+Enable tuned profiles to automatically optimize the performance settings of {Project} for its workloads.
+This improves overall system performance by applying configuration optimizations tailored to your deployment type.
 
 .Procedure
 . Install `tuned` on your {SmartProxy}:

--- a/guides/common/modules/proc_enabling-tuned-profiles.adoc
+++ b/guides/common/modules/proc_enabling-tuned-profiles.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 Enable tuned profiles to automatically optimize the performance settings of {Project} for its workloads.
-This improves overall system performance by applying configuration optimizations tailored to your deployment type.
+This improves overall system performance by applying configuration optimizations tailored to your environment.
 
 .Procedure
 . Install `tuned` on your {SmartProxy}:

--- a/guides/common/modules/proc_increasing-host-limit-for-pull-based-rex-transport.adoc
+++ b/guides/common/modules/proc_increasing-host-limit-for-pull-based-rex-transport.adoc
@@ -4,7 +4,7 @@
 = Increasing host limit for pull-based REX transport
 
 [role="_abstract"]
-Tune the `mosquitto` MQTT server on your {SmartProxy} to support more than the default limit of 1014 connected hosts when scaling pull-based remote execution to larger deployments.
+Tune the `mosquitto` MQTT server on your {SmartProxy} to support more than the default limit of 1024 connected hosts when scaling pull-based remote execution to larger deployments.
 
 .Prerequisites
 * You have enabled pull-based remote execution on your {SmartProxy}.

--- a/guides/common/modules/proc_increasing-host-limit-for-pull-based-rex-transport.adoc
+++ b/guides/common/modules/proc_increasing-host-limit-for-pull-based-rex-transport.adoc
@@ -4,10 +4,7 @@
 = Increasing host limit for pull-based REX transport
 
 [role="_abstract"]
-You can tune the `mosquitto` MQTT server and increase the maximum number of hosts connected to it.
-By default, {SmartProxies} support a maximum of 1014 connected hosts.
-
-This example configures the `mosquitto` service on your {SmartProxy} to handle up to 5000 hosts.
+Tune the `mosquitto` MQTT server on your {SmartProxy} to support more than the default limit of 1014 connected hosts when scaling pull-based remote execution to larger deployments.
 
 .Prerequisites
 * You have enabled pull-based remote execution on your {SmartProxy}.
@@ -23,6 +20,8 @@ systemd::dropin_files:
     unit: mosquitto.service
     content: "[Service]\nLimitNOFILE=5000\n"
 ----
++
+This example configures the `mosquitto` service on your {SmartProxy} to handle up to 5000 hosts.
 . Re-run the installer for the changes to take effect:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_tuning-apache-httpd-child-processes.adoc
+++ b/guides/common/modules/proc_tuning-apache-httpd-child-processes.adoc
@@ -4,6 +4,8 @@
 = Tuning Apache httpd child processes
 
 [role="_abstract"]
+You can tune Apache httpd child processes to handle more concurrent requests and prevent HTTP 503 errors and component failures during high load.
+
 By default, httpd uses event request handling mechanism.
 When the number of requests to httpd exceeds the maximum number of child processes that can be launched to handle the incoming connections, httpd raises an HTTP 503 Service Unavailable error.
 Amidst httpd running out of processes to handle, the incoming connections can also result in multiple component failures on your {Project} services side due to the dependency of some components on the availability of httpd processes.

--- a/guides/common/modules/proc_tuning-dynflow.adoc
+++ b/guides/common/modules/proc_tuning-dynflow.adoc
@@ -4,7 +4,7 @@
 = Tuning Dynflow
 
 [role="_abstract"]
-When you have many clients checking in and running concurrent tasks, you can increase the number of Dynflow workers to improve {Project} task execution performance.
+When you have many hosts checking in and running concurrent tasks, you can increase the number of Dynflow workers to improve {Project} task execution performance.
 
 Dynflow is the workflow management system and task orchestrator which is a {Project} plugin and is used to execute the different tasks of {Project} in an out-of-order execution manner.
 Under the conditions when there are many hosts checking in on {Project} and running several tasks, Dynflow can take some help from an added tuning specifying how many executors it can launch.

--- a/guides/common/modules/proc_tuning-dynflow.adoc
+++ b/guides/common/modules/proc_tuning-dynflow.adoc
@@ -7,7 +7,7 @@
 When you have many clients checking in and running concurrent tasks, you can increase the number of Dynflow workers to improve {Project} task execution performance.
 
 Dynflow is the workflow management system and task orchestrator which is a {Project} plugin and is used to execute the different tasks of {Project} in an out-of-order execution manner.
-Under the conditions when there are many clients checking in on {Project} and running several tasks, Dynflow can take some help from an added tuning specifying how many executors it can launch.
+Under the conditions when there are many hosts checking in on {Project} and running several tasks, Dynflow can take some help from an added tuning specifying how many executors it can launch.
 
 For more information about the tunings involved related to Dynflow, see `\https://{foreman-example-com}/foreman_tasks/sidekiq`.
 

--- a/guides/common/modules/proc_tuning-dynflow.adoc
+++ b/guides/common/modules/proc_tuning-dynflow.adoc
@@ -4,10 +4,10 @@
 = Tuning Dynflow
 
 [role="_abstract"]
-
+When you have many clients checking in and running concurrent tasks, you can increase the number of Dynflow workers to improve {Project} task execution performance.
 
 Dynflow is the workflow management system and task orchestrator which is a {Project} plugin and is used to execute the different tasks of {Project} in an out-of-order execution manner.
-Under the conditions when there are many clients checking in on {Project} and running several tasks, Dynflow can take some help from an added tuning specifying how many executors can it launch.
+Under the conditions when there are many clients checking in on {Project} and running several tasks, Dynflow can take some help from an added tuning specifying how many executors it can launch.
 
 For more information about the tunings involved related to Dynflow, see `\https://{foreman-example-com}/foreman_tasks/sidekiq`.
 

--- a/guides/common/modules/proc_tuning-dynflow.adoc
+++ b/guides/common/modules/proc_tuning-dynflow.adoc
@@ -4,6 +4,8 @@
 = Tuning Dynflow
 
 [role="_abstract"]
+
+
 Dynflow is the workflow management system and task orchestrator which is a {Project} plugin and is used to execute the different tasks of {Project} in an out-of-order execution manner.
 Under the conditions when there are many clients checking in on {Project} and running several tasks, Dynflow can take some help from an added tuning specifying how many executors can it launch.
 

--- a/guides/common/modules/proc_tuning-postgresql.adoc
+++ b/guides/common/modules/proc_tuning-postgresql.adoc
@@ -4,9 +4,7 @@
 = Tuning PostgreSQL
 
 [role="_abstract"]
-{Project} uses the PostgreSQL database for the storage of persistent context across a wide variety of tasks.
-The database sees an extensive usage is usually working on to provide the {Project} with the data which it needs for its smooth functioning.
-This makes PostgreSQL a heavily used process which if tuned can have several benefits on the overall operational response of {Project}.
+Configure PostgreSQL database settings in {Project} to improve response times and operational performance. Tuning PostgreSQL reduces database query latency and enhances overall system responsiveness, especially in environments with high database activity.
 
 The PostgreSQL authors recommend disabling Transparent Hugepage on servers running PostgreSQL.
 For more information, see xref:transparent-hugepage-and-database-performance_{context}[].

--- a/guides/common/modules/proc_tuning-postgresql.adoc
+++ b/guides/common/modules/proc_tuning-postgresql.adoc
@@ -9,7 +9,7 @@ The database sees an extensive usage is usually working on to provide the {Proje
 This makes PostgreSQL a heavily used process which if tuned can have several benefits on the overall operational response of {Project}.
 
 The PostgreSQL authors recommend disabling Transparent Hugepage on servers running PostgreSQL.
-For more information, see xref:Disable_Transparent_Hugepage_{context}[].
+For more information, see xref:Transparent_Hugepage_and_database_performance_{context}[].
 
 You can apply a set of tunings to PostgreSQL to improve its response times, which will modify the `postgresql.conf` file.
 You can use this to effectively tune down your {Project} instance irrespective of a tuning profile.

--- a/guides/common/modules/proc_tuning-postgresql.adoc
+++ b/guides/common/modules/proc_tuning-postgresql.adoc
@@ -9,7 +9,7 @@ The database sees an extensive usage is usually working on to provide the {Proje
 This makes PostgreSQL a heavily used process which if tuned can have several benefits on the overall operational response of {Project}.
 
 The PostgreSQL authors recommend disabling Transparent Hugepage on servers running PostgreSQL.
-For more information, see xref:Transparent_Hugepage_and_database_performance_{context}[].
+For more information, see xref:transparent-hugepage-and-database-performance_{context}[].
 
 You can apply a set of tunings to PostgreSQL to improve its response times, which will modify the `postgresql.conf` file.
 You can use this to effectively tune down your {Project} instance irrespective of a tuning profile.

--- a/guides/common/modules/proc_tuning-postgresql.adoc
+++ b/guides/common/modules/proc_tuning-postgresql.adoc
@@ -4,10 +4,11 @@
 = Tuning PostgreSQL
 
 [role="_abstract"]
-Configure PostgreSQL database settings in {Project} to improve response times and operational performance. Tuning PostgreSQL reduces database query latency and enhances overall system responsiveness, especially in environments with high database activity.
+Configure PostgreSQL database settings in {Project} to improve response times and operational performance.
+Tuning PostgreSQL reduces database query latency and enhances overall system responsiveness, especially in environments with high database activity.
 
 The PostgreSQL authors recommend disabling Transparent Hugepage on servers running PostgreSQL.
-For more information, see xref:transparent-hugepage-and-database-performance_{context}[].
+For more information, see xref:transparent-hugepage-and-database-performance[].
 
 You can apply a set of tunings to PostgreSQL to improve its response times, which will modify the `postgresql.conf` file.
 You can use this to effectively tune down your {Project} instance irrespective of a tuning profile.


### PR DESCRIPTION
Going through the Tuning Performance Guide and fixing the pre-migration warnings.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
