### PR TITLE
Include one more level in toc

### DIFF
--- a/guides/scripts/extract_links_toc
+++ b/guides/scripts/extract_links_toc
@@ -48,7 +48,7 @@ files.each do |file|
   document = Nokogiri::HTML.parse(File.open(file))
 
   file_toc = document.css('h2').to_h do |chapter|
-    subchapters = (chapter.parent.css('h3') + chapter.parent.css('div[id]'))
+    subchapters = (chapter.parent.css('h3') + chapter.parent.css('div[id]') + chapter.parent.css('h4'))
     ([chapter] + subchapters).each do |element|
       element_auxiliary_ids(element).each do |aux_id|
         id = element['id']


### PR DESCRIPTION
#### What changes are you introducing?
Including one more level of heading in TOC.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Recently, some heading were pushed to a lower level, making them disappear from the TOC.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Extracted from https://github.com/theforeman/foreman-documentation/pull/4809

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
