### PR TITLE
 [CQA] Shorten abstracts in Provisioning Hosts

### DIFF
--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -32,7 +32,7 @@ include::modules/proc_creating-image-based-hosts-on-amazon-ec2-by-using-web-ui.a
 
 include::modules/proc_creating-image-based-hosts-on-amazon-ec2-by-using-cli.adoc[leveloffset=+1]
 
-include::modules/proc_connecting-to-an-amazon-ec2-instance-using-ssh.adoc[leveloffset=+1]
+include::modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc[leveloffset=+1]
 
 include::modules/proc_configuring-a-finish-template-for-amazon-ec2.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_discovering-hosts-on-a-network.adoc
+++ b/guides/common/modules/con_discovering-hosts-on-a-network.adoc
@@ -4,5 +4,5 @@
 = Discovering hosts on a network
 
 [role="_abstract"]
-You can detect hosts not in your inventory by booting them into the Discovery image.
+You can detect networked hosts not in your inventory by booting them into the Discovery image.
 The hosts relay hardware information to {ProjectServer} without manually entering MAC addresses.

--- a/guides/common/modules/con_discovering-hosts-on-a-network.adoc
+++ b/guides/common/modules/con_discovering-hosts-on-a-network.adoc
@@ -5,4 +5,4 @@
 
 [role="_abstract"]
 You can detect hosts not in your inventory by booting them into the Discovery image.
-The hosts relay hardware information to {ProjectServer}, which eliminates the need to manually enter MAC addresses.
+The hosts relay hardware information to {ProjectServer} without manually entering MAC addresses.

--- a/guides/common/modules/con_discovering-hosts-on-a-network.adoc
+++ b/guides/common/modules/con_discovering-hosts-on-a-network.adoc
@@ -4,6 +4,5 @@
 = Discovering hosts on a network
 
 [role="_abstract"]
-{ProjectName} can detect hosts on a network that are not in your {Project} inventory.
-These hosts boot the Discovery image that performs hardware detection and relays this information back to {ProjectServer}.
-This method creates a list of ready-to-provision hosts in {ProjectServer} without needing to enter the MAC address of each host.
+You can detect hosts not in your inventory by booting them into the Discovery image.
+The hosts relay hardware information to {ProjectServer}, which eliminates the need to manually enter MAC addresses.

--- a/guides/common/modules/con_discovery-in-pxe-mode.adoc
+++ b/guides/common/modules/con_discovery-in-pxe-mode.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 {Project} provides PXE-based Discovery that uses DHCP and TFTP services.
-Discovered nodes scheduled for installation reboot and provision through PXE.
+Discovered hosts queued for installation reboot and provision through PXE.
 
 .Discovery workflow in PXE mode
 ifdef::satellite[]

--- a/guides/common/modules/con_discovery-in-pxe-mode.adoc
+++ b/guides/common/modules/con_discovery-in-pxe-mode.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 {Project} provides PXE-based Discovery that uses DHCP and TFTP services.
-Discovery nodes scheduled for installation reboot and provision through PXE.
+Discovered nodes scheduled for installation reboot and provision through PXE.
 
 .Discovery workflow in PXE mode
 ifdef::satellite[]

--- a/guides/common/modules/con_discovery-in-pxe-mode.adoc
+++ b/guides/common/modules/con_discovery-in-pxe-mode.adoc
@@ -4,9 +4,8 @@
 = Discovery in PXE mode
 
 [role="_abstract"]
-{Project} provides a PXE-based Discovery service that uses DHCP and TFTP services.
-You discover unknown nodes by booting them into the Discovery kernel and initial RAM disk images from {ProjectServer} or {SmartProxyServer}.
-When a discovered node is scheduled for installation, it reboots and continues with the configured PXE-based host provisioning.
+{Project} provides PXE-based Discovery that uses DHCP and TFTP services.
+Discovery nodes scheduled for installation reboot and provision through PXE.
 
 .Discovery workflow in PXE mode
 ifdef::satellite[]

--- a/guides/common/modules/con_discovery-in-pxeless-mode.adoc
+++ b/guides/common/modules/con_discovery-in-pxeless-mode.adoc
@@ -4,9 +4,8 @@
 = Discovery in PXE-less mode
 
 [role="_abstract"]
-{Project} provides a PXE-less Discovery service for environments without DHCP and TFTP services.
-You discover unknown nodes by using the Discovery ISO from {ProjectServer}.
-When a discovered node is scheduled for installation, the `kexec` command reloads a Linux kernel with an operating system installer without rebooting the node.
+In environments without DHCP and TFTP, you can use PXE-less Discovery by using a Discovery ISO.
+Discovery nodes scheduled for installation reload the kernel with an operating system installer without rebooting.
 
 ifdef::satellite[]
 :FeatureName: Discovery `kexec`

--- a/guides/common/modules/con_discovery-in-pxeless-mode.adoc
+++ b/guides/common/modules/con_discovery-in-pxeless-mode.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 In environments without DHCP and TFTP, you can use PXE-less Discovery by using a Discovery ISO.
-Discovery nodes scheduled for installation reload the kernel with an operating system installer without rebooting.
+Discovered hosts queued for installation reload the kernel with an operating system installer without rebooting.
 
 ifdef::satellite[]
 :FeatureName: Discovery `kexec`

