### PR TITLE
Add prereq with port details

### DIFF
--- a/guides/common/modules/proc_opening-required-ports.adoc
+++ b/guides/common/modules/proc_opening-required-ports.adoc
@@ -17,6 +17,14 @@ ifndef::satellite,orcharhino[]
 If you do not use `firewall-cmd` to configure the Linux firewall, implement using the tool of your choice.
 endif::[]
 
+.Prerequisites
+ifeval::["{context}" == "{project-context}"]
+* You have reviewed the {PlanningDocURL}{project-context}-port-and-firewall-requirements[{ProjectServer} port and firewall requirements] in _{PlanningDocTitle}_ and identified the ports required for your {Project} deployment.
+endif::[]
+ifeval::["{context}" == "{smart-proxy-context}"]
+* You have reviewed the {PlanningDocURL}{smart-proxy-context}-port-and-firewall-requirements[{SmartProxy} port and firewall requirements] in _{PlanningDocTitle}_ and identified the ports required for your {Project} deployment.
+endif::[]
+
 .Procedure
 ifdef::katello,satellite,orcharhino[]
 ifeval::["{context}" == "{project-context}"]

--- a/guides/common/modules/proc_opening-required-ports.adoc
+++ b/guides/common/modules/proc_opening-required-ports.adoc
@@ -18,10 +18,10 @@ If you do not use `firewall-cmd` to configure the Linux firewall, implement usin
 endif::[]
 
 .Prerequisites
-ifeval::["{context}" == "{project-context}"]
+ifdef::installing-satellite-server-connected[]
 * You have reviewed the {PlanningDocURL}{project-context}-port-and-firewall-requirements[{ProjectServer} port and firewall requirements] in _{PlanningDocTitle}_ and identified the ports required for your {Project} deployment.
 endif::[]
-ifeval::["{context}" == "{smart-proxy-context}"]
+ifdef::installing-capsule-server[]
 * You have reviewed the {PlanningDocURL}{smart-proxy-context}-port-and-firewall-requirements[{SmartProxy} port and firewall requirements] in _{PlanningDocTitle}_ and identified the ports required for your {Project} deployment.
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?
Add prereq with details on port numbers.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
The port details are included in Additional resources, but not obvious. Customer reported missing them.
https://redhat.atlassian.net/browse/SAT-48470

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Cannot expand Additional resources wording or add link to body text due to style constraints.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
