### PR TITLE
Make tuning containerized

### DIFF
--- a/guides/common/modules/proc_configuring-performance-with-tuning-profiles.adoc
+++ b/guides/common/modules/proc_configuring-performance-with-tuning-profiles.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="configuring-performance-with-tuning-profiles"]
+= Configuring performance with tuning profiles
+
+If your {Project} deployment includes a large number of hosts, you can use predefined tuning profiles to configure your {ProjectServer} to use the optimal amount of CPU cores and memory.
+This can help improve {Project} performance.
+
+.Procedure
+. Select the profile that best matches your use case:
++
+.Predefined tuning profiles
+[options="header"]
+|====
+|Tuning profile |Number of hosts |RAM |Number of CPU cores
+|default |0{range}5000 |20G |4
+|medium |5001{range}10000 |32G |8
+|large |10001{range}20000 |64G |16
+|extra-large |20001{range}60000 |128G |32
+|extra-extra-large |60000+ |256G |48+
+|====
+
+. Apply a predefined tuning profile to your {ProjectServer}:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {foremanctl} deploy --tuning _My_profile_
+----
++
+Replace `_My_profile_` with the name of the profile you want to apply.

--- a/guides/common/modules/proc_configuring-performance-with-tuning-profiles.adoc
+++ b/guides/common/modules/proc_configuring-performance-with-tuning-profiles.adoc
@@ -20,7 +20,6 @@ This can help improve {Project} performance.
 |extra-large |20001{range}60000 |128G |32
 |extra-extra-large |60000+ |256G |48+
 |====
-
 . Apply a predefined tuning profile to your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,attributes"]

--- a/guides/common/modules/proc_configuring-performance-with-tuning-profiles.adoc
+++ b/guides/common/modules/proc_configuring-performance-with-tuning-profiles.adoc
@@ -3,6 +3,7 @@
 [id="configuring-performance-with-tuning-profiles"]
 = Configuring performance with tuning profiles
 
+[role="_abstract"]
 If your {Project} deployment includes a large number of hosts, you can use predefined tuning profiles to configure your {ProjectServer} to use the optimal amount of CPU cores and memory.
 This can help improve {Project} performance.
 

--- a/guides/common/modules/proc_tuning-performance-with-predefined-profiles.adoc
+++ b/guides/common/modules/proc_tuning-performance-with-predefined-profiles.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-performance-with-tuning-profiles"]
-= Configuring performance with tuning profiles
+[id="tuning-performance-with-predefined-profiles"]
+= Tuning performance with predefined profiles
 
 [role="_abstract"]
 If your {Project} deployment includes a large number of hosts, you can use predefined tuning profiles to configure your {ProjectServer} to use the optimal amount of CPU cores and memory.

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -21,7 +21,15 @@ include::common/assembly_cloning-project-server.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]
+
+ifdef::containerized[]
+include::common/modules/proc_tuning-performance-with-predefined-profiles.adoc[leveloffset=+1]
+endif::[]
+
+ifndef::containerized[]
 include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]
+endif::[]
+
 endif::[]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -24,7 +24,7 @@ include::common/assembly_preparing-environment-for-project-server-installation.a
 include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 
 ifdef::containerized[]
-include::common/modules/proc_configuring-performance-with-tuning-profiles.adoc[leveloffset=+1]
+include::common/modules/proc_tuning-performance-with-predefined-profiles.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::containerized[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -23,14 +23,16 @@ include::common/assembly_preparing-environment-for-project-server-installation.a
 
 include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
+
 ifdef::containerized[]
 include::common/modules/proc_tuning-performance-with-predefined-profiles.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::containerized[]
-ifdef::katello,orcharhino,satellite[]
 include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]
 endif::[]
+
 endif::[]
 
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -26,6 +26,7 @@ include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 ifdef::containerized[]
 include::common/modules/proc_configuring-performance-with-tuning-profiles.adoc[leveloffset=+1]
 endif::[]
+
 ifndef::containerized[]
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -23,6 +23,9 @@ include::common/assembly_preparing-environment-for-project-server-installation.a
 
 include::common/assembly_installing-server-connected.adoc[leveloffset=+1]
 
+ifdef::containerized[]
+include::common/modules/proc_configuring-performance-with-tuning-profiles.adoc[leveloffset=+1]
+endif::[]
 ifndef::containerized[]
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -32,8 +32,19 @@ include::common/assembly_preparing-environment-for-project-server-installation.a
 
 include::common/assembly_installing-satellite-server-disconnected.adoc[leveloffset=+1]
 
+ifdef::katello,orcharhino,satellite[]
+
+ifdef::containerized[]
+include::common/modules/proc_tuning-performance-with-predefined-profiles.adoc[leveloffset=+1]
+endif::[]
+
 ifndef::containerized[]
 include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]
+endif::[]
+
+endif::[]
+
+ifndef::containerized[]
 
 [id="performing-additional-configuration"]
 == Performing Additional Configuration on {ProjectServer}


### PR DESCRIPTION
#### What changes are you introducing?
Add tuning section to containerized installer docs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-41407

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Because there is no basic or custom hiera in containerized, con_how-predefined-tuning-profiles-apply is excluded.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
