### PR TITLE
Publish missing guide that has containerized content

### DIFF
--- a/guides/doc-Managing_Organizations_and_Locations/master.adoc
+++ b/guides/doc-Managing_Organizations_and_Locations/master.adoc
@@ -4,14 +4,6 @@ include::common/header.adoc[]
 
 = {ManagingOrganizationsLocationsDocTitle}
 
-ifdef::containerized[]
-ifdef::katello[]
-include::common/modules/ref_guide-not-ready.adoc[leveloffset=+1]
-endif::[]
-endif::[]
-
-ifndef::containerized[]
-
 ifdef::satellite[]
 {Project} documentation includes the content in {AdministeringDocURL}[{AdministeringDocTitle}].
 endif::[]
@@ -26,5 +18,4 @@ endif::[]
 
 ifndef::orcharhino,satellite[]
 include::common/ribbons.adoc[]
-endif::[]
 endif::[]

--- a/web/releases/5.0.json
+++ b/web/releases/5.0.json
@@ -151,7 +151,8 @@
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],
           ["Configuring_User_Authentication", "Configuring user authentication"],
-          ["Managing_Content", "Managing content"]
+          ["Managing_Content", "Managing content"],
+          ["Managing_Organizations_and_Locations", "Managing organizations and locations in Foreman"]
         ],
         "Administering hosts": [
         ],

--- a/web/releases/nightly.json
+++ b/web/releases/nightly.json
@@ -151,7 +151,8 @@
         "Administering Foreman server": [
           ["Administering_Project", "Administering Foreman"],
           ["Configuring_User_Authentication", "Configuring user authentication"],
-          ["Managing_Content", "Managing content"]
+          ["Managing_Content", "Managing content"],
+          ["Managing_Organizations_and_Locations", "Managing organizations and locations in Foreman"]
         ],
         "Administering hosts": [
         ],


### PR DESCRIPTION
#### What changes are you introducing?

Adding the Managing organizations and locations guide to website navigation.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://github.com/theforeman/foreman-documentation/pull/5174 has included the content for containerization, but the guide itself hasn't been added to navigation yet

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
