### PR TITLE
Add verification steps to host registration

### DIFF
--- a/guides/common/modules/proc_registering-a-host-by-using-ansible.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-ansible.adoc
@@ -11,6 +11,10 @@ You can register a host with an Ansible playbook by using registration templates
 +
 For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.registration_command`.
 
+ifdef::katello,orcharhino,satellite[]
+include::snip_verification-repositories-enabled.adoc[]
+endif::[]
+
 ifdef::managing-hosts[]
 .Additional resources
 * xref:registration-command-customization[]

--- a/guides/common/modules/proc_registering-a-host-by-using-api.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-api.adoc
@@ -13,6 +13,10 @@ include::snip_registering-a-host-prerequisites.adoc[]
 .Procedure
 * Use the POST `/api/registration_commands` resource.
 
+ifdef::katello,orcharhino,satellite[]
+include::snip_verification-repositories-enabled.adoc[]
+endif::[]
+
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
 

--- a/guides/common/modules/proc_registering-a-host-by-using-cli.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-cli.adoc
@@ -16,6 +16,10 @@ include::snip_registering-a-host-prerequisites.adoc[]
 +
 For more information, see the Hammer CLI help with `hammer host-registration generate-command --help`.
 
+ifdef::katello,orcharhino,satellite[]
+include::snip_verification-repositories-enabled.adoc[]
+endif::[]
+
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
 

--- a/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
@@ -72,6 +72,10 @@ Using certificate-based authentication also enforces lifecycle management of con
 . Run the registration command as `root` on the host that you want to register.
 After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.
 
+ifdef::katello,orcharhino,satellite[]
+include::snip_verification-repositories-enabled.adoc[]
+endif::[]
+
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
 

--- a/guides/common/modules/snip_verification-repositories-enabled.adoc
+++ b/guides/common/modules/snip_verification-repositories-enabled.adoc
@@ -1,0 +1,11 @@
+.Verification
+ifdef::orcharhino,satellite[]
+* If your activation key was supposed to enable repositories, check the `{client-redhat-repo-path}` file and verify that the repositories have been enabled.
+endif::[]
+ifdef::katello[]
+* If your activation key was supposed to enable repositories, verify that the repositories have been enabled:
++
+* On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+* On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+* On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
+endif::[]

--- a/guides/common/modules/snip_verification-repositories-enabled.adoc
+++ b/guides/common/modules/snip_verification-repositories-enabled.adoc
@@ -4,8 +4,7 @@ ifdef::orcharhino,satellite[]
 endif::[]
 ifdef::katello[]
 * If your activation key was supposed to enable repositories, verify that the repositories have been enabled:
-+
-* On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
-* On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
-* On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
+** On {EL}: Check the `/etc/yum.repos.d/redhat.repo` file and ensure that the appropriate repositories have been enabled.
+** On {DL}: Check the `/etc/apt/sources.list` file and ensure that the appropriate repositories have been enabled.
+** On {SLES}: Check the `/etc/zypp/repos.d/` directory and ensure that the appropriate repositories have been enabled.
 endif::[]

--- a/guides/common/modules/snip_verification-repositories-enabled.adoc
+++ b/guides/common/modules/snip_verification-repositories-enabled.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 .Verification
 ifdef::orcharhino,satellite[]
 * If your activation key was supposed to enable repositories, check the `{client-redhat-repo-path}` file and verify that the repositories have been enabled.


### PR DESCRIPTION
#### What changes are you introducing?

Adding verification steps to global host registration in the _Managing hosts_ guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We have duplicates of host registration procedures ([example](https://github.com/theforeman/foreman-documentation/blob/master/guides/common/modules/proc_registering-a-host-to-project-by-using-web-ui.adoc?plain=1)) that contain these verification steps.
This is the first step towards eliminating those duplicates.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- **Let me know if you think it's a bad idea to deduplicate those procedures.**
- Is it an overkill to add verification to procedures by using API and Ansible?

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