--- a/guides/common/modules/con_preparing-templates-for-provisioning.adoc
+++ b/guides/common/modules/con_preparing-templates-for-provisioning.adoc
@@ -4,7 +4,8 @@
 = Preparing templates for provisioning
 
 [role="_abstract"]
-You can customize the provisioning process without editing the default provisioning templates. You can affect provisioning with host parameters and add custom steps by creating custom `pre` or `post` snippets.
+You can customize the provisioning process without editing the default provisioning templates.
+You can affect provisioning with host parameters and add custom steps by creating custom `pre` or `post` snippets.
 
 {Project} provides the following default template types:
 

--- a/guides/common/modules/con_preparing-templates-for-provisioning.adoc
+++ b/guides/common/modules/con_preparing-templates-for-provisioning.adoc
@@ -4,9 +4,7 @@
 = Preparing templates for provisioning
 
 [role="_abstract"]
-{Project} contains provisioning templates to provision hosts.
-Provisioning templates are implemented with parameters that you can configure as host parameters to affect the provisioning process.
-You can also add custom steps to certain templates by creating custom `pre` or `post` snippets and thus customize the provisioning process further without editing the default templates.
+You can customize the provisioning process without editing the default provisioning templates. You can affect provisioning with host parameters and add custom steps by creating custom `pre` or `post` snippets.
 
 {Project} provides the following default template types:
 

--- a/guides/common/modules/con_preparing-templates-for-provisioning.adoc
+++ b/guides/common/modules/con_preparing-templates-for-provisioning.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can customize the provisioning process without editing the default provisioning templates.
-You can affect provisioning with host parameters and add custom steps by creating custom `pre` or `post` snippets.
+You can define host parameters and add custom steps by creating custom `pre` or `post` snippets.
 
 {Project} provides the following default template types:
 

--- a/guides/common/modules/con_provisioning-cloud-instances-on-amazon-ec2.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-amazon-ec2.adoc
@@ -4,6 +4,5 @@
 = Provisioning cloud instances on Amazon EC2
 
 [role="_abstract"]
-Amazon Elastic Compute Cloud (Amazon EC2) is a web service that provides public cloud compute resources.
-Using {Project}, you can interact with Amazon EC2's public API to create cloud instances and control their power management states.
-Use the procedures in this chapter to add a connection to an Amazon EC2 account and provision a cloud instance.
+You can use {Project} to create cloud instances and control their power management states through Amazon Elastic Compute Cloud (Amazon EC2) public API.
+

--- a/guides/common/modules/con_provisioning-cloud-instances-on-amazon-ec2.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-amazon-ec2.adoc
@@ -5,4 +5,3 @@
 
 [role="_abstract"]
 You can use {Project} to create cloud instances and control their power management states through Amazon Elastic Compute Cloud (Amazon EC2) public API.
-

--- a/guides/common/modules/con_provisioning-cloud-instances-on-microsoft-azure.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-microsoft-azure.adoc
@@ -5,4 +5,4 @@
 
 [role="_abstract"]
 You can create virtual machines and control their power management states on Microsoft Azure by using image-based provisioning.
-You can provision from Marketplace images, custom images, and shared image gallery.
+You can provision from Marketplace images, custom images, and shared image galleries.

--- a/guides/common/modules/con_provisioning-cloud-instances-on-microsoft-azure.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-microsoft-azure.adoc
@@ -4,6 +4,5 @@
 = Provisioning cloud instances on Microsoft Azure
 
 [role="_abstract"]
-You can create virtual machines and control their power management states on Microsoft Azure using image-based provisioning.
-
+You can create virtual machines and control their power management states on Microsoft Azure by using image-based provisioning.
 You can provision from Marketplace images, custom images, and shared image gallery.

--- a/guides/common/modules/con_provisioning-cloud-instances-on-microsoft-azure.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-microsoft-azure.adoc
@@ -4,6 +4,6 @@
 = Provisioning cloud instances on Microsoft Azure
 
 [role="_abstract"]
-{Project} can interact with Microsoft Azure, including creating new virtual machines and controlling their power management states.
-Only image-based provisioning is supported for creating Azure hosts.
-This includes provisioning by using Marketplace images, custom images, and shared image gallery.
+You can create virtual machines and control their power management states on Microsoft Azure using image-based provisioning.
+
+You can provision from Marketplace images, custom images, and shared image gallery.

--- a/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
@@ -6,4 +6,3 @@
 [role="_abstract"]
 You can use {Project} to create cloud instances and control their power management states through the {OpenStack} REST API.
 {OpenStack} is an Infrastructure-as-a-Service (IaaS) platform for building private or public clouds.
-

--- a/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
+++ b/guides/common/modules/con_provisioning-cloud-instances-on-openstack.adoc
@@ -4,6 +4,6 @@
 = Provisioning cloud instances on {OpenStack}
 
 [role="_abstract"]
-{OpenStack} provides the foundation to build a private or public Infrastructure-as-a-Service (IaaS) cloud.
-It offers a massively scalable, fault-tolerant platform for the development of cloud-enabled workloads.
-In {Project}, you can interact with {OpenStack} REST API to create cloud instances and control their power management states.
+You can use {Project} to create cloud instances and control their power management states through the {OpenStack} REST API.
+{OpenStack} is an Infrastructure-as-a-Service (IaaS) platform for building private or public clouds.
+

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -4,11 +4,10 @@
 = Provisioning virtual machines on {KubeVirt}
 
 [role="_abstract"]
