### PR TITLE
Move the registration command note

### DIFF
--- a/guides/common/assembly_registering-hosts-to-project.adoc
+++ b/guides/common/assembly_registering-hosts-to-project.adoc
@@ -31,6 +31,8 @@ include::modules/proc_customizing-the-registration-templates.adoc[leveloffset=+2
 
 include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+2]
 
+include::modules/ref_registration-command-customization.adoc[leveloffset=+2]
+
 // Invalidating registration tokens
 include::modules/con_invalidating-registration-tokens.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_registering-a-host-by-using-ansible.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-ansible.adoc
@@ -10,3 +10,6 @@ You can register a host with an Ansible playbook by using registration templates
 * Use the `{ansible-namespace}.registration_command` module.
 +
 For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.registration_command`.
+
+.Additional resources
+* xref:registration-command-customization[]

--- a/guides/common/modules/proc_registering-a-host-by-using-ansible.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-ansible.adoc
@@ -11,5 +11,7 @@ You can register a host with an Ansible playbook by using registration templates
 +
 For more information, see the Ansible module documentation with `ansible-doc {ansible-namespace}.registration_command`.
 
+ifdef::managing-hosts[]
 .Additional resources
 * xref:registration-command-customization[]
+endif::[]

--- a/guides/common/modules/proc_registering-a-host-by-using-api.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-api.adoc
@@ -16,5 +16,7 @@ include::snip_registering-a-host-prerequisites.adoc[]
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
 
+ifdef::managing-hosts[]
 .Additional resources
 * xref:registration-command-customization[]
+endif::[]

--- a/guides/common/modules/proc_registering-a-host-by-using-api.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-api.adoc
@@ -15,3 +15,6 @@ include::snip_registering-a-host-prerequisites.adoc[]
 
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
+
+.Additional resources
+* xref:registration-command-customization[]

--- a/guides/common/modules/proc_registering-a-host-by-using-cli.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-cli.adoc
@@ -19,5 +19,7 @@ For more information, see the Hammer CLI help with `hammer host-registration gen
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
 
+ifdef::managing-hosts[]
 .Additional resources
 * xref:registration-command-customization[]
+endif::[]

--- a/guides/common/modules/proc_registering-a-host-by-using-cli.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-cli.adoc
@@ -18,3 +18,6 @@ For more information, see the Hammer CLI help with `hammer host-registration gen
 
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
+
+.Additional resources
+* xref:registration-command-customization[]

--- a/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
@@ -75,5 +75,7 @@ After registration completes, any Ansible roles assigned to a host group you spe
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
 
+ifdef::managing-hosts[]
 .Additional resources
 * xref:registration-command-customization[]
+endif::[]

--- a/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
@@ -66,21 +66,6 @@ If the user loses or gains additional permissions, the permissions of the JWT ch
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
-+
-[NOTE]
-====
-{Project} generates the registration command with parameters that search resources by ID.
-You can edit the registration command to search the following resources by title:
-
-Organization:: URL fragment example: `organization=My%20Organization` or `organization=My+Organization`
-Location:: URL fragment example: `location=My%20Location` or `location=My+Location`
-Host group:: If a host group is nested, include the parent group separated with the slash character (`/`).
-+
-URL fragment example: `hostgroup=Parent%20Group%2FMy%20Host%20Group`
-Operating system:: URL fragment example: `operatingsystem=My%20Operating%20System` or `operatingsystem=My+Operating+System`
-
-The parameter values must be URL encoded.
-====
 * On the *Advanced* tab, you can enable container and Flatpak registry access without a username or password by selecting the *Set up container registry certs* checkbox.
 Using certificate-based authentication also enforces lifecycle management of container and Flatpak content for the host.
 . Click *Generate* to generate a registration command.
@@ -89,3 +74,6 @@ After registration completes, any Ansible roles assigned to a host group you spe
 
 .Next steps
 * To set up monitoring of outdated services and applications using Tracer, see {ManagingHostsDocURL}configuring-tracer-on-a-host_managing-hosts[Configuring Tracer on a host] in _{ManagingHostsDocTitle}_.
+
+.Additional resources
+* xref:registration-command-customization[]

--- a/guides/common/modules/ref_registration-command-customization.adoc
+++ b/guides/common/modules/ref_registration-command-customization.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="registration-command-customization"]
+= Registration command customization
+
+[role="_abstract"]
+{Project} generates registration commands with ID-based search parameters.
+Customize URL parameters to search organizations, locations, host groups, and operating systems by title, using URL-encoded values.
+
+You can use the following URL parameters to search resources by title:
+
+Organization::
+URL fragment example: `organization=My%20Organization` or `organization=My+Organization`
+
+Location::
+URL fragment example: `location=My%20Location` or `location=My+Location`
+
+Host group::
+If a host group is nested, include the parent group separated with the slash character (`/`).
++
+URL fragment example: `hostgroup=Parent%20Group%2FMy%20Host%20Group`
+
+Operating system::
+URL fragment example: `operatingsystem=My%20Operating%20System` or `operatingsystem=My+Operating+System`
+
+The parameter values must be URL encoded.


### PR DESCRIPTION
#### What changes are you introducing?

Moving the registration command note after command generation and into a reference module.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* Users can only edit the registration command AFTER it has been generated.
* This is reference info.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
