### PR TITLE
Add upgrade warning for Smart Proxy TLS parameter changes

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -79,7 +79,20 @@ endif::[]
 == Upgrade warnings
 
 //If there are upgrade warnings, comment out the following line:
-There are no upgrade warnings with Foreman {ProjectVersion}.
+//There are no upgrade warnings with Foreman {ProjectVersion}.
+
+Smart Proxy TLS configuration parameters have been renamed::
++
+--
+The `ssl_disabled_ciphers` and `tls_disabled_versions` Smart Proxy parameters have been replaced by `tls_ciphers` and `tls_min_version`.
+
+* `ssl_disabled_ciphers` (an array of cipher suites to disable) is replaced by `tls_ciphers` (an OpenSSL cipher string). When unset, the Smart Proxy auto-detects: `PROFILE=SYSTEM` if crypto-policies are present, otherwise `HIGH`.
+* `tls_disabled_versions` (an array of TLS versions to disable) is replaced by `tls_min_version` (a single minimum version: `1.0`, `1.1`, `1.2`, or `1.3`). When unset, the minimum version is determined by the system OpenSSL configuration.
+
+If you customized these settings through `{foreman-installer}`, the old parameters are automatically removed during upgrade.
+No automatic migration of values is performed.
+If you previously set custom TLS cipher or version restrictions, reconfigure them using the new parameters after upgrading.
+--
 
 //To add a headline feature, use AsciiDoc's description list: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
 //Summary::


### PR DESCRIPTION
## Summary
- Add an upgrade warning documenting the replacement of `ssl_disabled_ciphers` and `tls_disabled_versions` with `tls_ciphers` and `tls_min_version`.

Companion to:
- https://github.com/theforeman/smart-proxy/pull/947
- https://github.com/theforeman/puppet-foreman_proxy/pull/901

Suggested in https://github.com/theforeman/puppet-foreman_proxy/pull/901#discussion_r3578677332.