-{KubeVirt} addresses the needs of development teams that have adopted or want to adopt {Kubernetesfirst} but possess existing virtual machine (VM) workloads that cannot be easily containerized.
-This technology provides a unified development platform where developers can build, modify, and deploy applications residing in application containers and VMs in a shared environment.
-These capabilities support rapid application modernization across the open hybrid cloud.
+You can create a compute resource for {KubeVirt} to provision and manage virtual machines in {Kubernetes} by using {Project}.
+{KubeVirt} enables development teams to run existing virtual machine workloads alongside containerized applications in {Kubernetesfirst}.
 
-You can create a compute resource for {KubeVirt} so that you can provision and manage virtual machines in {Kubernetes} by using {Project}.
+
 
 ifdef::satellite[]
 Note that template provisioning is not supported for this release.

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -8,7 +8,6 @@ You can create a compute resource for {KubeVirt} to provision and manage virtual
 {KubeVirt} enables development teams to run existing virtual machine workloads alongside containerized applications in {Kubernetesfirst}.
 
 
-
 ifdef::satellite[]
 Note that template provisioning is not supported for this release.
 

--- a/guides/common/modules/con_security-settings-for-provisioning.adoc
+++ b/guides/common/modules/con_security-settings-for-provisioning.adoc
@@ -4,7 +4,8 @@
 = Security settings for provisioning
 
 [role="_abstract"]
-Configure global security settings to secure your provisioning environment, including default encrypted root passwords for newly provisioned hosts, configuring security token validity, and provisioning FIPS-compliant hosts.
+Configure global security settings to secure your provisioning environment.
+You can set default encrypted root passwords for newly provisioned hosts, configure security token validity, and provision FIPS-compliant hosts.
 
 .Additional resources
 * {AdministeringDocURL}provisioning_settings_admin[Provisioning settings in _{AdministeringDocTitle}_]

--- a/guides/common/modules/con_security-settings-for-provisioning.adoc
+++ b/guides/common/modules/con_security-settings-for-provisioning.adoc
@@ -4,8 +4,7 @@
 = Security settings for provisioning
 
 [role="_abstract"]
-You can configure global security settings for provisioning to secure your host provisioning environment.
-For example, you can set a default encrypted root password for newly provisioned hosts, configure the validity duration of the security token used for authentication, or provision FIPS-compliant hosts that meet strict governmental or regulatory security standards for data processing.
+Configure global security settings to secure your provisioning environment, including default encrypted root passwords for newly provisioned hosts, configuring security token validity, and provisioning FIPS-compliant hosts.
 
 .Additional resources
 * {AdministeringDocURL}provisioning_settings_admin[Provisioning settings in _{AdministeringDocTitle}_]

--- a/guides/common/modules/con_using-boot-disks-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-boot-disks-to-provision-hosts.adoc
@@ -4,5 +4,5 @@
 = Using boot disks to provision hosts
 
 [role="_abstract"]
-In environments without PXE boot or network boot, you can provision hosts by generating a boot ISO.
+In environments without PXE boot or network boot, you can provision hosts by generating a boot disk ISO.
 The host uses the ISO to boot installation media, connect to {SmartProxy}, and install the operating system.

--- a/guides/common/modules/con_using-boot-disks-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-boot-disks-to-provision-hosts.adoc
@@ -4,7 +4,5 @@
 = Using boot disks to provision hosts
 
 [role="_abstract"]
-Some hardware does not provide a PXE boot interface or your environment may not support network boot.
-In {Project}, you can provision a host without PXE boot.
-This is also known as PXE-less provisioning and involves generating a boot ISO that hosts can use.
-Using this ISO, the host can boot the installation media, connect to {SmartProxy}, and install the operating system.
+In environments without PXE boot or network boot, you can provision hosts by generating a boot ISO.
+The host uses the ISO to boot installation media, connect to {SmartProxy}, and install the operating system.

--- a/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/modules/con_using-network-boot-to-provision-hosts.adoc
@@ -4,9 +4,8 @@
 = Using network boot to provision hosts
 
 [role="_abstract"]
-After integrating provisioning infrastructure services with {Project}, you can provision hosts with {ProjectName} by booting hosts over a network.
-Once the host boots, {ProjectServer} or {SmartProxyServer} provides operating system installation content that the host downloads.
-After the operating system has been installed, the host registers to {Project} and {Project} performs an initial configuration of the host.
+You can provision hosts by booting over a network, where {ProjectServer} or {SmartProxyServer} provides the operating system installation content.
+After installing the system on the host, the host registers to {Project} for initial configuration.
 
 BIOS and UEFI interfaces::
 Both BIOS and UEFI interfaces work as interpreters between the operating system and firmware of a computer, initializing hardware components and starting the operating system at boot time.

--- a/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-an-amazon-ec2-connection-to-server-by-using-web-ui.adoc
@@ -31,4 +31,4 @@ For more information, see http://docs.aws.amazon.com/general/latest/gr/managing-
 ifndef::orcharhino[]
 Until https://bugzilla.redhat.com/show_bug.cgi?id=1793138[BZ1793138] is resolved, you can download a copy of the SSH keys only immediately after creating the Amazon EC2 compute resource.
 endif::[]
