### PR TITLE
Add RN links to nightly and 3.19 katello indexes

### DIFF
--- a/web/releases/3.19.json
+++ b/web/releases/3.19.json
@@ -137,6 +137,7 @@
       "filename": "index-containerized-katello.html",
       "sections": {
         "Release notes and upgrading": [
+          ["Release_Notes", "Release Notes"],
           ["Upgrading_Project", "Upgrading Foreman to {FOREMAN_VER}"]
         ],
         "Quickstart": [

--- a/web/releases/3.19.json
+++ b/web/releases/3.19.json
@@ -137,7 +137,7 @@
       "filename": "index-containerized-katello.html",
       "sections": {
         "Release notes and upgrading": [
-          ["Release_Notes", "Release Notes"],
+          ["Release_Notes", "Release notes"],
           ["Upgrading_Project", "Upgrading Foreman to {FOREMAN_VER}"]
         ],
         "Quickstart": [

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -137,6 +137,7 @@
       "filename": "index-containerized-katello.html",
       "sections": {
         "Release notes and upgrading": [
+          ["Release_Notes", "Release Notes"],
           ["Upgrading_Project", "Upgrading Foreman to {FOREMAN_VER}"]
         ],
         "Quickstart": [

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -137,7 +137,7 @@
       "filename": "index-containerized-katello.html",
       "sections": {
         "Release notes and upgrading": [
-          ["Release_Notes", "Release Notes"],
+          ["Release_Notes", "Release notes"],
           ["Upgrading_Project", "Upgrading Foreman to {FOREMAN_VER}"]
         ],
         "Quickstart": [


### PR DESCRIPTION
#### What changes are you introducing?
Add links to release notes in containerized katello index, both nightly and 3.19

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-45581

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
