### PR TITLE
Use colon before code block for list items

### DIFF
--- a/guides/common/modules/proc_renewing-a-custom-server-ca-certificate.adoc
+++ b/guides/common/modules/proc_renewing-a-custom-server-ca-certificate.adoc
@@ -7,20 +7,20 @@
 If you need to update the certification authority (CA) certificate that signed your {ProjectServer} and {SmartProxyServers} certificates, add the new CA certificate and use a temporary dual CA certificate file to retain the HTTPS connections to your {ProjectServer} during the renewal.
 
 .Procedure
-. Check if the existing server certificate can be validated with the new CA certificate.
+. Check if the existing server certificate can be validated with the new CA certificate:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # openssl verify -CAfile _/root/{project-context}_cert/old_ca_cert_bundle.pem_ /root/_{project-context}_cert/{project-context}_cert.pem_
 ----
 . If the check did not succeed, use both the old and the new CA certificate while updating consumers.
-.. Add the new SSL certificate to the CA certificate file on {ProjectServer} and keep the old SSL certificate.
+.. Add the new SSL certificate to the CA certificate file on {ProjectServer} and keep the old SSL certificate:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # cat _/root/{project-context}_cert/old_ca_cert_bundle.pem_ _/root/{project-context}_cert/new_ca_cert_bundle.pem_ > _/root/{project-context}_cert/ca_cert_bundle.pem_
 ----
-.. Renew the certificates on {ProjectServer}.
+.. Renew the certificates on {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ifdef::containerized[]
@@ -44,13 +44,13 @@ ifndef::containerized[]
 endif::[]
 .. Refresh the certificates on any {SmartProxyServers}.
 .. Deploy the dual CA certificate on hosts.
-.. Remove the old certificate from the CA certificates file on {ProjectServer}, so the CA certificate file contains only the new SSL certificate.
+.. Remove the old certificate from the CA certificates file on {ProjectServer}, so the CA certificate file contains only the new SSL certificate:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 # cat _/root/{project-context}_cert/new_ca_cert_bundle.pem_ > _/root/{project-context}_cert/ca_cert_bundle.pem_
 ----
-. Renew the certificates on {ProjectServer}.
+. Renew the certificates on {ProjectServer}:
 +
 [options="nowrap" subs="+quotes,attributes"]
 ifdef::containerized[]


### PR DESCRIPTION
#### What changes are you introducing?

Items in lists before code blocks should end with a colon, not a dot.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #5072 (Document renewal of SSL certs for containerized)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
