### PR TITLE
Add enabling IoP (connected) for containerized

### DIFF
--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -43,7 +43,8 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --enable-iop
+ifndef::containerized[# {foreman-installer} --enable-iop]
+ifdef::containerized[# {foremanctl} deploy --add-feature iop]
 ----
 . If you want to use the {vulnerabilityengine} and your {ProjectServer} connects to `\https://security.access.redhat.com` through an HTTP proxy, configure the `iop-cvemap-download` service to use the same HTTP proxy:
 .. Edit the `iop-cvemap-download` service:

--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -43,8 +43,12 @@ endif::[]
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-ifndef::containerized[# {foreman-installer} --enable-iop]
-ifdef::containerized[# {foremanctl} deploy --add-feature iop]
+ifndef::containerized[]
+# {foreman-installer} --enable-iop
+endif::[]
+ifdef::containerized[]
+# {foremanctl} deploy --add-feature iop
+endif::[]
 ----
 . If you want to use the {vulnerabilityengine} and your {ProjectServer} connects to `\https://security.access.redhat.com` through an HTTP proxy, configure the `iop-cvemap-download` service to use the same HTTP proxy:
 .. Edit the `iop-cvemap-download` service:

--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -25,20 +25,8 @@ endif::[]
 ifndef::satellite[]
 For more information, see https://podman.io/docs/installation#installing-on-linux[Installing Podman on Linux].
 endif::[]
-* Ensure that Podman is configured to use the netavark network backend.
-For more information, see https://access.redhat.com/solutions/7055981[How to switch to netavark network backend in Podman in the Red{nbsp}Hat Knowledgebase].
 
 .Procedure
-ifdef::satellite[]
-. Log in to the Red{nbsp}Hat registry by using Podman:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# podman login --authfile /etc/foreman/registry-auth.json registry.redhat.io
-----
-+
-This command creates the `/etc/foreman/registry-auth.json` file.
-endif::[]
 . Enable the plugin:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -20,13 +20,15 @@ This command creates the `/etc/foreman/registry-auth.json` file.
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --iop-ensure present
+ifndef::containerized[# {foreman-installer} --iop-ensure present]
+ifdef::containerized[# {foremanctl} deploy --add-feature iop]
 ----
 ** If {insights-iop} was not previously enabled:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --enable-iop
+ifndef::containerized[# {foreman-installer} --enable-iop]
+ifdef::containerized[# {foremanctl} deploy --add-feature iop]
 ----
 . On your hosts, re-register the Insights client:
 +

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -7,14 +7,6 @@
 Migrate from hosted {Insights} to {insights-iop} when you need local analysis on your {ProjectServer} without sending host data to the {RHCloud}.
 
 .Procedure
-. Log in to the Red{nbsp}Hat container registry:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# podman login --authfile /etc/foreman/registry-auth.json registry.redhat.io
-----
-+
-This command creates the `/etc/foreman/registry-auth.json` file.
 . On {ProjectServer}, enable {insights-iop}:
 ifdef::containerized[]
 +

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -16,20 +16,27 @@ Migrate from hosted {Insights} to {insights-iop} when you need local analysis on
 +
 This command creates the `/etc/foreman/registry-auth.json` file.
 . On {ProjectServer}, enable {insights-iop}:
+ifdef::containerized[]
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# {foremanctl} deploy --add-feature iop
+----
+endif::[]
+ifndef::containerized[]
 ** If {insights-iop} was previously enabled:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-ifndef::containerized[# {foreman-installer} --iop-ensure present]
-ifdef::containerized[# {foremanctl} deploy --add-feature iop]
+# {foreman-installer} --iop-ensure present
 ----
 ** If {insights-iop} was not previously enabled:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-ifndef::containerized[# {foreman-installer} --enable-iop]
-ifdef::containerized[# {foremanctl} deploy --add-feature iop]
+# {foreman-installer} --enable-iop
 ----
+endif::[]
 . On your hosts, re-register the Insights client:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_migrating-from-in-project-to-hosted-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-in-project-to-hosted-insights.adoc
@@ -15,7 +15,8 @@ Migrate from {insights-iop} to hosted {Insights} when you want cloud-based analy
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --iop-ensure absent
+ifndef::containerized[# {foreman-installer} --iop-ensure absent]
+ifdef::containerized[# {foremanctl} deploy --remove-feature iop]
 ----
 . Reconfigure the cloud connector on {ProjectServer}.
 For more information, see xref:configuring-{project-context}-server-for-cloud-connection[].

--- a/guides/common/modules/proc_migrating-from-in-project-to-hosted-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-in-project-to-hosted-insights.adoc
@@ -15,8 +15,12 @@ Migrate from {insights-iop} to hosted {Insights} when you want cloud-based analy
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-ifndef::containerized[# {foreman-installer} --iop-ensure absent]
-ifdef::containerized[# {foremanctl} deploy --remove-feature iop]
+ifdef::containerized[]
+# {foremanctl} deploy --remove-feature iop
+endif::[]
+ifndef::containerized[]
+# {foreman-installer} --iop-ensure absent
+endif::[]
 ----
 . Reconfigure the cloud connector on {ProjectServer}.
 For more information, see xref:configuring-{project-context}-server-for-cloud-connection[].

--- a/guides/common/modules/proc_updating-project-server.adoc
+++ b/guides/common/modules/proc_updating-project-server.adoc
@@ -17,8 +17,11 @@ If you want to upgrade {Project} to the next version, see xref:sources/installat
 endif::[]
 
 ifdef::satellite[]
-ifndef::containerized[]
 If you use the {insights-iop}, the following process updates {insights-iop} to the latest version.
+ifdef::containerized[]
+The `{foremanctl}` tool pulls the new container images of the {insights-iop} automatically.
+endif::[]
+ifndef::containerized[]
 The `{foreman-maintain}` tool pulls the new container images of the {insights-iop} automatically.
 endif::[]
 endif::[]

--- a/guides/common/modules/proc_updating-project-server.adoc
+++ b/guides/common/modules/proc_updating-project-server.adoc
@@ -16,11 +16,6 @@ ifdef::orcharhino[]
 If you want to upgrade {Project} to the next version, see xref:sources/installation_and_maintenance/upgrading_orcharhino_server.adoc[Upgrading {ProjectServer}] or xref:sources/installation_and_maintenance/upgrading_orcharhino_proxy_server.adoc[Upgrading {SmartProxyServer}].
 endif::[]
 
-ifdef::satellite[]
-If you use the {insights-iop}, the following process updates {insights-iop} to the latest version.
-The `{foremanctl}` tool pulls the new container images of the {insights-iop} automatically.
-endif::[]
-
 .Prerequisites
 * Back up your {ProjectServer}.
 For more information, see {AdministeringDocURL}backing-up-{project-context}[Backing up {Project}] in _{AdministeringDocTitle}_.

--- a/guides/common/modules/proc_updating-project-server.adoc
+++ b/guides/common/modules/proc_updating-project-server.adoc
@@ -18,12 +18,7 @@ endif::[]
 
 ifdef::satellite[]
 If you use the {insights-iop}, the following process updates {insights-iop} to the latest version.
-ifdef::containerized[]
 The `{foremanctl}` tool pulls the new container images of the {insights-iop} automatically.
-endif::[]
-ifndef::containerized[]
-The `{foreman-maintain}` tool pulls the new container images of the {insights-iop} automatically.
-endif::[]
 endif::[]
 
 .Prerequisites

--- a/guides/doc-Administering_Project/master.adoc
+++ b/guides/doc-Administering_Project/master.adoc
@@ -80,8 +80,11 @@ ifdef::katello,orcharhino,satellite[]
 include::common/assembly_renaming-server-or-smart-proxy.adoc[leveloffset=+1]
 endif::[]
 
+endif::[]
+
 include::common/assembly_configuring-project-for-insights-analytics.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 include::common/assembly_reducing-storage-use-on-project-server.adoc[leveloffset=+1]
 
 endif::[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -41,11 +41,8 @@ endif::[]
 
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 
-
-ifndef::containerized[]
 ifdef::orcharhino,satellite[]
 include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffset=+2]
-endif::[]
 endif::[]
 
 ifdef::satellite[]


### PR DESCRIPTION
#### What changes are you introducing?

Adding enabling/disabling IoP in connected envs for containerized:

- Enable installing IoP in the connected _Installing_ guide
- Enable migrating between hosted Insights and IoP in the _Admin_ guide
- Add `foremanctl` commands

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Containerization

- Supersedes #5096
- [SAT-40194](https://redhat.atlassian.net/browse/SAT-40194)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
