### PR TITLE
Mention Advisory property in IoP Vulnerability

### DIFF
--- a/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
+++ b/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
@@ -14,7 +14,7 @@ You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Vulnerability*.
-. Optional: Refine the list of vulnerabilities.
-* In the *Filter by advisory* list, select whether you want to display CVEs for which Advisory is *Available*, *Not available*, or both.
-* From the options menu next to the filters, select *Hide CVEs without advisory* to hide CVEs without Advisory.
+. Optional: Refine the list of vulnerabilities by using filters.
+* In the filters list, select the property you want to filter by, such as *Severity* or *Advisory*, and select the required values.
+* From the options menu next to the filters, select *Hide CVEs without advisory* to hide CVEs without advisory.
 . In the *CVE ID* column, click the ID of the vulnerability to see details.

--- a/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
+++ b/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
@@ -16,5 +16,5 @@ You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Vulnerability*.
 . Optional: Refine the list of vulnerabilities by using filters.
 * In the filters list, select the property you want to filter by, such as *Severity* or *Advisory*, and select the required values.
-* From the options menu next to the filters, select *Hide CVEs without advisory* to hide CVEs without advisory.
+* From the options menu next to the filters, select *Hide CVEs without advisories* to hide CVEs without advisories.
 . In the *CVE ID* column, click the ID of the vulnerability to see details.

--- a/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
+++ b/guides/common/modules/proc_examining-vulnerability-of-hosts.adoc
@@ -14,4 +14,7 @@ You can get these permissions with the `ForemanRhCloud Read Only` built-in role.
 
 .Procedure
 . In the {ProjectWebUI}, navigate to *{Insights}* > *Vulnerability*.
+. Optional: Refine the list of vulnerabilities.
+* In the *Filter by advisory* list, select whether you want to display CVEs for which Advisory is *Available*, *Not available*, or both.
+* From the options menu next to the filters, select *Hide CVEs without advisory* to hide CVEs without Advisory.
 . In the *CVE ID* column, click the ID of the vulnerability to see details.


### PR DESCRIPTION
#### What changes are you introducing?

Adding an optional step to refine vulnerabilities in IoP by filtering them and hiding per Advisory availability

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

CVEs can be displayed according to various properties + new Advisory property
[SAT-49535](https://redhat.atlassian.net/browse/SAT-49535)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
