### PR TITLE
Extend list of content sources

### DIFF
--- a/guides/common/modules/con_defining-your-content-library-and-content-access-strategy.adoc
+++ b/guides/common/modules/con_defining-your-content-library-and-content-access-strategy.adoc
@@ -4,14 +4,19 @@
 = Defining your content library and content access strategy
 
 [role="_abstract"]
-To ensure that your {ProjectServer} can manage software and provide it to your hosts, you create repositories and synchronize them.
+To ensure that your {Project} can manage software and provide it to your hosts, you create repositories and synchronize them.
 You can also define which hosts can access which content and content versions.
 
 Your {Project} content library can include various types of content.
 Creating repositories allows you to choose the specific software required for your environment.
 By creating only the necessary repositories, you avoid downloading unnecessary content.
 
+ifdef::satellite[]
 Synchronizing repositories downloads the content from Red{nbsp}Hat CDN or another source to your {ProjectServer}.
+endif::[]
+ifndef::satellite[]
+Synchronizing repositories downloads the content from Canonical, Oracle, Red{nbsp}Hat, SUSE, or other sources to your {ProjectServer}.
+endif::[]
 The synchronized content is stored on your {ProjectServer}, eliminating the need for hosts to access the repositories.
 You can synchronize repositories manually, or you can create a sync plan to ensure synchronization runs on a regular basis.
 


### PR DESCRIPTION
#### What changes are you introducing?

Extend list of content sources for non-Satellite builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Late review of https://github.com/theforeman/foreman-documentation/pull/5210/changes

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
