### PR TITLE
Update OSTree docs for containerization

### DIFF
--- a/guides/common/modules/proc_enabling-os-tree-content.adoc
+++ b/guides/common/modules/proc_enabling-os-tree-content.adoc
@@ -9,7 +9,15 @@ You can enable OSTree on your {Project} to synchronize and manage OSTree branche
 .Procedure
 * On your {ProjectServer}, enable OSTree content:
 +
+ifdef::containerized[]
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foremanctl} -add-feature content/ostree
+----
+endif::[]
+ifndef::containerized[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # {foreman-installer} --foreman-proxy-content-enable-ostree true
 ----
+endif::[]

--- a/guides/common/modules/proc_enabling-os-tree-content.adoc
+++ b/guides/common/modules/proc_enabling-os-tree-content.adoc
@@ -12,7 +12,7 @@ You can enable OSTree on your {Project} to synchronize and manage OSTree branche
 ifdef::containerized[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foremanctl} -add-feature content/ostree
+# {foremanctl} --add-feature content/ostree
 ----
 endif::[]
 ifndef::containerized[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -61,11 +61,15 @@ include::common/assembly_managing-suse-content.adoc[leveloffset=+1]
 endif::[]
 
 include::common/assembly_making-errata-available-through-content-views.adoc[leveloffset=+1]
+endif::[]
+endif::[]
 
-ifndef::satellite[]
+ifdef::katello,orcharhino[]
 include::common/assembly_managing-ostree-content.adoc[leveloffset=+1]
 endif::[]
 
+ifndef::containerized[]
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]
 
 include::common/assembly_managing-flatpak-repositories-in-project.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

* Exposing the Using an NFS share appendix in containerized docs
* Adding containerized Using an NFS share to website navigation
* Updating the appendix contents for containerization

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

https://github.com/theforeman/foremanctl/pull/652/

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
