### PR TITLE
Document foremanctl impact on Pulp import/export paths

### DIFF
--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -37,12 +37,22 @@ endif::[]
 ----
 # mkdir -p /var/lib/pulp/__local_repos__/__my_file_repo__
 ----
+ifndef::containerized[]
 . Add the parent folder into allowed import paths:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} --foreman-proxy-content-pulpcore-additional-import-paths /var/lib/pulp/__local_repos__
 ----
+endif::[]
+ifdef::containerized[]
+. Add the parent folder to allowed import paths:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {foremanctl} deploy --content-import-path /var/lib/pulp/__local_repos__
+----
+endif::[]
 . Add files to the directory or create a test file:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-the-syncable-format.adoc
@@ -16,7 +16,9 @@ include::snip_generating-content.adoc[]
 include::snip_content-types-syncable-export.adoc[]
 
 .Prerequisites
+ifdef::containerized[]
 include::snip_allowed-export-paths-prerequisite.adoc[]
+endif::[]
 * Ensure that you set the download policy to *Immediate* for all repositories within the content view you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 * Ensure that you synchronize products you export to the required date.

--- a/guides/common/modules/proc_exporting-a-content-view-version-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-content-view-version-in-the-syncable-format.adoc
@@ -16,6 +16,7 @@ include::snip_generating-content.adoc[]
 include::snip_content-types-syncable-export.adoc[]
 
 .Prerequisites
+include::snip_allowed-export-paths-prerequisite.adoc[]
 * Ensure that you set the download policy to *Immediate* for all repositories within the content view you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 * Ensure that you synchronize products you export to the required date.

--- a/guides/common/modules/proc_exporting-a-repository-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-in-the-syncable-format.adoc
@@ -11,6 +11,7 @@ include::snip_generating-content.adoc[]
 include::snip_content-types-syncable-export.adoc[]
 
 .Prerequisites
+include::snip_allowed-export-paths-prerequisite.adoc[]
 * Ensure that you set the download policy to *Immediate* for the repository within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 

--- a/guides/common/modules/proc_exporting-a-repository-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-in-the-syncable-format.adoc
@@ -11,7 +11,9 @@ include::snip_generating-content.adoc[]
 include::snip_content-types-syncable-export.adoc[]
 
 .Prerequisites
+ifdef::containerized[]
 include::snip_allowed-export-paths-prerequisite.adoc[]
+endif::[]
 * Ensure that you set the download policy to *Immediate* for the repository within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-the-syncable-format.adoc
@@ -14,6 +14,9 @@ include::snip_content-types-syncable-export.adoc[]
 
 The procedure below shows an incremental export of a repository in the Library lifecycle environment.
 
+.Prerequisites
+include::snip_allowed-export-paths-prerequisite.adoc[]
+
 .Procedure
 . Create an incremental export:
 +

--- a/guides/common/modules/proc_exporting-a-repository-incrementally-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-a-repository-incrementally-in-the-syncable-format.adoc
@@ -14,8 +14,10 @@ include::snip_content-types-syncable-export.adoc[]
 
 The procedure below shows an incremental export of a repository in the Library lifecycle environment.
 
+ifdef::containerized[]
 .Prerequisites
 include::snip_allowed-export-paths-prerequisite.adoc[]
+endif::[]
 
 .Procedure
 . Create an incremental export:

--- a/guides/common/modules/proc_exporting-repositories-from-the-connected-project-server.adoc
+++ b/guides/common/modules/proc_exporting-repositories-from-the-connected-project-server.adoc
@@ -6,8 +6,10 @@
 [role="_abstract"]
 Export the required repositories on the connected {ProjectServer} to transfer to the disconnected {ProjectServer}.
 
+ifdef::containerized[]
 .Prerequisites
 include::snip_allowed-export-paths-prerequisite.adoc[]
+endif::[]
 
 .Procedure
 . Synchronize the following repositories on your connected {ProjectServer}:

--- a/guides/common/modules/proc_exporting-repositories-from-the-connected-project-server.adoc
+++ b/guides/common/modules/proc_exporting-repositories-from-the-connected-project-server.adoc
@@ -6,6 +6,9 @@
 [role="_abstract"]
 Export the required repositories on the connected {ProjectServer} to transfer to the disconnected {ProjectServer}.
 
+.Prerequisites
+include::snip_allowed-export-paths-prerequisite.adoc[]
+
 .Procedure
 . Synchronize the following repositories on your connected {ProjectServer}:
 +

--- a/guides/common/modules/proc_exporting-the-library-environment-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-the-syncable-format.adoc
@@ -19,6 +19,7 @@ include::snip_content-types-syncable-export.adoc[]
 The export contains directories with the packages, *listing* files, and metadata of the repository in Yum format that can be used to synchronize in the importing {ProjectServer}.
 
 .Prerequisites
+include::snip_allowed-export-paths-prerequisite.adoc[]
 * Ensure that you set the download policy to *Immediate* for all repositories within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 * Ensure that you synchronize products you export to the required date.

--- a/guides/common/modules/proc_exporting-the-library-environment-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_exporting-the-library-environment-in-the-syncable-format.adoc
@@ -19,7 +19,9 @@ include::snip_content-types-syncable-export.adoc[]
 The export contains directories with the packages, *listing* files, and metadata of the repository in Yum format that can be used to synchronize in the importing {ProjectServer}.
 
 .Prerequisites
