### PR TITLE
CQA Fix abstract for disconnected installation guides

### DIFF
--- a/guides/common/modules/proc_configuring-project-server.adoc
+++ b/guides/common/modules/proc_configuring-project-server.adoc
@@ -4,14 +4,8 @@
 = Configuring {ProjectServer}
 
 [role="_abstract"]
-Install {ProjectServer} by using the `{foreman-installer}` installation script.
-This initial configuration procedure creates an organization, location, user name, and password.
-After the initial configuration, you can create additional organizations and locations if required.
-The initial configuration also installs PostgreSQL databases on the same server.
-
-This method is performed by running the installation script with one or more command options.
+You can use the `{foreman-installer}` installation script to configure the {ProjectServer} to use the default local database or an external PostgreSQL server.
 The command options override the corresponding default initial configuration options and are recorded in the {Project} answer file.
-You can run the script as often as needed to configure any necessary options.
 
 include::snip_deploy-overwrites-note.adoc[]
 

--- a/guides/common/modules/proc_configuring-project-server.adoc
+++ b/guides/common/modules/proc_configuring-project-server.adoc
@@ -4,7 +4,7 @@
 = Configuring {ProjectServer}
 
 [role="_abstract"]
-You can use the `{foreman-installer}` installation script to configure the {ProjectServer} to use the default local database or an external PostgreSQL server.
+You can use the `{foreman-installer}` installation script to configure the {ProjectServer} with the default local database or an external PostgreSQL server.
 The command options override the corresponding default initial configuration options and are recorded in the {Project} answer file.
 
 include::snip_deploy-overwrites-note.adoc[]

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -5,7 +5,7 @@
 = Configuring repositories
 
 [role="_abstract"]
-Configure the required repositories.
+Enable the necessary repositories on your {Project} host to access installation packages and dependencies.
 
 .Procedure
 ifdef::satellite[]

--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -18,7 +18,7 @@ endif::[]
 ifndef::containerized[]
 [NOTE]
 ====
-* Some SMTP servers with anti-spam protection or greylisting features are known to cause problems.
+Some SMTP servers with anti-spam protection or greylisting features are known to cause problems.
 To set up outgoing email with such a service, install and configure an SMTP service on {ProjectServer} for relay or use the `sendmail` command.
 ====
 endif::[]

--- a/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
+++ b/guides/common/modules/proc_configuring-satellite-for-outgoing-emails.adoc
@@ -16,9 +16,11 @@ include::snip_deprecated-feature.adoc[]
 endif::[]
 
 ifndef::containerized[]
-.Prerequisites
+[NOTE]
+====
 * Some SMTP servers with anti-spam protection or greylisting features are known to cause problems.
 To set up outgoing email with such a service, install and configure an SMTP service on {ProjectServer} for relay or use the `sendmail` command.
+====
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-web-ui.adoc
@@ -4,11 +4,8 @@
 = Configuring {ProjectServer} to consume content from a custom CDN by using {ProjectWebUI}
 
 [role="_abstract"]
-If you have an internal Content Delivery Network (CDN) or serve content on an accessible web server, you can configure your {ProjectServer} to consume Red{nbsp}Hat repositories from this CDN server instead of the Red{nbsp}Hat CDN.
-A CDN server can be any web server that mirrors repositories in the same directory structure as the Red{nbsp}Hat CDN.
-
-You can configure the source of content for each organization.
-{Project} recognizes automatically which Red{nbsp}Hat repositories from the subscription manifest in your organization are available on your CDN server.
+Configure your {ProjectServer} to consume Red{nbsp}Hat repositories from a custom CDN server or web server instead of the Red{nbsp}Hat CDN.
+{Project} automatically recognizes which repositories from your subscription manifest are available on your CDN server.
 
 .Prerequisites
 * You have a CDN server that provides Red{nbsp}Hat content and is accessible by {ProjectServer}.
