### PR TITLE
Drop PF3 deprecation notice

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -154,33 +154,6 @@ Custom templates extending this snippet may need updates.
 Hammer CLI plugin Admin is deprecated::
 As an alternative, you can use the `{foreman-installer}` to manage your {ProjectServer} or {SmartProxyServer}.
 
-PatternFly 3 components::
-+
---
-The following PatternFly 3 components are deprecated and will be removed in a future release.
-Migrate to PatternFly 5 equivalents:
-
-* PF3-based table implementation
-* Unused PF3 buttons
-* PF3-based SearchInput component
-* RedirectCancelButton
---
-
-//To add a headline feature, use AsciiDoc's description list: https://docs.asciidoctor.org/asciidoc/latest/lists/description/
-Form components::
-+
---
-Multiple form-related components have been deprecated in favor of PatternFly 5 alternatives:
-
-* `forms/Form.js`
-* `forms/TextField`
-* `forms/RadioButtonGroup`
-* `forms/DateTime`
-* Multiple components in `common/forms/*`
-
-Use the PatternFly 5 form components for new development.
---
-
 //Summary::
 //Description
 //+


### PR DESCRIPTION
#### What changes are you introducing?

Drop the PF deprecation notice from the Foreman 3.19 release notes.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This is a developer focused deprecation while the release notes should be user focused.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman-documentation/blob/master/CONTRIBUTING.md) guidelines.

Please cherry-pick my commits into:

* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* [ ] Foreman 3.13/Katello 4.15 (EL9 only)
* [ ] Foreman 3.12/Katello 4.14 (Satellite 6.16; orcharhino 7.2 on EL9 only; orcharhino 7.3)
* We do not accept PRs for Foreman older than 3.12.