### PR TITLE
Display manual procedures for external usergroup refresh in containerized deployments

### DIFF
--- a/guides/common/assembly_managing-external-user-groups.adoc
+++ b/guides/common/assembly_managing-external-user-groups.adoc
@@ -4,6 +4,6 @@ include::modules/proc_associating-external-users-with-user-groups.adoc[leveloffs
 
 ifndef::containerized[]
 include::modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_refreshing-external-user-groups-for-ldap-using-web-ui.adoc[leveloffset=+1]
-endif::[]

--- a/guides/common/assembly_managing-external-user-groups.adoc
+++ b/guides/common/assembly_managing-external-user-groups.adoc
@@ -3,6 +3,9 @@ include::modules/con_managing-external-user-groups.adoc[]
 include::modules/proc_associating-external-users-with-user-groups.adoc[leveloffset=+1]
 
 ifndef::containerized[]
+// While this is available and seems to work, we want to drop this in favor of
+// the other mechanisms (periodic sync through systemd timers, manual refresh using
+// WebUI). Keep things hidden rather than displaying this and then removing it again.
 include::modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?
Display manual procedures for external usergroup refresh in containerized deployments.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
The procedures are currently hidden, even though both should be available and functional.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Eventually, we'd like the CLI procedure to go away, but as of now, it is there and should work. 

Keeping as a draft until I double check that those do actually work.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
