### PR TITLE
Pre-migration CQA task for the REST API title

### DIFF
--- a/guides/common/modules/con_api-call-authentication.adoc
+++ b/guides/common/modules/con_api-call-authentication.adoc
@@ -4,5 +4,4 @@
 = API call authentication
 
 [role="_abstract"]
-Interaction with the {Project} API requires SSL authentication with {ProjectServer} CA certificate and authentication with valid {Project} user credentials.
-You can use the following authentication methods.
+You must authenticate API calls to {ProjectServer} by using SSL certificates and valid user credentials, with options for HTTP basic authentication, SSL client certificates, or personal access tokens.

--- a/guides/common/modules/con_api-cheat-sheet.adoc
+++ b/guides/common/modules/con_api-cheat-sheet.adoc
@@ -4,7 +4,12 @@
 = API cheat sheet
 
 [role="_abstract"]
-You can review the following examples of how to use the {ProjectName} API to perform various tasks.
+ifdef::foreman-el,foreman-deb[]
+Use the {ProjectName} API to automate host management and searches.
+endif::[]
+ifdef::katello,orcharhino,satellite[]
+Use the {ProjectName} API to automate host management, lifecycle environments, content uploads, and searches.
+endif::[]
 
 You can use the API on {ProjectServer} via HTTPS on port 443.
 

--- a/guides/common/modules/con_api-request-composition.adoc
+++ b/guides/common/modules/con_api-request-composition.adoc
@@ -4,7 +4,8 @@
 = API request composition
 
 [role="_abstract"]
-You can use the information from the built-in API reference documentation to compose API requests.
+You can use the built-in API reference documentation to compose valid API requests.
+
 This example shows how to compose a `curl` API request.
 
 The built-in API reference shows the API route, or path, preceded by an HTTP method:

--- a/guides/common/modules/con_api-requests-in-various-languages.adoc
+++ b/guides/common/modules/con_api-requests-in-various-languages.adoc
@@ -4,4 +4,4 @@
 = API requests in various languages
 
 [role="_abstract"]
-You can review the following examples of sending API requests to {ProjectName} from curl, Ruby, or Python.
+You can interact with {Project} API using `curl` for quick testing, Ruby for automation scripts with apipie bindings, or Python for integration with existing Python-based workflows.

--- a/guides/common/modules/con_api-syntax.adoc
+++ b/guides/common/modules/con_api-syntax.adoc
@@ -4,7 +4,7 @@
 = API syntax
 
 [role="_abstract"]
-You can review the basic syntax of API requests and JSON responses.
+Understanding the basic syntax of API requests and JSON responses enables you to construct valid API calls and interpret the returned data.
 
 [IMPORTANT]
 ====

--- a/guides/common/modules/con_calling-the-api-in-curl.adoc
+++ b/guides/common/modules/con_calling-the-api-in-curl.adoc
@@ -4,7 +4,7 @@
 = Calling the API in curl
 
 [role="_abstract"]
-You can use `curl` with the {Project} API to perform various tasks.
+You can use `curl` to test API endpoints, debug requests, and perform quick operations without writing scripts.
 
 You can use `curl` to manipulate resources on your {ProjectServer}.
 API calls to {Project} require data in `json` format.

--- a/guides/common/modules/con_calling-the-api-in-python.adoc
+++ b/guides/common/modules/con_calling-the-api-in-python.adoc
@@ -4,7 +4,7 @@
 = Calling the API in Python
 
 [role="_abstract"]
-You can use Python with the {Project} API to perform various tasks.
+You can use Python with the `requests` module to integrate {Project} API calls into existing Python automation workflows, data processing pipelines, or DevOps tooling.
 
 [IMPORTANT]
 ====

--- a/guides/common/modules/con_calling-the-api-in-ruby.adoc
+++ b/guides/common/modules/con_calling-the-api-in-ruby.adoc
@@ -4,7 +4,8 @@
 = Calling the API in Ruby
 
 [role="_abstract"]
-You can use Ruby with the {Project} API to perform various tasks.
+You can use Ruby to automate complex {Project} workflows. 
+Use REST client libraries or apipie bindings to get type-safe API calls with built-in validation.
 
 [IMPORTANT]
 ====

--- a/guides/common/modules/con_http-authentication-overview.adoc
+++ b/guides/common/modules/con_http-authentication-overview.adoc
@@ -4,8 +4,9 @@
 = HTTP authentication overview
 
 [role="_abstract"]
