### PR TITLE
Reword Microsoft Azure Resource Manager

### DIFF
--- a/guides/common/modules/proc_adding-a-microsoft-azure-connection-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-a-microsoft-azure-connection-by-using-web-ui.adoc
@@ -8,7 +8,8 @@ Add Microsoft Azure as a compute resource to provision and manage hosts on Azure
 Note that you must add a separate compute resource for each Microsoft Azure region that you want to use.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources* and click *Create Compute Resource*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Compute Resources*.
+. Click *Create Compute Resource*.
 . In the *Name* field, enter a name for the compute resource.
 . From the *Provider* list, select *Azure Resource Manager*.
 . Optional: In the *Description* field, enter a description for the resource.

--- a/guides/common/modules/proc_adding-microsoft-azure-details-to-a-compute-profile-by-using-cli.adoc
+++ b/guides/common/modules/proc_adding-microsoft-azure-details-to-a-compute-profile-by-using-cli.adoc
@@ -8,13 +8,13 @@ You can create custom compute profiles to bundle {compute-resource} hardware set
 When you create a host on Microsoft Azure using this compute profile, these settings are automatically populated.
 
 .Procedure
-. Create a compute profile to use with the Azure Resource Manager compute resource:
+. Create a compute profile to use with {compute-resource}:
 +
 [options="nowrap" subs="+quotes"]
 ----
 $ hammer compute-profile create --name _compute_profile_name_
 ----
-. Add Azure details to the compute profile.
+. Add {compute-resource} details to the compute profile.
 With the `username` setting, enter the SSH user name for image access.
 Note that the username that you enter for compute profile must be the same that you use when creating an image.
 +

--- a/guides/common/modules/proc_creating-image-based-hosts-on-compute-resource-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-image-based-hosts-on-compute-resource-by-using-web-ui.adoc
@@ -21,7 +21,7 @@ include::snip_steps-create-a-host-tab-interfaces.adoc[]
 . Click the *Operating System* tab, and confirm that all fields automatically contain values.
 ifdef::openstack-provisioning[. If you want to change the image that populates automatically from your compute profile, from the *Images* list, select a different image to base the new host's root volume on.]
 ifdef::azure-provisioning[. For *Provisioning Method*, ensure *Image Based* is selected.]
-ifdef::azure-provisioning[. From the *Image* list, select the Azure Resource Manager image that you want to use for provisioning.]
+ifdef::azure-provisioning[. From the *Image* list, select the {compute-resource} image that you want to use for provisioning.]
 ifdef::azure-provisioning[. In the *Root Password* field, enter the root password to authenticate with.]
 . Click *Resolve* in *Provisioning templates* to check the new host can identify the right provisioning templates to use.
 . Click the *Virtual Machine* tab and confirm that these settings are populated with details from the host group and compute profile.


### PR DESCRIPTION
#### What changes are you introducing?

Rename Azure Resource Manager with "Microsoft Azure" to align with other docs.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Tested on Foreman 3.18: The provider is called "Azure Resource Manager" on Settings > About > Available Providers.

That's why this patch does not fix this instance of Azure, but aligns other instances with other compute resources by using the "compute-resource" attribute.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Found via `rg -i "resource manager"`

Fixes #4535

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
