### PR TITLE
Remove an obsolete foreman-rake troubleshooting advice

### DIFF
--- a/guides/common/modules/ref_troubleshooting-synchronization-errors.adoc
+++ b/guides/common/modules/ref_troubleshooting-synchronization-errors.adoc
@@ -13,13 +13,6 @@ If you encounter the following errors during content synchronization, follow the
 # chown --recursive pulp:pulp /var/lib/pulp/media/
 ----
 
-"{"policy":[""" is not a valid choice."]}" during Debian repository syncing::
-+
-[options="nowrap" subs="+quotes,attributes"]
-----
-# foreman-rake katello:migrate_deb_content_attributes_to_pulp3
-----
-
 500 API error during syncing with "cryptography.fernet.InvalidToken" in /var/log/messages traceback::
 Run this command on your {ProjectServer} and all {SmartProxyServers}:
 +


### PR DESCRIPTION
#### What changes are you introducing?

Removing a foreman-rake command that is obsolete per the conversation in https://github.com/theforeman/foreman-documentation/pull/5075

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Originally, the foreman-rake command was a one-time migration tool used to fix database entries when transitioning from Pulp 2 to Pulp 3. Since the Pulp 2 migration phase is over, users are unlikely to need it, and thus we can remove it from documentation.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
