### PR TITLE
Publish 5.x branches to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,8 @@ jobs:
       github.repository_owner == 'theforeman' &&
       (github.ref == 'refs/heads/master' ||
       startsWith(github.ref, 'refs/heads/2.') ||
-      startsWith(github.ref, 'refs/heads/3.'))
+      startsWith(github.ref, 'refs/heads/3.') ||
+      startsWith(github.ref, 'refs/heads/5.'))
     needs:
       - build-html
       - build-web


### PR DESCRIPTION
#### What changes are you introducing?

Adds the `5.` branch prefix to the `publish` job's `if` condition in `.github/workflows/deploy.yml`, alongside the existing `master`, `2.`, and `3.` cases.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

`docs.theforeman.org/5.0/*` currently 404s for every page, including `Configuring_Load_Balancer/index-katello.html`. The `5.0` branching commit (352423e4f7, "Update master for 5.0 branching") added `web/releases/5.0.json` and updated the Makefile, but didn't update this workflow condition. As a result, pushes to the `5.0` branch build successfully but the `publish` job's `if` evaluates false, so the build is never deployed to `gh-pages`.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Because GitHub Actions reads the workflow file from the ref that triggered the push, this fix on `master` alone won't cause `5.0` pushes to publish — the `5.0` branch needs its own copy of the same change. Companion PR: #5215.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0 (filed directly as #5215 instead, so no cherry-pick needed)
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.