### PR TITLE
Move links out of concept main body

### DIFF
--- a/guides/common/modules/con_api-request-composition.adoc
+++ b/guides/common/modules/con_api-request-composition.adoc
@@ -36,14 +36,15 @@ _API_ROUTE_ \
 For example, `--request POST`.
 `--insecure`:: Add the `--insecure` option to skip SSL peer certificate verification check.
 {Team} recommends you to configure SSL authentication and use secured calls.
-For more information, see xref:ssl-authentication-overview[].
 `--user`:: Provide {Project} user credentials with the `--user` option.
 `--data`:: For `POST` and `PUT` requests, use the `--data` option to pass JSON-formatted data.
-For more information, see xref:passing-json-data-to-the-api-request[].
 `--header`:: When passing the JSON data with the `--data` option, you must specify the following headers with the `--header` option.
-For more information, see xref:passing-json-data-to-the-api-request[].
 `--output`:: When downloading content from {ProjectServer}, specify the output file with the `--output` option.
 `_API_ROUTE_`:: Use the API route in the following format: `https://_{foreman-example-com}_/api/architectures`.
 In {ProjectX}, version 2 of the API is the default.
 Therefore, it is not necessary to use `v2` in the URL for API calls.
 `json.tool`:: Redirect the output to the Python `json.tool` module to make the output easier to read.
+
+.Additional resources
+* xref:ssl-authentication-overview[]
+* xref:passing-json-data-to-the-api-request[]

--- a/guides/common/modules/con_calling-the-api-in-curl.adoc
+++ b/guides/common/modules/con_calling-the-api-in-curl.adoc
@@ -8,10 +8,9 @@ You can use `curl` to test API endpoints, debug requests, and perform quick oper
 
 You can use `curl` to manipulate resources on your {ProjectServer}.
 API calls to {Project} require data in `json` format.
-For more information, see xref:passing-json-data-to-the-api-request[].
 
 {ProjectName} requires the use of HTTPS, and by default, a certificate for host identification.
-If you have not added the {ProjectServer} certificate as described in xref:ssl-authentication-overview[], then you can use the `--insecure` option to bypass certificate checks.
+If you have not added the {ProjectServer} certificate, then you can use the `--insecure` option to bypass certificate checks.
 
 For user authentication, you can use the `--user` option to provide {Project} user credentials in the form `--user _My_User_Name:_My_Password_`. 
 If you do not include the password, the command prompts you to enter it.
@@ -21,3 +20,7 @@ For simplicity, the examples in this section include the password.
 Be aware that if you use the `--silent` option, `curl` does not display a progress meter or any error messages.
 
 Examples in this chapter use the Python `json.tool` module to format the output.
+
+.Additional resources
+* xref:passing-json-data-to-the-api-request[]
+* xref:ssl-authentication-overview[]

--- a/guides/common/modules/con_configuration-management-with-puppet-in-project.adoc
+++ b/guides/common/modules/con_configuration-management-with-puppet-in-project.adoc
@@ -6,4 +6,7 @@
 [role="_abstract"]
 Puppet is a configuration management tool to automate configurations of hosts across your infrastructure.
 In a {Project} environment, you can use Puppet configuration management features for consistent management of {Project} hosts.
-For more information about Puppet, see https://puppet.com/docs/puppet/[Open Source Puppet documentation] and https://forge.puppet.com/[Puppet Forge].
+
+.Additional resources
+* https://puppet.com/docs/puppet/[Open Source Puppet documentation]
+* https://forge.puppet.com/[Puppet Forge]

--- a/guides/common/modules/con_content-view-environments-overview.adoc
+++ b/guides/common/modules/con_content-view-environments-overview.adoc
@@ -7,8 +7,6 @@
 The *Allow multiple content views* setting controls whether hosts and activation keys can be assigned to multiple content view environments.
 By default, this feature is disabled, limiting assignments to a single content view environment.
 Enable this setting to assign multiple content view environments to hosts and activation keys.
-For more information on content settings, see {AdministeringDocURL}content_settings_admin[Content settings] in _{AdministeringDocTitle}_.
-
 Hosts registered with multiple activation keys handle content view environment assignments based on the key order and settings configuration.
 
 When you disable *Allow multiple content views*, multi-environment hosts remain assigned to multiple content view environments and retain access to all their content.
@@ -22,5 +20,6 @@ You can also reassign a multi-environment activation key to a single content vie
 This setting provides flexibility in managing how content view environments are applied to hosts and activation keys while ensuring consistent behavior when disabled.
 
 .Additional resources
