### PR TITLE
More Client OS-specific changes for katello and orcharhino builds

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -188,6 +188,7 @@
 :client-os-context: enterprise-linux
 :client-os-label: Enterprise_Linux
 :client-os-major: 9
+:client-os-major-previous: 8
 :client-os-minor: 5
 :client-os-minor-bumped: 6
 :client-package-install-deb: apt install

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -63,6 +63,7 @@
 :client-os-codename: Resolute
 :client-os-context: ubuntu
 :client-os-major: 26.04
+:client-os-major-previous: 24.04
 :client-os-minor: 0
 :client-os: Ubuntu
 // Client attributes in alphabetical order that use other attributes

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -56,6 +56,7 @@
 :atix-kb-clients: https://atixservice.zendesk.com/hc/en-001/articles/19430263501468[{Project} Clients gen3]
 :atix-kb-debian-ubuntu-installation-media: https://atixservice.zendesk.com/hc/en-001/articles/7044086506908[Using file repositories for installation media for Debian/Ubuntu]
 :atix-kb-register-to-occ: https://atixservice.zendesk.com/hc/en-001/articles/9464966748444[Registering {ProjectServer} to OCC]
+:atix-kb-rex-become-user: https://atixservice.zendesk.com/hc/en-001/articles/12639783656348[become_user not working as expected]
 :atix-kb-salt-authentication-version: https://atixservice.zendesk.com/hc/en-001/articles/24283411290908[Salt Master Authentication Version]
 :atix-kb-tech-previews: https://atixservice.zendesk.com/hc/en-001/articles/16772654610844[Technical Previews]
 // Client attributes; overwritten in downstream for docs.orcharhino.com for all supported Client OS

--- a/guides/common/modules/con_managing-alternate-content-sources.adoc
+++ b/guides/common/modules/con_managing-alternate-content-sources.adoc
@@ -17,7 +17,7 @@ A weekly cron job refreshes all alternate content sources.
 You can also refresh the alternate content sources manually by using the {ProjectWebUI} or Hammer CLI.
 Alternate content sources associated with your {ProjectServer}, or {SmartProxyServers} attached to multiple organizations, affect all organizations.
 
-There are three types of alternate content sources:
+There are the following types of alternate content sources:
 
 Custom::
 Custom alternate content sources download the content from any upstream repository on the network or filesystem.

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -99,6 +99,15 @@ endif::[]
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
 # chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi
 ----
