### PR TITLE
Hide Complete Mirroring mirroring policy for SLES

### DIFF
--- a/guides/common/modules/con_mirroring-policies-overview.adoc
+++ b/guides/common/modules/con_mirroring-policies-overview.adoc
@@ -17,6 +17,7 @@ Content Only::
 Mirrors only content and not the repodata.
 Some repositories do not support metadata mirroring, in such cases you can set the mirroring policy to content only to only mirror the content.
 
+ifdef::katello,satellite,almalinux,amazon_linux,centos,debian,oracle_linux,red_hat_enterprise_linux,rocky_linux,ubuntu[]
 Complete Mirroring::
 Mirrors content as well as repodata.
 This is the fastest method.
@@ -27,3 +28,4 @@ This mirroring policy is only available for Yum content.
 Avoid republishing metadata for repositories with Complete Mirror mirroring policy.
 This also applies to content views containing repositories with the Complete Mirror mirroring policy.
 ====
+endif::[]

--- a/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-cli.adoc
+++ b/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-cli.adoc
@@ -7,23 +7,37 @@
 Set default mirroring policies for new {customrepos} so they inherit additive, content-only, or complete mirroring without affecting existing repositories.
 
 Depending on whether it is a Yum or non-Yum {customrepo}, {Project} uses separate settings.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 Only Yum repositories support the `mirror_complete` mirroring policy.
+endif::[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 Red{nbsp}Hat repositories use the `mirror_complete` policy by default and are not affected by these settings.
+endif::[]
 Changing the default value does not change existing mirroring policy settings per repository.
 For more information on mirroring policies, see xref:Mirroring_Policies_Overview_{context}[].
 
 .Procedure
+ifdef::katello,satellite,almalinux,amazon_linux,centos,debian,oracle_linux,red_hat_enterprise_linux,rocky_linux,ubuntu[]
 * Change the default mirroring policy for a Yum {customrepo} to `additive`, `mirror_content_only`, or `mirror_complete`:
+endif::[]
+ifdef::suse_linux_enterprise_server[]
+* Change the default mirroring policy for a Yum {customrepo} to `additive` or `mirror_content_only`:
+endif::[]
 +
-[subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ hammer settings set \
 --name default_yum_mirroring_policy \
+ifdef::katello,satellite,almalinux,amazon_linux,centos,debian,oracle_linux,red_hat_enterprise_linux,rocky_linux,ubuntu[]
 --value _mirror_complete_
+endif::[]
+ifdef::suse_linux_enterprise_server[]
+--value _additive_
+endif::[]
 ----
 * Change the default mirroring policy for a non-Yum {customrepo} to `additive` or `mirror_content_only`:
 +
-[subs="+quotes"]
+[options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
 $ hammer settings set \
 --name default_non_yum_mirroring_policy \

--- a/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-web-ui.adoc
+++ b/guides/common/modules/proc_updating-the-default-mirroring-policy-by-using-web-ui.adoc
@@ -7,8 +7,12 @@
 Set default mirroring policies for new {customrepos} so they inherit additive, content-only, or complete mirroring without affecting existing repositories.
 
 Depending on whether it is a Yum or non-Yum {customrepo}, {Project} uses separate settings.
+ifdef::katello,satellite,almalinux,amazon_linux,centos,oracle_linux,red_hat_enterprise_linux,rocky_linux,suse_linux_enterprise_server[]
 Only Yum repositories support the `mirror_complete` mirroring policy.
+endif::[]
+ifdef::katello,satellite,red_hat_enterprise_linux[]
 Red{nbsp}Hat repositories use the `mirror_complete` policy by default and are not affected by these settings.
+endif::[]
 Changing the default value does not change existing mirroring policy settings per repository.
 For more information on mirroring policies, see xref:Mirroring_Policies_Overview_{context}[].
 


### PR DESCRIPTION
#### What changes are you introducing?

The SCC Manager plugin does not allow users to configure mirroring policy "Complete Mirroring" for new SUSE content. However, users can theoretically change the mirroring policy after setting up SUSE content via SCC Manager plugin.

This patch hides this section for SUSE Linux Enterprise Server Clients.

This patch also hides Yum repositories for Deb Clients. Downstream docs for Debian or Ubuntu Client OS do not show the mirroring policy for Yum content. Only RHEL Clients show the mirroring policy for Red Hat content.

This patch does not affect upstream builds.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

<img width="1827" height="526" alt="scc_manager" src="https://github.com/user-attachments/assets/603f1e2d-d7bf-4751-a32e-39f7c8ae08a7" />

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Fixes #4333 (SUSE content: Avoid mirroring policy "Complete Mirroring")

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
