### PR TITLE
MCP server should not be deployed on Foreman server

### DIFF
--- a/guides/common/modules/proc_deploying-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/proc_deploying-the-mcp-server-for-project.adoc
@@ -7,7 +7,7 @@
 Deploy the Model Context Protocol (MCP) server for {Project} as a container and make it accessible to your MCP client.
 
 In this scenario, you deploy the MCP server on the same system where your MCP client will run.
-This should be separate from the system {ProjectServer} is running on.
+Do not deploy the MCP server on the system your {ProjectServer} is running on, to avoid insecure communication between the MCP server and client.
 
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_deploying-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/proc_deploying-the-mcp-server-for-project.adoc
@@ -7,7 +7,7 @@
 Deploy the Model Context Protocol (MCP) server for {Project} as a container and make it accessible to your MCP client.
 
 In this scenario, you deploy the MCP server on the same system where your MCP client will run.
-This can also be the system {ProjectServer} is running on.
+This should be separate from the system {ProjectServer} is running on.
 
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_deploying-the-mcp-server-for-project.adoc
+++ b/guides/common/modules/proc_deploying-the-mcp-server-for-project.adoc
@@ -7,7 +7,7 @@
 Deploy the Model Context Protocol (MCP) server for {Project} as a container and make it accessible to your MCP client.
 
 In this scenario, you deploy the MCP server on the same system where your MCP client will run.
-Do not deploy the MCP server on the system your {ProjectServer} is running on, to avoid insecure communication between the MCP server and client.
+Do not deploy the MCP server on your {ProjectServer} to avoid insecure communication between the MCP server and client.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Deploying MCP server on the same system as the Foreman server should be avoided. Edited to reflect this.

JIRA: https://redhat.atlassian.net/browse/SAT-45880

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
