### PR TITLE
Add 'syncing content' and 'recovering corrupted content' to containerized

### DIFF
--- a/guides/common/modules/proc_republishing-repository-metadata-by-using-cli.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata-by-using-cli.adoc
@@ -13,7 +13,6 @@ Republish repository metadata when published metadata does not match repository 
 
 .Prerequisites
 * The mirroring policy of the repository is not set to *Complete Mirroring*.
-For more information, see xref:Mirroring_Policies_Overview_{context}[].
 +
 This action is not available for repositories that use the *Complete Mirroring* policy because the metadata is copied verbatim from the upstream source of the repository.
 

--- a/guides/common/modules/proc_republishing-repository-metadata-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_republishing-repository-metadata-by-using-web-ui.adoc
@@ -13,7 +13,6 @@ Republish repository metadata when published metadata does not match repository 
 
 .Prerequisites
 * The mirroring policy of the repository is not set to *Complete Mirroring*.
-For more information, see xref:Mirroring_Policies_Overview_{context}[].
 +
 This action is not available for repositories that use the *Complete Mirroring* policy because the metadata is copied verbatim from the upstream source of the repository.
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -35,9 +35,15 @@ endif::[]
 include::common/assembly_managing-red-hat-subscriptions.adoc[leveloffset=+1]
 
 include::common/assembly_adding-content-to-foreman.adoc[leveloffset=+1]
+endif::[]
+endif::[]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_synchronizing-content-to-foreman.adoc[leveloffset=+1]
+endif::[]
 
+ifndef::containerized[]
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-alternate-content-sources.adoc[leveloffset=+1]
 
 include::common/assembly_optimizing-content-synchronization-and-storage.adoc[leveloffset=+1]
@@ -47,9 +53,15 @@ include::common/assembly_content-access-control-for-hosts.adoc[leveloffset=+1]
 include::common/assembly_managing-application-lifecycles.adoc[leveloffset=+1]
 
 include::common/assembly_managing-content-views-and-content-view-environments.adoc[leveloffset=+1]
+endif::[]
+endif::[]
 
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_recovering-corrupted-content.adoc[leveloffset=+1]
+endif::[]
 
+ifndef::containerized[]
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_synchronizing-content-between-servers.adoc[leveloffset=+1]
 
 include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Adding the two chapters to containerized guides.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47728
https://redhat.atlassian.net/browse/SAT-47729

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The two xrefs that I'm removing were causing build failures. I could address them by excluding them from containerized build targets with `ifndef::containerized[]`, but I actually think the rest of the prerequisite text explains everything the user needs to know about this particular mirroring policy limitation. Cleaning up the xrefs doesn't seem like a bad idea from that perspective.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
