### PR TITLE
Add disaster recovery to additional deployment tasks

### DIFF
--- a/guides/common/assembly_deployment-path.adoc
+++ b/guides/common/assembly_deployment-path.adoc
@@ -26,8 +26,6 @@ include::modules/con_best-practices-for-role-based-access-control-in-project.ado
 
 include::modules/con_configuring-provisioning.adoc[leveloffset=+1]
 
-include::modules/ref_overview-of-recommended-disaster-recovery-plans.adoc[leveloffset=+1]
-
 ifdef::katello,orcharhino,satellite[]
 include::modules/ref_subscriptions-tracking-configuration.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/modules/ref_additional-deployment-tasks.adoc
+++ b/guides/common/modules/ref_additional-deployment-tasks.adoc
@@ -50,6 +50,7 @@ For more information, see {InstallingServerDocURL}performing-additional-configur
 endif::[]
 
 Preparing for disaster recovery::
-By preparing a disaster recovery plan, you can ensure the continuity of {Project} services in case of a disruptive event and restore your {Project} deployment to an operational state after an incident.
+By preparing a disaster recovery plan, you can ensure the continuity of {Project} services in case of a disruptive event.
+This helps you restore your {Project} deployment to an operational state after an incident.
 +
 For more information, see {AdministeringDocURL}preparing-for-disaster-recovery-and-recovering-from-data-loss[Preparing for disaster recovery and recovering from data loss in _{AdministeringDocTitle}_].

--- a/guides/common/modules/ref_additional-deployment-tasks.adoc
+++ b/guides/common/modules/ref_additional-deployment-tasks.adoc
@@ -48,3 +48,8 @@ With {Insights} enabled on your {ProjectServer}, you can identify key risks to s
 +
 For more information, see {InstallingServerDocURL}performing-additional-configuration-on-server_{project-context}[Performing additional configuration on {ProjectServer}] in _{InstallingServerDocTitle}_.
 endif::[]
+
+Preparing for disaster recovery::
+By preparing a disaster recovery plan, you can ensure the continuity of {Project} services in case of a disruptive event and restore your {Project} deployment to an operational state after an incident.
++
+For more information, see {AdministeringDocURL}preparing-for-disaster-recovery-and-recovering-from-data-loss[Preparing for disaster recovery and recovering from data loss in _{AdministeringDocTitle}_].


### PR DESCRIPTION
#### What changes are you introducing?

Move the disaster recovery pointer from the deployment path assembly into the additional deployment tasks reference, with a brief description and a link to the Administering guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To make the chapter on deployment path shorter, with fewer sections.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
