### PR TITLE
Refactor 'changing' to 'updating' in Optimizing assembly

### DIFF
--- a/guides/common/assembly_optimizing-content-synchronization-and-storage.adoc
+++ b/guides/common/assembly_optimizing-content-synchronization-and-storage.adoc
@@ -4,23 +4,23 @@ include::modules/con_optimizing-content-synchronization-and-storage.adoc[]
 
 include::modules/con_download-policies-overview.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-default-download-policy-by-using-web-ui.adoc[leveloffset=+1]
+include::modules/proc_updating-the-default-download-policy-by-using-web-ui.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-default-download-policy-by-using-cli.adoc[leveloffset=+1]
+include::modules/proc_updating-the-default-download-policy-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-download-policy-for-a-repository-by-using-web-ui.adoc[leveloffset=+1]
+include::modules/proc_updating-the-download-policy-for-a-repository-by-using-web-ui.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-download-policy-for-a-repository-by-using-cli.adoc[leveloffset=+1]
+include::modules/proc_updating-the-download-policy-for-a-repository-by-using-cli.adoc[leveloffset=+1]
 
 include::modules/con_mirroring-policies-overview.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-default-mirroring-policy-by-using-web-ui.adoc[leveloffset=+1]
+include::modules/proc_updating-the-default-mirroring-policy-by-using-web-ui.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-default-mirroring-policy-by-using-cli.adoc[leveloffset=+1]
+include::modules/proc_updating-the-default-mirroring-policy-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-mirroring-policy-for-a-repository-by-using-web-ui.adoc[leveloffset=+1]
+include::modules/proc_updating-the-mirroring-policy-for-a-repository-by-using-web-ui.adoc[leveloffset=+1]
 
-include::modules/proc_changing-the-mirroring-policy-for-a-repository-by-using-cli.adoc[leveloffset=+1]
+include::modules/proc_updating-the-mirroring-policy-for-a-repository-by-using-cli.adoc[leveloffset=+1]
 
 include::modules/proc_limiting-synchronization-concurrency.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_discovering-container-image-repositories-in-a-registry.adoc
