### PR TITLE
Update Katello 4.21.0 release notes and contributors

### DIFF
--- a/guides/doc-Release_Notes/topics/katello-4.21.0.adoc
+++ b/guides/doc-Release_Notes/topics/katello-4.21.0.adoc
@@ -4,15 +4,21 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 == Katello
 
+* pass:[Organization destroy fails with 'Couldn't find Katello::Repository' after PR #11762] - https://projects.theforeman.org/issues/39392[#39392]
 * pass:[Fix typos and scan issues for rubygem-katello] - https://projects.theforeman.org/issues/39136[#39136]
 * pass:[Structured APT migration rake task not marked as applied if there are no deb repos during upgrade] - https://projects.theforeman.org/issues/39091[#39091]
 * pass:[Remove remainder of entitlement mode code] - https://projects.theforeman.org/issues/39078[#39078]
 * pass:[Add warning for Change Content Source] - https://projects.theforeman.org/issues/39072[#39072]
 
+=== API
+
+* pass:[API endpoint GET /api/host_packages/installed_packages in apidoc is wrong] - https://projects.theforeman.org/issues/39351[#39351]
+* pass:[Non-admin users cannot curl /rhsm/ endpoints even if they have proper permissions] - https://projects.theforeman.org/issues/39313[#39313]
+
 === Activation Key
 
 * pass:[API call to list the activation keys associated with a specific lifecycle environment returns all activation keys in the organization] - https://projects.theforeman.org/issues/39252[#39252]
-* pass:[Remove activation key in host group does not work in Web UI] - https://projects.theforeman.org/issues/38928[#38928]
+* pass:[Remove Activation Key in Hostgroup does not work on UI] - https://projects.theforeman.org/issues/38928[#38928]
 
 === Alternate Content Sources
 
@@ -24,10 +30,11 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 === Container
 
-* pass:[Repository update ID parameter in hammer command in docker repos is failing] - https://projects.theforeman.org/issues/39186[#39186]
+* pass:[Repository update ID parameter in hammer command in docker repos is failing.] - https://projects.theforeman.org/issues/39186[#39186]
 
 === Content Credentials
 
+* pass:[Content Credentials overview - Create modal + Remove action] - https://projects.theforeman.org/issues/39332[#39332]
 * pass:[Missing validation to prevent CC deletion when used by ACS] - https://projects.theforeman.org/issues/39309[#39309]
 * pass:[Content credentials - new details page] - https://projects.theforeman.org/issues/39197[#39197]
 * pass:[New Content Credentials Page - Index page] - https://projects.theforeman.org/issues/39140[#39140]
@@ -35,6 +42,8 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 === Content Views
 
+* pass:[Incremental update fails with undefined method version_href' for nil:NilClass, when multiple content views are assigned] - https://projects.theforeman.org/issues/39379[#39379]
+* pass:[Fail to delete CV / CCV versions with error "The repository version cannot be deleted because it (or its publications) are currently being used to distribute content"] - https://projects.theforeman.org/issues/39346[#39346]
 * pass:[Issue when creating filter in content view using openssl package] - https://projects.theforeman.org/issues/39217[#39217]
 * pass:[Incremental update of content view version should throw error when no content is added] - https://projects.theforeman.org/issues/39214[#39214]
 * pass:[Unable to delete empty CCV] - https://projects.theforeman.org/issues/39155[#39155]
@@ -44,7 +53,8 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 === Foreman Proxy Content
 
-* pass:[n-1/2 Smart Proxy syncs with publication-less Python-type repositories on Pulp 3.105+] - https://projects.theforeman.org/issues/39289[#39289]
+* pass:[Ensure load balanced capsules have same data in auth tables] - https://projects.theforeman.org/issues/39314[#39314]
+* pass:[n-1/2 proxy syncs with publication-less python repos on 3.105+ pulp] - https://projects.theforeman.org/issues/39289[#39289]
 * pass:[Incorrect smart proxy Sync Status after failure] - https://projects.theforeman.org/issues/39203[#39203]
 * pass:[orphan cleanup triggers CapsuleContent::UpdateContentCounts regardless of automatic_content_count_updates setting] - https://projects.theforeman.org/issues/39112[#39112]
 
@@ -54,16 +64,19 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 === Hosts
 
+* pass:[Changing focus doesn't close dropdowns on bulk repository set wizard] - https://projects.theforeman.org/issues/39341[#39341]
 * pass:[Activation Keys tab is blank when creating/editing HostGroup] - https://projects.theforeman.org/issues/39284[#39284]
 * pass:[Applicable/Installable toggle is hidden for hosts assigned to rolling content views] - https://projects.theforeman.org/issues/39282[#39282]
+* pass:[Remove content_facet.uuid usage in favor of subscription_facet.uuid] - https://projects.theforeman.org/issues/39259[#39259]
 * pass:[Unable to save host configuration due to missing variant_repos method] - https://projects.theforeman.org/issues/39258[#39258]
 * pass:[Hosts end up with a nil content source when registered to a foremanctl setup] - https://projects.theforeman.org/issues/39257[#39257]
 * pass:[Hostgroup::ContentFacet should have 1:1 relationship to Content View Environment] - https://projects.theforeman.org/issues/39223[#39223]
 * pass:[As an external Smart Proxy user, the web UI allows me to change hosts' content source and preserve multi-environment hosts] - https://projects.theforeman.org/issues/39216[#39216]
 * pass:[Remove redundant Candlepin pre-flight check and cache /rhsm/status response] - https://projects.theforeman.org/issues/39204[#39204]
+* pass:[Eliminate redundant Candlepin GETs during host registration] - https://projects.theforeman.org/issues/39202[#39202]
 * pass:[Installable updates column has no space between icon and number of updates] - https://projects.theforeman.org/issues/39170[#39170]
 * pass:[Replace JS snapshot tests – Registration Commands] - https://projects.theforeman.org/issues/39168[#39168]
-* pass:[Host links from Packages Details page open Legacy UI instead of new Web UI] - https://projects.theforeman.org/issues/39147[#39147]
+* pass:[Host links from Packages Details page open Legacy UI instead of New UI] - https://projects.theforeman.org/issues/39147[#39147]
 * pass:[Update import of useBulkModal in Katello] - https://projects.theforeman.org/issues/39138[#39138]
 * pass:[bootc information is nullified after Ansible facts upload] - https://projects.theforeman.org/issues/39135[#39135]
 * pass:[MultiCV will get reset after editing a host] - https://projects.theforeman.org/issues/39122[#39122]
@@ -75,12 +88,23 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 
 === Organizations and Locations
 
-* pass:[Migrate SetOrganization from pf3 to pf5] - https://projects.theforeman.org/issues/39307[#39307]
+* pass:[LoadingState component does not clear setTimeout on unmount] - https://projects.theforeman.org/issues/39338[#39338]
+* pass:[[katello] Update SetOrganization from pf3 to pf5] - https://projects.theforeman.org/issues/39307[#39307]
 * pass:[Organization delete fails with HasManyThroughNestedAssociationsAreReadonly on environment destroy] - https://projects.theforeman.org/issues/39280[#39280]
 * pass:[API docs for organizations still show taxonomy params] - https://projects.theforeman.org/issues/39084[#39084]
 
+=== Performance
+
+* pass:[Missing content_facet_id indexes on join tables cause sequential scans at scale] - https://projects.theforeman.org/issues/39358[#39358]
+
+=== Reporting
+
+* pass:[Errata severity macro is not available in 'Host - Applied Errata' report] - https://projects.theforeman.org/issues/39326[#39326]
+
 === Repositories
 
+* pass:[Red Hat container registry authentication not working as expected in Repo Discovery] - https://projects.theforeman.org/issues/39337[#39337]
+* pass:[Generic content pages are not scoped by organization] - https://projects.theforeman.org/issues/39319[#39319]
 * pass:[Some Pulp tasks not tracked due to change in Pulp update APIs] - https://projects.theforeman.org/issues/39305[#39305]
 * pass:[Replace JS snapshot tests - Misc components] - https://projects.theforeman.org/issues/39215[#39215]
 * pass:[Stop using Python publications with pulp_python 3.27] - https://projects.theforeman.org/issues/39205[#39205]

--- a/guides/doc-Release_Notes/topics/katello-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/katello-contributors.adoc
@@ -1,6 +1,8 @@
 Adam Lazik
 Aiden Fine
+Archana Kumari
 Bernhard Suttner
+Cole Higgins
 Eric Helms
 Ian Ballou
 Jeremy Lenz
@@ -8,13 +10,17 @@ Jonathon Turel
 Ladislav Vašina
 Lucy Fu
 Lukáš Ježek
+Markus Bucher
 Nofar Alfasi
 Oleh Fedorenko
 Pablo Méndez Hernández
 Pavan Soma Shekar
+Pavel Moravec
 Quinn James
+Quirin Pamp
 Samir Jha
 Samuel Bible
+Sayan Das
 Tobias Grigo
 Vijaykumar Sawant
 Vladimir Sedmik


### PR DESCRIPTION
## Summary
- Regenerated Katello 4.21.0 release notes from Redmine to include all cherry-picked fixes
- Updated contributors list with new contributors since 4.20 branching

## New entries in release notes
Picks up fixes that were cherry-picked into the 4.21.0 GA release (#39392, #39351, #39313, #39379, #39346, #39314, #39341, #39259, #39202, #39338, #39358, #39326, #39337, #39319, #39332)

## New contributors
Archana Kumari, Cole Higgins, Markus Bucher, Pavel Moravec, Quirin Pamp, Sayan Das