### PR TITLE
Add disaster recovery for containerized

### DIFF
--- a/guides/common/assembly_backing-up-project.adoc
+++ b/guides/common/assembly_backing-up-project.adoc
@@ -20,7 +20,12 @@ endif::[]
 
 ifndef::containerized[]
 include::modules/proc_performing-an-incremental-backup.adoc[leveloffset=+1]
+endif::[]
 
+ifdef::containerized[]
+include::modules/ref_example-of-a-weekly-full-backup.adoc[leveloffset=+1]
+endif::[]
+ifndef::containerized[]
 include::modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc[leveloffset=+1]
 
 include::modules/proc_performing-an-online-backup.adoc[leveloffset=+1]

--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -6,9 +6,6 @@ include::modules/proc_recovering-from-disaster-with-active-and-passive-project-s
 
 include::modules/proc_retrieving-status-of-services-by-using-cli.adoc[leveloffset=+1]
 
-ifdef::containerized[]
-include::modules/ref_example-of-a-weekly-full-backup.adoc[leveloffset=+1]
-endif::[]
 ifndef::containerized[]
 include::modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc[leveloffset=+1]
 endif::[]

--- a/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/assembly_disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -6,4 +6,9 @@ include::modules/proc_recovering-from-disaster-with-active-and-passive-project-s
 
 include::modules/proc_retrieving-status-of-services-by-using-cli.adoc[leveloffset=+1]
 
+ifdef::containerized[]
+include::modules/ref_example-of-a-weekly-full-backup.adoc[leveloffset=+1]
+endif::[]
+ifndef::containerized[]
 include::modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc[leveloffset=+1]
+endif::[]

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -24,9 +24,8 @@ For an example of a `cron` job that ensures regular backups, see xref:Example_of
 endif::[]
 ifdef::containerized[]
 Incremental backups are not available.
-For an example of a `cron` job that ensures regular full backups, see xref:example-of-a-weekly-full-backup_{context}[].
+For an example of a `cron` job that ensures regular full backups, see xref:example-of-a-weekly-full-backup[].
 endif::[]
-
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 For information about performing backups, see xref:backing-up-{project-context}[].
 . Ensure that the backup directories are encrypted and regularly synchronized to a secure location.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -23,7 +23,7 @@ You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
 endif::[]
 ifdef::containerized[]
-For an example of a `cron` job that ensures regular full backups, see xref:example-of-a-weekly-full-backup[].
+For an example of a `cron` job that ensures regular full backups, see xref:example-of-a-weekly-full-backup_{context}[].
 endif::[]
 
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -23,6 +23,7 @@ You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
 endif::[]
 ifdef::containerized[]
+Incremental backups are not available.
 For an example of a `cron` job that ensures regular full backups, see xref:example-of-a-weekly-full-backup_{context}[].
 endif::[]
 

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -30,10 +30,6 @@ endif::[]
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 For information about performing backups, see xref:backing-up-{project-context}[].
 . Ensure that the backup directories are encrypted and regularly synchronized to a secure location.
-ifdef::containerized[]
-The `{foremanctl} backup` command has no default storage location.
-A backup directory must be supplied as a positional argument at the end of the command.
-endif::[]
 ifndef::containerized[]
 By default, {Project} stores the backups in the `_/var/{project-context}-backup_` directory.
 endif::[]

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -23,7 +23,13 @@ For an example of a `cron` job that ensures regular backups, see xref:Example_of
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 For information about performing backups, see xref:backing-up-{project-context}[].
 . Ensure that the backup directories are encrypted and regularly synchronized to a secure location.
+ifdef::containerized[]
+The `{foremanctl} backup` command has no default storage location.
+A backup directory must be supplied as a positional argument at the end of the command.
+endif::[]
+ifndef::containerized[]
 By default, {Project} stores the backups in the `_/var/{project-context}-backup_` directory.
+endif::[]
 +
 [IMPORTANT]
 ====

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-and-backup-and-restore.adoc
@@ -18,8 +18,14 @@ ifdef::katello,satellite[]
 For information about the size of {Project} backups, see xref:estimating-the-size-of-a-backup[].
 endif::[]
 +