+++ b/guides/common/modules/proc_discovering-container-image-repositories-in-a-registry.adoc
@@ -15,7 +15,7 @@ You can discover container image repositories in a registry by using the {Projec
 . In the *Registry Search Parameter* field, enter any search criteria that you want to use to filter your search, and then click *Discover*.
 . Optional: To further refine the *Discovered Repository* list, in the *Filter* field, enter any additional search criteria that you want to use.
 . From the *Discovered Repository* list, select any repositories that you want to import, and then click *Create Selected*.
-. Optional: To change the download policy for this container repository to _on demand_, see xref:changing-the-download-policy-for-a-repository-by-using-web-ui[].
+. Optional: To change the download policy for this container repository to _on demand_, see xref:updating-the-download-policy-for-a-repository-by-using-web-ui[].
 . Optional: If you want to create a product, from the *Product* list, select *New Product*.
 . In the *Name* field, enter a product name.
 . Optional: In the *Repository Name* and *Repository Label* columns, you can edit the repository names and labels.

--- a/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
+++ b/guides/common/modules/proc_importing-and-exporting-content-to-project-server-for-flatpak.adoc
@@ -10,7 +10,7 @@ Use Hammer CLI to transfer Flatpak content to {ProjectServer} in environments wi
 * Enable the Flatpak remote.
 For more information about enabling the Flatpak remote, see xref:enabling-the-flatpak-remote-by-using-cli[].
 * Use download policy *Immediate* to synchronize Flatpak content to {ProjectServer}.
-For more information, see xref:changing-the-download-policy-for-a-repository-by-using-web-ui[].
+For more information, see xref:updating-the-download-policy-for-a-repository-by-using-web-ui[].
 
 .Procedure
 . On your connected {ProjectServer}, export your Flatpak repository:

--- a/guides/common/modules/proc_updating-the-default-download-policy-by-using-cli.adoc
+++ b/guides/common/modules/proc_updating-the-default-download-policy-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-default-download-policy-by-using-cli"]
-= Changing the default download policy by using Hammer CLI
+[id="updating-the-default-download-policy-by-using-cli"]
+= Updating the default download policy by using Hammer CLI
 
 [role="_abstract"]
 Set the default download policy so new repositories inherit immediate or on-demand behavior without updating existing repositories.

--- a/guides/common/modules/proc_updating-the-default-download-policy-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_updating-the-default-download-policy-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-default-download-policy-by-using-web-ui"]
-= Changing the default download policy by using {ProjectWebUI}
+[id="updating-the-default-download-policy-by-using-web-ui"]
+= Updating the default download policy by using {ProjectWebUI}
 
 [role="_abstract"]
 Set the default download policy so new repositories inherit immediate or on-demand behavior without updating existing repositories.

--- a/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-cli.adoc
+++ b/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-default-mirroring-policy-by-using-web-ui"]
-= Changing the default mirroring policy by using {ProjectWebUI}
+[id="updating-the-default-mirroring-policy-by-using-cli"]
+= Updating the default mirroring policy by using Hammer CLI
 
 [role="_abstract"]
 Set default mirroring policies for new {customrepos} so they inherit additive, content-only, or complete mirroring without affecting existing repositories.
@@ -13,8 +13,19 @@ Changing the default value does not change existing mirroring policy settings pe
 For more information on mirroring policies, see xref:Mirroring_Policies_Overview_{context}[].
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
-. Click the *Content* tab.
-. Change the default mirroring policy depending on your requirements:
-* To change the default mirroring policy for a Yum {customrepo}, change the value of the *Default custom yum repository mirroring policy* setting.
-* To change the default mirroring policy for a non-Yum {customrepo}, change the value of the *Default custom non-yum repository mirroring policy* setting.
+* Change the default mirroring policy for a Yum {customrepo} to `additive`, `mirror_content_only`, or `mirror_complete`:
++
+[subs="+quotes"]
+----
+$ hammer settings set \
+--name default_yum_mirroring_policy \
+--value _mirror_complete_
+----
+* Change the default mirroring policy for a non-Yum {customrepo} to `additive` or `mirror_content_only`:
++
+[subs="+quotes"]
+----
+$ hammer settings set \
+--name default_non_yum_mirroring_policy \
+--value _additive_
+----

--- a/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-default-mirroring-policy-by-using-cli"]
-= Changing the default mirroring policy by using Hammer CLI
+[id="updating-the-default-mirroring-policy-by-using-web-ui"]
+= Updating the default mirroring policy by using {ProjectWebUI}
 
 [role="_abstract"]
 Set default mirroring policies for new {customrepos} so they inherit additive, content-only, or complete mirroring without affecting existing repositories.
@@ -13,19 +13,8 @@ Changing the default value does not change existing mirroring policy settings pe
 For more information on mirroring policies, see xref:Mirroring_Policies_Overview_{context}[].
 
 .Procedure
-* Change the default mirroring policy for a Yum {customrepo} to `additive`, `mirror_content_only`, or `mirror_complete`:
-+
-[subs="+quotes"]
-----
-$ hammer settings set \
---name default_yum_mirroring_policy \
---value _mirror_complete_
-----
-* Change the default mirroring policy for a non-Yum {customrepo} to `additive` or `mirror_content_only`:
-+
-[subs="+quotes"]
-----
-$ hammer settings set \
---name default_non_yum_mirroring_policy \
---value _additive_
-----
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
+. Click the *Content* tab.
+. Change the default mirroring policy depending on your requirements:
+* To change the default mirroring policy for a Yum {customrepo}, change the value of the *Default custom yum repository mirroring policy* setting.
+* To change the default mirroring policy for a non-Yum {customrepo}, change the value of the *Default custom non-yum repository mirroring policy* setting.

--- a/guides/common/modules/proc_updating-the-download-policy-for-a-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_updating-the-download-policy-for-a-repository-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-download-policy-for-a-repository-by-using-cli"]
-= Changing the download policy for a repository by using Hammer CLI
+[id="updating-the-download-policy-for-a-repository-by-using-cli"]
+= Updating the download policy for a repository by using Hammer CLI
 
 [role="_abstract"]
 Update the download policy for a specific repository when you need immediate full downloads or on-demand lazy synchronization for that repository.

--- a/guides/common/modules/proc_updating-the-download-policy-for-a-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_updating-the-download-policy-for-a-repository-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-download-policy-for-a-repository-by-using-web-ui"]
-= Changing the download policy for a repository by using {ProjectWebUI}
+[id="updating-the-download-policy-for-a-repository-by-using-web-ui"]
+= Updating the download policy for a repository by using {ProjectWebUI}
 
 [role="_abstract"]
 Change the download policy for an existing repository when you need immediate full downloads or on-demand storage.

--- a/guides/common/modules/proc_updating-the-mirroring-policy-for-a-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_updating-the-mirroring-policy-for-a-repository-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-mirroring-policy-for-a-repository-by-using-cli"]
-= Changing the mirroring policy for a repository by using Hammer CLI
+[id="updating-the-mirroring-policy-for-a-repository-by-using-cli"]
+= Updating the mirroring policy for a repository by using Hammer CLI
 
 [role="_abstract"]
 Update the mirroring policy for a specific repository to control whether synchronization adds content only, mirrors repodata, or removes content deleted upstream.

--- a/guides/common/modules/proc_updating-the-mirroring-policy-for-a-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_updating-the-mirroring-policy-for-a-repository-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="changing-the-mirroring-policy-for-a-repository-by-using-web-ui"]
-= Changing the mirroring policy for a repository by using {ProjectWebUI}
+[id="updating-the-mirroring-policy-for-a-repository-by-using-web-ui"]
+= Updating the mirroring policy for a repository by using {ProjectWebUI}
 
 [role="_abstract"]
 Update the mirroring policy for an existing repository to control whether synchronization adds content only, mirrors repodata, or removes content deleted upstream.


### PR DESCRIPTION
#### What changes are you introducing?

Refactoring module titles that use the verb "change" to "update"

Scoped to a single assembly in _Managing content_

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The verb "change" is too generic and we should avoid it, especially in headings.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
