### PR TITLE
Include 'Red Hat build of Keycloak' for Satellite build for older ver…

### DIFF
--- a/guides/common/modules/snip_table-authentication-methods.adoc
+++ b/guides/common/modules/snip_table-authentication-methods.adoc
@@ -73,12 +73,12 @@ ifndef::satellite[]
 |No
 endif::[]
 |xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[]
-ifndef::foreman-deb,satellite[]
+ifndef::foreman-deb[]
 |{Keycloak-quarkus}|Yes|Yes|Yes|Yes
 ifndef::satellite[]
 |Yes
 endif::[]
-|xref:configuring-sso-and-2fa-with-keycloak-wildfly-in-project_keycloak-wildfly[]
+|xref:configuring-sso-and-2fa-with-keycloak-wildfly-in-project_keycloak-quarkus[]
 endif::[]
 ifndef::foreman-deb[]
 |{Keycloak-wildfly}|Yes|Yes|Yes|Yes

--- a/guides/common/modules/snip_table-authentication-methods.adoc
+++ b/guides/common/modules/snip_table-authentication-methods.adoc
@@ -78,7 +78,7 @@ ifndef::foreman-deb[]
 ifndef::satellite[]
 |Yes
 endif::[]
-|xref:configuring-sso-and-2fa-with-keycloak-wildfly-in-project_keycloak-quarkus[]
+|xref:configuring-sso-and-2fa-with-keycloak-in-project_keycloak-quarkus[]
 endif::[]
 ifndef::foreman-deb[]
 |{Keycloak-wildfly}|Yes|Yes|Yes|Yes


### PR DESCRIPTION
…sion

Same change as https://github.com/theforeman/foreman-documentation/pull/4876 for 3.17 and lower versions.

Include the 'Red Hat build of Keycloak' entry in the 'verview of authentication methods' table for the Satellite build.

JIRA:
https://redhat.atlassian.net/browse/SAT-44787

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.
