### PR TITLE
Fix parallel build race on shared images and CSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,12 @@ clean:
 	$(MAKE) -C guides/ clean
 	rm -rf $(DEST) web/output/
 
-html: build-foreman-el build-foreman-deb build-containerized-katello build-containerized-orcharhino build-katello build-orcharhino build-satellite
+BUILDS = foreman-el foreman-deb containerized-katello containerized-orcharhino katello orcharhino satellite
+
+html: FORCE prep
+	@for b in $(BUILDS); do \
+		$(MAKE) -C guides/ html BUILD=$$b || exit 1; \
+	done
 
 build-%: FORCE prep
 	$(MAKE) -C guides/ html BUILD=$*


### PR DESCRIPTION
#### What changes are you introducing?

This is an attempt to prevent race condition failures that seem to be appearing randomly on build jobs.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

I've been getting build-html errors quite often, such as this one https://github.com/theforeman/foreman-documentation/actions/runs/30290215039/job/90073083775. Re-running the failed job helps but it would be best to prevent them entirely.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I couldn't figure out what the problem was and a race condition was just a hunch. Claude seems to agree with me and this is the fix it proposes.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
