### PR TITLE
Add UEFI Secure Boot for hosts on Proxmox

### DIFF
--- a/guides/common/modules/proc_creating-hosts-on-compute-resource-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_creating-hosts-on-compute-resource-by-using-web-ui.adoc
@@ -58,6 +58,13 @@ You can set UEFI instead of legacy BIOS for your virtual machine:
 
 .. On the *Advanced Options* tab, set *BIOS* to `OVMF (UEFI)`.
 .. On the *Storage* tab, click *Add Efi Disk*.
+
++
+To deploy virtual machines on {compute-resource} with UEFI Secure Boot enabled:
+
+.. On the *Advanced Options* tab, set *BIOS* to `OVMF (UEFI Secure Boot)`.
+.. On the *Storage* tab, click *Add Efi Disk*.
+{Project} will automatically enable pre-enrolled keys for your host.
 endif::[]
 ifdef::vmware-provisioning[]
 +


### PR DESCRIPTION
#### What changes are you introducing?

Document options to enable provisioning of Secure Boot-enabled hosts on Proxmox.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

New feature in foreman_fog_proxmox.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs [PR 500 in foreman_fog_proxmox](https://github.com/theforeman/foreman_fog_proxmox/pull/500)
Refs [b1d1e7f501f1e5ceba47a4cbb619faddea1a1861 in foreman_fog_proxmox](https://github.com/theforeman/foreman_fog_proxmox/commit/b1d1e7f501f1e5ceba47a4cbb619faddea1a1861)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