-If you require SSH keys at a later stage, follow the procedure in xref:Connecting_to_an_Amazon_EC2_Instance_Using_SSH_{context}[].
+If you require SSH keys at a later stage, follow the procedure in xref:connecting-to-an-amazon-ec2-instance-by-using-ssh[].

--- a/guides/common/modules/proc_adding-installation-media-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-installation-media-by-using-cli.adoc
@@ -4,13 +4,13 @@
 = Adding installation media to {Project} by using Hammer CLI
 
 [role="_abstract"]
-Installation media are sources of packages that {Project} uses to install a base operating system on a machine from an external repository.
+You can add installation media as package sources to install a base operating system from an external repository.
 ifdef::foreman-el,katello[]
 When you install the Katello plugin, you can download packages from a Pulp mirror.
 In this case, installation media are ignored.
 endif::[]
 ifdef::satellite[]
-You can use this parameter to install third-party content.
+You can add installation media to install third-party content.
 Content to provision {RHEL} hosts is delivered through Kickstart repositories.
 endif::[]
 

--- a/guides/common/modules/proc_adding-installation-media-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-installation-media-by-using-web-ui.adoc
@@ -4,13 +4,13 @@
 = Adding installation media to {Project} by using {ProjectWebUI}
 
 [role="_abstract"]
-Installation media are sources of packages that {Project} uses to install a base operating system on a machine from an external repository.
+You can add installation media as package sources to install a base operating system from an external repository.
 ifdef::foreman-el,katello[]
 When you install the Katello plugin, you can download packages from a Pulp mirror.
 In this case, installation media are ignored.
 endif::[]
 ifdef::satellite[]
-You can use this parameter to install third-party content.
+You can add installation media to install third-party content.
 Content to provision {RHEL} hosts is delivered through Kickstart repositories.
 endif::[]
 

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Adding {OpenStack} details to a compute profile by using Hammer CLI
 
 [role="_abstract"]
-You can automatically populate after provisioning hosts within your {OpenStack} environment by adding {OpenStack} hardware settings to a compute profile.
+You can automatically populate settings when provisioning hosts within your {OpenStack} environment by adding {OpenStack} hardware settings to a compute profile.
 
 .Procedure
 * Set {OpenStack} details to a compute profile:

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile-by-using-cli.adoc
@@ -4,8 +4,7 @@
 = Adding {OpenStack} details to a compute profile by using Hammer CLI
 
 [role="_abstract"]
-You can provision virtual machines (VMs) within your {OpenStack} environment by using {Project} more efficiently and consistently by adding {OpenStack} hardware settings to a compute profile.
-When you create a host on {OpenStack} using this compute profile, these settings are automatically populated.
+You can automatically populate after provisioning hosts within your {OpenStack} environment by adding {OpenStack} hardware settings to a compute profile.
 
 .Procedure
 * Set {OpenStack} details to a compute profile:

--- a/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-openstack-details-to-a-compute-profile-by-using-web-ui.adoc
@@ -4,8 +4,7 @@
 = Adding {OpenStack} details to a compute profile by using {ProjectWebUI}
 
 [role="_abstract"]
-You can provision virtual machines (VMs) within your {OpenStack} environment by using {Project} more efficiently and consistently by adding {OpenStack} hardware settings to a compute profile.
-When you create a host on {OpenStack} using this compute profile, these settings are automatically populated.
+You can automatically populate settings when provisioning hosts within your {OpenStack} environment by adding {OpenStack} hardware settings to a compute profile.
 
 .Procedure
 

--- a/guides/common/modules/proc_configuring-the-security-token-validity-duration.adoc
+++ b/guides/common/modules/proc_configuring-the-security-token-validity-duration.adoc
@@ -4,7 +4,7 @@
 = Configuring the security token validity duration
 
 [role="_abstract"]
-You can configure the validity duration of the unique security token that {Project} generates for provisioning.
+You can change the validity duration of the unique security token that {Project} generates for provisioning.
 By default, the token is valid for 360 minutes, and you must reboot the host within this time frame.
 
 If the token expires, you receive a 404 error and the operating system installer download fails.

--- a/guides/common/modules/proc_configuring-the-security-token-validity-duration.adoc
+++ b/guides/common/modules/proc_configuring-the-security-token-validity-duration.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can change the validity duration of the unique security token that {Project} generates for provisioning.
-By default, the token is valid for 360 minutes, and you must reboot the host within this time frame.
+By default, the token is valid for 360 minutes, and the host must reboot within this time frame.
 
 If the token expires, you receive a 404 error and the operating system installer download fails.
 

--- a/guides/common/modules/proc_configuring-the-security-token-validity-duration.adoc
+++ b/guides/common/modules/proc_configuring-the-security-token-validity-duration.adoc
@@ -4,10 +4,10 @@
 = Configuring the security token validity duration
 
 [role="_abstract"]
-When performing any kind of provisioning, as a security measure, {Project} automatically generates a unique token and adds this token to the {provision-script} URL in the PXE configuration file (PXELinux, Grub2).
-By default, the token is valid for 360 minutes.
-When you provision a host, ensure that you reboot the host within this time frame.
-If the token expires, it is no longer valid and you receive a 404 error and the operating system installer download fails.
+You can configure the validity duration of the unique security token that {Project} generates for provisioning.
+By default, the token is valid for 360 minutes, and you must reboot the host within this time frame.
+
+If the token expires, you receive a 404 error and the operating system installer download fails.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings*, and click the *Provisioning* tab.

