### PR TITLE
Remove containerized 3.18

### DIFF
--- a/web/releases/3.18.json
+++ b/web/releases/3.18.json
@@ -130,29 +130,6 @@
           ["Hammer_Reference", "Hammer reference"]
         ]
       }
-    },
-    {
-      "title": "Foreman with Katello (containerized)",
-      "header": "Foreman {FOREMAN_VER} and Katello {KATELLO_VER} (containerized)",
-      "filename": "index-containerized-katello.html",
-      "sections": {
-        "Release notes and upgrading": [
-          ["Upgrading_Project", "Upgrading Foreman to {FOREMAN_VER}"]
-        ],
-        "Quickstart": [
-          ["Quickstart", "Quickstart guide"]
-        ],
-        "Deploying Foreman": [
-          ["Installing_Server", "Installing Foreman Server"]
-        ],
-        "Administering Foreman server": [
-          ["Configuring_User_Authentication", "Configuring user authentication"]
-        ],
-        "Administering hosts": [
-        ],
-        "Reference": [
-        ]
-      }
     }
   ]
 }


### PR DESCRIPTION
#### What changes are you introducing?
Remove containerized links from 3.18

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Containerized should not be available in 3.18

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
https://redhat.atlassian.net/browse/SAT-46059

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
