### PR TITLE
Move xrefs to additional resources

### DIFF
--- a/guides/common/assembly_adding-content-to-foreman.adoc
+++ b/guides/common/assembly_adding-content-to-foreman.adoc
@@ -48,7 +48,7 @@ include::modules/proc_adding-deb-repositories-by-using-web-ui.adoc[leveloffset=+
 include::modules/proc_adding-deb-repositories-by-using-cli.adoc[leveloffset=+2]
 endif::[]
 
-ifndef::satellite[]
+ifdef::katello,red_hat_enterprise_linux[]
 include::modules/proc_enabling-red-hat-repositories-by-using-web-ui.adoc[leveloffset=+2]
 
 include::modules/proc_enabling-red-hat-repositories-by-using-cli.adoc[leveloffset=+2]

--- a/guides/common/modules/con_products-and-repositories.adoc
+++ b/guides/common/modules/con_products-and-repositories.adoc
@@ -40,5 +40,7 @@ ifdef::satellite[]
 For more information about creating and packaging RPMs, see the {RHELDocsBaseURL}7/html-single/rpm_packaging_guide/[_{RHEL}{nbsp}7 RPM Packaging Guide_].
 endif::[]
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 .Additional resources
 * xref:enabling-red-hat-repositories-by-using-web-ui[]
+endif::[]

--- a/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments-by-using-cli.adoc
+++ b/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments-by-using-cli.adoc
@@ -38,4 +38,4 @@ If you want to remove your rolling content view from all lifecycle environments,
 
 .Next steps
 * Synchronize lifecycle environments to {SmartProxyServers}.
-For more information, see {AdministeringDocURL}Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_admin[Synchronizing content from {ProjectServer} to {SmartProxyServers}] in _{AdministeringDocTitle}_.
+For more information, see {ContentManagementDocURL}synchronizing-a-content-view-to-a-{smart-proxy-context}-server[Synchronizing a content view to a {SmartProxyServer}] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_assigning-a-rolling-content-view-to-lifecycle-environments-by-using-web-ui.adoc
@@ -24,4 +24,4 @@ By using environments other than Library, you can synchronize your rolling conte
 
 .Next steps
 * Synchronize lifecycle environments to {SmartProxyServers}.
-For more information, see {AdministeringDocURL}Synchronizing_Content_from_{project-context}_Server_to_{smart-proxy-context-titlecase}_Servers_admin[Synchronizing content from {ProjectServer} to {SmartProxyServers}] in _{AdministeringDocTitle}_.
+For more information, see {ContentManagementDocURL}adding-lifecycle-environments-by-using-web-ui[Adding lifecycle environments to {SmartProxyServers} by using {ProjectWebUI}] in _{ContentManagementDocTitle}_.

--- a/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network-by-using-cli.adoc
+++ b/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network-by-using-cli.adoc
@@ -9,9 +9,7 @@ To synchronize content over a network, configure your downstream {ProjectServer}
 .Prerequisites
 * A network connection exists between the upstream {ProjectServer} and the downstream {ProjectServer}.
 * You imported the same subscription manifest on both the upstream and downstream {ProjectServer}.
-For more information, see xref:importing-red-hat-subscription-manifests-into-{project-context}[].
 * On the upstream {ProjectServer}, you enabled the required repositories for the organization.
-For more information, see {ContentManagementDocURL}enabling-red-hat-repositories-by-using-web-ui[Enabling Red Hat Repositories] in _{ContentManagementDocTitle}_.
 * The upstream user is an admin or has the following permissions:
 ** `view_organizations`
 ** `view_products`
@@ -19,7 +17,6 @@ For more information, see {ContentManagementDocURL}enabling-red-hat-repositories
 ** `view_lifecycle_environments`
 ** `view_content_views`
 * On the downstream {ProjectServer}, you have imported the SSL certificate of the upstream {ProjectServer} using the contents of `http://_upstream-{foreman-example-com}_/pub/katello-server-ca.crt`.
-For more information, see {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-web-ui[Importing SSL Certificates] in _{ContentManagementDocTitle}_.
 * The downstream user is an admin or has the permissions to create product repositories and organizations.
 
 .Procedure
@@ -51,3 +48,10 @@ $ hammer organization configure-cdn \
 +
 The default lifecycle environment label is `Library`.
 The default content view label is `Default_Organization_View`.
+
+.Additional resources
+ifdef::katello,satellite,red_hat_enterprise_linux[]
+* xref:importing-red-hat-subscription-manifests-into-{project-context}[]
+* {ContentManagementDocURL}enabling-red-hat-repositories-by-using-web-ui[Enabling Red{nbsp}Hat repositories in _{ContentManagementDocTitle}_]
+endif::[]
+* {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-web-ui[Importing {customssl} certificates by using {ProjectWebUI} in _{ContentManagementDocTitle}_]

--- a/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_configuring-projectserver-to-synchronize-content-over-a-network-by-using-web-ui.adoc
@@ -9,9 +9,7 @@ To synchronize content over a network, configure your downstream {ProjectServer}
 .Prerequisites
 * A network connection exists between the upstream {ProjectServer} and the downstream {ProjectServer}.
 * You imported the same subscription manifest on both the upstream and downstream {ProjectServer}.
-For more information, see xref:importing-red-hat-subscription-manifests-into-{project-context}[].
 * On the upstream {ProjectServer}, you enabled the required repositories for the organization.
-For more information, see {ContentManagementDocURL}enabling-red-hat-repositories-by-using-web-ui[Enabling Red Hat Repositories] in _{ContentManagementDocTitle}_.
 * The upstream user is an admin or has the following permissions:
 ** `view_organizations`
 ** `view_products`
@@ -19,9 +17,7 @@ For more information, see {ContentManagementDocURL}enabling-red-hat-repositories
 ** `view_lifecycle_environments`
 ** `view_content_views`
 * On the downstream {ProjectServer}, you have imported the SSL certificate of the upstream {ProjectServer} using the contents of `http://_upstream-{foreman-example-com}_/pub/katello-server-ca.crt`.
-For more information, see {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-web-ui[Importing SSL Certificates] in _{ContentManagementDocTitle}_.
 * The downstream user is an admin or has the permissions to create product repositories and organizations.
-
 
 .Procedure
 . Navigate to *Content* > *Subscriptions*.
@@ -43,4 +39,11 @@ Default is `Default_Organization_View`.
 . From the *Select Action* menu, select *Sync Now* to synchronize all repositories within the product.
 +
 You can also create a synchronization plan to ensure updates on a regular basis.
-For more information, see {ContentManagementDocURL}creating-a-sync-plan-by-using-web-ui[Creating a Synchronization Plan] in _{ContentManagementDocTitle}_.
+
+.Additional resources
+ifdef::katello,satellite,red_hat_enterprise_linux[]
+* xref:importing-red-hat-subscription-manifests-into-{project-context}[]
+* {ContentManagementDocURL}enabling-red-hat-repositories-by-using-web-ui[Enabling Red{nbsp}Hat repositories in _{ContentManagementDocTitle}_]
+endif::[]
+* {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-web-ui[Importing {customssl} certificates by using {ProjectWebUI} in _{ContentManagementDocTitle}_]
+* {ContentManagementDocURL}creating-a-sync-plan-by-using-web-ui[Creating a sync plan by using {ProjectWebUI} in _{ContentManagementDocTitle}_]

--- a/guides/common/modules/proc_enabling-the-project-client-name-repository.adoc
+++ b/guides/common/modules/proc_enabling-the-project-client-name-repository.adoc
@@ -9,7 +9,6 @@ After enabling a Red Hat repository, {Project} creates a product for this reposi
 
 .Prerequisites
 * Ensure that a subscription manifest has been imported to your organization.
-For more information, see xref:importing-red-hat-subscription-manifests-into-{project-context}[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Red Hat Repositories*.
@@ -18,3 +17,8 @@ For more information, see xref:importing-red-hat-subscription-manifests-into-{pr
 Optionally, enable the *Recommended Repositories* filter to limit the results.
 . Click the name of the required repository to expand the repository set.
 . For the required architecture, click the *+* icon to enable the repository.
+
+ifdef::katello,satellite,red_hat_enterprise_linux[]
+.Additional resources
+* xref:importing-red-hat-subscription-manifests-into-{project-context}[]
+endif::[]

--- a/guides/common/modules/ref_repository-definitions-for-oracle-linux-on-uln.adoc
+++ b/guides/common/modules/ref_repository-definitions-for-oracle-linux-on-uln.adoc
@@ -12,18 +12,14 @@ There are two main differences compared to generic Yum content:
 Combined, `uln://ol7_x86_64_MySQL80_community` is a valid upstream URL for a Yum repository.
 * Authentication against the repository through an *Upstream Username* and *Upstream Password* is mandatory.
 Use your single sign-on user name and token of your Oracle account to authenticate from {Project}.
-+
-For more information, see https://docs.oracle.com/en/operating-systems/oracle-linux/uln/uln-GeneratingAuthToken.html[Generating an Authentication Token] in _Unbreakable Linux Network User's Guide_.
 
 To obtain a list of available ULN channel labels, log in to https://linux.oracle.com/[Oracle Unbreakable Linux Network].
 Navigate to the *channels* tab and select an operating system release version and architecture.
 Copy the required *ULN Channel Label* from the list of available content.
 
 Adding ULN repositories is different compared to Yum repositories for {client-os}, for example, `\https://yum.oracle.com/oracle-linux-9.html`, which you can add as Yum-type content.
-For more information, see xref:adding-custom-rpm-repositories-by-using-web-ui[].
 
 {Team} recommends that you limit the number of retained packages on {Project}.
-For more information, see xref:limiting-growth-of-synchronized-content-by-using-web-ui[].
 
 Oracle Unbreakable Linux Network (ULN) channel labels for Oracle Linux releases on `x86_64`.
 Combine each label with the `uln://` prefix to form the *Upstream URL* for a Yum repository, for example `uln://ol9_x86_64_baseos_latest`.
@@ -66,3 +62,8 @@ include::snip_important-oracle-linux-content.adoc[]
 | Unbreakable Enterprise Kernel Release 6 | `uln://ol8_x86_64_UEKR6`
 | kSplice | `uln://ol8_x86_64_ksplice`
 |===
+
+.Additional resources
+* https://docs.oracle.com/en/operating-systems/oracle-linux/uln/uln-GeneratingAuthToken.html[Generating an Authentication Token in _Unbreakable Linux Network User's Guide_]
+* xref:adding-custom-rpm-repositories-by-using-web-ui[]
+* xref:limiting-growth-of-synchronized-content-by-using-web-ui[]


### PR DESCRIPTION
#### What changes are you introducing?

This patch hides links about Red Hat manifests for orcharhino builds of non-RHEL Clients; moves links to ".Additional resources", and shows RHEL-specific modules for orcharhino builds only for RHEL Clients.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Broken links upstream & downstream and DITA compliance

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
