### PR TITLE
Hide some lines for non-RHEL Clients for orcharhino builds

### DIFF
--- a/guides/common/modules/con_defining-your-content-library.adoc
+++ b/guides/common/modules/con_defining-your-content-library.adoc
@@ -19,15 +19,21 @@ When you enable a Red{nbsp}Hat repository, {Project} automatically creates an as
 ifdef::katello,orcharhino[]
 Oracle ULN content::
 You can use {Project} to manage hosts running Oracle Linux.
+ifdef::katello,oracle_linux[]
 For more information, see {ContentManagementDocURL}uln-repositories[ULN repositories] in _{ContentManagementDocTitle}_.
+endif::[]
 
 SUSE content::
 You can use {Project} to manage hosts running {SLES}.
+ifdef::katello,suse_linux_enterprise_server[]
 For more information, see {ContentManagementDocURL}Managing_SUSE_Content_content-management[Managing SUSE content] in _{ContentManagementDocTitle}_.
+endif::[]
 
 Ubuntu ESM content::
 You can use {Project} to manage hosts running Ubuntu.
+ifdef::katello,ubuntu[]
 For more information, see {ContentManagementDocURL}Synchronizing-Ubuntu-Expanded-Security-Maintenance-content_content-management[Synchronizing Ubuntu Expanded Security Maintenance content] in _{ContentManagementDocTitle}_.
+endif::[]
 endif::[]
 
 Other sources of content::

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -29,10 +29,12 @@ ifdef::satellite[]
 Selecting the Red{nbsp}Hat products when creating a simplified alternate content source will download the content to the {SmartProxyservers} from the Red{nbsp}Hat CDN.
 endif::[]
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 RHUI::
 RHUI alternate content sources download content from a Red{nbsp}Hat Update Infrastructure (RHUI) server.
 {ProjectWebUI} provides examples to help you find the network paths and to import authentication credentials.
 ifdef::satellite[]
 The RHUI alternate content source must be RHUI version 4 or greater and use the default installation configuration.
 For example, AWS RHUI is unsupported because it uses an installation scenario with unique authentication requirements.
+endif::[]
 endif::[]

