### PR TITLE
Replace attribute FreeIPA-context

### DIFF
--- a/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/assembly_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -4,7 +4,7 @@ include::modules/proc_installing-and-configuring-freeipa-packages-on-project-ser
 
 include::modules/proc_configuring-project-server-or-smart-proxy-server-for-freeipa-realm-support.adoc[leveloffset=+1]
 
-include::modules/proc_creating-a-realm-for-the-freeipa-enabled-smartproxy.adoc[leveloffset=+1]
+include::modules/proc_creating-a-realm-for-the-freeipa-enabled-smart-proxy.adoc[leveloffset=+1]
 
 include::modules/proc_updating-host-groups-with-realm-information.adoc[leveloffset=+1]
 

--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -86,7 +86,6 @@
 :foreman-installer: foreman-installer
 :foreman-maintain: foreman-maintain
 :FreeIPA: FreeIPA
-:FreeIPA-context: {FreeIPA}
 :FreeIPA-id: freeipa
 :freeipaserver-example-com: freeipa-server.example.com
 :hammer-smart-proxy: hammer proxy

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -83,7 +83,6 @@
 :foreman-installer: satellite-installer
 :foreman-maintain: satellite-maintain
 :FreeIPA: Identity{nbsp}Management
-:FreeIPA-context: Identity_Management
 :FreeIPA-id: identity-management
 :freeipaserver-example-com: idm-server.example.com
 :hammer-smart-proxy: hammer capsule

--- a/guides/common/modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc
+++ b/guides/common/modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}"]
+[id="configuring-kerberos-sso-with-{FreeIPA-id}-in-{project-context}"]
 = Configuring Kerberos SSO with {FreeIPA} in {Project}
 
 [role="_abstract"]

--- a/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
+++ b/guides/common/modules/con_configuring-project-to-manage-the-lifecycle-of-a-host-registered-to-a-freeipa-realm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 
-[id="configuring-{project-context}-to-manage-the-lifecycle-of-a-host-registered-to-a-{freeipa-id}-realm"]
+[id="configuring-{project-context}-to-manage-the-lifecycle-of-a-host-registered-to-a-{FreeIPA-id}-realm"]
 = Configuring {Project} to manage the lifecycle of a host registered to a {FreeIPA} realm
 
 [role="_abstract"]

--- a/guides/common/modules/proc_adding-hosts-to-a-freeipa-host-group.adoc
+++ b/guides/common/modules/proc_adding-hosts-to-a-freeipa-host-group.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="adding-hosts-to-a-{freeipa-context}-host-group"]
+[id="adding-hosts-to-a-{FreeIPA-id}-host-group"]
 = Adding hosts to a {FreeIPA} host group
 
 [role="_abstract"]

--- a/guides/common/modules/proc_configuring-a-cross-forest-trust-between-freeipa-and-active-directory-for-project.adoc
+++ b/guides/common/modules/proc_configuring-a-cross-forest-trust-between-freeipa-and-active-directory-for-project.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Configuring-a-cross-forest-trust-between-{FreeIPA-context}-and-Active-Directory-for-{Project}_{context}"]
+[id="configuring-a-cross-forest-trust-between-{FreeIPA-id}-and-active-directory-for-{project-context}"]
 = Configuring a cross-forest trust between {FreeIPA} and Active Directory for {Project}
 
 [role="_abstract"]

--- a/guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc
+++ b/guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-hammer-cli-to-accept-{FreeIPA-context}-credentials_{context}"]
+[id="configuring-hammer-cli-to-accept-{FreeIPA-id}-credentials"]
 = Configuring Hammer CLI to accept {FreeIPA} credentials
 
 [role="_abstract"]

--- a/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
+++ b/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-host-based-access-control-for-{FreeIPA-context}-users-logging-in-to-project_{context}"]
+[id="configuring-host-based-access-control-for-{FreeIPA-id}-users-logging-in-to-{project-context}"]
 = Configuring host-based access control for {FreeIPA} users logging in to {Project}
 
 [role="_abstract"]