+ifdef::containerized[]
 include::snip_allowed-export-paths-prerequisite.adoc[]
+endif::[]
 * Ensure that you set the download policy to *Immediate* for all repositories within the Library lifecycle environment you export.
 For more information, see xref:Download_Policies_Overview_{context}[].
 * Ensure that you synchronize products you export to the required date.

--- a/guides/common/modules/proc_importing-exports-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_importing-exports-in-the-syncable-format.adoc
@@ -7,12 +7,12 @@
 You can import syncable exports into the Library environment of an organization.
 
 .Prerequisites
-* The syncable exports must be located in one of your allowed import paths.
 ifndef::containerized[]
-The default import path is `/var/lib/pulp/imports/`.
-To configure additional paths, use `ALLOWED_IMPORT_PATHS` in `/etc/pulp/settings.py`.
+* The syncable exports must be located in one of your `ALLOWED_IMPORT_PATHS` as specified in `/etc/pulp/settings.py`.
+By default, this includes `/var/lib/pulp/imports/`.
 endif::[]
 ifdef::containerized[]
+* The syncable exports must be located in one of your allowed import paths.
 The default import paths are `/var/lib/pulp/imports/` and `/var/lib/pulp/sync_imports/`.
 To configure additional paths, run `{foremanctl} deploy` with one or more `--content-import-path` options.
 endif::[]

--- a/guides/common/modules/proc_importing-exports-in-the-syncable-format.adoc
+++ b/guides/common/modules/proc_importing-exports-in-the-syncable-format.adoc
@@ -7,8 +7,15 @@
 You can import syncable exports into the Library environment of an organization.
 
 .Prerequisites
-* The syncable exports must be located in one of your `ALLOWED_IMPORT_PATHS` as specified in `/etc/pulp/settings.py`.
-By default, this includes `/var/lib/pulp/imports/`.
+* The syncable exports must be located in one of your allowed import paths.
+ifndef::containerized[]
+The default import path is `/var/lib/pulp/imports/`.
+To configure additional paths, use `ALLOWED_IMPORT_PATHS` in `/etc/pulp/settings.py`.
+endif::[]
+ifdef::containerized[]
+The default import paths are `/var/lib/pulp/imports/` and `/var/lib/pulp/sync_imports/`.
+To configure additional paths, run `{foremanctl} deploy` with one or more `--content-import-path` options.
+endif::[]
 * The importing organization must be configured to synchronize content through exports.
 ifdef::satellite[]
 For more information, see {InstallingServerDisconnectedDocURL}configuring-projectserver-to-synchronize-content-through-exports-by-using-web-ui[Configuring {ProjectServer} to synchronize content through exports by using {ProjectWebUI}] in _{InstallingServerDisconnectedDocTitle}_.

--- a/guides/common/modules/snip_allowed-export-paths-prerequisite.adoc
+++ b/guides/common/modules/snip_allowed-export-paths-prerequisite.adoc
@@ -1,11 +1,5 @@
 :_mod-docs-content-type: SNIPPET
 
 * Exports are written to one of your allowed export paths.
-ifndef::containerized[]
-The default export path is `/var/lib/pulp/exports/`.
-To configure additional paths, use `ALLOWED_EXPORT_PATHS` in `/etc/pulp/settings.py`.
-endif::[]
-ifdef::containerized[]
 The default export path is `/var/lib/pulp/exports/`.
 To configure additional paths, run `{foremanctl} deploy` with one or more `--content-export-path` options.
-endif::[]

--- a/guides/common/modules/snip_allowed-export-paths-prerequisite.adoc
+++ b/guides/common/modules/snip_allowed-export-paths-prerequisite.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: SNIPPET
+
+* Exports are written to one of your allowed export paths.
+ifndef::containerized[]
+The default export path is `/var/lib/pulp/exports/`.
+To configure additional paths, use `ALLOWED_EXPORT_PATHS` in `/etc/pulp/settings.py`.
+endif::[]
+ifdef::containerized[]
+The default export path is `/var/lib/pulp/exports/`.
+To configure additional paths, run `{foremanctl} deploy` with one or more `--content-export-path` options.
+endif::[]

--- a/guides/scripts/find_unused_modules
+++ b/guides/scripts/find_unused_modules
@@ -43,6 +43,10 @@ unused = ((modules + assemblies) - absolute_included).map do |path|
   Pathname.new(path).relative_path_from(doc_root).to_s
 end
 
+# containerized content build isn't published
+# https://github.com/theforeman/foreman-documentation/issues/4964
+unused.delete('guides/common/modules/snip_allowed-export-paths-prerequisite.adoc')
+
 if unused.any?
   puts unused
   if ENV.key?('GITHUB_ACTIONS')


### PR DESCRIPTION
#### What changes are you introducing?

* Updating existing information on allowed import paths for foremanctl
* Adding a snippet with information on export paths

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foremanctl/pull/455
https://github.com/theforeman/foremanctl/blob/744ba31fd0ee4e4a74eef97e2c705acca1b2961d/src/roles/pulp/defaults/main.yaml#L29-L30
https://github.com/theforeman/foremanctl/issues/445

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Assisted-by: Cursor

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
