### PR TITLE
Update CONTRIBUTING with guidance for draft PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Examples of trivial PRs: Fixing a typo, fixing markup, or fixing links.
 Non-trivial PRs might not only benefit from additional review but they also represent an opportunity for community members to ask questions and learn.
 +
 Time-critical release changes, such as release notes, can be merged without waiting 24 hours, but still require peer review and an ACK.
+* If a PR is switched from *draft* state to a *ready for review* state, keep it open for 24 hours after switching (72 hours if over the weekend) to allow for input from the community.
 * Make sure all PRs, including trivial ones, have received an ACK before merging.
 
 ## Pull request checklists


### PR DESCRIPTION
#### What changes are you introducing?

Adding guidance that PRs that were switched from draft to ready-for-review should also be kept open for additional 24 hours.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This comes up from time to time and it's good to agree on what the exact guideline should be and write it down.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
