### PR TITLE
Add IGNORE content type in pre-processing

### DIFF
--- a/.github/scripts/preprocess-vale-dita.sh
+++ b/.github/scripts/preprocess-vale-dita.sh
@@ -24,7 +24,7 @@ for file in "$@"; do
   if [[ $(basename "$file") == assembly_*.adoc ]]; then
     # Inject content type definition at the beginning
     {
-      echo ":_mod-docs-content-type: ASSEMBLY"
+      echo ":_mod-docs-content-type: IGNORE"
       echo ""
       cat "$file"
     } > "$TEMP_DIR/$file"

--- a/.github/scripts/preprocess-vale-dita.sh
+++ b/.github/scripts/preprocess-vale-dita.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Preprocess AsciiDoc files for Vale DITA linting by injecting content type metadata
+set -euo pipefail
+
+# Create temp directory for preprocessed files
+TEMP_DIR=".vale-temp"
+mkdir -p "$TEMP_DIR"
+
+# Track if we processed any files
+file_count=0
+
+# Process files passed as arguments
+for file in "$@"; do
+  # Skip if file doesn't exist
+  if [[ ! -f "$file" ]]; then
+    echo "Warning: File not found: $file" >&2
+    continue
+  fi
+
+  # Create directory structure in temp
+  mkdir -p "$TEMP_DIR/$(dirname "$file")"
+
+  # Check if it's an assembly file
+  if [[ $(basename "$file") == assembly_*.adoc ]]; then
+    # Inject content type definition at the beginning
+    {
+      echo ":_mod-docs-content-type: ASSEMBLY"
+      echo ""
+      cat "$file"
+    } > "$TEMP_DIR/$file"
+    echo "Preprocessed assembly: $file" >&2
+  else
+    # Copy non-assembly files as-is
+    cp "$file" "$TEMP_DIR/$file"
+  fi
+
+  file_count=$((file_count + 1))
+done
+
+echo "Preprocessed $file_count file(s)" >&2
+
+# Output preprocessed file paths to stdout (one per line)
+for file in "$@"; do
+  if [[ -f "$file" ]]; then
+    echo "$TEMP_DIR/$file"
+  fi
+done

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -86,9 +86,6 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         id: preprocess
         run: |
-          # Make script executable
-          chmod +x .github/scripts/preprocess-vale-dita.sh
-
           # Convert JSON array to space-separated list
           FILES=$(echo '${{ steps.changed-files.outputs.all_changed_files }}' | jq -r '.[]' | tr '\n' ' ')
 

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -82,11 +82,30 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         run: sudo apt-get install -y asciidoctor
 
