### PR TITLE
Make Ansible plugin optional for non-Satellite builds

### DIFF
--- a/guides/common/modules/proc_assigning-ansible-roles-to-a-host-group.adoc
+++ b/guides/common/modules/proc_assigning-ansible-roles-to-a-host-group.adoc
@@ -7,6 +7,12 @@
 You can assign a previously imported Ansible role to a host group.
 This enables {Project} to apply the configuration defined by the role when you provision a new host by using the host group.
 
+ifndef::satellite[]
+.Prerequisites
+* You have enabled the Ansible plugin on your {Project}.
+For more information, see {ManagingConfigurationsAnsibleDocURL}enabling-the-ansible-plugin[Enabling the Ansible plugin] in _{ManagingConfigurationsAnsibleDocTitle}_.
+endif::[]
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
 . Click the host group name to which you want to assign an Ansible role.

--- a/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
+++ b/guides/common/modules/proc_assigning-ansible-roles-to-an-existing-host.adoc
@@ -7,6 +7,12 @@
 You can assign a previously imported Ansible role to an existing host.
 This enables {Project} to apply the configuration defined by the role when you run the Ansible roles on the host.
 
+ifndef::satellite[]
+.Prerequisites
+* You have enabled the Ansible plugin on your {Project}.
+For more information, see {ManagingConfigurationsAnsibleDocURL}enabling-the-ansible-plugin[Enabling the Ansible plugin] in _{ManagingConfigurationsAnsibleDocTitle}_.
+endif::[]
+
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Select the host and click *Edit*.

--- a/guides/common/modules/proc_creating-a-host-group-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-host-group-by-using-web-ui.adoc
@@ -7,12 +7,19 @@
 You can create a host group from the {ProjectWebUI} to use as a template for common host settings.
 
 .Procedure
-. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups* and click *Create Host Group*.
+. In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.
+. Click *Create Host Group*.
 . If you have an existing host group that you want to inherit attributes from, you can select a host group from the *Parent* list.
 If you do not, leave this field blank.
 . Enter a *Name* for the new host group.
 . Enter any further information that you want future hosts to inherit.
+ifdef::satellite[]
 . Click the *Ansible Roles* tab, and from the *Ansible Roles* list, select one or more roles that you want to add to the host.
+endif::[]
+ifndef::satellite[]
+. If you use the Ansible plugin and you want to configure your hosts through Ansible roles, click the *Ansible Roles* tab.
+. From the *Ansible Roles* list, select one or more roles that you want to add to the host.
+endif::[]
 Use the *arrow* icon to manage the roles that you add or remove.
 . Click the additional tabs and add any details that you want to attribute to the host group.
 +

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
@@ -10,6 +10,10 @@ The SCAP content in the compliance policy might require remote resources.
 For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
 
 .Prerequisites
+ifndef::satellite[]
+* You have enabled the Ansible plugin on your {Project}.
+For more information, see {ManagingConfigurationsAnsibleDocURL}enabling-the-ansible-plugin[Enabling the Ansible plugin] in _{ManagingConfigurationsAnsibleDocTitle}_.
+endif::[]
 * You have enabled OpenSCAP on your {SmartProxy}.
 For more information, see xref:enabling-openscap[].
 +


### PR DESCRIPTION
#### What changes are you introducing?

Reword adding Ansible roles to hosts/host groups.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

foreman_ansible is installed on Satellite by default. For Foreman, Foreman+Katello, and orcharhino, it's optional similar to Puppet and Salt.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
