### PR TITLE
Fix external usergroup refresh interval

### DIFF
--- a/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc
+++ b/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc
@@ -8,7 +8,7 @@ You can refresh external user groups manually.
 This is useful if you want to immediately update membership changes from your LDAP source.
 
 To set the LDAP source to synchronize user group membership automatically on user login, in the *Auth Source* page, select the *Usergroup Sync* option.
-If this option is not selected, LDAP user groups are refreshed automatically through a scheduled cron job synchronizing the LDAP Authentication source every 30 minutes by default.
+If this option is not selected, LDAP user groups are refreshed automatically through a scheduled cron job synchronizing the LDAP Authentication source every hour by default.
 
 If the user groups in the LDAP Authentication source change in the lapse of time between scheduled tasks, the user can be assigned to incorrect external user groups.
 This is corrected automatically when the scheduled task runs.

--- a/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc
+++ b/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc
@@ -8,7 +8,7 @@ You can refresh external user groups manually.
 This is useful if you want to immediately update membership changes from your LDAP source.
 
 To set the LDAP source to synchronize user group membership automatically on user login, in the *Auth Source* page, select the *Usergroup Sync* option.
-If this option is not selected, LDAP user groups are refreshed automatically through a scheduled cron job synchronizing the LDAP Authentication source every hour by default.
+If this option is not selected, LDAP user groups are refreshed automatically every hour by default.
 
 If the user groups in the LDAP Authentication source change in the lapse of time between scheduled tasks, the user can be assigned to incorrect external user groups.
 This is corrected automatically when the scheduled task runs.

--- a/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-web-ui.adoc
+++ b/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-web-ui.adoc
@@ -8,7 +8,7 @@ You can refresh external user groups manually.
 This is useful if you want to immediately update membership changes from your LDAP source.
 
 To set the LDAP source to synchronize user group membership automatically on user login, in the *Auth Source* page, select the *Usergroup Sync* option.
-If this option is not selected, LDAP user groups are refreshed automatically through a scheduled cron job synchronizing the LDAP Authentication source every 30 minutes by default.
+If this option is not selected, LDAP user groups are refreshed automatically through a scheduled cron job synchronizing the LDAP Authentication source every hour by default.
 
 If the user groups in the LDAP Authentication source change in the lapse of time between scheduled tasks, the user can be assigned to incorrect external user groups.
 This is corrected automatically when the scheduled task runs.

--- a/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-web-ui.adoc
+++ b/guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-web-ui.adoc
@@ -8,7 +8,7 @@ You can refresh external user groups manually.
 This is useful if you want to immediately update membership changes from your LDAP source.
 
 To set the LDAP source to synchronize user group membership automatically on user login, in the *Auth Source* page, select the *Usergroup Sync* option.
-If this option is not selected, LDAP user groups are refreshed automatically through a scheduled cron job synchronizing the LDAP Authentication source every hour by default.
+If this option is not selected, LDAP user groups are refreshed automatically every hour by default.
 
 If the user groups in the LDAP Authentication source change in the lapse of time between scheduled tasks, the user can be assigned to incorrect external user groups.
 This is corrected automatically when the scheduled task runs.


### PR DESCRIPTION
#### What changes are you introducing?
Changing the interval at which `ldap:refresh_usergroups` rake task is expected to run.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
`ldap:refresh_usergroups` rake task used to be run by cron every 30 minutes. In https://github.com/theforeman/foreman/pull/10784 and https://github.com/theforeman/foreman-packaging/pull/13001 it was changed to run every hour.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
