### PR TITLE
Remove containerized tag from Satellite install heading

### DIFF
--- a/guides/common/attributes-titles.adoc
+++ b/guides/common/attributes-titles.adoc
@@ -69,7 +69,6 @@ ifdef::katello[]
 :QuickstartDocTitle: Quickstart guide for {Project} with Katello (containerized) on {install-on-os}
 endif::[]
 ifdef::satellite[]
-:InstallingServerDocTitle: Installing {ProjectServerTitle} (containerized) in a connected network environment
 :QuickstartDocTitle: Quickstart (containerized)
 :UpgradingDocTitle: Upgrading connected {ProjectName} to {ProjectVersion} (containerized)
 endif::[]


### PR DESCRIPTION
#### What changes are you introducing?
^^

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Satellite is always containerized, no reason to distinguish in guide headings. It also breaks our Pantheon builds because Pantheon titles don't have the containerized tag.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
