### PR TITLE
Update other guides for OpenVox for 3.14 and lower

### DIFF
--- a/guides/common/assembly_logging-and-reporting-problems.adoc
+++ b/guides/common/assembly_logging-and-reporting-problems.adoc
@@ -20,9 +20,9 @@ ifdef::katello,orcharhino,satellite[]
 include::modules/proc_increasing-the-logging-level-for-pulp.adoc[leveloffset=+2]
 endif::[]
 
-include::modules/proc_increasing-the-logging-level-for-puppet-agent.adoc[leveloffset=+2]
+include::modules/proc_increasing-the-logging-level-for-openvox-agent.adoc[leveloffset=+2]
 
-include::modules/proc_increasing-the-logging-level-for-puppet-server.adoc[leveloffset=+2]
+include::modules/proc_increasing-the-logging-level-for-openvox-server.adoc[leveloffset=+2]
 
 ifndef::satellite[]
 include::modules/proc_increasing-the-logging-level-for-salt.adoc[leveloffset=+2]

--- a/guides/common/modules/con_network-boot-provisioning-workflow.adoc
+++ b/guides/common/modules/con_network-boot-provisioning-workflow.adoc
@@ -12,7 +12,7 @@ When you complete all the options for the new host, submit the new host request.
 * A forward DNS record on {SmartProxyServer} that is associated with the domain.
 * A reverse DNS record on the DNS {SmartProxyServer} that is associated with the subnet.
 * PXELinux, Grub, Grub2, and iPXE configuration files for the host in the TFTP {SmartProxyServer} that is associated with the subnet.
-* A Puppet certificate on the associated Puppet server.
+* A Puppet certificate on the associated OpenVox server.
 * A realm on the associated identity server.
 . The host is configured to boot from the network as the first device and HDD as the second device.
 . The new host requests a DHCP reservation from the DHCP server.

--- a/guides/common/modules/con_smartproxy-features.adoc
+++ b/guides/common/modules/con_smartproxy-features.adoc
@@ -44,7 +44,7 @@ Realm::
 {SmartProxy} can integrate with an existing infrastructure, including {FreeIPA} and Active Directory.
 
 Puppet server::
-{SmartProxy} can act as a configuration management server by running a OpenVox server.
+{SmartProxy} can act as a configuration management server by running an OpenVox server.
 
 Puppet Certificate Authority::
 {SmartProxy} can integrate with the Puppet certificate authority (CA) to provide certificates to hosts.

--- a/guides/common/modules/con_smartproxy-features.adoc
+++ b/guides/common/modules/con_smartproxy-features.adoc
@@ -44,7 +44,7 @@ Realm::
 {SmartProxy} can integrate with an existing infrastructure, including {FreeIPA} and Active Directory.
 
 Puppet server::
-{SmartProxy} can act as a configuration management server by running a Puppet server.
+{SmartProxy} can act as a configuration management server by running a OpenVox server.
 
 Puppet Certificate Authority::
 {SmartProxy} can integrate with the Puppet certificate authority (CA) to provide certificates to hosts.

--- a/guides/common/modules/con_supported-client-architectures-for-configuration-management.adoc
+++ b/guides/common/modules/con_supported-client-architectures-for-configuration-management.adoc
@@ -13,4 +13,4 @@ You can use the following combinations of major versions of {RHEL} and hardware 
 |{RHEL} 7 |x86_64
 |====
 
-Note that Puppet agent is currently unavailable for {RHEL} 10.
+Note that OpenVox agent is currently unavailable for {RHEL} 10.