-All requests to the {Project} API require a valid {Project} user name and password.
-The API uses Basic HTTP authentication to encode these credentials and add to the `Authorization` header.
+You must provide valid {Project} credentials to access the {Project} API.
+
+The API uses HTTP Basic authentication to send encoded user credentials in the `Authorization` header.
 If a request does not include an appropriate `Authorization` header, the API returns a `401 Authorization Required` error.
 
 [IMPORTANT]

--- a/guides/common/modules/con_introduction-to-project-api.adoc
+++ b/guides/common/modules/con_introduction-to-project-api.adoc
@@ -4,6 +4,5 @@
 = Introduction to {Project} API
 
 [role="_abstract"]
-{ProjectName} provides a Representational State Transfer (REST) API.
-The API provides software developers and system administrators with control over their {ProjectName} environment outside of the standard web interface.
-The REST API is useful for developers and administrators who aim to integrate the functionality of {ProjectName} with custom scripts or external applications that access the API over HTTP.
+With the Representational State Transfer (REST) API of {Project}, you can control your {Project} environment outside of the standard web interface.
+That way, you can integrate your {Project} with custom scripts or external applications over HTTP.

--- a/guides/common/modules/con_json-response-format.adoc
+++ b/guides/common/modules/con_json-response-format.adoc
@@ -4,5 +4,4 @@
 = JSON response format
 
 [role="_abstract"]
-Calls to the API return results in JSON format.
-The API call returns the result for a single-option response or for responses collections.
+{Project} API returns results in JSON format, which you can parse programmatically to extract data from single-object responses or collections responses.

--- a/guides/common/modules/con_overview-of-the-project-api.adoc
+++ b/guides/common/modules/con_overview-of-the-project-api.adoc
@@ -4,7 +4,8 @@
 = Overview of the {Project} API
 
 [role="_abstract"]
-The {Project} API offers several benefits and supports various use cases for integrating the API into your workflows.
+Integrate with enterprise systems, automate repetitive tasks, and manage your infrastructure programmatically using the resource-based REST model of the {Project} API.
+You can use any HTTP client to interact with {Project}.
 
 The benefits of using the REST API are:
 

--- a/guides/common/modules/con_project-api-compared-to-hammer-cli.adoc
+++ b/guides/common/modules/con_project-api-compared-to-hammer-cli.adoc
@@ -7,6 +7,12 @@
 Hammer serves as a human-friendly interface to {Project} API.
 Use Hammer for interactive tasks and testing API calls, but use the API directly for better performance when executing many commands in scripts.
 
+For example, to test responses to API calls before applying them in a script, use the `--debug` option to inspect API calls that Hammer issues: `hammer --debug organization list`.
+
+In the background, each Hammer command first establishes a binding to the API, then sends a request.
+This can have performance implications when executing a large number of Hammer commands in sequence.
+In contrast, a script communicating directly with the API establishes the binding only once.
+
 .Additional resources
 ifdef::rest-api[]
 * {HammerDocURL}[_{HammerDocTitle}_]
@@ -14,3 +20,4 @@ endif::[]
 ifdef::hammer-cli[]
 * {APIDocURL}[_{APIDocTitle}_]
 endif::[]
+* {AnsibleDocURL}[_{AnsibleDocTitle}_]

--- a/guides/common/modules/con_ssl-authentication-overview.adoc
+++ b/guides/common/modules/con_ssl-authentication-overview.adoc
@@ -4,7 +4,9 @@
 = SSL authentication overview
 
 [role="_abstract"]
-{ProjectName} uses HTTPS, which provides a degree of encryption and identity verification when communicating with {ProjectServer}.
+{ProjectName} requires HTTPS for all API communications to provide encryption and identity verification.
+You can use either self-signed certificates or custom SSL certificates you configure.
+
 {Project} {ProjectVersion} does not support non-SSL communications.
 
 By default, {ProjectServer} uses a self-signed certificate.

--- a/guides/common/modules/con_token-authentication-overview.adoc
+++ b/guides/common/modules/con_token-authentication-overview.adoc
@@ -4,5 +4,5 @@
 = Token authentication overview
 
 [role="_abstract"]
