### PR TITLE
Fixed structure of the Upgrading Project guide

### DIFF
--- a/guides/common/assembly_upgrading-project.adoc
+++ b/guides/common/assembly_upgrading-project.adoc
@@ -1,20 +1,14 @@
-:_mod-docs-content-type: ASSEMBLY
-
 include::modules/con_upgrading-project.adoc[]
 
-// Upgrading a Connected Project Server
 include::modules/proc_upgrading-your-project-server.adoc[leveloffset=+1]
 
 ifdef::satellite[]
-// Synchronizing the New Repositories
 include::modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+1]
 endif::[]
 
-// Upgrading Smart Proxy Server
 include::modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+1]
 
 ifdef::foreman-el,katello,satellite,orcharhino[]
-// Upgrading the External database
 include::modules/proc_upgrading-the-external-database-operating-system.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/common/assembly_upgrading-project.adoc
+++ b/guides/common/assembly_upgrading-project.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+
+include::modules/con_upgrading-project.adoc[]
+
+// Upgrading a Connected Project Server
+include::modules/proc_upgrading-your-project-server.adoc[leveloffset=+1]
+
+ifdef::satellite[]
+// Synchronizing the New Repositories
+include::modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+1]
+endif::[]
+
+// Upgrading Smart Proxy Server
+include::modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+1]
+
+ifdef::foreman-el,katello,satellite,orcharhino[]
+// Upgrading the External database
+include::modules/proc_upgrading-the-external-database-operating-system.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::satellite[]
+include::modules/proc_refreshing-clients-of-insights-iop.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-puppet-agent-7-to-openvox-agent-8.adoc[leveloffset=+1]
+endif::[]

--- a/guides/doc-Upgrading_Project/master.adoc
+++ b/guides/doc-Upgrading_Project/master.adoc
@@ -28,29 +28,8 @@ endif::[]
 
 include::common/assembly_preparing-for-project-upgrade.adoc[leveloffset=+1]
 
-include::common/modules/con_upgrading-project.adoc[leveloffset=+1]
+include::common/assembly_upgrading-project.adoc[leveloffset=+1]
 
-// Upgrading a Connected Project Server
-include::common/modules/proc_upgrading-your-project-server.adoc[leveloffset=+2]
-
-ifdef::satellite[]
-// Synchronizing the New Repositories
-include::common/modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+2]
-endif::[]
-
-// Upgrading Smart Proxy Server
-include::common/modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+2]
-
-ifdef::foreman-el,katello,satellite,orcharhino[]
-// Upgrading the External database
-include::common/modules/proc_upgrading-the-external-database-operating-system.adoc[leveloffset=+2]
-endif::[]
-
-ifdef::satellite[]
-include::common/modules/proc_refreshing-clients-of-insights-iop.adoc[leveloffset=+2]
-
-include::common/modules/proc_upgrading-puppet-agent-7-to-openvox-agent-8.adoc[leveloffset=+2]
-endif::[]
 
 [appendix]
 include::common/modules/proc_troubleshooting-permission-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?
* Created a new assembly and added Upgrading RH Satellite module into a new assembly.
* Moved the upgrade-related modules under the new assembly structure.
* Updated module inclusions to use the assembly hierarchy instead of relying on `leveloffset=+2`.
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
* The previous structure relied on leveloffset=+2 to maintain the document hierarchy. Converting the upgrade content into an assembly provides a more modular and maintainable structure that aligns with modular documentation practices.
* The new structure establishes a clear parent-child relationship between the upgrade content and its associated modules, improving content organization and reducing dependence on level offsets.

#### Contributor checklists
* The content itself remains unchanged; only the document structure has been reorganized.
* This change simplifies future maintenance by making the hierarchy explicit in the assembly rather than through include-time level adjustments.

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
