### PR TITLE
Add URL for KernelCare Client for Ubuntu 26.04

### DIFF
--- a/guides/common/modules/ref_kernelcare-client-repositories.adoc
+++ b/guides/common/modules/ref_kernelcare-client-repositories.adoc
@@ -127,6 +127,14 @@ ifdef::katello,rocky_linux[]
 endif::[]
 
 ifdef::katello,ubuntu[]
+[id="kernelcare-client-ubuntu-26-04"]
+.KernelCare client Ubuntu 26.04
+[width="100%",cols="20%,34%,22%,12%,12%",options="header"]
+|===
+| Name | Upstream URL | Releases/Distributions | Components | Architectures
+| `KernelCare client Ubuntu 26.04` | `https://repo.cloudlinux.com/kernelcare-ubuntu/26.04/` | `resolute` | `main` | `amd64`
+|===
+
 [id="kernelcare-client-ubuntu-24-04"]
 .KernelCare client Ubuntu 24.04
 [width="100%",cols="20%,34%,22%,12%,12%",options="header"]


### PR DESCRIPTION
#### What changes are you introducing?

This patch adds the URL for the KernelCare Client which was not yet available when Ubuntu 26.04 was GA by Canonical and docs moved to 26.04 as default Client OS major version.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Refs PR #4681 (Use Ubuntu 26.04 as latest Ubuntu release)
Refs d7e15081d8f22070bb6f7e91fa35b8bfad53805b

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
