### PR TITLE
Fix misplaced heading

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -1,6 +1,5 @@
 include::common/attributes.adoc[]
 include::common/header.adoc[]
-:doctype: book
 :context: planning
 
 = {PlanningDocTitle}
@@ -18,7 +17,6 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 endif::[]
 
 [id="Project_Overview_and_Concepts_{context}"]
-[part]
 == {Project} overview and concepts
 
 {ProjectName} is a centralized tool for provisioning, remote management, and monitoring of multiple {EL} deployments.
@@ -35,10 +33,6 @@ include::common/assembly_major-project-components.adoc[leveloffset=+1]
 include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1]
 
 include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]
-
-[[part-Deployment_Planning]]
-[part]
-== {Project} deployment planning
 
 include::topics/Deployment_Scenarios.adoc[]
 

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -1,5 +1,6 @@
 include::common/attributes.adoc[]
 include::common/header.adoc[]
+:doctype: book
 :context: planning
 
 = {PlanningDocTitle}
@@ -17,6 +18,7 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 endif::[]
 
 [id="Project_Overview_and_Concepts_{context}"]
+[part]
 == {Project} overview and concepts
 
 {ProjectName} is a centralized tool for provisioning, remote management, and monitoring of multiple {EL} deployments.
@@ -35,6 +37,7 @@ include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1
 include::common/assembly_supported-usage-and-versions-of-project-components.adoc[leveloffset=+1]
 
 [[part-Deployment_Planning]]
+[part]
 == {Project} deployment planning
 
 include::topics/Deployment_Scenarios.adoc[]


### PR DESCRIPTION
Foreman 3.12 document at https://docs.theforeman.org/3.12/Planning_for_Project/index-katello.html#part-Deployment_Planning 
"8. Foreman deployment planning" is empty.

Proposing a fix by adding the "part" declaration and the "book" doctype.
Other options are on the table as well, however, this seems the most elegant. 
Downstream ticket https://redhat.atlassian.net/browse/SAT-47264 