--- a/guides/common/modules/proc_configuring-project-server-or-smart-proxy-server-for-freeipa-realm-support.adoc
+++ b/guides/common/modules/proc_configuring-project-server-or-smart-proxy-server-for-freeipa-realm-support.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="configuring-{project-context}-server-or-{smart-proxy-context}-server-for-{FreeIPA-context}-realm-support"]
+[id="configuring-{project-context}-server-or-{smart-proxy-context}-server-for-{FreeIPA-id}-realm-support"]
 = Configuring {ProjectServer} or {SmartProxyServer} for {FreeIPA} realm support
 
 [role="_abstract"]

--- a/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
+++ b/guides/common/modules/proc_configuring-project-to-use-ldap.adoc
@@ -10,7 +10,7 @@ Configure an LDAP authentication source to enable users to log in to {Project} w
 ====
 While you can configure the LDAP server integrated with {FreeIPA} as an external authentication source, {FreeIPA} users will not be able to log in by using single sign-on.
 Instead, consider configuring {FreeIPA} as an external identity provider.
-For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-id}-in-{project-context}[].
 ====
 
 [IMPORTANT]

--- a/guides/common/modules/proc_creating-a-realm-for-the-freeipa-enabled-smart-proxy.adoc
+++ b/guides/common/modules/proc_creating-a-realm-for-the-freeipa-enabled-smart-proxy.adoc
@@ -1,13 +1,14 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="creating-a-realm-for-the-{FreeIPA-context}-enabled-{smart-proxy-context}"]
+[id="creating-a-realm-for-the-{FreeIPA-id}-enabled-{smart-proxy-context}"]
 = Creating a realm for the {FreeIPA}-enabled {SmartProxy}
 
 [role="_abstract"]
 After you configure your {SmartProxy} with {FreeIPA}, you must create a realm and add the {FreeIPA}-configured {SmartProxy} to the realm.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Infrastructure* > *Realms* and click *Create Realm*.
+. In the {ProjectWebUI}, navigate to *Infrastructure* > *Realms*.
+. Click *Create Realm*.
 . In the *Name* field, enter a name for the realm.
 . From the *Realm Type* list, select the type of realm.
 . From the *Realm {SmartProxy}* list, select {SmartProxyServer} where you have configured {FreeIPA}.

--- a/guides/common/modules/proc_installing-and-configuring-freeipa-packages-on-project-server-or-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_installing-and-configuring-freeipa-packages-on-project-server-or-smart-proxy-server.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="installing-and-configuring-{FreeIPA-context}-packages-on-{project-context}-server-or-{smart-proxy-context}-server"]
+[id="installing-and-configuring-{FreeIPA-id}-packages-on-{project-context}-server-or-{smart-proxy-context}-server"]
 = Installing and configuring {FreeIPA} packages on {ProjectServer} or {SmartProxyServer}
 
 [role="_abstract"]

--- a/guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc
+++ b/guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="logging-in-to-hammer-cli-with-{FreeIPA-context}-credentials"]
+[id="logging-in-to-hammer-cli-with-{FreeIPA-id}-credentials"]
 = Logging in to Hammer CLI with {FreeIPA} credentials
 
 [role="_abstract"]
@@ -9,7 +9,7 @@ Authenticate to the {Project} Hammer CLI with your {FreeIPA} username and passwo
 ifndef::containerized[]
 .Prerequisites
 * You have configured Hammer CLI to accept {FreeIPA} credentials.
-See xref:configuring-hammer-cli-to-accept-{FreeIPA-context}-credentials_{context}[].
+See xref:configuring-hammer-cli-to-accept-{FreeIPA-id}-credentials[].
 endif::[]
 
 .Procedure
@@ -17,7 +17,7 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ kinit _{FreeIPA-context}_user_
+$ kinit _{FreeIPA-id}_user_
 ----
 +
 [WARNING]

