### PR TITLE
Move other snippets out of assemblies

### DIFF
--- a/guides/common/assembly_adding-content-to-foreman.adoc
+++ b/guides/common/assembly_adding-content-to-foreman.adoc
@@ -1,9 +1,5 @@
 include::modules/con_adding-content-to-foreman.adoc[]
 
-ifdef::katello,suse_linux_enterprise_server[]
-include::modules/snip_tip-scc-manager.adoc[]
-endif::[]
-
 include::modules/con_products-and-repositories.adoc[leveloffset=+1]
 
 include::modules/ref_best-practices-for-products-and-repositories.adoc[leveloffset=+1]

--- a/guides/common/assembly_introduction-to-provisioning.adoc
+++ b/guides/common/assembly_introduction-to-provisioning.adoc
@@ -1,9 +1,5 @@
 include::modules/con_introduction-to-provisioning.adoc[]
 
-ifdef::foreman-el,foreman-deb,katello,almalinux,red_hat_enterprise_linux,rocky_linux[]
-include::modules/snip_important-do-not-provision-el-host-with-minimal-iso-image.adoc[]
-endif::[]
-
 include::modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]
 
 include::modules/con_provisioning-hardware-types.adoc[leveloffset=+1]

--- a/guides/common/assembly_managing-iso-images.adoc
+++ b/guides/common/assembly_managing-iso-images.adoc
@@ -1,9 +1,5 @@
 include::modules/con_managing-iso-images.adoc[]
 
-ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]
-include::modules/snip_important-do-not-provision-el-host-with-minimal-iso-image.adoc[]
-endif::[]
-
 ifdef::katello,satellite,red_hat_enterprise_linux[]
 include::modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc[leveloffset=+1]
 

--- a/guides/common/assembly_preparing-provisioning-content.adoc
+++ b/guides/common/assembly_preparing-provisioning-content.adoc
@@ -4,10 +4,6 @@ ifdef::katello,satellite,almalinux,centos,oracle_linux,red_hat_enterprise_linux,
 include::modules/proc_preparing-a-synchronized-kickstart-repository.adoc[leveloffset=+1]
 endif::[]
 
-ifdef::debian,ubuntu[]
-include::modules/snip_file-type-repositories-for-installation-media-for-debian-and-ubuntu.adoc[]
-endif::[]
-
 include::modules/proc_adding-installation-media-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_adding-installation-media-by-using-cli.adoc[leveloffset=+1]

--- a/guides/common/assembly_registering-hosts-to-project.adoc
+++ b/guides/common/assembly_registering-hosts-to-project.adoc
@@ -1,9 +1,5 @@
 include::modules/con_registering-hosts-to-project.adoc[]
 
-ifdef::katello,orcharhino[]
-include::modules/snip_important-content-during-registration-workflow.adoc[]
-endif::[]
-
 include::modules/ref_supported-clients-in-registration.adoc[leveloffset=+1]
 
 // Registering hosts by using global registration

--- a/guides/common/assembly_registering-hosts-to-project.adoc
+++ b/guides/common/assembly_registering-hosts-to-project.adoc
@@ -13,10 +13,6 @@ include::modules/ref_global-parameters-for-registration.adoc[leveloffset=+2]
 
 include::modules/proc_configuring-a-host-for-registration.adoc[leveloffset=+2]
 
-ifdef::foreman-el,foreman-deb,katello,almalinux,red_hat_enterprise_linux,rocky_linux[]
-include::modules/snip_important-do-not-provision-el-host-with-minimal-iso-image.adoc[]
-endif::[]
-
 include::modules/proc_registering-a-host-by-using-web-ui.adoc[leveloffset=+2]
 
 include::modules/proc_registering-a-host-by-using-cli.adoc[leveloffset=+2]

--- a/guides/common/modules/con_adding-content-to-foreman.adoc
+++ b/guides/common/modules/con_adding-content-to-foreman.adoc
@@ -5,3 +5,7 @@
 
 [role="_abstract"]
 Start adding content to {Project} by organizing products and repositories, securing upstream connections, and synchronizing or uploading packages for your hosts.
+
+ifdef::katello,suse_linux_enterprise_server[]
+include::snip_tip-scc-manager.adoc[]
+endif::[]

--- a/guides/common/modules/con_introduction-to-provisioning.adoc
+++ b/guides/common/modules/con_introduction-to-provisioning.adoc
@@ -6,3 +6,7 @@
 [role="_abstract"]
 Provisioning is a process that starts with a blank machine and ends with a fully configured, ready-to-use operating system.
 Using {ProjectName}, you can define and automate fine-grained provisioning for a large number of hosts.
+
+ifdef::foreman-el,foreman-deb,katello,almalinux,red_hat_enterprise_linux,rocky_linux[]
+include::snip_important-do-not-provision-el-host-with-minimal-iso-image.adoc[]
+endif::[]

--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -6,3 +6,7 @@
 [role="_abstract"]
 You can use {Project} to store ISO images, either from Red{nbsp}Hat's Content Delivery Network or other sources.
 You can also upload other files, such as virtual machine images, and publish them in repositories.
+
+ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]
+include::snip_important-do-not-provision-el-host-with-minimal-iso-image.adoc[]
+endif::[]

--- a/guides/common/modules/con_preparing-provisioning-content.adoc
+++ b/guides/common/modules/con_preparing-provisioning-content.adoc
@@ -14,6 +14,10 @@ Note that you cannot solely set *Content Source* because provisioning templates 
 ====
 endif::[]
 
+ifdef::debian,ubuntu[]
+include::snip_file-type-repositories-for-installation-media-for-debian-and-ubuntu.adoc[]
+endif::[]
+
 ifdef::katello,orcharhino,satellite[]
 .Additional resources
 * {ContentManagementDocURL}[_{ContentManagementDocTitle}_]

--- a/guides/common/modules/con_registering-hosts-to-project.adoc
+++ b/guides/common/modules/con_registering-hosts-to-project.adoc
@@ -6,3 +6,7 @@
 [role="_abstract"]
 Before you can use {Project} to manage hosts that have not been provisioned through {Project}, you must register them.
 You can register hosts through {ProjectServer} or {SmartProxyServer}.
+
+ifdef::katello,orcharhino[]
+include::snip_important-content-during-registration-workflow.adoc[]
+endif::[]

--- a/guides/common/modules/proc_configuring-a-host-for-registration.adoc
+++ b/guides/common/modules/proc_configuring-a-host-for-registration.adoc
@@ -16,6 +16,10 @@ If the system clock is not synchronized, SSL certificate verification might fail
 For example, you can use the Chrony suite for timekeeping.
 endif::[]
 
+ifdef::foreman-el,foreman-deb,katello,almalinux,red_hat_enterprise_linux,rocky_linux[]
+include::snip_important-do-not-provision-el-host-with-minimal-iso-image.adoc[]
+endif::[]
+
 .Procedure
 ifdef::satellite,orcharhino,katello[]
 . Enable and start a time-synchronization tool on your host.


### PR DESCRIPTION
#### What changes are you introducing?

Move snippets from assemblies to modules.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Follow-up to https://github.com/theforeman/foreman-documentation/pull/4940

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
