### PR TITLE
Remove --lifecycle-environment-ids from rolling CV create

### DIFF
--- a/guides/common/modules/proc_creating-a-rolling-content-view-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-rolling-content-view-by-using-cli.adoc
@@ -31,7 +31,6 @@ $ hammer repository list \
 [options="nowrap" subs="+quotes"]
 ----
 $ hammer content-view create \
---lifecycle-environment-ids _My_List_Of_Lifecycle_Environment_IDs_ \
 --name "_My_Rolling_Content_View_" \
 --organization "_My_Organization_" \
 --repository-ids _My_List_Of_Repository_IDs_ \


### PR DESCRIPTION
#### What changes are you introducing?

Remove `--lifecycle-environment-ids` from the hammer content-view create command in the rolling content view CLI procedure.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The `--lifecycle-environment-ids` option does not exist for hammer content-view create on Satellite 6.18. It was introduced in Satellite 6.19. 
Jira: [SAT-47481](https://redhat.atlassian.net/browse/SAT-47481)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
