### PR TITLE
Fix broken include in Migration Maps

### DIFF
--- a/guides/doc-Satellite_Migration_Maps/map_discover.adoc
+++ b/guides/doc-Satellite_Migration_Maps/map_discover.adoc
@@ -4,7 +4,7 @@
 [id="discover"]
 = Discover
 
-include::../common/modules/con_introduction-to-project.adoc[leveloffset=+1]
+include::../common/modules/con_project-use-cases.adoc[leveloffset=+1]
 
 include::../common/assembly_content-and-patch-management-with-project.adoc[leveloffset=+1]
 


### PR DESCRIPTION
PR #4969 deleted con_introduction-to-project.adoc and replaced it with con_project-use-cases.adoc, breaking the build for the Migration Maps guide added in PR #4984.

#### What changes are you introducing?

Updating include to point to new file.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Fix broken build.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

build-html-base job fails because PR #4984 has been merged to master. Merging this PR will fix the build problem.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
