### PR TITLE
Update containerized variant of Troubleshooting in Managing Hosts

### DIFF
--- a/guides/common/modules/ref_troubleshooting-insights-iop.adoc
+++ b/guides/common/modules/ref_troubleshooting-insights-iop.adoc
@@ -6,4 +6,30 @@
 [role="_abstract"]
 You can check the logs to troubleshoot issues with {insights-iop}.
 
+ifndef::containerized[]
 To troubleshoot hosts monitoring, you can find the logs in the `/var/log/foreman/production.log` file.
+endif::[]
+
+ifdef::containerized[]
+To troubleshoot hosts monitoring, you can check the logs by running: 
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# journalctl -u foreman.service
+---- 
+endif::[]
+
+To view all available logs, you can list all services by running: 
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+# systemctl list-units foreman*
+---- 
+ifdef::containerized[]
+To manually trigger a VMaas response scan, you can run: 
++
+[options="nowrap" subs="+quotes,attributes"]
+----
+#  systemctl start iop-service-vuln-vmaas-sync.service
+---- 
+endif::[]


### PR DESCRIPTION
Updated the command to view logs based on the most recent demo: https://youtu.be/010dkpNnQDw?si=VfWd_TpYXV42lp47&t=679

#### What changes are you introducing?
Troubleshooting Red Hat Lightspeed in Satellite has outdated instructions for containerized release.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
