### PR TITLE
Add disaster recovery for containerized

### DIFF
--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -13,23 +13,32 @@ Configure periodic backups of the active server.
 
 .Procedure
 . Define a schedule for periodic offline backups of your active {ProjectServer}.
-Consider your tolerance for potential data loss and your storage options: Taking backups frequently will result in smaller amounts of data loss in case of a disaster, but backups require a significant amount of storage space.
+Consider your tolerance for potential data loss and your storage options: Taking backups often will result in smaller amounts of data loss in case of a disaster, but backups require a significant amount of storage space.
 ifdef::katello,satellite[]
 For information about the size of {Project} backups, see xref:estimating-the-size-of-a-backup[].
 endif::[]
 +
+ifndef::containerized[]
 You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
+endif::[]
+ifdef::containerized[]
+{foremanctl} currently supports only full backups.
+For an example of a `cron` job that ensures regular full backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
+endif::[]
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 For information about performing backups, see xref:backing-up-{project-context}[].
 . Ensure that the backup directories are encrypted and regularly synchronized to a secure location.
-By default, {Project} stores the backups in the `_/var/{project-context}-backup_` directory.
+{Project} creates the backup in the directory that you specify when you run the backup command, for example, `_/var/{project-context}-backup_`.
 +
 [IMPORTANT]
 ====
-ifndef::foreman-el,foreman-deb[]
+ifndef::foreman-el,foreman-deb,containerized[]
 {ProjectServer} backups contain sensitive information from the `/root/ssl-build` directory.
-For example, they can contain hostnames, ssh keys, request files, and SSL certificates.
+For example, they can contain hostnames, SSH keys, request files, and SSL certificates.
+endif::[]
+ifdef::containerized[]
+{ProjectServer} backups contain sensitive information such as database passwords, OAuth keys, and encryption keys.
 endif::[]
 Encrypting or moving the backups to a secure location helps minimize the risk of damage or unauthorized access to the hosts.
 ====
@@ -37,6 +46,15 @@ Encrypting or moving the backups to a secure location helps minimize the risk of
 For information about restoring backups, see xref:restoring-{project-context}-from-backup[].
 . Optional: Automate backup restoration to keep the passive server periodically updated with the latest backup.
 A regularly restored passive server helps reduce switchover time if the active server fails.
+Because restoring a backup requires the passive server to be powered on and reachable, schedule the automation to power on the passive server for the duration of each restore and power it off again afterward.
++
+ifdef::containerized[]
+[NOTE]
+====
+After the first automated restore, the passive server already has an existing deployment.
+Each subsequent restore in the automation must include the `--force` option of the `{foremanctl} restore` command, otherwise the restore fails.
+====
+endif::[]
 +
 Consider how often you want the backups to be restored: More frequent updates reduce potential data loss but increase infrastructure and automation costs.
 . Power off the passive server.
@@ -49,7 +67,9 @@ Consider how many backups you want to store: Regularly removing outdated backups
 . Perform further testing steps in an isolated staging environment:
 .. Mimic a full outage on the active server.
 To make sure the active server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+.. Power on the passive server.
 .. Switch DNS records of the active server with the DNS records of the passive server.
 .. Assess the functionality of the test {ProjectServer}.
 For more information, see xref:retrieving-the-status-of-services-by-using-cli_{context}[].
+.. Power off the passive server after the test completes.
 .. Perform these verification checks regularly.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
@@ -4,10 +4,10 @@
 = Preparing for disaster recovery with active and passive {ProjectServer} with external storage
 
 [role="_abstract"]
-ifdef::satellite[]
+ifndef::containerized[]
 Create your passive {ProjectServer} as a clone of your active {ProjectServer}.
 endif::[]
-ifndef::satellite[]
+ifdef::containerized[]
 Create your passive {ProjectServer} as a backup of your active {ProjectServer}.
 endif::[]
 Ensure that the `/var/lib/pulp` and `{postgresql-lib-dir}` directories on your shared storage are available to both servers.
@@ -16,16 +16,14 @@ Ensure that the `/var/lib/pulp` and `{postgresql-lib-dir}` directories on your s
 * You have reviewed xref:overview-of-recommended-disaster-recovery-plans[] and determined that this disaster recovery plan works for you.
 * Your shared storage meets the requirements for holding the contents of `/var/lib/pulp` and `{postgresql-lib-dir}`.
 For more information, see {InstallingServerDocURL}storage-requirements_{project-context}[Storage requirements] in _{InstallingServerDocTitle}_.
