### PR TITLE
Fix linkchecker errors related to Contributing

### DIFF
--- a/guides/doc-Contributing/build.rb
+++ b/guides/doc-Contributing/build.rb
@@ -9,6 +9,7 @@ require 'fileutils'
 ROOT_DIR = File.expand_path('../..', __dir__)
 DOC_DIR = __dir__
 OUTPUT_FILE = File.join(DOC_DIR, 'topics', 'contributing-generated.adoc')
+GITHUB_REPO_URL = 'https://github.com/theforeman/foreman-documentation'
 
 # Source files
 CONTRIBUTING_MD = File.join(ROOT_DIR, 'CONTRIBUTING.md')
@@ -168,12 +169,13 @@ def read_skill_files
       next
     end
 
+    skill_base_dir = File.dirname(skill_file)
     skills << {
       name: skill_name,
       dir_name: skill_dir_name,
       category: categorize_skill(skill_dir_name),
-      visible_content: visible_content,
-      ai_content: ai_content
+      visible_content: rewrite_local_links(visible_content, skill_base_dir),
+      ai_content: rewrite_local_links(ai_content, skill_base_dir)
     }
   end
 
@@ -223,6 +225,22 @@ def read_vale_rules
   rules
 end
 
+def rewrite_local_links(markdown_content, base_dir)
+  markdown_content.gsub(/\[([^\]]+)\]\(([^)]+)\)/) do |match|
+    text = Regexp.last_match(1)
+    path = Regexp.last_match(2)
+
+    if path =~ /\A(https?:|#|mailto:|ftp:)/
+      match
+    else
+      full_path = File.expand_path(path, base_dir)
+      repo_relative = full_path.sub("#{ROOT_DIR}/", '')
+      kind = File.directory?(full_path) ? 'tree' : 'blob'
+      "[#{text}](#{GITHUB_REPO_URL}/#{kind}/master/#{repo_relative})"
+    end
+  end
+end
+
 def build_markdown
   markdown = []
 
@@ -230,11 +248,14 @@ def build_markdown
   markdown << "# About the Foreman Documentation Contributors' Guide"
   markdown << ""
   markdown << "The Foreman Documentation Contributors' Guide consolidates contribution guidelines for the Foreman Documentation project from the following sources:"
-  markdown << " - [CONTRIBUTING.md](../../CONTRIBUTING.md)"
-  markdown << " - [Documentation AI Skills](../../.claude/skills)"
-  markdown << " - [Vale Rules for Foreman documentation](../../.vale/styles/foreman-documentation)"
-  markdown << ""
-  markdown << "The guide concatenates resources from the above sources into a single guide for easy reference. When one of these resources changes, the guide is automatically updated. For more information, see the [doc-Contributing/README](README.md)."
+  header_links = <<~HEADER
+     - [CONTRIBUTING.md](../../CONTRIBUTING.md)
+     - [Documentation AI Skills](../../.claude/skills)
+     - [Vale Rules for Foreman documentation](../../.vale/styles/foreman-documentation)
+
+    The guide concatenates resources from the above sources into a single guide for easy reference. When one of these resources changes, the guide is automatically updated. For more information, see the [doc-Contributing/README](README.md).
+  HEADER
+  markdown << rewrite_local_links(header_links, DOC_DIR)
   markdown << ""
   markdown << "Last updated: #{Time.now.strftime('%Y-%m-%d')}"
   markdown << ""
@@ -243,7 +264,7 @@ def build_markdown
 
   # Add CONTRIBUTING.md
   if File.exist?(CONTRIBUTING_MD)
-    markdown << File.read(CONTRIBUTING_MD)
+    markdown << rewrite_local_links(File.read(CONTRIBUTING_MD), ROOT_DIR)
     markdown << ""
     markdown << "---"
     markdown << ""

--- a/guides/doc-Contributing/master.adoc
+++ b/guides/doc-Contributing/master.adoc
@@ -4,12 +4,4 @@ include::common/header.adoc[]
 
 = Contributors' Guide
 
-The Foreman Documentation Contributors' Guide consolidates contribution guidelines for the Foreman Documentation project from the following sources:
-
-* CONTRIBUTING.md
-* Documentation AI Skills
-* Vale Rules for Foreman documentation
-
-The guide concatenates resources from the above sources into a single guide for easy reference. When one of these resources changes, the guide is automatically updated.
-
 include::topics/contributing-generated.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

This PR adds a `rewrite_local_links` method that converts local relative markdown links to absolute URLs in the Contributing guide.

(I'm also removing the introduction about the guide, which somehow is now repeated twice.)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The guide merged in https://github.com/theforeman/foreman-documentation/pull/4830 now causes linkchecker failures. The doc-Contributing/build.rb script creats markdown with local relative links. When kramdown converts these links to AsciiDoc and the HTML guide is built, the links are resolved relative to guides/build/Contributing/, where the link targets don't exist. This is why linkchecker identifies them as broken.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
