### PR TITLE
Drop obsolete description of disconnected install options

### DIFF
--- a/guides/common/modules/con_installing-a-project-server.adoc
+++ b/guides/common/modules/con_installing-a-project-server.adoc
@@ -13,7 +13,7 @@ You can install a {ProjectServer} in a connected or disconnected setup:
 * Disconnected deployment is suitable for high-security environments where direct internet access is restricted or prohibited.
 
 In the disconnected setup, your {ProjectServer} uses {ISS} (ISS) to obtain content from another, connected {ProjectServer}.
-Although a disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN, you can still provision systems with the latest security updates, errata, packages, and other content.
+Although a disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN, you can still provision hosts with the latest security updates, errata, packages, and other content.
 endif::[]
 
 .Additional resources

--- a/guides/common/modules/con_installing-a-project-server.adoc
+++ b/guides/common/modules/con_installing-a-project-server.adoc
@@ -12,7 +12,7 @@ You can install a {ProjectServer} in a connected or disconnected setup:
 * Connected deployment is suitable for networked environments where your {ProjectServer} is connected to the Red{nbsp}Hat CDN.
 * Disconnected deployment is suitable for high-security environments where direct internet access is restricted or prohibited.
 
-In the disconnected setup, your {ProjectServer} uses Inter-Server Synchronization (ISS) to obtain content from another, connected {ProjectServer}.
+In the disconnected setup, your {ProjectServer} uses {ISS} (ISS) to obtain content from another, connected {ProjectServer}.
 Although a disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN, you can still provision systems with the latest security updates, errata, packages, and other content.
 endif::[]
 

--- a/guides/common/modules/con_installing-a-project-server.adoc
+++ b/guides/common/modules/con_installing-a-project-server.adoc
@@ -13,18 +13,6 @@ You can install a {ProjectServer} in a connected or disconnected setup:
 * Disconnected deployment is suitable for high-security environments where direct internet access is restricted or prohibited.
 
 A disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN but you can still provision systems with the latest security updates, errata, packages, and other content.
-You can use the following methods to import content to a disconnected {ProjectServer}:
-
-Content ISO::
-In this setup, you download ISO images with content from the Red{nbsp}Hat Customer Portal and extract them to {ProjectServer} or a local web server.
-The content on {ProjectServer} is then synchronized locally.
-+
-This allows for complete network isolation of {ProjectServer}, however, the release frequency of content ISO images is around six weeks and not all product content is included.
-
-Disconnected {Project} with {ISS}::
-In this setup, you install a connected {ProjectServer} and export content from it to populate a disconnected {Project} using a storage device.
-+
-This allows for exporting both Red{nbsp}Hat provided and custom content at the frequency you choose, but requires deploying an additional server with a separate subscription.
 endif::[]
 
 .Additional resources

--- a/guides/common/modules/con_installing-a-project-server.adoc
+++ b/guides/common/modules/con_installing-a-project-server.adoc
@@ -12,7 +12,8 @@ You can install a {ProjectServer} in a connected or disconnected setup:
 * Connected deployment is suitable for networked environments where your {ProjectServer} is connected to the Red{nbsp}Hat CDN.
 * Disconnected deployment is suitable for high-security environments where direct internet access is restricted or prohibited.
 
-A disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN but you can still provision systems with the latest security updates, errata, packages, and other content.
+In the disconnected setup, your {ProjectServer} uses Inter-Server Synchronization (ISS) to obtain content from another, connected {ProjectServer}.
+Although a disconnected {ProjectServer} is isolated from Red{nbsp}Hat CDN, you can still provision systems with the latest security updates, errata, packages, and other content.
 endif::[]
 
 .Additional resources


### PR DESCRIPTION
#### What changes are you introducing?

Removing a list of options for disconnected installation

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The list is obsolete and inaccurate. The link to the disconnected installation guide should be sufficient here.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
