### PR TITLE
Hide virt-who deployment on containerized ProjectServer

### DIFF
--- a/guides/common/assembly_configuring-virt-who-hyperv.adoc
+++ b/guides/common/assembly_configuring-virt-who-hyperv.adoc
@@ -4,7 +4,12 @@
 :context: hyperv-virt-who
 :hyperv-virt-who:
 :provider: Microsoft Hyper-V
+ifdef::containerized[]
+:targets: {SmartProxyServer} or on a dedicated {EL} server
+endif::[]
+ifndef::containerized[]
 :targets: {ProjectServer}, {SmartProxyServer}, or on a dedicated {EL} server
+endif::[]
 include::modules/con_configuring-virt-who-for-provider.adoc[]
 
 :hypervisor-ui: Microsoft Hyper-V (hyperv)
@@ -16,12 +21,14 @@ include::modules/proc_creating-a-virt-who-configuration-by-using-web-ui.adoc[lev
 include::modules/proc_creating-a-virt-who-configuration-by-using-cli.adoc[leveloffset=+1]
 :!hyperv-virt-who:
 
+ifndef::containerized[]
 :context: hyperv-projectserver
 :hyperv-projectserver:
 :a-target: {ProjectServer}
 :the-target: {ProjectServer}
 include::modules/proc_deploying-a-virt-who-configuration-on-target-server.adoc[leveloffset=+1]
 :!hyperv-projectserver:
+endif::[]
 
 :context: hyperv-smartproxy
 :hyperv-smartproxy:

--- a/guides/common/assembly_configuring-virt-who-nutanix.adoc
+++ b/guides/common/assembly_configuring-virt-who-nutanix.adoc
@@ -4,7 +4,12 @@
 :context: nutanix-virt-who
 :nutanix-virt-who:
 :provider: Nutanix AHV
+ifdef::containerized[]
+:targets: {SmartProxyServer} or on a dedicated {EL} server
+endif::[]
+ifndef::containerized[]
 :targets: {ProjectServer}, {SmartProxyServer}, or on a dedicated {EL} server
+endif::[]
 include::modules/con_configuring-virt-who-for-provider.adoc[]
 
 :hypervisor-ui: Nutanix AHV (ahv)
@@ -16,12 +21,14 @@ include::modules/proc_creating-a-virt-who-configuration-by-using-web-ui.adoc[lev
 include::modules/proc_creating-a-virt-who-configuration-by-using-cli.adoc[leveloffset=+1]
 :!nutanix-virt-who:
 
+ifndef::containerized[]
 :context: nutanix-projectserver
 :nutanix-projectserver:
 :a-target: {ProjectServer}
 :the-target: {ProjectServer}
 include::modules/proc_deploying-a-virt-who-configuration-on-target-server.adoc[leveloffset=+1]
 :!nutanix-projectserver:
+endif::[]
 
 :context: nutanix-smartproxy
 :nutanix-smartproxy:

--- a/guides/common/assembly_configuring-virt-who-vmware.adoc
+++ b/guides/common/assembly_configuring-virt-who-vmware.adoc
@@ -4,7 +4,12 @@
 :context: vmware-virt-who
 :vmware-virt-who:
 :provider: VMware vSphere
+ifdef::containerized[]
+:targets: {SmartProxyServer} or on a dedicated {EL} server
+endif::[]
+ifndef::containerized[]
 :targets: {ProjectServer}, {SmartProxyServer}, or on a dedicated {EL} server
+endif::[]
 include::modules/con_configuring-virt-who-for-provider.adoc[]
 
 :hypervisor-ui: VMware vSphere / vCenter (esx)
@@ -16,12 +21,14 @@ include::modules/proc_creating-a-virt-who-configuration-by-using-web-ui.adoc[lev
 include::modules/proc_creating-a-virt-who-configuration-by-using-cli.adoc[leveloffset=+1]
 :!vmware-virt-who:
 
+ifndef::containerized[]
 :context: vmware-projectserver
 :vmware-projectserver:
 :a-target: {ProjectServer}
 :the-target: {ProjectServer}
 include::modules/proc_deploying-a-virt-who-configuration-on-target-server.adoc[leveloffset=+1]
 :!vmware-projectserver:
+endif::[]
 
 :context: vmware-smartproxy
 :vmware-smartproxy:

--- a/guides/common/modules/con_configuring-virt-who-for-provider.adoc
+++ b/guides/common/modules/con_configuring-virt-who-for-provider.adoc
@@ -7,6 +7,8 @@
 Configure virt-who for {provider} to enable {Project} to discover and manage subscriptions for your virtual machines.
 This ensures proper subscription entitlements are applied based on the relationship between virtual machines and their physical hosts.
 
+You can deploy virt-who on {targets}.
+
 ifdef::kubevirt-virt-who[]
 ifdef::satellite[]
 :FeatureName: The {KubeVirt} hypervisor

--- a/guides/common/modules/proc_deploying-a-virt-who-configuration-on-target-server.adoc
+++ b/guides/common/modules/proc_deploying-a-virt-who-configuration-on-target-server.adoc
@@ -42,6 +42,34 @@ endif::[]
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Virt-who Configurations*.
 . Click a virt-who configuration.
 . Click the *Deploy* tab.
+ifdef::containerized[]
+. Under *Configuration script*, click *Download the script*.
+. Copy the script from {ProjectServer} to {the-target}:
++
+[options="nowrap" subs="+quotes,verbatim,attributes"]
+----
+$ scp _deploy_virt_who_config_1_.sh root@_{target-name}_:
+----
+. Log in to {the-target} and make the script executable:
++
+[options="nowrap" subs="+quotes"]
+----
+$ chmod +x _deploy_virt_who_config_1_.sh
+----
+. Run the script:
++
+[options="nowrap" subs="+quotes"]
+----
+$ sh _deploy_virt_who_config_1_.sh
+----
+. After the deployment is complete, delete the script:
++
+[options="nowrap" subs="+quotes"]
+----
+$ rm _deploy_virt_who_config_1_.sh
+----
+endif::[]
+ifndef::containerized[]
 ifdef::vmware-projectserver,hyperv-projectserver,nutanix-projectserver[]
 . Under *Hammer command*, click *Copy to clipboard*.
 . Log in to {ProjectServer}, paste the Hammer command into your terminal, and then run the command.
@@ -72,4 +100,5 @@ $ sh _deploy_virt_who_config_1_.sh
 ----
 $ rm _deploy_virt_who_config_1_.sh
 ----
+endif::[]
 endif::[]

--- a/guides/common/modules/ref_virt-who-configuration-overview.adoc
+++ b/guides/common/modules/ref_virt-who-configuration-overview.adoc
@@ -5,7 +5,7 @@
 
 [role="_abstract"]
 You configure virt-who by creating a virt-who configuration on {ProjectServer}.
-Then, you deploy the configuration on a target host such as a hypervisor or a dedicated {EL} server.
+Then, you deploy the configuration on a target host, such as a dedicated {EL} server.
 
 Preparing your environment::
 * Import a subscription manifest that includes a host-based subscription into {ProjectServer}.

--- a/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
+++ b/guides/doc-Configuring_virt_who_VM_Subscriptions/master.adoc
@@ -12,8 +12,6 @@ include::common/modules/ref_guide-not-ready.adoc[leveloffset=+1]
 endif::[]
 endif::[]
 
-ifndef::containerized[]
-
 ////
 Persona: Admin
 
@@ -63,5 +61,4 @@ endif::[]
 
 ifndef::orcharhino,satellite[]
 include::common/ribbons.adoc[]
-endif::[]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Updates for the _Configuring virt-who for virtual machine subscriptions_ guide

- Enabling containerized build
- Hiding virt-who deployment on containerized ProjectServer

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

- Need to see the preview
- virt-who cannot run on containerized ProjectServer

[SAT-45985](https://redhat.atlassian.net/browse/SAT-45985)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Assisted-by: Claude Code
- Will be added to upstream navigation later
- There will be more changes to this guide for containerized before it will be ready

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into: N/A