--- a/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc
+++ b/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Connecting_to_an_Amazon_EC2_Instance_Using_SSH_{context}"]
-= Connecting to an Amazon EC2 instance using SSH
+[id="connecting-to-an-amazon-ec2-instance-by-using-ssh"]
+= Connecting to an Amazon EC2 instance by using SSH
 
 [role="_abstract"]
-You can connect remotely to an Amazon EC2 instance from {ProjectServer} using SSH.
-However, to connect to any Amazon Web Services EC2 instance that you provision through {ProjectName}, you must first access the private key that is associated with the compute resource in the Foreman database, and use this key for authentication.
+You can connect remotely to Amazon EC2 instances that you provision through {Project} by using SSH.
+To authenticate, you must first retrieve the private key associated with the compute resource from the Foreman database.
 
 .Procedure
 . To locate the compute resource list, on your {ProjectServer} base system, enter the following command, and note the ID of the compute resource that you want to use:

--- a/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc
+++ b/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc
@@ -5,11 +5,12 @@
 
 [role="_abstract"]
 You can connect remotely to Amazon EC2 instances that you provision through {Project} by using SSH.
-To authenticate, you must first retrieve the private key associated with the compute resource from the Foreman database.
+To authenticate, retrieve the private key associated with the compute resource from the Foreman database.
 
 .Procedure
-. To locate the compute resource list, on your {ProjectServer} base system, enter the following command, and note the ID of the compute resource that you want to use:
+. On your {ProjectServer} base system, locate the ID of the compute resource that you want to use:
 +
+[options="nowrap" subs="+quotes"]
 ----
 $ hammer compute-resource list
 ----

--- a/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc
+++ b/guides/common/modules/proc_connecting-to-an-amazon-ec2-instance-by-using-ssh.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can connect remotely to Amazon EC2 instances that you provision through {Project} by using SSH.
-To authenticate, retrieve the private key associated with the compute resource from the Foreman database.
+To authenticate, retrieve the private key associated with the compute resource from the `foreman` database.
 
 .Procedure
 . On your {ProjectServer} base system, locate the ID of the compute resource that you want to use:
@@ -14,7 +14,7 @@ To authenticate, retrieve the private key associated with the compute resource f
 ----
 $ hammer compute-resource list
 ----
-. Connect to the Foreman database as the user `postgres`:
+. Connect to the `foreman` database as the user `postgres`:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_creating-discovery-rules-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-discovery-rules-by-using-cli.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can automate provisioning of discovered hosts by creating Discovery rules that assign hosts to host groups based on hardware attributes.
-For example, you can automatically provision high-CPU hosts as hypervisors and hosts with large disks as storage servers.
+For example, you can automatically provision hosts with a large number of CPU cores as hypervisors and hosts with large disks as storage servers.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_creating-discovery-rules-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-discovery-rules-by-using-cli.adoc
@@ -4,10 +4,8 @@
 = Creating Discovery rules by using Hammer CLI
 
 [role="_abstract"]
-As a method of automating the provisioning process for discovered hosts, {Project} provides a feature to create Discovery rules.
-These rules define how discovered hosts automatically provision themselves, based on the assigned host group.
-For example, you can automatically provision hosts with a high CPU count as hypervisors.
-Likewise, you can provision hosts with large hard disks as storage servers.
+You can automate provisioning of discovered hosts by creating Discovery rules that assign hosts to host groups based on hardware attributes.
+For example, you can automatically provision high-CPU hosts as hypervisors and hosts with large disks as storage servers.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_creating-discovery-rules-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-discovery-rules-by-using-web-ui.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can automate provisioning of discovered hosts by creating Discovery rules that assign hosts to host groups based on hardware attributes.
-For example, you can automatically provision hosts with high CPU counts as hypervisors or hosts with large disks as storage servers.
+For example, you can automatically provision hosts with a large number of CPU cores as hypervisors and hosts with large disks as storage servers.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_creating-discovery-rules-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-discovery-rules-by-using-web-ui.adoc
@@ -4,10 +4,8 @@
 = Creating Discovery rules by using {ProjectWebUI}
 
 [role="_abstract"]
-As a method of automating the provisioning process for discovered hosts, {Project} provides a feature to create Discovery rules.
-These rules define how discovered hosts automatically provision themselves, based on the assigned host group.
-For example, you can automatically provision hosts with a high CPU count as hypervisors.
-Likewise, you can provision hosts with large hard disks as storage servers.
+You can automate provisioning of discovered hosts by creating Discovery rules that assign hosts to host groups based on hardware attributes.
+For example, you can automatically provision hosts with high CPU counts as hypervisors or hosts with large disks as storage servers.
 
 [NOTE]
 ====

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-cli.adoc
@@ -4,7 +4,8 @@
 = Creating hosts with UEFI HTTP boot provisioning by using Hammer CLI
 
 [role="_abstract"]
-You can provision hosts with UEFI HTTP boot to transfer files over HTTP. This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
+You can provision hosts with UEFI HTTP boot to transfer files over HTTP.
+This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
 
 You enter the host details on {ProjectServer} and boot your host.
 {ProjectServer} automatically manages the HTTP boot configuration, organizes networking services, and provides the operating system and configuration for the host.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-cli.adoc
@@ -4,10 +4,7 @@
 = Creating hosts with UEFI HTTP boot provisioning by using Hammer CLI
 
 [role="_abstract"]
