### PR TITLE
Update containerized version of Admin Satellite guide's Configuring Satellite for Red Hat Lightspeed analytics

### DIFF
--- a/guides/common/assembly_configuring-project-for-insights-analytics.adoc
+++ b/guides/common/assembly_configuring-project-for-insights-analytics.adoc
@@ -2,9 +2,9 @@ include::modules/con_configuring-project-for-insights-analytics.adoc[]
 
 include::modules/con_insights-overview.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::modules/con_enabling-hosted-insights.adoc[leveloffset=+1]
 
-ifndef::containerized[]
 include::modules/proc_installing-red-hat-cloud-plugin.adoc[leveloffset=+2]
 
 include::modules/proc_adding-project-server-ssh-key-to-authorized-keys.adoc[leveloffset=+2]

--- a/guides/common/assembly_configuring-project-for-insights-analytics.adoc
+++ b/guides/common/assembly_configuring-project-for-insights-analytics.adoc
@@ -4,14 +4,13 @@ include::modules/con_insights-overview.adoc[leveloffset=+1]
 
 include::modules/con_enabling-hosted-insights.adoc[leveloffset=+1]
 
-ifndef::satellite[]
-// Enabled by default on Satellite
+ifndef::containerized[]
 include::modules/proc_installing-red-hat-cloud-plugin.adoc[leveloffset=+2]
-endif::[]
 
 include::modules/proc_adding-project-server-ssh-key-to-authorized-keys.adoc[leveloffset=+2]
 
 include::modules/proc_configuring-project-server-for-cloud-connection.adoc[leveloffset=+2]
+endif::[]
 
 include::modules/con_data-control-settings-for-hosted-insights.adoc[leveloffset=+1]
 

--- a/guides/common/modules/con_insights-overview.adoc
+++ b/guides/common/modules/con_insights-overview.adoc
@@ -38,7 +38,12 @@ If you use {Insights} in the {RHCloud}:
 
 * You can use {Insights} services online in the {RHCloud}.
 * The Insights client collects data of your hosts and {Project} forwards the data to the {RHCloud} to calculate recommendations.
+ifndef::containerized[]
 * You can view and remediate those recommendations both in the {ProjectWebUI} and in the {RHCloud}.
+endif::[]
+ifdef::containerized[]
+* You can view and remediate those recommendations in the {ProjectWebUI}.
+endif::[]
 * {Project} uploads host inventory reports to the {RHCloud}.
 * You have control over how much information is included in those reports.
 ifdef::satellite[]

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -16,8 +16,8 @@ Migrate from hosted {Insights} to {insights-iop} when you need local analysis on
 +
 This command creates the `/etc/foreman/registry-auth.json` file.
 . On {ProjectServer}, enable {insights-iop}:
-** If {insights-iop} was previously enabled:
 ifndef::containerized[]
+** If {insights-iop} was previously enabled:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -34,7 +34,7 @@ ifdef::containerized[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# foremanctl deploy --add-feature iop
+# {foremanctl} deploy --add-feature iop
 ----
 endif::[]
 . On your hosts, re-register the Insights client:

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -17,6 +17,7 @@ Migrate from hosted {Insights} to {insights-iop} when you need local analysis on
 This command creates the `/etc/foreman/registry-auth.json` file.
 . On {ProjectServer}, enable {insights-iop}:
 ** If {insights-iop} was previously enabled:
+ifndef::containerized[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
@@ -28,6 +29,14 @@ This command creates the `/etc/foreman/registry-auth.json` file.
 ----
 # {foreman-installer} --enable-iop
 ----
+endif::[]
+ifdef::containerized[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foremanctl deploy --add-feature iop
+----
+endif::[]
 . On your hosts, re-register the Insights client:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_migrating-from-in-project-to-hosted-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-in-project-to-hosted-insights.adoc
@@ -11,6 +11,15 @@ Migrate from {insights-iop} to hosted {Insights} when you want cloud-based analy
 * Your {ProjectServer} can access the https://console.redhat.com[{RHCloud}].
 
 .Procedure
+ifdef::containerized[]
+. On {ProjectServer}, disable {insights-iop}:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# foremanctl deploy --remove-feature iop
+----
+endif::[]
+ifndef::containerized[]
 . On {ProjectServer}, disable {insights-iop}:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -19,6 +28,7 @@ Migrate from {insights-iop} to hosted {Insights} when you want cloud-based analy
 ----
 . Reconfigure the cloud connector on {ProjectServer}.
 For more information, see xref:configuring-{project-context}-server-for-cloud-connection[].
+endif::[]
 . On your hosts, re-register the Insights client:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -10,9 +10,11 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 endif::[]
 
 ifndef::containerized[]
+
 ifdef::satellite[]
 include::common/assembly_cloning-project-server.adoc[leveloffset=+1]
 endif::[]
+
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]
@@ -77,13 +79,17 @@ include::common/assembly_backing-up-project.adoc[leveloffset=+1]
 
 include::common/assembly_restoring-project-from-backup.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renaming-server-or-smart-proxy.adoc[leveloffset=+1]
+endif::[]
 endif::[]
 
 include::common/assembly_configuring-project-for-insights-analytics.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::common/assembly_reducing-storage-use-on-project-server.adoc[leveloffset=+1]
+endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renewing-certificates.adoc[leveloffset=+1]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -10,11 +10,9 @@ include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[le
 endif::[]
 
 ifndef::containerized[]
-
 ifdef::satellite[]
 include::common/assembly_cloning-project-server.adoc[leveloffset=+1]
 endif::[]
-
 endif::[]
 
 ifdef::katello,orcharhino,satellite[]
@@ -79,7 +77,6 @@ include::common/assembly_backing-up-project.adoc[leveloffset=+1]
 
 include::common/assembly_restoring-project-from-backup.adoc[leveloffset=+1]
 
-ifndef::containerized[]
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renaming-server-or-smart-proxy.adoc[leveloffset=+1]
 endif::[]
@@ -87,8 +84,6 @@ endif::[]
 include::common/assembly_configuring-project-for-insights-analytics.adoc[leveloffset=+1]
 
 include::common/assembly_reducing-storage-use-on-project-server.adoc[leveloffset=+1]
-
-endif::[]
 
 ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renewing-certificates.adoc[leveloffset=+1]


### PR DESCRIPTION

#### What changes are you introducing?
Update Configuring Satellite for Red Hat Lightspeed analytic for containerized version of the Administering Satellite guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
* Cloud Connector setup is not supported
* Cloud-initiated remediations are not supported (Satellite-initiated remediations still work, though.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
