### PR TITLE
Add in-place upgrade as prerequisite to upgrade

### DIFF
--- a/guides/common/modules/con_upgrading-prerequisites.adoc
+++ b/guides/common/modules/con_upgrading-prerequisites.adoc
@@ -12,6 +12,14 @@ For more information, see {AdministeringDocURL}backing-up-{project-context}-serv
 * Plan for updating any scripts you use that contain {Project} API commands because some API commands differ between versions of {Project}.
 ifdef::satellite[]
 * Ensure that all {ProjectServer}s are on the same version.
+* Ensure that your {ProjectServer} and all {SmartProxyServers} are running on {RHEL} 9.
+If you need to upgrade from {RHEL} 8 to {RHEL} 9, see
+ifeval::["{mode}" == "connected"]
+{UpgradingPreviousDocURL}upgrading_EL_on_{project-context}_or_proxy_{context}[Upgrading {EL} on {Project} or {SmartProxy}] in _{UpgradingPreviousDocTitle}_.
+endif::[]
+ifeval::["{mode}" == "disconnected"]
+{UpgradingDisconnectedPreviousDocURL}upgrading_EL_on_{project-context}_or_proxy_{context}[Upgrading {EL} on {Project} or {SmartProxy}] in _{UpgradingDisconnectedPreviousDocTitle}_.
+endif::[]
 endif::[]
 
 include::snip_warning-maintain-config-noop.adoc[]


### PR DESCRIPTION
#### What changes are you introducing?
Satellite\capsule 6.16 installation must be running on RHEL 9 before it can be upgraded to 6.17 

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://redhat.atlassian.net/browse/SAT-45385

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
