### PR TITLE
Hide Usage metrics collection in Satellite for containerized version

### DIFF
--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -53,13 +53,6 @@ include::common/assembly_disaster-recovery-with-active-and-passive-project-serve
 
 include::common/assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+2]
 
-// TODO: Hidden until feature returns in a later release.
-////
-ifdef::satellite[]
-include::common/assembly_usage-metrics-collection-in-project.adoc[leveloffset=+1]
-endif::[]
-////
-
 endif::[]
 
 ifdef::satellite[]
@@ -133,13 +126,6 @@ endif::[]
 [appendix]
 include::common/assembly_administer-settings-information.adoc[leveloffset=+1]
 
-// TODO: Hidden until feature returns in a later release.
-////
-ifdef::satellite[]
-[appendix]
-include::common/modules/ref_usage-metrics-collected-by-project.adoc[leveloffset=+1]
-endif::[]
-////
 endif::[]
 
 ifndef::orcharhino,satellite[]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -53,7 +53,7 @@ include::common/assembly_disaster-recovery-with-active-and-passive-project-serve
 
 include::common/assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+2]
 
-ifdef::satellite[]
+ifndef::containerized[]
 include::common/assembly_usage-metrics-collection-in-project.adoc[leveloffset=+1]
 endif::[]
 

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -53,9 +53,12 @@ include::common/assembly_disaster-recovery-with-active-and-passive-project-serve
 
 include::common/assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+2]
 
-ifndef::containerized[]
+// TODO: Hidden until feature returns in a later release.
+////
+ifdef::satellite[]
 include::common/assembly_usage-metrics-collection-in-project.adoc[leveloffset=+1]
 endif::[]
+////
 
 endif::[]
 
@@ -130,10 +133,13 @@ endif::[]
 [appendix]
 include::common/assembly_administer-settings-information.adoc[leveloffset=+1]
 
+// TODO: Hidden until feature returns in a later release.
+////
 ifdef::satellite[]
 [appendix]
 include::common/modules/ref_usage-metrics-collected-by-project.adoc[leveloffset=+1]
 endif::[]
+////
 endif::[]
 
 ifndef::orcharhino,satellite[]


### PR DESCRIPTION



#### What changes are you introducing?
Exclude Usage metrics collection in Satellite for containerized version.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
This section is deprecated for current containerized versions.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Due to hidden sections' interdependency, this PR encompasses SAT-48104 and SAT-48106

Hid in comments rather than using tags since they cannot appear in uncontainerized versions or within Satellite, despite only appearing in Satellite versions. This change allows the change to be easily reversed once the feature is updated in a later release.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
