### PR TITLE
Foreman 5.0.0 release notes

### DIFF
--- a/guides/doc-Release_Notes/master.adoc
+++ b/guides/doc-Release_Notes/master.adoc
@@ -13,6 +13,7 @@ include::topics/katello.adoc[leveloffset=+1]
 endif::[]
 
 // Start inserting specific x.y.z releases here
+include::topics/foreman-5.0.0.adoc[leveloffset=+1]
 
 [appendix]
 [id="foreman-contributors"]

--- a/guides/doc-Release_Notes/topics/foreman-5.0.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-5.0.0.adoc
@@ -1,0 +1,192 @@
+= Foreman 5.0.0
+
+You can find the complete list of changes on https://projects.theforeman.org/issues?set_filter=1&sort=id%3Adesc&status_id=closed&f%5B%5D=cf_12&op%5Bcf_12%5D=%3D&v%5Bcf_12%5D%5B%5D=2086[Redmine].
+
+== Foreman
+
+* pass:[Rubocop/CI job fails in GitHub Actions: cap2 gem fails to compile, missing libcap-dev] - https://projects.theforeman.org/issues/39600[#39600]
+* pass:[PageLayout uses PF3 layout of Breadcrumbs instead of PF5] - https://projects.theforeman.org/issues/39592[#39592]
+* pass:[Loosen upper bound on scoped_search] - https://projects.theforeman.org/issues/39588[#39588]
+* pass:[Subnet: invalid mask bypasses validation when the network address contains a CIDR suffix] - https://projects.theforeman.org/issues/39572[#39572]
+* pass:[Update eslint-plugin-rules require-ouiaid with PF5 components] - https://projects.theforeman.org/issues/39562[#39562]
+* pass:[Remove unused NumericInput and drop the rc-input-number dependency] - https://projects.theforeman.org/issues/39558[#39558]
+* pass:[Automatically change title to text in APIActions toast handlers text] - https://projects.theforeman.org/issues/39547[#39547]
+* pass:[Add configurable CA cert to LDAP auth source] - https://projects.theforeman.org/issues/39534[#39534]
+* pass:[Add host parameter to skip rhsm registration for RHEL hosts and use the redhat_register snippet instead] - https://projects.theforeman.org/issues/39521[#39521]
+* pass:[Add audits for user login / logout / failed logins] - https://projects.theforeman.org/issues/39512[#39512]
+* pass:[Update EditorNavbar and EditorRadioButton components to PF5 and the tests to RTL] - https://projects.theforeman.org/issues/39507[#39507]
+* pass:[Update OrderableSelect to PF5] - https://projects.theforeman.org/issues/39505[#39505]
+* pass:[package upgrade did upgrade all packages] - https://projects.theforeman.org/issues/39499[#39499]
+* pass:[Update EditorOptions to PF5 and it's tests to RTL] - https://projects.theforeman.org/issues/39497[#39497]
+* pass:[Update EditorSettings to PF5 and it's tests to RTL] - https://projects.theforeman.org/issues/39496[#39496]
+* pass:[Replace forms/FormField to PF5] - https://projects.theforeman.org/issues/39486[#39486]
+* pass:[deprecate ForemanForm] - https://projects.theforeman.org/issues/39485[#39485]
+* pass:[Refactor HOC Enzyme tests to RTL] - https://projects.theforeman.org/issues/39472[#39472]
+* pass:[Refactor Component Wrapper Enzyme tests to RTL] - https://projects.theforeman.org/issues/39468[#39468]
+* pass:[taxonomies.ignore_types being a yaml-serialized array prevents exact db-level operations] - https://projects.theforeman.org/issues/39465[#39465]
+* pass:[error toasts for disassociate and change owner are not shown] - https://projects.theforeman.org/issues/39463[#39463]
+* pass:[Update DiffModal in config reports to PF5] - https://projects.theforeman.org/issues/39461[#39461]
+* pass:[Refactor long date time Enzyme tests to RTL] - https://projects.theforeman.org/issues/39460[#39460]
+* pass:[Replace JS snapshot tests - TokenLifeTime field] - https://projects.theforeman.org/issues/39459[#39459]
+* pass:[Replace JS snapshot tests - Taxonomies field] - https://projects.theforeman.org/issues/39458[#39458]
+* pass:[Replace JS snapshot tests - Repository field] - https://projects.theforeman.org/issues/39457[#39457]
+* pass:[Replace JS snapshot tests - HostGroup field] - https://projects.theforeman.org/issues/39455[#39455]
+* pass:[Replace JS snapshot tests - General component] - https://projects.theforeman.org/issues/39454[#39454]
+* pass:[Replace JS snapshot tests - ConfigParams field] - https://projects.theforeman.org/issues/39453[#39453]
+* pass:[Replace JS snapshot tests - Command component] - https://projects.theforeman.org/issues/39452[#39452]
+* pass:[Replace JS snapshot tests - Advanced component] - https://projects.theforeman.org/issues/39451[#39451]
+* pass:[Refactor ISO Date Enzyme tests to RTL] - https://projects.theforeman.org/issues/39450[#39450]
+* pass:[Replace JS snapshot tests - AuditsPageSelectors] - https://projects.theforeman.org/issues/39445[#39445]
+* pass:[Replace JS snapshot tests - AuditsPageActions] - https://projects.theforeman.org/issues/39443[#39443]
+* pass:[Replace JS snapshot tests - LoginPage] - https://projects.theforeman.org/issues/39442[#39442]
+* pass:[Replace JS snapshot tests - AuditsPage] - https://projects.theforeman.org/issues/39439[#39439]
+* pass:[Refactor Relative date time Enzyme tests to RTL] - https://projects.theforeman.org/issues/39436[#39436]
+* pass:[Refactor Short Date Time Enzyme tests to RTL] - https://projects.theforeman.org/issues/39435[#39435]
+* pass:[Refactor ConfirmModal Enzyme tests to RTL] - https://projects.theforeman.org/issues/39431[#39431]
+* pass:[Fix padding in register host page] - https://projects.theforeman.org/issues/39422[#39422]
+* pass:[sudo-rs on Ubuntu 26.04 does not support requiretty] - https://projects.theforeman.org/issues/39417[#39417]
+* pass:[Developer docs are out of date at places] - https://projects.theforeman.org/issues/39416[#39416]
+* pass:[Move FieldConstructor from webhooks plugin to core] - https://projects.theforeman.org/issues/39408[#39408]
+* pass:[Move reusable Area chart functions to helpers] - https://projects.theforeman.org/issues/39403[#39403]
+* pass:[Deprecate MessageBox and replace it with EmptyState] - https://projects.theforeman.org/issues/39401[#39401]
+* pass:[reusable empty state page] - https://projects.theforeman.org/issues/39395[#39395]
+* pass:[Add script to handle running plugin tests in multiple ways inspired by ktest] - https://projects.theforeman.org/issues/39391[#39391]
+* pass:[REX job "Schedule a job" with "select all" check does not run for any host] - https://projects.theforeman.org/issues/39389[#39389]
+* pass:[hosts index page loads full Host objects when only hostgroup_ids are needed] - https://projects.theforeman.org/issues/39381[#39381]
+* pass:[Bump safemode to 2.0] - https://projects.theforeman.org/issues/39370[#39370]
+* pass:[Deprecate Loader and update its usage to PF5] - https://projects.theforeman.org/issues/39366[#39366]
+* pass:[Add Ruby 3.3 support to Foreman] - https://projects.theforeman.org/issues/39361[#39361]
+* pass:[Deprecate LineChart wrapper in Foreman core] - https://projects.theforeman.org/issues/39357[#39357]
+* pass:[Add support for `settings.d`] - https://projects.theforeman.org/issues/39347[#39347]
+* pass:[Merge page logic and styles from TableIndexPage to PageLayout] - https://projects.theforeman.org/issues/39340[#39340]
+* pass:[N+1 queries when loading taxonomy descendants] - https://projects.theforeman.org/issues/39336[#39336]
+* pass:[Add additive fact import mode] - https://projects.theforeman.org/issues/39299[#39299]
+* pass:[Use bulk insert for new fact values on persisted hosts] - https://projects.theforeman.org/issues/39298[#39298]
+* pass:[container_certs_setup snippet missing cert directories for load balancer backend hostnames] - https://projects.theforeman.org/issues/39193[#39193]
+* pass:[Subnet UI allows CIDR in Network Address causing duplicated prefix (/24/24)] - https://projects.theforeman.org/issues/39159[#39159]
+* pass:[Update host vmware form to PF5] - https://projects.theforeman.org/issues/38992[#38992]
+
+=== Authentication
+
+* pass:[SSO login via Apache OIDC fails with a 500 Internal Server Error on Ruby 3.2] - https://projects.theforeman.org/issues/39099[#39099]
+
+=== BMC
+
+* pass:[Specifying organization_id/location_id in hammer host boot causes ERF42-5227 unknown parent permission error] - https://projects.theforeman.org/issues/39374[#39374]
+* pass:[Remove SSH provider for BMC in foreman] - https://projects.theforeman.org/issues/39321[#39321]
+
+=== Inventory
+
+* pass:[Host actions are disabled after bulk action] - https://projects.theforeman.org/issues/39538[#39538]
+* pass:[Registration form checkboxes not vertically aligned with text] - https://projects.theforeman.org/issues/38674[#38674]
+
+=== JavaScript stack
+
+* pass:[Share time unit JS consts for plugins] - https://projects.theforeman.org/issues/39568[#39568]
+* pass:[Add PF lint rules: prefer-pf-components/props] - https://projects.theforeman.org/issues/39513[#39513]
+* pass:[update ui test guidelines and best practices] - https://projects.theforeman.org/issues/39438[#39438]
+* pass:[add no-magic-numbers js lint rule] - https://projects.theforeman.org/issues/39383[#39383]
+* pass:[TypeScript support for the frontend] - https://projects.theforeman.org/issues/39137[#39137]
+* pass:[Update CounterInput component to PF5] - https://projects.theforeman.org/issues/39056[#39056]
+
+=== Logging
+
+* pass:[foreman-rake drops RAILS_LOG_TO_STDOUT and writes production.log during RPM install (Containerised installation)] - https://projects.theforeman.org/issues/39536[#39536]
+
+=== Organizations and Locations
+
+* pass:a[Exclude host taxonomies that don't match the {SmartProxy} taxonomies from used_taxonomy_ids] - https://projects.theforeman.org/issues/39220[#39220]
+
+=== Rails
+
+* pass:[Missing validation for domain name input under Infrastructure in Foreman UI] - https://projects.theforeman.org/issues/39287[#39287]
+
+=== Rake tasks
+
+* pass:[Provide a way for plugins to run a predefined subset of core tests] - https://projects.theforeman.org/issues/39545[#39545]
+
+=== Reporting
+
+* pass:[Errata severity macro is not available in 'Host - Applied Errata' report] - https://projects.theforeman.org/issues/39334[#39334]
+* pass:[Add still_applicable column to Host - Applied Errata report template] - https://projects.theforeman.org/issues/39212[#39212]
+
+=== Security
+
+* pass:[CVE-2026-5138: Information disclosure via improper validation of nested request parameters] - https://projects.theforeman.org/issues/39481[#39481]
+* pass:[CVE-2026-5135: Unauthorized modification of host configurations via broken access control] - https://projects.theforeman.org/issues/39480[#39480]
+* pass:[CVE-2026-5142: Cross-tenant private SSH key disclosure via taxonomy scoping bypass] - https://projects.theforeman.org/issues/39479[#39479]
+* pass:[CVE-2026-5136: Privilege escalation via usergroup role assignment manipulation] - https://projects.theforeman.org/issues/39478[#39478]
+
+=== Smart Proxy
+
+* pass:[SmartProxy model should be able to find smart proxies located on the same host] - https://projects.theforeman.org/issues/39574[#39574]
+* pass:[auth_smart_proxy can set @detected_proxy incorrectly] - https://projects.theforeman.org/issues/39570[#39570]
+* pass:[Track and surface unrecognized Smart Proxy features] - https://projects.theforeman.org/issues/39413[#39413]
+
+=== Templates
+
+* pass:[Allow custom pre-install script in kickstart default template] - https://projects.theforeman.org/issues/39293[#39293]
+
+=== Users, Roles and Permissions
+
+* pass:[I'd like to enable/disable users directly from the users table] - https://projects.theforeman.org/issues/39474[#39474]
+
+=== VM management
+
+* pass:[VMware - Normalize firmware type in clone args] - https://projects.theforeman.org/issues/39310[#39310]
+
+=== Web Interface
+
+* pass:[Apply pf-v5-c-page--BackgroundColor to #rails-app-content] - https://projects.theforeman.org/issues/39593[#39593]
+* pass:[Fix React tables toolbar alignment] - https://projects.theforeman.org/issues/39523[#39523]
+* pass:[Hide count in SelectAllCheckbox when unavailable] - https://projects.theforeman.org/issues/39475[#39475]
+* pass:[Foreman performs bulk actions on hosts in different location then marked] - https://projects.theforeman.org/issues/39437[#39437]
+* pass:[Update TableIndexPage ActionButtons OuiaId to be customizable.] - https://projects.theforeman.org/issues/39426[#39426]
+* pass:[Some links still redirect to the old /hosts page] - https://projects.theforeman.org/issues/39396[#39396]
+* pass:[AutocompleteInput doesn't allow to select typed value] - https://projects.theforeman.org/issues/39311[#39311]
+* pass:[Host search breaks when using % in search bar] - https://projects.theforeman.org/issues/39302[#39302]
+* pass:[Add Stylelint rule to block global css overrides] - https://projects.theforeman.org/issues/39276[#39276]
+* pass:a[Web UI -> Infrastructures -> {SmartProxies} page takes long time to load] - https://projects.theforeman.org/issues/38275[#38275]
+
+== Hammer CLI - Foreman
+
+* pass:[Implement LDAP CA certs support ] - https://projects.theforeman.org/issues/39537[#39537]
+
+=== Proxy
+
+* pass:[Display unknown proxy features, if there are any] - https://projects.theforeman.org/issues/39414[#39414]
+
+== Installer
+
+* pass:[katello-certs-check can sometimes not be used with wildcards] - https://projects.theforeman.org/issues/39546[#39546]
+
+=== Foreman modules
+
+* pass:[Warn about unrecognized smart proxy features] - https://projects.theforeman.org/issues/39415[#39415]
+
+== Packaging
+
+* pass:[Remove unused nodejs-rc-input-number] - https://projects.theforeman.org/issues/39561[#39561]
+
+== SELinux
+
+* pass:[Foreman policy uses deprecated functions] - https://projects.theforeman.org/issues/39343[#39343]
+
+=== Smart proxy
+
+* pass:[Proxy policy can't be compiled on EL10] - https://projects.theforeman.org/issues/39342[#39342]
+
+== Smart Proxy
+
+* pass:[Add tls_min_version and tls_ciphers to smart proxy] - https://projects.theforeman.org/issues/39405[#39405]
+* pass:[Cache global registration script in smart-proxy] - https://projects.theforeman.org/issues/39208[#39208]
+
+=== BMC
+
+* pass:[Expose bmc_default_provider setting via v2/features API] - https://projects.theforeman.org/issues/39320[#39320]
+* pass:[Identify LED operations do not support LocationIndicatorActive, failing on BMCs where IndicatorLED is deprecated] - https://projects.theforeman.org/issues/39301[#39301]
+* pass:[Identify LED on operation fails due to invalid IndicatorLED value On] - https://projects.theforeman.org/issues/39300[#39300]
+
+=== Tests
+
+* pass:[smart-proxy test failures due to rake 13.4.2 breaking ci_reporter_test_unit] - https://projects.theforeman.org/issues/39315[#39315]

--- a/guides/doc-Release_Notes/topics/foreman-contributors.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-contributors.adoc
@@ -1,0 +1,5 @@
+We'd like to thank the following people who contributed to the Foreman {ProjectVersion} release:
+
+Adam Lazik,Adam Růžička,Alexander Olofsson,Alleny244,Andrei Lakatos,Arvind Jangir,Bernhard Suttner,Danny Synk,Eric Helms,Evgeni Golov,Gerald Vogt,Ian Ballou,Jakub Duchek,Jeremy Lenz,Karolina Malyjurkova,Leos Stejskal,Lucy Fu,Lukas Hellebrandt,Lukas Jezek,Lukas Pramuk,Marek Hulán,Maria Agaphontzev,Matt Darcy,Michal Gritzbach,Nadja Heitmann,Odilon Sousa,Oleh Fedorenko,Ondřej Gajdušek,Pablo Méndez Hernández,Pascal Kontschan,Pavan Soma Shekar,Peter Ondrejka,Quinn James,Sam Bible,Samir Jha,Shubham Ganar,Thorben Denzer,Tim Meusel,Titani Labaj,Yusuke Hirota,Zachary Huntington-Meath
+
+As well as all users who helped test releases, report bugs and provide feedback on the project.

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -10,24 +10,25 @@
 [id="user-interface-and-experience"]
 === User interface & experience
 
-//If this section would be empty otherwise, comment out the section heading.
-
-//To add a headline feature, use AsciiDoc's description lists: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
-//Summary::
-//Description
-//+
-//Optional second paragraph of description
+TypeScript support for the frontend::
+The {Project} frontend can now use TypeScript, giving contributors static typing and better editor tooling when working on frontend code.
 
 [id="infrastructure-and-platform-updates"]
 === Infrastructure & platform updates
 
-//If this section would be empty otherwise, comment out the section heading.
+ifndef::foreman-deb[]
+(Containerized deployments only) Enterprise Linux 10 support::
++
+--
+{Project} {ProjectVersion} introduces support for running {ProjectServer} and {SmartProxyServers} on {EL} 10, but only for containerized deployments managed with `{foremanctl}`.
 
-//To add a headline feature, use AsciiDoc's description lists: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
-//Summary::
-//Description
-//+
-//Optional second paragraph of description
+Running {Project} through the RPM installer on {EL} 10 is not supported, and there is currently no migration path from an RPM-installer-based installation to a `{foremanctl}`-based one.
+This migration path is planned for an upcoming {Project} release.
+If you run {Project} through the RPM installer, remain on your current, supported {EL} release until migration guidance is available.
+
+For more details, see the https://community.theforeman.org/t/rebuilding-our-rpms-for-el10/47083[EL10 RPM rebuild announcement].
+--
+endif::[]
 
 ifdef::containerized[]
 Containerized deployments use Valkey instead of Redis::
@@ -42,8 +43,27 @@ See https://developers.redhat.com/articles/2024/01/02/exploring-x86-64-v3-red-ha
 --
 endif::[]
 
-[id="networking-and-connectivity"]
-=== Networking & connectivity
+Ruby 3.3 support::
+{Project} can now run on Ruby 3.3.
+
+`settings.d` support::
++
+--
+{Project} settings can now be split across multiple files in a `settings.d` directory instead of a single settings file.
+
+For example, instead of editing `config/settings.yaml` directly, you can create `config/settings.d/10-local.yaml` with just the keys you want to override:
+
+[source,yaml]
+----
+---
+:require_ssl: true
+----
+
+Files in `config/settings.d/` are loaded in sorted filename order, after `config/settings.plugins.d/*.yaml`, so they can override both the defaults in `config/settings.yaml` and any plugin-provided settings.
+--
+
+//[id="networking-and-connectivity"]
+//=== Networking & connectivity
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -53,8 +73,8 @@ endif::[]
 //+
 //Optional second paragraph of description
 
-[id="clients"]
-=== Clients
+//[id="clients"]
+//=== Clients
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -75,6 +95,10 @@ endif::[]
 //+
 //Optional second paragraph of description
 
+(Containerized deployments only) Documentation is incomplete at time of release::
+Documentation is not yet complete and does not describe the complete set of functionality available in containerized deployments.
+This is work in progress and we are continuously adding the remaining documentation to our guides, as we continue verifying that the described functionality is working as expected in containerized deployments.
+
 [id="foreman-upgrade-warnings"]
 == Upgrade warnings
 
@@ -89,16 +113,21 @@ The `ssl_disabled_ciphers` and `tls_disabled_versions` Smart Proxy parameters ha
 * `ssl_disabled_ciphers` (an array of cipher suites to disable) is replaced by `tls_ciphers` (an OpenSSL cipher string). When unset, the Smart Proxy auto-detects: `PROFILE=SYSTEM` if crypto-policies are present, otherwise `HIGH`.
 * `tls_disabled_versions` (an array of TLS versions to disable) is replaced by `tls_min_version` (a single minimum version: `1.0`, `1.1`, `1.2`, or `1.3`). When unset, the minimum version is determined by the system OpenSSL configuration.
 
+ifndef::containerized[]
 If you customized these settings through `{foreman-installer}`, the old parameters are automatically removed during upgrade.
+endif::[]
 No automatic migration of values is performed.
 If you previously set custom TLS cipher or version restrictions, reconfigure them using the new parameters after upgrading.
 --
 
-//To add a headline feature, use AsciiDoc's description list: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
-//Summary::
-//Description
-//+
-//Optional second paragraph of description
+ifdef::containerized[]
+Container image builds no longer drop `RAILS_LOG_TO_STDOUT`::
++
+--
+`script/foreman-rake` used a login shell (`runuser - foreman ...`), which cleared `RAILS_LOG_TO_STDOUT` during the container image build and caused install-time `rake` boots to write `production.log` into the image layer instead of stdout.
+The variable is now preserved across `runuser`, so container image logs correctly include this output.
+--
+endif::[]
 
 ifdef::containerized[]
 {Project} rejects HTTP requests with unrecognized host headers::
@@ -113,9 +142,3 @@ endif::[]
 
 //If there are deprecations, comment out the following line.
 There are no deprecations with Foreman {ProjectVersion}.
-
-//To add a headline feature, use AsciiDoc's description list: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
-//Summary::
-//Description
-//+
-//Optional second paragraph of description


### PR DESCRIPTION
#### What changes are you introducing?

Release notes for Foreman 5.0.0:

Headline features, upgrade warnings, and deprecations, including a new Enterprise Linux 10 support entry (containerized deployments only — `foreman-installer`-based installs are not supported on EL10 yet, and there is currently no migration path to `foremanctl`; this is called out explicitly).

While adding the EL10 entry I found that the existing Smart Proxy TLS upgrade-warning paragraph uses `{foreman-installer}` unwrapped by `ifdef::containerized[]`. That attribute is deliberately poisoned to `DO_NOT_USE_foreman-installer_IN_CONTAINERIZED_BUILDS` in containerized builds (see `attributes-containerized.adoc`), so it was rendering broken text for Satellite/orcharhino/containerized-katello/containerized-orcharhino builds. Fixed that alongside the new content so the same mistake wasn't reintroduced.

The theforeman.org (website) counterpart is prepared but not yet opened — I'd like to get this one reviewed first and will open/adjust that PR once this merges, so it can pick up any changes review here surfaces.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Foreman 5.0.0 release notes, per the [5.0.0 RC1 release process checklist](https://community.theforeman.org/t/foreman-5-0-0-rc1-release-process/47303)'s "Update docs.theforeman.org" step.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The EL10 entry deliberately spells out that `foreman-installer`-based installs do **not** get EL10 support this release, and that the `foreman-installer` -> `foremanctl` migration path isn't available yet. Flagging in case anyone wants softer wording before this goes out.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightlhtml#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.

(Not applicable here — these are 5.0-specific release notes, nothing to cherry-pick backward.)
