### PR TITLE
Omitted reference to Flatpak in containzerized Registering a host by using Satellite web UI

### DIFF
--- a/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_registering-a-host-by-using-web-ui.adoc
@@ -66,8 +66,10 @@ If the user loses or gains additional permissions, the permissions of the JWT ch
 Therefore, do not delete, block, or change permissions of the user during the token duration.
 +
 The scope of the JWTs is limited to the registration endpoints only and cannot be used anywhere else.
+ifndef::containerized[]
 * On the *Advanced* tab, you can enable container and Flatpak registry access without a username or password by selecting the *Set up container registry certs* checkbox.
 Using certificate-based authentication also enforces lifecycle management of container and Flatpak content for the host.
+endif::[]
 . Click *Generate* to generate a registration command.
 . Run the registration command as `root` on the host that you want to register.
 After registration completes, any Ansible roles assigned to a host group you specified when configuring the registration template will run on the host.


### PR DESCRIPTION

#### What changes are you introducing?

Hid reference to Flatpak in the containerized version of the Managing Hosts guide Registering a host by using Satellite web UI. Per review, this reference is not needed.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Part of effort in [reviewing Managing Hosts guide for containerization](https://redhat.atlassian.net/browse/SAT-47761). Review of a different section impacted this chapter.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [X] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
