### PR TITLE
Clean up deprecation and upgrade warnings

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -7,8 +7,8 @@
 //If there are no headline features, uncomment the following line:
 //There are no highlights with Foreman {ProjectVersion}.
 
-[id="user-interface-and-experience"]
-=== User interface & experience
+//[id="user-interface-and-experience"]
+//=== User interface & experience
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -18,8 +18,8 @@
 //+
 //Optional second paragraph of description
 
-[id="infrastructure-and-platform-updates"]
-=== Infrastructure & platform updates
+//[id="infrastructure-and-platform-updates"]
+//=== Infrastructure & platform updates
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -29,21 +29,9 @@
 //+
 //Optional second paragraph of description
 
-ifdef::containerized[]
-Containerized deployments use Valkey instead of Redis::
-+
---
-Containerized deployments now utilize Valkey 8 running inside an {EL} 10 container, instead of Redis 6.
-The change is transparent to users and no action is necessary.
 
-As the new container is based on {EL} 10, the system requirements of {EL} 10 apply, even if the host system is not running {EL} 10.
-Especially this means the system needs to support the x86_64-v3 microarchitecture level.
-See https://developers.redhat.com/articles/2024/01/02/exploring-x86-64-v3-red-hat-enterprise-linux-10[Exploring x86-64-v3 for Red Hat Enterprise Linux 10] for further information.
---
-endif::[]
-
-[id="networking-and-connectivity"]
-=== Networking & connectivity
+//[id="networking-and-connectivity"]
+//=== Networking & connectivity
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -53,8 +41,8 @@ endif::[]
 //+
 //Optional second paragraph of description
 
-[id="clients"]
-=== Clients
+//[id="clients"]
+//=== Clients
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -64,8 +52,8 @@ endif::[]
 //+
 //Optional second paragraph of description
 
-[id="documentation-and-tooling"]
-=== Documentation & tooling
+//[id="documentation-and-tooling"]
+//=== Documentation & tooling
 
 //If this section would be empty otherwise, comment out the section heading.
 
@@ -79,34 +67,13 @@ endif::[]
 == Upgrade warnings
 
 //If there are upgrade warnings, comment out the following line:
-//There are no upgrade warnings with Foreman {ProjectVersion}.
-
-Smart Proxy TLS configuration parameters have been renamed::
-+
---
-The `ssl_disabled_ciphers` and `tls_disabled_versions` Smart Proxy parameters have been replaced by `tls_ciphers` and `tls_min_version`.
-
-* `ssl_disabled_ciphers` (an array of cipher suites to disable) is replaced by `tls_ciphers` (an OpenSSL cipher string). When unset, the Smart Proxy auto-detects: `PROFILE=SYSTEM` if crypto-policies are present, otherwise `HIGH`.
-* `tls_disabled_versions` (an array of TLS versions to disable) is replaced by `tls_min_version` (a single minimum version: `1.0`, `1.1`, `1.2`, or `1.3`). When unset, the minimum version is determined by the system OpenSSL configuration.
-
-If you customized these settings through `{foreman-installer}`, the old parameters are automatically removed during upgrade.
-No automatic migration of values is performed.
-If you previously set custom TLS cipher or version restrictions, reconfigure them using the new parameters after upgrading.
---
+There are no upgrade warnings with Foreman {ProjectVersion}.
 
 //To add a headline feature, use AsciiDoc's description list: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
 //Summary::
 //Description
 //+
 //Optional second paragraph of description
-
-ifdef::containerized[]
-{Project} rejects HTTP requests with unrecognized host headers::
-{Project} now validates the HTTP `Host` header against the FQDN of the server and any declared aliases.
-Requests that use an IP address, a short hostname, or any undeclared name are rejected with a `403 Forbidden` error.
-To allow access from an alternate hostname, declare it as a server alias.
-For more information, see {InstallingServerDocURL}configuring-an-alternate-cname_{project-context}[Configuring an alternate CNAME for {Project}] in _{InstallingServerDocTitle}_.
-endif::[]
 
 [id="foreman-deprecations"]
 == Deprecations

--- a/guides/doc-Release_Notes/topics/katello.adoc
+++ b/guides/doc-Release_Notes/topics/katello.adoc
@@ -14,13 +14,4 @@ There are no upgrade warnings with Katello {KatelloVersion}.
 [id="katello-deprecations"]
 == Deprecations
 
-// There are no deprecations with Katello {KatelloVersion}.
-The `katello-ca-consumer` RPM package and `katello-rhsm-consumer` script::
-+
---
-The `katello-ca-consumer` RPM package and the `katello-rhsm-consumer` script are deprecated and will be removed in a future release.
-Use the following alternatives instead:
-
-* For registering hosts to {ProjectServer}, use {ManagingHostsDocURL}registering-hosts-by-using-global-registration[Registering hosts by using global registration] in _{ManagingHostsDocTitle}_.
-* For deploying custom SSL certificates to hosts, use {ManagingHostsDocURL}refreshing-the-self-signed-ca-certificate-on-hosts[Refreshing the self-signed CA certificate on hosts] in _{ManagingHostsDocTitle}_.
---
+There are no deprecations with Katello {KatelloVersion}.


### PR DESCRIPTION
#### What changes are you introducing?
Remove the headline features, upgrade warnings, and deprecations that
were added before the 5.0 branch point (ef598f1f0a) and are now
captured in the 5.0 release notes, so master starts the next cycle
with the clean template. Matches the pattern from #4841 after the
3.19 branch point.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Foreman 5.0 (post) branching

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
