### PR TITLE
Replace ASSEMBLY content type with IGNORE

### DIFF
--- a/.cursor/skills/review-assembly-user-story/SKILL.md
+++ b/.cursor/skills/review-assembly-user-story/SKILL.md
@@ -56,7 +56,7 @@ The assembly is fine if:
 For each identified user story:
 
 1. **Create a new assembly file** - Name it `assembly_<descriptive-name>.adoc`
-2. **Add the assembly header** - Include `:_mod-docs-content-type: ASSEMBLY`
+2. **Add the assembly header** - Include `:_mod-docs-content-type: IGNORE`
 3. **Include relevant modules** - Copy the appropriate module includes for this user story
 4. **Create or update the introductory concept module** - Write a focused concept module with an abstract for this specific user story if needed
 5. **Update parent files** - Replace the original assembly include with includes for all new assemblies in the `master.adoc` file

--- a/guides/common/assembly_accessing-project-from-web-ui.adoc
+++ b/guides/common/assembly_accessing-project-from-web-ui.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_accessing-project-from-web-ui.adoc[]
 

--- a/guides/common/assembly_adding-content-to-foreman.adoc
+++ b/guides/common/assembly_adding-content-to-foreman.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_adding-content-to-foreman.adoc[]
 

--- a/guides/common/assembly_administer-settings-information.adoc
+++ b/guides/common/assembly_administer-settings-information.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_administration-settings.adoc[]
 

--- a/guides/common/assembly_api-call-authentication.adoc
+++ b/guides/common/assembly_api-call-authentication.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_api-call-authentication.adoc[]
 

--- a/guides/common/assembly_api-cheat-sheet.adoc
+++ b/guides/common/assembly_api-cheat-sheet.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_api-cheat-sheet.adoc[]
 

--- a/guides/common/assembly_api-requests-in-various-languages.adoc
+++ b/guides/common/assembly_api-requests-in-various-languages.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_api-requests-in-various-languages.adoc[]
 

--- a/guides/common/assembly_api-syntax.adoc
+++ b/guides/common/assembly_api-syntax.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_api-syntax.adoc[]
 

--- a/guides/common/assembly_backing-up-server-and-proxy.adoc
+++ b/guides/common/assembly_backing-up-server-and-proxy.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_backing-up-server-and-proxy.adoc[]
 

--- a/guides/common/assembly_basic-content-management-workflow.adoc
+++ b/guides/common/assembly_basic-content-management-workflow.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_basic-content-management-workflow.adoc[]
 

--- a/guides/common/assembly_bootloader-binary-location.adoc
+++ b/guides/common/assembly_bootloader-binary-location.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_boot-loader-management-and-file-structure.adoc[]
 

--- a/guides/common/assembly_building-cloud-images.adoc
+++ b/guides/common/assembly_building-cloud-images.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/ref_building-cloud-images.adoc[]
 

--- a/guides/common/assembly_cloning-project-server.adoc
+++ b/guides/common/assembly_cloning-project-server.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_cloning-project-server.adoc[]
 

--- a/guides/common/assembly_common-deployment-scenarios.adoc
+++ b/guides/common/assembly_common-deployment-scenarios.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_common-deployment-scenarios.adoc[]
 

--- a/guides/common/assembly_configuring-an-alternate-cname.adoc
+++ b/guides/common/assembly_configuring-an-alternate-cname.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/assembly_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc[]
 

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-and-setting-up-remote-jobs.adoc[]
 

--- a/guides/common/assembly_configuring-dhcp-integration.adoc
+++ b/guides/common/assembly_configuring-dhcp-integration.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-dhcp-integration.adoc[]
 

--- a/guides/common/assembly_configuring-dns-integration.adoc
+++ b/guides/common/assembly_configuring-dns-integration.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-dns-integration.adoc[]
 

--- a/guides/common/assembly_configuring-email-notifications.adoc
+++ b/guides/common/assembly_configuring-email-notifications.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-email-notifications.adoc[]
 

--- a/guides/common/assembly_configuring-host-collections.adoc
+++ b/guides/common/assembly_configuring-host-collections.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-host-collections.adoc[]
 

--- a/guides/common/assembly_configuring-inter-server-synchronization.adoc
+++ b/guides/common/assembly_configuring-inter-server-synchronization.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-inter-server-synchronization.adoc[]
 

