### PR TITLE
Implement slide-out drawer TOC for mobile responsiveness

### DIFF
--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -891,14 +891,14 @@ body.toc2 #header>h1:nth-last-child(2) {
     position: fixed;
     width: 18em;
     left: 0;
-    top: 70px;
+    top: 0;
     border-right: 1px solid #e7e7e9;
     border-top-width: 0!important;
     border-bottom-width: 0!important;
     z-index: 1000;
     padding: 1.25em 1em;
-    height: calc(100vh - 70px);
-    overflow-y: auto;
+    height: calc(100% - (70px + 2.5em));
+    overflow: auto;
   }
 
   #toc.toc2 #toctitle {

--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -602,8 +602,15 @@ body>div[id] {
   margin: 0 auto;
   max-width: 62.5em;
   position: relative;
-  padding-left: .9375em;
-  padding-right: .9375em
+  padding-left: 1rem;
+  padding-right: 1rem
+}
+
+@media screen and (max-width: 600px) {
+  body>div[id] {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem
+  }
 }
 
 body>div[id]::before,
@@ -733,79 +740,200 @@ body.toc2 #header>h1:nth-last-child(2) {
   font-size: 1.2em
 }
 
-@media screen and (min-width:768px) {
-  #toctitle {
-    font-size: 1.375em
-  }
+/* Mobile/Tablet: Slide-out drawer */
+@media screen and (max-width: 1279px) {
   body.toc2 {
-    padding-left: 15em;
-    padding-right: 0
+    padding-left: 0;
+    padding-right: 0;
   }
+
+  #toc.toc2 {
+    position: fixed;
+    left: -100%;
+    top: 70px;
+    width: 85%;
+    max-width: 320px;
+    height: calc(100vh - 70px);
+    overflow-y: auto;
+    background: #f8f8f7;
+    border-right: 1px solid #e7e7e9;
+    border-top-width: 0;
+    border-bottom-width: 0;
+    z-index: 10000;
+    padding: 1.25em 1em;
+    transition: left 0.3s ease-in-out;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+  }
+
+  #toc.toc2 #toctitle {
+    margin-top: 0;
+    margin-bottom: .8rem;
+    font-size: 1.2em;
+  }
+
+  #toc.toc2>ul {
+    font-size: .9em;
+    margin-bottom: 0;
+  }
+
+  #toc.toc2 ul ul {
+    margin-left: 0;
+    padding-left: 1em;
+  }
+
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
+    padding-left: 0;
+    margin-top: .5em;
+    margin-bottom: .5em;
+  }
+
+  /* Show drawer when toggled */
+  body.toc-visible #toc.toc2 {
+    left: 0;
+  }
+
+  /* Backdrop overlay */
+  body.toc-visible::before {
+    content: "";
+    position: fixed;
+    top: 70px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    animation: fadeIn 0.3s ease-in-out;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  /* TOC toggle button */
+  .toc-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    position: fixed;
+    top: 76px;
+    left: 1rem;
+    z-index: 1001;
+    padding: 0.5rem 0.75rem;
+    background: #025d8c;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-family: "Open Sans", "DejaVu Sans", sans-serif;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: background 0.2s ease;
+  }
+
+  .toc-toggle:hover {
+    background: #014a6e;
+  }
+
+  .toc-toggle:active {
+    transform: translateY(1px);
+  }
+
+  /* Hamburger icon */
+  .toc-toggle-icon {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    width: 18px;
+  }
+
+  .toc-toggle-icon span {
+    display: block;
+    width: 100%;
+    height: 2px;
+    background: white;
+    border-radius: 1px;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+
+  /* Animate to X when open */
+  body.toc-visible .toc-toggle-icon span:nth-child(1) {
+    transform: translateY(5px) rotate(45deg);
+  }
+
+  body.toc-visible .toc-toggle-icon span:nth-child(2) {
+    opacity: 0;
+  }
+
+  body.toc-visible .toc-toggle-icon span:nth-child(3) {
+    transform: translateY(-5px) rotate(-45deg);
+  }
+}
+
+/* Desktop: Fixed sidebar */
+@media screen and (min-width: 1280px) {
+  #toctitle {
+    font-size: 1.375em;
+  }
+
+  body.toc2 {
+    padding-left: 18em;
+    padding-right: 0;
+  }
+
   #toc.toc2 {
     margin-top: 0!important;
     background: #f8f8f7;
     position: fixed;
-    width: 15em;
+    width: 18em;
     left: 0;
-    top: 0;
+    top: 70px;
     border-right: 1px solid #e7e7e9;
     border-top-width: 0!important;
     border-bottom-width: 0!important;
     z-index: 1000;
     padding: 1.25em 1em;
-    height: calc(100% - (70px + 2.5em));
-    overflow: auto
+    height: calc(100vh - 70px);
+    overflow-y: auto;
   }
+
   #toc.toc2 #toctitle {
     margin-top: 0;
     margin-bottom: .8rem;
-    font-size: 1.2em
+    font-size: 1.375em;
   }
+
   #toc.toc2>ul {
     font-size: .9em;
-    margin-bottom: 0
+    margin-bottom: 0;
   }
+
   #toc.toc2 ul ul {
     margin-left: 0;
-    padding-left: 1em
+    padding-left: 1.25em;
   }
+
   #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
     padding-left: 0;
     margin-top: .5em;
-    margin-bottom: .5em
+    margin-bottom: .5em;
   }
