### PR TITLE
Make the build pass again

### DIFF
--- a/guides/common/assembly_building-cloud-images.adoc
+++ b/guides/common/assembly_building-cloud-images.adoc
@@ -8,7 +8,7 @@ include::modules/proc_configuring-a-host-for-registration.adoc[leveloffset=+1]
 
 include::modules/proc_registering-a-host.adoc[leveloffset=+1]
 
-include::modules/proc_configuring-openvox-agent-on-a-host.adoc[leveloffset=+1]
+include::modules/proc_configuring-openvox-agent-on-a-host-manually.adoc[leveloffset=+1]
 
 ifdef::satellite[]
 include::modules/proc_completing-the-rhel7-image.adoc[leveloffset=+1]

--- a/guides/common/assembly_building-cloud-images.adoc
+++ b/guides/common/assembly_building-cloud-images.adoc
@@ -8,7 +8,7 @@ include::modules/proc_configuring-a-host-for-registration.adoc[leveloffset=+1]
 
 include::modules/proc_registering-a-host.adoc[leveloffset=+1]
 
-include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]
+include::modules/proc_configuring-openvox-agent-on-a-host.adoc[leveloffset=+1]
 
 ifdef::satellite[]
 include::modules/proc_completing-the-rhel7-image.adoc[leveloffset=+1]

--- a/guides/common/assembly_registering-hosts.adoc
+++ b/guides/common/assembly_registering-hosts.adoc
@@ -55,9 +55,9 @@ include::modules/proc_providing-an-alternative-fqdn-for-the-host.adoc[leveloffse
 endif::[]
 
 // Host tools
-include::modules/proc_installing-and-configuring-puppet-agent-during-host-registration.adoc[leveloffset=+1]
+include::modules/proc_configuring-openvox-agent-on-a-host-during-provisioning.adoc[leveloffset=+1]
 
-include::modules/proc_installing-and-configuring-puppet-agent-manually.adoc[leveloffset=+1]
+include::modules/proc_configuring-openvox-agent-on-a-host-manually.adoc[leveloffset=+1]
 
 include::modules/proc_running-ansible-roles-during-host-registration.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
+++ b/guides/common/modules/con_registering-hosts-and-setting-up-host-integration.adoc
@@ -10,5 +10,4 @@ Use the following procedures to install and configure host tools:
 ifdef::katello,orcharhino,satellite[]
 * xref:configuring-tracer-on-a-host_{context}[]
 endif::[]
-* xref:installing-and-configuring-puppet-agent-during-host-registration_{context}[]
-* xref:Installing_and_Configuring_Puppet_Agent_Manually_{context}[]
+* xref:configuring-openvox-agent-on-a-host-manually[]


### PR DESCRIPTION
#### What changes are you introducing?

https://github.com/theforeman/foreman-documentation/pull/5019 changed a couple of anchors that are now causing build errors on 3.15

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

A follow-up on https://github.com/theforeman/foreman-documentation/pull/5170

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
