### PR TITLE
Add AutoYaST and Autoinstall provisioning templates

### DIFF
--- a/guides/common/assembly_preparing-templates-for-provisioning.adoc
+++ b/guides/common/assembly_preparing-templates-for-provisioning.adoc
@@ -14,7 +14,7 @@ include::modules/proc_running-custom-code-during-host-provisioning-by-using-web-
 
 include::modules/proc_running-custom-code-during-host-provisioning-by-using-cli.adoc[leveloffset=+1]
 
-ifdef::foreman-el,foreman-deb,katello,debian,ubuntu[]
+ifdef::foreman-el,foreman-deb,katello,debian[]
 include::modules/ref_custom-provisioning-snippet-example-for-debian.adoc[leveloffset=+1]
 endif::[]
 
@@ -24,6 +24,10 @@ endif::[]
 
 ifdef::foreman-el,foreman-deb,katello,suse_linux_enterprise_server[]
 include::modules/ref_custom-provisioning-snippet-example-for-sles.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::foreman-el,foreman-deb,katello,ubuntu[]
+include::modules/ref_custom-provisioning-snippet-example-for-ubuntu.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/proc_associating-templates-with-operating-systems-by-using-web-ui.adoc[leveloffset=+1]

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -91,6 +91,8 @@
 :client-package-remove: apt-get remove
 :client-pkg-arch: all
 :client-pkg-ext: deb
+:client-provisioning-template-default-ipxe: Preseed default iPXE Autoinstall
+:client-provisioning-template-default: Preseed default
 :client-provisioning-template-type: Preseed
 :client-puppet-repo-url: http://_{foreman-example-com}_/pulp/content/_My_Organization_/Library/custom/Puppet_Agent/Puppet_Agent_{client-os}_{client-os-major}/
 :client-query-yggdrasil-package: dpkg-query --show yggdrasil-mqtt

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -147,6 +147,8 @@
 :client-extracted-gpg-key-target-path: ~/RPM-GPG-KEY-EXAMPLE-95
 :client-install-yggdrasil-package: dnf install foreman_ygg_migration
 :client-package-manager: dnf
+:client-provisioning-template-default-ipxe: Kickstart default iPXE
+:client-provisioning-template-default: Kickstart default
 :client-query-yggdrasil-package: rpm --query yggdrasil
 :client-redhat-repo-path: /etc/yum.repos.d/redhat.repo
 :client-update-certificates-command: update-ca-trust

--- a/guides/common/modules/con_content-types-in-project.adoc
+++ b/guides/common/modules/con_content-types-in-project.adoc
@@ -46,8 +46,8 @@ endif::[]
 
 ifndef::satellite[]
 Provisioning templates::
-Templates to provision hosts running EL based on synchronized content and Debian, Ubuntu, or SUSE Linux Enterprise Server based on local installation media.
-{Project} contains predefined Agama, Kickstart, and Preseed templates as well as the ability to create your own, which are used to provision systems and customize the installation.
+Templates to provision hosts running Enterprise Linux based on synchronized content and Debian, Ubuntu, or SUSE Linux Enterprise Server based on local installation media.
+{Project} contains predefined `Agama`, `AutoYaST`, `Kickstart`, `Preseed`, and `Preseed Autoinstall` templates as well as the ability to create your own, which are used to provision hosts and customize the installation.
 ifdef::almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 You can provision hosts running {client-os} based on synchronized content.
 endif::[]

--- a/guides/common/modules/con_provisioning-methods-in-project.adoc
+++ b/guides/common/modules/con_provisioning-methods-in-project.adoc
@@ -16,7 +16,7 @@ ifdef::satellite[]
 This method uses the Anaconda operating system installer and template-generated Kickstart script for installation automation downloaded from {Project}.
 endif::[]
 ifndef::satellite[]
-This method uses an operating system installer, such as Anaconda, Debian Installer, or Agama, and template-generated file with installation options downloaded from {Project}, such as Kickstart, Preseed, or Agama.
+This method uses an operating system installer, such as Anaconda, Debian Installer, Agama, or AutoYaST, and a template-generated file with installation options downloaded from {Project}, such as `Agama`, `AutoYaST`, `Kickstart`, `Preseed`, or `Preseed Autoinstall` templates.
 endif::[]
 
 Network based with PXE Discovery:::

