### PR TITLE
Add attribute for source of Client ISO images

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -184,6 +184,7 @@
 :client-installation-medium-path: download.example.com/centos/$version/Server/$arch/os/
 :client-clevis-repository: AppStream
 :client-cv-filter: RPM
+:client-iso-image-source: the Red{nbsp}Hat Content Delivery Network
 :client-os-family-hammer: Redhat
 :client-os-family: Red Hat
 :client-os: {EL}

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -84,6 +84,7 @@
 :client-extracted-gpg-key-target-path: ~/_My_GPG_Public_Key_
 :client-install-yggdrasil-package: apt-get install foreman-ygg-migration
 :client-installation-medium-path: download.example.com/{client-os-context}/{client-os-major}.{client-os-minor}/
+:client-iso-image-source: Canonical
 :client-os-family-hammer: Debian
 :client-os-family: Debian
 :client-os-label: {client-os}

--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -4,12 +4,7 @@
 = Managing ISO images
 
 [role="_abstract"]
-ifdef::orcharhino[]
 You can use {Project} to store ISO images from {client-iso-image-source} or other sources for host provisioning and creating installation media.
-endif::[]
-ifndef::orcharhino[]
-You can use {Project} to store ISO images from the Red{nbsp}Hat Content Delivery Network or other sources for host provisioning and creating installation media.
-endif::[]
 You can also upload other files, such as virtual machine images, and publish them in repositories.
 
 ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]

--- a/guides/common/modules/con_managing-iso-images.adoc
+++ b/guides/common/modules/con_managing-iso-images.adoc
@@ -1,10 +1,15 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="Managing_ISO_Images_{context}"]
+[id="managing-iso-images"]
 = Managing ISO images
 
 [role="_abstract"]
+ifdef::orcharhino[]
+You can use {Project} to store ISO images from {client-iso-image-source} or other sources for host provisioning and creating installation media.
+endif::[]
+ifndef::orcharhino[]
 You can use {Project} to store ISO images from the Red{nbsp}Hat Content Delivery Network or other sources for host provisioning and creating installation media.
+endif::[]
 You can also upload other files, such as virtual machine images, and publish them in repositories.
 
 ifdef::katello,almalinux,red_hat_enterprise_linux,rocky_linux[]


### PR DESCRIPTION
#### What changes are you introducing?

Add attribute to allow different ISO image sources based on the Client OS.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This fixes an issue for orcharhino builds.

Refs https://docs.orcharhino.com/or/docs/sources/guides/suse_linux_enterprise_server/managing_content/managing_iso_images.html

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The anchor is not referenced anywhere.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
