### PR TITLE
Do not suggest to update Proxy certs after updating Server certs

### DIFF
--- a/guides/common/modules/proc_renewing-self-signed-certificates-on-server.adoc
+++ b/guides/common/modules/proc_renewing-self-signed-certificates-on-server.adoc
@@ -36,7 +36,3 @@ This is typically displayed as a shield, padlock, or tune icon next to the addre
 ----
 +
 The output displays the `notBefore` and `notAfter` dates of the certificate, where `notBefore` is the date when the certificate becomes valid and `notAfter` is the date when it expires.
-
-.Next steps
-* If you have {SmartProxyServers}, you must update their certificates to trust the renewed {ProjectServer} certificates.
-For more information, see {InstallingSmartProxyDocURL}configuring-{smart-proxy-context}-server-with-ssl-certificates_{smart-proxy-context}[Configuring {SmartProxyServer} with SSL certificates] in _{InstallingSmartProxyDocTitle}_.


### PR DESCRIPTION
#### What changes are you introducing?

title

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The CA didn't change, so no update on the proxy is required

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