--- a/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="logging-in-to-the-web-ui-with-{FreeIPA-context}-credentials-in-chrome"]
+[id="logging-in-to-the-web-ui-with-{FreeIPA-id}-credentials-in-chrome"]
 = Logging in to the {ProjectWebUI} with {FreeIPA} credentials in Chrome
 
 [role="_abstract"]
@@ -10,7 +10,7 @@ Use the latest stable Chrome browser.
 
 .Prerequisites
 * You have {FreeIPA} authentication configured in your {Project} environment.
-For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-id}-in-{project-context}[].
 * The host on which you are using Chrome is a client in the {FreeIPA} domain.
 * Your Chrome browser is configured for Single Sign-On (SSO).
 ifdef::satellite[]

--- a/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-mozilla-firefox.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-mozilla-firefox.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="logging-in-to-the-web-ui-with-{FreeIPA-context}-credentials-in-mozilla-firefox"]
+[id="logging-in-to-the-web-ui-with-{FreeIPA-id}-credentials-in-mozilla-firefox"]
 = Logging in to the {ProjectWebUI} with {FreeIPA} credentials in Mozilla Firefox
 
 [role="_abstract"]
@@ -10,7 +10,7 @@ Use the latest stable Mozilla Firefox browser.
 
 .Prerequisites
 * You have {FreeIPA} authentication configured in your {Project} environment.
-For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[].
+For more information, see xref:configuring-kerberos-sso-with-{FreeIPA-id}-in-{project-context}[].
 * The host on which you are using Mozilla Firefox is a client in the {FreeIPA} domain.
 * Your Mozilla Firefox is configured for Single Sign-On (SSO).
 ifdef::satellite[]

--- a/guides/common/modules/snip_table-authentication-methods.adoc
+++ b/guides/common/modules/snip_table-authentication-methods.adoc
@@ -72,7 +72,7 @@ endif::[]
 ifndef::satellite[]
 |No
 endif::[]
-|xref:configuring-kerberos-sso-with-{FreeIPA-context}-in-{project-context}[]
+|xref:configuring-kerberos-sso-with-{FreeIPA-id}-in-{project-context}[]
 ifndef::containerized,foreman-deb[]
 |{Keycloak-quarkus}|Yes|Yes|Yes|Yes
 ifndef::satellite[]

--- a/scripts/check-filename-id-heading-match.sh
+++ b/scripts/check-filename-id-heading-match.sh
@@ -68,9 +68,7 @@ check_file() {
     normalized_id="${normalized_id//\{customreposid\}/repositories}"
     normalized_id="${normalized_id//\{customrepoid\}/repository}"
     normalized_id="${normalized_id//\{customproductid\}/product}"
-    normalized_id="${normalized_id//\{FreeIPA-context\}/freeipa}"
-    normalized_id="${normalized_id//\{freeipa-context\}/freeipa}"
-    normalized_id="${normalized_id//\{freeipa-id\}/freeipa}"
+    normalized_id="${normalized_id//\{FreeIPA-id\}/freeipa}"
     normalized_id="${normalized_id//\{insights-id\}/insights}"
     normalized_id="${normalized_id//\{insights-iop-id\}/insights}"
     normalized_id="${normalized_id//\{ISS-id\}/inter-server-synchronization}"
@@ -113,7 +111,7 @@ check_file() {
 
         # Normalize Hammer CLI and Web UI text in headings
         # The convention is: ID and filename contain "by-using-cli"/"by-using-web-ui", heading contains "by using Hammer CLI"/"by using {ProjectWebUI}"
-        normalized_heading="${normalized_heading//hammer-cli/cli}"
+        normalized_heading="${normalized_heading//by-using-hammer-cli/by-using-cli}"
         normalized_heading="${normalized_heading//\{projectwebui\}/web-ui}"
     fi
 


### PR DESCRIPTION
#### What changes are you introducing?

This patch replaces "FreeIPA-context" with "FreeIPA-id" in all modules.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To drop a duplicate attriubute: before this patch, we had both `freeipa-id` and `freeipa-context`.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #5076

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
