### PR TITLE
Improve abstracts in Managing ISO images assembly (Managing content)

### DIFF
--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can use {Project} to store ISO images for host provisioning and creating installation media.
-{Project} supports ISO images from Red{nbsp}Hat's Content Delivery Network or other sources.
+{Project} supports ISO images from Red{nbsp}Hat Content Delivery Network or other sources.
 You can also upload other files, such as virtual machine images, and publish them in repositories.
 
 ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]

--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -4,8 +4,7 @@
 = Managing ISO images
 
 [role="_abstract"]
-You can use {Project} to store ISO images for host provisioning and creating installation media.
-{Project} supports ISO images from Red{nbsp}Hat Content Delivery Network or other sources.
+You can use {Project} to store ISO images from the Red{nbsp}Hat Content Delivery Network or other sources for host provisioning and creating installation media.
 You can also upload other files, such as virtual machine images, and publish them in repositories.
 
 ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]

--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -4,7 +4,8 @@
 = Managing ISO images
 
 [role="_abstract"]
-You can use {Project} to store ISO images, either from Red{nbsp}Hat's Content Delivery Network or other sources.
+You can use {Project} to store ISO images for host provisioning and creating installation media.
+{Project} supports ISO images from Red{nbsp}Hat's Content Delivery Network or other sources.
 You can also upload other files, such as virtual machine images, and publish them in repositories.
 
 ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]

--- a/guides/common/modules/proc_importing-an-iso-image-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-an-iso-image-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Importing an ISO image by using Hammer CLI
 
 [role="_abstract"]
-You can manually import an ISO image to {ProjectServer} by using Hammer CLI. 
+You can manually import an ISO image to {ProjectServer} by using Hammer CLI.
 You must use the Hammer CLI to upload files larger than 15 MB to a repository.
 
 .Procedure

--- a/guides/common/modules/proc_importing-an-iso-image-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-an-iso-image-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Importing an ISO image by using Hammer CLI
 
 [role="_abstract"]
-Use this procedure to manually import an ISO image to {ProjectServer} by using Hammer CLI.
+You can manually import an ISO image to {ProjectServer} by using Hammer CLI. 
 You must use the Hammer CLI to upload files larger than 15 MB to a repository.
 
 .Procedure

--- a/guides/common/modules/proc_importing-an-iso-image-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-an-iso-image-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Importing an ISO image by using {ProjectWebUI}
 
 [role="_abstract"]
-You can manually import an ISO image to {ProjectServer} by using {ProjectWebUI}. 
+You can manually import an ISO image to {ProjectServer} by using {ProjectWebUI}.
 However, if the file size is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
 
 .Procedure

--- a/guides/common/modules/proc_importing-an-iso-image-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-an-iso-image-by-using-web-ui.adoc
@@ -4,8 +4,8 @@
 = Importing an ISO image by using {ProjectWebUI}
 
 [role="_abstract"]
-Use this procedure to manually import an ISO image to {ProjectServer} by using {ProjectWebUI}.
-However, if the size of the file that you want to upload is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
+You can manually import an ISO image to {ProjectServer} by using {ProjectWebUI}. 
+However, if the file size is larger than 15 MB, you must use the Hammer CLI to upload it to a repository.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products* and click *Create Product*.

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-cli.adoc
@@ -4,8 +4,8 @@
 = Importing ISO images from Red Hat by using Hammer CLI
 
 [role="_abstract"]
-The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
-The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
+You can import ISO images for certain products from the Red Hat Content Delivery Network. 
+The process is similar to enabling repositories for RPM content.
 
 .Procedure
 . Locate the {RHELServer} product for `file` repositories:

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Importing ISO images from Red Hat by using Hammer CLI
 
 [role="_abstract"]
-You can import ISO images for certain products from the Red Hat Content Delivery Network. 
+You can import ISO images for certain products from the Red{nbsp}Hat Content Delivery Network.
 The process is similar to enabling repositories for RPM content.
 
 .Procedure

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-cli.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can import ISO images for certain products from the Red{nbsp}Hat Content Delivery Network.
-The process is similar to enabling repositories for RPM content.
+The process is similar to enabling repositories for Yum content.
 
 .Procedure
 . Locate the {RHELServer} product for `file` repositories:

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You can import ISO images for certain products from the Red{nbsp}Hat Content Delivery Network.
-The process is similar to enabling repositories for RPM content.
+The process is similar to enabling repositories for Yum content.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Red{nbsp}Hat Repositories*.

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
@@ -4,8 +4,8 @@
 = Importing ISO images from Red Hat by using {ProjectWebUI}
 
 [role="_abstract"]
-The Red{nbsp}Hat Content Delivery Network provides ISO images for certain products.
-The procedure for importing this content is similar to the procedure for enabling repositories for RPM content.
+You can import ISO images for certain products from the Red Hat Content Delivery Network. 
+The process is similar to enabling repositories for RPM content.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Red{nbsp}Hat Repositories*.
@@ -14,7 +14,7 @@ The procedure for importing this content is similar to the procedure for enablin
 . For the *x86_64 7.2* entry, click the *Enable* icon to enable the repositories for the image.
 . In the {ProjectWebUI}, navigate to *Content* > *Products* and click *{RHELServer}*.
 . Click the *Repositories* tab of the {RHEL} Server window, and click *{RHEL} 7 Server ISOs x86_64 7.2*.
-. In the upper right of the {RHEL} 7 Server ISOs x86_64 7.2 window, click *Select Action* and select *Sync Now*.
+. In the upper right of the {RHEL} 7 Server ISO images x86_64 7.2 window, click *Select Action* and select *Sync Now*.
 
 .Next steps
 * To view the synchronization status, navigate to *Content* > *Sync Status* and expand *{RHELServer}*.

--- a/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Importing ISO images from Red Hat by using {ProjectWebUI}
 
 [role="_abstract"]
-You can import ISO images for certain products from the Red Hat Content Delivery Network. 
+You can import ISO images for certain products from the Red{nbsp}Hat Content Delivery Network.
 The process is similar to enabling repositories for RPM content.
 
 .Procedure


### PR DESCRIPTION
#### What changes are you introducing?
Update abstracts across five modules in the Managing ISO images assembly to follow modular documentation guidelines:

Expand con_managing-iso-images.adoc abstract to include why users store ISO images (host provisioning and installation media)

Remove self-referential language from procedure abstracts in:
  - proc_importing-iso-images-from-red-hat-by-using-web-ui.adoc
  - proc_importing-iso-images-from-red-hat-by-using-cli.adoc
  - proc_importing-an-iso-image-by-using-web-ui.adoc
  - proc_importing-an-iso-image-by-using-cli.adoc
 
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
These changes ensure abstracts describe what users accomplish rather than referencing "the procedure" or "use this procedure", and provide both the "what" and "why" to help readers quickly understand the content's purpose and relevance.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
