### PR TITLE
Move host patching practices to Managing hosts

### DIFF
--- a/guides/common/assembly_managing-content-views.adoc
+++ b/guides/common/assembly_managing-content-views.adoc
@@ -8,8 +8,6 @@ include::modules/con_content-views-in-project.adoc[leveloffset=+1]
 
 include::modules/ref_best-practices-for-content-views.adoc[leveloffset=+1]
 
-include::modules/ref_best-practices-for-patching-content-hosts.adoc[leveloffset=+1]
-
 include::modules/proc_creating-a-content-view-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-content-view-by-using-cli.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-packages.adoc
+++ b/guides/common/assembly_managing-packages.adoc
@@ -15,3 +15,5 @@ include::modules/proc_upgrading-packages-on-a-host.adoc[leveloffset=+1]
 include::modules/proc_removing-packages-from-a-host.adoc[leveloffset=+1]
 
 include::modules/proc_managing-packages-on-a-host-by-using-api.adoc[leveloffset=+1]
+
+include::modules/ref_best-practices-for-host-patching.adoc[leveloffset=+1]

--- a/guides/common/modules/ref_best-practices-for-host-patching.adoc
+++ b/guides/common/modules/ref_best-practices-for-host-patching.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="best-practices-for-patching-content-hosts_{context}"]
-= Best practices for patching hosts
+[id="best-practices-for-host-patching"]
+= Best practices for host patching
 
 [role="_abstract"]
-{Team} recommends you follow these practices for patching content hosts.
+Follow these guidelines when you patch hosts in {Project} so errata reporting stays accurate, updates go through supported tools, and bulk patching actions run reliably.
 
 * Registering hosts to {Project} requires {project-client-name}, which contains the `katello-host-tools` package and its dependencies.
-For more information, see {ManagingHostsDocURL}registering-hosts-by-using-global-registration[Registering hosts by using global registration] in _{ManagingHostsDocTitle}_.
+For more information, see xref:registering-hosts-by-using-global-registration[].
 * Use the {ProjectWebUI} to install, upgrade, and remove packages from hosts.
 You can update hosts with job templates using SSH and Ansible.
 * Apply errata on hosts using the {ProjectWebUI}.


### PR DESCRIPTION
#### What changes are you introducing?

- Moving the "_Best practices for patching hosts_" module from _Managing content_ to _Managing hosts_
- Refactoring the module title
- Optimizing the abstract

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because it's about hosts, not content, it belongs to Host management.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- This placement looks most accurate to me, but let me know if it works better somewhere else in the TOC.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