--- a/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
@@ -12,7 +12,9 @@ Flatpak repositories function similarly to other content repositories in {Projec
 You can synchronize, manage access permissions, and assign repositories to specific lifecycle environments to control which applications are available to systems. 
 You can also use Hammer CLI to manage Flatpak repositories.
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For more information, see {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment[Installing applications using Flatpak].
+endif::[]
 
 ifdef::orcharhino[]
 include::snip_important-consuming-content-requires-a-subscription.adoc[]

--- a/guides/common/modules/con_preparing-client-platforms.adoc
+++ b/guides/common/modules/con_preparing-client-platforms.adoc
@@ -7,7 +7,7 @@
 You have to configure the platforms that you will provision.
 That entails creating a hardware model, CPU architecture, and operating system.
 
-ifdef::katello,orcharhino,satellite[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 [NOTE]
 ====
 The records for Red{nbsp}Hat supported platforms are created automatically when you enable a Red{nbsp}Hat repository.

--- a/guides/common/modules/proc_adding-an-http-proxy-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy-by-using-cli.adoc
@@ -7,11 +7,13 @@
 You can add HTTP proxies to {Project} by using Hammer CLI.
 You can then specify which HTTP proxy to use for products, repositories, and supported compute resources.
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 .Prerequisites
 * Your HTTP proxy must allow access to the following hosts:
 +
 include::snip_host-names-for-http-proxy.adoc[]
 * If {ProjectServer} uses an HTTP proxy to communicate with `subscription.rhsm.redhat.com` and `cdn.redhat.com`, then your HTTP proxy must not perform SSL inspection on these communications.
+endif::[]
 
 .Procedure
 * Add your HTTP proxy to {Project}:
@@ -22,8 +24,10 @@ $ hammer http-proxy create \
 --name _My_HTTP_Proxy_ \
 --url _http-proxy.example.com:8080_
 ----
+ifdef::katello,orcharhino,satellite[]
 +
 Optional: To set the HTTP proxy as default for content synchronization, add the `--content-default-http-proxy true` option.
+endif::[]
 +
 If your HTTP proxy requires authentication, add the `--username _My_User_Name_` and `--password _My_Password_` options.
 

--- a/guides/common/modules/proc_adding-an-http-proxy-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-an-http-proxy-by-using-web-ui.adoc
@@ -5,13 +5,17 @@
 
 [role="_abstract"]
 You can add HTTP proxies to {Project} by using the {ProjectWebUI}.
+ifdef::katello,orcharhino,satellite[]
 You can then specify which HTTP proxy to use for products, repositories, and supported compute resources.
+endif::[]
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 .Prerequisites
 * Your HTTP proxy must allow access to the following hosts:
 +
 include::snip_host-names-for-http-proxy.adoc[]
 * If {ProjectServer} uses an HTTP proxy to communicate with `subscription.rhsm.redhat.com` and `cdn.redhat.com`, then your HTTP proxy must not perform SSL inspection on these communications.
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *HTTP Proxies*.
@@ -21,7 +25,9 @@ include::snip_host-names-for-http-proxy.adoc[]
 . If your HTTP proxy requires authentication, enter a *Username* and *Password*.
 . In the *Cacert* field, enter the SSL CA certificate if your HTTP proxy requires authentication.
 . Optional: In the *Test URL* field, enter a URL, then click *Test Connection* to ensure that {ProjectServer} can connect to the URL through your HTTP proxy.
+ifdef::katello,orcharhino,satellite[]
 . Optional: Select the *Default content HTTP proxy* option to set your HTTP proxy as default to synchronize content.
+endif::[]
 . Click the *Locations* tab and add a location.
 . Click the *Organization* tab and add an organization.
 . Click *Submit*.

--- a/guides/common/modules/proc_adding-rhel-system-roles.adoc
+++ b/guides/common/modules/proc_adding-rhel-system-roles.adoc
@@ -8,10 +8,12 @@
 You can use {RHEL} System Roles to add Ansible roles in {Project}.
 Using Ansible Roles in {Project} can make configuration faster and easier.
 
+ifdef::foreman-el,katello,satellite,red_hat_enterprise_linux[]
 Support levels for some of the {RHEL} System Roles might be in Technology Preview.
 For up-to-date information about support levels and general information about {RHEL} System Roles, see https://access.redhat.com/articles/3050101[{RHEL} System Roles].
 
 Before subscribing to the Extras or AppStream channels, see https://access.redhat.com/support/policy/updates/extras[{RHEL} Extras Product Lifecycle] or https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
+endif::[]
 
 .Procedure
 . Ensure that the following repository is enabled:
@@ -28,12 +30,14 @@ You must enable an AppStream repository that is designated for your architecture
 ifdef::satellite[]
 For more information, see {RHELDocsBaseURL}8/html/upgrading_from_rhel_7_to_rhel_8/appendix_rhel-8-repositories_upgrading-from-rhel-7-to-rhel-8[RHEL 8 repositories].
 endif::[]
+ifdef::foreman-el,katello,satellite,red_hat_enterprise_linux[]
 * On {RHEL} 7, ensure that the *Extras* repository is enabled:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos --enable=rhel-7-server-extras-rpms
 ----
+endif::[]
 . Install the `rhel-system-roles` package:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_creating-a-content-view-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-by-using-cli.adoc
@@ -6,8 +6,10 @@
 [role="_abstract"]
 Use this procedure to create a content view by using Hammer CLI.
 
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 While you can stipulate whether you want to resolve any package dependencies on a content view by content view basis, you might want to change the default {Project} settings to enable or disable package resolution for all content views.
 For more information, see xref:Resolving_Package_Dependencies_{context}[].
+endif::[]
 
 .Procedure
 . Obtain a list of repository IDs:

--- a/guides/common/modules/proc_creating-a-content-view-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-content-view-by-using-web-ui.adoc
@@ -6,8 +6,10 @@
 [role="_abstract"]
 Use this procedure to create a content view by using the {ProjectWebUI}.
 
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 While you can stipulate whether you want to resolve any package dependencies on a content view by content view basis, you might want to change the default {Project} settings to enable or disable package resolution for all content views.
 For more information, see xref:Resolving_Package_Dependencies_{context}[].
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.
@@ -16,9 +18,11 @@ For more information, see xref:Resolving_Package_Dependencies_{context}[].
 {Project} automatically completes the *Label* field from the name you enter.
 . In the *Description* field, enter a description of the view.
 . In the *Type* field, select a *Content view* or a *Composite content view*.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 . Optional: If you want to solve dependencies automatically every time you publish this content view, select the *Solve dependencies* checkbox.
 Dependency solving slows the publishing time and might ignore any content view filters you use.
 This can also cause errors when resolving dependencies for errata.
+endif::[]
 . Click *Create content view*.
 . On the *Repositories* tab, select the repository from the *Type* list that you want to add to your content view, select the checkbox next to the available repositories you want to add, then click *Add repositories*.
 . Click *Publish new version* and in the *Description* field, enter information about the version to log changes.

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -8,7 +8,9 @@ You can create a {customfiletype} repository source, from a directory of files, 
 You can then synchronize the files into a repository and manage the {customfiletype} content like any other content type.
 
 Use this procedure to configure a repository in a directory on the base system where {Project} is installed.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 To create a file type repository in a directory on a remote server, see xref:creating-a-remote-source-for-a-custom-file-type-repository[].
+endif::[]
 
 .Procedure
 . On your {ProjectServer}, install the Pulp Manifest package:
@@ -64,6 +66,8 @@ PULP_MANIFEST test.txt
 .Next steps
 * You can import your local source as a {customfiletype} repository.
 Use the `file://` URL scheme and the name of the directory to specify an *Upstream URL*, such as `\file:///var/lib/pulp/__local_repos__/__my_file_repo__`.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For more information, see xref:creating-a-custom-file-type-repository-by-using-web-ui[].
+endif::[]
 * If you update the contents of your directory, re-run Pulp Manifest and sync the repository in {Project}.
 For more information, see xref:synchronizing-repositories-on-demand[].

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -8,7 +8,9 @@ You can create a {customfiletype} repository source from a directory of files th
 You can then synchronize the files into a repository on {ProjectServer} over HTTP or HTTPS and manage the {customfiletype} content like any other content type.
 
 Use this procedure to configure a repository in a directory on a remote server.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 To create a file type repository in a directory on the base system where {ProjectServer} is installed, see xref:creating-a-local-source-for-a-custom-file-type-repository[].
+endif::[]
 
 .Prerequisites
 ifdef::katello,orcharhino[]
@@ -83,6 +85,8 @@ PULP_MANIFEST test.txt
 .Next steps
 * You can import your remote source as a {customfiletype} repository.
 Use the path to the directory to specify an *Upstream URL*, such as `\http://{server-example-com}/__my_file_repo__`.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For more information, see xref:creating-a-custom-file-type-repository-by-using-web-ui[].
+endif::[]
 * If you update the contents of your directory, re-run Pulp Manifest and sync the repository in {Project}.
 For more information, see xref:synchronizing-repositories-on-demand[].

--- a/guides/common/modules/proc_creating-an-activation-key-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-by-using-cli.adoc
@@ -18,6 +18,7 @@ $ hammer activation-key create \
 --content-view-environments "_Development_/_Stack_" \
 --organization "_My_Organization_"
 ----
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 . Optional: Configure the activation key with system purpose attributes to set on hosts during registration.
 This helps determine which repositories are available on the host.
 It also helps with reporting in the Subscriptions service of the Red Hat Hybrid Cloud Console.
@@ -31,6 +32,7 @@ $ hammer activation-key update \
 --purpose-usage "_Development/Test_" \
 --purpose-role "_{RHELServer}_"
 ----
+endif::[]
 . List the product content associated with the activation key:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_creating-an-activation-key-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-by-using-cli.adoc
@@ -55,7 +55,9 @@ $ hammer activation-key content-override \
 +
 For a {customrepo}, the content label consists of your organization label, product label, and repository label split by underscores.
 For example, `Example_{Project}_Client_{client-os-label}_{client-os-major}`.
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For content from Red{nbsp}Hat, the content label is taken from the Red{nbsp}Hat manifest.
 For example, `rhel-10-for-x86_64-baseos-rpms`.
+endif::[]
 +
 The default status is set to disabled.

--- a/guides/common/modules/proc_creating-an-activation-key-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-an-activation-key-by-using-web-ui.adoc
@@ -7,7 +7,8 @@
 Create an activation key from the {ProjectWebUI} to assign various attributes to hosts during registration.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys* and click *Create Activation Key*.
+. In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.
+. Click *Create Activation Key*.
 . In the *Name* field, enter the name of the activation key.
 . If you want to set a limit, clear the *Unlimited hosts* checkbox, and in the *Limit* field, enter the maximum number of systems you can register with the activation key.
 If you want unlimited hosts to register with the activation key, ensure the *Unlimited Hosts* checkbox is selected.
@@ -19,8 +20,10 @@ If you want unlimited hosts to register with the activation key, ensure the *Unl
 . Optional: Drag and drop the content view environments to change the order of the content view environments.
 . Click *Save* to save the content view environments.
 . Click *Save* to save the activation key.
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 . Optional: In the *System Purpose* section, you can configure the activation key to set system purpose attributes on hosts during registration.
 This helps determine which repositories are available on the host.
 It also helps with reporting in the Subscriptions service of the Red Hat Hybrid Cloud Console.
+endif::[]
 . On the *Repository Sets* tab, override repositories to Enabled or Disabled as desired.
 For more information, see xref:enabling-and-disabling-repositories-on-activation-key_{context}[].

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-cli.adoc
@@ -8,7 +8,9 @@ You can download files to a client over HTTPS using `curl -O`, and optionally ov
 
 .Prerequisites
 * You have a {customfiletype} repository.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For more information, see xref:creating-a-custom-file-type-repository-by-using-cli[].
+endif::[]
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 ** The `katello-server-ca.crt`.

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-web-ui.adoc
@@ -8,7 +8,9 @@ You can download files to a client over HTTPS using `curl -O`, and optionally ov
 
 .Prerequisites
 * You have a {customfiletype} repository.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For more information, see xref:creating-a-custom-file-type-repository-by-using-web-ui[].
+endif::[]
 * You know the name of the file you want to download to clients from the file type repository.
 * To use HTTPS you require the following certificates on the client:
 ** The `katello-server-ca.crt`.

--- a/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-cli.adoc
+++ b/guides/common/modules/proc_enabling-the-flatpak-remote-by-using-cli.adoc
@@ -10,7 +10,9 @@ This procedure configures and manages Flatpak repositories by using Hammer CLI.
  * Your {Project} account has a role that grants the permissions `view_flatpak_remotes`, `create_flatpak_remotes`, `edit_flatpak_remotes`, and `destroy_flatpak_remotes`. 
 
 * Set up Flatpak. 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For more information, see {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment#setting-up-flatpak_assembly_installing-applications-using-flatpak[Setting up Flatpak].
+endif::[]
 
 * Flatpak applications rely on Flatpak runtimes. 
 For example, `rhel9/firefox-flatpak` depends on `rhel9/flatpak-runtime`. 

--- a/guides/common/modules/proc_installing-flatpak-applications-on-project-hosts.adoc
+++ b/guides/common/modules/proc_installing-flatpak-applications-on-project-hosts.adoc
@@ -9,7 +9,9 @@ Use the command line to install selected applications from the enabled Flatpak r
 .Prerequisites
 * Flatpak is installed on the host.
 * Set up Flatpak on the host that consumes applications from {ProjectServer}.
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 For more information, see {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment#setting-up-flatpak_assembly_installing-applications-using-flatpak[Setting up Flatpak].
+endif::[]
 * Ensure that Flatpak runtime repositories are available to hosts alongside application repositories.
 Flatpak applications, such as `rhel9/firefox-flatpak`, depend on the runtime for installation.
 ifdef::satellite[]
@@ -47,6 +49,8 @@ For example, to install the Mozilla Firefox Flatpak:
 $ flatpak install firefox
 ----
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 .Additional resources
 * {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment#launching-flatpak-applications_assembly_installing-applications-using-flatpak[Launching Flatpak applications]
 * {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment#updating-flatpak-applications_assembly_installing-applications-using-flatpak[Updating Flatpak applications]
+endif::[]

--- a/guides/common/modules/proc_mirroring-remote-flatpak-repositories-to-project-products-by-using-cli.adoc
+++ b/guides/common/modules/proc_mirroring-remote-flatpak-repositories-to-project-products-by-using-cli.adoc
@@ -11,12 +11,16 @@ You can now synchronize the repository to pull down its content.
 Flatpak repositories are container repositories and you can add them to content views like other container repositories.
 
 Flatpak applications require a corresponding runtime environment, which the Flatpak remote also provides.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 To make the {EL} 10 Mozilla Firefox Flatpak available to a host, ensure that the host can access the matching `rhel10/flatpak-runtime` repository.
+endif::[]
 
 .Prerequisites
 * Your {Project} account has a role that grants the `view_flatpak_remotes` and `edit_flatpak_remotes` permissions.
 * Ensure that Flatpak runtime repositories are available to hosts alongside application repositories.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 Flatpak applications, such as `rhel9/firefox-flatpak`, depend on the runtime for installation.
+endif::[]
 * You have created a {customproduct} on {Project}.
 
 .Procedure

--- a/guides/common/modules/proc_mirroring-remote-flatpak-repositories-to-project-products-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_mirroring-remote-flatpak-repositories-to-project-products-by-using-web-ui.adoc
@@ -11,12 +11,16 @@ You can now synchronize the repository to pull down its content.
 Flatpak repositories are container repositories and you can add them to content views like other container repositories.
 
 Flatpak applications require a corresponding runtime environment, which the Flatpak remote also provides.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 To make the {EL} 10 Mozilla Firefox Flatpak available to a host, ensure that the host can access the matching `rhel10/flatpak-runtime` repository.
+endif::[]
 
 .Prerequisites
 * Your {Project} account has a role that grants the `view_flatpak_remotes` and `edit_flatpak_remotes` permissions.
 * Ensure that Flatpak runtime repositories are available to hosts alongside application repositories.
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 Flatpak applications, such as `rhel9/firefox-flatpak`, depend on the runtime for installation.
+endif::[]
 * You have created a {customproduct} on {Project}.
 
 .Procedure

--- a/guides/common/modules/ref_prerequisites-for-microsoft-azure-provisioning.adoc
+++ b/guides/common/modules/ref_prerequisites-for-microsoft-azure-provisioning.adoc
@@ -15,7 +15,9 @@ For more information, see https://docs.microsoft.com/en-us/azure/active-director
 * Based on your needs, associate a `finish` or `user_data` provisioning template with the operating system you want to use.
 For more information about provisioning templates, see {ProvisioningDocURL}provisioning-templates[Provisioning Templates].
 * Optional: If you want the virtual machine to use a static private IP address, create a subnet in {Project} with the *Network Address* field matching the Azure subnet address.
+ifdef::foreman-el,foreman-deb,katello,satellite,red_hat_enterprise_linux[]
 * Before creating {RHEL} BYOS images, you must accept the image terms either in the Azure CLI or Portal so that the image can be used to create and manage virtual machines for your subscription.
+endif::[]
 
 .Additional resources
 * https://docs.microsoft.com/en-us/azure/azure-resource-manager/[Azure Resource Manager documentation]


### PR DESCRIPTION
#### What changes are you introducing?

This set of patches introduces various macros to hide certain content that does not apply to all Client OS.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Foreman Docs contain many Client OS-specific note. There are some parts that are only relevant to RHEL Clients. In orcharhino downstream, they should only be shown for RHEL Clients.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

You can review this commit by commit but I intend to squash them when merging because they all belong together (and I want to cherry-pick them).

This is a follow-up to #4839.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
