### PR TITLE
Add ISS to normalization strings in the pipeline check

### DIFF
--- a/scripts/check-filename-id-heading-match.sh
+++ b/scripts/check-filename-id-heading-match.sh
@@ -72,6 +72,7 @@ check_file() {
     normalized_id="${normalized_id//\{freeipa-context\}/freeipa}"
     normalized_id="${normalized_id//\{insights-id\}/insights}"
     normalized_id="${normalized_id//\{insights-iop-id\}/insights}"
+    normalized_id="${normalized_id//\{ISS-id\}/iss}"
     normalized_id="${normalized_id//\{foreman-installer\}/foreman-installer}"
     normalized_id="${normalized_id//\{awx-context\}/awx}"
     normalized_id="${normalized_id//\{compute-resource-context\}/computeresource}"
@@ -95,6 +96,7 @@ check_file() {
         normalized_heading="${normalized_heading//\{freeipa\}/freeipa}"
         normalized_heading="${normalized_heading//\{insights\}/insights}"
         normalized_heading="${normalized_heading//\{insights-iop\}/insights}"
+        normalized_heading="${normalized_heading//\{ISS\}/iss}"
         normalized_heading="${normalized_heading//\{nbsp\}/}"  # Remove non-breaking spaces
         normalized_heading="${normalized_heading//\{customssl\}/custom-ssl}"
         normalized_heading="${normalized_heading//\{customfiletype\}/custom-file-type}"

--- a/scripts/check-filename-id-heading-match.sh
+++ b/scripts/check-filename-id-heading-match.sh
@@ -72,7 +72,7 @@ check_file() {
     normalized_id="${normalized_id//\{freeipa-context\}/freeipa}"
     normalized_id="${normalized_id//\{insights-id\}/insights}"
     normalized_id="${normalized_id//\{insights-iop-id\}/insights}"
-    normalized_id="${normalized_id//\{ISS-id\}/iss}"
+    normalized_id="${normalized_id//\{ISS-id\}/inter-server-synchronization}"
     normalized_id="${normalized_id//\{foreman-installer\}/foreman-installer}"
     normalized_id="${normalized_id//\{awx-context\}/awx}"
     normalized_id="${normalized_id//\{compute-resource-context\}/computeresource}"
@@ -96,7 +96,7 @@ check_file() {
         normalized_heading="${normalized_heading//\{freeipa\}/freeipa}"
         normalized_heading="${normalized_heading//\{insights\}/insights}"
         normalized_heading="${normalized_heading//\{insights-iop\}/insights}"
-        normalized_heading="${normalized_heading//\{ISS\}/iss}"
+        normalized_heading="${normalized_heading//\{iss\}/inter-server-synchronization}"
         normalized_heading="${normalized_heading//\{nbsp\}/}"  # Remove non-breaking spaces
         normalized_heading="${normalized_heading//\{customssl\}/custom-ssl}"
         normalized_heading="${normalized_heading//\{customfiletype\}/custom-file-type}"


### PR DESCRIPTION
#### What changes are you introducing?

Adding ISS attributes to the Filename-ID-Heading check

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

<img width="766" height="384" alt="image" src="https://github.com/user-attachments/assets/3259f879-f4fa-42e7-a089-f8a9584d9241" />

Found in #4922 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: **???**

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