--- a/guides/common/modules/con_using-activation-keys-for-host-registration.adoc
+++ b/guides/common/modules/con_using-activation-keys-for-host-registration.adoc
@@ -9,10 +9,10 @@ You can use activation keys to register new hosts during provisioning through {P
 [NOTE]
 ====
 ifdef::orcharhino,satellite[]
-The {client-provisioning-template-type} provisioning templates in {ProjectName} contain commands to register the host using an activation key that is defined when creating a host.
+The `{client-provisioning-template-type}` provisioning templates in {Project} contain commands to register the host, using an activation key that is defined when creating a host.
 endif::[]
 ifdef::katello[]
-The Agama, Kickstart, and Preseed provisioning templates in {ProjectName} contain commands to register the host using an activation key that is defined when creating a host.
+The `Agama`, `AutoYaST`, `Kickstart`, `Preseed`, and `Preseed Autoinstall` provisioning templates in {Project} contain commands to register the host, using an activation key that is defined when creating a host.
 endif::[]
 ====
 

--- a/guides/common/modules/proc_booting-virtual-machines.adoc
+++ b/guides/common/modules/proc_booting-virtual-machines.adoc
@@ -20,14 +20,23 @@ For more information, see xref:Configuring_iPXE_Environment_{context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
-ifdef::satellite[]
-. Search for the `Kickstart default iPXE` template.
-endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . Search for the required template:
-* The `Agama default iPXE` template for {SLES} hosts.
-* The `Kickstart default iPXE` template for {EL} hosts.
-* The `Preseed default iPXE` template for {DL} hosts.
+* For Debian hosts, select the `Preseed default iPXE` template.
+* For {EL} hosts, select the `Kickstart default iPXE` template.
+* For {SLES} hosts, select the `Agama default iPXE` template for SLES 16 or `AutoYaST default iPXE` for SLES 15 and SLES 12.
+* For Ubuntu hosts, select the `Preseed default iPXE Autoinstall` template.
+endif::[]
+ifdef::orcharhino,satellite[]
+. Search for the `{client-provisioning-template-default-ipxe}` template.
+ifdef::ubuntu[]
++
+For {client-os} 18.04 hosts, select the `Preseed default iPXE` template.
+endif::[]
+ifdef::suse_linux_enterprise_server[]
++
+For {client-os} 15 and 12 hosts, select the `AutoYaST default iPXE` template.
+endif::[]
 endif::[]
 . Click the name of the template.
 . Click the *Association* tab and select the operating systems that your host uses.
@@ -36,14 +45,23 @@ endif::[]
 . Click *Submit* to save the changes.
 . In the {ProjectWebUI}, navigate to *Hosts* > *Operating systems* and select the operating system of your host.
 . Click the *Templates* tab.
-ifdef::satellite[]
-. From the *iPXE template* list, select the `Kickstart default iPXE` template.
-endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . From the *iPXE template* list, select the required template:
-* The `Agama default iPXE` template for {SLES} hosts.
-* The `Kickstart default iPXE` template for {EL} hosts.
-* The `Preseed default iPXE` template for {DL} hosts.
+* For Debian hosts, select the `Preseed default iPXE` template.
+* For {EL} hosts, select the `Kickstart default iPXE` template.
+* For {SLES} hosts, select the `Agama default iPXE` template for SLES 16 or `AutoYaST default iPXE` for SLES 15 and SLES 12.
+* For Ubuntu hosts, select the `Preseed default iPXE Autoinstall` template.
+endif::[]
+ifdef::orcharhino,satellite[]
+. From the *iPXE template* list, select the `{client-provisioning-template-default-ipxe}` template.
+ifdef::ubuntu[]
++
+For {client-os} 18.04 hosts, select the `Preseed default iPXE` template.
+endif::[]
+ifdef::suse_linux_enterprise_server[]
++
+For {client-os} 15 and 12 hosts, select the `AutoYaST default iPXE` template.
+endif::[]
 endif::[]
 . Click *Submit* to save the changes.
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
+++ b/guides/common/modules/proc_chainbooting-ipxe-from-pxelinux.adoc
@@ -25,14 +25,23 @@ For more information, see xref:Configuring_iPXE_Environment_{context}[].
 . Click the *Locations* tab and add the location where the host resides.
 . Click the *Organizations* tab and add the organization that the host belongs to.
 . Click *Submit* to save the changes.
-ifdef::satellite[]
-. On the *Provisioning Templates* page, search for the `Kickstart default iPXE` template.
-endif::[]
-ifndef::satellite[]
+ifndef::foreman-el,foreman-deb,katello[]
 . On the *Provisioning Templates* page, search for the required template:
-* The `Agama default iPXE` template for {SLES} hosts.
-* The `Kickstart default iPXE` template for {EL} hosts.
-* The `Preseed default iPXE` template for {DL} hosts.
+* For Debian hosts, search for `Preseed default iPXE` templates.
+* For {EL} hosts, search for `Kickstart default iPXE` template.
+* For {SLES} hosts, search for `Agama default iPXE` templates for SLES 16 or `AutoYaST default iPXE` for SLES 15 and SLES 12.
+* For Ubuntu hosts, search for `Preseed default iPXE Autoinstall` templates.
+endif::[]
+ifdef::orcharhino,satellite[]
+. On the *Provisioning Templates* page, search for the `{client-provisioning-template-default-ipxe}` template.
+ifdef::ubuntu[]
++
+For {client-os} 18.04 hosts, select the `Preseed default iPXE` template.
+endif::[]
+ifdef::suse_linux_enterprise_server[]
++
+For {client-os} 15 and 12 hosts, select the `AutoYaST default iPXE` template.
+endif::[]
 endif::[]
 . Click the name of the template.
 . Click the *Association* tab and associate the template with the operating system that your host uses.
@@ -42,14 +51,23 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts* > *Operating systems* and select the operating system of your host.
 . Click the *Templates* tab.
 . From the *PXELinux template* list, select the template you want to use.
-ifdef::satellite[]
-. From the *iPXE template* list, select the `Kickstart default iPXE` template.
-endif::[]
-ifndef::satellite[]
+ifdef::foreman-el,foreman-deb,katello[]
 . From the *iPXE template* list, select the required template:
-* The `Agama default iPXE` template for {SLES} hosts.
-* The `Kickstart default iPXE` template for {EL} hosts.
-* The `Preseed default iPXE` template for {DL} hosts.
+* For Debian hosts, select the `Preseed default iPXE` template.
+* For {EL} hosts, select the `Kickstart default iPXE` template.
+* For {SLES} hosts, select the `Agama default iPXE` template for SLES 16 or `AutoYaST default iPXE` for SLES 15 and SLES 12.
+* For Ubuntu hosts, select the `Preseed default iPXE Autoinstall` template.
+endif::[]
+ifdef::orcharhino,satellite[]
+. From the *iPXE template* list, select the `{client-provisioning-template-default-ipxe}` template.
+ifdef::ubuntu[]
++
+For {client-os} 18.04 hosts, select the `Preseed default iPXE` template.
+endif::[]
+ifdef::suse_linux_enterprise_server[]
++
+For {client-os} 15 and 12 hosts, select the `AutoYaST default iPXE` template.
+endif::[]
 endif::[]
 . Click *Submit* to save the changes.
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*, and select the host group you want to configure.

--- a/guides/common/modules/proc_configuring-openvox-agent-on-a-host-during-provisioning.adoc
+++ b/guides/common/modules/proc_configuring-openvox-agent-on-a-host-during-provisioning.adoc
@@ -32,7 +32,7 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
 . Select a provisioning template depending on your host provisioning method.
 For more information, see {ProvisioningDocURL}kinds-of-provisioning-templates[Kinds of Provisioning Templates] in _{ProvisioningDocTitle}_.
-ifndef::katello,orcharhino,satellite[]
+ifdef::foreman-el,foreman-deb[]
 . Ensure the `puppetlabs_repo` snippet is included as follows:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -40,7 +40,7 @@ ifndef::katello,orcharhino,satellite[]
 <%= snippet 'puppetlabs_repo' %>
 ----
 +
-Note that this snippet is already included in the templates shipped with {Project}, such as `Kickstart default` or `Preseed default`.
+Note that this snippet is already included in the templates shipped with {Project}, for example, in `Kickstart default` and `Preseed default finish` templates.
 endif::[]
 . Ensure the `puppet_setup` snippet is included as follows:
 +
@@ -49,7 +49,12 @@ endif::[]
 <%= snippet 'puppet_setup' %>
 ----
 +
-Note that this snippet is already included in the templates shipped with {Project}, such as `Kickstart default` or `Preseed default`.
+ifdef::foreman-el,foreman-deb,katello[]
+Note that this snippet is already included in the templates shipped with {Project}, for example, in `Agama sles default`, `AutoYaST SLES default`, `Kickstart default`, and `Preseed default finish` templates.
+endif::[]
+ifdef::orcharhino,satellite[]
+Note that this snippet is already included in the templates shipped with {Project}, for example, in the `{client-provisioning-template-default}` template.
+endif::[]
 ifdef::katello,orcharhino,satellite[]
 . Enable the OpenVox agent using a host parameter in global parameters, a host group, or for a single host.
 Add a host parameter named `enable-puppet8`, select the *boolean* type, and set the value to `true`.

--- a/guides/common/modules/ref_custom-provisioning-snippet-example-for-debian.adoc
+++ b/guides/common/modules/ref_custom-provisioning-snippet-example-for-debian.adoc
@@ -4,9 +4,9 @@
 = Custom provisioning snippet example for Debian
 
 [role="_abstract"]
-You can use `Custom Post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
+You can use `custom post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
 
-.`Preseed default custom post` Example for Debian/Ubuntu
+.`Preseed default custom post` Example for Debian
 ====
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/ref_custom-provisioning-snippet-example-for-sles.adoc
+++ b/guides/common/modules/ref_custom-provisioning-snippet-example-for-sles.adoc
@@ -4,7 +4,7 @@
 = Custom provisioning snippet example for {SLES}
 
 [role="_abstract"]
-You can use `Custom Post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
+You can use `custom post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
 
 .`Agama default custom post` Example for {SLES}
 ====
@@ -20,3 +20,7 @@ curl -X POST \
 "https://api.example.com/"
 ----
 ====
+
+ifdef::suse_linux_enterprise_server[]
+If your host runs {client-os} 15 or 12, name your template `AutoYaST default custom post`.
+endif::[]

--- a/guides/common/modules/ref_custom-provisioning-snippet-example-for-ubuntu.adoc
+++ b/guides/common/modules/ref_custom-provisioning-snippet-example-for-ubuntu.adoc
@@ -1,18 +1,18 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="Custom_Provisioning_Snippet_Example_for_Enterprise_Linux_{context}"]
-= Custom provisioning snippet example for {EL}
+[id="custom-provisioning-snippet-example-for-ubuntu"]
+= Custom provisioning snippet example for Ubuntu
 
 [role="_abstract"]
 You can use `custom post` snippets to call external APIs from within the provisioning template directly after provisioning a host.
 
-.`Kickstart default finish custom post` Example for {EL}
+.`Preseed Autoinstall default custom post` Example for Ubuntu
 ====
-[options="nowrap" subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 echo "Calling API to report successful host deployment"
 
-yum install -y curl ca-certificates
+{client-package-install-deb} -y curl ca-certificates
 
 curl -X POST \
 -H "Content-Type: application/json" \

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -389,9 +389,11 @@ endif::[]
 ifndef::satellite[]
 {Project} contains provisioning templates for all supported host operating system families:
 
-* Agama for SUSE Linux Enterprise Server
-* Kickstart for AlmaLinux, Amazon Linux, CentOS, Oracle Linux, Red Hat Enterprise Linux, and Rocky Linux
-* Preseed files for Debian and Ubuntu
+* `Agama` templates for SUSE Linux Enterprise Server 16
+* `AutoYaST` templates for SUSE Linux Enterprise Server 15 and 12
+* `Kickstart` templates for AlmaLinux, Amazon Linux, CentOS, Oracle Linux, Red Hat Enterprise Linux, and Rocky Linux
+* `Preseed Autoinstall` templates for Ubuntu
+* `Preseed` templates for Debian
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

This patch adds AutoYaST templates for SLES 15 and below, and Preseed Autoinstall templates for Ubuntu 20.04 and above.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* Enterprise Linux: Always Kickstart
* Debian: Always Preseed
* Ubuntu 18.04: Preseed
* Ubuntu 20.04+: Preseed Autoinstall
* SLES 12/15: AutoYaST
* SLES 16+: Agama

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The "Preseed default" template in foreman for "develop" does not contain the "puppet_setup" snippet:

`$ rg --files-with-matches "puppet_setup" | sort -u`

The "puppetlabs_repo" snippet is not included in any default provisioning templates for SLES (only cloud init-based templates):

`$ rg --files-with-matches "puppetlabs_repo" | sort -u`

New custom provisioning snippet for Ubuntu that uses "Preseed Autoinstall" templates compared to "Preseed" for Debian:

`$ cp -i guides/common/modules/ref_custom-provisioning-snippet-example-for-debian.adoc guides/common/modules/ref_custom-provisioning-snippet-example-for-ubuntu.adoc
`

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