-You can provision hosts from {Project} by using the UEFI HTTP boot if the hosts have this capability.
-In HTTP boot, configuration files are transferred over HTTP instead of TFTP as in PXE boot.
-Using this method can help reduce the booting time during host provisioning.
-HTTP is also more reliable for transfer of large files, such as Live images, than TFTP.
+You can provision hosts with UEFI HTTP boot to transfer files over HTTP. This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
 
 You enter the host details on {ProjectServer} and boot your host.
 {ProjectServer} automatically manages the HTTP boot configuration, organizes networking services, and provides the operating system and configuration for the host.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-cli.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can provision hosts with UEFI HTTP boot to transfer files over HTTP.
-This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
+This improves reliability for large files, such as Live images, and reduces boot time compared to TFTP.
 
 You enter the host details on {ProjectServer} and boot your host.
 {ProjectServer} automatically manages the HTTP boot configuration, organizes networking services, and provides the operating system and configuration for the host.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui.adoc
@@ -4,10 +4,7 @@
 = Creating hosts with UEFI HTTP boot provisioning by using {ProjectWebUI}
 
 [role="_abstract"]
-You can provision hosts from {Project} by using the UEFI HTTP boot if the hosts have this capability.
-In HTTP boot, configuration files are transferred over HTTP instead of TFTP as in PXE boot.
-Using this method can help reduce the booting time during host provisioning.
-HTTP is also more reliable for transfer of large files, such as Live images, than TFTP.
+You can provision hosts with UEFI HTTP boot to transfer files over HTTP. This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
 
 You enter the host details on {ProjectServer} and boot your host.
 {ProjectServer} automatically manages the HTTP boot configuration, organizes networking services, and provides the operating system and configuration for the host.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui.adoc
@@ -4,7 +4,8 @@
 = Creating hosts with UEFI HTTP boot provisioning by using {ProjectWebUI}
 
 [role="_abstract"]
-You can provision hosts with UEFI HTTP boot to transfer files over HTTP. This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
+You can provision hosts with UEFI HTTP boot to transfer files over HTTP.
+This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
 
 You enter the host details on {ProjectServer} and boot your host.
 {ProjectServer} automatically manages the HTTP boot configuration, organizes networking services, and provides the operating system and configuration for the host.

--- a/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-uefi-http-boot-provisioning-by-using-web-ui.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can provision hosts with UEFI HTTP boot to transfer files over HTTP.
-This reduces boot time and improving reliability for large files such as Live images compared to TFTP.
+This improves reliability for large files, such as Live images, and reduces boot time compared to TFTP.
 
 You enter the host details on {ProjectServer} and boot your host.
 {ProjectServer} automatically manages the HTTP boot configuration, organizes networking services, and provides the operating system and configuration for the host.

--- a/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
@@ -4,10 +4,9 @@
 = Creating partition tables by using Hammer CLI
 
 [role="_abstract"]
-A partition table is a type of template that defines the way {Project} configures the disks available on a new host.
-Partition tables use the ERB syntax similar to provisioning templates.
-{ProjectName} contains a set of default partition tables to use, including a `{client-provisioning-template-type} default`.
-You can also edit partition table entries to configure the preferred partitioning scheme, or create a partition table entry and add it to the operating system entry.
+You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
+
+Partition tables use ERB syntax similar to provisioning templates. You must associate partition tables with operating systems to use them during host provisioning.
 
 .Procedure
 . Create a plain text file, such as `_~/My_Partition_Table_`, that contains the partition layout.

--- a/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
@@ -5,8 +5,9 @@
 
 [role="_abstract"]
 You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
-Partition tables use ERB syntax similar to provisioning templates.
 To use them during provisioning, associate partition tables with operating systems.
+
+Partition tables use ERB syntax similar to provisioning templates.
 
 .Procedure
 . Create a plain text file, such as `_~/My_Partition_Table_`, that contains the partition layout.

--- a/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
@@ -5,9 +5,8 @@
 
 [role="_abstract"]
 You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
-
 Partition tables use ERB syntax similar to provisioning templates.
-You must associate partition tables with operating systems to use them during host provisioning.
+To use them during provisioning, associate partition tables with operating systems.
 
 .Procedure
 . Create a plain text file, such as `_~/My_Partition_Table_`, that contains the partition layout.

--- a/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-cli.adoc
@@ -6,7 +6,8 @@
 [role="_abstract"]
 You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
 
-Partition tables use ERB syntax similar to provisioning templates. You must associate partition tables with operating systems to use them during host provisioning.
+Partition tables use ERB syntax similar to provisioning templates.
+You must associate partition tables with operating systems to use them during host provisioning.
 
 .Procedure
 . Create a plain text file, such as `_~/My_Partition_Table_`, that contains the partition layout.

--- a/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
@@ -5,8 +5,9 @@
 
 [role="_abstract"]
 You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
-Partition tables use ERB syntax similar to provisioning templates.
 To use them during provisioning, associate partition tables with operating systems.
+
+Partition tables use ERB syntax similar to provisioning templates.
 
 .Procedure
 

--- a/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
@@ -4,9 +4,10 @@
 = Creating partition tables by using {ProjectWebUI}
 
 [role="_abstract"]
-You can create custom partition tables with your preferred partitioning scheme. {Project} also provides default partition tables that you can use.
+You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
 
