### PR TITLE
Add deprecation notices to relevant modules

### DIFF
--- a/guides/common/modules/con_katello-ca-consumer-rpm-and-rhsm-consumer-script.adoc
+++ b/guides/common/modules/con_katello-ca-consumer-rpm-and-rhsm-consumer-script.adoc
@@ -4,9 +4,9 @@
 = Katello CA consumer RPM and RHSM consumer script
 
 [role="_abstract"]
-The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script were previously available to register hosts to {Project}.
+The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script were previously available to register hosts to {Project}.
 
-:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
 include::snip_deprecated-feature.adoc[]
 

--- a/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
+++ b/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
@@ -8,6 +8,10 @@ By default, the bootstrap script uses HTTP to download the consumer RPM from `\h
 In some environments, you might want to allow HTTPS only between the host and {Project}.
 Use `--download-method` to change the download method from HTTP to HTTPS.
 
+:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
+include::snip_deprecated-feature.adoc[]
+
 .Procedure
 * On {EL} 8, enter the following command:
 +

--- a/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
+++ b/guides/common/modules/proc_changing-the-method-the-bootstrap-script-uses-to-download-the-consumer-rpm.adoc
@@ -8,7 +8,7 @@ By default, the bootstrap script uses HTTP to download the consumer RPM from `\h
 In some environments, you might want to allow HTTPS only between the host and {Project}.
 Use `--download-method` to change the download method from HTTP to HTTPS.
 
-:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
 include::snip_deprecated-feature.adoc[]
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -59,4 +59,3 @@ endif::[]
 .Next steps
 * After you configure {ProjectServer} to use a custom SSL certificate, you must refresh the self-signed CA certificate on registered hosts.
 For more information, see {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_.
-

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-foreman-server.adoc
@@ -55,3 +55,8 @@ endif::[]
 .Verification
 . On a computer with network access to {ProjectServer}, navigate to the following URL: `\https://{foreman-example-com}`.
 . In your browser, view the certificate details to verify the deployed certificate.
+
+.Next steps
+* After you configure {ProjectServer} to use a custom SSL certificate, you must refresh the self-signed CA certificate on registered hosts.
+For more information, see {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_.
+

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -7,7 +7,7 @@
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
 :FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
-:FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_
+:FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[]
 include::snip_deprecated-feature.adoc[]
 
 .Procedure

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
-:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_
 include::snip_deprecated-feature.adoc[]
 

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -6,11 +6,9 @@
 [role="_abstract"]
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
-ifdef::satellite[]
 :FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_
 include::snip_deprecated-feature.adoc[]
-endif::[]
 
 .Procedure
 * Update the SSL certificate on each host:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -7,7 +7,7 @@
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
 :FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
-:FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
+:FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_
 include::snip_deprecated-feature.adoc[]
 
 .Procedure

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -7,7 +7,7 @@
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
 :FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
-:FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[]
+:FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts]
 include::snip_deprecated-feature.adoc[]
 
 .Procedure

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -6,9 +6,11 @@
 [role="_abstract"]
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
+ifdef::satellite[]
 :FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_
 include::snip_deprecated-feature.adoc[]
+endif::[]
 
 .Procedure
 * Update the SSL certificate on each host:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-hosts.adoc
@@ -6,6 +6,10 @@
 [role="_abstract"]
 After you configure {Project} to use a {customssl} certificate, you must deploy the certificate to hosts registered to {Project}.
 
+:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
+include::snip_deprecated-feature.adoc[]
+
 .Procedure
 * Update the SSL certificate on each host:
 +

--- a/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
@@ -4,9 +4,9 @@
 = Migrating a host from one {Project} to another {Project}
 
 [role="_abstract"]
-Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` packages on the new {Project}.
+Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` RPM packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` RPM packages on the new {Project}.
 
-:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
 include::snip_deprecated-feature.adoc[]
 

--- a/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
@@ -6,6 +6,10 @@
 [role="_abstract"]
 Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` packages on the new {Project}.
 
+:FeatureName: The `katello-ca-consumer-rpm` package and `katello-rhsm-consumer` script
+:FeatureAlternative: xref:registering-hosts-by-using-global-registration[]
+include::snip_deprecated-feature.adoc[]
+
 .Procedure
 * On {EL} 8, enter the following command:
 +

--- a/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
+++ b/guides/common/modules/proc_migrating-a-host-from-one-server-to-another-server.adoc
@@ -4,7 +4,7 @@
 = Migrating a host from one {Project} to another {Project}
 
 [role="_abstract"]
-Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` RPM packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` RPM packages on the new {Project}.
+Use the script with `--force` to remove the `katello-ca-consumer-{asterisk}` packages from the old {Project} and install the `katello-ca-consumer-{asterisk}` packages on the new {Project}.
 
 :FeatureName: The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script
 :FeatureAlternative: xref:registering-hosts-by-using-global-registration[]

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -14,6 +14,7 @@ There are no upgrade warnings with Katello {KatelloVersion}.
 [id="katello-deprecations"]
 == Deprecations
 
+// There are no deprecations with Katello {KatelloVersion}.
 The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script::
 +
 --

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -14,4 +14,12 @@ There are no upgrade warnings with Katello {KatelloVersion}.
 [id="katello-deprecations"]
 == Deprecations
 
-There are no deprecations with Katello {KatelloVersion}.
+The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script::
++
+--
+The `katello-ca-consumer` RPM package and the `katello-rhsm-consumer` script are deprecated and will be removed in a future release.
+Use the following alternatives instead:
+
+* For registering hosts to {ProjectServer}, use {ManagingHostsDocURL}registering-hosts-by-using-global-registration[Registering hosts by using global registration] in _{ManagingHostsDocTitle}_.
+* For deploying custom SSL certificates to hosts, use {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_.
+--


### PR DESCRIPTION
#### What changes are you introducing?
Add deprecation notices to all modules that mention katello-ca-consumer

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
katello-ca-consumer was deprecated a long time ago, but not all locations were marked as deprecated.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
https://redhat.atlassian.net/browse/SAT-38083

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
