### PR TITLE
KubeVirt: Add module to delete VMs

### DIFF
--- a/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
+++ b/guides/common/assembly_provisioning-virtual-machines-kubevirt.adoc
@@ -6,6 +6,8 @@ include::modules/con_provisioning-virtual-machines-on-kubevirt.adoc[]
 
 include::modules/proc_adding-kubevirt-connection.adoc[leveloffset=+1]
 
+include::modules/proc_deleting-a-virtual-machine-on-compute-resource.adoc[leveloffset=+1]
+
 :!compute-resource-id:
 :!compute-resource:
 :!kubevirt-provisioning:

--- a/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
+++ b/guides/common/modules/con_provisioning-virtual-machines-on-kubevirt.adoc
@@ -27,8 +27,6 @@ Ensure that no other DHCP services run on this network to avoid conflicts with {
 For more information about network service configuration for {SmartProxyServers}, see xref:preparing-networking-for-host-management[].
 * Ensure the provisioning user has the required permissions to provision hosts.
 
-include::snip_warning-destroy-vm-on-host-delete.adoc[]
-
 .Additional resources
 ifdef::satellite[]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/virtualization/about#authorization_virt-security-policies[Authorization for OpenShift Container Platform Virtualization]


### PR DESCRIPTION
#### What changes are you introducing?

Add module to document how to delete hosts on KubeVirt.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Lacking docs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Follow-up to https://github.com/theforeman/foreman-documentation/pull/4956

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