--- a/guides/common/modules/con_supported-usage-of-project-components.adoc
+++ b/guides/common/modules/con_supported-usage-of-project-components.adoc
@@ -41,8 +41,8 @@ Interact with the embedded Tomcat application server only by using the {ProjectW
 Not supported: Direct interaction with the embedded Tomcat application server local API or database.
 
 Puppet::
-When you run the {Project} installation program, you can install and configure Puppet servers as part of {SmartProxyServers}.
-A Puppet module, running on a Puppet server on your {ProjectServer} or any {SmartProxyServer}, is also supported by {Team}.
+When you run the {Project} installation program, you can install and configure OpenVox servers as part of {SmartProxyServers}.
+A Puppet module, running on the OpenVox server on your {ProjectServer} or any {SmartProxyServer}, is also supported by {Team}.
 
 .Additional resources
 * Red{nbsp}Hat supports many different scripting and other frameworks.

--- a/guides/common/modules/proc_configuring-installation.adoc
+++ b/guides/common/modules/proc_configuring-installation.adoc
@@ -32,8 +32,8 @@ This means that running the installer on a broken system should restore it to wo
 For more information on how to apply custom configuration on other services, see {InstallingServerDocURL}applying-custom-configuration_{project-context}[Applying Custom Configuration to {Project}].
 
 ifdef::foreman-el,foreman-deb[]
-* By default, {ProjectServer} is installed with the Puppet agent running as a service.
-If required, you can disable Puppet agent on {ProjectServer} using the `--puppet-runmode=none` option.
+* By default, {ProjectServer} is installed with the OpenVox agent running as a service.
+If required, you can disable OpenVox agent on {ProjectServer} using the `--puppet-runmode=none` option.
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-custom-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -56,7 +56,7 @@ Retain a copy of the example `{foreman-installer}` command from the output for i
 --puppet-server true \
 --puppet-server-ca "true"
 ----
-. On {SmartProxyServer} that is the Puppetserver Certificate Authority, stop the Puppet server:
+. On {SmartProxyServer} that is the Puppet Certificate Authority, stop the OpenVox server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -78,7 +78,7 @@ This command creates the following files:
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
-. Start the Puppet server:
+. Start the OpenVox server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
+++ b/guides/common/modules/proc_configuring-smart-proxy-server-with-default-ssl-certificates-to-generate-and-sign-puppet-certificates.adoc
@@ -53,7 +53,7 @@ Retain a copy of the example `{foreman-installer}` command that is output by the
 --puppet-server true \
 --puppet-server-ca "true"
 ----
-. On {SmartProxyServer} that is the Puppetserver Certificate Authority, stop the Puppet server:
+. On {SmartProxyServer} that is the Puppet Certificate Authority, stop the OpenVox server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -75,7 +75,7 @@ This command creates the following files:
 * `/etc/puppetlabs/puppet/ssl/private_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppet/ssl/public_keys/_{smartproxy-example-com}_.pem`
 * `/etc/puppetlabs/puppetserver/ca/signed/_{smartproxy-example-com}_.pem`
-. Start the Puppet server:
+. Start the OpenVox server:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
@@ -1,7 +1,7 @@
 [id="Deploying_a_Policy_in_a_Host_Group_Using_Puppet_{context}"]
 = Deploying a policy in a host group using Puppet
 
-After you deploy a compliance policy in a host group using Puppet, the Puppet agent installs the SCAP client and configures OpenSCAP scans on the hosts on the next Puppet run according to the selected compliance policy.
+After you deploy a compliance policy in a host group using Puppet, the OpenVox agent installs the SCAP client and configures OpenSCAP scans on the hosts on the next Puppet run according to the selected compliance policy.
 
 The SCAP content in your compliance policy might require remote resources.
 For more information, see xref:inclusion-of-remote-scap-resources_{context}[].

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
@@ -1,7 +1,7 @@
 [id="Deploying_a_Policy_on_a_Host_Using_Puppet_{context}"]
 = Deploying a policy on a host using Puppet
 
-After you deploy a compliance policy on a host using Puppet, the Puppet agent installs the SCAP client and configures OpenSCAP scans on the host on the next Puppet run according to the selected compliance policy.
+After you deploy a compliance policy on a host using Puppet, the OpenVox agent installs the SCAP client and configures OpenSCAP scans on the host on the next Puppet run according to the selected compliance policy.
 
 The SCAP content in your compliance policy might require remote resources.
 For more information, see xref:inclusion-of-remote-scap-resources_{context}[].

--- a/guides/common/modules/proc_editing-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_editing-a-compliance-policy.adoc
@@ -3,7 +3,7 @@
 
 In the {ProjectWebUI}, you can edit compliance policies.
 
-Puppet agent applies an edited policy to the host on the next run.
+OpenVox agent applies an edited policy to the host on the next run.
 By default, this occurs every 30 minutes.
 If you use Ansible, you must run the Ansible role manually again or have configured a recurring remote execution job that runs the Ansible role on hosts.
 

--- a/guides/common/modules/proc_increasing-the-logging-level-for-openvox-agent.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-level-for-openvox-agent.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="increasing-the-logging-level-for-puppet-agent"]
-= Increasing the logging level for Puppet agent
+[id="increasing-the-logging-level-for-openvox-agent"]
+= Increasing the logging level for OpenVox agent
 
 You can find the logs in `/var/log/puppetlabs/puppet/`.
 

