### PR TITLE
Add Pathways to IoP

### DIFF
--- a/guides/common/assembly_monitoring-hosts-by-using-insights-in-project.adoc
+++ b/guides/common/assembly_monitoring-hosts-by-using-insights-in-project.adoc
@@ -19,6 +19,10 @@ include::modules/proc_examining-recommendations-for-hosts.adoc[leveloffset=+1]
 
 include::modules/proc_remediating-issues-based-on-insights-recommendations.adoc[leveloffset=+1]
 
+include::modules/con_pathways-for-insights-recommendations.adoc[leveloffset=+1]
+
+include::modules/proc_examining-pathways-for-hosts.adoc[leveloffset=+1]
+
 include::modules/proc_disabling-recommendations-in-project.adoc[leveloffset=+1]
 
 include::modules/proc_enabling-recommendations-in-project.adoc[leveloffset=+1]

--- a/guides/common/modules/con_insights-overview.adoc
+++ b/guides/common/modules/con_insights-overview.adoc
@@ -60,8 +60,6 @@ If you use {insights-iop}:
 * {Project} does not send any reports to the {RHCloud}.
 * {Project} does not forward any data through the Insights client to the {RHCloud}.
 * You cannot use any of the hosted services on the {RHCloud}.
-* Pathways use the same underlying Advisor rule engine and grouping logic as hosted {Insights}.
-However, features that depend on a live connection to the {RHCloud}, such as {RHCloud} notifications for recommendations and the *View in {Insights}* link, are not available.
 --
 endif::[]
 

--- a/guides/common/modules/con_insights-overview.adoc
+++ b/guides/common/modules/con_insights-overview.adoc
@@ -13,7 +13,7 @@
 {Insights} services include:
 
 * Advisor, which provides recommendations for host improvements.
-{Project} groups related recommendations into pathways.
+Advisor groups related recommendations into pathways.
 * Vulnerability, which provides reports on vulnerabilities found on your hosts.
 * Compliance, which provides reports on compliance with regulatory requirements.
 

--- a/guides/common/modules/con_insights-overview.adoc
+++ b/guides/common/modules/con_insights-overview.adoc
@@ -13,6 +13,7 @@
 {Insights} services include:
 
 * Advisor, which provides recommendations for host improvements.
+{Project} groups related recommendations into pathways.
 * Vulnerability, which provides reports on vulnerabilities found on your hosts.
 * Compliance, which provides reports on compliance with regulatory requirements.
 
@@ -59,6 +60,8 @@ If you use {insights-iop}:
 * {Project} does not send any reports to the {RHCloud}.
 * {Project} does not forward any data through the Insights client to the {RHCloud}.
 * You cannot use any of the hosted services on the {RHCloud}.
+* Pathways use the same underlying Advisor rule engine and grouping logic as hosted {Insights}.
+However, features that depend on a live connection to the {RHCloud}, such as {RHCloud} notifications for recommendations and the *View in {Insights}* link, are not available.
 --
 endif::[]
 

--- a/guides/common/modules/con_pathways-for-insights-recommendations.adoc
+++ b/guides/common/modules/con_pathways-for-insights-recommendations.adoc
@@ -15,5 +15,4 @@ You remediate the recommendations that a pathway groups the same way that you re
 In an air-gapped or disconnected {Project} deployment, pathways refresh only when you update the container images of {insights-iop}.
 
 .Additional resources
-* xref:examining-recommendations-for-hosts_{context}[]
 * xref:examining-pathways-for-hosts[]

--- a/guides/common/modules/con_pathways-for-insights-recommendations.adoc
+++ b/guides/common/modules/con_pathways-for-insights-recommendations.adoc
@@ -12,7 +12,7 @@ Pathways in {insights-iop} is the same Advisor pathways capability that is alrea
 
 You remediate the recommendations that a pathway groups the same way that you remediate any other {Insights} recommendation.
 
