### PR TITLE
Fix Secure Boot attributes for Oracle Linux and SLES

### DIFF
--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -81,15 +81,15 @@ ifdef::foreman-el,foreman-deb,katello,oracle_linux[]
 :client-os-context: oracle_linux
 :client-os: Oracle Linux
 :client-pkg-ext: rpm
-:secureboot-os-name: redhat
+:secureboot-os-name: oraclelinux
 :grub_efi_download_url: https://yum.oracle.com/repo/OracleLinux/OL10/baseos/latest/x86_64/
 :grub_efi_downloaded_package_name: grub2-efi-x64.rpm
 :grub_efi_package_name: grub2-efi-x64
-:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/grubx64.efi
+:grub_efi_tmp_binary_path: /tmp/boot/efi/EFI/redhat/grubx64.efi
 :shim_efi_download_url: https://yum.oracle.com/repo/OracleLinux/OL10/baseos/latest/x86_64/
 :shim_efi_downloaded_package_name: shim-x64.rpm
 :shim_efi_package_name: shim-x64
-:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/{secureboot-os-name}/shimx64.efi
+:shim_efi_tmp_binary_path: /tmp/boot/efi/EFI/redhat/shimx64.efi
 :extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
 :extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -144,11 +144,11 @@ ifdef::katello,suse_linux_enterprise_server[]
 :grub_efi_download_url: the {client-os} Basesystem Pool repository published on your {SmartProxy}
 :grub_efi_downloaded_package_name: grub2-x86_64-efi.rpm
 :grub_efi_package_name: grub2-x86_64-efi
-:grub_efi_tmp_binary_path: /tmp/usr/lib64/efi/grub.efi
+:grub_efi_tmp_binary_path: /tmp/usr/share/efi/x86_64/shim.efi
 :shim_efi_download_url: the {client-os} Basesystem Pool repository published on your {SmartProxy}
 :shim_efi_downloaded_package_name: shim.x86_64.rpm
 :shim_efi_package_name: shim
-:shim_efi_tmp_binary_path: /tmp/usr/lib64/efi/shim.efi
+:shim_efi_tmp_binary_path: /tmp/usr/share/efi/x86_64/shim.efi
 :extract_grub: {extract_rpm_prefix}/{grub_efi_downloaded_package_name} {extract_rpm_suffix}
 :extract_shim: {extract_rpm_prefix}/{shim_efi_downloaded_package_name} {extract_rpm_suffix}
 include::modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc[leveloffset=+2]

--- a/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
+++ b/guides/common/assembly_using-network-boot-to-provision-hosts.adoc
@@ -144,7 +144,7 @@ ifdef::katello,suse_linux_enterprise_server[]
 :grub_efi_download_url: the {client-os} Basesystem Pool repository published on your {SmartProxy}
 :grub_efi_downloaded_package_name: grub2-x86_64-efi.rpm
 :grub_efi_package_name: grub2-x86_64-efi
-:grub_efi_tmp_binary_path: /tmp/usr/share/efi/x86_64/shim.efi
+:grub_efi_tmp_binary_path: /tmp/usr/share/efi/x86_64/grub.efi
 :shim_efi_download_url: the {client-os} Basesystem Pool repository published on your {SmartProxy}
 :shim_efi_downloaded_package_name: shim.x86_64.rpm
 :shim_efi_package_name: shim

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -96,22 +96,15 @@ endif::[]
 ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grub.efi
 # cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shim.efi
+# ln -sr $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/boot.efi
+# ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
+# chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shim.efi
 endif::[]
 ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grubx64.efi
 # cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shimx64.efi
-endif::[]
-ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
-# ln -sr $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/boot.efi
-endif::[]
-ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # ln -sr $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/boot.efi
-endif::[]
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
-ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
-# chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shim.efi
-endif::[]
-ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi
 endif::[]
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -97,7 +97,7 @@ ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grub.efi
 # cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shim.efi
 # ln -sr $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/boot.efi
-# ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
+# ln -sr $BOOTLOADER_PATH/shim.efi $BOOTLOADER_PATH/boot-sb.efi
 # chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shim.efi
 endif::[]
 ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -107,7 +107,12 @@ ifndef::suse_linux_enterprise_server[]
 # ln -sr $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/boot.efi
 endif::[]
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
+ifdef::suse_linux_enterprise_server[]
+# chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shimx64.efi
+endif::[]
+ifndef::suse_linux_enterprise_server[]
 # chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi
+endif::[]
 ----
 ifdef::ubuntu[]
 . Some older Ubuntu versions look for the GRUB configuration on the TFTP server at `grub/grub.cfg`.

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -93,28 +93,28 @@ endif::[]
 +
 [options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-ifdef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grub.efi
 endif::[]
-ifndef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grubx64.efi
 endif::[]
 # cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shimx64.efi
-ifdef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # ln -sr $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/boot.efi
 endif::[]
-ifndef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # ln -sr $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/boot.efi
 endif::[]
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
-ifdef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shimx64.efi
 endif::[]
-ifndef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi
 endif::[]
 ----
-ifdef::ubuntu[]
+ifeval::["{client-os-context}" == "ubuntu"]
 . Some older Ubuntu versions look for the GRUB configuration on the TFTP server at `grub/grub.cfg`.
 To support these versions for Secure Boot, create the legacy `grub/` directory and link `grub2/grub.cfg` into it:
 +
@@ -135,17 +135,17 @@ endif::[]
     └── {secureboot-os-name}
         └── default
             └── x86_64
-ifdef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
                 ├── boot.efi -> grub.efi
 endif::[]
-ifndef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
                 ├── boot.efi -> grubx64.efi
 endif::[]
                 ├── boot-sb.efi -> shimx64.efi
-ifdef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
                 ├── grub.efi
 endif::[]
-ifndef::suse_linux_enterprise_server[]
+ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
                 ├── grubx64.efi
 endif::[]
                 └── shimx64.efi

--- a/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-to-provision-secure-boot-enabled-hosts.adoc
@@ -95,11 +95,12 @@ endif::[]
 ----
 ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grub.efi
+# cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shim.efi
 endif::[]
 ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # cp {grub_efi_tmp_binary_path} $BOOTLOADER_PATH/grubx64.efi
-endif::[]
 # cp {shim_efi_tmp_binary_path} $BOOTLOADER_PATH/shimx64.efi
+endif::[]
 ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
 # ln -sr $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/boot.efi
 endif::[]
@@ -108,7 +109,7 @@ ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 endif::[]
 # ln -sr $BOOTLOADER_PATH/shimx64.efi $BOOTLOADER_PATH/boot-sb.efi
 ifeval::["{client-os-context}" == "suse_linux_enterprise_server"]
-# chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shimx64.efi
+# chmod 644 $BOOTLOADER_PATH/grub.efi $BOOTLOADER_PATH/shim.efi
 endif::[]
 ifeval::["{client-os-context}" != "suse_linux_enterprise_server"]
 # chmod 644 $BOOTLOADER_PATH/grubx64.efi $BOOTLOADER_PATH/shimx64.efi


### PR DESCRIPTION
#### What changes are you introducing?

This PR contains three patches to fix the docs to configure Smart Proxies to provision Secure Boot-enabled hosts.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Because the docs were wrong.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

built docs: https://theforeman-foreman-documentation-preview-pr-5127.surge.sh/nightly/Provisioning_Hosts/index-katello.html#configuring-smart-proxy-for-secure-boot

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
