### PR TITLE
Move snippet inside modules

### DIFF
--- a/guides/common/assembly_managing-activation-keys.adoc
+++ b/guides/common/assembly_managing-activation-keys.adoc
@@ -18,10 +18,6 @@ ifdef::katello,satellite,red_hat_enterprise_linux[]
 include::modules/proc_setting-the-service-level-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_setting-the-service-level-by-using-cli.adoc[leveloffset=+1]
-
-ifdef::katello,red_hat_enterprise_linux[]
-include::modules/snip_note-premium-service-level-for-rhel.adoc[]
-endif::[]
 endif::[]
 
 include::modules/proc_enabling-and-disabling-repositories-on-activation-key.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_setting-the-service-level-by-using-cli.adoc
+++ b/guides/common/modules/proc_setting-the-service-level-by-using-cli.adoc
@@ -6,6 +6,10 @@
 [role="_abstract"]
 You can configure an activation key by using Hammer CLI to define a default service level for the new host created with the activation key.
 
+ifdef::katello,red_hat_enterprise_linux[]
+include::snip_note-premium-service-level-for-rhel.adoc[]
+endif::[]
+
 .Procedure
 * Set the service level to Premium on your activation key:
 +

--- a/guides/common/modules/proc_setting-the-service-level-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_setting-the-service-level-by-using-web-ui.adoc
@@ -6,6 +6,10 @@
 [role="_abstract"]
 You can configure an activation key from the {ProjectWebUI} to define a default service level for the new host created with the activation key.
 
+ifdef::katello,red_hat_enterprise_linux[]
+include::snip_note-premium-service-level-for-rhel.adoc[]
+endif::[]
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Lifecycle* > *Activation Keys*.
 . Click the activation key name you want to edit.


### PR DESCRIPTION
#### What changes are you introducing?

Move snippet with a note about RHEL Premium SLA inside modules about service level on AK

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Snippets are not supposed to be included in assemblies.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
