### PR TITLE
Add application lifecycles to containerized guide

### DIFF
--- a/guides/common/assembly_managing-application-lifecycles.adoc
+++ b/guides/common/assembly_managing-application-lifecycles.adoc
@@ -12,14 +12,18 @@ include::modules/proc_creating-a-lifecycle-environment-path-by-using-web-ui.adoc
 
 include::modules/proc_creating-a-lifecycle-environment-path-by-using-cli.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::modules/proc_adding-lifecycle-environments-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_adding-lifecycle-environments-by-using-cli.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_removing-lifecycle-environments-from-foreman-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_removing-lifecycle-environments-from-foreman-by-using-cli.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::modules/proc_removing-lifecycle-environments-from-smart-proxy-by-using-web-ui.adoc[leveloffset=+1]
 
 include::modules/proc_removing-lifecycle-environments-from-smart-proxy-by-using-cli.adoc[leveloffset=+1]
+endif::[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -54,10 +54,8 @@ ifdef::katello,satellite,orcharhino[]
 include::common/assembly_content-access-control-for-hosts.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::containerized[]
 ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-application-lifecycles.adoc[leveloffset=+1]
-endif::[]
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?

Exposing the chapter about application lifecycles in containerized guides.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47726

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
