### PR TITLE
Fill in a concept module with content

### DIFF
--- a/guides/common/assembly_tools-for-administration-of-project.adoc
+++ b/guides/common/assembly_tools-for-administration-of-project.adoc
@@ -6,9 +6,9 @@ include::modules/con_hammer-cli-overview.adoc[leveloffset=+1]
 
 include::modules/con_api-overview.adoc[leveloffset=+1]
 
-include::modules/con_remote-execution-in-project.adoc[leveloffset=+1]
-
 include::modules/con_automating-project-management-with-project-ansible-collection.adoc[leveloffset=+1]
+
+include::modules/con_remote-execution-in-project.adoc[leveloffset=+1]
 
 ifdef::katello,satellite[]
 include::modules/con_kickstart-workflow.adoc[leveloffset=+1]

--- a/guides/common/modules/con_automating-project-management-with-project-ansible-collection.adoc
+++ b/guides/common/modules/con_automating-project-management-with-project-ansible-collection.adoc
@@ -7,7 +7,7 @@
 {Project} Ansible Collection is a set of Ansible modules that interact with the {Project} API.
 You can use these modules to automate many aspects of {Project} administration.
 
-Modules from the {Project} Ansible Collection are provided by the `ansible-collection-redhat-satellite package`.
+Modules from the {Project} Ansible Collection are provided by the `{ansible-collection-package}` package.
 On your {ProjectServer}, the package is installed by default.
 
 Using the modules, you can write playbooks to automate the administration of your {Project}.

--- a/guides/common/modules/con_automating-project-management-with-project-ansible-collection.adoc
+++ b/guides/common/modules/con_automating-project-management-with-project-ansible-collection.adoc
@@ -7,6 +7,10 @@
 {Project} Ansible Collection is a set of Ansible modules that interact with the {Project} API.
 You can use these modules to automate many aspects of {Project} administration.
 
+Modules from the {Project} Ansible Collection are provided by the `ansible-collection-redhat-satellite package`.
+On your {ProjectServer}, the package is installed by default.
+
+Using the modules, you can write playbooks to automate the administration of your {Project}.
+
 .Additional resources
-* {ManagingConfigurationsAnsibleDocURL}[{ManagingConfigurationsAnsibleDocTitle}]
 * {AnsibleDocURL}[_{AnsibleDocTitle}_]


### PR DESCRIPTION
#### What changes are you introducing?

Adding a few lines of descriptions to a concept module about the Foreman Ansible collection.

Also, dropping a link to a guide that describes managing hosts (using Ansible), rather than administering Satellite itself.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

A concept module should have a body, not just an abstract.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

The new lines are just content copied from the Foreman Ansible Collection guide, slightly edited. I don't think this needs a `tech review` so I'm requesting a `style review` only.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
