### PR TITLE
Include a link in all relevant builds

### DIFF
--- a/guides/common/modules/con_content-flow-in-project.adoc
+++ b/guides/common/modules/con_content-flow-in-project.adoc
@@ -40,6 +40,4 @@ endif::[]
 
 .Additional resources
 * xref:Major-{Project}-Components_{context}[]
-ifdef::satellite[]
 * {ContentManagementDocURL}[_{ContentManagementDocTitle}_]
-endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Making sure a link to Managing Content is included in all relevant build targets

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/5062#discussion_r3584840789

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
