### PR TITLE
Update Appendix A: Starting and stopping services in the Administering Satellite for containerized release.

### DIFF
--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -26,7 +26,7 @@ To stop {Project} services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# systemctl service stop foreman.target
+# systemctl stop foreman.target
 ----
 
 To start {Project} services, execute:

--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -33,7 +33,7 @@ To start {Project} services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# systemctl service start foreman.target
+# systemctl start foreman.target
 ----
 
 To restart {Project} services, execute:

--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -9,6 +9,43 @@
 After installing {Project} with the `{foreman-installer}` command, all {Project} services are started and enabled automatically.
 View the list of these services by executing:
 
+ifdef::containerized[]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl list-dependencies foreman.target
+----
+
+To see the status of running services, execute:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl service status foreman.target
+----
+
+To stop {Project} services, execute:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl service stop foreman.target
+----
+
+To start {Project} services, execute:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl service start foreman.target
+----
+
+To restart {Project} services, execute:
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl service restart foreman.target
+----
+
+endif::[]
+
+ifndef::containerized[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} service list
@@ -41,3 +78,4 @@ To restart {Project} services, execute:
 ----
 # {foreman-maintain} service restart
 ----
+endif::[]

--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -19,7 +19,7 @@ To see the status of running services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# systemctl status foreman.target
+# systemctl list-units $(systemctl show -p Wants --value foreman.target)
 ----
 
 To stop {Project} services, execute:

--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -19,7 +19,7 @@ To see the status of running services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# systemctl service status foreman.target
+# systemctl status foreman.target
 ----
 
 To stop {Project} services, execute:

--- a/guides/common/modules/ref_starting-and-stopping-project-services.adoc
+++ b/guides/common/modules/ref_starting-and-stopping-project-services.adoc
@@ -40,7 +40,7 @@ To restart {Project} services, execute:
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# systemctl service restart foreman.target
+# systemctl restart foreman.target
 ----
 
 endif::[]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -113,9 +113,10 @@ include::common/assembly_using-foreman-webhooks.adoc[leveloffset=+1]
 
 include::common/assembly_working-efficiently-with-web-ui.adoc[leveloffset=+1]
 
-ifndef::containerized[]
 [appendix]
 include::common/modules/ref_starting-and-stopping-project-services.adoc[leveloffset=+1]
+
+ifndef::containerized[]
 
 [appendix]
 include::common/assembly_logging-and-reporting-problems.adoc[leveloffset=+1]
@@ -138,6 +139,7 @@ ifdef::satellite[]
 [appendix]
 include::common/modules/ref_usage-metrics-collected-by-project.adoc[leveloffset=+1]
 endif::[]
+
 endif::[]
 
 ifndef::orcharhino,satellite[]


### PR DESCRIPTION


#### What changes are you introducing?
Update Starting and stopping services in the Administering Satellite guide with new `systemctl` commands

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Relates to SAT-48120.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
