### PR TITLE
Include the three sections into containerized version of Administering Satellite guide

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -57,6 +57,8 @@ ifdef::satellite[]
 include::common/assembly_usage-metrics-collection-in-project.adoc[leveloffset=+1]
 endif::[]
 
+endif::[]
+
 ifdef::satellite[]
 include::common/assembly_managing-organizations-in-project.adoc[leveloffset=+1]
 
@@ -65,6 +67,7 @@ endif::[]
 
 include::common/assembly_managing-users-and-roles.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::common/assembly_creating-and-managing-roles.adoc[leveloffset=+1]
 
 include::common/assembly_configuring-email-notifications.adoc[leveloffset=+1]


### PR DESCRIPTION

#### What changes are you introducing?
Include "Managing organizations in Satellite", "Managing locations in Satellite", and "Managing Users and Roles in Satellite" to the containerized version of the Administering Satellite guide. 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
These sections required no changes and are needed for the containerized version, so they are grouped together.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
