### PR TITLE
Fix package name of xz on EL9

### DIFF
--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -29,10 +29,20 @@ endif::[]
 
 .Prerequisites
 ifeval::["{client-os}" == "Debian"]
+ifdef::foreman-deb[]
 * Ensure that the `binutils` and `xz-utils` packages are installed on your {SmartProxy}.
 endif::[]
+ifndef::foreman-deb[]
+* Ensure that the `binutils` and `xz` packages are installed on your {SmartProxy}.
+endif::[]
+endif::[]
 ifeval::["{client-os}" == "Ubuntu"]
+ifdef::foreman-deb[]
 * Ensure that the `binutils`, `xz-utils`, and `zstd` packages are installed on your {SmartProxy}.
+endif::[]
+ifndef::foreman-deb[]
+* Ensure that the `binutils`, `xz`, and `zstd` packages are installed on your {SmartProxy}.
+endif::[]
 endif::[]
 ifeval::["{client-pkg-ext}" == "rpm"]
 * Ensure that the `cpio` package is installed on your {SmartProxy}.


### PR DESCRIPTION
#### What changes are you introducing?

This patch fixes the RPM package name of "xz" on Smart Proxies on EL9.

The nested macros are the result of a combination of Project OS and
Client OS.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Local reproducer:

````
$ podman run --rm -it docker.io/library/debian:bookworm /bin/bash -c "apt-get update && apt-get install -y binutils xz-utils zstd"
$ podman run --rm -it docker.io/library/ubuntu:jammy /bin/bash -c "apt-get update && apt-get install -y binutils xz-utils zstd"
$ podman run --rm -it quay.io/almalinuxorg/almalinux:9.8 /bin/bash -c "dnf install -y binutils xz zstd"
````

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
