### PR TITLE
Move an actionable step from assembly intro to a module

### DIFF
--- a/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/assembly_migrating-from-internal-databases-to-external-databases.adoc
@@ -4,6 +4,8 @@ ifdef::context[:parent-context: {context}]
 
 include::modules/con_migrating-from-internal-databases-to-external-databases.adoc[]
 
+include::modules/proc_determining-whether-your-projectserver-uses-internal-or-external-databases.adoc[leveloffset=+1]
+
 include::modules/ref_postgresql-as-an-external-database-considerations.adoc[leveloffset=+1]
 
 include::modules/proc_installing-postgresql.adoc[leveloffset=+1]

--- a/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
+++ b/guides/common/modules/con_migrating-from-internal-databases-to-external-databases.adoc
@@ -7,15 +7,11 @@
 When you install {ProjectName}, the *{foreman-installer}* command installs PostgreSQL databases on the same server as {Project}.
 If you are using the default internal databases but want to start using external databases to help with the server load, you can migrate your internal databases to external databases.
 
-To confirm whether your {ProjectServer} has internal or external databases, you can query the status of your databases:
-
-[options="nowrap" subs="+quotes,attributes"]
-----
-# {foreman-maintain} service status --only postgresql
-----
-
 ifdef::satellite[]
+[IMPORTANT]
+====
 Red Hat does not provide support or tools for external database maintenance.
 This includes backups, upgrades, and database tuning.
 You must have your own database administrator to support and maintain external databases.
+====
 endif::[]

--- a/guides/common/modules/proc_determining-whether-your-projectserver-uses-internal-or-external-databases.adoc
+++ b/guides/common/modules/proc_determining-whether-your-projectserver-uses-internal-or-external-databases.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="determining-whether-your-projectserver-uses-internal-or-external-databases"]
+= Determining whether your {ProjectServer} uses internal or external databases
+
+[role="_abstract"]
+You can confirm whether your {ProjectServer} uses internal or external databases by checking the status of the PostgreSQL database service.
+
+.Procedure
+* On {ProjectServer}, query the status of your databases:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foreman-maintain} service status --only postgresql
+----


### PR DESCRIPTION
#### What changes are you introducing?

Making sure the assembly for migrating to external DB does not contain steps.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This is part of the requirements for Content Quality Assessment (CQA).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is the last change I want to make to address CQA's modularization requirements. It's only a single change because I've fixed up other things in other PRs already.

Assisted-by: Cursor

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