-* You have configured your {ProjectServer} to use external databases.
-For more information, see {AdministeringDocURL}Migrating_from_Internal_Databases_to_External_Databases_admin[Migrating from internal {Project} databases to external databases] in _{InstallingServerDocTitle}_.
 
 .Procedure
 . Replicate the `/var/lib/pulp` and `{postgresql-lib-dir}` directories from the active {ProjectServer} to your shared storage.
-ifdef::satellite[]
+ifndef::containerized[]
 . Clone your active {ProjectServer}.
 For more information, see xref:cloning-{project-context}-server[].
 endif::[]
-ifndef::satellite[]
+ifdef::containerized[]
 . Back up your active {ProjectServer} and restore it on a system that will serve as your passive {ProjectServer}.
 For more information, see xref:backing-up-{project-context}[] and xref:restoring-{project-context}-from-backup[].
 endif::[]
@@ -33,7 +31,7 @@ endif::[]
 Power off the new server.
 +
 The source server remains your active primary server, while the new server becomes the passive secondary server.
-. Determine how you want to attach the database content on the shared storage to your passive server:
+. Decide how you want to attach the database content on the shared storage to your passive server:
 * If you mount the storage directly on both your active and passive server, the servers will always see the same, up-to-date content.
 * If you mount the storage only on your active server, the passive server will access the data only if it takes over as the active server.
 
@@ -42,6 +40,7 @@ Perform this test in an isolated staging environment:
 
 . Mimic a full outage on the active server.
 To make sure the active server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+. Power on the passive server and mount the shared storage on it if it is not already mounted.
 . Switch DNS records of the active server with the DNS records of the passive server.
 . Verify that your passive server can access the data stored on your shared storage.
 . Assess the functionality of the test {ProjectServer}.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -5,11 +5,11 @@
 
 [role="_abstract"]
 Create a second {ProjectServer} by restoring a backup of your first {ProjectServer}.
-Configure both servers to operate independently in their respective data centers, but ensure that their content does not drift apart over time.
+Configure both servers to operate independently in their own data centers, but ensure that their content does not drift apart over time.
 
 [NOTE]
 ====
-Ansible playbooks can help you automate failover, re-registration, and synchronization.
+Ansible playbooks can help you automate failover, reregistration, and synchronization.
 For more information, see {AnsibleDocURL}[_{AnsibleDocTitle}_].
 ====
 
@@ -25,8 +25,7 @@ For more information, see xref:restoring-{project-context}-from-backup[].
 +
 [NOTE]
 ====
-Each server must have a distinct hostname and IP address.
-This enables you to re-register hosts if one of the servers fails.
+Each server must have a distinct hostname and IP address so that you can reregister hosts if one of the servers fails.
 ====
 . Ensure that content on your servers remains consistent:
 * If you want both servers to manage content synchronization and content view creation, follow these guidelines to prevent content drift:
@@ -36,15 +35,20 @@ You can use the following Ansible modules to automate repository synchronization
 * If you want one server to manage content synchronization and content view creation, use one of these features to prevent content drift:
 ** If your disaster recovery site has network access to your primary site, use {ISS} (ISS) to ensure your disaster recovery server synchronizes its content from the primary server.
 ** If your disaster recovery site does not have network access to your primary site, synchronize content by using export and import.
-* If you want one server to manage only content view creation but not content synchronization, you can configure the other server or multiple other servers to import content views from the first server but synchronize content from repositories.
+* If you want one server to manage only content view creation but not content synchronization, you can configure the other server or many other servers to import content views from the first server but synchronize content from repositories.
 //      |------------ Foreman/Katello for CVs only ---------------|
 //                /                               \
 //              /                                   \
 //            /                                       \
 // |--Foreman/Katello for Hosts --|     |--Foreman/Katello for hosts--|
-. Register hosts to your servers so that each server manages hosts in its respective data center.
+. Register hosts to your servers so that each server manages hosts in its own data center.
 For example, register all hosts in _My_Data_Center_1_ to one {ProjectServer} and all hosts in _My_Data_Center_2_ to the other {ProjectServer}.