+* {AdministeringDocURL}content_settings_admin[Content settings in _{AdministeringDocTitle}_]
 * {AdministeringDocURL}content-management-settings[Content management settings in _{AdministeringDocTitle}_]
 * xref:content-view-environment-ordering-and-priority[]

--- a/guides/common/modules/con_high-level-steps-for-puppet-integration-with-project.adoc
+++ b/guides/common/modules/con_high-level-steps-for-puppet-integration-with-project.adoc
@@ -9,21 +9,29 @@ To integrate Puppet with {Project}, you need to enable integration, import agent
 Puppet integration with {Project} involves the following high-level steps:
 
 ifdef::katello,orcharhino,satellite[]
-. xref:enabling-puppet-integration-with-{project-context}[Enable Puppet integration].
+. Enable Puppet integration.
 endif::[]
 ifdef::katello,satellite,orcharhino[]
 . Import Puppet agent packages into {Project}.
 Puppet agent packages can be managed like any other content with {Project}
 ifdef::satellite[]
-by {ContentManagementDocURL}enabling-red-hat-repositories-by-using-web-ui[enabling Red Hat repositories]
+by enabling Red Hat repositories
 endif::[]
 ifndef::satellite[]
 by syncing repositories in custom products
 endif::[]
-and by using {ContentManagementDocURL}Managing_Activation_Keys_content-management[activation keys] and {ContentManagementDocURL}Managing_Content_Views_content-management[content views].
+and by using activation keys and content views.
 endif::[]
 . Install Puppet agent on hosts by using one of the following options:
+* during host provisioning
+* during host registration
+* manually
+* by executing a remote job
+
+.Additional resources
+ifdef::katello,orcharhino,satellite[]
+* xref:enabling-puppet-integration-with-{project-context}[]
+endif::[]
 * xref:Installing_and_Configuring_Puppet_Agent_during_Host_Provisioning_{context}[]
 * xref:installing-and-configuring-puppet-agent-during-host-registration_{context}[]
 * xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[]
-* by executing a remote job

--- a/guides/common/modules/con_how-puppet-integrates-with-project.adoc
+++ b/guides/common/modules/con_how-puppet-integrates-with-project.adoc
@@ -10,7 +10,7 @@ As a configuration management tool, Puppet uses a server-agent architecture.
 Puppet server and Puppet agent::
 The Puppet server is the central component that stores configuration definitions.
 {ProjectServer} or {SmartProxyServers} are typically deployed with the Puppet server.
-{Project} acts as an https://puppet.com/docs/puppet/8/nodes_external.html[External Node Classifier (ENC)] for such Puppet server.
+{Project} acts as an External Node Classifier (ENC) for such Puppet server.
 Hosts run the Puppet agent that communicates with the Puppet server.
 +
 The Puppet agent collects _facts_ about a host and reports them to the Puppet server on each run.
@@ -36,3 +36,6 @@ You can define the parameters in your {Project} as _key-value_ pairs, which beha
 
 Puppet environments::
 You can also create multiple Puppet environments to control versions of configuration definitions or to manage variants of the definitions, and to test the definitions before you deploy them on production.
+
+.Additional resources
+* https://puppet.com/docs/puppet/8/nodes_external.html[External Node Classifier (ENC)]

--- a/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
+++ b/guides/common/modules/con_red-hat-offline-knowledge-portal.adoc
@@ -9,4 +9,6 @@
 You can install the Red{nbsp}Hat Offline Knowledge Portal to access Red{nbsp}Hat documentation and search the Red{nbsp}Hat Knowledgebase offline in a restricted or secure network environment.
 
 By installing the Red{nbsp}Hat Offline Knowledge Portal, you can gain access to content from the Red{nbsp}Hat Customer Portal and Knowledgebase in environments with limited or no internet connectivity.
-For more information, see {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation].
+
+.Additional resources
+* {RHDocsBaseURL}red_hat_offline_knowledge_portal/1.0/html-single/user_guide/index[Red{nbsp}Hat Offline Knowledge Portal documentation]


### PR DESCRIPTION
#### What changes are you introducing?

Moving links from bodies of concept modules on 3.17 (to be cherry-picked to 3.16)

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Discovered thanks to https://github.com/theforeman/foreman-documentation/pull/5153 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I ran both AsciiDocDITA style package's ConceptLink rule and foreman-documentation style package's ConceptAttributeLink rule on all guides/common/modules/con*.adoc files when searching for what to fix.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
