### PR TITLE
Add missing deploy subcommand to foremanctl invocations

### DIFF
--- a/guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc
+++ b/guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc
@@ -13,7 +13,7 @@ If you want to enable users to authenticate to the Hammer CLI by using their {Fr
 [NOTE]
 ====
 Updating Hammer configuration manually is not required on systems that have been configured with `foremanctl`.
-Running `foremanctl --add-feature hammer` updates the Hammer configuration as necessary.
+Running `foremanctl deploy --add-feature hammer` updates the Hammer configuration as necessary.
 ====
 endif::[]
 

--- a/guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc
+++ b/guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc
@@ -13,7 +13,7 @@ If you want to enable users to authenticate to the Hammer CLI by using their {Fr
 [NOTE]
 ====
 Updating Hammer configuration manually is not required on systems that have been configured with `foremanctl`.
-Running `foremanctl deploy --add-feature hammer` updates the Hammer configuration as necessary.
+Running `{foremanctl} deploy --add-feature hammer` updates the Hammer configuration as necessary.
 ====
 endif::[]
 

--- a/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
+++ b/guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc
@@ -37,7 +37,7 @@ endif::[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::containerized[]
-# foremanctl deploy --external-authentication-pam-service foreman-prod
+# {foremanctl} deploy --external-authentication-pam-service foreman-prod
 endif::[]
 ifndef::containerized[]
 # {foreman-installer} --foreman-pam-service foreman-prod
@@ -120,7 +120,7 @@ $ ipa hbacrule-disable allow_all
 
 On {ProjectServer}, a {Project} administrator re-runs
 ifdef::containerized[]
-`foremanctl deploy`
+`{foremanctl} deploy`
 endif::[]
 ifndef::containerized[]
 `{foreman-installer}`
@@ -130,7 +130,7 @@ to load the host-based access control rules from {FreeIPA}:
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::containerized[]
-# foremanctl deploy --external-authentication-pam-service foreman-prod
+# {foremanctl} deploy --external-authentication-pam-service foreman-prod
 endif::[]
 ifndef::containerized[]
 # {foreman-installer} --foreman-pam-service foreman-prod

--- a/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-project-server.adoc
+++ b/guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-project-server.adoc
@@ -82,7 +82,7 @@ Without the option, AD users are unable to use `kinit` to authenticate to {Proje
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::containerized[]
-# foremanctl deploy --external-authentication ipa
+# {foremanctl} deploy --external-authentication ipa
 endif::[]
 ifndef::containerized[]
 # {foreman-installer} --foreman-ipa-authentication true

--- a/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-project-server.adoc
+++ b/guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-project-server.adoc
@@ -18,7 +18,7 @@ include::snip_ext-auth-mutually-exclusive.adoc[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::containerized[]
-# foremanctl deploy --external-authentication ipa
+# {foremanctl} deploy --external-authentication ipa
 endif::[]
 ifndef::containerized[]
 # {foreman-installer} \
@@ -30,7 +30,7 @@ endif::[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 ifdef::containerized[]
-# foremanctl deploy --external-authentication ipa_with_api
+# {foremanctl} deploy --external-authentication ipa_with_api
 endif::[]
 ifndef::containerized[]
 # {foreman-installer} \

--- a/guides/common/modules/proc_enabling-os-tree-content.adoc
+++ b/guides/common/modules/proc_enabling-os-tree-content.adoc
@@ -12,7 +12,7 @@ You can enable OSTree on your {Project} to synchronize and manage OSTree branche
 ifdef::containerized[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foremanctl} --add-feature content/ostree
+# {foremanctl} deploy --add-feature content/ostree
 ----
 endif::[]
 ifndef::containerized[]

--- a/guides/common/modules/proc_enabling-the-ansible-plugin.adoc
+++ b/guides/common/modules/proc_enabling-the-ansible-plugin.adoc
@@ -18,7 +18,7 @@ ifndef::containerized[]
 --enable-foreman-proxy-plugin-ansible
 endif::[]
 ifdef::containerized[]
-# {foremanctl} \
+# {foremanctl} deploy \
 --add-feature ansible
 endif::[]
 ----

--- a/guides/common/modules/proc_installing-webhooks-plugin.adoc
+++ b/guides/common/modules/proc_installing-webhooks-plugin.adoc
@@ -13,7 +13,7 @@ ifdef::containerized[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# {foremanctl} --add-feature webhooks
+# {foremanctl} deploy --add-feature webhooks
 ----
 endif::[]
 ifndef::containerized[]

--- a/guides/common/modules/proc_resetting-external-authentication-configuration-for-kerberos-sso.adoc
+++ b/guides/common/modules/proc_resetting-external-authentication-configuration-for-kerberos-sso.adoc
@@ -19,7 +19,7 @@ ifdef::containerized[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# foremanctl deploy --reset-external-authentication
+# {foremanctl} deploy --reset-external-authentication
 ----
 endif::[]
 ifndef::containerized[]

--- a/guides/common/modules/proc_running-project-deployment-utility.adoc
+++ b/guides/common/modules/proc_running-project-deployment-utility.adoc
@@ -45,7 +45,7 @@ ifdef::containerized[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf install foremanctl
+# dnf install {project-installer-package}
 ----
 . Deploy the configuration on your server:
 +

--- a/guides/common/modules/proc_running-project-deployment-utility.adoc
+++ b/guides/common/modules/proc_running-project-deployment-utility.adoc
@@ -51,10 +51,10 @@ ifdef::containerized[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# foremanctl deploy
+# {foremanctl} deploy
 ----
 +
 You can find credentials to access your {ProjectServer} in the message shown in the `TASK [post_install : Admin credentials]` task results.
 +
-For a list of available options, run `foremanctl --help`.
+For a list of available options, run `{foremanctl} --help`.
 endif::[]

--- a/guides/common/modules/snip_ext-auth-mutually-exclusive.adoc
+++ b/guides/common/modules/snip_ext-auth-mutually-exclusive.adoc
@@ -5,7 +5,7 @@
 The {FreeIPA} and Active{nbsp}Directory authentication sources are mutually exclusive.
 Running
 ifdef::containerized[]
-`foremanctl deploy --external-authentication`
+`{foremanctl} deploy --external-authentication`
 endif::[]
 ifndef::containerized[]
 `{foreman-installer} --foreman-ipa-authentication` or `{foreman-installer} --foreman-ipa-authentication-api`


### PR DESCRIPTION
#### What changes are you introducing?
Adding a missing subcommand to foremanctl invocations

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Some places used `{foremanctl} --add-feature $something`, which ended up being rendered as `foremanctl --add-feature $something`, making `foremanctl` error out with the following:
```
foremanctl: error: the following arguments are required: action
```

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
For context see [matrix thread](https://matrix.to/#/!dxfWqeLNsImROheGXo:matrix.org/$17865240273479GHQui:matrix.org?via=matrix.org&via=ctrl-c.liu.se&via=veskamyr.de)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
