### PR TITLE
Include 'Katello required' only once for Deb builds

### DIFF
--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -15,7 +15,7 @@ The Katello plugin required to manage content in Foreman is not supported for {P
 With {Project} and Katello on {EL}, you can provide content to hosts running {DL}.
 endif::[]
 
-ifdef::foreman-el,foreman-deb[]
+ifdef::foreman-el[]
 == Katello plugin required
 
 If you want to manage content using Foreman/Katello, you have to run Foreman/Katello on {EL}.


### PR DESCRIPTION
#### What changes are you introducing?

Adjusting conditionals for Foreman-Deb so that a "Katello plugin required" section is shown only once.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

<img width="1282" height="625" alt="Screenshot From 2026-08-04 12-06-18" src="https://github.com/user-attachments/assets/a2335290-9f3e-459c-8c50-ec89efd980db" />

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
