### PR TITLE
Add Vale rule to flag attribute-based links in concepts

### DIFF
--- a/.vale/styles/foreman-documentation/ConceptAttributeLink.yml
+++ b/.vale/styles/foreman-documentation/ConceptAttributeLink.yml
@@ -1,0 +1,87 @@
+# Report links included as attributes outside of Additional resources in
+# concept modules.
+#
+# To improve content usability and user focus, links and cross references in
+# the main body of a concept topic are discouraged. If the links and cross
+# references are needed, move them to the Additional resources section.
+#
+# Based on https://github.com/jhradilek/asciidoctor-dita-vale ConceptLink.
+---
+extends: script
+message: "Move all links and cross references to Additional resources."
+level: warning
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
+  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
+  r_attr_link       := text.re_compile("\\{[A-Za-z]+URL\\}[^\\[\\n]*\\[[^\\]]*\\]")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:assembly|concept)")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  is_relevant       := false
+  in_code_block     := false
+  in_comment_block  := false
+  in_add_resources  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      is_relevant = true
+      continue
+    }
+
+    if r_add_resources.match(line) {
+      in_add_resources = true
+      continue
+    }
+
+    if r_any_title.match(line) {
+      in_add_resources = false
+      continue
+    }
+
+    if in_add_resources { continue }
+
+    for i, entry in r_attr_link.find(line, -1) {
+      link := entry[0]
+      matches = append(matches, {begin: start + link.begin, end: start + link.end - 1})
+    }
+  }
+
+  if ! is_relevant {
+    matches = []
+  }

--- a/.vale/styles/foreman-documentation/ConceptAttributeLink.yml
+++ b/.vale/styles/foreman-documentation/ConceptAttributeLink.yml
@@ -17,7 +17,7 @@ script: |
 
   r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
   r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
-  r_attr_link       := text.re_compile("\\{[A-Za-z]+URL\\}[^\\[\\n]*\\[[^\\]]*\\]")
+  r_attr_link       := text.re_compile("\\{[0-9A-Za-z_][0-9A-Za-z_-]*URL\\}[^\\[\\n]*\\[[^\\]]*\\]")
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")

--- a/.vale/styles/foreman-documentation/ConceptAttributeLink.yml
+++ b/.vale/styles/foreman-documentation/ConceptAttributeLink.yml
@@ -1,14 +1,10 @@
-# Report links included as attributes outside of Additional resources in
-# concept modules.
+# Do not include links or cross references in the main body of a concept module.
+# In concept modules, links are allowed only in the Additional resources section.
 #
-# To improve content usability and user focus, links and cross references in
-# the main body of a concept topic are discouraged. If the links and cross
-# references are needed, move them to the Additional resources section.
-#
-# Based on https://github.com/jhradilek/asciidoctor-dita-vale ConceptLink.
+# Based on ConceptLink.yml from https://github.com/jhradilek/asciidoctor-dita-vale.
 ---
 extends: script
-message: "Move all links and cross references to Additional resources."
+message: "To improve content usability and user focus, links and cross references in the main body of a concept module are discouraged. Move them to the Additional resources section."
 level: warning
 scope: raw
 script: |


### PR DESCRIPTION
#### What changes are you introducing?

Add ConceptAttributeLink rule that reports {*URL}...[...] links in concept and assembly modules outside of Additional resources sections. Based on the upstream AsciiDocDITA ConceptLink rule, adapted to match attribute-based links used in foreman-documentation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/styles/AsciiDocDITA/ConceptLink.yml flags links in concept modules that are outside of the `.Additional resources` section. However, as explained in https://github.com/jhradilek/asciidoctor-dita-vale/issues/186, the rule does not flag links that are included as attributes (such as `{AdministeringDocURL}`). Attributes effectively obscure such links.

This PR is an attempt to develop our own, Foreman-specific Vale rule that reports links included through our usual attributes, which follow the pattern of `{SomethingURL}`.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Developing a Vale rule such as this one is an alternative to modifying our link conventions as suggested in https://github.com/theforeman/foreman-documentation/pull/4804

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
