### PR TITLE
Add link to connected installation for IoP

### DIFF
--- a/guides/common/modules/con_prerequisites-for-using-insights-iop.adoc
+++ b/guides/common/modules/con_prerequisites-for-using-insights-iop.adoc
@@ -7,7 +7,9 @@
 Your environment must meet certain requirements before you can use {insights-iop}.
 
 * You have installed {insights-iop} on your {ProjectServer}.
-For more information, see {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}] in _{InstallingServerDisconnectedDocTitle}_.
+For more information, see one of the following resources:
+** {InstallingServerDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}] in _{InstallingServerDocTitle}_
+** {InstallingServerDisconnectedDocURL}installing-and-configuring-{insights-iop-id}[Installing and configuring {insights-iop}] in _{InstallingServerDisconnectedDocTitle}_
 * Install and configure the Insights client on hosts during host registration or provisioning.
 For more information, see xref:registering-hosts-by-using-global-registration[].
 * For hosts already registered to {Project}, install and configure the Insights client on your hosts by using an Ansible role.


### PR DESCRIPTION
#### What changes are you introducing?

Adding a link to the connected installation guide to IoP prerequisites

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

IoP can be used in both connected and disconnected environments. Mentioning just disconnected makes the prerequisites misleading.

[SAT-43604](https://redhat.atlassian.net/browse/SAT-43604)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