--- a/guides/common/modules/proc_increasing-the-logging-level-for-openvox-server.adoc
+++ b/guides/common/modules/proc_increasing-the-logging-level-for-openvox-server.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="increasing-the-logging-level-for-puppet-server"]
-= Increasing the logging level for Puppet server
+[id="increasing-the-logging-level-for-openvox-server"]
+= Increasing the logging level for OpenVox server
 
 You can find the logs in `/var/log/puppetlabs/puppetserver/`.
 

--- a/guides/common/modules/proc_registering-a-host.adoc
+++ b/guides/common/modules/proc_registering-a-host.adoc
@@ -19,7 +19,7 @@ This is required to install the `insights-client` package on your host.
 endif::[]
 ifdef::katello,orcharhino,satellite[]
 include::snip_prerequisite-project-client-repository-ak.adoc[]
-This repository is required for the remote execution pull client, Puppet agent, Tracer, and other tools.
+This repository is required for the remote execution pull client, OpenVox agent, Tracer, and other tools.
 endif::[]
 include::snip_prerequisite-configured-smart-proxy-registration-provisioning.adoc[]
 ifdef::katello,orcharhino,satellite[]

--- a/guides/common/modules/proc_using-the-project-content-dashboard.adoc
+++ b/guides/common/modules/proc_using-the-project-content-dashboard.adoc
@@ -32,7 +32,7 @@ Click the particular configuration status to view hosts associated with it.
 +
 Monitor this section for global notifications sent to all users and to detect any unusual activity or errors.
 
-*Run Distribution (last 30 minutes)*:: A graph shows the distribution of the running Puppet agents during the last puppet interval which is 30 minutes by default.
+*Run Distribution (last 30 minutes)*:: A graph shows the distribution of the running OpenVox agents during the last puppet interval which is 30 minutes by default.
 In this case, each column represents a number of reports received from clients during 3 minutes.
 
 *New Hosts*:: A list of the recently created hosts.

--- a/guides/common/modules/proc_using-the-project-content-dashboard.adoc
+++ b/guides/common/modules/proc_using-the-project-content-dashboard.adoc
@@ -33,7 +33,7 @@ Click the particular configuration status to view hosts associated with it.
 Monitor this section for global notifications sent to all users and to detect any unusual activity or errors.
 
 *Run Distribution (last 30 minutes)*:: A graph shows the distribution of the running OpenVox agents during the last puppet interval which is 30 minutes by default.
-In this case, each column represents a number of reports received from clients during 3 minutes.
+In this case, each column represents the number of reports received from clients during 3 minutes.
 
 *New Hosts*:: A list of the recently created hosts.
 Click the host for more details.

--- a/guides/common/modules/ref_compliance-policy-deployment-options.adoc
+++ b/guides/common/modules/ref_compliance-policy-deployment-options.adoc
@@ -7,7 +7,7 @@ Ansible deployment::
 You use an Ansible role to configure hosts for compliance scans.
 
 Puppet deployment::
-You use a Puppet class and the Puppet agent to configure hosts for compliance scans.
+You use a Puppet class and the OpenVox agent to configure hosts for compliance scans.
 
 Manual deployment::
 You manually configure hosts for compliance scans.

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -71,7 +71,7 @@ endif::[]
 [[Catalog]]
 Catalog:: A document that describes the desired system state for one specific host managed by Puppet.
 It lists all of the resources that need to be managed, as well as any dependencies between those resources.
-Catalogs are compiled by a Puppet server from Puppet Manifests and data from Puppet agents.
+Catalogs are compiled by a OpenVox server from Puppet Manifests and data from OpenVox agents.
 
 ifdef::katello,orcharhino,satellite[]
 [[Candlepin]]
@@ -189,7 +189,7 @@ endif::[]
 External node classifier (ENC)::
 A construct that provides additional data for a server to use when configuring hosts.
 When Puppet obtains information about nodes from an external source instead of its own database, the external source is called External node classifier.
