### PR TITLE
Replace undefined attribute 3.17 + 3.16

### DIFF
--- a/guides/common/modules/con_dependency-resolution-limitations-for-incremental-errata-updates.adoc
+++ b/guides/common/modules/con_dependency-resolution-limitations-for-incremental-errata-updates.adoc
@@ -21,7 +21,7 @@ The `example_tools-1.1` package requires the `example_repository-libs-1.1` packa
 After an incremental content view update, the `example_tools-1.1`, `example_tools-1.0`, and `example_repository-libs-1.1` are now in the repository.
 The repository also has the packages `example_repository-1.0` and `example_repository-libs-1.0`.
 Note that the incremental update to the content view did not add the package `example_repository-1.1`.
-Because you can install all these packages by using `{package-manager}`, no potential problem is detected.
+Because you can install all these packages by using the package manager, no potential problem is detected.
 However, when the client installs the `example_tools-1.1` package, a dependency resolution problem occurs because both `example_repository-libs-1.0` and `example_repository-libs-1.1` cannot be installed.
 ====
 


### PR DESCRIPTION
#### What changes are you introducing?

Replacing attribute with a generic phrase

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Attribute undefined on 3.17 and 3.16 -> failing builds

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Follow-up for cherry picks in #4962

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
