### PR TITLE
Delete old CV versions

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -66,12 +66,6 @@ include::modules/proc_creating-a-content-view-filter-by-using-web-ui.adoc[levelo
 
 include::modules/proc_creating-a-content-view-filter-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.adoc[leveloffset=+1]
-
-include::modules/proc_deleting-multiple-content-view-versions-by-using-cli.adoc[leveloffset=+1]
-
-include::modules/proc_deleting-multiple-content-view-versions-by-using-ansible.adoc[leveloffset=+1]
-
 include::modules/con_clearing-the-search-filter.adoc[leveloffset=+1]
 
 include::modules/con_standardizing-content-view-empty-states.adoc[leveloffset=+1]
@@ -79,5 +73,11 @@ include::modules/con_standardizing-content-view-empty-states.adoc[leveloffset=+1
 include::modules/proc_comparing-content-view-versions.adoc[leveloffset=+1]
 
 include::modules/proc_distributing-archived-content-view-versions.adoc[leveloffset=+1]
+
+include::modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.adoc[leveloffset=+1]
+
+include::modules/proc_deleting-multiple-content-view-versions-by-using-cli.adoc[leveloffset=+1]
+
+include::modules/proc_deleting-multiple-content-view-versions-by-using-ansible.adoc[leveloffset=+1]
 
 include::modules/proc_purging-content-view-versions-by-using-cli.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -68,6 +68,8 @@ include::modules/proc_creating-a-content-view-filter-by-using-cli.adoc[leveloffs
 
 include::modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.adoc[leveloffset=+1]
 
+include::modules/proc_deleting-multiple-content-view-versions-by-using-cli.adoc[leveloffset=+1]
+
 include::modules/con_clearing-the-search-filter.adoc[leveloffset=+1]
 
 include::modules/con_standardizing-content-view-empty-states.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -66,7 +66,7 @@ include::modules/proc_creating-a-content-view-filter-by-using-web-ui.adoc[levelo
 
 include::modules/proc_creating-a-content-view-filter-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_deleting-multiple-content-view-versions.adoc[leveloffset=+1]
+include::modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/con_clearing-the-search-filter.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -70,6 +70,8 @@ include::modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.ad
 
 include::modules/proc_deleting-multiple-content-view-versions-by-using-cli.adoc[leveloffset=+1]
 
+include::modules/proc_deleting-multiple-content-view-versions-by-using-ansible.adoc[leveloffset=+1]
+
 include::modules/con_clearing-the-search-filter.adoc[leveloffset=+1]
 
 include::modules/con_standardizing-content-view-empty-states.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -79,3 +79,5 @@ include::modules/con_standardizing-content-view-empty-states.adoc[leveloffset=+1
 include::modules/proc_comparing-content-view-versions.adoc[leveloffset=+1]
 
 include::modules/proc_distributing-archived-content-view-versions.adoc[leveloffset=+1]
+
+include::modules/proc_purging-content-view-versions-by-using-cli.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_deleting-multiple-content-view-versions-by-using-ansible.adoc
+++ b/guides/common/modules/proc_deleting-multiple-content-view-versions-by-using-ansible.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-multiple-content-view-versions-by-using-ansible"]
+= Deleting multiple content view versions by using Ansible
+
+[role="_abstract"]
+You can delete multiple content view versions simultaneously by using {Project} Ansible collection.
+
+.Procedure
+* Use the `{ansible-namespace}.content_view_version` module.
++
+For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.content_view_version`.

--- a/guides/common/modules/proc_deleting-multiple-content-view-versions-by-using-cli.adoc
+++ b/guides/common/modules/proc_deleting-multiple-content-view-versions-by-using-cli.adoc
@@ -1,0 +1,35 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="deleting-multiple-content-view-versions-by-using-cli"]
+= Deleting multiple content view versions by using Hammer CLI
+
+[role="_abstract"]
+You can delete multiple content view versions simultaneously by using Hammer CLI.
+
+.Procedure
+. List versions of your content view:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer content-view info \
+--name "_My_Content_View_Name_" \
+--organization-id _My_Organization_ID_
+----
+. Delete content view versions:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer content-view remove \
+--content-view-version-ids _My_Content_View_Version_ID_1_,_My_Content_View_Version_ID_2_ \
+--id _My_Content_View_ID_
+----
+
+.Verification
+* Verify that {Project} deleted the content view versions:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer content-view info \
+--name "_My_Content_View_Name_" \
+--organization-id _My_Organization_ID_
+----

--- a/guides/common/modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_deleting-multiple-content-view-versions-by-using-web-ui.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deleting_Multiple_Content_View_Versions_{context}"]
-= Deleting multiple content view versions
+[id="deleting-multiple-content-view-versions-by-using-web-ui"]
+= Deleting multiple content view versions by using {ProjectWebUI}
 
 [role="_abstract"]
-You can delete multiple content view versions simultaneously.
+You can delete multiple content view versions simultaneously by using {ProjectWebUI}.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Content Views*.

--- a/guides/common/modules/proc_purging-content-view-versions-by-using-cli.adoc
+++ b/guides/common/modules/proc_purging-content-view-versions-by-using-cli.adoc
@@ -1,0 +1,43 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="purging-content-view-versions-by-using-cli"]
+= Purging content view versions by using Hammer CLI
+
+[role="_abstract"]
+You can purge excess numbers of content view versions on {Project} to limit disk space usage.
+By default, {Project} keeps every version of a content view.
+Removing content view versions is a tradeoff between disk space and possibly bandwidth during content synchronizations to {SmartProxyServers} and the possibility to roll back to older content snapshots.
+
+{Project} only considers deleting content view versions that are not part of any lifecycle environment.
+
+.Procedure
+. Optional: View your content view versions:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer content-view info \
+--name "_My_Content_View_Name_" \
+--organization-id _My_Organization_ID_
+----
+. Clean up content view versions:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer content-view purge \
+--name "_My_Content_View_Name_" \
+--organization-id _My_Organization_ID_ \
+--versions-to-keep _My_Number_Of_Versions_To_Keep_
+----
+
+.Verification
+* Verify that {Project} deleted the content view versions:
++
+[options="nowrap", subs="verbatim,quotes,attributes"]
+----
+$ hammer content-view info \
+--name "_My_Content_View_Name_" \
+--organization-id _My_Organization_ID_
+----
+
+.Additional resources
+* {AdministeringDocURL}Recovering_from_a_Full_Disk_admin[Recovering from a full disk in _{AdministeringDocTitle}_]


### PR DESCRIPTION
#### What changes are you introducing?

Modules to delete old CV versions.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Response to https://community.theforeman.org/t/quick-question-on-automating-the-removal-of-old-content-versions/46402?u=maximilian which I consider valuable feedback so I tested it (minus the Ansible stuff in a Playbook) and wrote some docs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
