### PR TITLE
Use singular for uploading content to a repository

### DIFF
--- a/guides/common/assembly_adding-content-to-foreman.adoc
+++ b/guides/common/assembly_adding-content-to-foreman.adoc
@@ -57,19 +57,19 @@ endif::[]
 include::modules/con_uploading-content-to-repositories.adoc[leveloffset=+1]
 
 ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
-include::modules/proc_uploading-content-to-custom-rpm-repositories-by-using-web-ui.adoc[leveloffset=+2]
+include::modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-web-ui.adoc[leveloffset=+2]
 
-include::modules/proc_uploading-content-to-custom-rpm-repositories-by-using-cli.adoc[leveloffset=+2]
+include::modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-cli.adoc[leveloffset=+2]
 endif::[]
 
-include::modules/proc_uploading-content-to-custom-file-repositories-by-using-web-ui.adoc[leveloffset=+2]
+include::modules/proc_uploading-content-to-a-custom-file-repository-by-using-web-ui.adoc[leveloffset=+2]
 
-include::modules/proc_uploading-content-to-custom-file-repositories-by-using-cli.adoc[leveloffset=+2]
+include::modules/proc_uploading-content-to-a-custom-file-repository-by-using-cli.adoc[leveloffset=+2]
 
 ifdef::katello,debian,ubuntu[]
-include::modules/proc_uploading-content-to-deb-repositories-by-using-web-ui.adoc[leveloffset=+2]
+include::modules/proc_uploading-content-to-a-deb-repository-by-using-web-ui.adoc[leveloffset=+2]
 
-include::modules/proc_uploading-content-to-deb-repositories-by-using-cli.adoc[leveloffset=+2]
+include::modules/proc_uploading-content-to-a-deb-repository-by-using-cli.adoc[leveloffset=+2]
 endif::[]
 
 ifdef::katello,almalinux,centos,debian,oracle_linux,rocky_linux,ubuntu[]

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-cli.adoc
@@ -59,4 +59,4 @@ $ hammer repository create \
 * If you set an upstream URL, you can synchronize content to {Project}.
 For more information, see xref:synchronizing-repositories-by-using-cli[].
 * If you did not set an upstream URL, you can upload content to your {customfiletype}.
-For more information, see xref:uploading-content-to-custom-file-repositories-by-using-cli[].
+For more information, see xref:uploading-content-to-a-custom-file-repository-by-using-cli[].

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-web-ui.adoc
@@ -17,7 +17,7 @@ You must create a product and then add a {customrepo}.
 . From the *Type* list, select `file` as type of repository.
 . Optional: In the *Upstream URL* field, enter the URL of the upstream repository to use as a source.
 If you do not enter an upstream URL, you can manually upload packages.
-For more information, see xref:uploading-content-to-custom-file-repositories-by-using-web-ui[].
+For more information, see xref:uploading-content-to-a-custom-file-repository-by-using-web-ui[].
 . Select *Verify SSL* to verify that the SSL certificates of the repository are signed by a trusted CA.
 . Optional: In the *Upstream Username* field, enter the user name for the upstream repository if required for authentication.
 Clear this field if the repository does not require authentication.

--- a/guides/common/modules/proc_uploading-content-to-a-custom-file-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-custom-file-repository-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-content-to-custom-file-repositories-by-using-cli"]
-= Uploading content to {customfiletype} repositories by using Hammer CLI
+[id="uploading-content-to-a-custom-file-repository-by-using-cli"]
+= Uploading content to a {customfiletype} repository by using Hammer CLI
 
 [role="_abstract"]
 If you cannot create a `PULP_MANIFEST` and synchronize your content from a local or remote repository to {Project}, you can manually upload content to a {customfiletype} repository.

--- a/guides/common/modules/proc_uploading-content-to-a-custom-file-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-custom-file-repository-by-using-web-ui.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-content-to-custom-file-repositories-by-using-web-ui"]
-= Uploading content to {customfiletype} repositories by using {ProjectWebUI}
+[id="uploading-content-to-a-custom-file-repository-by-using-web-ui"]
+= Uploading content to a {customfiletype} repository by using {ProjectWebUI}
 
 [role="_abstract"]
 If you cannot create a `PULP_MANIFEST` and synchronize your content from a local or remote repository to {Project}, you can manually upload content to a {customfiletype} repository.

--- a/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-content-to-custom-rpm-repositories-by-using-cli"]
-= Uploading content to {customrpm} repositories by using Hammer CLI
+[id="uploading-content-to-a-custom-rpm-repository-by-using-cli"]
+= Uploading content to a {customrpm} repository by using Hammer CLI
 
 [role="_abstract"]
 You can upload individual RPM packages to a {customrpm} repository to distribute Yum content that you cannot synchronize.

