### PR TITLE
Adds documentation for debian architecture variant support

### DIFF
--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -41,18 +41,13 @@ Note that some third party Debian repositories use the components in ways that m
 ====
 Ensure that you enter both *Releases* and *Components* exactly as they are in an `/etc/apt/sources.list` file.
 ====
-. Optional: In the *Architectures* field, enter one or multiple architectures.
-[NOTE]
-====
-*Architecture variants must be entered using the form `base:variant`.*
-
-Examples:
-* `amd64` syncs `binary-amd64/`
-* `amd64:v3` syncs the variant index `binary-amd64v3/`
-* You can specify both: `amd64 amd64:v3`
-
-{Project} always synchronizes `all` packages regardless of the architecture selection, so `binary-all/` is expected to be present in the published repository.
-====
+. Optional: In the *Architectures* field, enter one or multiple architectures separated by whitespace.
++
+If you want to synchronize packages for specific architecture variants, enter the architecture and its variant separated by colon.
+For example, enter `amd64:v3` to synchronize content for `binary-amd64v3/` or `amd64 amd64:v3` to synchronize content for architectures `amd64` and `amd64v3`.
++
+{Project} always synchronizes packages of architecture `all` regardless of your architecture selection.
++
 If you want to make the repository available to all hosts regardless of the architecture, ensure to select *No restriction*.
 ifdef::orcharhino[]
 . Optional: In the *Errata URL* field, enter the URL of an errata service.

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -43,9 +43,6 @@ Ensure that you enter both *Releases* and *Components* exactly as they are in an
 ====
 . Optional: In the *Architectures* field, enter one or multiple architectures separated by whitespace.
 +
-If you want to synchronize packages for specific architecture variants, enter the architecture and its variant separated by colon.
-For example, enter `amd64:v3` to synchronize content for architecture `amd64v3` or `amd64 amd64:v3` to synchronize content for architectures `amd64` and `amd64v3`.
-+
 {Project} always synchronizes packages of architecture `all` regardless of your architecture selection.
 +
 If you want to make the repository available to all hosts regardless of the architecture, ensure to select *No restriction*.

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -44,7 +44,7 @@ Ensure that you enter both *Releases* and *Components* exactly as they are in an
 . Optional: In the *Architectures* field, enter one or multiple architectures separated by whitespace.
 +
 If you want to synchronize packages for specific architecture variants, enter the architecture and its variant separated by colon.
-For example, enter `amd64:v3` to synchronize content for `binary-amd64v3/` or `amd64 amd64:v3` to synchronize content for architectures `amd64` and `amd64v3`.
+For example, enter `amd64:v3` to synchronize content for architecture `amd64v3` or `amd64 amd64:v3` to synchronize content for architectures `amd64` and `amd64v3`.
 +
 {Project} always synchronizes packages of architecture `all` regardless of your architecture selection.
 +

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -42,6 +42,17 @@ Note that some third party Debian repositories use the components in ways that m
 Ensure that you enter both *Releases* and *Components* exactly as they are in an `/etc/apt/sources.list` file.
 ====
 . Optional: In the *Architectures* field, enter one or multiple architectures.
+[NOTE]
+====
+*Architecture variants must be entered using the form `base:variant`.*
+
+Examples:
+* `amd64` syncs `binary-amd64/`
+* `amd64:v3` syncs the variant index `binary-amd64v3/`
+* You can specify both: `amd64 amd64:v3`
+
+{Project} always synchronizes `all` packages regardless of the architecture selection, so `binary-all/` is expected to be present in the published repository.
+====
 If you want to make the repository available to all hosts regardless of the architecture, ensure to select *No restriction*.
 ifdef::orcharhino[]
 . Optional: In the *Errata URL* field, enter the URL of an errata service.

--- a/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-deb-repositories-by-using-web-ui.adoc
@@ -41,7 +41,7 @@ Note that some third party Debian repositories use the components in ways that m
 ====
 Ensure that you enter both *Releases* and *Components* exactly as they are in an `/etc/apt/sources.list` file.
 ====
-. Optional: In the *Architectures* field, enter one or multiple architectures separated by whitespace.
+. Optional: In the *Architectures* field, enter one or multiple architectures separated with spaces.
 +
 {Project} always synchronizes packages of architecture `all` regardless of your architecture selection.
 +


### PR DESCRIPTION
#### What changes are you introducing?

Debian Architecture-Variant support documentation for Katello. 
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The behavior is not intuitive and requires the user to be explicitly set the variant architectures in a particular form so pulp can handle it correctly.

- [Katello Redmin Ticket](https://projects.theforeman.org/issues/39345)
- [Katello PR](https://github.com/Katello/katello/pull/11761)
- [pulp_deb issue](https://github.com/pulp/pulp_deb/issues/1419)
- [pulp_deb PR](https://github.com/pulp/pulp_deb/pull/1392)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- This requires the a new pulp_deb version to be added to Katello so it can take a while. Will update cherry picks accordingly

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
