### PR TITLE
Address an ifdef -containerized issue 

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -5,14 +5,16 @@ include::common/header.adoc[]
 
 = {AdministeringDocTitle}
 
-ifndef::containerized[]
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]
 
+ifndef::containerized[]
+
 ifdef::satellite[]
 include::common/assembly_cloning-project-server.adoc[leveloffset=+1]
+endif::[]
+
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]
@@ -25,7 +27,7 @@ ifndef::containerized[]
 include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]
 endif::[]
 
-endif::[]
+ifndef::containerized[]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
 
@@ -68,6 +70,8 @@ include::common/assembly_creating-and-managing-roles.adoc[leveloffset=+1]
 include::common/assembly_configuring-email-notifications.adoc[leveloffset=+1]
 endif::[]
 
+endif::[]
+
 include::common/assembly_backing-up-project.adoc[leveloffset=+1]
 
 ifndef::containerized[]
@@ -82,9 +86,11 @@ include::common/assembly_configuring-project-for-insights-analytics.adoc[levelof
 include::common/assembly_reducing-storage-use-on-project-server.adoc[leveloffset=+1]
 
 endif::[]
+
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renewing-certificates.adoc[leveloffset=+1]
 endif::[]
+
 ifndef::containerized[]
 
 include::common/assembly_synchronizing-template-repositories.adoc[leveloffset=+1]


### PR DESCRIPTION
I spotted an issue in the master.adoc file of the Administrating Guide. 
The following two modules were missing in the RH Satellite (containerized) build:
* Providing feedback on Red Hat documentation 
* Tuning performance with predefined profiles  - based on https://github.com/theforeman/foreman-documentation/commit/5d0807868e8f9bf6693625a86d2266f87a521698 

This is an attempt to fix the issue. 

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
