### PR TITLE
Simplify Planning guide structure

### DIFF
--- a/guides/common/assembly_content-and-patch-management-with-project.adoc
+++ b/guides/common/assembly_content-and-patch-management-with-project.adoc
@@ -1,3 +1,0 @@
-include::modules/con_content-and-patch-management-with-project.adoc[]
-
-include::modules/con_content-flow-in-project.adoc[leveloffset=+1]

--- a/guides/common/assembly_provisioning-management-with-project.adoc
+++ b/guides/common/assembly_provisioning-management-with-project.adoc
@@ -1,3 +1,0 @@
-include::modules/con_provisioning-management-with-project.adoc[]
-
-include::modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]

--- a/guides/common/modules/con_content-and-patch-management-with-project.adoc
+++ b/guides/common/modules/con_content-and-patch-management-with-project.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-[id="content-and-patch-management-with-{project-context}"]
-= Content and patch management with {ProjectName}
-
-[role="_abstract"]
-With {ProjectName}, you can provide content and apply patches to hosts systematically in all lifecycle stages.

--- a/guides/common/modules/con_provisioning-management-with-project.adoc
+++ b/guides/common/modules/con_provisioning-management-with-project.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-[id="Provisioning-Management-with-{ProjectNameID}_{context}"]
-= Provisioning management with {ProjectName}
-
-[role="_abstract"]
-With {ProjectName}, you can provision hosts on various compute resources with many provisioning methods from a unified interface.

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -19,16 +19,6 @@ endif::[]
 include::common/modules/con_project-use-cases.adoc[leveloffset=+1]
 
 ifndef::containerized[]
-ifdef::katello,satellite,orcharhino[]
-include::common/modules/con_content-flow-in-project.adoc[leveloffset=+1]
-endif::[]
-
-include::common/modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]
-
-ifdef::katello,orcharhino,satellite[]
-include::common/assembly_expense-management-for-red-hat-subscriptions.adoc[leveloffset=+1]
-endif::[]
-
 include::common/assembly_major-project-components.adoc[leveloffset=+1]
 
 include::common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1]
@@ -43,6 +33,16 @@ include::common/assembly_networking-considerations-in-project.adoc[leveloffset=+
 
 ifdef::satellite[]
 include::common/modules/con_red-hat-offline-knowledge-portal.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::katello,satellite,orcharhino[]
+include::common/modules/con_content-flow-in-project.adoc[leveloffset=+1]
+endif::[]
+
+include::common/modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]
+
+ifdef::katello,orcharhino,satellite[]
+include::common/assembly_expense-management-for-red-hat-subscriptions.adoc[leveloffset=+1]
 endif::[]
 
 include::common/assembly_deployment-path.adoc[leveloffset=+1]

--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -20,10 +20,10 @@ include::common/modules/con_project-use-cases.adoc[leveloffset=+1]
 
 ifndef::containerized[]
 ifdef::katello,satellite,orcharhino[]
-include::common/assembly_content-and-patch-management-with-project.adoc[leveloffset=+1]
+include::common/modules/con_content-flow-in-project.adoc[leveloffset=+1]
 endif::[]
 
-include::common/assembly_provisioning-management-with-project.adoc[leveloffset=+1]
+include::common/modules/con_provisioning-methods-in-project.adoc[leveloffset=+1]
 
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_expense-management-for-red-hat-subscriptions.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Migration_Maps/map_discover.adoc
+++ b/guides/doc-Satellite_Migration_Maps/map_discover.adoc
@@ -6,10 +6,6 @@
 
 include::../common/modules/con_project-use-cases.adoc[leveloffset=+1]
 
-include::../common/assembly_content-and-patch-management-with-project.adoc[leveloffset=+1]
-
-include::../common/assembly_provisioning-management-with-project.adoc[leveloffset=+1]
-
 include::../common/assembly_major-project-components.adoc[leveloffset=+1]
 
 include::../common/assembly_tools-for-administration-of-project.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

* Dropping two assemblies that each contained a single module (the information from the dropped assembly abstracts is covered in the use cases added in https://github.com/theforeman/foreman-documentation/pull/4969)
* Changing the order of the sections in Planning (the previous ordering was based on the idea that first, use cases -- content management, provisioning management -- should be explained before talking about components; the new use cases section does that now)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I'm reviewing the current state of Planning before we start getting it ready for containerization

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
