### PR TITLE
Update GPG public keys of Debian 11

### DIFF
--- a/guides/common/modules/ref_gpg-public-keys-for-debian.adoc
+++ b/guides/common/modules/ref_gpg-public-keys-for-debian.adoc
@@ -81,10 +81,10 @@ $ gpg --armor --export ED541312A33F1128F10B1C6C54404762BBB6E853 B0CAB9266E8C3929
 ----
 $ wget http://ftp.debian.org/debian/dists/bullseye/Release && wget http://ftp.debian.org/debian/dists/bullseye/Release.gpg
 $ gpg --verify Release.gpg Release
-$ gpg --keyserver pgp.mit.edu --recv-key 0146DC6D4A0B2914BDED34DB648ACFD622F3D138
+$ gpg --keyserver pgp.mit.edu --recv-key 4CB50190207B4758A3F73A796ED0E7B82643E131
 $ gpg --keyserver pgp.mit.edu --recv-key A4285295FC7B1A81600062A9605C66F00D6C9793
 $ gpg --keyserver pgp.mit.edu --recv-key A7236886F3CCCAAD148A27F80E98404D386FA1D9
-$ gpg --armor --export DC30D7C23CBBABEE 605C66F00D6C9793 73A4F27B8DD47936 > debian_bullseye_main.txt
+$ gpg --armor --export 4CB50190207B4758A3F73A796ED0E7B82643E131 A4285295FC7B1A81600062A9605C66F00D6C9793 A7236886F3CCCAAD148A27F80E98404D386FA1D9 > debian_bullseye_main.txt
 ----
 
 [id="gpg-debian-bullseye-updates"]
@@ -93,9 +93,9 @@ $ gpg --armor --export DC30D7C23CBBABEE 605C66F00D6C9793 73A4F27B8DD47936 > debi
 ----
 $ wget http://ftp.debian.org/debian/dists/bullseye-updates/Release && wget http://ftp.debian.org/debian/dists/bullseye-updates/Release.gpg
 $ gpg --verify Release.gpg Release
-$ gpg --keyserver pgp.mit.edu --recv-key 0146DC6D4A0B2914BDED34DB648ACFD622F3D138
+$ gpg --keyserver pgp.mit.edu --recv-key 4CB50190207B4758A3F73A796ED0E7B82643E131
 $ gpg --keyserver pgp.mit.edu --recv-key A7236886F3CCCAAD148A27F80E98404D386FA1D9
-$ gpg --armor --export DC30D7C23CBBABEE 73A4F27B8DD47936 > debian_bullseye_updates.txt
+$ gpg --armor --export 4CB50190207B4758A3F73A796ED0E7B82643E131 A7236886F3CCCAAD148A27F80E98404D386FA1D9 > debian_bullseye_updates.txt
 ----
 
 [id="gpg-debian-bullseye-security"]
@@ -106,5 +106,5 @@ $ wget https://security.debian.org/debian-security/dists/bullseye-security/Relea
 $ gpg --verify Release.gpg Release
 $ gpg --keyserver pgp.mit.edu --recv-key B0CAB9266E8C3929798B3EEEBDE6D2B9216EC7A8
 $ gpg --keyserver pgp.mit.edu --recv-key ED541312A33F1128F10B1C6C54404762BBB6E853
-$ gpg --armor --export 254CF3B5AEC0A8F0 A48449044AAD5C5D > debian_bullseye_security.txt
+$ gpg --armor --export B0CAB9266E8C3929798B3EEEBDE6D2B9216EC7A8 ED541312A33F1128F10B1C6C54404762BBB6E853 > debian_bullseye_security.txt
 ----

--- a/guides/common/modules/ref_gpg-public-keys-for-debian.adoc
+++ b/guides/common/modules/ref_gpg-public-keys-for-debian.adoc
@@ -81,9 +81,9 @@ $ gpg --armor --export ED541312A33F1128F10B1C6C54404762BBB6E853 B0CAB9266E8C3929
 ----
 $ wget http://ftp.debian.org/debian/dists/bullseye/Release && wget http://ftp.debian.org/debian/dists/bullseye/Release.gpg
 $ gpg --verify Release.gpg Release
-$ gpg --keyserver pgp.mit.edu --recv-key 4CB50190207B4758A3F73A796ED0E7B82643E131
-$ gpg --keyserver pgp.mit.edu --recv-key A4285295FC7B1A81600062A9605C66F00D6C9793
-$ gpg --keyserver pgp.mit.edu --recv-key A7236886F3CCCAAD148A27F80E98404D386FA1D9
+$ gpg --keyserver keys.gnupg.net --recv-key 4CB50190207B4758A3F73A796ED0E7B82643E131
+$ gpg --keyserver keys.gnupg.net --recv-key A4285295FC7B1A81600062A9605C66F00D6C9793
+$ gpg --keyserver keys.gnupg.net --recv-key A7236886F3CCCAAD148A27F80E98404D386FA1D9
 $ gpg --armor --export 4CB50190207B4758A3F73A796ED0E7B82643E131 A4285295FC7B1A81600062A9605C66F00D6C9793 A7236886F3CCCAAD148A27F80E98404D386FA1D9 > debian_bullseye_main.txt
 ----
 
@@ -93,8 +93,8 @@ $ gpg --armor --export 4CB50190207B4758A3F73A796ED0E7B82643E131 A4285295FC7B1A81
 ----
 $ wget http://ftp.debian.org/debian/dists/bullseye-updates/Release && wget http://ftp.debian.org/debian/dists/bullseye-updates/Release.gpg
 $ gpg --verify Release.gpg Release
-$ gpg --keyserver pgp.mit.edu --recv-key 4CB50190207B4758A3F73A796ED0E7B82643E131
-$ gpg --keyserver pgp.mit.edu --recv-key A7236886F3CCCAAD148A27F80E98404D386FA1D9
+$ gpg --keyserver keys.gnupg.net --recv-key 4CB50190207B4758A3F73A796ED0E7B82643E131
+$ gpg --keyserver keys.gnupg.net --recv-key A7236886F3CCCAAD148A27F80E98404D386FA1D9
 $ gpg --armor --export 4CB50190207B4758A3F73A796ED0E7B82643E131 A7236886F3CCCAAD148A27F80E98404D386FA1D9 > debian_bullseye_updates.txt
 ----
 
@@ -104,7 +104,7 @@ $ gpg --armor --export 4CB50190207B4758A3F73A796ED0E7B82643E131 A7236886F3CCCAAD
 ----
 $ wget https://security.debian.org/debian-security/dists/bullseye-security/Release && wget https://security.debian.org/debian-security/dists/bullseye-security/Release.gpg
 $ gpg --verify Release.gpg Release
-$ gpg --keyserver pgp.mit.edu --recv-key B0CAB9266E8C3929798B3EEEBDE6D2B9216EC7A8
-$ gpg --keyserver pgp.mit.edu --recv-key ED541312A33F1128F10B1C6C54404762BBB6E853
+$ gpg --keyserver keys.gnupg.net --recv-key B0CAB9266E8C3929798B3EEEBDE6D2B9216EC7A8
+$ gpg --keyserver keys.gnupg.net --recv-key ED541312A33F1128F10B1C6C54404762BBB6E853
 $ gpg --armor --export B0CAB9266E8C3929798B3EEEBDE6D2B9216EC7A8 ED541312A33F1128F10B1C6C54404762BBB6E853 > debian_bullseye_security.txt
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Update fingerprints for Debian 11 GPG key pairs used to sign metadata of Debian 11 upstream repositories.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
