### PR TITLE
Do not version control guides/doc-Contributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@
 Gemfile.lock
 data.json
 guides/common/default.css
+guides/doc-Contributing/
 publish.sh
 result.json


### PR DESCRIPTION
#### What changes are you introducing?

On "master", we have added the contributing guide as guide. If you switch from "master" to "3.19" and below, git reports this untracked directory.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

to improve the maintainer experience

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