+ifdef::containerized[]
+. Automate running the `{foremanctl} health` command on both servers.
+endif::[]
+ifndef::containerized[]
 . Automate running the `{foreman-maintain} health check` command on both servers.
+endif::[]
 The health check verifies whether the servers remain fully operational.
 
 .Verification
@@ -52,9 +56,14 @@ Perform this test in an isolated staging environment:
 
 . Mimic a full outage on one of your servers.
 To verify that the server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+ifdef::containerized[]
+. Verify that your `{foremanctl} health` automation reported an error.
+endif::[]
+ifndef::containerized[]
 . Verify that your `{foreman-maintain} health check` automation reported an error.
-. Re-register all hosts from the inaccessible server to the accessible server.
-. Verify that hosts have been properly re-registered to the accessible server.
+endif::[]
+. Reregister all hosts from the inaccessible server to the accessible server.
+. Verify that hosts have been properly reregistered to the accessible server.
 . Perform these verification checks regularly.
 
 .Additional resources

--- a/guides/common/modules/proc_retrieving-status-of-services-by-using-cli.adoc
+++ b/guides/common/modules/proc_retrieving-status-of-services-by-using-cli.adoc
@@ -14,6 +14,7 @@ When troubleshooting, you can check the status of {Project} services by using Ha
 ----
 $ hammer ping
 ----
+ifndef::containerized[]
 * Check the status of the services running in systemd:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -22,6 +23,15 @@ $ hammer ping
 ----
 +
 Run `{foreman-maintain} service --help` for more information.
+endif::[]
+ifdef::containerized[]
+* Check the status of the {Project} services running in systemd:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+$ systemctl status foreman.target
+----
+endif::[]
 * Perform a health check:
 +
 ifdef::containerized[]

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc
@@ -4,9 +4,15 @@
 = Example of a weekly full backup followed by daily incremental backups
 
 [role="_abstract"]
+ifndef::containerized[]
 The following script performs a full backup on a Sunday followed by incremental backups for each of the following days.
 A new subdirectory is created for each day that an incremental backup is performed.
 The script requires a daily cron job.
+endif::[]
+ifdef::containerized[]
+The following script performs a full backup.
+{foremanctl} does not yet support incremental backups, so schedule the cron job to run weekly instead of daily.
+endif::[]
 
 ifdef::containerized[]
 [source, bash, options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -14,12 +20,7 @@ ifdef::containerized[]
 #!/bin/bash -e
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESTINATION=/var/backup_directory
-if [[ $(date +%w) == 0 ]]; then
-  {foremanctl} backup $DESTINATION
-else
-  LAST=$(ls -td -- $DESTINATION/*/ | head -n 1)
-  {foreman-maintain} backup offline --assumeyes --incremental "$LAST" $DESTINATION
-fi
+{foremanctl} backup $DESTINATION
 exit 0
 ----
 endif::[]
@@ -41,7 +42,8 @@ endif::[]
 
 ifdef::containerized[]
 Note that the {foremanctl} backup command requires `/sbin` and `/usr/sbin` directories to be in `PATH`.
+{foremanctl} does not yet support incremental backup, so run only a weekly full backup until incremental backup support is added.
 endif::[]
 ifndef::containerized[]
-Note that the {``{foreman-maintain} backup``} command requires `/sbin` and `/usr/sbin` directories to be in `PATH` and the `--assumeyes` option is used to skip the confirmation prompt.
+Note that the `{foreman-maintain} backup` command requires `/sbin` and `/usr/sbin` directories to be in `PATH` and the `--assumeyes` option is used to skip the confirmation prompt.
 endif::[]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -28,8 +28,8 @@ include::common/assembly_tuning-with-predefined-profiles.adoc[leveloffset=+1]
 endif::[]
 
 ifndef::containerized[]
-
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
+endif::[]
 
 include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
 
@@ -53,10 +53,10 @@ include::common/assembly_disaster-recovery-with-active-and-passive-project-serve
 
 include::common/assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+2]
 
+ifndef::containerized[]
 ifdef::satellite[]
 include::common/assembly_usage-metrics-collection-in-project.adoc[leveloffset=+1]
 endif::[]
-
 endif::[]
 
 ifdef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Including the chapter for disaster recovery in the containerized _Admin_ guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Containerization

[SAT-40457](https://redhat.atlassian.net/browse/SAT-40457)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- AI assisted
- Needs to be tech reviewed and tested

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