+
   body.toc2.toc-right {
     padding-left: 0;
-    padding-right: 15em
+    padding-right: 18em;
   }
+
   body.toc2.toc-right #toc.toc2 {
     border-right-width: 0;
     border-left: 1px solid #e7e7e9;
     left: auto;
-    right: 0
+    right: 0;
   }
-}
 
-@media screen and (min-width:1280px) {
-  body.toc2 {
-    padding-left: 20em;
-    padding-right: 0
-  }
-  #toc.toc2 {
-    width: 20em
-  }
-  #toc.toc2 #toctitle {
-    font-size: 1.375em
-  }
-  #toc.toc2>ul {
-    font-size: .95em
-  }
-  #toc.toc2 ul ul {
-    padding-left: 1.25em
-  }
-  body.toc2.toc-right {
-    padding-left: 0;
-    padding-right: 20em
+  /* Hide toggle button on desktop */
+  .toc-toggle {
+    display: none;
   }
 }
 

--- a/web/content/css/_asciidoc.scss
+++ b/web/content/css/_asciidoc.scss
@@ -810,8 +810,12 @@ body.toc2 #header>h1:nth-last-child(2) {
     to { opacity: 1; }
   }
 
-  /* TOC toggle button */
+  /* TOC toggle button - only show if TOC exists */
   .toc-toggle {
+    display: none;
+  }
+
+  body.toc2 .toc-toggle {
     display: flex;
     align-items: center;
     gap: 0.5rem;

--- a/web/content/css/_site.scss
+++ b/web/content/css/_site.scss
@@ -4,11 +4,15 @@
 */
 @media screen {
   div.narrow {
-    max-width: 1080px;
-    margin: 0 auto !important;
-    margin-top: 70px auto !important;
+    max-width: 75ch;
+    margin: 70px auto 0 !important;
+    padding: 0 1rem;
     float: none !important;
   }
+}
+
+/* TOC margin-top only for fixed positioning (desktop) */
+@media screen and (min-width: 1280px) {
   #toc.toc2 {
     margin-top: 70px!important;
   }

--- a/web/content/css/_site.scss
+++ b/web/content/css/_site.scss
@@ -4,15 +4,11 @@
 */
 @media screen {
   div.narrow {
-    max-width: 75ch;
-    margin: 70px auto 0 !important;
-    padding: 0 1rem;
+    max-width: 1080px;
+    margin: 0 auto !important;
+    margin-top: 70px auto !important;
     float: none !important;
   }
-}
-
-/* TOC margin-top only for fixed positioning (desktop) */
-@media screen and (min-width: 1280px) {
   #toc.toc2 {
     margin-top: 70px!important;
   }

--- a/web/layouts/default.html.erb
+++ b/web/layouts/default.html.erb
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Foreman documentation: <%= @item[:title] %></title>
     <link rel="stylesheet" href="/css/default.css">
     <meta name="generator" content="Nanoc <%= Nanoc::VERSION %>">

--- a/web/layouts/nav.html.erb
+++ b/web/layouts/nav.html.erb
@@ -8,3 +8,53 @@
         document.close();
       </script>
     </div>
+    <button class="toc-toggle" aria-label="Toggle table of contents" aria-expanded="false">
+      <span class="toc-toggle-icon">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="toc-toggle-text">Contents</span>
+    </button>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        var toggleBtn = document.querySelector('.toc-toggle');
+        var toc = document.getElementById('toc');
+
+        if (!toggleBtn || !toc) {
+          console.log('TOC toggle elements not found:', { toggleBtn: !!toggleBtn, toc: !!toc });
+          return;
+        }
+
+        function toggleToc() {
+          var isVisible = document.body.classList.contains('toc-visible');
+          document.body.classList.toggle('toc-visible');
+          toggleBtn.setAttribute('aria-expanded', !isVisible);
+          console.log('TOC toggled:', !isVisible ? 'visible' : 'hidden');
+        }
+
+        toggleBtn.addEventListener('click', function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          toggleToc();
+        });
+
+        // Close drawer when clicking backdrop
+        document.body.addEventListener('click', function(e) {
+          if (document.body.classList.contains('toc-visible') &&
+              !toc.contains(e.target) &&
+              !toggleBtn.contains(e.target)) {
+            toggleToc();
+          }
+        });
+
+        // Close drawer on escape key
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape' && document.body.classList.contains('toc-visible')) {
+            toggleToc();
+          }
+        });
+
+        console.log('TOC drawer initialized');
+      });
+    </script>

--- a/web/layouts/nav.html.erb
+++ b/web/layouts/nav.html.erb
@@ -39,6 +39,16 @@
           toggleToc();
         });
 
+        // Close drawer when clicking a TOC link
+        var tocLinks = toc.querySelectorAll('a');
+        tocLinks.forEach(function(link) {
+          link.addEventListener('click', function() {
+            if (document.body.classList.contains('toc-visible')) {
+              toggleToc();
+            }
+          });
+        });
+
         // Close drawer when clicking backdrop
         document.body.addEventListener('click', function(e) {
           if (document.body.classList.contains('toc-visible') &&


### PR DESCRIPTION
#### What changes are you introducing?

Making the guide HTMLs more friendly to smaller screens and mobile screens:

* Adjusting padding
* Switching to a "Contents" button with a ToC drawer when on a narrow screen
* Adding a viewport metadata tag that instructs mobile browsers how to render the page

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Lack of responsive layout is a known issue reported by users

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This PR is based on my request to Claude, asking it to make recommendations based on modern website strategies for responsiveness.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
