### PR TITLE
Do not use ifeval macros for Client OS

### DIFF
--- a/guides/common/modules/con_dependency-solving-for-content-views.adoc
+++ b/guides/common/modules/con_dependency-solving-for-content-views.adoc
@@ -22,7 +22,7 @@ As an alternative, consider updating the content view.
 ====
 Dependency solving only considers packages within the repositories of the content view.
 It does not consider packages installed on clients.
-ifeval::["{client-os-family}" == "Red Hat"]
+ifdef::katello,satellite,almalinux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux[]
 For example, if a content view includes only AppStream, dependency solving does not include dependent BaseOS content at publish time.
 endif::[]
 
@@ -45,7 +45,7 @@ For example, if you create a filter for security purposes but enable dependency 
 To mitigate this problem, carefully test filtering rules to determine the required dependencies.
 If dependency solving includes unwanted packages, manually identify the core basic dependencies that the extra packages and errata need.
 
-ifeval::["{client-os}" == "{RHEL}"]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 [id="Combining_exclusion_filters_with_dependency_solving_{context}"]
 .Combining exclusion filters with dependency solving
 ====
@@ -59,9 +59,7 @@ As a result, the host diverges from {client-os}{nbsp}9.3 machines.
 If you do not need the extra errata and packages, do not configure content view filtering.
 Instead, enable and use the {client-os}{nbsp}9.3 repository on the *Content* > *Red Hat Repositories* page in the {ProjectWebUI}.
 ====
-endif::[]
 
-ifeval::["{client-os}" == "{RHEL}"]
 [id="Excluding_packages_and_dependency_solving_with_DNF_{context}"]
 .Excluding packages sometimes makes dependency solving impossible for DNF
 ====

--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -143,7 +143,7 @@ Possible values:
 | Needed security errata | Error | 3
 |===
 
-ifeval::["{client-os}" == "{RHEL}"]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 RHEL Lifecycle::
 Indicates the current state of the {RHEL} operating system installed on the host.
 +

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -20,10 +20,10 @@ endif::[]
 You have to perform the following configuration steps on each TFTP {SmartProxy} for a subnet to provision Secure Boot enabled hosts on that subnet.
 ====
 
-ifeval::["{client-os-context}" == "rhel"]
+ifdef::satellite[]
 {client-os} supports Secure Boot on x86_64 architecture only.
 endif::[]
-ifeval::["{client-os-context}" != "rhel"]
+ifndef::satellite[]
 The following example works for {client-os} on x86_64 architecture.
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Reduce number of "ifeval" macros.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

It is easier to look at the macro than finding out what the value of "client-os" is for certain builds or assemblies.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
