### PR TITLE
Split procedure and verification of Proxmox installation

### DIFF
--- a/guides/common/modules/proc_installing-the-proxmox-plugin.adoc
+++ b/guides/common/modules/proc_installing-the-proxmox-plugin.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Installing_the_Proxmox_plugin_{context}"]
+[id="installing-the-proxmox-plugin"]
 = Installing the Proxmox plugin
 
 [role="_abstract"]
@@ -8,10 +8,13 @@ Install the Proxmox plugin to attach a Proxmox compute resource provider to {Pro
 This allows you to manage and deploy hosts to Proxmox.
 
 .Procedure
-. Install the Proxmox plugin on your {ProjectServer}:
+* Install the Proxmox plugin on your {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-installer} --enable-foreman-plugin-proxmox
 ----
-. Optional: In the {ProjectWebUI}, navigate to *Administer* > *About* and select the *Compute Resources* tab to verify the installation of the Proxmox plugin.
+
+.Verification
+. In the {ProjectWebUI}, navigate to *Administer* > *About*.
+. On the *Available Providers* tab, verify that the Proxmox provider is present.


### PR DESCRIPTION
#### What changes are you introducing?

This patch splits the steps to install the Proxmox plugin and verify its installation. It also changes the anchor. There are no broken links.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To align with other docs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

`$ rg -i "Installing_the_Proxmox_plugin_"`

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
