### PR TITLE
Replace 'podman' with 'docker' in a section about docker

### DIFF
--- a/guides/common/modules/proc_configuring-docker-to-trust-the-certificate-authority.adoc
+++ b/guides/common/modules/proc_configuring-docker-to-trust-the-certificate-authority.adoc
@@ -34,5 +34,5 @@ In the following examples, replace `hostname.example.com` with `{foreman-example
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-$ podman login _hostname.example.com_
+$ docker login _hostname.example.com_
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Changing a command to refer to `docker`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The whole section is about `docker`, not `podman`

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