--- a/guides/common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-kerberos-sso-for-active-directory-users-in-project.adoc[]
 

--- a/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc[]
 

--- a/guides/common/assembly_configuring-network-interfaces.adoc
+++ b/guides/common/assembly_configuring-network-interfaces.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-network-interfaces.adoc[]
 

--- a/guides/common/assembly_configuring-project-for-performance.adoc
+++ b/guides/common/assembly_configuring-project-for-performance.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-project-for-performance.adoc[]
 

--- a/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[]
 

--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-foreman-server-with-a-custom-ssl-certificate.adoc[]
 

--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_configuring-scap-contents-for-compliance-policies-in-project.adoc
+++ b/guides/common/assembly_configuring-scap-contents-for-compliance-policies-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-scap-contents-for-compliance-policies-in-project.adoc[]
 

--- a/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc[]
 

--- a/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc[]
 

--- a/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc[]
 

--- a/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc[]
 

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc[]
 

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc[]
 

--- a/guides/common/assembly_configuring-tftp-integration.adoc
+++ b/guides/common/assembly_configuring-tftp-integration.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_configuring-tftp-integration.adoc[]
 

--- a/guides/common/assembly_configuring-virt-who-hyperv.adoc
+++ b/guides/common/assembly_configuring-virt-who-hyperv.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :configuring-virt-who-hyperv:
 :parent-context: {context}

--- a/guides/common/assembly_configuring-virt-who-kubevirt.adoc
+++ b/guides/common/assembly_configuring-virt-who-kubevirt.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :configuring-virt-who-kubevirt:
 :parent-context: {context}

--- a/guides/common/assembly_configuring-virt-who-kvm.adoc
+++ b/guides/common/assembly_configuring-virt-who-kvm.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :configuring-virt-who-kvm:
 :parent-context: {context}

--- a/guides/common/assembly_configuring-virt-who-nutanix.adoc
+++ b/guides/common/assembly_configuring-virt-who-nutanix.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :configuring-virt-who-nutanix:
 :parent-context: {context}

--- a/guides/common/assembly_configuring-virt-who-openstack.adoc
+++ b/guides/common/assembly_configuring-virt-who-openstack.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :configuring-virt-who-openstack:
 :parent-context: {context}

--- a/guides/common/assembly_configuring-virt-who-vmware.adoc
+++ b/guides/common/assembly_configuring-virt-who-vmware.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :configuring-virt-who-vmware:
 :parent-context: {context}

--- a/guides/common/assembly_connecting-ai-applications-to-the-mcp-server-for-project.adoc
+++ b/guides/common/assembly_connecting-ai-applications-to-the-mcp-server-for-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc[]
 

--- a/guides/common/assembly_content-access-control-for-hosts.adoc
+++ b/guides/common/assembly_content-access-control-for-hosts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_content-access-control-for-hosts.adoc[]
 

--- a/guides/common/assembly_content-and-patch-management-with-project.adoc
+++ b/guides/common/assembly_content-and-patch-management-with-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_content-and-patch-management-with-project.adoc[]
 

--- a/guides/common/assembly_converting-hosts-to-rhel.adoc
+++ b/guides/common/assembly_converting-hosts-to-rhel.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_creating-and-managing-roles.adoc
+++ b/guides/common/assembly_creating-and-managing-roles.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_creating-and-managing-roles.adoc[]
 

--- a/guides/common/assembly_deploying-compliance-policies.adoc
+++ b/guides/common/assembly_deploying-compliance-policies.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_deploying-compliance-policies.adoc[]
 

--- a/guides/common/assembly_deployment-path.adoc
+++ b/guides/common/assembly_deployment-path.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_deployment-path.adoc[]
 

--- a/guides/common/assembly_determining-hardware-and-operating-system-configuration.adoc
+++ b/guides/common/assembly_determining-hardware-and-operating-system-configuration.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_hardware-and-operating-system-configuration.adoc[]
 

--- a/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_disaster-recovery-by-virtualizing-your-projectserver.adoc[]
 

--- a/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc[]
 

--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc[]
 

--- a/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_disaster-recovery-with-two-active-project-servers.adoc[]
 

--- a/guides/common/assembly_discovering-hosts-on-a-network.adoc
+++ b/guides/common/assembly_discovering-hosts-on-a-network.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_discovering-hosts-on-a-network.adoc[]
 

