### PR TITLE
Switch to  postgres 16 as a minimum requirement

### DIFF
--- a/guides/common/modules/proc_installing-postgresql-as-an-external-database.adoc
+++ b/guides/common/modules/proc_installing-postgresql-as-an-external-database.adoc
@@ -12,7 +12,10 @@ ifdef::foreman-deb[]
 The examples below assume PostgreSQL 14 as used on Ubuntu 22.04.
 If you run {ProjectServer} on Debian 12, you have to adjust the paths of PostgreSQL config and data directories which depend on the PostgreSQL version.
 endif::[]
-ifndef::foreman-deb[]
+ifdef::containerized[]
+{Project} supports PostgreSQL version 16, which is available in {EL} 10 repositories.
+endif::[]
+ifndef::foreman-deb,containerized[]
 {Project} supports PostgreSQL version 13.
 endif::[]
 

--- a/guides/common/modules/ref_postgresql-as-an-external-database-considerations.adoc
+++ b/guides/common/modules/ref_postgresql-as-an-external-database-considerations.adoc
@@ -15,7 +15,10 @@ ifdef::foreman-deb[]
 {Project} requires PostgreSQL version 13 or later.
 {Team} recommends that you use the PostgreSQL version that is part of the default operating system repositories.
 endif::[]
-ifndef::foreman-deb[]
+ifdef::containerized[]
+{Project} supports PostgreSQL version 16, which is available in {EL} 10 repositories.
+endif::[]
+ifndef::foreman-deb,containerized[]
 {Project} supports PostgreSQL version 13.
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Update the minimum version of PostgreSQL db to 16

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We are switching from PostgreSQL 13 to 16.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
