### PR TITLE
Use 8443 for all containerized smart proxy deployments

### DIFF
--- a/guides/common/attributes-containerized.adoc
+++ b/guides/common/attributes-containerized.adoc
@@ -9,6 +9,7 @@
 // Containerized deployment overrides
 :installer-log-file: /var/log/foremanctl/foremanctl.log
 :project-installer-package: foremanctl
+:smartproxy_port: 8443
 
 // WARNING: foreman-installer is NOT available in containerized deployments
 // Use {foremanctl} instead

--- a/guides/common/modules/proc_opening-required-ports.adoc
+++ b/guides/common/modules/proc_opening-required-ports.adoc
@@ -27,11 +27,11 @@ ifeval::["{context}" == "{smart-proxy-context}"]
 . Open the ports for clients on {SmartProxyServer}:
 endif::[]
 +
-[options="nowrap"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # firewall-cmd \
 --add-port="8000/tcp" \
---add-port="9090/tcp"
+--add-port="{smartproxy_port}/tcp"
 ----
 endif::[]
 ifeval::["{context}" == "{project-context}"]


### PR DESCRIPTION
#### What changes are you introducing?

Changing the Smart Proxy port to 8443

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We wanted to standardize on 8443 for a while now (Foreman uses it, while Katello used 9090 which clashes with Cockpit), and taking the Containerization effort as a trigger.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I've not updated the diagrams, as I am lazy.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
