### PR TITLE
Flip default of use-redhat-register-snippet for orcharhino

### DIFF
--- a/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning-by-using-cli.adoc
@@ -40,6 +40,7 @@ $ hammer host create \
 ----
 . Configure the network interface:
 +
+[options="nowrap" subs="+quotes"]
 ----
 $ hammer host interface update \
 --host "_My_Host_Name_" \

--- a/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning-by-using-cli.adoc
@@ -38,6 +38,16 @@ $ hammer host create \
 --name "_My_Host_Name_" \
 --organization "_My_Organization_"
 ----
+ifdef::katello[]
++
+If you want to use the `redhat_register` snippet instead of the `kickstart_rhsm` snippet to provision {RHEL} 9 and 10 hosts, append `--parameters "use-redhat-register-snippet=true"`.
+This ensures that the provisioning workflow of {RHEL} hosts aligns with RHEL-like hosts.
+endif::[]
+ifdef::red_hat_enterprise_linux[]
++
+If you want to use a different provisioning workflow for {RHEL} hosts compared to RHEL-like hosts, append `--parameters "use-redhat-register-snippet=false"`.
+This ensures that {Project} uses the `kickstart_rhsm` snippet to provision {RHEL} 9 and 10 hosts.
+endif::[]
 . Configure the network interface:
 +
 [options="nowrap" subs="+quotes"]

--- a/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-with-pxe-boot-provisioning-by-using-web-ui.adoc
@@ -38,9 +38,14 @@ ifdef::katello,satellite,orcharhino[]
 +
 include::snip_step-parameter-ak.adoc[]
 endif::[]
-ifdef::katello,red_hat_enterprise_linux[]
+ifdef::katello[]
 +
 If you want to use the `redhat_register` snippet instead of the `kickstart_rhsm` snippet to provision {RHEL} 9 and 10 hosts, add a parameter named `use-redhat-register-snippet` of type `boolean` and set it to `true`.
 This ensures that the provisioning workflow of {RHEL} hosts aligns with RHEL-like hosts.
+endif::[]
+ifdef::red_hat_enterprise_linux[]
++
+If you want to use a different provisioning workflow for {RHEL} hosts compared to RHEL-like hosts, set the parameter `use-redhat-register-snippet` to `false`.
+This ensures that {Project} uses the `kickstart_rhsm` snippet to provision {RHEL} 9 and 10 hosts.
 endif::[]
 . Click *Submit* to save the host details.


### PR DESCRIPTION
#### What changes are you introducing?

Flip default value of `use-redhat-register-snippet` for orcharhino builds & adjusted the wording.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

For orcharhino nightly, there's a global parameter "use-redhat-register-snippet" that is set to "true" by default. This patch ensures that the docs suggest users to set it to "false" if they want to change this behavior.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #5131 (Add docs for use-redhat-register-snippet parameter)
Refs PR 11100 in foreman
Refs Redmine issue 39521

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
