### PR TITLE
Remove registering upstream

### DIFF
--- a/guides/common/assembly_installing-smart-proxy-server.adoc
+++ b/guides/common/assembly_installing-smart-proxy-server.adoc
@@ -2,7 +2,7 @@ ifdef::context[:parent-context: {context}]
 
 include::modules/con_installing-smart-proxy-server.adoc[]
 
-ifdef::satellite,katello[]
+ifdef::satellite[]
 // Registering {SmartProxyServer} to {ProjectServer}
 include::modules/con_registering-smart-proxy-server.adoc[leveloffset=+1]
 

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
@@ -10,9 +10,7 @@ Use this section to configure {SmartProxyServer} with an SSL certificate that is
 ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
 ifdef::satellite[]
-ifndef::orcharhino[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
-endif::[]
 endif::[]
 endif::[]
 * {SmartProxyServer} packages are installed.

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
@@ -7,14 +7,20 @@
 Use this section to configure {SmartProxyServer} with an SSL certificate that is signed by {ProjectServer} default Certificate Authority (CA).
 
 .Prerequisites
+ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
 ifdef::satellite[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
 endif::[]
+endif::[]
 * {SmartProxyServer} packages are installed.
+ifndef::orcharhino[]
 For more information, see xref:installing-{smart-proxy-context}-packages[].
+endif::[]
 * The required ports are open.
+ifndef::orcharhino[]
 For more information, see xref:opening-required-ports[].
+endif::[]
 
 .Procedure
 . On {ProjectServer}, to store all the source certificate files for your {SmartProxyServer}, create a directory that is accessible only to the `root` user, for example `/root/{smart-proxy-context}_cert`:

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
@@ -10,7 +10,9 @@ Use this section to configure {SmartProxyServer} with an SSL certificate that is
 ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
 ifdef::satellite[]
+ifndef::orcharhino[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
+endif::[]
 endif::[]
 endif::[]
 * {SmartProxyServer} packages are installed.

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
@@ -9,8 +9,10 @@ Use this section to configure {SmartProxyServer} with an SSL certificate that is
 .Prerequisites
 ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
+ifdef::satellite[]
 ifndef::orcharhino[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
+endif::[]
 endif::[]
 endif::[]
 * {SmartProxyServer} packages are installed.

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-a-default-ssl-certificate.adoc
@@ -7,20 +7,14 @@
 Use this section to configure {SmartProxyServer} with an SSL certificate that is signed by {ProjectServer} default Certificate Authority (CA).
 
 .Prerequisites
-ifndef::foreman-deb[]
 * {SmartProxyServer} is registered to {ProjectServer}.
 ifdef::satellite[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
 endif::[]
-endif::[]
 * {SmartProxyServer} packages are installed.
-ifndef::orcharhino[]
 For more information, see xref:installing-{smart-proxy-context}-packages[].
-endif::[]
 * The required ports are open.
-ifndef::orcharhino[]
 For more information, see xref:opening-required-ports[].
-endif::[]
 
 .Procedure
 . On {ProjectServer}, to store all the source certificate files for your {SmartProxyServer}, create a directory that is accessible only to the `root` user, for example `/root/{smart-proxy-context}_cert`:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -14,9 +14,7 @@ Do not use the same command on more than one {SmartProxyServer}.
 For more information, see {InstallingServerDocURL}configuring-{project-context}-server-with-a-custom-ssl-certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
 ifdef::satellite[]
-ifndef::orcharhino[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
-endif::[]
 endif::[]
 * {SmartProxyServer} packages are installed.
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -17,9 +17,13 @@ ifdef::satellite[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
 endif::[]
 * {SmartProxyServer} packages are installed.
+ifndef::orcharhino[]
 For more information, see xref:installing-{smart-proxy-context}-packages[].
+endif::[]
 * The required ports are open.
+ifndef::orcharhino[]
 For more information, see xref:opening-required-ports[].
+endif::[]
 
 .Procedure
 . On your {ProjectServer}, generate a certificate bundle:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -17,13 +17,9 @@ ifdef::satellite[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
 endif::[]
 * {SmartProxyServer} packages are installed.
-ifndef::orcharhino[]
 For more information, see xref:installing-{smart-proxy-context}-packages[].
-endif::[]
 * The required ports are open.
-ifndef::orcharhino[]
 For more information, see xref:opening-required-ports[].
-endif::[]
 
 .Procedure
 . On your {ProjectServer}, generate a certificate bundle:

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -13,8 +13,10 @@ Do not use the same command on more than one {SmartProxyServer}.
 * {ProjectServer} is configured with a custom certificate.
 For more information, see {InstallingServerDocURL}configuring-{project-context}-server-with-a-custom-ssl-certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
+ifdef::satellite[]
 ifndef::orcharhino[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
+endif::[]
 endif::[]
 * {SmartProxyServer} packages are installed.
 ifndef::orcharhino[]

--- a/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
+++ b/guides/common/modules/proc_deploying-a-custom-ssl-certificate-to-smart-proxy-server.adoc
@@ -14,7 +14,9 @@ Do not use the same command on more than one {SmartProxyServer}.
 For more information, see {InstallingServerDocURL}configuring-{project-context}-server-with-a-custom-ssl-certificate[Configuring {ProjectServer} with a custom SSL certificate] in _{InstallingServerDocTitle}_.
 * {SmartProxyServer} is registered to {ProjectServer}.
 ifdef::satellite[]
+ifndef::orcharhino[]
 For more information, see xref:registering-{smart-proxy-context}-server[].
+endif::[]
 endif::[]
 * {SmartProxyServer} packages are installed.
 ifndef::orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?
Remove registration from upstream proxy installation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Separate PR that was part of [install-containerized-proxy](https://github.com/theforeman/foreman-documentation/pull/5097)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
