### PR TITLE
Add content access control to containerized builds

### DIFF
--- a/guides/common/modules/ref_content-access-strategies.adoc
+++ b/guides/common/modules/ref_content-access-strategies.adoc
@@ -11,10 +11,12 @@ Evaluate those options from lifecycle environments through overrides toward the 
 
 Content views and lifecycle environments::
 Use content views and lifecycle environments, incorporating content view filters as needed.
+ifndef::containerized[]
 +
 For more information about content views, see xref:managing-content-views-and-content-view-environments[].
 +
 For more information about lifecycle environments, see xref:Managing_Application_Lifecycles_{context}[].
+endif::[]
 
 Content overrides::
 By default, content hosted by {Project} can be either enabled or disabled.
@@ -41,11 +43,15 @@ For more information about adding content overrides to activation keys, see xref
 
 Content view environments::
 Assign hosts to multiple content view environments to provide access to content from more than one content view.
+ifndef::containerized[]
 For more information about multiple content view environments, see xref:managing-content-view-environments[].
+endif::[]
 
 Composite content views::
 You can use composite content views to combine and give hosts access to the content from multiple content views.
+ifndef::containerized[]
 For more information about composite content views, see xref:creating-a-composite-content-view-by-using-web-ui[].
+endif::[]
 
 Architecture and operating system version restrictions::
 In custom products, you can set restrictions on the architecture and operating system versions for `{client-content-type}` repositories on which the product will be available.

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -50,10 +50,12 @@ ifdef::katello,satellite,orcharhino[]
 include::common/assembly_optimizing-content-synchronization-and-storage.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::containerized[]
 ifdef::katello,satellite,orcharhino[]
 include::common/assembly_content-access-control-for-hosts.adoc[leveloffset=+1]
+endif::[]
 
+ifndef::containerized[]
+ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-application-lifecycles.adoc[leveloffset=+1]
 
 include::common/assembly_managing-content-views-and-content-view-environments.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Adding content access control to containerized builds

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47725

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
