### PR TITLE
Label only PRs that are ready for review

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   label:
-
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - ready_for_review
 
 jobs:
   label:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   label:
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
#### What changes are you introducing?

Excluding PRs that are opened as drafts from the labeler workflow. I propose for the labels to be attached only when the PR is switched from `draft` to `ready for review`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Whenever someone opens a PR in the draft state, when there are labels attached about that PR needing review, it can be counterproductive -- the author of that PR can receive a lot of feedback requests at a time when that PR is actually not ready for a review yet.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
