### PR TITLE
Add example content for orcharhino Quickstart

### DIFF
--- a/guides/common/assembly_getting-started-with-content-management.adoc
+++ b/guides/common/assembly_getting-started-with-content-management.adoc
@@ -2,7 +2,9 @@ include::modules/con_getting-started-with-content-management.adoc[]
 
 include::modules/proc_creating-a-product-and-a-repository.adoc[leveloffset=+1]
 
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 include::modules/proc_importing-a-subscription-manifest-and-enabling-red-hat-repositories.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/proc_synchronizing-your-content.adoc[leveloffset=+1]
 

--- a/guides/common/attributes-orcharhino.adoc
+++ b/guides/common/attributes-orcharhino.adoc
@@ -61,6 +61,7 @@
 // Client attributes; overwritten in downstream for docs.orcharhino.com for all supported Client OS
 :ubuntu:
 :client-os-codename: Resolute
+:client-os-codename-lowercase: resolute
 :client-os-context: ubuntu
 :client-os-major-previous: 24.04
 :client-os-major: 26.04
@@ -85,6 +86,7 @@
 :client-install-yggdrasil-package: apt-get install foreman-ygg-migration
 :client-installation-medium-path: download.example.com/{client-os-context}/{client-os-major}.{client-os-minor}/
 :client-iso-image-source: Canonical
+:client-nginx-upstream-url: https://nginx.org/packages/ubuntu/
 :client-os-family-hammer: Debian
 :client-os-family: Debian
 :client-os-label: {client-os}

--- a/guides/common/modules/proc_creating-a-product-and-a-repository.adoc
+++ b/guides/common/modules/proc_creating-a-product-and-a-repository.adoc
@@ -17,6 +17,9 @@ endif::[]
 ifdef::katello[]
 This example adds a repository with CentOS content.
 endif::[]
+ifdef::orcharhino[]
+This example adds a repository with {client-content-type} content for {client-os} to install Nginx.
+endif::[]
 ifdef::satellite[]
 This example adds a repository with RPM content from EPEL (Extra Packages for Enterprise Linux).
 endif::[]
@@ -32,6 +35,9 @@ To configure the new product:
 ifdef::katello[]
 For example: `CentOS Stream`.
 endif::[]
+ifdef::orcharhino[]
+For example: `Nginx`.
+endif::[]
 ifdef::satellite[]
 For example: `EPEL`.
 endif::[]
@@ -42,14 +48,24 @@ To configure the new repository:
 ifdef::katello[]
 For example: `BaseOS`.
 endif::[]
+ifdef::orcharhino[]
+For example: `Nginx for {client-os}`.
+endif::[]
 ifdef::satellite[]
-For example: `EPEL 9`.
+For example: `EPEL 10`.
 endif::[]
 .. From the *Type* list, select the required repository type.
-For example: `yum`.
+For example: `{client-content-type}`.
 .. In the *Upstream URL* field, enter the URL of the upstream repository.
 ifdef::katello[]
 For example: `https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/`.
+endif::[]
+ifdef::orcharhino[]
+For example: `{client-nginx-upstream-url}`.
+ifdef::debian,ubuntu[]
+.. In the *Releases/Distributions* field, enter `{client-os-codename-lowercase}`.
+.. In the *Components* field, enter `nginx`.
+endif::[]
 endif::[]
 ifdef::satellite[]
 For example: `https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/`.


### PR DESCRIPTION
#### What changes are you introducing?

This patch add a Client OS-specific example for the content that is the example in the Quickstart guide for orcharhino.

This patch also align the major OS version for Satellite builds and hides importing RH content for non-RHEL Clients for orcharhino builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/5196#discussion_r3841013328

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #5196 (Update getting started with content management)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
