### PR TITLE
Exclude hyphenated ansible from Capitalization rule

### DIFF
--- a/.vale/styles/foreman-documentation/Capitalization.yml
+++ b/.vale/styles/foreman-documentation/Capitalization.yml
@@ -7,7 +7,7 @@ message: "Use '%s' instead of '%s' unless you are using the term in a context th
 action:
   name: replace
 swap:
-  ansible: Ansible
+  '(?<!-)ansible(?!-)': Ansible
   candlepin: candlepin
   chef: Chef
   discovery: Discovery


### PR DESCRIPTION
#### What changes are you introducing?

Updating the project's native Vale rule for capitalization conventions to ignore lowercase `ansible` when preceded or followed by `-`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/5118/changes#r3720270567

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Vale misattributes lowercase "ansible" in AsciiDoc link URL slugs (e.g. consuming-content-from-an-ansible-collection-repository) to backtick-protected paths earlier in the file. Adding negative lookbehind/lookahead for hyphens prevents matching URL fragments while still catching bare "ansible" in prose.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
