### PR TITLE
Fix build error

### DIFF
--- a/guides/common/assembly_logging-and-reporting-problems.adoc
+++ b/guides/common/assembly_logging-and-reporting-problems.adoc
@@ -20,9 +20,9 @@ ifdef::katello,orcharhino,satellite[]
 include::modules/proc_increasing-the-logging-level-for-pulp.adoc[leveloffset=+2]
 endif::[]
 
-include::modules/proc_increasing-the-logging-level-for-puppet-agent.adoc[leveloffset=+2]
+include::modules/proc_increasing-the-logging-level-for-openvox-agent.adoc[leveloffset=+2]
 
-include::modules/proc_increasing-the-logging-level-for-puppet-server.adoc[leveloffset=+2]
+include::modules/proc_increasing-the-logging-level-for-openvox-server.adoc[leveloffset=+2]
 
 ifndef::satellite[]
 include::modules/proc_increasing-the-logging-level-for-salt.adoc[leveloffset=+2]


### PR DESCRIPTION
#### What changes are you introducing?

https://github.com/theforeman/foreman-documentation/pull/5027 renamed two Puppet modules but their include references in Admin are currently still using the original name. I'm updating those includes.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To fix a build error on 3.15

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