-{ProjectName} supports {PAT}s that you can use to authenticate API requests instead of using your password.
-You can set an expiration date for your {PAT} and you can revoke it if you decide it should expire before the expiration date.
+You can use {PAT}s to authenticate API requests instead of passwords.
+Additionally, you can manage your security by setting expiration dates or revoking tokens at any time.

--- a/guides/common/modules/con_working-with-hosts.adoc
+++ b/guides/common/modules/con_working-with-hosts.adoc
@@ -4,4 +4,5 @@
 = Working with hosts
 
 [role="_abstract"]
-Review the following examples to understand how to compose API requests that target host entries.
+You can use API requests to manage hosts.
+Namely, you can list, query, search, and delete hosts programmatically.

--- a/guides/common/modules/con_working-with-lifecycle-environments.adoc
+++ b/guides/common/modules/con_working-with-lifecycle-environments.adoc
@@ -4,8 +4,8 @@
 = Working with lifecycle environments
 
 [role="_abstract"]
-{Project} divides application life cycles into lifecycle environments, which represent each stage of the application life cycle.
-Lifecycle environments are linked to from an environment path.
+Lifecycle environments represent stages in your application life cycle such as development, testing, and production, enabling controlled content promotion through linked lifecycle environment paths.
+
 To create linked lifecycle environments with the API, use the `prior_id` parameter.
 
 You can find the built-in API reference for lifecycle environments at `https://_{foreman-example-com}_/apidoc/v2/lifecycle_environments.html`.

--- a/guides/common/modules/proc_configuring-ssl-authentication.adoc
+++ b/guides/common/modules/proc_configuring-ssl-authentication.adoc
@@ -4,7 +4,7 @@
 = Configuring SSL authentication
 
 [role="_abstract"]
-Configure an SSL authentication for the API requests to {ProjectServer}.
+Configure SSL authentication to enable secure API requests to {Project} by installing and trusting the CA certificate.
 
 .Procedure
 . Obtain a certificate from your {ProjectServer} by using one of the following options:

--- a/guides/common/modules/proc_creating-linked-lifecycle-environments.adoc
+++ b/guides/common/modules/proc_creating-linked-lifecycle-environments.adoc
@@ -4,7 +4,8 @@
 = Creating linked lifecycle environments
 
 [role="_abstract"]
-Use this example to create a path of lifecycle environments.
+Create a linked path of lifecycle environments to establish a controlled content promotion workflow from development through testing to production stages.
+
 This procedure uses the default Library environment with ID `1` as the starting point for creating lifecycle environments.
 
 .Procedure

--- a/guides/common/modules/proc_deleting-openscap-reports.adoc
+++ b/guides/common/modules/proc_deleting-openscap-reports.adoc
@@ -4,9 +4,7 @@
 = Deleting OpenSCAP reports
 
 [role="_abstract"]
-In {ProjectServer}, you can delete one or more OpenSCAP reports.
-However, when you delete reports, you must delete one page at a time.
-If you want to delete all OpenSCAP reports, use the bash script that follows.
+Delete OpenSCAP compliance reports to free up storage space or remove outdated scan results, either individually by ID or in bulk using a bash script for large-scale cleanup.
 
 .Procedure
 . List all OpenSCAP reports.

--- a/guides/common/modules/proc_modifying-a-smart-class-parameter-by-using-an-external-file.adoc
+++ b/guides/common/modules/proc_modifying-a-smart-class-parameter-by-using-an-external-file.adoc
@@ -4,10 +4,9 @@
 = Modifying a Smart Class parameter by using an external file
 
 [role="_abstract"]
-You can modify a Puppet Smart Class parameter by using an external file.
+You can modify Puppet Smart Class parameters by using external JSON files to simplify working with complex parameter values. 
+That way, you can enable syntax highlighting and error detection in your editor.
 
-Using external files simplifies working with JSON data.
-You can use an editor with syntax highlighting to avoid and locate mistakes.
 This example uses a MOTD Puppet manifest.
 
 .Procedure

--- a/guides/common/modules/proc_overriding-smart-class-parameters.adoc
+++ b/guides/common/modules/proc_overriding-smart-class-parameters.adoc
@@ -4,7 +4,9 @@
 = Overriding Smart Class parameters
 
 [role="_abstract"]
-You can search for Smart Parameters by using the API and supply a value to override a Smart Parameter in a Class.
+You can override Smart Class parameters to customize Puppet configuration values for specific hosts or host groups.
+This way you customize different environments without changing the original Puppet classes.
+
 You can find the full list of attributes that you can modify in the built-in API reference at `https://_{foreman-example-com}_/apidoc/v2/smart_class_parameters/update.html`.
 
 .Procedure

