### PR TITLE
Fix style issue to Managing Security Compliance

### DIFF
--- a/guides/common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc
+++ b/guides/common/modules/proc_applying-remote-scap-resources-in-a-disconnected-environment.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="applying-remote-scap-resources-in-a-disconnected-environment_{context}"]
+[id="applying-remote-scap-resources-in-a-disconnected-environment"]
 = Applying remote SCAP resources in a disconnected environment
 
 [role="_abstract"]
@@ -10,7 +10,7 @@ If your hosts do not have internet access, you must download remote SCAP resourc
 .Prerequisites
 * You have registered your host to {Project} with remote execution enabled.
 * Fetching remote resources must be disabled, which is the default.
-For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
+For more information, see xref:inclusion-of-remote-scap-resources[].
 
 .Procedure
 . On your {ProjectServer}, examine the data stream you use in your compliance policy to find out which missing resource you must download:

--- a/guides/common/modules/proc_creating-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_creating-a-compliance-policy.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Creating_a_Compliance_Policy_{context}"]
+[id="creating-a-compliance-policy"]
 = Creating a compliance policy
 
 [role="_abstract"]
 By creating a compliance policy, you can define and plan your security compliance requirements, and ensure that your hosts remain compliant to your security policies.
 
 .Prerequisites
-* You have configured {Project} for your selected xref:compliance-policy-deployment-options_{context}[compliance policy deployment method].
+* You have configured {Project} for your selected xref:compliance-policy-deployment-options[compliance policy deployment method].
 * You have available SCAP contents, and eventually tailoring files, in {Project}.
 ** To verify what SCAP contents are available by using {ProjectWebUI}, see xref:listing-available-scap-contents-using-web-ui[].
 ** To verify what SCAP contents are available by using CLI, see xref:listing-available-scap-contents-using-cli[].

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_in_a_Host_Group_Using_Ansible_{context}"]
+[id="deploying-a-policy-in-a-host-group-using-ansible"]
 = Deploying a policy in a host group using Ansible
 
 [role="_abstract"]
 After you deploy a compliance policy in a host group using Ansible, the Ansible role installs the SCAP client and configures OpenSCAP scans on the hosts according to the selected compliance policy.
 
 The SCAP content in the compliance policy might require remote resources.
-For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
+For more information, see xref:inclusion-of-remote-scap-resources[].
 
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Ansible deployment option and assigned the host group.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Ansible deployment option and assigned the host group.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_in_a_Host_Group_Using_Puppet_{context}"]
+[id="deploying-a-policy-in-a-host-group-using-puppet"]
 = Deploying a policy in a host group using Puppet
 
 [role="_abstract"]
 After you deploy a compliance policy in a host group using Puppet, the OpenVox agent installs the SCAP client and configures OpenSCAP scans on the hosts on the next Puppet run according to the selected compliance policy.
 
 The SCAP content in your compliance policy might require remote resources.
-For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
+For more information, see xref:inclusion-of-remote-scap-resources[].
 
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Puppet deployment option and assigned the host group.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Puppet deployment option and assigned the host group.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_on_a_Host_Using_Ansible_{context}"]
+[id="deploying-a-policy-on-a-host-using-ansible"]
 = Deploying a policy on a host using Ansible
 
 [role="_abstract"]
 After you deploy a compliance policy on a host using Ansible, the Ansible role installs the SCAP client and configures OpenSCAP scans on the host according to the selected compliance policy.
 
 The SCAP content in the compliance policy might require remote resources.
-For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
+For more information, see xref:inclusion-of-remote-scap-resources[].
 
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Ansible deployment option.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Ansible deployment option.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_on_a_Host_Using_Puppet_{context}"]
+[id="deploying-a-policy-on-a-host-using-puppet"]
 = Deploying a policy on a host using Puppet
 
 [role="_abstract"]
 After you deploy a compliance policy on a host using Puppet, the OpenVox agent installs the SCAP client and configures OpenSCAP scans on the host on the next Puppet run according to the selected compliance policy.
 
 The SCAP content in your compliance policy might require remote resources.
-For more information, see xref:inclusion-of-remote-scap-resources_{context}[].
+For more information, see xref:inclusion-of-remote-scap-resources[].
 
 .Prerequisites
 * You have enabled OpenSCAP on your {SmartProxy}.
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Puppet deployment option.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Puppet deployment option.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/ref_compliance-policy-deployment-options.adoc
+++ b/guides/common/modules/ref_compliance-policy-deployment-options.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="compliance-policy-deployment-options_{context}"]
+[id="compliance-policy-deployment-options"]
 = Compliance policy deployment options
 
 [role="_abstract"]

--- a/guides/common/modules/ref_inclusion-of-remote-scap-resources.adoc
+++ b/guides/common/modules/ref_inclusion-of-remote-scap-resources.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="inclusion-of-remote-scap-resources_{context}"]
+[id="inclusion-of-remote-scap-resources"]
 = Inclusion of remote SCAP resources
 
 [role="_abstract"]
@@ -24,7 +24,7 @@ The skipped rules then result in the `notchecked` status.
 
 For hosts with internet access, you can enable the download of remote resources on hosts in {Project}.
 ifdef::orcharhino,satellite[]
-For information about applying remote SCAP resources to hosts that cannot access the internet, see xref:applying-remote-scap-resources-in-a-disconnected-environment_{context}[].
+For information about applying remote SCAP resources to hosts that cannot access the internet, see xref:applying-remote-scap-resources-in-a-disconnected-environment[].
 endif::[]
 
 Using the Ansible deployment method::


### PR DESCRIPTION
(Deploying compliance policies) and all related xrefs.

Addressing issues found in Issue #4214 by removing deprecated {context} tags in headings.

Because this issue is broad and covers multiple sections throughout the entire Managing Security Compliance guide, PRs are broken into chapter reviews per Endeavor's guidance.

This PR relates to Section 5, Deploying compliance policies and all related xref links in that section.

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
