### PR TITLE
Fix link to Contributing from main navigating

### DIFF
--- a/web/content/index.adoc.erb
+++ b/web/content/index.adoc.erb
@@ -55,4 +55,4 @@ A release candidate is available for testing:
 
 === Contributing
 
-* link:/nightly/Contributing/index.html[Contributors' Guide] - Guidelines for contributing to Foreman documentation
+* link:/nightly/Contributing/index-katello.html[Contributors' Guide] - Guidelines for contributing to Foreman documentation


### PR DESCRIPTION
#### What changes are you introducing?

Fixing a link

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The current link doesn't work

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Introduced in https://github.com/theforeman/foreman-documentation/pull/4830

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