--- a/guides/common/modules/proc_uploading-content-larger-than-2-mb.adoc
+++ b/guides/common/modules/proc_uploading-content-larger-than-2-mb.adoc
@@ -4,7 +4,8 @@
 = Uploading content larger than 2 MB
 
 [role="_abstract"]
-The following example demonstrates how to split a large file into chunks, create an upload request, upload the individual files, import them to {Project}, and then delete the upload request.
+To upload packages and ISO images that are larger than 2 MB, split them into smaller chunks before uploading each piece to repositories in {Project} sequentially.
+
 Note that this example uses sample content, host names, user names, repository ID, and file names.
 
 .Procedure

--- a/guides/common/modules/proc_uploading-content-to-projectserver.adoc
+++ b/guides/common/modules/proc_uploading-content-to-projectserver.adoc
@@ -4,9 +4,9 @@
 = Uploading Content to {ProjectServer}
 
 [role="_abstract"]
-You can use the {Project} API to upload and import large files to your {ProjectServer}.
+You can upload and import files up to 2 MB to {customrepos} on {Project}, automate content management for packages, scripts, and other repository artifacts.
 
-This process involves four steps:
+This process involves the following steps:
 
 . Create an upload request.
 . Upload the content.

--- a/guides/common/modules/proc_uploading-duplicate-content.adoc
+++ b/guides/common/modules/proc_uploading-duplicate-content.adoc
@@ -4,7 +4,7 @@
 = Uploading duplicate content
 
 [role="_abstract"]
-You can reuse existing content in {Project} instead of uploading duplicate content to {Project} through the API.
+Reuse existing content when uploading files with matching checksums to save storage space and transfer time.
 
 .Procedure
 * Upload content to {Project}:

--- a/guides/common/modules/proc_using-extended-searches.adoc
+++ b/guides/common/modules/proc_using-extended-searches.adoc
@@ -4,7 +4,9 @@
 = Using extended searches
 
 [role="_abstract"]
-You can find search parameters that you can use to build your search queries in the {ProjectWebUI}.
+You can combine search parameters in your API queries to filter hosts. 
+This way you can target specific hosts by their operating system or hardware model.
+
 For more information, see {AdministeringDocURL}working-efficiently-with-web-ui[Working efficiently with {ProjectWebUI}] in _{AdministeringDocTitle}_.
 
 For example, you can search for hosts.

--- a/guides/common/modules/proc_using-the-delete-http-method.adoc
+++ b/guides/common/modules/proc_using-the-delete-http-method.adoc
@@ -4,8 +4,9 @@
 = Using the DELETE HTTP method
 
 [role="_abstract"]
-To delete a resource, use the DELETE method with an API route that includes the ID of the resource you want to delete.
-This example deletes the `TestKey` activation key which ID is 2.
+Use the DELETE HTTP method with an API route to permanently remove resources such as activation keys or hosts from {Project}.
+
+This example deletes the `TestKey` activation key, whose ID is 2.
 
 .Procedure
 * Submit a DELETE request by using `curl`.

--- a/guides/common/modules/proc_using-the-post-http-method.adoc
+++ b/guides/common/modules/proc_using-the-post-http-method.adoc
@@ -4,7 +4,8 @@
 = Using the POST HTTP method
 
 [role="_abstract"]
-Use the POST HTTP verb to submit data to the API to create an entry or resource.
+Use the POST HTTP method to create new resources such as activation keys or hosts.
+
 You must submit the data in JSON format.
 For more information, see xref:passing-json-data-to-the-api-request[].
 

--- a/guides/common/modules/proc_using-the-put-http-method.adoc
+++ b/guides/common/modules/proc_using-the-put-http-method.adoc
@@ -4,11 +4,10 @@
 = Using the PUT HTTP method
 
 [role="_abstract"]
-Use the PUT HTTP method to change an existing value or append to an existing resource.
+Use the PUT HTTP method to update existing resources such as changing activation key properties or host configurations.
+
 You must submit the data in JSON format.
 For more information, see xref:passing-json-data-to-the-api-request[].
-
-This example updates the `TestKey` activation key created in the previous example.
 
 .Procedure
 . Edit the `activation-key.json` file created previously as follows:

