### PR TITLE
Restructure containerized attributes into attributes-containerized

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -90,12 +90,7 @@
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy
 :install-on-os: {EL}
-ifdef::containerized[]
-:installer-log-file: /var/log/foremanctl/foremanctl.log
-endif::[]
-ifndef::containerized[]
 :installer-log-file: /var/log/foreman-installer/foreman.log
-endif::[]
 // this is foreman-installer or foreman-installer --scenario MyScenario if there are multiple
 :installer-scenario: {foreman-installer}
 :installer-scenario-smartproxy: {foreman-installer} --no-enable-foreman --no-enable-foreman-plugin-puppet --no-enable-foreman-cli --no-enable-foreman-cli-puppet
@@ -133,12 +128,7 @@ endif::[]
 :project-client-RHEL8-url: {project-client-url}/el8/x86_64/foreman-client-release.rpm
 :project-context: foreman
 :project-change-hostname: katello-change-hostname
-ifdef::containerized[]
-:project-installer-package: foremanctl
-endif::[]
-ifndef::containerized[]
 :project-installer-package: foreman-installer
-endif::[]
 :Project: Foreman
 :ProjectFeed: https://theforeman.org/feed.xml
 :ProjectName: {Project}

--- a/guides/common/attributes-containerized-katello.adoc
+++ b/guides/common/attributes-containerized-katello.adoc
@@ -1,6 +1,4 @@
 :_mod-docs-content-type: ATTRIBUTES
 
 include::attributes-katello.adoc[]
-
-// Containerized deployment overrides
-:installer-log-file: /var/log/foremanctl/foremanctl.log
+include::attributes-containerized.adoc[]

--- a/guides/common/attributes-containerized-orcharhino.adoc
+++ b/guides/common/attributes-containerized-orcharhino.adoc
@@ -1,6 +1,4 @@
 :_mod-docs-content-type: ATTRIBUTES
 
 include::attributes-orcharhino.adoc[]
-
-// Containerized deployment overrides
-:installer-log-file: /var/log/foremanctl/foremanctl.log
+include::attributes-containerized.adoc[]

--- a/guides/common/attributes-containerized-satellite.adoc
+++ b/guides/common/attributes-containerized-satellite.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ATTRIBUTES
 
 include::attributes-satellite.adoc[]
+include::attributes-containerized.adoc[]
 
-// Containerized deployment overrides
-:installer-log-file: /var/log/foremanctl/foremanctl.log
+// Satellite-specific containerized overrides
 :project-package-install: {package-install}

--- a/guides/common/attributes-containerized.adoc
+++ b/guides/common/attributes-containerized.adoc
@@ -13,3 +13,4 @@
 // WARNING: foreman-installer is NOT available in containerized deployments
 // Use {foremanctl} instead
 :foreman-installer: DO_NOT_USE_foreman-installer_IN_CONTAINERIZED_BUILDS
+:foreman-maintain: DO_NOT_USE_foreman-maintain_IN_CONTAINERIZED_BUILDS

--- a/guides/common/attributes-containerized.adoc
+++ b/guides/common/attributes-containerized.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ATTRIBUTES
+
+// Common containerized deployment attributes
+// This file is included by all containerized flavor attribute files:
+// - attributes-containerized-katello.adoc
+// - attributes-containerized-orcharhino.adoc
+// - attributes-containerized-satellite.adoc
+
+// Containerized deployment overrides
+:installer-log-file: /var/log/foremanctl/foremanctl.log
+:project-installer-package: foremanctl
+
+// WARNING: foreman-installer is NOT available in containerized deployments
+// Use {foremanctl} instead
+:foreman-installer: DO_NOT_USE_foreman-installer_IN_CONTAINERIZED_BUILDS


### PR DESCRIPTION
#### What changes are you introducing?
Combine the containerized attributes into one attributes-containerized file
Add an obviously wrong value for the foreman-installer and foreman-maintain tool in containerized builds

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Easier maintenance, troubleshooting, and verification

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