+      - name: Preprocess assembly files for DITA linting
+        if: steps.changed-files.outputs.any_changed == 'true'
+        id: preprocess
+        run: |
+          # Make script executable
+          chmod +x .github/scripts/preprocess-vale-dita.sh
+
+          # Convert JSON array to space-separated list
+          FILES=$(echo '${{ steps.changed-files.outputs.all_changed_files }}' | jq -r '.[]' | tr '\n' ' ')
+
+          # Run preprocessing script with changed files
+          PREPROCESSED_OUTPUT=$(.github/scripts/preprocess-vale-dita.sh $FILES)
+
+          # Convert newline-separated output back to JSON array for vale-action
+          PREPROCESSED_FILES=$(echo "$PREPROCESSED_OUTPUT" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+          # Save preprocessed file list for Vale step
+          echo "PREPROCESSED_FILES=$PREPROCESSED_FILES" >> $GITHUB_ENV
+
       - name: Vale DITA lint
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: errata-ai/vale-action@v2
         with:
-          files: ${{ steps.changed-files.outputs.all_changed_files }}
+          files: ${{ env.PREPROCESSED_FILES }}
           filter_mode: diff_context
           vale_flags: "--no-exit --minAlertLevel=warning --config=.vale-dita.ini"
           reporter: github-pr-review

--- a/guides/common/assembly_accessing-project-from-web-ui.adoc
+++ b/guides/common/assembly_accessing-project-from-web-ui.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_accessing-project-from-web-ui.adoc[]
 
 include::modules/proc_logging-in-to-the-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_adding-content-to-foreman.adoc
+++ b/guides/common/assembly_adding-content-to-foreman.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_adding-content-to-foreman.adoc[]
 
 include::modules/con_products-and-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_administer-settings-information.adoc
+++ b/guides/common/assembly_administer-settings-information.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_administration-settings.adoc[]
 
 include::modules/ref_general-settings-information.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-call-authentication.adoc
+++ b/guides/common/assembly_api-call-authentication.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_api-call-authentication.adoc[]
 
 include::modules/con_ssl-authentication-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-cheat-sheet.adoc
+++ b/guides/common/assembly_api-cheat-sheet.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_api-cheat-sheet.adoc[]
 
 include::modules/con_working-with-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-requests-in-various-languages.adoc
+++ b/guides/common/assembly_api-requests-in-various-languages.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_api-requests-in-various-languages.adoc[]
 
 include::modules/con_calling-the-api-in-curl.adoc[leveloffset=+1]

--- a/guides/common/assembly_api-syntax.adoc
+++ b/guides/common/assembly_api-syntax.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_api-syntax.adoc[]
 
 include::modules/con_api-request-composition.adoc[leveloffset=+1]

--- a/guides/common/assembly_applying-ansible-definitions-to-hosts.adoc
+++ b/guides/common/assembly_applying-ansible-definitions-to-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_applying-ansible-definitions-to-hosts.adoc[]
 
 include::modules/proc_running-ansible-roles-on-a-host.adoc[leveloffset=+1]

--- a/guides/common/assembly_backing-up-server-and-proxy.adoc
+++ b/guides/common/assembly_backing-up-server-and-proxy.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_backing-up-server-and-proxy.adoc[]
 
 include::modules/con_planning-project-server-and-smart-proxy-server-backup.adoc[leveloffset=+1]

--- a/guides/common/assembly_basic-content-management-workflow.adoc
+++ b/guides/common/assembly_basic-content-management-workflow.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_basic-content-management-workflow.adoc[]
 
 include::modules/proc_creating-repositories-to-synchronize.adoc[leveloffset=+1]

--- a/guides/common/assembly_bootloader-binary-location.adoc
+++ b/guides/common/assembly_bootloader-binary-location.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_boot-loader-management-and-file-structure.adoc[]
 
 include::modules/ref_boot-loader-types-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_building-cloud-images.adoc
+++ b/guides/common/assembly_building-cloud-images.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/ref_building-cloud-images.adoc[]
 
 include::modules/ref_host-requirements-for-custom-images.adoc[leveloffset=+1]

--- a/guides/common/assembly_cloning-project-server.adoc
+++ b/guides/common/assembly_cloning-project-server.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_cloning-project-server.adoc[]
 
 include::modules/con_cloning-process-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_common-deployment-scenarios.adoc
+++ b/guides/common/assembly_common-deployment-scenarios.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_common-deployment-scenarios.adoc[]
 
 include::modules/con_single-location-with-segregated-subnets.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuration-management-with-ansible-in-project.adoc
+++ b/guides/common/assembly_configuration-management-with-ansible-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuration-management-with-ansible-in-project.adoc[]
 
 include::modules/con_high-level-steps-for-configuration-management-with-ansible.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-an-alternate-cname.adoc
+++ b/guides/common/assembly_configuring-an-alternate-cname.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 [id="configuring-an-alternate-cname_{context}"]

--- a/guides/common/assembly_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
+++ b/guides/common/assembly_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc[]
 
 include::modules/proc_configuring-tls-for-secure-ldap.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-and-setting-up-remote-jobs.adoc[]
 
 include::modules/con_remote-execution-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-ansible-definitions-to-apply-to-hosts.adoc
+++ b/guides/common/assembly_configuring-ansible-definitions-to-apply-to-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-ansible-definitions-to-apply-to-hosts.adoc[]
 
 ifndef::foreman-deb[]

--- a/guides/common/assembly_configuring-dhcp-integration.adoc
+++ b/guides/common/assembly_configuring-dhcp-integration.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-dhcp-integration.adoc[]
 
 include::modules/con_dhcp-service-providers.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-dns-integration.adoc
+++ b/guides/common/assembly_configuring-dns-integration.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-dns-integration.adoc[]
 
 include::modules/con_dns-service-providers.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-email-notifications.adoc
+++ b/guides/common/assembly_configuring-email-notifications.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-email-notifications.adoc[]
 
 include::modules/ref_email-notification-types.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-host-collections.adoc
+++ b/guides/common/assembly_configuring-host-collections.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-host-collections.adoc[]
 
 include::modules/proc_creating-a-host-collection-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-inter-server-synchronization.adoc
+++ b/guides/common/assembly_configuring-inter-server-synchronization.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-inter-server-synchronization.adoc[]
 
 include::modules/proc_configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-for-active-directory-users-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-kerberos-sso-for-active-directory-users-in-project.adoc[]
 
 include::modules/proc_joining-the-project-server-system-to-an-ad-domain.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
+++ b/guides/common/assembly_configuring-kerberos-sso-with-freeipa-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc[]
 
 include::modules/proc_enrolling-projectserver-in-your-freeipa-domain.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-network-interfaces.adoc
+++ b/guides/common/assembly_configuring-network-interfaces.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-network-interfaces.adoc[]
 
 include::modules/proc_configuring-a-physical-interface.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-project-for-performance.adoc
+++ b/guides/common/assembly_configuring-project-for-performance.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-project-for-performance.adoc[]
 
 include::modules/con_considerations-for-performance-tuning.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc[]
 
 include::modules/proc_installing-and-configuring-freeipa-packages-on-projectserver-or-smartproxyserver.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
+++ b/guides/common/assembly_configuring-satellite-custom-server-certificate.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-foreman-server-with-a-custom-ssl-certificate.adoc[]
 
 :cert-name: {project-context}

--- a/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
+++ b/guides/common/assembly_configuring-satellite-with-an-http-proxy.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_configuring-project-server-to-use-an-http-proxy.adoc[]

--- a/guides/common/assembly_configuring-scap-contents-for-compliance-policies-in-project.adoc
+++ b/guides/common/assembly_configuring-scap-contents-for-compliance-policies-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-scap-contents-for-compliance-policies-in-project.adoc[]
 
 include::modules/proc_listing-available-scap-contents-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-with-puppet.adoc[]
 
 :ProductName: {SmartProxyServer}

--- a/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-smartproxyservers-with-custom-ssl-certificates-for-load-balancing-without-puppet.adoc[]
 
 :ProductName: {SmartProxyServer}

--- a/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-with-puppet.adoc[]
 
 include::modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
+++ b/guides/common/assembly_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-smartproxyservers-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc[]
 
 include::modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-for-load-balancing-without-puppet.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc[]
 
 include::modules/ref_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
+++ b/guides/common/assembly_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc[]
 
 include::modules/ref_prerequisites-for-configuring-project-with-keycloak-wildfly-authentication.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-tftp-integration.adoc
+++ b/guides/common/assembly_configuring-tftp-integration.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_configuring-tftp-integration.adoc[]
 
 include::modules/proc_enabling-the-installer-managed-tftp-service.adoc[leveloffset=+1]

--- a/guides/common/assembly_configuring-virt-who-hyperv.adoc
+++ b/guides/common/assembly_configuring-virt-who-hyperv.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :configuring-virt-who-hyperv:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-kubevirt.adoc
+++ b/guides/common/assembly_configuring-virt-who-kubevirt.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :configuring-virt-who-kubevirt:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-kvm.adoc
+++ b/guides/common/assembly_configuring-virt-who-kvm.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :configuring-virt-who-kvm:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-nutanix.adoc
+++ b/guides/common/assembly_configuring-virt-who-nutanix.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :configuring-virt-who-nutanix:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-openstack.adoc
+++ b/guides/common/assembly_configuring-virt-who-openstack.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :configuring-virt-who-openstack:
 :parent-context: {context}
 

--- a/guides/common/assembly_configuring-virt-who-vmware.adoc
+++ b/guides/common/assembly_configuring-virt-who-vmware.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :configuring-virt-who-vmware:
 :parent-context: {context}
 

--- a/guides/common/assembly_connecting-ai-applications-to-the-mcp-server-for-project.adoc
+++ b/guides/common/assembly_connecting-ai-applications-to-the-mcp-server-for-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_connecting-ai-applications-to-the-mcp-server-for-project.adoc[]
 
 include::modules/con_project-mcp-integration-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_content-access-control-for-hosts.adoc
+++ b/guides/common/assembly_content-access-control-for-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_content-access-control-for-hosts.adoc[]
 
 include::modules/ref_content-access-strategies.adoc[leveloffset=+1]

--- a/guides/common/assembly_content-and-patch-management-with-project.adoc
+++ b/guides/common/assembly_content-and-patch-management-with-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_content-and-patch-management-with-project.adoc[]
 
 include::modules/con_content-flow-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_converting-hosts-to-rhel.adoc
+++ b/guides/common/assembly_converting-hosts-to-rhel.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_converting-hosts-to-rhel.adoc[]

--- a/guides/common/assembly_creating-and-managing-roles.adoc
+++ b/guides/common/assembly_creating-and-managing-roles.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_creating-and-managing-roles.adoc[]
 
 include::modules/proc_creating-a-role-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_deploying-compliance-policies.adoc
+++ b/guides/common/assembly_deploying-compliance-policies.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_deploying-compliance-policies.adoc[]
 
 include::modules/ref_inclusion-of-remote-scap-resources.adoc[leveloffset=+1]

--- a/guides/common/assembly_deployment-path.adoc
+++ b/guides/common/assembly_deployment-path.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_deployment-path.adoc[]
 
 include::modules/con_installing-a-project-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_determining-hardware-and-operating-system-configuration.adoc
+++ b/guides/common/assembly_determining-hardware-and-operating-system-configuration.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_hardware-and-operating-system-configuration.adoc[]
 
 include::modules/proc_enabling-tuned-profiles.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
+++ b/guides/common/assembly_disaster-recovery-by-virtualizing-your-projectserver.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_disaster-recovery-by-virtualizing-your-projectserver.adoc[]
 
 include::modules/proc_preparing-for-disaster-recovery-by-virtualizing-your-projectserver.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/assembly_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-external-storage.adoc[]
 
 include::modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_disaster-recovery-for-active-and-passive-project-server-with-backup-and-restore.adoc[]
 
 include::modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/assembly_disaster-recovery-with-two-active-project-servers.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_disaster-recovery-with-two-active-project-servers.adoc[]
 
 include::modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+1]

