### PR TITLE
Add proxy guide to 5.0 and nightly

### DIFF
--- a/web/releases/5.0.json
+++ b/web/releases/5.0.json
@@ -145,7 +145,8 @@
         ],
         "Deploying Foreman": [
           ["Planning_for_Project", "Planning for Foreman with Katello"],
-          ["Installing_Server", "Installing Foreman Server"]
+          ["Installing_Server", "Installing Foreman Server"],
+          ["Installing_Proxy", "Installing Smart Proxy Server with content"]
         ],
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -145,7 +145,8 @@
         ],
         "Deploying Foreman": [
           ["Planning_for_Project", "Planning for Foreman with Katello"],
-          ["Installing_Server", "Installing Foreman Server"]
+          ["Installing_Server", "Installing Foreman Server"],
+          ["Installing_Proxy", "Installing Smart Proxy Server with content"]
         ],
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],


### PR DESCRIPTION
#### What changes are you introducing?
^^

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
https://github.com/theforeman/foreman-documentation/pull/5097 is done but guides were not made visible

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