-In an air-gapped or disconnected {Project} deployment, pathways and the hosts they affect refresh only when you update the container images of {insights-iop}.
+In an air-gapped or disconnected {Project} deployment, pathways refresh only when you update the container images of {insights-iop}.
 
 .Additional resources
 * xref:examining-recommendations-for-hosts_{context}[]

--- a/guides/common/modules/con_pathways-for-insights-recommendations.adoc
+++ b/guides/common/modules/con_pathways-for-insights-recommendations.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="pathways-for-{insights-id}-recommendations"]
+= Pathways for {Insights} recommendations
+
+[role="_abstract"]
+A pathway groups related {Insights} recommendations that share a common component and resolution risk.
+Instead of triaging each of these recommendations one by one, you can review and remediate the whole group as a single guided path.
+
+Pathways in {insights-iop} is the same Advisor pathways capability that is already available in the hosted {Insights}.
+{Project} exposes this capability locally on the *Recommendations* page, so you do not need a connection to the {RHCloud} to use it.
+
+You remediate the recommendations that a pathway groups the same way that you remediate any other {Insights} recommendation.
+
+In an air-gapped or disconnected {Project} deployment, pathways and the hosts they affect refresh only when you update the container images of {insights-iop}.
+
+.Additional resources
+* xref:examining-recommendations-for-hosts_{context}[]
+* xref:examining-pathways-for-hosts[]

--- a/guides/common/modules/proc_examining-pathways-for-hosts.adoc
+++ b/guides/common/modules/proc_examining-pathways-for-hosts.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="examining-pathways-for-hosts"]
+= Examining pathways for hosts
+
+[role="_abstract"]
+You can open a pathway to review the recommendations that it groups and the hosts that it affects, then remediate those recommendations the same way that you remediate any other {Insights} recommendation.
+
+.Prerequisites
+* Your {Project} account has a role that grants the `view_foreman_rh_cloud`, `view_insights_hits`, and `view_advisor` permissions.
+You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
+
+.Procedure
+. In the {ProjectWebUI}, navigate to *{Insights}* > *Recommendations*.
+. Click the *Pathways* tab.
+The *Pathways* tab is displayed only when at least one pathway currently affects a host in your environment.
+. Click the name of a pathway to open its detail page.
+. On the *Recommendations* tab, review the individual recommendations that {Project} groups under the pathway.
+. Click the *Systems* tab to view the hosts that the pathway affects.
+. Click the name of a system to navigate to the details page of the host.
+
+.Next steps
+* xref:remediating-issues-based-on-{insights-id}-recommendations_{context}[]
++
+NOTE: You can only remediate recommendations that have an associated playbook.
+
+.Additional resources
+* xref:pathways-for-{insights-id}-recommendations[]

--- a/guides/common/modules/proc_examining-pathways-for-hosts.adoc
+++ b/guides/common/modules/proc_examining-pathways-for-hosts.adoc
@@ -25,3 +25,4 @@ NOTE: You can only remediate recommendations that have an associated playbook.
 
 .Additional resources
 * xref:pathways-for-{insights-id}-recommendations[]
+* xref:examining-recommendations-for-hosts_{context}[]

--- a/guides/common/modules/proc_examining-pathways-for-hosts.adoc
+++ b/guides/common/modules/proc_examining-pathways-for-hosts.adoc
@@ -13,7 +13,6 @@ You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
 .Procedure
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Recommendations*.
 . Click the *Pathways* tab.
-The *Pathways* tab is displayed only when at least one pathway currently affects a host in your environment.
 . Click the name of a pathway to open its detail page.
 . On the *Recommendations* tab, review the individual recommendations that {Project} groups under the pathway.
 . Click the *Systems* tab to view the hosts that the pathway affects.


### PR DESCRIPTION
#### What changes are you introducing?

Adding information about Pathways to IoP docs

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

IoP Advisor can now group recommendations into Pathways.
[SAT-48681](https://redhat.atlassian.net/browse/SAT-48681)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