--- a/guides/common/assembly_discovering-hosts-on-a-network.adoc
+++ b/guides/common/assembly_discovering-hosts-on-a-network.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_discovering-hosts-on-a-network.adoc[]
 
 include::modules/con_prerequisites-for-using-discovery.adoc[leveloffset=+1]

--- a/guides/common/assembly_example-playbooks-based-on-modules-from-project-ansible-collection.adoc
+++ b/guides/common/assembly_example-playbooks-based-on-modules-from-project-ansible-collection.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_example-playbooks-based-on-modules-from-project-ansible-collection.adoc[]
 
 include::modules/ref_help-resources-for-example-playbooks-from-project-ansible-collection.adoc[leveloffset=+1]

--- a/guides/common/assembly_expense-management-for-red-hat-subscriptions.adoc
+++ b/guides/common/assembly_expense-management-for-red-hat-subscriptions.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_expense-management-for-red-hat-subscriptions.adoc[]
 
 include::modules/con_subscriptions-usage-data.adoc[leveloffset=+1]

--- a/guides/common/assembly_host-management-and-monitoring-using-cockpit.adoc
+++ b/guides/common/assembly_host-management-and-monitoring-using-cockpit.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_host-management-and-monitoring-by-using-cockpit.adoc[]
 
 include::modules/proc_enabling-cockpit-on-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_importing-the-project-client-name-repository.adoc