@@ -24,4 +21,4 @@ For more information, see {ContentManagementDocURL}importing-custom-ssl-certific
 . In the *URL* field, enter the URL of your CDN server from which you want {ProjectServer} to consume Red{nbsp}Hat repositories.
 . Optional: In the *SSL CA Content Credential*, select the SSL certificate of the CDN server.
 . Click *Update*.
-. You can now enable Red{nbsp}Hat repositories consumed from your internal CDN server.
+. Enable Red{nbsp}Hat repositories consumed from your internal CDN server.

--- a/guides/common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Configuring {ProjectServer} to consume content from a custom CDN by using {ProjectWebUI}
 
 [role="_abstract"]
-Configure your {ProjectServer} to consume Red{nbsp}Hat repositories from a custom CDN server or web server instead of the Red{nbsp}Hat CDN.
+Configure your {ProjectServer} to consume Red{nbsp}Hat repositories from a custom Content Delivery Network (CDN) server or web server instead of the Red{nbsp}Hat CDN.
 {Project} automatically recognizes which repositories from your subscription manifest are available on your CDN server.
 
 .Prerequisites

--- a/guides/common/modules/proc_disabling-subscription-connection-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_disabling-subscription-connection-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Disabling subscription connection by using {ProjectWebUI}
 
 [role="_abstract"]
-Disable subscription connection on disconnected {ProjectServer} to avoid connecting to the Red{nbsp}Hat Portal.
+Disable subscription connection on your disconnected {ProjectServer} to avoid connecting to the Red{nbsp}Hat Portal.
 This will also prevent you from refreshing the manifest and updating upstream entitlements.
 
 .Procedure

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -4,7 +4,7 @@
 = Enabling power management on hosts
 
 [role="_abstract"]
-To perform power management tasks on hosts, you must enable the baseboard management controller (BMC) module on {ProductName}.
+Enable the baseboard management controller (BMC) module on {ProductName} to perform power management tasks on hosts.
 
 {ProjectName} supports the following BMC providers:
 

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -4,7 +4,7 @@
 = Enabling power management on hosts
 
 [role="_abstract"]
-Enable the baseboard management controller (BMC) module on {ProductName} to perform power management tasks on hosts.
+To perform power management tasks on hosts, you must enable the baseboard management controller (BMC) module on {ProductName}.
 
 {ProjectName} supports the following BMC providers:
 

--- a/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
+++ b/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
@@ -4,7 +4,7 @@
 = Installing the {Project} packages from the offline repositories
 
 [role="_abstract"]
-You can install the {Project} packages from the offline repositories using locally mounted ISO images. 
+You can install the {Project} packages from the offline repositories using locally mounted ISO images.
 
 .Procedure
 

--- a/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
+++ b/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
@@ -4,7 +4,7 @@
 = Installing the {Project} packages from the offline repositories
 
 [role="_abstract"]
-Use this procedure to install the {Project} packages from the offline repositories using locally mounted ISO images. 
+You can install the {Project} packages from the offline repositories using locally mounted ISO images. 
 
 .Procedure
 

--- a/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
+++ b/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
@@ -4,7 +4,7 @@
 = Installing the {Project} packages from the offline repositories
 
 [role="_abstract"]
-You can install the {Project} packages from the offline repositories using locally mounted ISO images.
+You can install the {Project} packages from the offline repositories by using locally mounted ISO images.
 
 .Procedure
 

--- a/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
+++ b/guides/common/modules/proc_installing-from-the-offline-repositories.adoc
@@ -4,7 +4,7 @@
 = Installing the {Project} packages from the offline repositories
 
 [role="_abstract"]
-Use this procedure to install the {Project} packages from the offline repositories.
+Use this procedure to install the {Project} packages from the offline repositories using locally mounted ISO images. 
 
 .Procedure
 


### PR DESCRIPTION
Fix abstracts flagged in disconnected guide installation CQA.

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
