### PR TITLE
Add Hammer CLI normalization to filename-ID-heading check

### DIFF
--- a/scripts/check-filename-id-heading-match.sh
+++ b/scripts/check-filename-id-heading-match.sh
@@ -87,7 +87,6 @@ check_file() {
         # These are the capitalized attribute names used in headings
         normalized_heading="${normalized_heading//\{projectname\}/project}"
         normalized_heading="${normalized_heading//\{project\}/project}"
-        normalized_heading="${normalized_heading//\{projectwebui\}/web-ui}"
         normalized_heading="${normalized_heading//\{projectserver\}/project-server}"
         normalized_heading="${normalized_heading//\{smartproxy\}/smartproxy}"
         normalized_heading="${normalized_heading//\{smartproxyserver\}/smartproxy-server}"
@@ -106,6 +105,11 @@ check_file() {
         normalized_heading="${normalized_heading//\{rhcloud\}/rhcloud}"
         normalized_heading="${normalized_heading//\{loraxcompose\}/lorax-compose}"
         normalized_heading="${normalized_heading//\{foreman-installer\}/foreman-installer}"
+
+        # Normalize Hammer CLI and Web UI text in headings
+        # The convention is: ID and filename contain "by-using-cli"/"by-using-web-ui", heading contains "by using Hammer CLI"/"by using {ProjectWebUI}"
+        normalized_heading="${normalized_heading//hammer-cli/cli}"
+        normalized_heading="${normalized_heading//\{projectwebui\}/web-ui}"
     fi
 
     # Check if ID matches filename


### PR DESCRIPTION
#### What changes are you introducing?

Introducing an exception to the filename-ID-heading script to cover CLI module naming conventions.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The filename-ID-heading check currently reports our "by using Hammer CLI" files for ID/heading mismatch but our convention says that the ID and filename for these modules is `by-using-cli`. See https://github.com/theforeman/foreman-documentation/issues/4933

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