+++ b/guides/common/assembly_importing-the-project-client-name-repository.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_importing-the-project-client-name-repository.adoc[]
 
 include::modules/proc_enabling-the-project-client-name-repository.adoc[leveloffset=+1]

--- a/guides/common/assembly_increasing-logging-levels-of-project-components.adoc
+++ b/guides/common/assembly_increasing-logging-levels-of-project-components.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_increasing-logging-levels-of-project-components.adoc[]
 
 include::modules/proc_increasing-the-logging-level-for-foreman.adoc[leveloffset=+1]

--- a/guides/common/assembly_installing-and-configuring-insights-iop.adoc
+++ b/guides/common/assembly_installing-and-configuring-insights-iop.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_installing-and-configuring-insights-iop.adoc[]
 
 ifdef::installing-satellite-server-connected[]

--- a/guides/common/assembly_installing-capsule-server.adoc
+++ b/guides/common/assembly_installing-capsule-server.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_installing-smart-proxy-server.adoc[]

--- a/guides/common/assembly_installing-satellite-server-disconnected.adoc
+++ b/guides/common/assembly_installing-satellite-server-disconnected.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_installing-project-server.adoc[leveloffset=+0]

--- a/guides/common/assembly_installing-server-connected.adoc
+++ b/guides/common/assembly_installing-server-connected.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_installing-project-server.adoc[]
 
 ifdef::containerized[]

--- a/guides/common/assembly_installing-the-load-balancer.adoc
+++ b/guides/common/assembly_installing-the-load-balancer.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_installing-and-configuring-the-load-balancer.adoc[]
 
 include::modules/proc_installing-the-load-balancer.adoc[leveloffset=+1]

--- a/guides/common/assembly_integrating-awx.adoc
+++ b/guides/common/assembly_integrating-awx.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_integrating-project-and-awx.adoc[]
 
 include::modules/proc_adding-project-server-to-awx-as-a-dynamic-inventory-item.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-managing-content.adoc
+++ b/guides/common/assembly_introduction-to-managing-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_introduction-to-content-management.adoc[]
 
 include::modules/ref_content-management-capabilities-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-project-ansible-collection.adoc
+++ b/guides/common/assembly_introduction-to-project-ansible-collection.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_introduction-to-project-ansible-collection.adoc[]
 
 include::modules/proc_installing-the-project-ansible-modules.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-project-api.adoc
+++ b/guides/common/assembly_introduction-to-project-api.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_introduction-to-project-api.adoc[]
 
 include::modules/con_overview-of-the-project-api.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-provisioning.adoc
+++ b/guides/common/assembly_introduction-to-provisioning.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_introduction-to-provisioning.adoc[]
 
 include::modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_job-template-examples-and-extensions.adoc
+++ b/guides/common/assembly_job-template-examples-and-extensions.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_job-template-examples-and-extensions.adoc[]
 
 include::modules/ref_customizing-job-templates.adoc[leveloffset=+1]