--- a/guides/common/modules/ref_creating-a-user.adoc
+++ b/guides/common/modules/ref_creating-a-user.adoc
@@ -4,6 +4,8 @@
 = Creating a user
 
 [role="_abstract"]
+You can create {Project} user accounts using POST requests.
+
 This example adds a user account named `_test_user_`.
 
 Example API request::

--- a/guides/common/modules/ref_creating-objects-by-using-python.adoc
+++ b/guides/common/modules/ref_creating-objects-by-using-python.adoc
@@ -4,9 +4,11 @@
 = Creating objects by using Python
 
 [role="_abstract"]
-This script connects to the {ProjectNameX} API, creates an organization, and then creates three environments in the organization.
+You can use the Python `requests` module to create {Project} organizations and lifecycle environments programmatically. 
+
+This script connects to the {Project} API, creates an organization, and then creates three lifecycle environments in the organization.
 If the organization already exists, the script uses that organization.
-If any of the environments already exist in the organization, the script raises an error and quits.
+If any of the lifecycle environments already exist in the organization, the script returns an error and exits.
 
 [source, Python, subs="attributes"]
 ----

--- a/guides/common/modules/ref_creating-objects-by-using-ruby.adoc
+++ b/guides/common/modules/ref_creating-objects-by-using-ruby.adoc
@@ -4,9 +4,11 @@
 = Creating objects by using Ruby
 
 [role="_abstract"]
+You can use Ruby-based REST clients to create {Project} organizations and lifecycle environments programmatically, with built-in error handling for existing resources.
+
 This script connects to the {ProjectNameX} API, creates an organization, and then creates three lifecycle environments in the organization.
 If the organization already exists, the script uses that organization.
-If any of the lifecycle environments already exist in the organization, the script raises an error and quits.
+If any of the lifecycle environments already exist in the organization, the script returns an error and exits.
 
 [source, ruby, subs="attributes"]
 ----

--- a/guides/common/modules/ref_deleting-a-host.adoc
+++ b/guides/common/modules/ref_deleting-a-host.adoc
@@ -4,7 +4,9 @@
 = Deleting a host
 
 [role="_abstract"]
-This request deletes a host with a name _host1.example.com_.
+You can permanently remove a host from {Project} when decommissioning a server, reclaiming software subscriptions, or clearing out stale inventory data to maintain accurate compliance reporting.
+
+This example request deletes a host with a name _host1.example.com_.
 
 Example API request::
 +

--- a/guides/common/modules/ref_deleting-a-lifecycle-environment.adoc
+++ b/guides/common/modules/ref_deleting-a-lifecycle-environment.adoc
@@ -4,7 +4,7 @@
 = Deleting a lifecycle environment
 
 [role="_abstract"]
-You can delete a lifecycle environment if it has no successor.
+You can remove lifecycle environments that have no successors to clean up unused promotion paths.
 
 When deleting lifecycle environments, delete them in reverse order.
 

--- a/guides/common/modules/ref_deleting-a-lifecycle-environment.adoc
+++ b/guides/common/modules/ref_deleting-a-lifecycle-environment.adoc
@@ -4,7 +4,7 @@
 = Deleting a lifecycle environment
 
 [role="_abstract"]
-You can remove lifecycle environments that have no successors to clean up unused promotion paths.
+You can remove lifecycle environments that have no successors to clear unused promotion paths.
 
 When deleting lifecycle environments, delete them in reverse order.
 

--- a/guides/common/modules/ref_downloading-a-full-host-boot-disk-image.adoc
+++ b/guides/common/modules/ref_downloading-a-full-host-boot-disk-image.adoc
@@ -4,6 +4,8 @@
 = Downloading a full-host boot disk image
 
 [role="_abstract"]
+You can download a bootable ISO image for a host to handle provisioning or recovery scenarios.
+
 This request downloads a full boot disk image for a host by its ID.
 
 Example API request::

--- a/guides/common/modules/ref_json-response-format-for-collections.adoc
+++ b/guides/common/modules/ref_json-response-format-for-collections.adoc
@@ -4,8 +4,8 @@
 = JSON response format for collections
 
 [role="_abstract"]
-Collections are a list of objects such as hosts and domains.
-The format for a collection JSON response consists of a metadata fields section and a results section.
+Collections return lists of objects, such as hosts and domains.
+Each response includes pagination metadata and a results section containing the data you can iterate through.
 
 This is an example of the format for a collection request for a list of {Project} domains:
 

