### PR TITLE
Clean up style issues in Managing Security (Configuring SCAP contents for compliance policies in Foremanthan)

### DIFF
--- a/guides/common/modules/proc_creating-a-compliance-policy.adoc
+++ b/guides/common/modules/proc_creating-a-compliance-policy.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Creating_a_Compliance_Policy_{context}"]
+[id="creating-a-compliance-policy"]
 = Creating a compliance policy
 
 [role="_abstract"]
 By creating a compliance policy, you can define and plan your security compliance requirements, and ensure that your hosts remain compliant to your security policies.
 
 .Prerequisites
-* You have configured {Project} for your selected xref:compliance-policy-deployment-options_{context}[compliance policy deployment method].
+* You have configured {Project} for your selected xref:compliance-policy-deployment-options[compliance policy deployment method].
 * You have available SCAP contents, and eventually tailoring files, in {Project}.
 ** To verify what SCAP contents are available by using {ProjectWebUI}, see xref:listing-available-scap-contents-using-web-ui[].
 ** To verify what SCAP contents are available by using CLI, see xref:listing-available-scap-contents-using-cli[].

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-ansible.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_in_a_Host_Group_Using_Ansible_{context}"]
+[id="deploying-a-policy-in-a-host-group-using-ansible"]
 = Deploying a policy in a host group using Ansible
 
 [role="_abstract"]
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Ansible deployment option and assigned the host group.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Ansible deployment option and assigned the host group.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.

--- a/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-in-a-host-group-using-puppet.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_in_a_Host_Group_Using_Puppet_{context}"]
+[id="deploying-a-policy-in-a-host-group-using-puppet"]
 = Deploying a policy in a host group using Puppet
 
 [role="_abstract"]
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Puppet deployment option and assigned the host group.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Puppet deployment option and assigned the host group.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Configure* > *Host Groups*.

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-ansible.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_on_a_Host_Using_Ansible_{context}"]
+[id="deploying-a-policy-on-a-host-using-ansible"]
 = Deploying a policy on a host using Ansible
 
 [role="_abstract"]
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Ansible deployment option.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Ansible deployment option.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
+++ b/guides/common/modules/proc_deploying-a-policy-on-a-host-using-puppet.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Deploying_a_Policy_on_a_Host_Using_Puppet_{context}"]
+[id="deploying-a-policy-on-a-host-using-puppet"]
 = Deploying a policy on a host using Puppet
 
 [role="_abstract"]
@@ -17,7 +17,7 @@ include::snip_prerequisite-repositories-with-oscap.adoc[]
 +
 include::snip_prerequisite-project-client-repository-enabled.adoc[]
 This repository is required for installing the SCAP client.
-* You have xref:Creating_a_Compliance_Policy_{context}[created a compliance policy] with the Puppet deployment option.
+* You have xref:creating-a-compliance-policy[created a compliance policy] with the Puppet deployment option.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/proc_getting-supported-scap-contents-for-rhel.adoc
+++ b/guides/common/modules/proc_getting-supported-scap-contents-for-rhel.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="getting-supported-scap-contents-for-rhel_{context}"]
+[id="getting-supported-scap-contents-for-rhel"]
 = Getting supported SCAP contents for RHEL
 
 [role="_abstract"]

--- a/guides/common/modules/proc_listing-available-scap-contents-using-cli.adoc
+++ b/guides/common/modules/proc_listing-available-scap-contents-using-cli.adoc
@@ -11,7 +11,7 @@ You can use Hammer CLI to view available SCAP contents.
 * Your user account has a role assigned that has the `view_scap_contents` permission.
 
 .Procedure