--- a/guides/common/assembly_example-playbooks-based-on-modules-from-project-ansible-collection.adoc
+++ b/guides/common/assembly_example-playbooks-based-on-modules-from-project-ansible-collection.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_example-playbooks-based-on-modules-from-project-ansible-collection.adoc[]
 

--- a/guides/common/assembly_expense-management-for-red-hat-subscriptions.adoc
+++ b/guides/common/assembly_expense-management-for-red-hat-subscriptions.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_expense-management-for-red-hat-subscriptions.adoc[]
 

--- a/guides/common/assembly_getting-started-with-ansible.adoc
+++ b/guides/common/assembly_getting-started-with-ansible.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_getting-started-with-Ansible-in-project.adoc[]
 

--- a/guides/common/assembly_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/assembly_host-management-and-monitoring-using-cockpit.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_host-management-and-monitoring-by-using-cockpit.adoc[]
 

--- a/guides/common/assembly_importing-the-project-client-name-repository.adoc
+++ b/guides/common/assembly_importing-the-project-client-name-repository.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_importing-the-project-client-name-repository.adoc[]
 

--- a/guides/common/assembly_increasing-logging-levels-of-project-components.adoc
+++ b/guides/common/assembly_increasing-logging-levels-of-project-components.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_increasing-logging-levels-of-project-components.adoc[]
 

--- a/guides/common/assembly_installing-and-configuring-insights-iop.adoc
+++ b/guides/common/assembly_installing-and-configuring-insights-iop.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_installing-and-configuring-insights-iop.adoc[]
 

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_installing-project-server.adoc[]
 

--- a/guides/common/assembly_installing-the-load-balancer.adoc
+++ b/guides/common/assembly_installing-the-load-balancer.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_installing-and-configuring-the-load-balancer.adoc[]
 

--- a/guides/common/assembly_integrating-awx.adoc
+++ b/guides/common/assembly_integrating-awx.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_integrating-project-and-awx.adoc[]
 

--- a/guides/common/assembly_introduction-to-managing-content.adoc
+++ b/guides/common/assembly_introduction-to-managing-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_introduction-to-content-management.adoc[]
 

--- a/guides/common/assembly_introduction-to-project-ansible-collection.adoc
+++ b/guides/common/assembly_introduction-to-project-ansible-collection.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_introduction-to-project-ansible-collection.adoc[]
 

--- a/guides/common/assembly_introduction-to-project-api.adoc
+++ b/guides/common/assembly_introduction-to-project-api.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_introduction-to-project-api.adoc[]
 

--- a/guides/common/assembly_introduction-to-provisioning.adoc
+++ b/guides/common/assembly_introduction-to-provisioning.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_introduction-to-provisioning.adoc[]
 

--- a/guides/common/assembly_job-template-examples-and-extensions.adoc
+++ b/guides/common/assembly_job-template-examples-and-extensions.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_job-template-examples-and-extensions.adoc[]
 

--- a/guides/common/assembly_limiting-host-resources.adoc
+++ b/guides/common/assembly_limiting-host-resources.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_limiting-host-resources.adoc[]
 

--- a/guides/common/assembly_logging-and-reporting-problems.adoc
+++ b/guides/common/assembly_logging-and-reporting-problems.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_logging-and-reporting-problems.adoc[]
 

--- a/guides/common/assembly_maintaining-server.adoc
+++ b/guides/common/assembly_maintaining-server.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_maintaining-server.adoc[]
 

--- a/guides/common/assembly_major-project-components.adoc
+++ b/guides/common/assembly_major-project-components.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_major-project-components.adoc[]
 

--- a/guides/common/assembly_managing-activation-keys.adoc
+++ b/guides/common/assembly_managing-activation-keys.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-activation-keys.adoc[]
 

--- a/guides/common/assembly_managing-alternate-content-sources.adoc
+++ b/guides/common/assembly_managing-alternate-content-sources.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-alternate-content-sources.adoc[]
 

--- a/guides/common/assembly_managing-ansible-content.adoc
+++ b/guides/common/assembly_managing-ansible-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-ansible-content.adoc[]
 

--- a/guides/common/assembly_managing-application-lifecycles.adoc
+++ b/guides/common/assembly_managing-application-lifecycles.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-application-lifecycles.adoc[]
 

