### PR TITLE
Expose containerized Admin guide in navigation

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -5,12 +5,6 @@ include::common/header.adoc[]
 
 = {AdministeringDocTitle}
 
-ifdef::containerized[]
-ifdef::katello[]
-include::common/modules/ref_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-endif::[]
-
 ifndef::containerized[]
 
 ifdef::satellite[]

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -147,6 +147,7 @@
           ["Installing_Server", "Installing Foreman Server"]
         ],
         "Administering Foreman server": [
+          ["Administering_Project", "Administering Foreman"],
           ["Configuring_User_Authentication", "Configuring user authentication"]
         ],
         "Administering hosts": [


### PR DESCRIPTION
#### What changes are you introducing?

* Adding Admin guide to the list of containerized guides in navigation (because it now contains containerized backup documentation that we want users to be aware of)
* Removing the guide-not-ready snippet (because the snippet was added as an additional warning for users who might stumble across the guide even though it was not in navigation; that's not needed anymore because the guide will be exposed in navigation intentionally and it will contain containerized documentation intended for user consumption)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/4850 will add first new content for the Admin guide and after that, we can add it to navigation.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