--- a/guides/common/assembly_limiting-host-resources.adoc
+++ b/guides/common/assembly_limiting-host-resources.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_limiting-host-resources.adoc[]
 
 include::modules/proc_installing-the-resource-quota-plugin.adoc[leveloffset=+1]

--- a/guides/common/assembly_logging-and-reporting-problems.adoc
+++ b/guides/common/assembly_logging-and-reporting-problems.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_logging-and-reporting-problems.adoc[]
 
 include::modules/ref_configuring-logging-type-and-layout.adoc[leveloffset=+1]

--- a/guides/common/assembly_maintaining-server.adoc
+++ b/guides/common/assembly_maintaining-server.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_maintaining-server.adoc[]
 
 include::modules/proc_deleting-audit-records-manually.adoc[leveloffset=+1]

--- a/guides/common/assembly_major-project-components.adoc
+++ b/guides/common/assembly_major-project-components.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_major-project-components.adoc[]
 
 include::modules/con_projectserver-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-activation-keys.adoc
+++ b/guides/common/assembly_managing-activation-keys.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-activation-keys.adoc[]
 
 include::modules/ref_best-practices-for-activation-keys.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-alternate-content-sources.adoc
+++ b/guides/common/assembly_managing-alternate-content-sources.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-alternate-content-sources.adoc[]
 
 include::modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-ansible-content.adoc
+++ b/guides/common/assembly_managing-ansible-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-ansible-content.adoc[]
 
 include::modules/proc_synchronizing-ansible-collections.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-application-lifecycles.adoc
+++ b/guides/common/assembly_managing-application-lifecycles.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-application-lifecycles.adoc[]
 
 include::modules/con_introduction-to-application-lifecycle.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-compliance-policies.adoc
+++ b/guides/common/assembly_managing-compliance-policies.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-compliance-policies.adoc[]
 
 include::modules/con_configuring-compliance-policy-deployment-methods.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-container-images.adoc
+++ b/guides/common/assembly_managing-container-images.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-container-images.adoc[]
 
 include::modules/con_importing-container-images.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-view-environments.adoc
+++ b/guides/common/assembly_managing-content-view-environments.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-content-view-environments.adoc[]
 
 include::modules/con_content-view-environments-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-content-views.adoc[]
 
 include::modules/ref_workflow-for-creating-content-views.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-custom-file-type-content.adoc
+++ b/guides/common/assembly_managing-custom-file-type-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-custom-file-type-content.adoc[]
 
 include::modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-errata.adoc
+++ b/guides/common/assembly_managing-errata.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-errata.adoc[]
 
 include::modules/ref_best-practices-for-errata.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-external-user-groups.adoc
+++ b/guides/common/assembly_managing-external-user-groups.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-external-user-groups.adoc[]
 
 include::modules/proc_associating-external-users-with-user-groups.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/assembly_managing-flatpak-repositories-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-flatpak-repositories-in-project.adoc[]
 
 include::modules/proc_creating-a-flatpak-remote-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-host-content-settings-and-system-purpose.adoc
+++ b/guides/common/assembly_managing-host-content-settings-and-system-purpose.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-host-content-settings-and-system-purpose.adoc[]
 
 include::modules/proc_editing-the-system-purpose-of-a-host-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-host-placement-and-associations.adoc
+++ b/guides/common/assembly_managing-host-placement-and-associations.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-host-placement-and-associations.adoc[]
 
 include::modules/proc_associating-a-virtual-machine-from-a-hypervisor.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-host-records-in-project.adoc
+++ b/guides/common/assembly_managing-host-records-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-host-records-in-project.adoc[]
 
 include::modules/proc_cloning-hosts-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-host-snapshots.adoc
+++ b/guides/common/assembly_managing-host-snapshots.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-host-snapshots.adoc[]
 
 include::modules/proc_installing-the-snapshot-management-plugin.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-iso-images.adoc
+++ b/guides/common/assembly_managing-iso-images.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-iso-images.adoc[]
 
 include::modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-locations.adoc
+++ b/guides/common/assembly_managing-locations.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-locations.adoc[]
 
 include::modules/proc_creating-a-location-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-organizations.adoc
+++ b/guides/common/assembly_managing-organizations.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-organizations.adoc[]
 
 include::modules/ref_examples-of-organization-management-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-ostree-content.adoc
+++ b/guides/common/assembly_managing-ostree-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-ostree-content.adoc[]
 
 include::modules/proc_enabling-os-tree-content.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-packages-in-project.adoc[]
 
 include::modules/proc_enabling-and-disabling-repositories-on-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-python-type-content.adoc
+++ b/guides/common/assembly_managing-python-type-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-python-type-content.adoc[]
 
 include::modules/proc_synchronizing-python-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-red-hat-subscriptions.adoc
