### PR TITLE
Re-add a 24-hour rule exception for time-critical changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,9 @@ As a maintainer, I will:
 * Keep non-trivial PRs open for at least 24 hours (72 hours if over the weekend) to allow for input from the community.
 Examples of trivial PRs: Fixing a typo, fixing markup, or fixing links.
 Non-trivial PRs might not only benefit from additional review but they also represent an opportunity for community members to ask questions and learn.
++
+Time-critical release changes, such as release notes, can be merged without waiting 24 hours, but still require peer review and an ACK.
+* Make sure all PRs, including trivial ones, have received an ACK before merging.
 
 ## Pull request checklists
 


### PR DESCRIPTION
#### What changes are you introducing?

Updating CONTRIBUTING.md with guidelines around merging time-critical changes.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This seems to have been dropped (unintentionally) in https://github.com/theforeman/foreman-documentation/commit/47132b4bd68b9c2cdd9763de4326ef5153adcbb6

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Kudos to @ogajduse for highlighting this

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