+ifndef::containerized[]
 You can combine full backups with incremental backups.
 For an example of a `cron` job that ensures regular backups, see xref:Example_of_a_Weekly_Full_Backup_Followed_by_Daily_Incremental_Backups_{context}[].
+endif::[]
+ifdef::containerized[]
+For an example of a `cron` job that ensures regular full backups, see xref:example-of-a-weekly-full-backup[].
+endif::[]
+
 . Schedule periodic offline backups of your active {ProjectServer} to be taken according to the schedule you defined.
 For information about performing backups, see xref:backing-up-{project-context}[].
 . Ensure that the backup directories are encrypted and regularly synchronized to a secure location.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-active-and-passive-project-server-with-external-storage.adoc
@@ -22,8 +22,16 @@ For more information, see {AdministeringDocURL}Migrating_from_Internal_Databases
 .Procedure
 . Replicate the `/var/lib/pulp` and `{postgresql-lib-dir}` directories from the active {ProjectServer} to your shared storage.
 ifdef::satellite[]
+ifdef::containerized[]
+. Back up your active {ProjectServer} and restore it on a system that will serve as your passive {ProjectServer}.
+For more information, see the following resources:
+* xref:backing-up-{project-context}[]
+* xref:restoring-{project-context}-from-backup[]
+endif::[]
+ifndef::containerized[]
 . Clone your active {ProjectServer}.
 For more information, see xref:cloning-{project-context}-server[].
+endif::[]
 endif::[]
 ifndef::satellite[]
 . Back up your active {ProjectServer} and restore it on a system that will serve as your passive {ProjectServer}.

--- a/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
+++ b/guides/common/modules/proc_preparing-for-disaster-recovery-with-two-active-project-servers.adoc
@@ -44,15 +44,26 @@ You can use the following Ansible modules to automate repository synchronization
 // |--Foreman/Katello for Hosts --|     |--Foreman/Katello for hosts--|
 . Register hosts to your servers so that each server manages hosts in its respective data center.
 For example, register all hosts in _My_Data_Center_1_ to one {ProjectServer} and all hosts in _My_Data_Center_2_ to the other {ProjectServer}.
+ifdef::containerized[]
+. Automate running the `{foremanctl} health` command on both servers.
+The health check verifies whether the servers remain fully operational.
+endif::[]
+ifndef::containerized[]
 . Automate running the `{foreman-maintain} health check` command on both servers.
 The health check verifies whether the servers remain fully operational.
+endif::[]
 
 .Verification
 Perform this test in an isolated staging environment:
 
 . Mimic a full outage on one of your servers.
 To verify that the server is inaccessible, you can turn the machine off, halt the virtual machine (VM) if your server runs on a VM, or isolate the machine by using a firewall.
+ifdef::containerized[]
+. Verify that your `{foremanctl} health` automation reported an error.
+endif::[]
+ifndef::containerized[]
 . Verify that your `{foreman-maintain} health check` automation reported an error.
+endif::[]
 . Re-register all hosts from the inaccessible server to the accessible server.
 . Verify that hosts have been properly re-registered to the accessible server.
 . Perform these verification checks regularly.

--- a/guides/common/modules/proc_retrieving-status-of-services-by-using-cli.adoc
+++ b/guides/common/modules/proc_retrieving-status-of-services-by-using-cli.adoc
@@ -16,12 +16,20 @@ $ hammer ping
 ----
 * Check the status of the services running in systemd:
 +
