### PR TITLE
Replace inline Chrome SSO config with link to upstream RHEL 9 IDM docs

### DIFF
--- a/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc
@@ -12,20 +12,16 @@ Use the latest stable Chrome browser.
 * You have {FreeIPA} authentication configured in your {Project} environment.
 For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
 * The host on which you are using Chrome is a client in the {FreeIPA} domain.
+* Your Chrome browser is configured for Single Sign-On (SSO).
+ifdef::satellite[]
+For more information, see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/accessing_identity_management_services/index#configuring-the-browser-for-kerberos-authentication-login-web-ui-krb[Configuring the browser for Kerberos authentication] in _Accessing Identity Management services in {RHEL}{nbsp}9_.
+endif::[]
+ifndef::satellite[]
+For more information, see https://www.freeipa.org/page/Fedora_Chrome.html#running-chrome[Running Chrome] in _FreeIPA_.
+endif::[]
 
 .Procedure
 . To use Kerberos authentication to log in:
-.. Enable the Chrome browser to use Kerberos authentication:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-$ google-chrome --auth-server-whitelist="\*._example.com_" --auth-negotiate-delegate-whitelist="*._example.com_"
-----
-+
-[NOTE]
-====
-Instead of allowlisting the whole domain, you can also allowlist a specific {ProjectServer}.
-====
 .. Obtain the Kerberos ticket-granting ticket (TGT):
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]


### PR DESCRIPTION
The Chrome-specific command line options (--auth-server-whitelist, --auth-negotiate-delegate-whitelist) were renamed since Chrome 101+. Replace the inline procedure with a prerequisite linking to the RHEL 9 Identity Management documentation, matching the pattern already used for Firefox instead of maintaining the option names.

Moreover, the IdM steps suggest to create a configuration file instead of launching Chrome with those options, so we shouldn't suggest something else.

#### What changes are you introducing?

Dropping Chrome options workaround for SSO auth in favor of IdM docs to be inline with Firefox procedure.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

See the commit message.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

An alternative would be just renaming these options to the actual ones.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.

I've selected all the available versions for cherry-picking, but please tell me if it's not applicable or doesn't make sense in the documentation world :)