### PR TITLE
Updated Satellite substatus to remove Salt support

### DIFF
--- a/guides/common/modules/con_host-substatus-overview.adoc
+++ b/guides/common/modules/con_host-substatus-overview.adoc
@@ -19,7 +19,12 @@ There can be more sub-statuses depending on which plugins you add to your {Proje
 endif::[]
 
 Configuration::
+ifndef::satellite[]
 This sub-status is only relevant if {Project} uses a configuration management system like Ansible, Puppet, or Salt.
+endif::[]
+ifdef::satellite[]
+This sub-status is only relevant if {Project} uses a configuration management system like Ansible or Puppet.
+endif::[]
 +
 Possible values:
 +


### PR DESCRIPTION
#### What changes are you introducing?
Removed the call out for Salt in the configuration section of Section 1.6.
 
#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Because Satellite does not support Salt, updated the configuration sub-status call out in _Host-substatus overview_.

Work is a part of SAT-47758.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
This change applies to downstream only.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