+ifdef::containerized[]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# systemctl status foreman.target --with-dependencies
+----
+endif::[]
+ifndef::containerized[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 # {foreman-maintain} service status
 ----
 +
 Run `{foreman-maintain} service --help` for more information.
+endif::[]
 * Perform a health check:
 +
 ifdef::containerized[]
@@ -29,6 +37,8 @@ ifdef::containerized[]
 ----
 $ {foremanctl} health
 ----
++
+Run `{foremanctl} health --help` for more information.
 endif::[]
 ifndef::containerized[]
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc
@@ -39,7 +39,7 @@ exit 0
 endif::[]
 
 ifdef::containerized[]
-Note that the {foremanctl} backup command requires `/sbin` and `/usr/sbin` directories to be in `PATH`.
+Note that the `{foremanctl} backup` command requires `/sbin` and `/usr/sbin` directories to be in `PATH`.
 Incremental backup is not available.
 endif::[]
 ifndef::containerized[]

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup-followed-by-daily-incremental-backups.adoc
@@ -17,8 +17,7 @@ DESTINATION=/var/backup_directory
 if [[ $(date +%w) == 0 ]]; then
   {foremanctl} backup $DESTINATION
 else
-  LAST=$(ls -td -- $DESTINATION/*/ | head -n 1)
-  {foreman-maintain} backup offline --assumeyes --incremental "$LAST" $DESTINATION
+  {foremanctl} backup $DESTINATION
 fi
 exit 0
 ----
@@ -41,6 +40,7 @@ endif::[]
 
 ifdef::containerized[]
 Note that the {foremanctl} backup command requires `/sbin` and `/usr/sbin` directories to be in `PATH`.
+Incremental backup is not available.
 endif::[]
 ifndef::containerized[]
 Note that the {``{foreman-maintain} backup``} command requires `/sbin` and `/usr/sbin` directories to be in `PATH` and the `--assumeyes` option is used to skip the confirmation prompt.

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="example-of-a-weekly-full-backup_{context}"]
+[id="example-of-a-weekly-full-backup"]
 = Example of a weekly full backup
 
 [role="_abstract"]

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
@@ -5,7 +5,6 @@
 
 [role="_abstract"]
 The following cron line runs a full backup every Sunday.
-Incremental backup is not available.
 
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 
-[id="example-of-a-weekly-full-backup"]
+[id="example-of-a-weekly-full-backup_{context}"]
 = Example of a weekly full backup
 
 [role="_abstract"]

--- a/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
+++ b/guides/common/modules/ref_example-of-a-weekly-full-backup.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: REFERENCE
+
+[id="example-of-a-weekly-full-backup"]
+= Example of a weekly full backup
+
+[role="_abstract"]
+The following cron line runs a full backup every Sunday.
+Incremental backup is not available.
+
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+0 0 * * 0 PATH=/sbin:/bin:/usr/sbin:/usr/bin {foremanctl} backup _/var/backup_directory_
+----
+
+Note that the `{foremanctl} backup` command requires `/sbin` and `/usr/sbin` directories to be in `PATH`.

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -29,8 +29,6 @@ endif::[]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
 
-ifndef::containerized[]
-
 include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
 
 :parent-context: {context}
@@ -52,8 +50,6 @@ include::common/assembly_disaster-recovery-with-active-and-passive-project-serve
 :!parent-context:
 
 include::common/assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+2]
-
-endif::[]
 
 ifdef::satellite[]
 include::common/assembly_managing-organizations-in-project.adoc[leveloffset=+1]

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -31,6 +31,8 @@ ifndef::containerized[]
 
 include::common/assembly_migrating-from-internal-databases-to-external-databases.adoc[leveloffset=+1]
 
+endif::[]
+
 include::common/assembly_preparing-for-disaster-recovery-and-recovering-from-data-loss.adoc[leveloffset=+1]
 
 :parent-context: {context}
@@ -52,8 +54,6 @@ include::common/assembly_disaster-recovery-with-active-and-passive-project-serve
 :!parent-context:
 
 include::common/assembly_disaster-recovery-with-two-active-project-servers.adoc[leveloffset=+2]
-
-endif::[]
 
 ifdef::satellite[]
 include::common/assembly_managing-organizations-in-project.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Adding disaster recovery for containerized in the _Admin_ guide

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Containerization

[SAT-40457](https://redhat.atlassian.net/browse/SAT-40457)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- AI assisted
- Needs to be tested

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
