### PR TITLE
Release Foreman 3.19.0, deprecate 3.17

### DIFF
--- a/web/releases/3.17.json
+++ b/web/releases/3.17.json
@@ -1,6 +1,6 @@
 {
   "katello": "4.19",
-  "state": "supported",
+  "state": "unsupported",
   "builds": [
     {
       "title": "Katello on EL",

--- a/web/releases/3.19.json
+++ b/web/releases/3.19.json
@@ -1,6 +1,6 @@
 {
   "katello": "4.21",
-  "state": "RC",
+  "state": "supported",
   "builds": [
     {
       "title": "Katello on EL",


### PR DESCRIPTION
#### What changes are you introducing?
Config changes. Flag 3.19.0 GA, deprecate 3.17
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
