### PR TITLE
Reduce host registration in mng AKs

### DIFF
--- a/guides/common/assembly_managing-activation-keys.adoc
+++ b/guides/common/assembly_managing-activation-keys.adoc
@@ -6,14 +6,6 @@ include::modules/proc_creating-an-activation-key-by-using-web-ui.adoc[leveloffse
 
 include::modules/proc_creating-an-activation-key-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/con_using-activation-keys-for-host-registration.adoc[leveloffset=+1]
-
-include::modules/proc_registering-a-host-to-project-by-using-web-ui.adoc[leveloffset=+2]
-
-include::modules/proc_registering-a-host-to-project-by-using-cli.adoc[leveloffset=+2]
-
-include::modules/proc_registering-a-host-to-project-by-using-api.adoc[leveloffset=+2]
-
 ifdef::katello,satellite,red_hat_enterprise_linux[]
 include::modules/proc_setting-the-service-level-by-using-web-ui.adoc[leveloffset=+1]
 
@@ -25,6 +17,8 @@ endif::[]
 endif::[]
 
 include::modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc[leveloffset=+1]
+
+include::modules/con_activation-keys-and-host-registration.adoc[leveloffset=+1]
 
 include::modules/con_multiple-activation-keys-and-content-view-environments.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_activation-keys-and-host-registration.adoc
+++ b/guides/common/modules/con_activation-keys-and-host-registration.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="Using_Activation_Keys_for_Host_Registration_{context}"]
-= Using activation keys for host registration
+[id="activation-keys-and-host-registration"]
+= Activation keys and host registration
 
 [role="_abstract"]
 You can use activation keys to register new hosts during provisioning through {ProjectName} and register existing {client-os} hosts.
@@ -24,3 +24,6 @@ If there are conflicting settings in activation keys, the rightmost key takes pr
 * Settings that conflict: *Service Level*, *Release Version*, *Environment*, *Content View*, and *Product Content*.
 * Settings that do not conflict and the host gets the union of them: *Host Collections*.
 * Settings that influence the behavior of the key itself and not the host configuration: *Content Host Limit*.
+
+.Additional resources
+* {ManagingHostsDocURL}registering-hosts-to-{project-context}[Registering hosts to {Project} in _{ManagingHostsDocTitle}_]


### PR DESCRIPTION
#### What changes are you introducing?

Reducing information about host registration in the chapter _Managing activation keys_ of _Managing content_

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Host registration is properly documented in _Managing hosts_; no need to duplicate those procedures since they already mention AKs; we can just link to host registration instead

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Shouldn't require tech review. LMK if unsure.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