-If the Puppet plugin is installed, {ProjectName} can act as an External node classifier to Puppet servers in a {Project} deployment.
+If the Puppet plugin is installed, {ProjectName} can act as an External node classifier to OpenVox servers in a {Project} deployment.
 
 [[Facter]]
 Facter:: A program that provides information (facts) about the system on which it is run; for example, Facter can report total memory, operating system version, architecture, and more.
@@ -340,7 +340,7 @@ Depending on the parameter scope, we distinguish between global, domain, host gr
 Depending on the parameter complexity, we distinguish between simple parameters (key-value pair) and smart parameters (conditional arguments, validation, overrides).
 
 [[Parametrized_class]]
-Parametrized class (smart class parameter):: A parameter created by importing a class from Puppet server.
+Parametrized class (smart class parameter):: A parameter created by importing a class from OpenVox server.
 
 ifdef::katello,orcharhino,satellite[]
 [[Patch-and-release-management]]
@@ -411,10 +411,10 @@ Puppet is a configuration management tool utilizing a declarative language in a 
 For more information about using Puppet to configure hosts, see {ManagingConfigurationsPuppetDocURL}[{ManagingConfigurationsPuppetDocTitle}].
 
 [[Puppet_agent]]
-Puppet agent:: A service running on a host that applies configuration changes to that host.
+OpenVox agent:: A service running on a host that applies configuration changes to that host.
 
 [[Puppet_environment]]
-Puppet environment:: An isolated set of Puppet agent nodes that can be associated with a specific set of Puppet Modules.
+Puppet environment:: An isolated set of OpenVox agent nodes that can be associated with a specific set of Puppet Modules.
 
 [[Puppet_manifest]]
 Puppet manifest:: Refers to Puppet scripts, which are files with the *.pp* extension.
@@ -423,7 +423,7 @@ The files contain code to define a set of necessary resources, such as packages,
 Do not confuse with xref:Manifest[Manifest (Red{nbsp}Hat subscription manifest)].
 
 [[Puppet_server]]
-Puppet server:: A {SmartProxyServer} component that provides a Puppet catalog to hosts for execution by the Puppet agent.
+OpenVox server:: A {SmartProxyServer} component that provides a Puppet catalog to hosts for execution by the OpenVox agent.
 
 [[Puppet_module]]
 Puppet module:: A self-contained bundle of code (Puppet Manifests) and data (facts) that you can use to manage resources such as users, files, and services.

--- a/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
+++ b/guides/common/modules/ref_glossary-of-terms-used-in-project.adoc
@@ -71,7 +71,7 @@ endif::[]
 [[Catalog]]
 Catalog:: A document that describes the desired system state for one specific host managed by Puppet.
 It lists all of the resources that need to be managed, as well as any dependencies between those resources.
-Catalogs are compiled by a OpenVox server from Puppet Manifests and data from OpenVox agents.
+Catalogs are compiled by an OpenVox server from Puppet Manifests and data from OpenVox agents.
 
 ifdef::katello,orcharhino,satellite[]
 [[Candlepin]]

--- a/guides/common/modules/ref_host-specific-variables.adoc
+++ b/guides/common/modules/ref_host-specific-variables.adoc
@@ -51,7 +51,7 @@ See xref:Parsing_Arrays_{context}[].
 Returns an interface object.
 |`@host.ptable` |The partition table name.
 |`@host.puppet_ca_server` *Deprecated* Use the `host_puppet_ca_server` variable instead. |The Puppet CA server the host must use.
-|`@host.puppetmaster` *Deprecated* Use the `host_puppet_server` variable instead. |The Puppet server the host must use.
+|`@host.puppetmaster` *Deprecated* Use the `host_puppet_server` variable instead. |The OpenVox server the host must use.
 |`@host.pxe_build?` |Returns `true` if the host is provisioned using the network or PXE.
 |`@host.shortname` |The short name of the host.
 |`@host.sp_ip` |The IP address of the BMC interface.

--- a/guides/common/modules/ref_port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_port-and-firewall-requirements.adoc
@@ -49,7 +49,7 @@ endif::[]
 | 5910{range}5930 | TCP | HTTPS | Browsers | Compute Resource's virtual console |
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTPS | Client | PXE Boot | Installation
-| 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
+| 8140 | TCP | HTTPS | Client | OpenVox agent | Client updates (optional)
 | {smartproxy_port} | TCP | HTTPS | {ProjectName} | {SmartProxy} API | Smart Proxy functionality
 | {smartproxy_port} | TCP | HTTPS | Client | OpenSCAP | Configure Client (if the OpenSCAP plugin is installed)
 | {smartproxy_port} | TCP | HTTPS | Discovered Node|Discovery |Host discovery and provisioning (if the discovery plugin is installed)

