### PR TITLE
Hide katello-repos-latest.rpm for containerized deployments

### DIFF
--- a/guides/common/modules/snip_configuring-repositories-foreman-rpm.adoc
+++ b/guides/common/modules/snip_configuring-repositories-foreman-rpm.adoc
@@ -6,6 +6,7 @@
 ----
 # {package-install} https://yum.theforeman.org/releases/{ProjectVersion}/el{distribution-major-version}/x86_64/foreman-release.rpm
 ----
+ifndef::containerized[]
 ifdef::katello[]
 . Install the `katello-repos-latest.rpm` package:
 +
@@ -14,7 +15,6 @@ ifdef::katello[]
 # {package-install} https://yum.theforeman.org/katello/{KatelloVersion}/katello/el{distribution-major-version}/x86_64/katello-repos-latest.rpm
 ----
 endif::[]
-ifndef::containerized[]
 . Install the `openvox-release` package:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?

You do not need `katello-repos-latest.rpm` to deploy containerized Foreman+Katello.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #4952

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Untested; needs tech ACK.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
