### PR TITLE
Allow webhooks in containerized deployments

### DIFF
--- a/guides/common/assembly_using-foreman-webhooks.adoc
+++ b/guides/common/assembly_using-foreman-webhooks.adoc
@@ -14,6 +14,7 @@ include::modules/proc_creating-a-webhook.adoc[leveloffset=+1]
 
 include::modules/ref_webhooks-available-events.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::modules/con_shellhooks-plugin-for-smartproxy.adoc[leveloffset=+1]
 
 include::modules/proc_installing-shellhooks-plugin.adoc[leveloffset=+1]
@@ -23,6 +24,7 @@ include::modules/proc_passing-arguments-to-shellhook-script-using-webhooks.adoc[
 include::modules/proc_passing-arguments-to-shellhook-script-using-curl.adoc[leveloffset=+1]
 
 include::modules/proc_creating-a-shellhook-to-print-arguments.adoc[leveloffset=+1]
+endif::[]
 
 ifdef::parent-context[:context: {parent-context}]
 ifndef::parent-context[:!context:]

--- a/guides/common/modules/con_webhooks-behavior-and-integration.adoc
+++ b/guides/common/modules/con_webhooks-behavior-and-integration.adoc
@@ -15,10 +15,12 @@ The application sending the request does not wait for the response, or ignores i
 Because webhooks use HTTP, no new infrastructure needs be added to existing web services.
 Webhooks are useful where the action you want to perform in the external system can be achieved through its API.
 
+ifndef::containerized[]
 Where it is necessary to run additional commands or edit files, the shellhooks plugin for {SmartProxies} is available.
 The shellhooks plugin enables you to define a shell script on the {SmartProxy} that can be executed through the API.
 
 You can use webhooks successfully without installing the shellhooks plugin.
+endif::[]
 
 Payload of a webhook is created from webhook templates.
 Webhook templates use the same ERB syntax as Provisioning templates.

--- a/guides/common/modules/proc_creating-a-webhook.adoc
+++ b/guides/common/modules/proc_creating-a-webhook.adoc
@@ -7,10 +7,12 @@
 When creating a webhook in the {ProjectWebUI}, you can customize events, payloads, HTTP authentication, content type, and headers.
 
 ifndef::foreman-deb,orcharhino[]
+ifndef::containerized[]
 [NOTE]
 ====
 When configuring webhooks with endpoints with non-standard HTTP or HTTPS ports, an SELinux port must be assigned, see {InstallingServerDocURL}configuring-selinux-to-ensure-access-on-custom-ports_{project-context}[Configuring SELinux to ensure access to {Project} on custom ports] in _{InstallingServerDocTitle}_.
 ====
+endif::[]
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -8,6 +8,15 @@ Use the following procedure to install the webhooks plugin.
 Then, you can configure {ProjectServer} to send webhook requests.
 
 .Procedure
+ifdef::containerized[]
+* On your {ProjectServer}, install the webhooks plugin:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {foremanctl} --add-feature webhooks
+----
+endif::[]
+ifndef::containerized[]
 . On your {ProjectServer}, install the webhooks plugin:
 +
 [options="nowrap" subs="+quotes,attributes"]
@@ -20,3 +29,4 @@ Then, you can configure {ProjectServer} to send webhook requests.
 ----
 # {foreman-installer} --enable-foreman-cli-webhooks
 ----
+endif::[]

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -12,6 +12,7 @@ For more information about payload, go to *Administer* > *About* > *Support* > *
 A list of available types is provided in the following table.
 Some events are marked as *custom*, in that case, the payload is an object object but a Ruby hash (key-value data structure) so syntax is different.
 
+TODO: What to do with this, considering some plugins providing events are not containerized yet? Be diligent or just wait it out?
 [cols="40%,30%,30%",options="header"]
 |====
 |Event name |Description|Payload

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -16,53 +16,53 @@ Some events are marked as *custom*, in that case, the payload is an object objec
 |====
 |Event name |Description|Payload
 ifdef::katello,orcharhino,satellite[]
-|Actions Katello Content View Promote Succeeded |A content view was successfully promoted.|Actions::Katello::ContentView::Promote
-|Actions Katello Content View Publish Succeeded |A repository was successfully synchronized.|Actions::Katello::ContentView::Publish
+|`Actions Katello Content View Promote Succeeded` |A content view was successfully promoted.|`Actions::Katello::ContentView::Promote`
+|`Actions Katello Content View Publish Succeeded` |A repository was successfully synchronized.|`Actions::Katello::ContentView::Publish`
 endif::[]
-|Actions Remote Execution Run Host Job Succeeded |A generic remote execution job succeeded for a host.
-This event is emitted for all Remote Execution jobs, when complete.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Succeeded` |A generic remote execution job succeeded for a host.
+This event is emitted for all Remote Execution jobs, when complete.|`Actions::RemoteExecution::RunHostJob`
 ifdef::katello,orcharhino,satellite[]
-|Actions Remote Execution Run Host Job Katello Errata Install Succeeded |Install errata using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Group Install Succeeded |Install package group using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Package Install Succeeded |Install package using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Group Remove |Remove package group using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Package Remove Succeeded |Remove package using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Service Restart Succeeded |Restart Services using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Group Update Succeeded |Update package group using the Katello interface.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Katello Package Update Succeeded |Update package using the Katello interface.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Katello Errata Install Succeeded` |Install errata using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Group Install Succeeded` |Install package group using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Package Install Succeeded` |Install package using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Group Remove` |Remove package group using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Package Remove Succeeded` |Remove package using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Service Restart Succeeded` |Restart Services using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Group Update Succeeded` |Update package group using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Katello Package Update Succeeded` |Update package using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
 endif::[]
 ifndef::containerized[]
-|Actions Remote Execution Run Host Job Foreman OpenSCAP Run Scans Succeeded |Run OpenSCAP scan.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Ansible Run Host Succeeded |Runs an Ansible Playbook containing all the roles defined for a host.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Ansible Run {SmartProxy} Upgrade Succeeded |Upgrade {SmartProxies} on given {SmartProxyServers}.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Ansible Configure Cloud Connector Succeeded |Configure Cloud Connector on given hosts.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Foreman OpenSCAP Run Scans Succeeded` |Run OpenSCAP scan.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Ansible Run Host Succeeded` |Runs an Ansible Playbook containing all the roles defined for a host.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Ansible Run {SmartProxy} Upgrade Succeeded` |Upgrade {SmartProxies} on given {SmartProxyServers}.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Ansible Configure Cloud Connector Succeeded` |Configure Cloud Connector on given hosts.|`Actions::RemoteExecution::RunHostJob`
 ifdef::satellite[]
-|Actions Remote Execution Run Host Job Ansible Run {Insights} Plan Succeeded |Runs a given maintenance plan from Red Hat Access {Insights} given an ID.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Ansible Run {Insights} Plan Succeeded` |Runs a given maintenance plan from Red Hat Access {Insights} given an ID.|`Actions::RemoteExecution::RunHostJob`
 endif::[]
-|Actions Remote Execution Run Host Job Ansible Run Playbook Succeeded |Run an Ansible Playbook against given hosts.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Ansible Enable Web Console Succeeded |Run an Ansible Playbook to enable the web console on given hosts.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Ansible Run Playbook Succeeded` |Run an Ansible Playbook against given hosts.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Ansible Enable Web Console Succeeded` |Run an Ansible Playbook to enable the web console on given hosts.|`Actions::RemoteExecution::RunHostJob`
 endif::[]
-|Actions Remote Execution Run Host Job Puppet Run Host Succeeded |Perform a single Puppet run.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Puppet Run Host Succeeded` |Perform a single Puppet run.|`Actions::RemoteExecution::RunHostJob`
 ifdef::katello,orcharhino,satellite[]
-|Actions Remote Execution Run Host Job Katello Module Stream Action Succeeded |Perform a module stream action using the Katello interface.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Katello Module Stream Action Succeeded` |Perform a module stream action using the Katello interface.|`Actions::RemoteExecution::RunHostJob`
 endif::[]
 ifndef::containerized[]
-|Actions Remote Execution Run Host Job Leapp Pre-upgrade Succeeded |Upgradeability check for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Leapp Remediation Plan Succeeded |Run Remediation plan with Leapp.|Actions::RemoteExecution::RunHostJob
-|Actions Remote Execution Run Host Job Leapp Upgrade Succeeded |Run Leapp upgrade job for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
+|`Actions Remote Execution Run Host Job Leapp Pre-upgrade Succeeded` |Upgradeability check for RHEL 7 host.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Leapp Remediation Plan Succeeded` |Run Remediation plan with Leapp.|`Actions::RemoteExecution::RunHostJob`
+|`Actions Remote Execution Run Host Job Leapp Upgrade Succeeded` |Run Leapp upgrade job for RHEL 7 host.|`Actions::RemoteExecution::RunHostJob`
 endif::[]
-|Build Entered |A host entered the build mode.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
-|Build Exited |A host build mode was canceled, either it was successfully provisioned or the user canceled the build manually.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
-|Config Report Created/Updated/Destroyed |Common database operations on a configuration report.|ConfigReport
+|`Build Entered` |A host entered the build mode.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
+|`Build Exited` |A host build mode was canceled, either it was successfully provisioned or the user canceled the build manually.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
+|`Config Report Created/Updated/Destroyed` |Common database operations on a configuration report.|`ConfigReport`
 ifdef::katello,orcharhino,satellite[]
-|Content View Created/Updated/Destroyed |Common database operations on a content view.|Katello::ContentView
+|`Content View Created/Updated/Destroyed` |Common database operations on a content view.|`Katello::ContentView`
 endif::[]
-|Domain Created/Updated/Destroyed |Common database operations on a domain.|Domain
-|Host Created/Updated/Destroyed |Common database operations on a host.|Host
-|Hostgroup Created/Updated/Destroyed |Common database operations on a hostgroup.|Hostgroup
-|Model Created/Updated/Destroyed |Common database operations on a model.|Model
-|Status Changed |Global host status of a host changed.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]`, `@payload[:global_status]` (hash)
-|Subnet Created/Updated/Destroyed |Common database operations on a subnet.|Subnet
-|Template Render Performed |A report template was rendered.|Template
-|User Created/Updated/Destroyed |Common database operations on a user.|User
+|`Domain Created/Updated/Destroyed` |Common database operations on a domain.|`Domain`
+|`Host Created/Updated/Destroyed` |Common database operations on a host.|`Host`
+|`Hostgroup Created/Updated/Destroyed` |Common database operations on a hostgroup.|`Hostgroup`
+|`Model Created/Updated/Destroyed` |Common database operations on a model.|`Model`
+|`Status Changed` |Global host status of a host changed.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]`, `@payload[:global_status]` (hash)
+|`Subnet Created/Updated/Destroyed` |Common database operations on a subnet.|`Subnet`
+|`Template Render Performed` |A report template was rendered.|`Template`
+|`User Created/Updated/Destroyed` |Common database operations on a user.|`User`
 |====

--- a/guides/common/modules/ref_webhooks-available-events.adoc
+++ b/guides/common/modules/ref_webhooks-available-events.adoc
@@ -12,7 +12,6 @@ For more information about payload, go to *Administer* > *About* > *Support* > *
 A list of available types is provided in the following table.
 Some events are marked as *custom*, in that case, the payload is an object object but a Ruby hash (key-value data structure) so syntax is different.
 
-TODO: What to do with this, considering some plugins providing events are not containerized yet? Be diligent or just wait it out?
 [cols="40%,30%,30%",options="header"]
 |====
 |Event name |Description|Payload
@@ -32,6 +31,7 @@ ifdef::katello,orcharhino,satellite[]
 |Actions Remote Execution Run Host Job Katello Group Update Succeeded |Update package group using the Katello interface.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Katello Package Update Succeeded |Update package using the Katello interface.|Actions::RemoteExecution::RunHostJob
 endif::[]
+ifndef::containerized[]
 |Actions Remote Execution Run Host Job Foreman OpenSCAP Run Scans Succeeded |Run OpenSCAP scan.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Run Host Succeeded |Runs an Ansible Playbook containing all the roles defined for a host.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Run {SmartProxy} Upgrade Succeeded |Upgrade {SmartProxies} on given {SmartProxyServers}.|Actions::RemoteExecution::RunHostJob
@@ -41,13 +41,16 @@ ifdef::satellite[]
 endif::[]
 |Actions Remote Execution Run Host Job Ansible Run Playbook Succeeded |Run an Ansible Playbook against given hosts.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Ansible Enable Web Console Succeeded |Run an Ansible Playbook to enable the web console on given hosts.|Actions::RemoteExecution::RunHostJob
+endif::[]
 |Actions Remote Execution Run Host Job Puppet Run Host Succeeded |Perform a single Puppet run.|Actions::RemoteExecution::RunHostJob
 ifdef::katello,orcharhino,satellite[]
 |Actions Remote Execution Run Host Job Katello Module Stream Action Succeeded |Perform a module stream action using the Katello interface.|Actions::RemoteExecution::RunHostJob
 endif::[]
+ifndef::containerized[]
 |Actions Remote Execution Run Host Job Leapp Pre-upgrade Succeeded |Upgradeability check for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Leapp Remediation Plan Succeeded |Run Remediation plan with Leapp.|Actions::RemoteExecution::RunHostJob
 |Actions Remote Execution Run Host Job Leapp Upgrade Succeeded |Run Leapp upgrade job for RHEL 7 host.|Actions::RemoteExecution::RunHostJob
+endif::[]
 |Build Entered |A host entered the build mode.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
 |Build Exited |A host build mode was canceled, either it was successfully provisioned or the user canceled the build manually.|Custom event: `@payload[:id]` (host id), `@payload[:hostname]` (host name).
 |Config Report Created/Updated/Destroyed |Common database operations on a configuration report.|ConfigReport

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -94,9 +94,11 @@ include::common/assembly_monitoring-project-resources.adoc[leveloffset=+1]
 ifndef::satellite[]
 include::common/assembly_limiting-host-resources.adoc[leveloffset=+1]
 endif::[]
+endif::[]
 
 include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 
+ifndef::satellite[]
 include::common/assembly_working-efficiently-with-web-ui.adoc[leveloffset=+1]
 
 [appendix]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -98,7 +98,7 @@ endif::[]
 
 include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 
-ifndef::satellite[]
+ifndef::containerized[]
 include::common/assembly_working-efficiently-with-web-ui.adoc[leveloffset=+1]
 
 [appendix]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/SAT-47668

#### What changes are you introducing?

Once https://github.com/theforeman/foremanctl/pull/694 goes in, webhooks (without shellhooks) will be available in containerized deployments. This change enables the relevant parts of documentation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

See above.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

See the TODOs in the changes.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
