### PR TITLE
Fix: Host groups take a single CVEnv

### DIFF
--- a/guides/common/modules/proc_creating-a-host-group-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-host-group-by-using-cli.adoc
@@ -14,7 +14,7 @@ You can create a host group by using Hammer CLI to use as a template for common 
 $ hammer hostgroup create \
 --architecture "My_Architecture" \
 --content-source-id _My_Content_Source_ID_ \
---content-view-environment "_My_Lifecycle_Environment_1_/_My_Content_View_1_,_My_Lifecycle_Environment_2_/_My_Content_View_2_" \
+--content-view-environment "_My_Content_View_Environment_Label_" \
 --domain "_My_Domain_" \
 --locations "_My_Location_" \
 --medium-id _My_Installation_Medium_ID_ \

--- a/guides/common/modules/proc_creating-a-host-group-by-using-cli.adoc
+++ b/guides/common/modules/proc_creating-a-host-group-by-using-cli.adoc
@@ -14,7 +14,7 @@ You can create a host group by using Hammer CLI to use as a template for common 
 $ hammer hostgroup create \
 --architecture "My_Architecture" \
 --content-source-id _My_Content_Source_ID_ \
---content-view-environment "_My_Content_View_Environment_Label_" \
+--content-view-environment "_My_Lifecycle_Environment_/_My_Content_View_" \
 --domain "_My_Domain_" \
 --locations "_My_Location_" \
 --medium-id _My_Installation_Medium_ID_ \


### PR DESCRIPTION
#### What changes are you introducing?

Fixing the example value in creating a host group by using CLI

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Host groups take a single CV environment

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Follow-up on #5233

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
