### PR TITLE
Clarify Discovery provisioning handoff

### DIFF
--- a/guides/common/modules/proc_building-a-custom-discovery-image.adoc
+++ b/guides/common/modules/proc_building-a-custom-discovery-image.adoc
@@ -7,7 +7,7 @@
 You can build a custom Discovery ISO or rebuild an ISO if you change configuration files.
 
 The Discovery image uses a minimal operating system that is booted on hosts to acquire initial hardware information and check in with {Project}.
-Discovered hosts keep running the Discovery operating system until they are rebooted into an operating system installer, which then initiates the provisioning process.
+Discovered hosts keep running the Discovery operating system until they start an operating system installer, either by rebooting or by using kexec, which then initiates the provisioning process.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
#### What changes are you introducing?

Reword the custom Discovery image docs to describe the handoff generically and mention both reboot and kexec, avoiding the implication that reboot is the only supported path.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Discovered hosts do not always reboot into the operating system installer. Depending on the Discovery workflow, the installer can also be started with kexec.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Thanks for the nice documentation :)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Side Note: they were recently slimmed down quite a bit and refactored into SKILL files, not sure about that.

Please cherry-pick my commits into:

no cherry picking needed, just improving a minor nitpick.
