### PR TITLE
Add 'adding content' to containerized guides

### DIFF
--- a/guides/common/modules/con_adding-content-to-foreman.adoc
+++ b/guides/common/modules/con_adding-content-to-foreman.adoc
@@ -5,7 +5,3 @@
 
 [role="_abstract"]
 Start adding content to {Project} by organizing products and repositories, securing upstream connections, and synchronizing or uploading packages for your hosts.
-
-ifdef::katello,suse_linux_enterprise_server[]
-include::snip_tip-scc-manager.adoc[]
-endif::[]

--- a/guides/common/modules/proc_enabling-red-hat-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories-by-using-cli.adoc
@@ -14,8 +14,10 @@ ifndef::orcharhino[]
 For more information, see {InstallingServerDocURL}adding-a-default-http-proxy-by-using-cli[Adding a default HTTP proxy by using Hammer CLI].
 endif::[]
 * Your Red{nbsp}Hat subscription manifest is imported to your organization and contains subscriptions.
+ifndef::containerized[]
 ifndef::orcharhino[]
 For more information, see xref:importing-red-hat-subscription-manifests-into-{project-context}[].
+endif::[]
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_enabling-red-hat-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories-by-using-cli.adoc
@@ -21,7 +21,7 @@ endif::[]
 endif::[]
 
 .Procedure
-. Search for your product:
+. List Red Hat products:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_enabling-red-hat-repositories-by-using-cli.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories-by-using-cli.adoc
@@ -21,7 +21,7 @@ endif::[]
 endif::[]
 
 .Procedure
-. List Red Hat products:
+. List Red{nbsp}Hat products:
 +
 [options="nowrap" subs="+quotes"]
 ----

--- a/guides/common/modules/proc_enabling-red-hat-repositories-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_enabling-red-hat-repositories-by-using-web-ui.adoc
@@ -14,8 +14,10 @@ ifndef::orcharhino[]
 For more information, see {InstallingServerDocURL}adding-a-default-http-proxy-by-using-web-ui[Adding a default HTTP proxy by using {ProjectWebUI}].
 endif::[]
 * Your Red{nbsp}Hat subscription manifest is imported to your organization and contains subscriptions.
+ifndef::containerized[]
 ifndef::orcharhino[]
 For more information, see xref:importing-red-hat-subscription-manifests-into-{project-context}[].
+endif::[]
 endif::[]
 
 .Procedure

--- a/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-cli.adoc
@@ -39,7 +39,9 @@ $ hammer settings set --name foreman_tasks_sync_task_timeout --value _seconds_
 
 .Next steps
 * Add your {customrpm} repository to a content view.
+ifndef::containerized[]
 For more information, see xref:creating-a-content-view-by-using-cli[].
+endif::[]
 * If your {customrpm} is unprotected, hosts can consume its content by using the *Published At* URL.
 +
 In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.

--- a/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-custom-rpm-repository-by-using-web-ui.adoc
@@ -26,7 +26,9 @@ The *Sync task timeout* setting is located on the *Tasks* tab.
 
 .Next steps
 * Add your {customrpm} repository to a content view.
+ifndef::containerized[]
 For more information, see xref:creating-a-content-view-by-using-web-ui[].
+endif::[]
 * If your {customrpm} is unprotected, hosts can consume its content by using the *Published At* URL.
 +
 In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.

--- a/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-cli.adoc
@@ -35,7 +35,9 @@ $ hammer settings set --name foreman_tasks_sync_task_timeout --value _seconds_
 
 .Next steps
 * Add your Deb repository to a content view.
+ifndef::containerized[]
 For more information, see xref:creating-a-content-view-by-using-cli[].
+endif::[]
 * If your Deb repository is unprotected, hosts can consume its content by using the *Published At* URL.
 +
 In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.

--- a/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_uploading-content-to-a-deb-repository-by-using-web-ui.adoc
@@ -24,7 +24,9 @@ The *Sync task timeout* setting is located on the *Tasks* tab.
 
 .Next steps
 * Add your Deb repository to a content view.
+ifndef::containerized[]
 For more information, see xref:creating-a-content-view-by-using-web-ui[].