--- a/guides/common/assembly_managing-compliance-policies.adoc
+++ b/guides/common/assembly_managing-compliance-policies.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-compliance-policies.adoc[]
 

--- a/guides/common/assembly_managing-container-images.adoc
+++ b/guides/common/assembly_managing-container-images.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-container-images.adoc[]
 

--- a/guides/common/assembly_managing-content-view-environments.adoc
+++ b/guides/common/assembly_managing-content-view-environments.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-content-view-environments.adoc[]
 

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-content-views.adoc[]
 

--- a/guides/common/assembly_managing-custom-file-type-content.adoc
+++ b/guides/common/assembly_managing-custom-file-type-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-custom-file-type-content.adoc[]
 

--- a/guides/common/assembly_managing-errata.adoc
+++ b/guides/common/assembly_managing-errata.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-errata.adoc[]
 

--- a/guides/common/assembly_managing-external-user-groups.adoc
+++ b/guides/common/assembly_managing-external-user-groups.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-external-user-groups.adoc[]
 

--- a/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-flatpak-repositories-in-project.adoc[]
 

--- a/guides/common/assembly_managing-host-content-settings-and-system-purpose.adoc
+++ b/guides/common/assembly_managing-host-content-settings-and-system-purpose.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-host-content-settings-and-system-purpose.adoc[]
 

--- a/guides/common/assembly_managing-host-placement-and-associations.adoc
+++ b/guides/common/assembly_managing-host-placement-and-associations.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-host-placement-and-associations.adoc[]
 

--- a/guides/common/assembly_managing-host-records-in-project.adoc
+++ b/guides/common/assembly_managing-host-records-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-host-records-in-project.adoc[]
 

--- a/guides/common/assembly_managing-host-snapshots.adoc
+++ b/guides/common/assembly_managing-host-snapshots.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-host-snapshots.adoc[]
 

--- a/guides/common/assembly_managing-iso-images.adoc
+++ b/guides/common/assembly_managing-iso-images.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-iso-images.adoc[]
 

--- a/guides/common/assembly_managing-locations.adoc
+++ b/guides/common/assembly_managing-locations.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-locations.adoc[]
 

--- a/guides/common/assembly_managing-organizations.adoc
+++ b/guides/common/assembly_managing-organizations.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-organizations.adoc[]
 

--- a/guides/common/assembly_managing-ostree-content.adoc
+++ b/guides/common/assembly_managing-ostree-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-ostree-content.adoc[]
 

--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-packages-in-project.adoc[]
 

--- a/guides/common/assembly_managing-python-type-content.adoc
+++ b/guides/common/assembly_managing-python-type-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-python-type-content.adoc[]
 

--- a/guides/common/assembly_managing-red-hat-subscriptions.adoc
+++ b/guides/common/assembly_managing-red-hat-subscriptions.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-red-hat-subscriptions.adoc[]
 

--- a/guides/common/assembly_managing-suse-content.adoc
+++ b/guides/common/assembly_managing-suse-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-client-os-major: {client-os-major}
 :parent-client-os-minor: {client-os-minor}

--- a/guides/common/assembly_managing-users-and-roles.adoc
+++ b/guides/common/assembly_managing-users-and-roles.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_managing-users-and-roles.adoc[]
 

--- a/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_monitoring-compliance.adoc
+++ b/guides/common/assembly_monitoring-compliance.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_monitoring-compliance.adoc[]
 

--- a/guides/common/assembly_monitoring-hosts-by-using-insights-in-cloud.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-insights-in-cloud.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: insights-in-cloud

--- a/guides/common/assembly_monitoring-hosts-by-using-insights-in-project.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-insights-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: insights-in-{project-context}

--- a/guides/common/assembly_monitoring-project-resources.adoc
+++ b/guides/common/assembly_monitoring-project-resources.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_monitoring-project-resources.adoc[]
 

--- a/guides/common/assembly_networking-considerations-in-project.adoc
+++ b/guides/common/assembly_networking-considerations-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_networking-considerations-in-project.adoc[]
 

--- a/guides/common/assembly_optimizing-content-synchronization-and-storage.adoc
+++ b/guides/common/assembly_optimizing-content-synchronization-and-storage.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_optimizing-content-synchronization-and-storage.adoc[]
 

--- a/guides/common/assembly_overview-of-load-balancing-in-project.adoc
+++ b/guides/common/assembly_overview-of-load-balancing-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_overview-of-load-balancing-in-project.adoc[]
 

