### PR TITLE
Add managing container images, flatpaks, and ISOs to containerized

### DIFF
--- a/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
+++ b/guides/common/modules/con_managing-flatpak-repositories-in-project.adoc
@@ -18,7 +18,6 @@ include::snip_important-consuming-content-requires-a-subscription.adoc[]
 endif::[]
 
 .Additional resources
-* xref:Synchronizing_Content_Between_Servers_{context}[]
 * {ManagingHostsDocURL}installing-flatpak-applications-on-hosts[Installing Flatpak applications on hosts in _{ManagingHostsDocTitle}_]
 ifdef::katello,satellite,red_hat_enterprise_linux[]
 * {RHELDocsBaseURL}9/html/administering_the_system_using_the_gnome_desktop_environment/assembly_installing-applications-using-flatpak_administering-the-system-using-the-gnome-desktop-environment[Installing applications using Flatpak]

--- a/guides/common/modules/proc_importing-a-container-image-repository-by-using-cli.adoc
+++ b/guides/common/modules/proc_importing-a-container-image-repository-by-using-cli.adoc
@@ -39,5 +39,7 @@ $ hammer repository synchronize \
 --product "{client-container-product-name}"
 ----
 
+ifndef::containerized[]
 .Additional resources
 * xref:adding-content-to-{project-context}[]
+endif::[]

--- a/guides/common/modules/proc_importing-a-container-image-repository-manually-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_importing-a-container-image-repository-manually-by-using-web-ui.adoc
@@ -22,5 +22,7 @@ Manually import a container image repository in the {ProjectWebUI} when you know
 * When the synchronization completes, you can click *Container Image Manifests* to list the available manifests.
 From the list, you can also remove any manifests that you do not require.
 
+ifndef::containerized[]
 .Additional resources
 * xref:adding-content-to-{project-context}[]
+endif::[]

--- a/guides/common/modules/proc_pushing-container-images-to-project.adoc
+++ b/guides/common/modules/proc_pushing-container-images-to-project.adoc
@@ -14,7 +14,9 @@ For more information, see one of the following resources:
 ** xref:configuring-docker-to-trust-the-certificate-authority[]
 * Your {Project} account has the `edit_products` permission.
 * A product exists in your organization.
+ifndef::containerized[]
 For more information, see xref:creating-a-custom-product-by-using-web-ui[].
+endif::[]
 * Your {Project} account has the `create_personal_access_tokens` permission.
 {Project} automatically generates a token when you run `podman login`.
 

--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -88,14 +88,16 @@ ifdef::katello,orcharhino[]
 include::common/assembly_managing-ostree-content.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::containerized[]
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_managing-container-images.adoc[leveloffset=+1]
 
 include::common/assembly_managing-flatpak-repositories-in-project.adoc[leveloffset=+1]
 
 include::common/assembly_managing-iso-images.adoc[leveloffset=+1]
+endif::[]
 
+ifndef::containerized[]
+ifdef::katello,orcharhino,satellite[]
 include::common/assembly_managing-ansible-content.adoc[leveloffset=+1]
 endif::[]
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding managing container images, flatpaks, and ISOs to containerized

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47732

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