+++ b/guides/common/assembly_managing-red-hat-subscriptions.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-red-hat-subscriptions.adoc[]
 
 include::modules/proc_tracking-subscription-usage-by-using-the-subscriptions-service.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-suse-content.adoc
+++ b/guides/common/assembly_managing-suse-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-client-os-major: {client-os-major}
 :parent-client-os-minor: {client-os-minor}
 :client-os-major: 16

--- a/guides/common/assembly_managing-users-and-roles.adoc
+++ b/guides/common/assembly_managing-users-and-roles.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_managing-users-and-roles.adoc[]
 
 include::modules/con_managing-users.adoc[leveloffset=+1]

--- a/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_migrating-from-internal-databases-to-external-databases.adoc[]

--- a/guides/common/assembly_monitoring-compliance.adoc
+++ b/guides/common/assembly_monitoring-compliance.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_monitoring-compliance.adoc[]
 
 include::modules/proc_searching-compliance-reports.adoc[leveloffset=+1]

--- a/guides/common/assembly_monitoring-hosts-by-using-insights-in-cloud.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-insights-in-cloud.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: insights-in-cloud
 :insights-in-cloud:

--- a/guides/common/assembly_monitoring-hosts-by-using-insights-in-project.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-insights-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: insights-in-{project-context}
 :insights-in-project:

--- a/guides/common/assembly_monitoring-project-resources.adoc
+++ b/guides/common/assembly_monitoring-project-resources.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_monitoring-project-resources.adoc[]
 
 include::modules/ref_using-the-project-content-dashboard.adoc[leveloffset=+1]

--- a/guides/common/assembly_networking-considerations-in-project.adoc
+++ b/guides/common/assembly_networking-considerations-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_networking-considerations-in-project.adoc[]
 
 include::modules/con_smart-proxy-networking.adoc[leveloffset=+1]

--- a/guides/common/assembly_optimizing-content-synchronization-and-storage.adoc
+++ b/guides/common/assembly_optimizing-content-synchronization-and-storage.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_optimizing-content-synchronization-and-storage.adoc[]
 
 include::modules/con_download-policies-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-load-balancing-in-project.adoc
+++ b/guides/common/assembly_overview-of-load-balancing-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_overview-of-load-balancing-in-project.adoc[]
 
 include::modules/con_components-of-a-load-balanced-setup.adoc[leveloffset=+1]

--- a/guides/common/assembly_overview-of-vm-subscriptions.adoc
+++ b/guides/common/assembly_overview-of-vm-subscriptions.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_virtual-machine-subscriptions-overview.adoc[]
 
 include::modules/ref_virt-who-configuration-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_package-mode-and-image-mode-hosts.adoc
+++ b/guides/common/assembly_package-mode-and-image-mode-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_package-mode-and-image-mode-hosts.adoc[]
 
 include::modules/con_overview-of-image-mode-for-hosts.adoc[leveloffset=+1]

--- a/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_performing-additional-configuration-on-smart-proxy-server.adoc[]
 
 include::modules/proc_configuring-smart-proxy-for-host-registration-and-provisioning.adoc[leveloffset=+1]

--- a/guides/common/assembly_planning-project-server-installation.adoc
+++ b/guides/common/assembly_planning-project-server-installation.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_planning-project-server-installation.adoc[]
 
 include::modules/ref_operating-system-requirements.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-client-platforms.adoc
+++ b/guides/common/assembly_preparing-client-platforms.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-client-platforms.adoc[]
 
 include::modules/ref_compute-profiles.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-capsule-installation.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 [id="preparing-environment-for-capsule-installation"]

--- a/guides/common/assembly_preparing-environment-for-project-server-installation.adoc
+++ b/guides/common/assembly_preparing-environment-for-project-server-installation.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-environment-for-project-server-installation.adoc[]
 
 include::modules/proc_opening-required-ports.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
+++ b/guides/common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[]
 
 include::modules/ref_overview-of-recommended-disaster-recovery-plans.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-for-project-upgrade.adoc
+++ b/guides/common/assembly_preparing-for-project-upgrade.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-for-project-upgrade.adoc[]
 
 include::modules/con_upgrade-path-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-networking.adoc
+++ b/guides/common/assembly_preparing-networking.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-networking.adoc[]
 
 include::modules/con_facts-and-nic-filtering.adoc[leveloffset=+1]

--- a/guides/common/assembly_preparing-provisioning-content.adoc
+++ b/guides/common/assembly_preparing-provisioning-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-provisioning-content.adoc[]
 
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
+++ b/guides/common/assembly_preparing-smartproxyservers-for-load-balancing.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-smartproxyservers-for-load-balancing.adoc[]
 
 ifdef::satellite,katello[]