-Partition tables use ERB syntax similar to provisioning templates. You must associate partition tables with operating systems to use them during host provisioning.
+Partition tables use ERB syntax similar to provisioning templates.
+You must associate partition tables with operating systems to use them during host provisioning.
 
 .Procedure
 

--- a/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
@@ -4,10 +4,9 @@
 = Creating partition tables by using {ProjectWebUI}
 
 [role="_abstract"]
-A partition table is a type of template that defines the way {Project} configures the disks available on a new host.
-Partition tables use the ERB syntax similar to provisioning templates.
-{ProjectName} contains a set of default partition tables to use, including a `{client-provisioning-template-type} default`.
-You can also edit partition table entries to configure the preferred partitioning scheme, or create a partition table entry and add it to the operating system entry.
+You can create custom partition tables with your preferred partitioning scheme. {Project} also provides default partition tables that you can use.
+
+Partition tables use ERB syntax similar to provisioning templates. You must associate partition tables with operating systems to use them during host provisioning.
 
 .Procedure
 

--- a/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-partition-tables-by-using-web-ui.adoc
@@ -5,9 +5,8 @@
 
 [role="_abstract"]
 You can create custom partition tables with your preferred partitioning scheme instead of the default tables in {Project}.
-
 Partition tables use ERB syntax similar to provisioning templates.
-You must associate partition tables with operating systems to use them during host provisioning.
+To use them during provisioning, associate partition tables with operating systems.
 
 .Procedure
 

--- a/guides/common/modules/proc_deploying-ssh-keys-during-provisioning.adoc
+++ b/guides/common/modules/proc_deploying-ssh-keys-during-provisioning.adoc
@@ -4,8 +4,7 @@
 = Deploying SSH keys during provisioning
 
 [role="_abstract"]
-Deploy SSH keys added to a user during provisioning to establish secure, passwordless remote access to your newly provisioned hosts immediately after the installation.
-For information on adding SSH keys to a user, see {AdministeringDocURL}managing-ssh-keys-for-a-user-by-using-web-ui[Managing SSH keys for a user by using {ProjectWebUI}] in _{AdministeringDocTitle}_.
+You can deploy SSH keys during provisioning to establish secure, passwordless remote access to newly provisioned hosts.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
@@ -26,3 +25,6 @@ For more information, see xref:creating-provisioning-templates-by-using-web-ui[]
 The SSH keys of the *Owned by* user are added automatically when the `create_users` snippet is executed during the provisioning process.
 You can set *Owned by* to an individual user or a user group.
 If you set *Owned by* to a user group, the SSH keys of all users in the user group are added automatically.
+
+.Additional resources
+* {AdministeringDocURL}managing-ssh-keys-for-a-user-by-using-web-ui[Managing SSH keys for a user by using {ProjectWebUI}]

--- a/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
+++ b/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
@@ -5,8 +5,9 @@
 
 [role="_abstract"]
 You can improve performance by filtering network interface card (NIC) connections from the database.
-By default, these options are set for most common hypervisors.
 If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
+
+By default, these options are set for most common hypervisors.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings* and select the *Facts* tab.

--- a/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
+++ b/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
@@ -4,9 +4,9 @@
 = Optimizing performance by removing NICs from database
 
 [role="_abstract"]
-Filter and exclude the connections using the `Exclude pattern for facts stored in {Project}` and `Ignore interfaces with matching identifier` option.
-By default, these options are set to most common hypervisors.
-If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
+You can optimize performance by filtering network interface card (NIC) connections from the database.
+
+By default, these options are set for most common hypervisors. If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings* and select the *Facts* tab.

--- a/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
+++ b/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
@@ -6,7 +6,8 @@
 [role="_abstract"]
 You can optimize performance by filtering network interface card (NIC) connections from the database.
 
-By default, these options are set for most common hypervisors. If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
+By default, these options are set for most common hypervisors.
+If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings* and select the *Facts* tab.

--- a/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
+++ b/guides/common/modules/proc_optimizing-performance-by-removing-nics-from-database.adoc
@@ -4,8 +4,7 @@
 = Optimizing performance by removing NICs from database
 
 [role="_abstract"]
-You can optimize performance by filtering network interface card (NIC) connections from the database.
-
+You can improve performance by filtering network interface card (NIC) connections from the database.
 By default, these options are set for most common hypervisors.
 If you name the virtual interfaces differently, you can update this filter to use it according to your requirements.
 

--- a/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
+++ b/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
@@ -4,8 +4,7 @@
 = Preparing a synchronized Kickstart repository
 
 [role="_abstract"]
-{Project} contains a set of synchronized Kickstart repositories that you use to install the provisioned host's operating system.
-For more information about adding repositories, see {ContentManagementDocURL}synchronizing-repositories-ad-hoc[Synchronizing repositories ad hoc] in _{ContentManagementDocTitle}_.
+You can use synchronized Kickstart repositories to install the operating system on provisioned hosts.
 
 .Prerequisites
 * *BaseOS* and *AppStream Kickstart* are enabled before provisioning.
@@ -20,13 +19,15 @@ If you use a disconnected environment, you must import the Kickstart repositorie
 endif::[]
 +
 . Publish a new version of the content view where the Kickstart repository is added and promote it to a required lifecycle environment.
