### PR TITLE
Bump GHA workflow peaceiris/actions-gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -190,7 +190,7 @@ jobs:
         working-directory: ./public
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that there is no warning today and no GHA failure in September due to the usage of NodeJS 20.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Warning in GHA on "master":

````
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: peaceiris/actions-gh-pages@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
````

Example: https://github.com/theforeman/foreman-documentation/actions/runs/26558905765

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/#what-you-need-to-do
Refs https://github.com/peaceiris/actions-gh-pages/pull/1147
Refs https://github.com/peaceiris/actions-gh-pages/releases/tag/v4.1.0

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [x] Foreman 3.13/Katello 4.15 (EL9 only)
* [x] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
