### PR TITLE
Add CV assemblies to containerized guide

### DIFF
--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -79,10 +79,8 @@ include::common/assembly_managing-activation-keys.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::containerized[]
-ifdef::katello,satellite,orcharhino[]
 ifdef::katello,orcharhino[]
 include::common/assembly_managing-suse-content.adoc[leveloffset=+1]
-endif::[]
 endif::[]
 endif::[]
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -57,9 +57,11 @@ ifdef::katello,satellite,orcharhino[]
 include::common/assembly_content-access-control-for-hosts.adoc[leveloffset=+1]
 
 include::common/assembly_managing-application-lifecycles.adoc[leveloffset=+1]
-
-include::common/assembly_managing-content-views-and-content-view-environments.adoc[leveloffset=+1]
 endif::[]
+endif::[]
+
+ifdef::katello,satellite,orcharhino[]
+include::common/assembly_managing-content-views-and-content-view-environments.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]
@@ -81,9 +83,11 @@ ifdef::katello,satellite,orcharhino[]
 ifdef::katello,orcharhino[]
 include::common/assembly_managing-suse-content.adoc[leveloffset=+1]
 endif::[]
-
-include::common/assembly_making-errata-available-through-content-views.adoc[leveloffset=+1]
 endif::[]
+endif::[]
+
+ifdef::katello,satellite,orcharhino[]
+include::common/assembly_making-errata-available-through-content-views.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello,orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?

Exposing assemblies related to content views in containerized guides, namely "Managing content views and content view environments" and "Making errata available through content views".

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47727

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