-For more information, see {ContentManagementDocURL}managing-content-views-and-content-view-environments[Managing content views and content view environments] in _{ContentManagementDocTitle}_.
 . When you create a host, in the *Operating System* tab, for *Media Selection*, select the *Synced Content* checkbox.
 
 .Verification
 * View the Kickstart tree:
-
++
 [subs="+quotes"]
 ----
 $ hammer medium list --organization "_My_Organization_"
 ----
+
+.Additional resources
+* {ContentManagementDocURL}managing-content-views-and-content-view-environments[Managing content views and content view environments]

--- a/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
+++ b/guides/common/modules/proc_preparing-a-synchronized-kickstart-repository.adoc
@@ -4,7 +4,7 @@
 = Preparing a synchronized Kickstart repository
 
 [role="_abstract"]
-You can use synchronized Kickstart repositories to install the operating system on provisioned hosts.
+You can use synchronized Kickstart repositories as the source of the operating system during host provisioning.
 
 .Prerequisites
 * *BaseOS* and *AppStream Kickstart* are enabled before provisioning.

--- a/guides/common/modules/proc_updating-the-details-of-multiple-operating-systems.adoc
+++ b/guides/common/modules/proc_updating-the-details-of-multiple-operating-systems.adoc
@@ -4,7 +4,8 @@
 = Updating the details of multiple operating systems
 
 [role="_abstract"]
-Use this procedure to update the details of multiple operating systems.
+Update multiple operating systems to assign partition tables, configuration templates, and provisioning templates using a Bash script.
+
 This example shows you how to assign each operating system a partition table called `{client-provisioning-template-type} default`, a configuration template called `{client-provisioning-template-type} default PXELinux`, and a provisioning template called `{client-provisioning-template-type} Default`.
 
 .Procedure

--- a/guides/common/modules/proc_updating-the-details-of-multiple-operating-systems.adoc
+++ b/guides/common/modules/proc_updating-the-details-of-multiple-operating-systems.adoc
@@ -4,9 +4,9 @@
 = Updating the details of multiple operating systems
 
 [role="_abstract"]
-Update multiple operating systems to assign partition tables, configuration templates, and provisioning templates using a Bash script.
+Update multiple operating systems to assign partition tables, configuration templates, and provisioning templates by using a Bash script.
 
-This example shows you how to assign each operating system a partition table called `{client-provisioning-template-type} default`, a configuration template called `{client-provisioning-template-type} default PXELinux`, and a provisioning template called `{client-provisioning-template-type} Default`.
+This example assigns each operating system a partition table called `{client-provisioning-template-type} default`, a configuration template called `{client-provisioning-template-type} default PXELinux`, and a provisioning template called `{client-provisioning-template-type} Default`.
 
 .Procedure
 

--- a/guides/common/modules/ref_http-capable-boot-loaders.adoc
+++ b/guides/common/modules/ref_http-capable-boot-loaders.adoc
@@ -4,9 +4,9 @@
 = HTTP-capable boot loaders
 
 [role="_abstract"]
-In addition to the TFTP-based PXE mechanism, {Project} supports boot methods that use HTTP.
-These methods use the *HTTPBoot* module of {SmartProxy} to deliver boot loaders and installation files.
-HTTP-capable boot methods in {Project} are *iPXE*, *iPXE chainloading*, *Grub2*, and *UEFI HTTP Boot*.
+{Project} supports HTTP-based boot methods including iPXE, iPXE chainloading, Grub2, and UEFI HTTP Boot.
+These methods use the HTTPBoot module of {SmartProxy} to deliver boot loaders and installation files.
+
 Each method offers advantages depending on the firmware type and network environment.
 
 The *HTTPBoot* feature exposes the same files that are available via TFTP, but over the HTTP or HTTPS protocol.

--- a/guides/common/modules/ref_pxelinux-boot-loaders.adoc
+++ b/guides/common/modules/ref_pxelinux-boot-loaders.adoc
@@ -4,8 +4,8 @@
 = PXELinux boot loaders
 
 [role="_abstract"]
-PXELinux is a Syslinux-based PXE boot loader for BIOS and UEFI systems.
-{Project} uses PXELinux to boot hosts into the operating system installer during provisioning.
+PXELinux is a Syslinux-based PXE boot loader used by {Project} for BIOS and UEFI systems.
+In {Project}, PXELinux enables hosts to boot into the OS installer automatically during provisioning.
 
 When a host is set to *Build mode*, {Project} generates a host-specific configuration file and places it in the TFTP directory managed by the {SmartProxy}.
 

--- a/guides/common/modules/ref_pxelinux-boot-loaders.adoc
+++ b/guides/common/modules/ref_pxelinux-boot-loaders.adoc
@@ -4,8 +4,9 @@
 = PXELinux boot loaders
 
 [role="_abstract"]
-*PXELinux* is a Syslinux-based PXE boot loader used by {Project} for BIOS and UEFI systems.
-In {Project}, PXELinux enables hosts to boot into the OS installer automatically during provisioning.
+PXELinux is a Syslinux-based PXE boot loader for BIOS and UEFI systems.
+{Project} uses PXELinux to boot hosts into the operating system installer during provisioning.
+
 When a host is set to *Build mode*, {Project} generates a host-specific configuration file and places it in the TFTP directory managed by the {SmartProxy}.
 
 .Default boot loader files


### PR DESCRIPTION
#### What changes are you introducing?
Shorten abstracts, make them more user focused, remove self-referential language ("this procedure...")

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
CQA

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