--- a/guides/common/modules/ref_listing-host-facts.adoc
+++ b/guides/common/modules/ref_listing-host-facts.adoc
@@ -4,6 +4,8 @@
 = Listing host facts
 
 [role="_abstract"]
+You can retrieve system facts such as hardware details, BIOS version, and installed software for a specific host.
+
 This request returns all facts for the host `{foreman-example-com}`.
 
 Example API request::

--- a/guides/common/modules/ref_listing-hosts.adoc
+++ b/guides/common/modules/ref_listing-hosts.adoc
@@ -4,6 +4,8 @@
 = Listing hosts
 
 [role="_abstract"]
+You can retrieve a list of all registered hosts from {Project}.
+
 This example returns a list of registered hosts.
 
 Example API request::

--- a/guides/common/modules/ref_listing-lifecycle-environments.adoc
+++ b/guides/common/modules/ref_listing-lifecycle-environments.adoc
@@ -4,7 +4,7 @@
 = Listing lifecycle environments
 
 [role="_abstract"]
-Use this API call to list all the current lifecycle environments on your {Project} for the default organization with ID `1`.
+You can retrieve all lifecycle environments for an organization to view your content promotion paths.
 
 Example API request::
 +

--- a/guides/common/modules/ref_modifying-a-user.adoc
+++ b/guides/common/modules/ref_modifying-a-user.adoc
@@ -4,7 +4,9 @@
 = Modifying a user
 
 [role="_abstract"]
-This example modifies given name and login of a user account named `test_user`.
+You can modify {Project} user accounts using PUT requests by specifying the user ID and the fields you want to update, such as login name or email address.
+
+This example changes the given name and login for the `test_user` account.
 
 Example API request::
 +

--- a/guides/common/modules/ref_passing-json-data-to-the-api-request.adoc
+++ b/guides/common/modules/ref_passing-json-data-to-the-api-request.adoc
@@ -4,8 +4,7 @@
 = Passing JSON data to the API request
 
 [role="_abstract"]
-You can pass data to {ProjectServer} with the API request.
-The data must be in JSON format.
+You can pass JSON-formatted data to {Project} API requests either as inline strings or external files.
 
 When specifying JSON data with the `--data` option, you must set the following HTTP headers with the `--header` option:
 

--- a/guides/common/modules/ref_requesting-information-for-a-host.adoc
+++ b/guides/common/modules/ref_requesting-information-for-a-host.adoc
@@ -4,7 +4,9 @@
 = Requesting information for a host
 
 [role="_abstract"]
-This request returns information for the host `{foreman-example-com}`.
+You can retrieve detailed information about a specific host, including architecture, build status, and capabilities.
+
+This request returns information for `host.example.com`.
 
 Example API request::
 +
@@ -13,7 +15,7 @@ Example API request::
 $ curl \
 --request GET \
 --user _My_User_Name_:__My_Password__ \
-https://_{foreman-example-com}_/api/v2/hosts/_{foreman-example-com}_ \
+https://_{foreman-example-com}_/api/v2/hosts/_host.example.com_ \
 | python3 -m json.tool
 ----
 
@@ -29,7 +31,7 @@ Example API response::
     "capabilities": [
         "build"
     ],
-    "certname": "_{foreman-example-com}_",
+    "certname": "_host.example.com_",
     "comment": null,
     "compute_profile_id": null,
     ...

--- a/guides/common/modules/ref_retrieving-a-list-of-resources.adoc
+++ b/guides/common/modules/ref_retrieving-a-list-of-resources.adoc
@@ -4,8 +4,7 @@
 = Retrieving a list of resources
 
 [role="_abstract"]
-This section outlines how to use `curl` with the {Project} API to request information from {Project}.
-These examples include both requests and responses.
+You can retrieve lists of {Project} resources such as users, hosts, or organizations using GET requests, with responses containing both metadata for pagination and the actual resource data.
 
 This example is a basic request that returns a list of {Project} resources, {Project} users in this case.
 Such requests return a list of data wrapped in metadata, while other request types only return the actual object.

--- a/guides/common/modules/ref_retrieving-resource-information-by-using-python.adoc
+++ b/guides/common/modules/ref_retrieving-resource-information-by-using-python.adoc
@@ -4,7 +4,8 @@
 = Retrieving resource information by using Python
 
 [role="_abstract"]
