### PR TITLE
Update information about working directory for push mode

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -38,9 +38,7 @@ include::modules/proc_configuring-the-global-smartproxy-remote-execution-setting
 
 include::modules/proc_configuring-the-global-smartproxy-remote-execution-setting-by-using-cli.adoc[leveloffset=+2]
 
-ifndef::containerized[]
 include::modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc[leveloffset=+2]
-endif::[]
 
 ifeval::["{context}" == "managing-hosts"]
 include::modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-pull-mode.adoc[leveloffset=+2]

--- a/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc
+++ b/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc
@@ -42,13 +42,7 @@ ifndef::foreman-deb[]
 ----
 endif::[]
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings* > *Remote Execution*.
-Set `remote_execution_remote_working_dir` to `My_Remote_Working_Directory`.
-+
-[NOTE]
-====
-The `remote_execution_remote_working_dir` only applies to the {ProjectVersion} {SmartProxies}.
-{ProjectVersionPrevious} {SmartProxies} use their own local setting.
-====
+. Set `remote_execution_remote_working_dir` to `My_Remote_Working_Directory`.
 
 :!rex-default-working-dir:
 :!installer-change-working-dir-opt:

--- a/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc
+++ b/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc
@@ -41,13 +41,14 @@ ifndef::foreman-deb[]
 # chcon --reference={rex-default-working-dir} _/My_Remote_Working_Directory_
 ----
 endif::[]
-. Configure your {ProjectServer} or {SmartProxyServer} to use the new directory:
+. In the {ProjectWebUI}, navigate to *Administer* > *Settings* > *Remote Execution*.
+Set `remote_execution_remote_working_dir` to `My_Remote_Working_Directory`.
 +
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# {foreman-installer} \
-{installer-change-working-dir-opt} _/My_Remote_Working_Directory_
-----
+[NOTE]
+====
+The `remote_execution_remote_working_dir` only applies to the {ProjectVersion} {SmartProxies}.
+{ProjectVersionPrevious} {SmartProxies} use their own local setting.
+====
 
 :!rex-default-working-dir:
 :!installer-change-working-dir-opt:

--- a/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc
+++ b/guides/common/modules/proc_setting-an-alternative-directory-for-remote-execution-jobs-in-push-mode.adoc
@@ -42,7 +42,7 @@ ifndef::foreman-deb[]
 ----
 endif::[]
 . In the {ProjectWebUI}, navigate to *Administer* > *Settings* > *Remote Execution*.
-. Set `remote_execution_remote_working_dir` to `My_Remote_Working_Directory`.
+. Set `Remote working directory` to `My_Remote_Working_Directory`.
 
 :!rex-default-working-dir:
 :!installer-change-working-dir-opt:


### PR DESCRIPTION

Users can set  remote working directory for REX jobs in push mode using the remote_execution_remote_working_dir setting. This applies only to the current Smart Proxy version.

JIRA:
https://redhat.atlassian.net/browse/SAT-49031

#### Open question
This module has references to Ansible, but I do not think this is being called anywhere but the Managing Hosts guide. What should be done about this?

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
