### PR TITLE
Fix: Move foremanctl from prereqs to first step

### DIFF
--- a/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-an-external-database.adoc
@@ -20,9 +20,14 @@ For more information, see {AdministeringDocURL}installing-postgresql-as-an-exter
 For more information, see {InstallingServerDocURL}planning-{project-context}-server-installation_{project-context}[Planning {ProjectServer} installation].
 * Your system is prepared for the installation.
 For more information, see {InstallingServerDocURL}preparing-environment-for-{project-context}-server-installation_{project-context}[Preparing environment for {ProjectServer} installation].
-* Your system has the `{foremanctl}` package installed.
 
 .Procedure
+. Install the `{foremanctl}` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} {foremanctl}
+----
 . Update the system to the latest available version:
 +
 [options="nowrap" subs="+quotes,attributes"]

--- a/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
+++ b/guides/common/modules/proc_deploy-project-server-configuration-with-the-default-database.adoc
@@ -17,9 +17,14 @@ include::snip_deploy-overwrites-note.adoc[]
 For more information, see xref:{InstallingServerDocURL}planning-{project-context}-server-installation_{project-context}[Planning {ProjectServer} installation].
 * Your system is prepared for the installation.
 For more information, see xref:{InstallingServerDocURL}preparing-environment-for-{project-context}-server-installation_{project-context}[Preparing environment for {ProjectServer} installation].
-* Your system has the `{foremanctl}` package installed.
 
 .Procedure
+. Install the `{foremanctl}` package:
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# {package-install} {foremanctl}
+----
 . Update the system to the latest available version:
 +
 [options="nowrap" subs="+quotes,attributes"]


### PR DESCRIPTION
#### What changes are you introducing?
Remove the foremanctl package from prereqs into the first step of the procedure

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Prereqs are easy to miss, as demonstrated by engineers.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