+endif::[]
 * If your Deb repository is unprotected, hosts can consume its content by using the *Published At* URL.
 +
 In the Default Organization View content view, the URL consists of your {SmartProxy} FQDN, `/pulp/content/`, your organization label, `/Library/custom/`, your product label, `/`, your repository label, and a trailing `/`, for example, `\https://foreman.example.com/pulp/content/Example/Library/custom/my-software/my-app/`.

--- a/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
+++ b/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
@@ -26,10 +26,6 @@ ifndef::containerized[]
 For more information, see xref:Managing_Red_Hat_Subscriptions_{context}[].
 endif::[]
 endif::[]
-ifdef::katello,suse_linux_enterprise_server[]
-* For SUSE content, use the SCC Manager plugin.
-For more information, see xref:Managing_SUSE_Content_{context}[].
-endif::[]
 ifdef::katello,oracle_linux[]
 * For Oracle Linux content, including ULN repositories, set the mirroring policy to *Additive* and the *Retain package versions* to either one or two.
 This mitigates out-of-memory issues on {ProjectServer} when synchronizing the content from Oracle.

--- a/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
+++ b/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
@@ -22,7 +22,9 @@ If you set *Protected* to true, you can only download content using a global deb
 * Automate the creation of multiple products and repositories by using a Hammer script or an {ansible-docs-url}[Ansible Playbook].
 ifdef::katello,satellite,red_hat_enterprise_linux[]
 * For Red Hat content, import your Red Hat manifest into {Project}.
+ifndef::containerized[]
 For more information, see xref:Managing_Red_Hat_Subscriptions_{context}[].
+endif::[]
 endif::[]
 ifdef::katello,suse_linux_enterprise_server[]
 * For SUSE content, use the SCC Manager plugin.

--- a/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
+++ b/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
@@ -25,6 +25,7 @@ ifdef::katello,satellite,red_hat_enterprise_linux[]
 ifndef::containerized[]
 For more information, see xref:Managing_Red_Hat_Subscriptions_{context}[].
 endif::[]
+endif::[]
 ifdef::katello,suse_linux_enterprise_server[]
 * For SUSE content, use the SCC Manager plugin.
 ifndef::containerized[]

--- a/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
+++ b/guides/common/modules/ref_best-practices-for-products-and-repositories.adoc
@@ -25,6 +25,11 @@ ifdef::katello,satellite,red_hat_enterprise_linux[]
 ifndef::containerized[]
 For more information, see xref:Managing_Red_Hat_Subscriptions_{context}[].
 endif::[]
+ifdef::katello,suse_linux_enterprise_server[]
+* For SUSE content, use the SCC Manager plugin.
+ifndef::containerized[]
+For more information, see xref:Managing_SUSE_Content_{context}[].
+endif::[]
 endif::[]
 ifdef::katello,oracle_linux[]
 * For Oracle Linux content, including ULN repositories, set the mirroring policy to *Additive* and the *Retain package versions* to either one or two.

--- a/guides/common/modules/snip_tip-scc-manager.adoc
+++ b/guides/common/modules/snip_tip-scc-manager.adoc
@@ -1,7 +1,0 @@
-:_mod-docs-content-type: SNIPPET
-
-[TIP]
-====
-You can use the SCC Manager plugin to import content from SUSE into {Project}.
-For more information, see xref:Managing_SUSE_Content_{context}[].
-====

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -33,12 +33,12 @@ include::common/assembly_basic-content-management-workflow.adoc[leveloffset=+1]
 endif::[]
 
 include::common/assembly_managing-red-hat-subscriptions.adoc[leveloffset=+1]
-
-include::common/assembly_adding-content-to-foreman.adoc[leveloffset=+1]
 endif::[]
 endif::[]
 
 ifdef::katello,satellite,orcharhino[]
+include::common/assembly_adding-content-to-foreman.adoc[leveloffset=+1]
+
 include::common/assembly_synchronizing-content-to-foreman.adoc[leveloffset=+1]
 endif::[]
 


### PR DESCRIPTION
#### What changes are you introducing?

Adding the chapter on adding content to containerized guides

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47722

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