--- a/guides/common/assembly_overview-of-vm-subscriptions.adoc
+++ b/guides/common/assembly_overview-of-vm-subscriptions.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_virtual-machine-subscriptions-overview.adoc[]
 

--- a/guides/common/assembly_package-mode-and-image-mode-hosts.adoc
+++ b/guides/common/assembly_package-mode-and-image-mode-hosts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_package-mode-and-image-mode-hosts.adoc[]
 

--- a/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_performing-additional-configuration-on-smart-proxy-server.adoc[]
 

--- a/guides/common/assembly_planning-project-server-installation.adoc
+++ b/guides/common/assembly_planning-project-server-installation.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_planning-project-server-installation.adoc[]
 

--- a/guides/common/assembly_preparing-client-platforms.adoc
+++ b/guides/common/assembly_preparing-client-platforms.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-client-platforms.adoc[]
 

--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_preparing-environment-for-project-server-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-project-server-installation.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-environment-for-project-server-installation.adoc[]
 

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[]
 

--- a/guides/common/assembly_preparing-for-project-upgrade.adoc
+++ b/guides/common/assembly_preparing-for-project-upgrade.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-for-project-upgrade.adoc[]
 

--- a/guides/common/assembly_preparing-networking.adoc
+++ b/guides/common/assembly_preparing-networking.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-networking.adoc[]
 

--- a/guides/common/assembly_preparing-provisioning-content.adoc
+++ b/guides/common/assembly_preparing-provisioning-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-provisioning-content.adoc[]
 

--- a/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
+++ b/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-smartproxyservers-for-load-balancing.adoc[]
 

--- a/guides/common/assembly_preparing-templates-for-provisioning.adoc
+++ b/guides/common/assembly_preparing-templates-for-provisioning.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_preparing-templates-for-provisioning.adoc[]
 

--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: azure-provisioning

--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :CRname: Amazon EC2

--- a/guides/common/assembly_provisioning-cloud-instances-gce.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-gce.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: gce-provisioning

--- a/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: openstack-provisioning

--- a/guides/common/assembly_provisioning-contexts.adoc
+++ b/guides/common/assembly_provisioning-contexts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_provisioning-contexts.adoc[]
 

--- a/guides/common/assembly_provisioning-management-with-project.adoc
+++ b/guides/common/assembly_provisioning-management-with-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_provisioning-management-with-project.adoc[]
 

--- a/guides/common/assembly_provisioning-requirements-in-project.adoc
+++ b/guides/common/assembly_provisioning-requirements-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_provisioning-requirements-in-project.adoc[]
 

--- a/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: kubevirt-provisioning

--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: kvm-provisioning

--- a/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: proxmox-provisioning

--- a/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :parent-context: {context}
 :context: vmware-provisioning

--- a/guides/common/assembly_recovering-corrupted-content.adoc
+++ b/guides/common/assembly_recovering-corrupted-content.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_recovering-corrupted-content.adoc[]
 

--- a/guides/common/assembly_refreshing-self-signed-ca-certificate-on-hosts.adoc
+++ b/guides/common/assembly_refreshing-self-signed-ca-certificate-on-hosts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_refreshing-the-self-signed-ca-certificate-on-hosts.adoc[]
 

--- a/guides/common/assembly_registering-clients-to-the-load-balancer.adoc
+++ b/guides/common/assembly_registering-clients-to-the-load-balancer.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_registering-clients-to-the-load-balancer.adoc[]
 

--- a/guides/common/assembly_registering-hosts-to-project.adoc
+++ b/guides/common/assembly_registering-hosts-to-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_registering-hosts-to-project.adoc[]
 

--- a/guides/common/assembly_renaming-server-or-smart-proxy.adoc
+++ b/guides/common/assembly_renaming-server-or-smart-proxy.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_renaming-server-or-smart-proxy.adoc[]
 

--- a/guides/common/assembly_renewing-certificates.adoc
+++ b/guides/common/assembly_renewing-certificates.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_renewing-certificates.adoc[]
 

--- a/guides/common/assembly_restarting-applications-on-hosts-through-tracer.adoc
+++ b/guides/common/assembly_restarting-applications-on-hosts-through-tracer.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_restarting-applications-on-hosts-through-tracer.adoc[]
 

