### PR TITLE
Hide foreman-console from containerized builds

### DIFF
--- a/guides/common/modules/proc_creating-a-complete-permission-table.adoc
+++ b/guides/common/modules/proc_creating-a-complete-permission-table.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 Generate a complete permission table from the {Project} console to review all available permissions and actions on your {Project}.
 
-ifndef::satellite[]
+ifndef::containerized[]
 .Prerequisites
 * The `foreman-console` package is installed on {ProjectServer}.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?
^^

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
foreman-console isn't necessary and won't be available for containerized builds
https://redhat.atlassian.net/browse/SAT-47644

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