-This is an example script that uses Python for various API requests.
+You can use Python to retrieve and display {Project} resource information such as host details, facts, and subscriptions.
+With this script, you can then format the {Project} API response specifically for your reporting or monitoring workflows.
 
 [source, Python, subs="attributes"]
 ----

--- a/guides/common/modules/ref_returning-multiple-pages.adoc
+++ b/guides/common/modules/ref_returning-multiple-pages.adoc
@@ -4,8 +4,7 @@
 = Returning multiple pages
 
 [role="_abstract"]
-You can use a `for` loop structure to get multiple pages of results.
-This example returns pages 1 to 3 of Content Views with 5 results per page.
+You can iterate through multiple pages of API results to retrieve complete datasets when the total number of items exceeds the per-page limit.
 
 Bash script::
 +

--- a/guides/common/modules/ref_searching-for-hosts-in-an-environment.adoc
+++ b/guides/common/modules/ref_searching-for-hosts-in-an-environment.adoc
@@ -4,6 +4,8 @@
 = Searching for hosts in an environment
 
 [role="_abstract"]
+You can filter hosts by environment to retrieve all hosts assigned to a specific environment.
+
 This query returns all hosts in the `production` environment.
 
 Example API request::

--- a/guides/common/modules/ref_searching-for-hosts-with-a-specific-fact-value.adoc
+++ b/guides/common/modules/ref_searching-for-hosts-with-a-specific-fact-value.adoc
@@ -4,6 +4,8 @@
 = Searching for hosts with a specific fact value
 
 [role="_abstract"]
+You can filter hosts by specific fact values such as host group, operating system, or custom facts.
+
 This query returns all hosts with the host group `My Host Group`.
 
 Example API request::

--- a/guides/common/modules/ref_searching-for-hosts-with-matching-patterns.adoc
+++ b/guides/common/modules/ref_searching-for-hosts-with-matching-patterns.adoc
@@ -4,6 +4,8 @@
 = Searching for hosts with matching patterns
 
 [role="_abstract"]
+You can filter hosts by hostname patterns or other matching criteria.
+
 This query returns all hosts that match the pattern "example".
 
 Example API request::

--- a/guides/common/modules/ref_updating-a-lifecycle-environment.adoc
+++ b/guides/common/modules/ref_updating-a-lifecycle-environment.adoc
@@ -4,7 +4,8 @@
 = Updating a lifecycle environment
 
 [role="_abstract"]
-You can update a lifecycle environment using a PUT command.
+You can modify lifecycle environment attributes such as name or description using a POST request.
+
 This example request updates a description of the lifecycle environment with ID `3`.
 
 Example API request::

--- a/guides/common/modules/ref_using-apipie-bindings-with-ruby.adoc
+++ b/guides/common/modules/ref_using-apipie-bindings-with-ruby.adoc
@@ -4,8 +4,8 @@
 = Using apipie bindings with Ruby
 
 [role="_abstract"]
-Apipie bindings are the Ruby bindings for apipie documented API calls.
-They fetch and cache the API definition from {Project} and then generate API calls as needed.
+You can use apipie bindings in Ruby to automatically fetch and cache {Project} API definitions.
+This way, you can write type-safe API calls with built-in validation and reduce manual endpoint configuration.
 
 [source, ruby, subs="attributes"]
 ----

--- a/guides/common/modules/ref_using-searches-with-pagination-control.adoc
+++ b/guides/common/modules/ref_using-searches-with-pagination-control.adoc
@@ -4,8 +4,9 @@
 = Using searches with pagination control
 
 [role="_abstract"]
-You can use the `per_page` and `page` pagination parameters to limit the search results that an API search query returns.
-The `per_page` parameter specifies the number of results per page and the `page` parameter specifies which page, as calculated by the `per_page` parameter, to return.
+You can control how many results an API query returns per page and which page to retrieve in order to manage large datasets efficiently.
+
+The `per_page` parameter specifies the number of results per page and the `page` parameter specifies which page, as calculated by the `per_page` parameter, to return. 
 
 The number of items to be presented is set using the setting `entries_per_page`, which defaults to `20`.
 However, you can change it per request by using the parameter `per_page`.


### PR DESCRIPTION
Making sure the "Using the Satellite REST API" title follows the CQA prerequisites for migrating. 
Mostly, editing abstracts and fixing vale errors and warnings. 

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