--- a/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc[]
 

--- a/guides/common/assembly_reviewing-hosts-in-project-web-ui.adoc
+++ b/guides/common/assembly_reviewing-hosts-in-project-web-ui.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_reviewing-hosts-in-project-web-ui.adoc[]
 

--- a/guides/common/assembly_searching-and-bookmarking.adoc
+++ b/guides/common/assembly_searching-and-bookmarking.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_searching-and-bookmarking.adoc[]
 

--- a/guides/common/assembly_security-compliance-management-in-project.adoc
+++ b/guides/common/assembly_security-compliance-management-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_security-compliance-management-in-project.adoc[]
 

--- a/guides/common/assembly_security-settings.adoc
+++ b/guides/common/assembly_security-settings.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_security-settings.adoc[]
 

--- a/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
+++ b/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_supported-usage-and-versions-of-project-components.adoc[]
 

--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_synchronizing-content-between-servers.adoc[]
 

--- a/guides/common/assembly_synchronizing-content-to-foreman.adoc
+++ b/guides/common/assembly_synchronizing-content-to-foreman.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_synchronizing-content-to-foreman.adoc[]
 

--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_synchronizing-template-repositories.adoc[]
 

--- a/guides/common/assembly_template-writing-reference.adoc
+++ b/guides/common/assembly_template-writing-reference.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_template-writing-reference.adoc[]
 

--- a/guides/common/assembly_tools-for-administration-of-project.adoc
+++ b/guides/common/assembly_tools-for-administration-of-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_tools-for-administration-of-project.adoc[]
 

--- a/guides/common/assembly_troubleshooting-virt-who.adoc
+++ b/guides/common/assembly_troubleshooting-virt-who.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_troubleshooting-virt-who.adoc[]
 

--- a/guides/common/assembly_tuning-with-predefined-profiles.adoc
+++ b/guides/common/assembly_tuning-with-predefined-profiles.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_tuning-projectserver-performance-with-predefined-profiles.adoc[]
 

--- a/guides/common/assembly_updating-foreman.adoc
+++ b/guides/common/assembly_updating-foreman.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_updating-project.adoc[]
 

--- a/guides/common/assembly_updating-satellite.adoc
+++ b/guides/common/assembly_updating-satellite.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_updating-project-to-next-patch-version.adoc[]
 

--- a/guides/common/assembly_usage-metrics-collection-in-project.adoc
+++ b/guides/common/assembly_usage-metrics-collection-in-project.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_usage-metrics-collection-in-project.adoc[]
 

--- a/guides/common/assembly_using-ansible-roles.adoc
+++ b/guides/common/assembly_using-ansible-roles.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_using-ansible-roles-to-automate-repetitive-tasks-on-hosts.adoc[]
 

--- a/guides/common/assembly_using-boot-disks-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-boot-disks-to-provision-hosts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :using-bootdisks-to-provision-hosts:
 :parent-context: {context}

--- a/guides/common/assembly_using-custom-ssl-certificate-for-hosts.adoc
+++ b/guides/common/assembly_using-custom-ssl-certificate-for-hosts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_using-custom-ssl-certificate-for-hosts.adoc[]
 

--- a/guides/common/assembly_using-foreman-webhooks.adoc
+++ b/guides/common/assembly_using-foreman-webhooks.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 ifdef::context[:parent-context: {context}]
 

--- a/guides/common/assembly_using-kernelcare.adoc
+++ b/guides/common/assembly_using-kernelcare.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_using-the-kernelcare-plugin.adoc[]
 

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 :using-network-boot-to-provision-hosts:
 :parent-context: {context}

--- a/guides/common/assembly_using-report-templates.adoc
+++ b/guides/common/assembly_using-report-templates.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_using-report-templates-to-monitor-hosts.adoc[]
 

--- a/guides/common/assembly_working-with-host-groups.adoc
+++ b/guides/common/assembly_working-with-host-groups.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: IGNORE
 
 include::modules/con_working-with-host-groups.adoc[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Replacing the assembly content type with the ignore content type throughout the repository.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Assemblies in foreman-documentation do not match the expectations defined by https://github.com/jhradilek/asciidoctor-dita-vale. Replacing the ASSEMBLY content type with the IGNORE content type prevents related Vale warnings.

https://github.com/jhradilek/asciidoctor-dita-vale/pull/179

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
