### PR TITLE
Add alternate content sources to containerized guide

### DIFF
--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-cli.adoc
@@ -8,7 +8,9 @@ You can create a custom alternate content source (ACS) to accelerate content syn
 
 .Prerequisites
 * If the repository requires SSL authentication, the SSL certificate and key must be imported into {Project}.
+ifndef::containerized[]
 For more information, see xref:importing-custom-ssl-certificates-by-using-cli[].
+endif::[]
 ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * You have the base URL and subpaths of your alternate content source.
 For example, if your base URL is `\https://{server-example-com}` and your subpaths are `{client-os-context}-{client-os-major}/` and `{client-os-context}-{client-os-major-previous}/`, then {Project} will search `\https://{server-example-com}/{client-os-context}-{client-os-major}/` and `\https://{server-example-com}/{client-os-context}-{client-os-major-previous}/`.

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-cli.adoc
@@ -8,7 +8,7 @@ You can create a custom alternate content source (ACS) to accelerate content syn
 
 .Prerequisites
 * If the repository requires SSL authentication, the SSL certificate and key must be imported into {Project}.
-For more information, see {ContentManagementDocURL}importing-custom-ssl-certificates-by-using-cli[Importing custom SSL certificates by using Hammer CLI] in _{ContentManagementDocTitle}_.
+For more information, see xref:importing-custom-ssl-certificates-by-using-cli[].
 ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * You have the base URL and subpaths of your alternate content source.
 For example, if your base URL is `\https://{server-example-com}` and your subpaths are `{client-os-context}-{client-os-major}/` and `{client-os-context}-{client-os-major-previous}/`, then {Project} will search `\https://{server-example-com}/{client-os-context}-{client-os-major}/` and `\https://{server-example-com}/{client-os-context}-{client-os-major-previous}/`.

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
@@ -8,7 +8,9 @@ You can create a custom alternate content source (ACS) to accelerate content syn
 
 .Prerequisites
 * If the repository requires SSL authentication, the SSL certificate and key must be imported into {Project}.
+ifndef::containerized[]
 For more information, see xref:importing-content-credentials-by-using-web-ui[].
+endif::[]
 ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * You have the base URL and subpaths of your alternate content source.
 For example, if your base URL is `\https://{server-example-com}` and your subpaths are `{client-os-context}-{client-os-major}/` and `{client-os-context}-{client-os-major-previous}/`, then {Project} will search `\https://{server-example-com}/{client-os-context}-{client-os-major}/` and `\https://{server-example-com}/{client-os-context}-{client-os-major-previous}/`.

--- a/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-a-custom-alternate-content-source-by-using-web-ui.adoc
@@ -8,7 +8,7 @@ You can create a custom alternate content source (ACS) to accelerate content syn
 
 .Prerequisites
 * If the repository requires SSL authentication, the SSL certificate and key must be imported into {Project}.
-For more information, see {ContentManagementDocURL}importing-content-credentials-by-using-web-ui[Importing content credentials by using {ProjectWebUI}] in _{ContentManagementDocTitle}_.
+For more information, see xref:importing-content-credentials-by-using-web-ui[].
 ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 * You have the base URL and subpaths of your alternate content source.
 For example, if your base URL is `\https://{server-example-com}` and your subpaths are `{client-os-context}-{client-os-major}/` and `{client-os-context}-{client-os-major-previous}/`, then {Project} will search `\https://{server-example-com}/{client-os-context}-{client-os-major}/` and `\https://{server-example-com}/{client-os-context}-{client-os-major-previous}/`.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -117,7 +117,7 @@ endif::[]
 
 ifdef::katello[]
 [appendix]
-include::common/modules/ref_troubleshooting-synchronization-errors.adoc[leveloffset+=1]
+include::common/modules/ref_troubleshooting-synchronization-errors.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -42,10 +42,8 @@ ifdef::katello,satellite,orcharhino[]
 include::common/assembly_synchronizing-content-to-foreman.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::containerized[]
 ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-alternate-content-sources.adoc[leveloffset=+1]
-endif::[]
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]


### PR DESCRIPTION
#### What changes are you introducing?

Exposing the chapter "Managing alternate content sources" in containerized guides

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47723

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This PR involves excluding some xrefs from the containerized builds. I have a downstream tracker https://redhat.atlassian.net/browse/SAT-48590 to make sure we re-include these and similar xrefs after the respective sections are also included.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
