### PR TITLE
Enable containerized deployment documentation for Katello

### DIFF
--- a/guides/common/attributes-katello.adoc
+++ b/guides/common/attributes-katello.adoc
@@ -9,3 +9,7 @@
 :smart-proxy-minimum-memory: 12 GB
 :smartproxy_port: 9090
 :smartproxy-installer-package: foreman-proxy-content
+
+// Containerized deployment overrides
+:containerized:
+include::attributes-containerized.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?

Cherry-pick of #5220 to the 5.0 branch.

Enable the `containerized` flag in Katello builds to include foremanctl installation and deployment procedures in the Installing Server guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Currently, the foremanctl installation instructions appear in Satellite documentation but not in Katello documentation. This is because the `:containerized:` attribute is only defined in `attributes-satellite.adoc` but not in `attributes-katello.adoc`.

This change brings Katello documentation in line with Satellite builds by:
- Enabling the `containerized` flag
- Including `attributes-containerized.adoc` which provides the necessary attribute overrides
- Allowing `proc_deploy-project-server-configuration-with-the-default-database.adoc` and `proc_deploy-project-server-configuration-with-an-external-database.adoc` to be included in Katello builds

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

This is a minimal change that reuses existing infrastructure. The `attributes-containerized.adoc` file already exists and contains all necessary overrides.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)