### PR TITLE
Fix CSS build race condition and redundant per-BUILD compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DEST := result
 PORT := 5000
 VERSION_LINKS := 5.0 3.19 3.18 3.17 3.16 3.15 3.14 3.13 3.12 3.11 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.5 2.4
 
-.PHONY: all clean html web compile serve prep FORCE toc
+.PHONY: all clean html web compile serve prep FORCE toc css
 
 UNAME = $(shell uname)
 ifeq ($(UNAME), Linux)
@@ -27,7 +27,13 @@ clean:
 
 html: build-foreman-el build-foreman-deb build-containerized-katello build-containerized-orcharhino build-katello build-orcharhino build-satellite
 
-build-%: FORCE prep
+# Built once, up front, and shared by every build-% below: the compiled CSS
+# does not vary by BUILD, and compiling it redundantly from N parallel
+# build-% processes races on the same output file.
+css: prep
+	$(MAKE) -C guides/ css
+
+build-%: FORCE prep css
 	$(MAKE) -C guides/ html BUILD=$*
 
 web: prep

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -3,17 +3,24 @@ SHELL := /bin/bash
 SUBDIRS = $(shell ls -d doc-* | grep -v 'doc-Contributing')
 CONTRIBUTING_DIR = doc-Contributing
 
-.PHONY: all clean html linkchecker linkchecker-tryer serve subdirs $(SUBDIRS) contributing
+.PHONY: all clean html linkchecker linkchecker-tryer serve subdirs $(SUBDIRS) contributing contributing-css css
 
 all: html
 
 html: subdirs contributing
+
+css: subdirs contributing-css
 
 subdirs: $(SUBDIRS)
 
 contributing:
 	@if [ -d "$(CONTRIBUTING_DIR)" ]; then \
 		$(MAKE) -C "$(CONTRIBUTING_DIR)" html; \
+	fi
+
+contributing-css:
+	@if [ -d "$(CONTRIBUTING_DIR)" ]; then \
+		$(MAKE) -C "$(CONTRIBUTING_DIR)" css; \
 	fi
 
 $(SUBDIRS):

--- a/guides/common/Makefile
+++ b/guides/common/Makefile
@@ -38,7 +38,7 @@ endif
 endif
 
 .SHELLFLAGS = -o pipefail -c
-.PHONY: all prepare html clean browser server linkchecker
+.PHONY: all prepare html clean browser server linkchecker css
 
 all: html
 
@@ -70,8 +70,10 @@ ccutil:
 		ccutil compile --lang=en-US --format html-single ; \
 	fi
 
+css: prepare $(DEST_DIR)/style.css
+
 $(DEST_DIR)/style.css: $(CSS_SOURCES)
-	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@
+	bundle exec sass --sourcemap=none --no-cache --style $(CSS_STYLE) -I $(COMMON_DIR)/css $(COMMON_DIR)/css/default.scss $@.tmp.$$$$ && mv $@.tmp.$$$$ $@
 
 $(IMAGES_TS): $(DEST_DIR) $(IMAGES)
 	@[[ -h ./images/common ]] || echo "FAILURE: Missing ./images dir with ./images/common symlink to commons!"


### PR DESCRIPTION
#### What changes are you introducing?

Fixes a race condition in the guide build's CSS compilation, which is currently causing occasional broken (unstyled) pages in CI-built previews and, presumably, real deploys.

CI builds all 7 product variants (`foreman-el`, `foreman-deb`, `katello`, `orcharhino`, `satellite`, `containerized-katello`, `containerized-orcharhino`) in parallel via `make -j 3 html`. Every variant's build independently recompiles each guide's `style.css`, but the compiled CSS is identical across variants and all of them write to the same output path — so concurrent variant builds can end up truncating and rewriting that file at the same time. If a page gets rendered in the gap, it embeds a corrupted (in the case I hit, completely empty) stylesheet.

Two changes:
- The Sass compile now writes to a temp file and atomically renames it into place, so a reader can never observe a partially-written file, no matter how many builds race on it.
- CSS is now compiled once per guide, up front, and shared across all 7 variant builds, instead of once per variant. Removes the redundant work as well as the race.

This is the CSS half of the parallel-build race #5105 called out; #5182 already fixed the images half of the same underlying problem.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Found while investigating a reviewer report of a broken-looking PR preview (theforeman/foreman-documentation#5199) — traced it to this race via the CI build logs, and confirmed the fix with two full `make -j 3 html` runs (CI's exact invocation).

Related: #5105, #5182

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Race conditions are hard to prove fixed just by watching CI logs. I reproduced the actual bug (the empty stylesheet) and confirmed it stopped happening across repeated full builds, but this is still more of a "merge and keep an eye on it" fix than something I can guarantee is 100% gone.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
