### PR TITLE
Hide module about Deb packages for non-Deb Clients

### DIFF
--- a/guides/common/assembly_making-errata-available-through-content-views.adoc
+++ b/guides/common/assembly_making-errata-available-through-content-views.adoc
@@ -26,7 +26,7 @@ include::modules/snip_important-do-not-use-phased-updates.adoc[]
 include::modules/proc_disabling-phased-updates.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::satellite[]
+ifdef::katello,debian,ubuntu[]
 include::modules/proc_creating-an-incremental-content-view-version-by-adding-deb-packages.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

This patch ensures that in downstream orcharhino builds, the module is hidden for all Client OS but Debian and Ubuntu.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

AlmaLinux et al. do not use Deb content.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
