### PR TITLE
Add Ansible and Python content management to containerized

### DIFF
--- a/guides/doc-Managing_Content/master.adoc
+++ b/guides/doc-Managing_Content/master.adoc
@@ -98,20 +98,14 @@ include::common/assembly_managing-flatpak-repositories-in-project.adoc[leveloffs
 include::common/assembly_managing-iso-images.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::containerized[]
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_managing-ansible-content.adoc[leveloffset=+1]
-endif::[]
-endif::[]
 
-ifdef::katello,satellite,orcharhino[]
 include::common/assembly_managing-custom-file-type-content-in-project.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::containerized[]
 ifdef::katello,orcharhino[]
 include::common/assembly_managing-python-content-in-project.adoc[leveloffset=+1]
-endif::[]
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

~~Adding SUSE, Ansible, and Python content management to containerized~~

Adding Ansible, and Python content management to containerized

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To extend our containerized docs set.

https://redhat.atlassian.net/browse/SAT-47731

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
