### PR TITLE
Rebuild container image on Fedora 44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:43
+FROM quay.io/fedora/fedora:44
 
 # hadolint ignore=DL3041
 RUN dnf group install -y development-tools && \
@@ -12,8 +12,8 @@ RUN dnf group install -y development-tools && \
     rm -fr /var/cache/dnf && \
     gem install \
         asciidoctor-tabs:1.0.0.beta.6 \
-        ffi:1.17.3 \
-        nokogiri:1.19.0 \
+        ffi:1.17.4 \
+        nokogiri:1.19.4 \
         racc:1.8.1 \
         rb-fsevent:0.11.2 \
         rb-inotify:0.11.1 \


### PR DESCRIPTION
#### What changes are you introducing?

Rebuild container image on Fedora 44.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fedora 44 uses Ruby 4.0 by default.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Tests/requires PR #5039

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
