### PR TITLE
Make the buildsystem compatible with ruby 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'sass'
 
 # For TOC generation
 gem 'nokogiri'
+
+gem 'logger'

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ endif
 all: html
 
 prep:
-	bundle install --path vendor
-	cd web && bundle install --path ../vendor
+	bundle config set path 'vendor'
+	bundle install
+	cd web && bundle config set path 'vendor' && bundle install
 	mkdir -p $(DEST)/nightly
 
 clean:


### PR DESCRIPTION
#### What changes are you introducing?

Adjusting the environment to work with Ruby 4

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

* `logger` is not bundled anymore, but one of our deps uses it unconditionally
* `--path` is not support anymore when doing `bundle install`

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
