### PR TITLE
Move xrefs to additional resources

### DIFF
--- a/guides/common/assembly_synchronizing-content-between-servers.adoc
+++ b/guides/common/assembly_synchronizing-content-between-servers.adoc
@@ -16,9 +16,9 @@ include::modules/proc_synchronizing-a-custom-repository.adoc[leveloffset=+1]
 
 include::modules/con_content-synchronization-by-using-export-and-import.adoc[leveloffset=+1]
 
-include::modules/proc_using-upstream-server-as-a-content-store.adoc[leveloffset=+2]
+include::modules/proc_using-an-upstream-project-server-as-a-content-store.adoc[leveloffset=+2]
 
-include::modules/proc_using-upstream-server-to-sync-content-view-versions.adoc[leveloffset=+2]
+include::modules/proc_using-an-upstream-project-server-to-synchronize-content-view-versions.adoc[leveloffset=+2]
 
 include::modules/proc_synchronizing-a-single-repository.adoc[leveloffset=+2]
 

--- a/guides/common/modules/proc_synchronizing-a-single-repository.adoc
+++ b/guides/common/modules/proc_synchronizing-a-single-repository.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="synchronizing-a-single-repository_{context}"]
+[id="synchronizing-a-single-repository"]
 = Synchronizing a single repository
 
 [role="_abstract"]
@@ -11,30 +11,33 @@ Export a single repository from the upstream {ProjectServer} and import it on th
 .. Ensure that the repository is using the *Immediate* download policy in one of the following ways:
 ... For existing repositories using *On Demand*, change their download policy on the repository details page to *Immediate*.
 ifdef::katello,satellite,red_hat_enterprise_linux[]
-... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
+... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red{nbsp}Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
 ifdef::almalinux,amazon_linux,centos,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[]
 ... Ensure that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
-
-+
-For more information, see xref:Download_Policies_Overview_{context}[].
 .. Enable the content that you want to synchronize.
-ifdef::katello,satellite,red_hat_enterprise_linux[]
-For more information, see xref:enabling-red-hat-repositories-by-using-web-ui[].
-endif::[]
 +
-If you want to sync custom content, first xref:creating-a-custom-product-by-using-web-ui[create a custom product] and then xref:synchronizing-repositories-ad-hoc[synchronize product repositories].
+If you want to sync custom content, first create a {customproduct} and then synchronize product repositories.
 .. Synchronize the enabled content:
 .. On the first export, perform a `complete` repository export so that all the synchronized content is exported.
 This generates content archives that you can later import into one or more downstream {ProjectServer}s.
-For more information on performing a complete repository export, see xref:Exporting_a_Repository_{context}[].
 .. Export all future updates on the upstream {ProjectServer} incrementally.
 This generates leaner content archives that contain only a recent set of updates.
-For more information on performing an incremental repository export, see xref:exporting-a-repository-incrementally[].
 . On the downstream {ProjectServer}, perform the following steps:
 .. Bring the content exported from the upstream {ProjectServer} over to the hard disk.
-.. Place it inside a directory under `/var/lib/pulp/imports`.
-.. Import the content to an organization. See xref:Importing_a_Repository_{context}[].
+.. Place it inside a directory under `/var/lib/pulp/imports/`.
+.. Import the content to an organization.
 +
 You can then manage content using content views or lifecycle environments as you require.
+
+.Additional resources
+ifdef::katello,satellite,red_hat_enterprise_linux[]
+* xref:enabling-red-hat-repositories-by-using-web-ui[]
+endif::[]
+* xref:Download_Policies_Overview_{context}[]
+* xref:creating-a-custom-product-by-using-web-ui[]
+* xref:synchronizing-repositories-ad-hoc[]
+* xref:Exporting_a_Repository_{context}[]
+* xref:exporting-a-repository-incrementally[]
+* xref:Importing_a_Repository_{context}[]

--- a/guides/common/modules/proc_using-an-upstream-project-server-as-a-content-store.adoc
+++ b/guides/common/modules/proc_using-an-upstream-project-server-as-a-content-store.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Using_Upstream_Server_as_a_Content_Store_{context}"]
+[id="using-an-upstream-{project-context}-server-as-a-content-store"]
 = Using an upstream {ProjectServer} as a content store
 
 [role="_abstract"]
@@ -11,31 +11,34 @@ Export Library content from an upstream {ProjectServer} that serves as a content
 .. Ensure that repositories are using the *Immediate* download policy in one of the following ways:
 ... For existing repositories using *On Demand*, change their download policy on the repository details page to *Immediate*.
 ifdef::katello,satellite,red_hat_enterprise_linux[]
-... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
+... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red{nbsp}Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
 ifdef::almalinux,amazon_linux,centos,debian,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[]
 ... Ensure that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
-
-+
-For more information, see xref:Download_Policies_Overview_{context}[].
 .. Enable the content that you want to synchronize.
-ifdef::katello,satellite,red_hat_enterprise_linux[]
-For more information, see xref:enabling-red-hat-repositories-by-using-web-ui[].
-endif::[]
 +
-If you want to sync custom content, first xref:creating-a-custom-product-by-using-web-ui[create a custom product] and then xref:synchronizing-repositories-ad-hoc[synchronize repositories].
+If you want to sync custom content, first create a {customproduct} and then synchronize repositories.
 .. Synchronize the enabled content:
 ... On the first export, perform a `complete` Library export so that all the synchronized content is exported.
 This generates content archives that you can later import into one or more downstream {ProjectServer}s.