--- a/guides/common/assembly_preparing-templates-for-provisioning.adoc
+++ b/guides/common/assembly_preparing-templates-for-provisioning.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_preparing-templates-for-provisioning.adoc[]
 
 include::modules/con_provisioning-templates.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-cloud-instances-azure.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-azure.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: azure-provisioning
 :azure-provisioning:

--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :CRname: Amazon EC2
 :compute-resource-context: amazon-ec2

--- a/guides/common/assembly_provisioning-cloud-instances-gce.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-gce.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: gce-provisioning
 :gce-provisioning:

--- a/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-openstack.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: openstack-provisioning
 :openstack-provisioning:

--- a/guides/common/assembly_provisioning-contexts.adoc
+++ b/guides/common/assembly_provisioning-contexts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_provisioning-contexts.adoc[]
 
 include::modules/proc_setting-the-provisioning-context-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-management-with-project.adoc
+++ b/guides/common/assembly_provisioning-management-with-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_provisioning-management-with-project.adoc[]
 
 include::modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-requirements-in-project.adoc
+++ b/guides/common/assembly_provisioning-requirements-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_provisioning-requirements-in-project.adoc[]
 
 include::modules/con_pxe-booting-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: kubevirt-provisioning
 :kubevirt-provisioning:

--- a/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kvm.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: kvm-provisioning
 :kvm-provisioning:

--- a/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-proxmox.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: proxmox-provisioning
 :proxmox-provisioning:

--- a/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-vmware.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :parent-context: {context}
 :context: vmware-provisioning
 :vmware-provisioning:

--- a/guides/common/assembly_recovering-corrupted-content.adoc
+++ b/guides/common/assembly_recovering-corrupted-content.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_recovering-corrupted-content.adoc[]
 
 include::modules/proc_recovering-a-corrupted-repository-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_refreshing-self-signed-ca-certificate-on-hosts.adoc
+++ b/guides/common/assembly_refreshing-self-signed-ca-certificate-on-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_refreshing-the-self-signed-ca-certificate-on-hosts.adoc[]
 
 include::modules/proc_deploying-the-ca-certificate-on-a-host-by-using-script-rex.adoc[leveloffset=+1]

--- a/guides/common/assembly_registering-clients-to-the-load-balancer.adoc
+++ b/guides/common/assembly_registering-clients-to-the-load-balancer.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_registering-clients-to-the-load-balancer.adoc[]
 
 include::modules/proc_setting-the-load-balancer-for-host-registration.adoc[leveloffset=+1]

--- a/guides/common/assembly_registering-hosts-to-project.adoc
+++ b/guides/common/assembly_registering-hosts-to-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_registering-hosts-to-project.adoc[]
 
 include::modules/ref_supported-clients-in-registration.adoc[leveloffset=+1]

--- a/guides/common/assembly_renaming-server-or-smart-proxy.adoc
+++ b/guides/common/assembly_renaming-server-or-smart-proxy.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_renaming-server-or-smart-proxy.adoc[]
 
 include::modules/proc_renaming-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_renewing-certificates.adoc
+++ b/guides/common/assembly_renewing-certificates.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_renewing-certificates.adoc[]
 
 include::modules/proc_planning-for-self-signed-ca-certificate-renewal.adoc[leveloffset=+1]

--- a/guides/common/assembly_restarting-applications-on-hosts-through-tracer.adoc
+++ b/guides/common/assembly_restarting-applications-on-hosts-through-tracer.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_restarting-applications-on-hosts-through-tracer.adoc[]
 
 include::modules/proc_configuring-tracer-on-a-host.adoc[leveloffset=+1]

--- a/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
+++ b/guides/common/assembly_restoring-server-or-smart-proxy-from-a-backup.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_restoring-server-or-smart-proxy-from-a-backup.adoc[]
 
 include::modules/proc_restoring-from-a-full-backup.adoc[leveloffset=+1]

--- a/guides/common/assembly_reviewing-hosts-in-project-web-ui.adoc
+++ b/guides/common/assembly_reviewing-hosts-in-project-web-ui.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_reviewing-hosts-in-project-web-ui.adoc[]
 
 include::modules/proc_browsing-hosts-in-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_searching-and-bookmarking.adoc
+++ b/guides/common/assembly_searching-and-bookmarking.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_searching-and-bookmarking.adoc[]
 
 include::modules/con_query-syntax.adoc[leveloffset=+1]

--- a/guides/common/assembly_security-compliance-management-in-project.adoc
+++ b/guides/common/assembly_security-compliance-management-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_security-compliance-management-in-project.adoc[]
 
 include::modules/con_security-content-automation-protocol.adoc[leveloffset=+1]

--- a/guides/common/assembly_security-settings.adoc
+++ b/guides/common/assembly_security-settings.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_security-settings.adoc[]
 
 include::modules/proc_configuring-the-security-token-validity-duration.adoc[leveloffset=+1]

