### PR TITLE
Differentiate importing GPG keys by Client OS

### DIFF
--- a/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-cli.adoc
@@ -4,7 +4,16 @@
 = Importing a {customgpg} key by using Hammer CLI
 
 [role="_abstract"]
+ifdef::katello[]
+For Deb content, import a vendor GPG key into {Project} so {Project} validates signatures on repository metadata when it synchronizes {customcontent} from upstream.
+For Yum content, import a vendor GPG key into {Project} so hosts validate signatures when they install signed {customcontent} from authorized sources.
+endif::[]
+ifdef::satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 Import a vendor GPG key into {Project} so hosts validate signatures when they install signed {customcontent} from authorized sources.
+endif::[]
+ifdef::debian,ubuntu[]
+Import a vendor GPG key into {Project} so {Project} validates signatures on repository metadata when it synchronizes {customcontent} from upstream.
+endif::[]
 
 ifdef::satellite[]
 Red{nbsp}Hat content is already configured with the appropriate GPG key and thus GPG Key management of Red{nbsp}Hat repositories is not supported.

--- a/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-a-custom-gpg-key-by-using-web-ui.adoc
@@ -4,7 +4,16 @@
 = Importing a {customgpg} key by using {ProjectWebUI}
 
 [role="_abstract"]
+ifdef::katello[]
+For Deb content, import a vendor GPG key into {Project} so {Project} validates signatures on repository metadata when it synchronizes {customcontent} from upstream.
+For Yum content, import a vendor GPG key into {Project} so hosts validate signatures when they install signed {customcontent} from authorized sources.
+endif::[]
+ifdef::satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 Import a vendor GPG key into {Project} so hosts validate signatures when they install signed {customcontent} from authorized sources.
+endif::[]
+ifdef::debian,ubuntu[]
+Import a vendor GPG key into {Project} so {Project} validates signatures on repository metadata when it synchronizes {customcontent} from upstream.
+endif::[]
 
 ifdef::satellite[]
 Red{nbsp}Hat content is already configured with the appropriate GPG key and thus GPG Key management of Red{nbsp}Hat repositories is not supported.


### PR DESCRIPTION
#### What changes are you introducing?

GPG public keys in Foreman+Katello serve a different purpose for Deb vs Yum content. This patch clarifies this.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Refs #4870

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

For Deb content, metadata is signed. -> Canonical signs the Release file. Users import the corresponding GPG public key so that Foreman+Katello can verify the signature during synchronization. Then, when users create Deb repository metadata, for example, by creating a CV, the pulp_deb signing service signs (or similar) the metadata with a key pair owned by Foreman+Katello/Pulp. Afterwards, hosts can use the pulp_deb_signing.key to verify the metadata provided by Foreman+Katello.

Error to proof this: Unable to verify any Release files from 'https://example.com/blub/Release' using the GPG key provided. <- which happens if you try to sync Deb content that has the wrong content credential assigned to it.

Also, if you do not add a GPG public key to a Deb repository, Foreman+Katello/Pulp will still sign it.

For Yum content, the OS vendors sign packages -> Users import the GPG public key from Red Hat/SUSE/etc so that registered hosts get this information (somehow) via subscription-manager/Candlepin. (I do not know how this works exactly.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