--- a/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
+++ b/guides/common/modules/ref_smart-proxy-port-and-firewall-requirements.adoc
@@ -44,7 +44,7 @@ Sending installed packages and traces
 endif::[]
 | 8000 | TCP | HTTP | Client | Provisioning templates | Template retrieval for client installers, iPXE or UEFI HTTP Boot
 | 8000 | TCP | HTTP | Client | PXE Boot | Installation
-| 8140 | TCP | HTTPS | Client | Puppet agent | Client updates (optional)
+| 8140 | TCP | HTTPS | Client | OpenVox agent | Client updates (optional)
 ifdef::katello,satellite,orcharhino[]
 | 8443 | TCP | HTTPS | Client | Content Host registration | Deprecated and only needed for Client hosts deployed before upgrades
 endif::[]

--- a/guides/common/modules/ref_smart-proxy-server-scalability-considerations-when-managing-puppet-clients.adoc
+++ b/guides/common/modules/ref_smart-proxy-server-scalability-considerations-when-managing-puppet-clients.adoc
@@ -2,17 +2,17 @@
 = {SmartProxyServer} scalability considerations when managing Puppet clients
 
 {SmartProxyServer} scalability when managing Puppet clients depends on the number of CPUs, the run-interval distribution, and the number of Puppet managed resources.
-{SmartProxyServer} has a limitation of 100 concurrent Puppet agents running at any single point in time.
-Running more than 100 concurrent Puppet agents results in a 503 HTTP error.
+{SmartProxyServer} has a limitation of 100 concurrent OpenVox agents running at any single point in time.
+Running more than 100 concurrent OpenVox agents results in a 503 HTTP error.
 
-For example, assuming that Puppet agent runs are evenly distributed with less than 100 concurrent Puppet agents running at any single point during a run-interval, a {SmartProxyServer} with 4 CPUs has a maximum of 1250{range}1600 Puppet clients with a moderate workload of 10 Puppet classes assigned to each Puppet client.
+For example, assuming that OpenVox agent runs are evenly distributed with less than 100 concurrent OpenVox agents running at any single point during a run-interval, a {SmartProxyServer} with 4 CPUs has a maximum of 1250{range}1600 Puppet clients with a moderate workload of 10 Puppet classes assigned to each Puppet client.
 Depending on the number of Puppet clients required, the {Project} installation can scale out the number of {SmartProxyServers} to support them.
 
 If you want to scale your {SmartProxyServer} when managing Puppet clients, the following assumptions are made:
 
 * There are no external Puppet clients reporting directly to your {ProjectServer}.
 * All other Puppet clients report directly to {SmartProxyServers}.
-* There is an evenly distributed run-interval of all Puppet agents.
+* There is an evenly distributed run-interval of all OpenVox agents.
 
 [NOTE]
 ====

--- a/guides/common/modules/snip_glossary-term-smart-proxy.adoc
+++ b/guides/common/modules/snip_glossary-term-smart-proxy.adoc
@@ -1,9 +1,9 @@
 {SmartProxyServer}::
 ifdef::satellite[]
-{SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node or Puppet server in separate networks.
+{SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node or OpenVox server in separate networks.
 endif::[]
 ifndef::satellite[]
-{SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node, Puppet server, or Salt Master in separate networks.
+{SmartProxyServers} can provide DHCP, DNS, and TFTP services and act as an Ansible control node, OpenVox server, or Salt Master in separate networks.
 endif::[]
 They interact with {ProjectServer} in a client-server model.
 ifdef::katello,orcharhino,satellite[]

--- a/guides/image-sources/prov-initial-configuration.iuml
+++ b/guides/image-sources/prov-initial-configuration.iuml
@@ -1,7 +1,7 @@
 !if ($puppet)
 opt when Puppet enabled
     Host -> Host : Install Puppet agent
-    Host -> Puppet : Send certificate signing request
+    Host -> OpenVox : Send certificate signing request
     Puppet -> Host : Send certificate (if allowed to)
 end
 !endif


### PR DESCRIPTION
Same change as https://github.com/theforeman/foreman-documentation/pull/5027 for 3.14 and lower.

Cherry pick all the way to 3.12.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