-* Run the following Hammer command on {ProjectServer}:
+* List SCAP contents on {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----

--- a/guides/common/modules/proc_listing-available-scap-contents-using-cli.adoc
+++ b/guides/common/modules/proc_listing-available-scap-contents-using-cli.adoc
@@ -11,7 +11,7 @@ You can use Hammer CLI to view available SCAP contents.
 * Your user account has a role assigned that has the `view_scap_contents` permission.
 
 .Procedure
-* List SCAP contents on {ProjectServer}:
+* List available SCAP contents on {ProjectServer}:
 +
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----

--- a/guides/common/modules/proc_loading-the-default-scap-contents.adoc
+++ b/guides/common/modules/proc_loading-the-default-scap-contents.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 
-[id="Loading_the_Default_SCAP_Contents_{context}"]
+[id="loading-the-default-scap-contents"]
 = Loading the default SCAP contents
 
 [role="_abstract"]
@@ -10,7 +10,7 @@ SSG is provided by the operating system of {ProjectServer} and installed in `/us
 Note that the available data streams depend on the operating system version on which {Project} runs.
 ifdef::satellite[]
 You can only use this SCAP content to scan hosts that have the same minor RHEL version as your {ProjectServer}.
-For more information, see xref:getting-supported-scap-contents-for-rhel_{context}[].
+For more information, see xref:getting-supported-scap-contents-for-rhel[].
 endif::[]
 
 ifdef::satellite[]

--- a/guides/common/modules/proc_propagating-scap-content-using-ansible-deployment.adoc
+++ b/guides/common/modules/proc_propagating-scap-content-using-ansible-deployment.adoc
@@ -26,8 +26,8 @@ For more information, see {ManagingSecurityDocURL}configuring-compliance-policy-
 . Click *Submit*.
 . Continue with deploying a compliance policy using Ansible.
 For more information, see:
-* {ManagingSecurityDocURL}Deploying_a_Policy_in_a_Host_Group_Using_Ansible_security-compliance[Deploying a Policy in a Host Group Using Ansible] in _{ManagingSecurityDocTitle}_
-* {ManagingSecurityDocURL}Deploying_a_Policy_on_a_Host_Using_Ansible_security-compliance[Deploying a Policy on a Host Using Ansible] in _{ManagingSecurityDocTitle}_
+* {ManagingSecurityDocURL}deploying-a-policy-in-a-host-group-using-ansible-security-compliance[Deploying a Policy in a Host Group Using Ansible] in _{ManagingSecurityDocTitle}_
+* {ManagingSecurityDocURL}deploying-a-policy-on-a-host-using-ansible-security-compliance[Deploying a Policy on a Host Using Ansible] in _{ManagingSecurityDocTitle}_
 
 .Verification
 * On the client, verify that the `/etc/foreman_scap_client/config.yaml` file contains the following lines:

--- a/guides/common/modules/proc_propagating-scap-content-using-puppet-deployment.adoc
+++ b/guides/common/modules/proc_propagating-scap-content-using-puppet-deployment.adoc
@@ -25,8 +25,8 @@ For more information, see {ManagingSecurityDocURL}configuring-compliance-policy-
 . In the lower left of the *Smart Class Parameter* window, click *Submit*.
 . Continue with deploying a compliance policy using Puppet.
 For more information, see:
-* {ManagingSecurityDocURL}Deploying_a_Policy_in_a_Host_Group_Using_Puppet_security-compliance[Deploying a Policy in a Host Group Using Puppet] in _{ManagingSecurityDocTitle}_
-* {ManagingSecurityDocURL}Deploying_a_Policy_on_a_Host_Using_Puppet_security-compliance[Deploying a Policy on a Host Using Puppet] in _{ManagingSecurityDocTitle}_
+* {ManagingSecurityDocURL}deploying-a-policy-in-a-host-group-using-puppet-security-compliance[Deploying a Policy in a Host Group Using Puppet] in _{ManagingSecurityDocTitle}_
+* {ManagingSecurityDocURL}deploying-a-policy-on-a-host-using-puppet-security-compliance[Deploying a Policy on a Host Using Puppet] in _{ManagingSecurityDocTitle}_
 
 .Verification
 * On the client, verify that the `/etc/foreman_scap_client/config.yaml` file contains the following lines:

--- a/guides/common/modules/proc_uploading-additional-scap-content-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-additional-scap-content-using-cli.adoc
@@ -23,11 +23,12 @@ endif::[]
 
 .Procedure
 . Place the SCAP data-stream file to a directory on your {ProjectServer}, such as `_/usr/share/xml/scap/my_content/_`.
-. Run the following Hammer command on {ProjectServer}:
+. On {ProjectServer}, upload the additional SCAP contents:
 +
 [options="nowrap", subs="+quotes,attributes,verbatim"]
 ----
-$ hammer scap-content bulk-upload --type directory \
+$ hammer scap-content bulk-upload \
+--type directory \
 --directory _/usr/share/xml/scap/my_content/_ \
 --location "_My_Location_" \
 --organization "_My_Organization_"

--- a/guides/common/modules/proc_uploading-additional-scap-content-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-additional-scap-content-using-web-ui.adoc
@@ -4,7 +4,7 @@
 = Uploading additional SCAP content using {ProjectWebUI}
 
 [role="_abstract"]
-You can upload additional SCAP content into {ProjectServer}, either content created by yourself or obtained elsewhere.
+You can upload additional SCAP contents into {ProjectServer}, either content created by yourself or obtained elsewhere.
 ifndef::satellite[]
 For example, you can get the latest OpenSCAP contents for additional systems from the https://github.com/ComplianceAsCode/content/releases[SSG GitHub repository].
 endif::[]
@@ -12,7 +12,7 @@ endif::[]
 ifdef::satellite[]
 [NOTE]
 ====
-{Team} only provides support for SCAP content obtained from {Team}.
+{Team} only provides support for SCAP contents obtained from {Team}.
 ====
 endif::[]
 

--- a/guides/common/modules/ref_compliance-policy-deployment-options.adoc
+++ b/guides/common/modules/ref_compliance-policy-deployment-options.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="compliance-policy-deployment-options_{context}"]
+[id="compliance-policy-deployment-options"]
 = Compliance policy deployment options
 
 [role="_abstract"]


### PR DESCRIPTION

#### What changes are you introducing?
Addressing issues found in Issue #4214 by removing deprecated {context} tags in headings. Also addressing other formatting issues within Configuring SCAP contents for compliance policies in Foreman.


#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Because this issue is broad and covers multiple sections throughout the entire Managing Security Compliance guide, PRs are broken into chapter reviews per engineering's guidance.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
