### PR TITLE
Remove 'guide not ready' from containerized Planning

### DIFF
--- a/guides/doc-Planning_for_Project/master.adoc
+++ b/guides/doc-Planning_for_Project/master.adoc
@@ -5,13 +5,6 @@ include::common/header.adoc[]
 
 = {PlanningDocTitle}
 
-ifdef::containerized[]
-ifdef::katello[]
-include::common/modules/ref_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-endif::[]
-
-
 ifdef::satellite[]
 include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Removing the "guide not ready" warning from containerized Planning

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

We've begun to make the guide ready and it now includes at least some content approved for containerization.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
