### PR TITLE
Always use double quotes for anchors

### DIFF
--- a/guides/common/modules/ref_activation-keys.adoc
+++ b/guides/common/modules/ref_activation-keys.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='activation-keys']
+[id="activation-keys"]
 = Activation keys
 
 [role="_abstract"]

--- a/guides/common/modules/ref_content-life-cycles.adoc
+++ b/guides/common/modules/ref_content-life-cycles.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='content-life-cycles']
+[id="content-life-cycles"]
 = Content life cycles
 
 [role="_abstract"]

--- a/guides/common/modules/ref_errata.adoc
+++ b/guides/common/modules/ref_errata.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='errata']
+[id="errata"]
 = Errata
 
 [role="_abstract"]

--- a/guides/common/modules/ref_general-information.adoc
+++ b/guides/common/modules/ref_general-information.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='general-information']
+[id="general-information"]
 = General information
 
 [role="_abstract"]

--- a/guides/common/modules/ref_hosts.adoc
+++ b/guides/common/modules/ref_hosts.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='hosts']
+[id="hosts"]
 = Hosts
 
 [role="_abstract"]

--- a/guides/common/modules/ref_orgs-locs-and-repos.adoc
+++ b/guides/common/modules/ref_orgs-locs-and-repos.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='organizations-locations-and-repositories']
+[id="organizations-locations-and-repositories"]
 = Organizations, locations, and repositories
 
 [role="_abstract"]

--- a/guides/common/modules/ref_provisioning-environments.adoc
+++ b/guides/common/modules/ref_provisioning-environments.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='provisioning-environments']
+[id="provisioning-environments"]
 = Provisioning environments
 
 [role="_abstract"]

--- a/guides/common/modules/ref_tasks.adoc
+++ b/guides/common/modules/ref_tasks.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='tasks']
+[id="tasks"]
 = Tasks
 
 [role="_abstract"]

--- a/guides/common/modules/ref_users-and-permissions.adoc
+++ b/guides/common/modules/ref_users-and-permissions.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id='users-and-permissions']
+[id="users-and-permissions"]
 = Users and permissions
 
 [role="_abstract"]


### PR DESCRIPTION
#### What changes are you introducing?

Change single quotes to double quotes.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To unify the style to help with downstream automation.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have 
explored, etc.)

````
$ rg "\[id='"
````

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
