### PR TITLE
Updating Using an NFS share for containerization

### DIFF
--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -18,10 +18,18 @@ This example uses a share at `nfs.example.com:/{Project}/pulp`.
 Ensure this share provides the appropriate permissions to {ProjectServer} and its `apache` user.
 . Stop {Project} services on your {ProjectServer}:
 +
+ifdef::containerized[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# systemctl stop foreman.target
+----
+endif::[]
+ifndef::containerized[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service stop
 ----
+endif::[]
 . Ensure {ProjectServer} has the `{nfs-server-package}` package installed:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -85,10 +93,18 @@ Also confirm that the existing content exists at the mount on `var/lib/pulp`:
 ----
 . Start {Project} services on your {ProjectServer}:
 +
+ifdef::containerized[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# systemctl start foreman.target
+----
+endif::[]
+ifndef::containerized[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-maintain} service start
 ----
+endif::[]
 ifndef::containerized[]
 
 .Verification

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -89,7 +89,9 @@ Also confirm that the existing content exists at the mount on `var/lib/pulp`:
 ----
 # {foreman-maintain} service start
 ----
+ifndef::containerized[]
 
 .Verification
 * Run content synchronization to ensure the NFS share works as expected.
 For more information, see xref:synchronizing-repositories-ad-hoc[].
+endif::[]

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -12,10 +12,11 @@ This appendix shows how to mount the NFS share on your {ProjectServer}'s content
 Use high-bandwidth, low-latency storage for the `/var/lib/pulp` file system.
 {ProjectName} has many I/O-intensive operations; therefore, high-latency, low-bandwidth storage might have issues with performance degradation.
 
-.Procedure
-. Create the NFS share.
+.Prerequisites
+* The NFS share exists and provides the appropriate permissions to {ProjectServer} and its `apache` user.
 This example uses a share at `nfs.example.com:/{Project}/pulp`.
-Ensure this share provides the appropriate permissions to {ProjectServer} and its `apache` user.
+
+.Procedure
 . Stop {Project} services on your {ProjectServer}:
 +
 ifdef::containerized[]

--- a/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
+++ b/guides/common/modules/proc_using-an-nfs-share-for-content-storage.adoc
@@ -87,7 +87,7 @@ nfs.example.com:/{Project}/pulp 309506048 58632800 235128224  20% /var/lib/pulp
 ...
 ----
 +
-Also confirm that the existing content exists at the mount on `var/lib/pulp`:
+Also confirm that the existing content exists at the mount on `/var/lib/pulp`:
 +
 ----
 # ls /var/lib/pulp

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -5,12 +5,6 @@ include::common/header.adoc[]
 
 = {ContentManagementDocTitle}
 
-ifdef::containerized[]
-ifdef::katello[]
-include::common/modules/ref_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-endif::[]
-
 ifndef::containerized[]
 
 ifdef::foreman-deb[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -94,11 +94,14 @@ ifdef::katello[]
 include::common/modules/ref_troubleshooting-synchronization-errors.adoc[leveloffset+=1]
 endif::[]
 
+endif::[]
+endif::[]
+
+ifdef::katello,satellite,orcharhino[]
 [appendix]
 include::common/modules/proc_using-an-nfs-share-for-content-storage.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::orcharhino,satellite[]
 include::common/ribbons.adoc[]
-endif::[]
 endif::[]

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -148,7 +148,8 @@
         ],
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],
-          ["Configuring_User_Authentication", "Configuring user authentication"]
+          ["Configuring_User_Authentication", "Configuring user authentication"],
+          ["Managing_Content", "Managing content"]
         ],
         "Administering hosts": [
         ],


### PR DESCRIPTION
#### What changes are you introducing?

* Exposing the Using an NFS share appendix in containerized docs
* Adding containerized Using an NFS share to website navigation
* Updating the appendix contents for containerization
* Ensuring the procedure only has 10 steps (not necessary, but why not -- it will resolve some Vale errors)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
