### PR TITLE
Introduce attribute for cloud-init templates

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -176,24 +176,27 @@
 :vulnerabilityengine: {Insights} Vulnerability
 :sectanchors:
 // Hosts
-:client-content-type: yum
+:client-clevis-repository: AppStream
 :client-container-image-name: rhel7
 :client-container-product-name: Red Hat Container Catalog
 :client-container-repository-name: RHEL7
 :client-container-url: http://registry.access.redhat.com/
-:client-installation-medium-path: download.example.com/centos/$version/Server/$arch/os/
-:client-clevis-repository: AppStream
+:client-content-content-view-label: AlmaLinux_9
+:client-content-product-label: AlmaLinux_9
+:client-content-repository-label: BaseOS
+:client-content-type: yum
 :client-cv-filter: RPM
+:client-installation-medium-path: download.example.com/centos/$version/Server/$arch/os/
 :client-iso-image-source: the Red{nbsp}Hat Content Delivery Network
+:client-os-context: enterprise-linux
 :client-os-family-hammer: Redhat
 :client-os-family: Red Hat
-:client-os: {EL}
-:client-os-context: enterprise-linux
 :client-os-label: Enterprise_Linux
-:client-os-major: 9
 :client-os-major-previous: 8
-:client-os-minor: 5
+:client-os-major: 9
 :client-os-minor-bumped: 6
+:client-os-minor: 5
+:client-os: {EL}
 :client-package-install-deb: apt install
 :client-package-install-el7: yum install
 :client-package-install-el8: dnf install
@@ -209,11 +212,8 @@
 :client-package-update-sles: zypper update
 :client-pkg-arch: noarch
 :client-pkg-ext: rpm
-:client-provisioning-template-type: Kickstart
-:client-content-content-view-label: AlmaLinux_9
-:client-content-product-label: {client-content-content-view-label}
-:client-content-repository-label: BaseOS
 :client-provisioning-template-default-cloudinit: CloudInit default
+:client-provisioning-template-type: Kickstart
 :client-salt-minion-repository-url: https://packages.broadcom.com/artifactory/saltproject-rpm/
 // Foreman Server and Smart Proxy Server
 :project-minimum-cpus: 4 CPU cores

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -213,6 +213,7 @@
 :client-content-content-view-label: AlmaLinux_9
 :client-content-product-label: {client-content-content-view-label}
 :client-content-repository-label: BaseOS
+:client-provisioning-template-default-cloudinit: CloudInit default
 :client-salt-minion-repository-url: https://packages.broadcom.com/artifactory/saltproject-rpm/
 // Foreman Server and Smart Proxy Server
 :project-minimum-cpus: 4 CPU cores

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -104,3 +104,4 @@
 :client-repo-url: {foreman-example-com}/pulp/content/My_Organization/Library/custom/{client-os-context}_Client/{client-os-context}_Client_{client-os-major}/
 :client-salt-minion-repository-url: https://packages.broadcom.com/artifactory/saltproject-deb/
 :client-update-certificates-command: update-ca-certificates
+:client-provisioning-template-default-cloudinit: CloudInit orcharhino

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -63,8 +63,8 @@
 :ubuntu:
 :client-os-codename: Resolute
 :client-os-context: ubuntu
-:client-os-major: 26.04
 :client-os-major-previous: 24.04
+:client-os-major: 26.04
 :client-os-minor: 0
 :client-os: Ubuntu
 // Client attributes in alphabetical order that use other attributes
@@ -95,6 +95,7 @@
 :client-package-remove: apt-get remove
 :client-pkg-arch: all
 :client-pkg-ext: deb
+:client-provisioning-template-default-cloudinit: CloudInit orcharhino
 :client-provisioning-template-default-ipxe: Preseed default iPXE Autoinstall
 :client-provisioning-template-default: Preseed default
 :client-provisioning-template-type: Preseed
@@ -104,4 +105,3 @@
 :client-repo-url: {foreman-example-com}/pulp/content/My_Organization/Library/custom/{client-os-context}_Client/{client-os-context}_Client_{client-os-major}/
 :client-salt-minion-repository-url: https://packages.broadcom.com/artifactory/saltproject-deb/
 :client-update-certificates-command: update-ca-certificates
-:client-provisioning-template-default-cloudinit: CloudInit orcharhino

--- a/guides/common/modules/proc_associating-the-userdata-and-cloud-init-templates-with-the-operating-system.adoc
+++ b/guides/common/modules/proc_associating-the-userdata-and-cloud-init-templates-with-the-operating-system.adoc
@@ -8,13 +8,13 @@ Before you can use VMware `cloud-init` and `userdata` templates for provisioning
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *Templates* > *Provisioning Templates*.
-. Search for the *CloudInit default* template and click its name.
+. Search for the *{client-provisioning-template-default-cloudinit}* template and click its name.
 . Click the *Association* tab.
 . Select all operating systems to which the template applies and click *Submit*.
 . Repeat the steps above for the *UserData open-vm-tools* template.
 . Navigate to *Hosts* > *Provisioning Setup* > *Operating Systems*.
 . Select the operating system that you want to use for provisioning.
 . Click the *Templates* tab.
-. From the *Cloud-init template* list, select *CloudInit default*.
+. From the *Cloud-init template* list, select *{client-provisioning-template-default-cloudinit}*.
 . From the *User data template* list, select *UserData open-vm-tools*.
 . Click *Submit* to save the changes.


### PR DESCRIPTION
#### What changes are you introducing?

This patch introduces an attribute for the name of the template. In downstream docs, the attribute will be set for those three Client to "CloudInit orcharhino", and to "CloudInit default" for AlmaLinux, Amazon Linux, CentOS, Oracle Linux, Red Hat Enterprise Linux, and, Rocky Linux.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

orcharhino provides a CloudInit template for Debian, SUSE Linux Enterprise Server, and Ubuntu Clients.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #4892

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
