### PR TITLE
Rephrase curl command to registration command

### DIFF
--- a/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
@@ -55,7 +55,9 @@ ifndef::orcharhino[]
 * On the *Advanced* tab, in the *Repositories* field, you can list repositories to be added before the registration is performed.
 You do not have to specify repositories if you provide them in an activation key.
 endif::[]
-* On the *Advanced* tab, you can configure remote execution, {Insights}, and packages to be installed.
+* On the *Advanced* tab, you can configure
+ifdef::katello,satellite,red_hat_enterprise_linux[remote execution, {Insights}, and packages to be installed.]
+ifdef::almalinux,amazon_linux,centos,debian,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[remote execution and packages to be installed.]
 * On the *Advanced* tab, in the *Token lifetime (hours)* field, you can change the validity duration of the JSON Web Token (JWT) that {Project} uses for authentication.
 The duration of this token defines how long the generated registration command works.
 +
@@ -81,8 +83,8 @@ The parameter values must be URL encoded.
 ====
 * On the *Advanced* tab, you can enable container and Flatpak registry access without a username or password by selecting the *Set up container registry certs* checkbox.
 Using certificate-based authentication also enforces lifecycle management of container and Flatpak content for the host.
-. Click *Generate* to generate a `curl` command.
-. Run the `curl` command as `root` on the host that you want to register.
+. Click *Generate* to generate a registration command.
+. Run the registration command as `root` on the host that you want to register.
 After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.
 
 .Next steps


### PR DESCRIPTION
#### What changes are you introducing?

This patch renames the command that the users runs on a host to register it to Foreman+Katello from "curl command" to "registration command" because the user can select to use "wget" in favor of curl.

By default, Foreman creates a curl command.

This patch also hides the "Insights" feature for non-RHEL Clients for orcharhino builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #4414 (Registering hosts: Rephrase registration command)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
