### PR TITLE
Rename certificate-cname to server-alias

### DIFF
--- a/guides/common/modules/proc_configuring-project-with-an-alternate-cname.adoc
+++ b/guides/common/modules/proc_configuring-project-with-an-alternate-cname.adoc
@@ -13,7 +13,7 @@ ifdef::containerized[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foremanctl} --certificate-cname _My-Alternate-FQDN.example.com_
+# {foremanctl} --server-alias _My-Alternate-FQDN.example.com_
 ----
 endif::[]
 ifndef::containerized[]


### PR DESCRIPTION
#### What changes are you introducing?

Renaming the `--certificate-cname` flag to `--server-alias`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foremanctl/pull/677 is changing the foremanctl flags.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