+ifdef::ubuntu[]
+. Some older Ubuntu versions look for the GRUB configuration on the TFTP server at `grub/grub.cfg`.
+To support these versions for Secure Boot, create the legacy `grub/` directory and link `grub2/grub.cfg` into it:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+# mkdir --parents /var/lib/tftpboot/grub/ && ln --relative --symbolic /var/lib/tftpboot/grub2/grub.cfg /var/lib/tftpboot/grub/grub.cfg
+----
+endif::[]
 
 .Verification
 * Verify the contents of your boot loader directory:

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-cli.adoc
@@ -9,8 +9,13 @@ You can create a custom alternate content source (ACS) to accelerate content syn
 .Prerequisites
 * If the repository requires SSL authentication, the SSL certificate and key must be imported into {Project}.
 For more information, see {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-cli[Importing custom SSL certificates by using Hammer CLI] in _{ContentManagementDocTitle}_.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * You have the base URL and subpaths of your alternate content source.
-For example, if your base URL is `\https://{server-example-com}` and your subpaths are `rhel10/` and `rhel9/`, then {Project} searches `\https://{server-example-com}/rhel10/` and `\https://{server-example-com}/rhel9/`.
+For example, if your base URL is `\https://{server-example-com}` and your subpaths are `{client-os-context}-{client-os-major}/` and `{client-os-context}-{client-os-major-previous}/`, then {Project} will search `\https://{server-example-com}/{client-os-context}-{client-os-major}/` and `\https://{server-example-com}/{client-os-context}-{client-os-major-previous}/`.
+endif::[]
+ifdef::debian,ubuntu[]
+* You have the base URL and architectures, components, and releases of the Deb repository.
+endif::[]
 
 .Procedure
 . Create a custom alternate content source:
@@ -20,8 +25,16 @@ For example, if your base URL is `\https://{server-example-com}` and your subpat
 $ hammer alternate-content-source create \
 --alternate-content-source-type custom \
 --base-url "_https://local-repo.example.com:port_" \
+ifdef::debian,ubuntu[]
+--deb-architectures "_My_Deb_Architecture_1_,_My_Deb_Architecture_2_" \
+--deb-components "_My_Deb_Component_1_,_My_Deb_Component_2_" \
+--deb-releases "_My_Deb_Release_1_,_My_Deb_Release_2_" \
+endif::[]
 --name "_My_ACS_Name_" \
 --smart-proxy-ids __My_{smart-proxy-context-titlecase}_ID_1__,__My_{smart-proxy-context-titlecase}_ID_2__ \
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
+--subpaths "_My_Subpath_1_/_,_My_Subpath_2_/_," \
+endif::[]
 --verify-ssl _true_
 ----
 . Refresh your alternate content source:

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
@@ -9,8 +9,13 @@ You can create a custom alternate content source (ACS) to accelerate content syn
 .Prerequisites
 * If the repository requires SSL authentication, the SSL certificate and key must be imported into {Project}.
 For more information, see {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-web-ui[Importing {customssl} certificates by using {ProjectWebUI}] in _{ContentManagementDocTitle}_.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * You have the base URL and subpaths of your alternate content source.
-For example, if your base URL is `\https://{server-example-com}` and your subpaths are `rhel10/` and `rhel9/`, then {Project} searches `\https://{server-example-com}/rhel10/` and `\https://{server-example-com}/rhel9/`.
+For example, if your base URL is `\https://{server-example-com}` and your subpaths are `{client-os-context}-{client-os-major}/` and `{client-os-context}-{client-os-major-previous}/`, then {Project} will search `\https://{server-example-com}/{client-os-context}-{client-os-major}/` and `\https://{server-example-com}/{client-os-context}-{client-os-major-previous}/`.
+endif::[]
+ifdef::debian,ubuntu[]
+* You have the base URL and architectures, components, and releases of the Deb repository.
+endif::[]
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Alternate Content Sources*.
@@ -22,7 +27,14 @@ For example, if your base URL is `\https://{server-example-com}` and your subpat
 . Select {SmartProxies} to which you want to synchronize content from your alternate content source.
 . If you require synchronizing content through the HTTP proxy of your {SmartProxies}, select *Use HTTP proxies*.
 . In the *Base URL* field, enter the base URL of the alternate content source.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 . In the *Subpaths* field, provide a comma-separated list of subpaths.
+endif::[]
+ifdef::debian,ubuntu[]
+. In the *Distributions* field, provide a whitespace-separated list of distributions.
+. Optional: In the *Components* field, provide a whitespace-separated list of components.
+. Optional: In the *Architectures* field, provide a whitespace-separated list of architectures.
+endif::[]
 . If your alternate content source requires authentication, select the *Manual authentication* or *Content credentials*.
 . If SSL verification is required, enable *Verify SSL* and select the SSL CA certificate.
 . Click *Add*.

--- a/guides/common/modules/proc_creating-a-simplified-alternate-content-source-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-simplified-alternate-content-source-by-using-cli.adoc
@@ -17,10 +17,21 @@ This accelerates synchronization by downloading content directly from the upstre
 ----
 $ hammer alternate-content-source create \
 --alternate-content-source-type simplified \
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
+--content-type yum \
+endif::[]
+ifdef::debian,ubuntu[]
+--content-type deb \
+--deb-architectures "_My_Deb_Architecture_1_,_My_Deb_Architecture_2_" \
+--deb-components "_My_Deb_Component_1_,_My_Deb_Component_2_" \
+--deb-releases "_My_Deb_Release_1_,_My_Deb_Release_2_" \
+endif::[]
 --name "_My_ACS_Name_" \
 --product-ids _My_Product_ID_1_,_My_Product_ID_2_ \
 --smart-proxy-ids __My_{smart-proxy-context-titlecase}_ID_1__,__My_{smart-proxy-context-titlecase}_ID_2__
 ----
++
+Use `--content-type file` if you want to create a simplified ACS for a product with file-type repositories.
 . Refresh your alternate content source:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
+++ b/guides/common/modules/proc_provisioning-ubuntu-autoinstall-through-smart-proxies.adoc
@@ -23,6 +23,10 @@ Set the *Path* to the extracted ISO image on your {SmartProxyServer}.
 . Assign the installation medium to your operating system entry for {client-os-example}.
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
 . Select the host group that you use to deploy {client-os-example} through a {SmartProxyServer} and set the installation medium entry accordingly.
+ifdef::orcharhino[]
++
+If you use the `Preseed Autoinstall cloud-init user data` template and you want to use a different Ubuntu mirror than your {SmartProxy}, you can set the parameter `ubuntu_mirror_uri` to your custom Ubuntu mirror.
+endif::[]
 . On your {SmartProxyServer}, verify that {SmartProxy} HTTP forward is enabled:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_using-older-salt-minions.adoc
+++ b/guides/common/modules/proc_using-older-salt-minions.adoc
@@ -28,5 +28,5 @@ By default, the Salt minimum authentication version is set to `3`.
 
 ifdef::orcharhino[]
 .Additional resources
-* {atix-kb-salt-authentication-version} in the _ATIX Service Portal_
+* {atix-kb-salt-authentication-version}
 endif::[]

--- a/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
+++ b/guides/common/modules/proc_using-vmware-cloud-init-and-userdata-templates-for-provisioning.adoc
@@ -32,8 +32,10 @@ include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc
 ----
 # {client-package-install-el8} cloud-init open-vm-tools perl-interpreter perl-File-Temp
 ----
+ifdef::foreman-el,foreman-deb,katello,satellite,almalinux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 +
 On {EL} 9, you also require the `dbus-tools` package for network connectivity.
+endif::[]
 . Disable network configuration by `cloud-init`:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/ref_advanced-settings-in-the-job-wizard.adoc
+++ b/guides/common/modules/ref_advanced-settings-in-the-job-wizard.adoc
@@ -48,3 +48,8 @@ This can prevent overload of system resources in a case of executing the job on 
 Execution ordering::
 Determines the order in which the job is executed on hosts.
 It can be alphabetical or randomized.
+
+ifdef::orcharhino[]
+.Additional resources
+* {atix-kb-rex-become-user}
+endif::[]

--- a/guides/common/modules/snip_file-type-repositories-for-installation-media-for-debian-and-ubuntu.adoc
+++ b/guides/common/modules/snip_file-type-repositories-for-installation-media-for-debian-and-ubuntu.adoc
@@ -11,7 +11,6 @@ For a list of upstream URLs, see {atix-kb-debian-ubuntu-installation-media} in t
 * Debian 13
 * Debian 12
 * Debian 11
-* Debian 10
 * Ubuntu 26.04
 * Ubuntu 24.04
 * Ubuntu 22.04

--- a/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
+++ b/guides/common/modules/snip_prerequisite-repositories-with-oscap.adoc
@@ -5,14 +5,22 @@ ifdef::foreman-el[]
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 * Repositories for the operating system version of the host are synchronized on {ProjectServer} and enabled on the host.
+ifdef::katello,satellite,almalinux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 ** {EL} 10: BaseOS and AppStream RPMs repositories
 ** {EL} 9: BaseOS and AppStream RPMs repositories
+endif::[]
+ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 ** {EL} 8: BaseOS and AppStream RPMs repositories
+endif::[]
+ifdef::katello,satellite,oracle_linux,red_hat_enterprise_linux[]
 ** {EL} 7: Server and Extras RPMs repositories
 endif::[]
-ifdef::katello,orcharhino[]
+endif::[]
+ifdef::katello,debian[]
 ** Debian 13 "Trixie": Suite `trixie` and component `main`
 ** Debian 12 "Bookworm": Suite `bookworm` and component `main`
+ifdef::katello,ubuntu[]
 ** Ubuntu 26.04 "Resolute": Suite `resolute` and components `main universe`
 ** Ubuntu 24.04 "Noble": Suite `noble` and components `main universe`
+endif::[]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Various Client OS-related changes for upstream and downstream docs.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

For upstream, not every Client runs EL. For downstream, there are docs for nine different Client OS.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

All commits have been cherry-picked from a stable downstream branch. Please review commit by commit.

#### Contributor checklists

* [ ] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
