### PR TITLE
Include 'managing activation keys' in containerized builds

### DIFF
--- a/guides/common/modules/proc_assigning-content-view-environments-to-an-activation-key-by-using-cli.adoc
+++ b/guides/common/modules/proc_assigning-content-view-environments-to-an-activation-key-by-using-cli.adoc
@@ -8,7 +8,6 @@ Assign content view environments to an activation key so registered hosts receiv
 
 .Prerequisites
 * If you want to assign multiple content view environments, the *Allow multiple content views* setting must be enabled.
-For more information, see xref:content-view-environments-overview[].
 * You have created an activation key.
 
 .Procedure

--- a/guides/common/modules/proc_assigning-content-view-environments-to-an-activation-key-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_assigning-content-view-environments-to-an-activation-key-by-using-web-ui.adoc
@@ -8,7 +8,6 @@ Assign content view environments to an activation key so registered hosts receiv
 
 .Prerequisites
 * If you want to assign multiple content view environments, the *Allow multiple content views* setting must be enabled.
-For more information, see xref:content-view-environments-overview[].
 * You have created an activation key.
 
 .Procedure

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -51,9 +51,15 @@ include::common/assembly_managing-content-views-and-content-view-environments.ad
 include::common/assembly_recovering-corrupted-content.adoc[leveloffset=+1]
 
 include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
+endif::[]
+endif::[]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
+endif::[]
 
+ifndef::containerized[]
+ifdef::katello,satellite,orcharhino[]
 ifdef::katello,orcharhino[]
 include::common/assembly_managing-suse-content.adoc[leveloffset=+1]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Exposing "Managing activation keys" in containerized guides.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47730

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This PR removes two xrefs that lead to a section in a different assembly (one that is not yet included in the containerized build). I debated whether I should hide those xrefs with `ifndef::containerized[]` or delete them, and decided to delete them because the linked section doesn't say where to enable the referenced setting so I would say the xref is not that useful anyway.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
