### PR TITLE
Add concurrency control to prevent gh-pages deployment race condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,6 +156,9 @@ jobs:
       - build-web
       - build-ccutil
     runs-on: ubuntu-24.04
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
==AI-suggested PR==

### What changes are you introducing?

This prevents simultaneous deployments from different branches from conflicting when pushing to gh-pages. The concurrency group ensures only one deployment runs at a time, while cancel-in-progress: false ensures all deployments complete rather than being cancelled.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Recent occasional fails such as https://github.com/theforeman/foreman-documentation/actions/runs/28227283361/job/83623321676

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