-For more information on performing a complete Library export, see xref:Exporting_the_Library_Environment_{context}[].
 ... Export all future updates on the upstream {ProjectServer} incrementally.
 This generates leaner content archives that contain only a recent set of updates.
 For example, if you enable and synchronize a new repository, the next exported content archive contains content only from the newly enabled repository.
-For more information on performing an incremental Library export, see xref:exporting-the-library-environment-incrementally_{context}[].
 . On the downstream {ProjectServer}, perform the following steps:
 .. Bring the content exported from the upstream {ProjectServer} over to the hard disk.
-.. Place it inside a directory under `/var/lib/pulp/imports`.
-.. Import the content to an organization using the procedure outlined in xref:Importing_into_the_Library_Environment_{context}[].
+.. Place it inside a directory under `/var/lib/pulp/imports/`.
+.. Import the content to an organization.
 +
 You can then manage content using content views or lifecycle environments as you require.
+
+.Additional resources
+ifdef::katello,satellite,red_hat_enterprise_linux[]
+* xref:enabling-red-hat-repositories-by-using-web-ui[]
+endif::[]
+* xref:Download_Policies_Overview_{context}[]
+* xref:creating-a-custom-product-by-using-web-ui[]
+* xref:synchronizing-repositories-ad-hoc[]
+* xref:Exporting_the_Library_Environment_{context}[]
+* xref:exporting-the-library-environment-incrementally_{context}[]
+* xref:Importing_into_the_Library_Environment_{context}[]

--- a/guides/common/modules/proc_using-an-upstream-project-server-to-synchronize-content-view-versions.adoc
+++ b/guides/common/modules/proc_using-an-upstream-project-server-to-synchronize-content-view-versions.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Using_Upstream_Server_to_Synchronize_Content_View_Versions_{context}"]
+[id="using-an-upstream-{project-context}-server-to-synchronize-content-view-versions"]
 = Using an upstream {ProjectServer} to synchronize content view versions
 
 [role="_abstract"]
@@ -11,34 +11,36 @@ Curate updates on the upstream {ProjectServer} into content views and lifecycle 
 .. Ensure that repositories are using the *Immediate* download policy in one of the following ways:
 ... For existing repositories using *On Demand*, change their download policy on the repository details page to *Immediate*.
 ifdef::katello,satellite,red_hat_enterprise_linux[]
-... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
+... For new repositories, ensure that the *Default Red Hat Repository download policy* setting is set to *Immediate* before enabling Red{nbsp}Hat repositories, and that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
 ifdef::katello,almalinux,amazon_linux,centos,debian,oracle_linux,rocky_linux,suse_linux_enterprise_server,ubuntu[]
 ... Ensure that the *Default download policy* is set to *Immediate* for custom repositories.
 endif::[]
-
-+
-For more information, see xref:Download_Policies_Overview_{context}[].
 .. Enable the content that you want to synchronize.
-ifdef::katello,satellite,red_hat_enterprise_linux[]
-For more information, see xref:enabling-red-hat-repositories-by-using-web-ui[].
-endif::[]
 +
-If you want to sync custom content, first xref:creating-a-custom-product-by-using-web-ui[create a custom product] and then xref:synchronizing-repositories-ad-hoc[synchronize repositories].
+If you want to sync custom content, first create a {customproduct} and then synchronize repositories.
 .. Synchronize the enabled content:
 ... For the first export, perform a `complete` version export on the content view version that you want to export.
-For more information see, xref:Exporting_a_Content_View_Version_{context}[].
 This generates content archives that you can import into one or more downstream {ProjectServer}s.
 ... Export all future updates in the connected {ProjectServer}s incrementally.
 This generates leaner content archives that contain changes only from the recent set of updates.
 For example, if your content view has a new repository, this exported content archive contains only the latest changes.
-For more information, see xref:Exporting_a_Content_View_Version_Incrementally_{context}[].
 ... When you have new content, republish the content views that include this content before exporting the increment.
-For more information, see xref:managing-content-views-and-content-view-environments[].
 This creates a new content view version with the appropriate content to export.
 . On the downstream {ProjectServer}, perform the following steps:
 .. Bring the content exported from the upstream {ProjectServer} over to the hard disk.
-.. Place it inside a directory under `/var/lib/pulp/imports`.
+.. Place it inside a directory under `/var/lib/pulp/imports/`.
 .. Import the content to the organization that you want.
-For more information, see xref:Importing_a_Content_View_Version_{context}[].
 This will create a content view version from the exported content archives and then import content appropriately.
+
+.Additional resources
+ifdef::katello,satellite,red_hat_enterprise_linux[]
+* xref:enabling-red-hat-repositories-by-using-web-ui[]
+endif::[]
+* xref:Download_Policies_Overview_{context}[]
+* xref:synchronizing-repositories-ad-hoc[]
+* xref:creating-a-custom-product-by-using-web-ui[]
+* xref:managing-content-views-and-content-view-environments[]
+* xref:Exporting_a_Content_View_Version_Incrementally_{context}[]
+* xref:Exporting_a_Content_View_Version_{context}[]
+* xref:Importing_a_Content_View_Version_{context}[]


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that there are no lines with two or more xrefs in those three modules. It also appends a slash to indicate a directory and places all xrefs in an alphabetically sorted list at the bottom of each module.

It also replaces "custom product" with "{customproduct}" and ensures that there is a non-breaking space in "Red Hat".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

DITA & to avoid broken links in downstream because there are two xrefs on one line.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

There are no broken xrefs:

````
$ rg -i "Using_Upstream_Server_as_a_Content_Store_"
$ rg -i "Using_Upstream_Server_to_Synchronize_Content_View_Versions_"
$ rg -i "synchronizing-a-single-repository_"
````

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
