### PR TITLE
DITA premigration changes-Upgrading Project Disconnected

### DIFF
--- a/guides/common/assembly_upgrading-project-disconnected.adoc
+++ b/guides/common/assembly_upgrading-project-disconnected.adoc
@@ -1,0 +1,15 @@
+include::modules/con_upgrading-project.adoc[]
+
+include::modules/proc_upgrading-container-images-of-insights-iop.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-a-disconnected-project-server.adoc[leveloffset=+1]
+
+include::modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-the-external-database-operating-system.adoc[leveloffset=+1]
+
+include::modules/proc_refreshing-clients-of-insights-iop.adoc[leveloffset=+1]
+
+include::modules/proc_upgrading-puppet-agent-7-to-openvox-agent-8.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -47,7 +47,7 @@ This prevents the upgrade process from overwriting your DNS and DHCP configurati
 ----
 
 . Export the required repositories from your connected {ProjectServer} to your disconnected {ProjectServer}:
-.. Ensure that the following repositories are synchronized on your connected server with the download policy set to *Immediate*:
+.. Ensure that your connected server synchronizes the following repositories with the download policy set to *Immediate*:
 +
 * `{RepoRHEL9BaseOS}`
 * `{RepoRHEL9AppStream}`
@@ -60,7 +60,7 @@ This prevents the upgrade process from overwriting your DNS and DHCP configurati
 $ hammer repository list \
 --organization-label _My_Organization_Label_
 ----
-.. Export each repository in the syncable format by using its repository ID:
+.. Export each repository in a format suitable for synchronization by using its repository ID:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
@@ -111,7 +111,7 @@ Keep the `{RepoRHEL9ServerSatelliteServerProjectVersion}` repository disabled.
 ----
 # {foreman-maintain} self-upgrade --maintenance-repo-label={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
 ----
-. Determine whether your system is ready for {Project} upgrade:
+. Check whether your system is ready for {Project} upgrade:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
@@ -123,7 +123,7 @@ Review the results and address any highlighted error conditions before performin
 [NOTE]
 ====
 The `{foreman-maintain} upgrade check` might prompt you for the Hammer admin user credentials.
-These changes are applied to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
+It applies changes to the `/etc/foreman-maintain/foreman-maintain-hammer.yml` file.
 ====
 . Edit the `/etc/yum.repos.d/upgrade.repo` file and enable the `{RepoRHEL9ServerSatelliteServerProjectVersion}` repository:
 +

--- a/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_upgrading-a-disconnected-project-server.adoc
@@ -60,7 +60,7 @@ This prevents the upgrade process from overwriting your DNS and DHCP configurati
 $ hammer repository list \
 --organization-label _My_Organization_Label_
 ----
-.. Export each repository in a format suitable for synchronization by using its repository ID:
+.. Export each repository in the syncable format by using its repository ID:
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_upgrading-container-images-of-insights-iop.adoc
+++ b/guides/common/modules/proc_upgrading-container-images-of-insights-iop.adoc
@@ -16,7 +16,7 @@ If you have {insights-iop} enabled on your {ProjectServer}, prepare the containe
 For more information, see {InstallingServerDisconnectedDocURL}installing-from-the-offline-repositories_{context}[Installing the {Project} packages from the offline repositories] in _{InstallingServerDisconnectedDocTitle}_.
 .. Set up the local repositories for disconnected environments.
 For more information, see {InstallingServerDisconnectedDocURL}installing-from-the-offline-repositories_{context}[Installing the {Project} packages from the offline repositories] in _{InstallingServerDisconnectedDocTitle}_.
-.. Run the container setup script from the mounted ISO so that the {insights-iop} images for {ProjectVersion} are loaded:
+.. Run the container setup script from the mounted ISO to load the {insights-iop} images for {ProjectVersion}:
 +
 [options="nowrap"]
 ----
@@ -30,7 +30,7 @@ For more information, see {InstallingServerDisconnectedDocURL}installing-from-th
 $ skopeo login --username _My_Username_ --password _My_Password_ registry.redhat.io
 ----
 .. On the connected system, export the container images.
-Save the following script to a file and execute it on the connected system so that the {insights-iop} container images for {ProjectVersion} are exported:
+Save the following script to a file and run it on the connected system to export the {insights-iop} container images for {ProjectVersion}:
 +
 [bash, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -65,7 +65,7 @@ done
 ----
 .. Transfer the archive files from `/tmp/` on the connected server to the `/tmp/` directory on the disconnected {ProjectServer}.
 .. On the disconnected {ProjectServer}, import the container images.
-Save the following script to a file and execute it on the disconnected {ProjectServer} so that the {insights-iop} container images for {ProjectVersion} are imported:
+Save the following script to a file and run it on the disconnected {ProjectServer} to import the {insights-iop} container images for {ProjectVersion}:
 +
 [bash, options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/doc-Upgrading_Project_Disconnected/master.adoc
+++ b/guides/doc-Upgrading_Project_Disconnected/master.adoc
@@ -29,21 +29,7 @@ include::common/modules/con_red-hat-offline-knowledge-portal.adoc[leveloffset=+1
 
 include::common/assembly_preparing-for-project-upgrade.adoc[leveloffset=+1]
 
-include::common/modules/con_upgrading-project.adoc[leveloffset=+1]
-
-include::common/modules/proc_upgrading-container-images-of-insights-iop.adoc[leveloffset=+2]
-
-include::common/modules/proc_upgrading-a-disconnected-project-server.adoc[leveloffset=+2]
-
-include::common/modules/proc_synchronizing-the-new-repositories.adoc[leveloffset=+2]
-
-include::common/modules/proc_upgrading-smartproxy-server.adoc[leveloffset=+2]
-
-include::common/modules/proc_upgrading-the-external-database-operating-system.adoc[leveloffset=+2]
-
-include::common/modules/proc_refreshing-clients-of-insights-iop.adoc[leveloffset=+2]
-
-include::common/modules/proc_upgrading-puppet-agent-7-to-openvox-agent-8.adoc[leveloffset=+2]
+include::common/assembly_upgrading-project-disconnected.adoc[leveloffset=+1]
 
 :!numbered:
 


### PR DESCRIPTION
#### What changes are you introducing?

* Fixed Vale validation issues across the guide. Here is the link to [the report](https://docs.google.com/spreadsheets/d/1Tlakxtr6DyW2PMfao6DPLXEQ2-vI6ciXAP6QmoToEZ8/edit?usp=sharing) for reference. 
* Restructured the guide to remove the `leveloffset=+2` dependency in `master.adoc` file.
* Added an assembly module and updated content organization to align with the modular documentation structure used in other guides.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
* To address Vale linting issues and improve documentation quality.
* To simplify the document structure and eliminate the need for `leveloffset=+2` making the content easier to maintain.
* To ensure consistency with the structure and organization of other documentation guides.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
* These changes are structural only and do not introduce significant content changes.
* The updated organization improves maintainability and consistency across the documentation set.
* Alternative approaches, such as retaining the existing structure and adjusting offsets, were considered but would have continued to add complexity and inconsistency.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
