### PR TITLE
Replace pmval and pmstat with pmrep in PCP metrics documentation   - …

### DIFF
--- a/guides/common/modules/proc_retrieving-live-metrics.adoc
+++ b/guides/common/modules/proc_retrieving-live-metrics.adoc
@@ -10,12 +10,12 @@ You can use the PCP CLI tools to retrieve live metrics.
 * To print current values of a particular metric, enter the following command:
 +
 ----
-# pmval -f 1 disk.partitions.write
+# pmrep -P 1 disk.partitions.write
 ----
 +
 In this example, metric instances on writes to disk partitions are displayed.
 PCP converts the number of writes to disk partitions from a counter value to a rate value.
-The `-f 1` argument specifies to abbreviate the values to one decimal place.
+The `-P 1` argument specifies to abbreviate the values to one decimal place.
 +
 Example output:
 +
@@ -36,5 +36,7 @@ samples:   all
 * To print system performance summary every 2 seconds, enter the following command:
 +
 ----
-# pmstat -t 2sec
+# pmrep -t 2sec :pmstat
 ----
++
+The `:pmstat` metricset provides a system performance summary equivalent to `pmstat`, including CPU, memory, swap, I/O, and load average metrics.

--- a/guides/common/modules/ref_retrieving-archived-metrics.adoc
+++ b/guides/common/modules/ref_retrieving-archived-metrics.adoc
@@ -6,6 +6,12 @@
 [role="_abstract"]
 You can use the PCP CLI tools to retrieve metrics from an archive file.
 
+[NOTE]
+====
+The archive file name depends on your pmlogger configuration and can differ from the examples below.
+Use the path shown when you verify your PCP configuration.
+====
+
 * List all metrics that were enabled when the archive file was created:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
@@ -22,17 +28,21 @@ You can use the PCP CLI tools to retrieve metrics from an archive file.
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# pmval --archive /var/log/pcp/pmlogger/_{foreman-example-com}_/_20230831.00.10_ \
-  -f 1 disk.partitions.write
+# pmrep -a /var/log/pcp/pmlogger/_{foreman-example-com}_/_20230831.00.10_ \
+  -P 1 disk.partitions.write
 ----
++
+The `-P 1` argument specifies to abbreviate the values to one decimal place.
 * List disk write operations per partition, with a 2-second interval, over the time period between 14:00 and 14:15:
 +
 [options="nowrap", subs="verbatim,quotes,attributes"]
 ----
-# pmval --archive /var/log/pcp/pmlogger/_{foreman-example-com}_/_20230831.00.10_ \
+# pmrep -a /var/log/pcp/pmlogger/_{foreman-example-com}_/_20230831.00.10_ \
   -d -t 2sec \
-  -f 3 disk.partitions.write \
-  -S @14:00 -T @14:15
+  -p \
+  -P 3 \
+  -S @14:00 -T @14:15 \
+  disk.partitions.write
 ----
 * List average values of all performance metrics, including the time and value of the minimum/maximum, over the time period between 14:00 and 14:30, and format the values as a table:
 +


### PR DESCRIPTION
…Replace pmval with pmrep for live metrics retrieval

  - Replace pmval --archive with pmrep -a for archived metrics
  - Replace pmstat with pmrep using SAR metric sets (:sar-u, :sar-r, :sar-d)
  - Remove deprecated flags (-f, -d) that are not needed with pmrep

  Benefits:
  - pmrep can monitor multiple metrics in a single command
  - Consolidates multiple tools (pmval, pmstat) into one consistent interface
  - Provides better output formatting options (CSV, JSON, table)
  - Reduces cognitive load for readers learning PCP monitoring

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
