### PR TITLE
Make ISS requirement for disconnected

### DIFF
--- a/guides/common/modules/con_configuring-inter-server-synchronization.adoc
+++ b/guides/common/modules/con_configuring-inter-server-synchronization.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 ifdef::satellite[]
 A disconnected {ProjectServer} does not have direct access to the Red Hat Content Delivery Network.
-You must configure {ISS} to synchronize content from a connected {ProjectServer} to your disconnected {ProjectServer}.
+Configure {ISS} on your disconnected {ProjectServer} to synchronize content from a connected {ProjectServer}.
 endif::[]
 ifndef::satellite[]
 Configure {ISS} on your downstream {ProjectServer} to provide content to its hosts.

--- a/guides/common/modules/con_configuring-inter-server-synchronization.adoc
+++ b/guides/common/modules/con_configuring-inter-server-synchronization.adoc
@@ -4,7 +4,7 @@
 = Configuring {ISS}
 
 [role="_abstract"]
-A disconnected {ProjectServer} does not have direct access to the Red Hat Content Delivery Network.
+A disconnected {ProjectServer} does not have direct access to networked content, such as content delivery networks, container registries, or software repositories.
 Configure {ISS} on your downstream {ProjectServer} to provide content to its hosts.
 
 .Additional resources

--- a/guides/common/modules/con_configuring-inter-server-synchronization.adoc
+++ b/guides/common/modules/con_configuring-inter-server-synchronization.adoc
@@ -5,8 +5,12 @@
 
 [role="_abstract"]
 ifdef::satellite[]
-Configure {ISS} on your disconnected {ProjectServer} to provide content in your disconnected network.
+A disconnected {ProjectServer} does not have direct access to the Red Hat Content Delivery Network.
+You must configure {ISS} to synchronize content from a connected {ProjectServer} to your disconnected {ProjectServer}.
 endif::[]
 ifndef::satellite[]
 Configure {ISS} on your downstream {ProjectServer} to provide content to its hosts.
 endif::[]
+
+.Additional resources
+* {PlanningDocURL}{ISS-id}-scenarios[{ISS} scenarios in _{PlanningDocTitle}_]

--- a/guides/common/modules/con_configuring-inter-server-synchronization.adoc
+++ b/guides/common/modules/con_configuring-inter-server-synchronization.adoc
@@ -4,13 +4,8 @@
 = Configuring {ISS}
 
 [role="_abstract"]
-ifdef::satellite[]
 A disconnected {ProjectServer} does not have direct access to the Red Hat Content Delivery Network.
-Configure {ISS} on your disconnected {ProjectServer} to synchronize content from a connected {ProjectServer}.
-endif::[]
-ifndef::satellite[]
 Configure {ISS} on your downstream {ProjectServer} to provide content to its hosts.
-endif::[]
 
 .Additional resources
 * {PlanningDocURL}{ISS-id}-scenarios[{ISS} scenarios in _{PlanningDocTitle}_]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -55,11 +55,11 @@ endif::[]
 ifdef::satellite[]
 ifeval::["{context}" == "{project-context}"]
 ifeval::["{mode}" == "disconnected"]
-* Ensure you have a connected {ProjectServer} from which you can synchronize content.
-A disconnected {ProjectServer} requires {ISS} to receive content updates.
+* Ensure you have a connected {ProjectServer} from which you can synchronize content to the disconnected {ProjectServer}.
+You can configure {ISS} for content synchronization.
 For more information, see {PlanningDocURL}{ISS-id}-scenarios[{ISS} scenarios in _{PlanningDocTitle}_].
 endif::[]
-* If you are installing in an environment with air-gapped {ProjectServer}s, ensure that all your {ProjectServer}s are on the same {Project} version for ISS Export Sync to work.
+* If you are installing in an environment with air-gapped {ProjectServer}s with {ISS}, ensure that all your {ProjectServer}s are on the same {Project} version for ISS Export Sync to work.
 ISS Network Sync works across all {Project} versions that support it.
 For more information, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing Content Between {Project} Servers] in _{ContentManagementDocTitle}_.
 endif::[]

--- a/guides/common/modules/ref_system-requirements.adoc
+++ b/guides/common/modules/ref_system-requirements.adoc
@@ -54,6 +54,11 @@ endif::[]
 
 ifdef::satellite[]
 ifeval::["{context}" == "{project-context}"]
+ifeval::["{mode}" == "disconnected"]
+* Ensure you have a connected {ProjectServer} from which you can synchronize content.
+A disconnected {ProjectServer} requires {ISS} to receive content updates.
+For more information, see {PlanningDocURL}{ISS-id}-scenarios[{ISS} scenarios in _{PlanningDocTitle}_].
+endif::[]
 * If you are installing in an environment with air-gapped {ProjectServer}s, ensure that all your {ProjectServer}s are on the same {Project} version for ISS Export Sync to work.
 ISS Network Sync works across all {Project} versions that support it.
 For more information, see {ContentManagementDocURL}Synchronizing_Content_Between_Servers_content-management[Synchronizing Content Between {Project} Servers] in _{ContentManagementDocTitle}_.

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -46,11 +46,11 @@ endif::[]
 
 ifndef::containerized[]
 
-include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+1]
-
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 
 include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffset=+2]
+
+include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+2]
 
 include::common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-web-ui.adoc[leveloffset=+2]
 

--- a/guides/doc-Installing_Server_Disconnected/master.adoc
+++ b/guides/doc-Installing_Server_Disconnected/master.adoc
@@ -46,6 +46,8 @@ endif::[]
 
 ifndef::containerized[]
 
+include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+1]
+
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 
 include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffset=+2]
@@ -53,8 +55,6 @@ include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffse
 include::common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-web-ui.adoc[leveloffset=+2]
 
 include::common/modules/proc_configuring-server-to-consume-content-from-a-custom-cdn-by-using-cli.adoc[leveloffset=+2]
-
-include::common/assembly_configuring-inter-server-synchronization.adoc[leveloffset=+2]
 
 include::common/modules/proc_configuring-pull-based-transport-for-remote-execution.adoc[leveloffset=+2]
 


### PR DESCRIPTION
#### What changes are you introducing?
Add ISS as a requirement for the disconnected installation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
ISS is required, after other methods were removed
https://redhat.atlassian.net/browse/SAT-48329

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Reorganizing the content further is out of scope.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
