### PR TITLE
Fix include directives that clip into Section 8.

### DIFF
--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-ansible-rex.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-ansible-rex.adoc
@@ -8,6 +8,7 @@ You can use remote execution (REX) with the Ansible provider to deploy the CA ce
 
 .Prerequisites
 * The host is registered to {Project}.
+
 include::snip_prerequisites-deploying-ca-cert-rex.adoc[]
 
 .Procedure

--- a/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-script-rex.adoc
+++ b/guides/common/modules/proc_deploying-the-ca-certificate-on-a-host-by-using-script-rex.adoc
@@ -8,6 +8,7 @@ You can use remote execution (REX) with the Script provider to deploy the CA cer
 
 .Prerequisites
 * The host is registered to {Project}.
+
 include::snip_prerequisites-deploying-ca-cert-rex.adoc[]
 
 .Procedure


### PR DESCRIPTION

#### What changes are you introducing?
Add line breaks in _Deploying the CA certificate on a host by using Script REX_ and _Deploying the CA certificate on a host by using Ansible REX_'s bulleted lists that have an include directive for `snip_prerequisites-deploying-ca-cert-rex.adoc[]`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
The "Refreshing the self-signed CA certificate on hosts" section has two subsections where the include directive clips into the document. This change adds a line break so the content is still included, but "_mod-docs-content-type:" does not appear beside it.

Relates to Issue #5121.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
