### PR TITLE
Add attribute for errata source based on Client OS

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -80,6 +80,7 @@
 :client-content-type: Deb
 :client-cv-filter: Deb
 :client-enable-chrony-service: systemctl enable --now chrony
+:client-errata-source: ATIX Errata Service for Ubuntu
 :client-extracted-gpg-key-extracted-path: ~/_My_GPG_Public_Key_
 :client-extracted-gpg-key-target-path: ~/_My_GPG_Public_Key_
 :client-install-yggdrasil-package: apt-get install foreman-ygg-migration

--- a/guides/common/modules/ref_prerequisites-for-installing-errata-on-hosts.adoc
+++ b/guides/common/modules/ref_prerequisites-for-installing-errata-on-hosts.adoc
@@ -6,11 +6,14 @@
 [role="_abstract"]
 Installing errata on hosts requires synchronized repositories, installable errata in the content view environment, registered hosts, and remote execution configuration.
 
+ifdef::katello[]
+* Repositories on {ProjectServer} are synchronized with the latest errata available from upstream.
+endif::[]
+ifdef::orcharhino[]
+* Repositories on {ProjectServer} are synchronized with the latest errata available from {client-errata-source}.
+endif::[]
 ifdef::satellite[]
 * Repositories on {ProjectServer} are synchronized with the latest errata available from Red{nbsp}Hat.
-endif::[]
-ifndef::satellite[]
-* Repositories on {ProjectServer} are synchronized with the latest errata available from upstream.
 endif::[]
 * The host is registered to a content view environment.
 * The host is configured for remote execution.


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that for orcharhino builds, the errata source is based on the Client OS. Examples:

* RHEL Clients: errata come from Red Hat
* Ubuntu Clients: errata come from orcharhino via ATIX Errata Service

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fixes #4991 (Add attribute for Client errata source)
Refs "con_making-errata-available-through-content-views.adoc"
Refs https://orcharhino.com/en/about-orcharhino/features/

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
