### PR TITLE
Ensure IMAGES_DIR exists when building images

### DIFF
--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -39,7 +39,7 @@ endif
 endif
 
 .SHELLFLAGS = -o pipefail -c
-.PHONY = all prepare html clean browser server linkchecker
+.PHONY: all prepare html clean browser server linkchecker
 
 all: html
 

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -7,7 +7,6 @@ ROOTDIR = $(realpath .)
 NAME = $(notdir $(ROOTDIR))
 DEST_DIR = $(BUILD_DIR)/$(subst doc-,,$(NAME))
 DEST_HTML = $(DEST_DIR)/index-$(BUILD).html
-IMAGES_DIR = $(DEST_DIR)/images
 IMAGES_TS = $(DEST_DIR)/.timestamp-images
 CSS_SOURCES = $(shell find $(COMMON_DIR)/css -type f)
 DOCINFO_SOURCES = $(shell find $(COMMON_DIR)/ -type f -name docinfo\*.html)
@@ -43,8 +42,13 @@ endif
 
 all: html
 
-prepare:
-	@mkdir -p $(BUILD_DIR) $(DEST_DIR) $(IMAGES_DIR)
+$(BUILD_DIR):
+	@mkdir -p $@
+
+$(DEST_DIR):
+	@mkdir -p $@
+
+prepare: $(BUILD_DIR) $(DEST_DIR)
 
 html: prepare $(IMAGES_TS) $(DEST_HTML)
 
@@ -69,9 +73,9 @@ ccutil:
 $(DEST_DIR)/style.css: $(CSS_SOURCES)
 	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
 
-$(IMAGES_TS): $(IMAGES)
+$(IMAGES_TS): $(DEST_DIR) $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"
-	cp -rf $(CP_ARGS) ./images/* $(IMAGES_DIR)
+	cp -rf --update $(CP_ARGS) -t $(DEST_DIR) ./images
 	@touch $(IMAGES_TS)
 
 $(DEST_HTML): $(SOURCES) $(DEPENDENCIES) $(DOCINFO_SOURCES) $(DEST_DIR)/style.css $(IMAGES_TS)


### PR DESCRIPTION
#### What changes are you introducing?

In a high concurrency it may happen that the copy happens before the target is created. This declares the dependency which tells make to order it correctly.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/5105 reported the problem and I think this is a better fix because it allows parallel builds, instead of reverting to sequential builds.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is hard to test because it's effectively a race condition. I'd suggest to merge this and observe if the problem still occurs.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.