### PR TITLE
Use PUT instead of POST for lifecycle environment update

### DIFF
--- a/guides/common/modules/ref_updating-a-lifecycle-environment.adoc
+++ b/guides/common/modules/ref_updating-a-lifecycle-environment.adoc
@@ -4,7 +4,7 @@
 = Updating a lifecycle environment
 
 [role="_abstract"]
-You can modify lifecycle environment attributes such as name or description using a POST request.
+You can modify lifecycle environment attributes such as name or description using a PUT request.
 
 This example request updates a description of the lifecycle environment with ID `3`.
 
@@ -15,7 +15,7 @@ Example API request::
 $ curl \
 --header "Accept: application/json" \
 --header "Content-Type: application/json" \
---request POST \
+--request PUT \
 --user _My_User_Name_:__My_Password__ \
 --data '{"description":"Quality Acceptance Testing"}' \
 https://_{foreman-example-com}_/katello/api/environments/3 \


### PR DESCRIPTION
#### What changes are you introducing?

Fix the HTTP verb from POST to PUT for updating a lifecycle environment in the API reference.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The "Updating a lifecycle environment" section incorrectly uses --request POST instead of --request PUT. Updates should use the PUT method.
Jira: [SAT-47288](https://redhat.atlassian.net/browse/SAT-47288)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
