### PR TITLE
Update managing custom file type content for containerization

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-cli.adoc
@@ -55,9 +55,11 @@ Set to `true` or `false`, `yes` or `no`, `1` or `0`.
 | `--url` _My_Repository_URL_                                 | URL of the remote repository
 | `--verify-ssl-on-sync` _boolean_   | Verify that the upstream SSL certificates of the remote repository are signed by a trusted CA? Set to `true` or `false`, `yes` or `no`, `1` or `0`.
 |====
+ifndef::containerized[]
 
 .Next steps
 * If you set an upstream URL, you can synchronize content to {Project}.
 For more information, see xref:synchronizing-repositories-by-using-cli[].
 * If you did not set an upstream URL, you can upload content to your {customfiletype}.
 For more information, see xref:uploading-content-to-a-custom-file-repository-by-using-cli[].
+endif::[]

--- a/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-file-type-repository-by-using-web-ui.adoc
@@ -17,7 +17,9 @@ Select the `file` repository type and follow the same workflow as when you add o
 . From the *Type* list, select `file` as type of repository.
 . Optional: In the *Upstream URL* field, enter the URL of the upstream repository to use as a source.
 If you do not enter an upstream URL, you can manually upload packages.
+ifndef::containerized[]
 For more information, see xref:uploading-content-to-a-custom-file-repository-by-using-web-ui[].
+endif::[]
 . Select *Verify SSL* to verify that the SSL certificates of the repository are signed by a trusted CA.
 . Optional: In the *Upstream Username* field, enter the user name for the upstream repository if required for authentication.
 Clear this field if the repository does not require authentication.
@@ -26,9 +28,13 @@ Clear this field if the repository does not require authentication.
 . Optional: In the *Upstream Authentication Token* field, provide the token of the upstream repository user for authentication.
 Leave this field empty if the repository does not require authentication.
 . From the *Download Policy* list, select the type of synchronization {ProjectServer} performs.
+ifndef::containerized[]
 For more information, see xref:Download_Policies_Overview_{context}[].
+endif::[]
 . From the *Mirroring Policy* list, select the type of content synchronization {ProjectServer} performs.
+ifndef::containerized[]
 For more information, see xref:Mirroring_Policies_Overview_{context}[].
+endif::[]
 . Optional: In the *HTTP Proxy Policy* field, select an HTTP proxy.
 By default, it uses the `Global Default` HTTP proxy.
 . Optional: You can clear the *Unprotected* checkbox to require a subscription entitlement certificate for accessing this repository.

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -25,20 +25,28 @@ endif::[]
 ----
 # mkdir -p /var/lib/pulp/__local_repos__/__my_file_repo__
 ----
-ifndef::containerized[]
-. Add the parent folder into allowed import paths:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-installer} --foreman-proxy-content-pulpcore-additional-import-paths /var/lib/pulp/__local_repos__
-----
-endif::[]
 ifdef::containerized[]
 . Add the parent folder to allowed import paths:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # {foremanctl} deploy --content-import-path /var/lib/pulp/__local_repos__
+----
++
+To add multiple import paths, use the `--content-import-path` option multiple times:
++
+[options="nowrap", subs="+quotes,attributes"]
+----
+# {foremanctl} deploy --content-import-path /var/lib/pulp/__local_repo1__ \
+--content-import-path /var/lib/pulp/__local_repo2__
+----
+endif::[]
+ifndef::containerized[]
+. Add the parent folder into allowed import paths:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foreman-installer} --foreman-proxy-content-pulpcore-additional-import-paths /var/lib/pulp/__local_repos__
 ----
 endif::[]
 . Add files to the directory or create a test file:

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -19,18 +19,6 @@ endif::[]
 ----
 # {project-package-install} pulp-manifest
 ----
-ifdef::satellite[]
-+
-Note that this command stops the {Project} service and re-runs `{foreman-installer}`.
-Alternatively, to prevent downtime caused by stopping the service, you can use the following:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-maintain} packages unlock
-# {project-package-install} pulp-manifest
-# {foreman-maintain} packages lock
-----
-endif::[]
 . Create a directory that you want to use as the file type repository, such as:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-local-source-for-a-custom-file-type-repository.adoc
@@ -79,5 +79,7 @@ Use the `file://` URL scheme and the name of the directory to specify an *Upstre
 ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For more information, see xref:creating-a-custom-file-type-repository-by-using-web-ui[].
 endif::[]
+ifndef::containerized[]
 * If you update the contents of your directory, re-run Pulp Manifest and sync the repository in {Project}.
 For more information, see xref:synchronizing-repositories-ad-hoc[].
+endif::[]

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -87,5 +87,7 @@ Use the path to the directory to specify an *Upstream URL*, such as `\http://{se
 ifdef::katello,satellite,almalinux,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For more information, see xref:creating-a-custom-file-type-repository-by-using-web-ui[].
 endif::[]
+ifndef::containerized[]
 * If you update the contents of your directory, re-run Pulp Manifest and sync the repository in {Project}.
 For more information, see xref:synchronizing-repositories-ad-hoc[].
+endif::[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -85,10 +85,8 @@ include::common/assembly_managing-custom-file-type-content-in-project.adoc[level
 endif::[]
 
 ifndef::containerized[]
-ifdef::katello,satellite,orcharhino[]
 ifdef::katello,orcharhino[]
 include::common/assembly_managing-python-content-in-project.adoc[leveloffset=+1]
-endif::[]
 
 [appendix]
 include::common/modules/ref_required-red-hat-repositories.adoc[leveloffset=+1]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -77,9 +77,15 @@ include::common/assembly_managing-flatpak-repositories-in-project.adoc[leveloffs
 include::common/assembly_managing-iso-images.adoc[leveloffset=+1]
 
 include::common/assembly_managing-ansible-content.adoc[leveloffset=+1]
+endif::[]
+endif::[]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-custom-file-type-content-in-project.adoc[leveloffset=+1]
+endif::[]
 
+ifndef::containerized[]
+ifdef::katello,satellite,orcharhino[]
 ifdef::katello,orcharhino[]
 include::common/assembly_managing-python-content-in-project.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

* Exposing the Managing custom file type assembly in containerized docs
* Adding containerized Managing Content to website navigation
* Updating the assembly contents for containerization

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Builds on the changes merged in https://github.com/theforeman/foreman-documentation/pull/4905/

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
