### PR TITLE
Fix modularization in Installing disconnected

### DIFF
--- a/guides/common/modules/con_performing-additional-configuration.adoc
+++ b/guides/common/modules/con_performing-additional-configuration.adoc
@@ -4,7 +4,12 @@
 = Performing additional configuration on {ProjectServer}
 
 [role="_abstract"]
+ifeval::["{mode}" == "connected"]
 You can enable additional features on {ProjectServer}, such as {Insights} integration, pull-based transport for remote execution, or the usage of HTTP proxies.
+endif::[]
+ifeval::["{mode}" == "disconnected"]
+You can enable additional features on {ProjectServer}, such as {Insights} integration or pull-based transport for remote execution.
+endif::[]
 While you can configure these features after the initial setup, you can also configure many of them during the installation by using the corresponding
 ifdef::containerized[`{foremanctl}`]
 ifndef::containerized[`{foreman-installer}`]

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -46,8 +46,7 @@ endif::[]
 
 ifndef::containerized[]
 
-[id="performing-additional-configuration"]
-== Performing Additional Configuration on {ProjectServer}
+include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 
 include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffset=+2]
 


### PR DESCRIPTION
#### What changes are you introducing?

Using a module for chapter heading+intro in Installing disconnected

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Modularization

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
