### PR TITLE
Add Smart Proxy config for Secure Boot of Client OS

### DIFF
--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -15,6 +15,7 @@ include::modules/ref_required-boot-order-for-network-boot.adoc[leveloffset=+1]
 :extract_deb_zst_suffix: && tar --use-compress-program=unzstd -xf data.tar.zst && cd -
 :extract_rpm_prefix: rpm2cpio /tmp
 :extract_rpm_suffix: | cpio -idv --directory /tmp
+:parent-client-os-context: {client-os-context}
 :parent-client-os: {client-os}
 :parent-client-pkg-ext: {client-pkg-ext}
 
@@ -40,6 +41,24 @@ ifdef::foreman-el,foreman-deb,katello,almalinux[]
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
 endif::[]
 
+ifdef::foreman-el,foreman-deb,katello,centos[]
+:client-os-context: centos
+:client-os: CentOS Stream
+:client-pkg-ext: rpm
+:secureboot-os-name: centos
+:grub_efi_download_url: https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/Packages/
+:grub_efi_downloaded_package_name: grub2-efi-x64.rpm
+:grub_efi_package_name: grub2-efi-x64
+:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/grubx64.efi
+:shim_efi_download_url: https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/Packages/
+:shim_efi_downloaded_package_name: shim-x64.rpm
+:shim_efi_package_name: shim-x64
+:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/shimx64.efi
+:extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
+:extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
+include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
+endif::[]
+
 ifdef::foreman-el,foreman-deb,katello,debian[]
 :client-os-context: debian
 :client-os: Debian
@@ -55,6 +74,24 @@ ifdef::foreman-el,foreman-deb,katello,debian[]
 :shim_efi_tmp_binary_path: /tmp/usr/lib/shim/shimx64.efi.signed
 :extract_grub: {extract_deb_prefix}/{grub_efi_downloaded_package_name} {extract_deb_xz_suffix}
 :extract_shim: {extract_deb_prefix}/{shim_efi_downloaded_package_name} {extract_deb_xz_suffix}
+include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
+endif::[]
+
+ifdef::foreman-el,foreman-deb,katello,oracle_linux[]
+:client-os-context: oracle_linux
+:client-os: Oracle Linux
+:client-pkg-ext: rpm
+:secureboot-os-name: redhat
+:grub_efi_download_url: https://yum.oracle.com/repo/OracleLinux/OL10/baseos/latest/x86_64/
+:grub_efi_downloaded_package_name: grub2-efi-x64.rpm
+:grub_efi_package_name: grub2-efi-x64
+:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/grubx64.efi
+:shim_efi_download_url: https://yum.oracle.com/repo/OracleLinux/OL10/baseos/latest/x86_64/
+:shim_efi_downloaded_package_name: shim-x64.rpm
+:shim_efi_package_name: shim-x64
+:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/shimx64.efi
+:extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
+:extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
 endif::[]
 
@@ -99,6 +136,24 @@ ifdef::foreman-el,foreman-deb,katello,rocky_linux[]
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
 endif::[]
 
+ifdef::katello,suse_linux_enterprise_server[]
+:client-os-context: suse_linux_enterprise_server
+:client-os: SUSE Linux Enterprise Server
+:client-pkg-ext: rpm
+:secureboot-os-name: sles
+:grub_efi_download_url: the {client-os} Basesystem Pool repository published on your {SmartProxy}
+:grub_efi_downloaded_package_name: grub2-x86_64-efi.rpm
+:grub_efi_package_name: grub2-x86_64-efi
+:grub_efi_tmp_binary_path: /tmp/usr/lib64/efi/grub.efi
+:shim_efi_download_url: the {client-os} Basesystem Pool repository published on your {SmartProxy}
+:shim_efi_downloaded_package_name: shim.x86_64.rpm
+:shim_efi_package_name: shim
+:shim_efi_tmp_binary_path: /tmp/usr/lib64/efi/shim.efi
+:extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
+:extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
+include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]
+endif::[]
+
 ifdef::foreman-el,foreman-deb,katello,ubuntu[]
 :client-os-context: ubuntu
 :client-os: Ubuntu
@@ -118,6 +173,7 @@ include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-h
 endif::[]
 
 // reset global attributes
+:client-os-context: {parent-client-os-context}
 :client-os: {parent-client-os}
 :client-pkg-ext: {parent-client-pkg-ext}
 :!client-os-context:
@@ -132,6 +188,7 @@ endif::[]
 :!grub_efi_downloaded_package_name:
 :!grub_efi_package_name:
 :!grub_efi_tmp_binary_path:
+:!parent-client-os-context:
 :!parent-client-os:
 :!parent-client-pkg-ext:
 :!secureboot-os-name:


### PR DESCRIPTION
#### What changes are you introducing?

Foreman & Foreman+Katello support provisioning of Secure Boot enabled hosts. Each Client OS requires different steps to prepare Smart Proxies to provide the correct grub2/shim binaries.

SLES depends on the SCC Manager plugin, which requires katello, so the docs are not shown for vanilla Foreman on Deb/EL.

This patch also resets the value of "client-os-context" after including the modules for all supported Client OS.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend support of Secure Boot-enabled host provisioning.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Mostly based on old downstream docs which I lost along the way :cry: 

* https://docs.orcharhino.com/or/7.5/sources/guides/centos/provisioning_hosts/pxe.html#configuring-orcharhino-proxy-to-provision-centos-on-Secure-Boot-enabled-hosts
* https://docs.orcharhino.com/or/7.5/sources/guides/oracle_linux/provisioning_hosts/pxe.html#configuring-orcharhino-proxy-to-provision-oracle_linux-on-Secure-Boot-enabled-hosts
* https://docs.orcharhino.com/or/7.5/sources/guides/suse_linux_enterprise_server/provisioning_hosts/pxe.html#configuring-orcharhino-proxy-to-provision-suse_linux_enterprise_server-on-Secure-Boot-enabled-hosts

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
