### PR TITLE
Revert "Limit testing label to procedures and assemblies"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,4 +8,4 @@ Needs style review:
 
 Needs testing:
 - changed-files:
-  - any-glob-to-any-file: ['guides/common/assembly_*.adoc','guides/common/modules/proc_*.adoc']
+  - any-glob-to-any-file: ['guides/**']


### PR DESCRIPTION
#### What changes are you introducing?

This reverts commit 84c3f9fefa5d26051189d8dfe5f40d1b91c7ff8c.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/4795, it was discussed that there is a risk in this change associated with updates to master.adoc not being labeled as needing testing. I've seen that happen with some containerization PRs. Therefore, I'd like to propose to revert the commit, as also mentioned in https://github.com/theforeman/foreman-documentation/pull/4795#discussion_r3157106984

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