--- a/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
+++ b/guides/common/assembly_supported-usage-and-versions-of-project-components.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_supported-usage-and-versions-of-project-components.adoc[]
 
 ifdef::satellite[]

--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_synchronizing-content-between-servers.adoc[]
 
 include::modules/ref_iss-configuration-options-for-content-synchronization.adoc[leveloffset=+1]

--- a/guides/common/assembly_synchronizing-content-to-foreman.adoc
+++ b/guides/common/assembly_synchronizing-content-to-foreman.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_synchronizing-content-to-foreman.adoc[]
 
 include::modules/con_configuring-network-for-content-synchronization.adoc[leveloffset=+1]

--- a/guides/common/assembly_synchronizing-template-repositories.adoc
+++ b/guides/common/assembly_synchronizing-template-repositories.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_synchronizing-template-repositories.adoc[]
 
 ifndef::satellite[]

--- a/guides/common/assembly_template-writing-reference.adoc
+++ b/guides/common/assembly_template-writing-reference.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_template-writing-reference.adoc[]
 
 include::modules/ref_template-rendering-and-erb-context.adoc[leveloffset=+1]

--- a/guides/common/assembly_tools-for-administration-of-project.adoc
+++ b/guides/common/assembly_tools-for-administration-of-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_tools-for-administration-of-project.adoc[]
 
 include::modules/con_web-ui-overview.adoc[leveloffset=+1]

--- a/guides/common/assembly_troubleshooting-virt-who.adoc
+++ b/guides/common/assembly_troubleshooting-virt-who.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_troubleshooting-virt-who.adoc[]
 
 include::modules/proc_checking-virt-who-status-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_tuning-with-predefined-profiles.adoc
+++ b/guides/common/assembly_tuning-with-predefined-profiles.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_tuning-projectserver-performance-with-predefined-profiles.adoc[]
 
 include::modules/con_how-predefined-tuning-profiles-apply.adoc[leveloffset=+1]

--- a/guides/common/assembly_updating-foreman.adoc
+++ b/guides/common/assembly_updating-foreman.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_updating-project.adoc[]
 
 include::modules/proc_updating-foreman-server.adoc[leveloffset=+1]

--- a/guides/common/assembly_updating-satellite.adoc
+++ b/guides/common/assembly_updating-satellite.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_updating-project-to-next-patch-version.adoc[]
 
 include::modules/proc_updating-server.adoc[]

--- a/guides/common/assembly_usage-metrics-collection-in-project.adoc
+++ b/guides/common/assembly_usage-metrics-collection-in-project.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_usage-metrics-collection-in-project.adoc[]
 
 include::modules/con_overview-of-usage-metrics-collection-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-boot-disks-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-boot-disks-to-provision-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :using-bootdisks-to-provision-hosts:
 :parent-context: {context}
 :context: using-bootdisks

--- a/guides/common/assembly_using-custom-ssl-certificate-for-hosts.adoc
+++ b/guides/common/assembly_using-custom-ssl-certificate-for-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_using-custom-ssl-certificate-for-hosts.adoc[]
 
 :common-example-com: {foreman-example-com}

--- a/guides/common/assembly_using-foreman-webhooks.adoc
+++ b/guides/common/assembly_using-foreman-webhooks.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 ifdef::context[:parent-context: {context}]
 
 include::modules/con_using-webhooks.adoc[]

--- a/guides/common/assembly_using-kernelcare.adoc
+++ b/guides/common/assembly_using-kernelcare.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_using-the-kernelcare-plugin.adoc[]
 
 include::modules/proc_installing-the-kernelcare-plugin.adoc[leveloffset=+1]

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 :using-network-boot-to-provision-hosts:
 :parent-context: {context}
 :context: using-network-boot

--- a/guides/common/assembly_using-report-templates.adoc
+++ b/guides/common/assembly_using-report-templates.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_using-report-templates-to-monitor-hosts.adoc[]
 
 include::modules/proc_generating-host-monitoring-reports-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/assembly_working-with-host-groups.adoc
+++ b/guides/common/assembly_working-with-host-groups.adoc
@@ -1,5 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_working-with-host-groups.adoc[]
 
 include::modules/con_host-groups-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

* Removing the ASSEMBLY content type
* Extending the Vale workflow with a pre-processing step that injects the IGNORE content type into assembly files

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Each assembly and module must include a content type definition to be evaluated by asciidoctor-dita-vale (https://github.com/jhradilek/asciidoctor-dita-vale/blob/af6c00940de1ce99994ddd1631aa18d35a7ff0a3/README.md?plain=1#L130). With this PR, I'm trying to avoid the need to include the IGNORE content type definition in assembly files by injecting the module type before the Vale check runs.

This saves us the need of adding two lines into 165 files that literally just say "ignore this file".

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Made with Claude but reviewed by myself to the best of my abilities :upside_down_face: 

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
