### PR TITLE
Use singular for adding details to compute profile for EC2

### DIFF
--- a/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
+++ b/guides/common/assembly_provisioning-cloud-instances-ec2.adoc
@@ -28,7 +28,7 @@ include::modules/proc_adding-amazon-ec2-images-to-server-by-using-cli.adoc[level
 
 include::modules/proc_adding-amazon-ec2-details-to-a-compute-profile-by-using-web-ui.adoc[leveloffset=+1]
 
-include::modules/proc_adding-amazon-ec2-details-to-compute-profiles-by-using-cli.adoc[leveloffset=+1]
+include::modules/proc_adding-amazon-ec2-details-to-a-compute-profile-by-using-cli.adoc[leveloffset=+1]
 
 include::modules/proc_creating-image-based-hosts-on-amazon-ec2-by-using-web-ui.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-amazon-ec2-details-to-a-compute-profile-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="adding-amazon-ec2-details-to-compute-profiles-by-using-cli"]
-= Adding Amazon EC2 details to compute profiles by using Hammer CLI
+[id="adding-amazon-ec2-details-to-a-compute-profile-by-using-cli"]
+= Adding Amazon EC2 details to a compute profile by using Hammer CLI
 
 [role="_abstract"]
 You can add hardware settings for instances on Amazon EC2 to a compute profile.


### PR DESCRIPTION
#### What changes are you introducing?

Rename module.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This patch ensures that the title/anchor/file name of the docs to add details to a compute profile for Amazon EC2 via Hammer CLI aligns with all other modules.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

````
$ fd details-to-a-compute-profile
$ rg -i "adding-amazon-ec2-details-to-compute-profiles-by-using-cli"
````

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
