### PR TITLE
Include 'Red Hat build of Keycloak' for Satellite build for 3.16

### DIFF
--- a/guides/common/modules/snip_table-authentication-methods.adoc
+++ b/guides/common/modules/snip_table-authentication-methods.adoc
@@ -72,13 +72,11 @@ ifndef::satellite[]
 |No
 endif::[]
 |xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[]
-ifndef::satellite[]
 |{Keycloak-quarkus}|Yes|Yes|Yes|Yes
 ifndef::satellite[]
 |Yes
 endif::[]
-|xref:configuring-sso-and-2fa-with-keycloak-wildfly-in-project_keycloak-wildfly[]
-endif::[]
+|xref:configuring-sso-and-2fa-with-keycloak-in-project_keycloak-quarkus[]
 |
 {Keycloak-wildfly}|Yes|Yes|Yes|Yes
 ifndef::satellite[]


### PR DESCRIPTION
Same change as #4876 for 3.16.

Include the 'Red Hat build of Keycloak' entry in the 'verview of authentication methods' table for the Satellite build.

JIRA:
https://redhat.atlassian.net/browse/SAT-44787

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
