### PR TITLE
Fix abstracts in Configuring virt-who for CQA

### DIFF
--- a/guides/common/modules/con_configuring-virt-who-for-provider.adoc
+++ b/guides/common/modules/con_configuring-virt-who-for-provider.adoc
@@ -4,7 +4,8 @@
 = Configuring virt-who for {provider}
 
 [role="_abstract"]
-Configure virt-who for {provider} to enable {Project} to discover and manage subscriptions for your virtual machines. This ensures proper subscription entitlements are applied based on the relationship between virtual machines and their physical hosts.
+Configure virt-who for {provider} to enable {Project} to discover and manage subscriptions for your virtual machines.
+This ensures proper subscription entitlements are applied based on the relationship between virtual machines and their physical hosts.
 
 ifdef::kubevirt-virt-who[]
 ifdef::satellite[]

--- a/guides/common/modules/con_configuring-virt-who-for-provider.adoc
+++ b/guides/common/modules/con_configuring-virt-who-for-provider.adoc
@@ -4,9 +4,7 @@
 = Configuring virt-who for {provider}
 
 [role="_abstract"]
-You create a virt-who configuration for {provider} by using the {ProjectWebUI} or the CLI on {ProjectServer}.
-
-Then, you deploy the generated script or Hammer command on the {targets}.
+Configure virt-who for {provider} to enable {Project} to discover and manage subscriptions for your virtual machines. This ensures proper subscription entitlements are applied based on the relationship between virtual machines and their physical hosts.
 
 ifdef::kubevirt-virt-who[]
 ifdef::satellite[]

--- a/guides/common/modules/proc_checking-for-subscriptions-that-require-virt-who.adoc
+++ b/guides/common/modules/proc_checking-for-subscriptions-that-require-virt-who.adoc
@@ -4,7 +4,8 @@
 = Checking for subscriptions that require virt-who
 
 [role="_abstract"]
-Identify which subscriptions require virt-who configuration to ensure accurate virtual machine reporting and maintain subscription compliance. This helps you avoid subscription violations and optimize license usage for virtualized environments.
+Identify which subscriptions require virt-who configuration to ensure accurate virtual machine reporting and maintain subscription compliance.
+This helps you avoid subscription violations and optimize license usage for virtualized environments.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*.

--- a/guides/common/modules/proc_checking-for-subscriptions-that-require-virt-who.adoc
+++ b/guides/common/modules/proc_checking-for-subscriptions-that-require-virt-who.adoc
@@ -4,7 +4,7 @@
 = Checking for subscriptions that require virt-who
 
 [role="_abstract"]
-You can check for subscriptions that require virt-who configuration.
+Identify which subscriptions require virt-who configuration to ensure accurate virtual machine reporting and maintain subscription compliance. This helps you avoid subscription violations and optimize license usage for virtualized environments.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Subscriptions*.

--- a/guides/common/modules/proc_checking-virt-who-status-by-using-cli.adoc
+++ b/guides/common/modules/proc_checking-virt-who-status-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Checking virt-who status by using Hammer CLI
 
 [role="_abstract"]
-You can check the status of virt-who by using Hammer CLI.
+Monitor the status of your virt-who instances by using Hammer CLI to verify they are successfully reporting virtual machines to {ProjectServer}. This helps you troubleshoot connectivity issues and ensure accurate subscription management for your virtualized infrastructure.
 
 .Procedure
 * List the status of all virt-who instances:

--- a/guides/common/modules/proc_checking-virt-who-status-by-using-cli.adoc
+++ b/guides/common/modules/proc_checking-virt-who-status-by-using-cli.adoc
@@ -4,7 +4,8 @@
 = Checking virt-who status by using Hammer CLI
 
 [role="_abstract"]
-Monitor the status of your virt-who instances by using Hammer CLI to verify they are successfully reporting virtual machines to {ProjectServer}. This helps you troubleshoot connectivity issues and ensure accurate subscription management for your virtualized infrastructure.
+Monitor the status of your virt-who instances by using Hammer CLI to verify they are successfully reporting virtual machines to {ProjectServer}.
+This helps you troubleshoot connectivity issues and ensure accurate subscription management for your virtualized infrastructure.
 
 .Procedure
 * List the status of all virt-who instances:

--- a/guides/common/modules/proc_checking-virt-who-status-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_checking-virt-who-status-by-using-web-ui.adoc
@@ -4,7 +4,8 @@
 = Checking virt-who status by using {ProjectWebUI}
 
 [role="_abstract"]
-Monitor the status of your virt-who instances to verify they are successfully reporting virtual machines to {ProjectServer}. This helps you troubleshoot connectivity issues and ensure accurate subscription management for your virtualized infrastructure.
+Monitor the status of your virt-who instances to verify they are successfully reporting virtual machines to {ProjectServer}.
+This helps you troubleshoot connectivity issues and ensure accurate subscription management for your virtualized infrastructure.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Virt-who Configurations*.

--- a/guides/common/modules/proc_checking-virt-who-status-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_checking-virt-who-status-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Checking virt-who status by using {ProjectWebUI}
 
 [role="_abstract"]
-You can check the status of virt-who by using the {ProjectWebUI}.
+Monitor the status of your virt-who instances to verify they are successfully reporting virtual machines to {ProjectServer}. This helps you troubleshoot connectivity issues and ensure accurate subscription management for your virtualized infrastructure.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Virt-who Configurations*.

--- a/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-cli.adoc
+++ b/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Editing a virt-who configuration by using Hammer CLI
 
 [role="_abstract"]
-You can edit a virt-who configuration by using Hammer CLI.
+Edit your virt-who configuration by using Hammer CLI to update settings such as reporting intervals, hypervisor credentials, or filtering options. This ensures accurate virtual machine reporting and proper subscription management.
 
 .Procedure
 . Update the virt-who configuration:

--- a/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-cli.adoc
+++ b/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-cli.adoc
@@ -4,7 +4,8 @@
 = Editing a virt-who configuration by using Hammer CLI
 
 [role="_abstract"]
-Edit your virt-who configuration by using Hammer CLI to update settings such as reporting intervals, hypervisor credentials, or filtering options. This ensures accurate virtual machine reporting and proper subscription management.
+Edit your virt-who configuration by using Hammer CLI to update settings such as reporting intervals, hypervisor credentials, and filtering options.
+This ensures accurate virtual machine reporting and proper subscription management.
 
 .Procedure
 . Update the virt-who configuration:

--- a/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Editing a virt-who configuration by using {ProjectWebUI}
 
 [role="_abstract"]
-You can edit a virt-who configuration by using {ProjectWebUI}.
+Edit your virt-who configuration to update settings such as reporting intervals, hypervisor credentials, and filtering options. This ensures accurate virtual machine reporting and proper subscription management.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Virt-who Configurations*.

--- a/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_editing-a-virt-who-configuration-by-using-web-ui.adoc
@@ -4,7 +4,8 @@
 = Editing a virt-who configuration by using {ProjectWebUI}
 
 [role="_abstract"]
-Edit your virt-who configuration to update settings such as reporting intervals, hypervisor credentials, and filtering options. This ensures accurate virtual machine reporting and proper subscription management.
+Edit your virt-who configuration to update settings such as reporting intervals, hypervisor credentials, and filtering options.
+This ensures accurate virtual machine reporting and proper subscription management.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Virt-who Configurations*.


### PR DESCRIPTION
#### What changes are you introducing?
Fix abstracts in Configuring virt-who to comply with CQA requirements

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-45363

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
