### PR TITLE
Add missing attribute 3.17 + 3.16

### DIFF
--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -59,6 +59,7 @@
 // Overwritten in downstream for docs.orcharhino.com
 :client-package-install: dnf install
 :client-package-remove: dnf remove
+:client-redhat-repo-path: /etc/apt/sources.list.d/rhsm.sources
 :client-repo-url: {foreman-example-com}/pulp/content/My_Organization/Library/custom/{client-os-context}_Client/{client-os-context}_Client_{client-os-major}/
 :client-puppet-repo-url: http://_{foreman-example-com}_/pulp/content/_My_Organization_/Library/custom/Puppet_Agent/Puppet_Agent_{client-os}_{client-os-major}/
 :client-yggdrasil-query-command: rpm --query yggdrasil

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -183,3 +183,4 @@
 :project-client-name: Red Hat Satellite Client 6
 :project-client-RHEL7-url: {RepoRHEL7ServerSatelliteToolsProjectVersion}
 :project-client-RHEL8-url: {RepoRHEL8ServerSatelliteToolsProjectVersion}
+:client-redhat-repo-path: /etc/yum.repos.d/redhat.repo


### PR DESCRIPTION
#### What changes are you introducing?

Adding missing definitions for `:client-redhat-repo-path:`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Failing builds because of cherry picks from #4938 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