--- a/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-web-ui.adoc
@@ -1,21 +1,23 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-content-to-deb-repositories-by-using-web-ui"]
-= Uploading content to Deb repositories by using {ProjectWebUI}
+[id="uploading-content-to-a-custom-rpm-repository-by-using-web-ui"]
+= Uploading content to a {customrpm} repository by using {ProjectWebUI}
 
 [role="_abstract"]
-You can upload individual Deb packages to a Deb repository to distribute Deb content that you cannot synchronize.
+You can upload individual RPM packages to a {customrpm} repository to distribute Yum content that you cannot synchronize.
+
+You must use Hammer CLI to upload source RPM packages.
+For more information, see xref:uploading-content-to-a-custom-rpm-repository-by-using-cli[].
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Select your {customproduct}.
-. Select the Deb repository that you want to upload packages to.
-Do not upload packages to a repository if you have set the *Upstream URL*.
-. Under *Upload Package*, click *Browse...* and select the Deb package that you want to upload.
+. Click the name of the {customproduct}.
+. In the *Repositories* tab, click the name of the {customrpm} repository.
+. Under *Upload Package*, click *Browse...* and select the RPM you want to upload.
 . Click *Upload*.
 
 .Verification
-* To view all Deb packages in this repository, click the number next to *Packages* under *Content Counts*.
+* To view all RPMs in this repository, click the number next to *Packages* under *Content Counts*.
 
 .Troubleshooting
 * If the upload times out when uploading very large files on a slow network, raise the *Sync task timeout* setting value.
@@ -23,12 +25,11 @@ In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
 The *Sync task timeout* setting is located on the *Tasks* tab.
 
 .Next steps
-* Add your Deb repository to a content view.
+* Add your {customrpm} repository to a content view.
 For more information, see xref:creating-a-content-view-by-using-web-ui[].
-* If your Deb repository is unprotected, hosts can consume its content by using the *Published At* URL.
+* If your {customrpm} is unprotected, hosts can consume its content by using the *Published At* URL.
 +
 In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.
-Use `katello` as the distribution to set up the repository on your host.
 ifdef::orcharhino[]
 +
 include::snip_important-consuming-content-requires-a-subscription.adoc[]

--- a/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-content-to-deb-repositories-by-using-cli"]
-= Uploading content to Deb repositories by using Hammer CLI
+[id="uploading-content-to-a-deb-repository-by-using-cli"]
+= Uploading content to a Deb repository by using Hammer CLI
 
 [role="_abstract"]
 You can upload individual Deb packages to a Deb repository to distribute Deb content that you cannot synchronize.

--- a/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-web-ui.adoc
@@ -1,23 +1,21 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="uploading-content-to-custom-rpm-repositories-by-using-web-ui"]
-= Uploading content to {customrpm} repositories by using {ProjectWebUI}
+[id="uploading-content-to-a-deb-repository-by-using-web-ui"]
+= Uploading content to a Deb repository by using {ProjectWebUI}
 
 [role="_abstract"]
-You can upload individual RPM packages to a {customrpm} repository to distribute Yum content that you cannot synchronize.
-
-You must use Hammer CLI to upload source RPM packages.
-For more information, see xref:uploading-content-to-custom-rpm-repositories-by-using-cli[].
+You can upload individual Deb packages to a Deb repository to distribute Deb content that you cannot synchronize.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Content* > *Products*.
-. Click the name of the {customproduct}.
-. In the *Repositories* tab, click the name of the {customrpm} repository.
-. Under *Upload Package*, click *Browse...* and select the RPM you want to upload.
+. Select your {customproduct}.
+. Select the Deb repository that you want to upload packages to.
+Do not upload packages to a repository if you have set the *Upstream URL*.
+. Under *Upload Package*, click *Browse...* and select the Deb package that you want to upload.
 . Click *Upload*.
 
 .Verification
-* To view all RPMs in this repository, click the number next to *Packages* under *Content Counts*.
+* To view all Deb packages in this repository, click the number next to *Packages* under *Content Counts*.
 
 .Troubleshooting
 * If the upload times out when uploading very large files on a slow network, raise the *Sync task timeout* setting value.
@@ -25,11 +23,12 @@ In the {ProjectWebUI}, navigate to *Administer* > *Settings*.
 The *Sync task timeout* setting is located on the *Tasks* tab.
 
 .Next steps
-* Add your {customrpm} repository to a content view.
+* Add your Deb repository to a content view.
 For more information, see xref:creating-a-content-view-by-using-web-ui[].
-* If your {customrpm} is unprotected, hosts can consume its content by using the *Published At* URL.
+* If your Deb repository is unprotected, hosts can consume its content by using the *Published At* URL.
 +
 In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.
+Use `katello` as the distribution to set up the repository on your host.
 ifdef::orcharhino[]
 +
 include::snip_important-consuming-content-requires-a-subscription.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that all modules to upload content to Foreman+Katello use repository in singular.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Original idea by Lena on upstream PR 4976

Fixes #4990 (Rename modules to upload content to repository)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Other DITA/vale issues are out of scope.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
