### PR TITLE
Update the rest for CV environments

### DIFF
--- a/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
@@ -11,8 +11,8 @@ This helps you balance load or point the host to a closer or preferred content s
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
 . Open the options menu next to the *Edit* button and select *Change content source*.
-. Select *Content Source*, *Lifecycle Content View*, and *Content Source* from the lists.
-. Click *Change content source*.
+. From the *Content source* list, select the new content source.
+. In the *Content view environments* list, assign the content view environments you want to use.
 +
 [NOTE]
 ====
@@ -21,6 +21,7 @@ ifndef::orcharhino[]
 For more information, see {ContentManagementDocURL}adding-lifecycle-environments-by-using-web-ui[Adding lifecycle environments to {SmartProxyServers}] in _{ContentManagementDocTitle}_.
 endif::[]
 ====
+. Click *Save*.
 . You can complete the content source change by using remote execution or manually.
 +
 To update configuration on host using remote execution, click *Run job invocation*.

--- a/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
@@ -13,6 +13,8 @@ This helps you balance load or point the host to a closer or preferred content s
 . Open the options menu next to the *Edit* button and select *Change content source*.
 . From the *Content source* list, select your {SmartProxy} that you want to use to provide software to your host.
 . In the *Content view environments* area, select the lifecycle environment and content view you want to use.
+Click *Assign another content view environment* to assign another content view environment.
+Drag and drop the content view environments to change their order.
 +
 [NOTE]
 ====

--- a/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
@@ -11,8 +11,8 @@ This helps you balance load or point the host to a closer or preferred content s
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.
 . Click the name of the host you want to modify.
 . Open the options menu next to the *Edit* button and select *Change content source*.
-. From the *Content source* list, select the new content source.
-. In the *Content view environments* area, assign the content view environments you want to use.
+. From the *Content source* list, select your {SmartProxy} that you want to use to provide software to your host.
+. In the *Content view environments* area, select the lifecycle environment and content view you want to use.
 +
 [NOTE]
 ====

--- a/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
+++ b/guides/common/modules/proc_changing-the-content-source-of-a-host.adoc
@@ -12,7 +12,7 @@ This helps you balance load or point the host to a closer or preferred content s
 . Click the name of the host you want to modify.
 . Open the options menu next to the *Edit* button and select *Change content source*.
 . From the *Content source* list, select the new content source.
-. In the *Content view environments* list, assign the content view environments you want to use.
+. In the *Content view environments* area, assign the content view environments you want to use.
 +
 [NOTE]
 ====

--- a/guides/common/modules/proc_installing-packages-on-a-host.adoc
+++ b/guides/common/modules/proc_installing-packages-on-a-host.adoc
@@ -8,7 +8,7 @@ You can review and install packages on a host from the {ProjectWebUI} so that th
 Available packages depend on the content view environments assigned to the host.
 
 .Prerequisites
-* The host is assigned to a content view and lifecycle environment.
+* The host is assigned to one or more content view environments.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*.

--- a/guides/common/modules/snip_prerequisite-project-client-repository-enabled.adoc
+++ b/guides/common/modules/snip_prerequisite-project-client-repository-enabled.adoc
@@ -4,7 +4,7 @@ ifdef::foreman-el[]
 * {project-client-name} repository is available on the host.
 endif::[]
 ifndef::foreman-el[]
-* {project-client-name} repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view and the lifecycle environment of the host, and enabled for the host.
+* {project-client-name} repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view environment of the host, and enabled for the host.
 ifndef::orcharhino[]
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]

--- a/guides/common/modules/snip_prerequisite-project-client-repository-enabled.adoc
+++ b/guides/common/modules/snip_prerequisite-project-client-repository-enabled.adoc
@@ -4,7 +4,7 @@ ifdef::foreman-el[]
 * {project-client-name} repository is available on the host.
 endif::[]
 ifndef::foreman-el[]
-* {project-client-name} repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view environment of the host, and enabled for the host.
+* {project-client-name} repository for the operating system version of the host is synchronized on {ProjectServer}, available in the content view environments of the host, and enabled for the host.
 ifndef::orcharhino[]
 For more information, see {ContentManagementDocURL}Changing_the_Repository_Sets_Status_for-a-Host-in_{project-context}_content-management[Changing the repository sets status for a host in {Project}] in _{ContentManagementDocTitle}_.
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?

Updating the rest of places for CV environments in _Managing hosts_:

- change content source of a host
- installing packages on a host
- snip_prerequisite-project-client-repository-enabled.adoc

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

New web UI with CV envs; separate LCEs and CVs no longer supported

[SAT-44518](https://redhat.atlassian.net/browse/SAT-44518)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- I've verified the UI on latest Foreman -> testing done

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
