### PR TITLE
Add troubleshooting sync errors to containerized docs

### DIFF
--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -86,13 +86,12 @@ endif::[]
 
 [appendix]
 include::common/modules/ref_required-red-hat-repositories.adoc[leveloffset=+1]
+endif::[]
+endif::[]
 
 ifdef::katello[]
 [appendix]
 include::common/modules/ref_troubleshooting-synchronization-errors.adoc[leveloffset+=1]
-endif::[]
-
-endif::[]
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?

Including the appendix on troubleshooting synchronization errors to containerized builds of Managing Content

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set

https://github.com/theforeman/foremanctl/pull/647

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
