### PR TITLE
Reword unprotected file repositories

### DIFF
--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-cli.adoc
@@ -4,7 +4,7 @@
 = Downloading files to a host from a {customfiletype} repository by using Hammer CLI
 
 [role="_abstract"]
-You can download files to a host over HTTPS and optionally over HTTP if the *Unprotected* option for the repository is selected.
+You can download files to a host over HTTPS if the *Unprotected* option for the repository is selected.
 Use Hammer CLI to find the download URL of the {customfiletype} repository.
 
 .Prerequisites

--- a/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_downloading-files-to-a-host-from-a-custom-file-repository-by-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Downloading files to a host from a {customfiletype} repository by using {ProjectWebUI}
 
 [role="_abstract"]
-You can download files to a host over HTTPS and optionally over HTTP if the *Unprotected* option for the repository is selected.
+You can download files to a host over HTTPS if the *Unprotected* option for the repository is selected.
 Use {ProjectWebUI} to find the download URL of the {customfiletype} repository.
 
 .Prerequisites


### PR DESCRIPTION
#### What changes are you introducing?

If a file repository is unprotected, anyone that can connect to Foreman+Katello can download files via curl.

If a file repository is protected, you need a valid debug certificate or entitlement.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Protected/unprotected does not relate to transport security/HTTP vs HTTPS.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #5056

Tested on Foreman 3.18/Katello 4.20 with a self-signed certificate. `wget` always redirected me from `http://foreman.example.com/...` to `https://foreman.example.com/...`. -> I could not access the file over plain HTTP due to HSTS: `URL transformed to HTTPS due to an HSTS policy`.

I also did not try to use a debug certificate/entitlement; I just tested that you _cannot_ access it without: `403: [('PEM routines', '', 'no start line')]`.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
