### PR TITLE
Update incremental update dependency solving docs

### DIFF
--- a/guides/common/modules/con_dependency-resolution-limitations-for-incremental-errata-updates.adoc
+++ b/guides/common/modules/con_dependency-resolution-limitations-for-incremental-errata-updates.adoc
@@ -4,9 +4,10 @@
 = Dependency resolution limitations for incremental errata updates
 
 [role="_abstract"]
-Incremental content view updates can resolve some package dependencies, but {Project} may still pull newer dependency versions that conflict with packages already in the repository.
+Incremental content view updates do not use dependency solving by default.
+If dependency solving is enabled for an incremental update, {Project} might pull newer dependency versions that conflict with packages already in the repository.
 
-When a repository update becomes available with a new dependency, {Project} retrieves the newest version of the package to solve the dependency, even if there are older versions available in the existing repository package.
+When a repository update becomes available with a new dependency and dependency solving is enabled, {Project} retrieves the newest version of the package to solve the dependency, even if there are older versions available in the existing repository package.
 This can create further dependency resolution problems when installing packages.
 
 .Dependency resolution limitation
@@ -29,5 +30,6 @@ endif::[]
 However, when the client installs the `example_tools-1.1` package, a dependency resolution problem occurs because both `example_repository-libs-1.0` and `example_repository-libs-1.1` cannot be installed.
 ====
 
-There is currently no workaround for this problem.
+There is currently no workaround that guarantees full dependency resolution.
+You can enable dependency solving for incremental updates, but this is a best-effort mechanism that significantly increases publish time and can introduce unwanted packages.
 The larger the time frame, and minor _Y_ releases between the base set of packages and the errata being applied, the higher the chance of a problem with dependency resolution.

--- a/guides/common/modules/con_dependency-solving-for-content-views.adoc
+++ b/guides/common/modules/con_dependency-solving-for-content-views.adoc
@@ -13,9 +13,9 @@ You might need to enable dependency solving to install that package.
 However, dependency solving is unnecessary in most situations.
 For example:
 
-* When incrementally adding a security errata to a content view, dependency solving can cause significant delays to content view publication without major benefits.
+* When incrementally adding a security erratum to a content view, enabling dependency solving causes significant delays to content view publication without major benefits.
 * Packages from a newer erratum might have dependencies that are incompatible with packages from an older content view version.
-Incrementally adding the erratum by solving dependencies might result in the inclusion of unwanted packages.
+Enabling dependency solving for the erratum might result in the inclusion of unwanted packages.
 As an alternative, consider updating the content view.
 
 [NOTE]

--- a/guides/common/modules/proc_adding-errata-to-an-incremental-content-view-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_adding-errata-to-an-incremental-content-view-by-using-web-ui.adoc
@@ -17,6 +17,11 @@ This is because enhancements are typically designed for the most current softwar
 . From the *Errata* list, click the name of the errata that you want to apply.
 . Select the content hosts that you want to apply the errata to, and click *Apply to Hosts*.
 This creates the incremental update to the content view.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
+. Optional: Select the *Enable dependency solving* checkbox to include package dependencies in the incremental update.
+This significantly increases publish time.
+For more information, see xref:dependency-solving-for-content-views[].
+endif::[]
 . If you want to apply the errata to the content host, select the *Apply Errata to Content Hosts immediately after publishing* checkbox.
 . Click *Confirm* to apply the errata.
 


### PR DESCRIPTION
#### What changes are you introducing?

Updated two concept modules to reflect that incremental content view updates no longer use dependency solving by default. Added guidance that users can enable dependency solving as a fallback if dependency issues are encountered, but it is best-effort and comes at a significant performance cost.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Katello [PR #11799](https://github.com/Katello/katello/pull/11799) changed the default for `resolve_dependencies` from `true` to `false` for incremental updates, and [PR #11800](https://github.com/Katello/katello/pull/11800) updated the UI checkbox text accordingly. The documentation previously assumed dependency solving was active during incremental updates, which is no longer accurate. See [SAT-46506](https://redhat.atlassian.net/browse/SAT-46506).

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
