### PR TITLE
Do not document how to renew certs during installation

### DIFF
--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -79,10 +79,6 @@ ifdef::katello,orcharhino,satellite[]
 
 include::common/assembly_configuring-an-alternate-cname.adoc[leveloffset=+2]
 
-ifdef::containerized[]
-include::common/modules/proc_renewing-self-signed-certificates-on-server.adoc[leveloffset=+2]
-endif::[]
-
 include::common/assembly_configuring-satellite-custom-server-certificate.adoc[leveloffset=+2]
 
 include::common/modules/proc_resetting-custom-ssl-certificate-to-default-self-signed-certificate-on-project.adoc[leveloffset=+2]


### PR DESCRIPTION
#### What changes are you introducing?

See subject

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This makes no sense: we can expect fresh and working certs on a fresh installation

Fixes: bd71c52a0e0655c04105d61d1669632a8deb4644

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
