### PR TITLE
Use EL 10 & remove the maintenance repository

### DIFF
--- a/guides/common/attributes-base.adoc
+++ b/guides/common/attributes-base.adoc
@@ -202,6 +202,7 @@
 :client-package-install-el7: yum install
 :client-package-install-el8: dnf install
 :client-package-install-el9: dnf install
+:client-package-install-el10: dnf install
 :client-package-install-sles: zypper install
 :client-package-remove-deb: apt remove
 :client-package-remove-el7: yum remove

--- a/guides/common/attributes-satellite.adoc
+++ b/guides/common/attributes-satellite.adoc
@@ -172,6 +172,12 @@
 // For a release
 :RepoSatelliteVersion: {ProjectVersion}
 
+// RHEL 10 Satellite repos
+:RepoRHEL10ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-10-x86_64-rpms
+:RepoRHEL10ServerSatelliteServerProjectVersion: satellite-{RepoSatelliteVersion}-for-rhel-10-x86_64-rpms
+:RepoRHEL10ServerSatelliteToolsProjectVersion: satellite-client-6-for-rhel-10-<arch>-rpms
+:RepoRHEL10ServerSatelliteUtils: satellite-utils-{RepoSatelliteVersion}-for-rhel-10-x86_64-rpms
+
 // RHEL 9 Satellite repos
 :RepoRHEL9ServerSatelliteCapsuleProjectVersion: satellite-capsule-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms
 :RepoRHEL9ServerSatelliteMaintenanceProjectVersion: satellite-maintenance-{RepoSatelliteVersion}-for-rhel-9-x86_64-rpms

--- a/guides/common/modules/con_installing-and-configuring-the-load-balancer.adoc
+++ b/guides/common/modules/con_installing-and-configuring-the-load-balancer.adoc
@@ -4,5 +4,5 @@
 = Installing and configuring the load balancer
 
 [role="_abstract"]
-{Team} provides general guidance for configuring an HAProxy load balancer using {EL} 9.
+{Team} provides general guidance for configuring an HAProxy load balancer using {EL} 10.
 However, you can install any suitable load balancing software solution that supports TCP forwarding.

--- a/guides/common/modules/con_prerequisites-for-cloning.adoc
+++ b/guides/common/modules/con_prerequisites-for-cloning.adoc
@@ -8,8 +8,8 @@ Ensure that your environment meets the following prerequisites before you can cl
 
 Ensure that the target server complies with all the required specifications for a {ProjectServer}:
 
-* The target server is a minimal install of {EL} 9.
-Do not install {EL} 9 software groups or third-party applications.
+* The target server is a minimal install of {EL} 10.
+Do not install {EL} 10 software groups or third-party applications.
 * You have a {Project} subscription for the target server.
 
 Before you begin cloning, ensure the following conditions exist:

--- a/guides/common/modules/con_project-operating-system.adoc
+++ b/guides/common/modules/con_project-operating-system.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 You can install {Project} on the following supported operating systems.
 
-You can run {ProjectServer} and {SmartProxyServers} on {EL} 9, Debian 12, and Ubuntu 22.04.
+You can run {ProjectServer} and {SmartProxyServers} on {EL} 10, Debian 12, and Ubuntu 22.04.
 Katello plugin packages, which provide content management capabilities, are only available for {EL}.
 
 {Team} only packages {Project} for x86_64.

--- a/guides/common/modules/proc_cloning-to-the-target-server.adoc
+++ b/guides/common/modules/proc_cloning-to-the-target-server.adoc
@@ -17,9 +17,8 @@ You can either mount the shared storage or copy the backup files to the `/backup
 ----
 # subscription-manager register
 # subscription-manager repos --disable=*
-# subscription-manager repos --enable={RepoRHEL9AppStream} \
---enable={RepoRHEL9BaseOS} \
---enable={RepoRHEL9ServerSatelliteMaintenanceProjectVersion}
+# subscription-manager repos --enable={RepoRHEL10AppStream} \
+--enable={RepoRHEL10BaseOS}
 ----
 .. Install the `satellite-clone` package:
 +

--- a/guides/common/modules/proc_configuring-repositories-proxy.adoc
+++ b/guides/common/modules/proc_configuring-repositories-proxy.adoc
@@ -19,9 +19,9 @@ Configure repositories to install your {SmartProxyServer}.
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos \
---enable={RepoRHEL9BaseOS} \
---enable={RepoRHEL9AppStream} \
---enable={RepoRHEL9ServerSatelliteCapsuleProjectVersion}
+--enable={RepoRHEL10BaseOS} \
+--enable={RepoRHEL10AppStream} \
+--enable={RepoRHEL10ServerSatelliteCapsuleProjectVersion}
 ----
 
 .Verification

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: PROCEDURE
-:distribution-major-version: 9
+:distribution-major-version: 10
 
 [id="configuring-repositories_{context}"]
 = Configuring repositories
@@ -20,9 +20,9 @@ ifdef::satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos \
---enable={RepoRHEL9BaseOS} \
---enable={RepoRHEL9AppStream} \
---enable={RepoRHEL9ServerSatelliteServerProjectVersion}
+--enable={RepoRHEL10BaseOS} \
+--enable={RepoRHEL10AppStream} \
+--enable={RepoRHEL10ServerSatelliteServerProjectVersion}
 ----
 endif::[]
 ifdef::foreman-deb[]

--- a/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
+++ b/guides/common/modules/proc_configuring-the-base-operating-system-with-offline-repositories.adoc
@@ -4,7 +4,7 @@
 = Configuring the base operating system with offline repositories
 
 [role="_abstract"]
-Use this procedure to configure offline repositories for {RHEL} 9 and {ProjectName} ISO images.
+Use this procedure to configure offline repositories for {RHEL} 10 and {ProjectName} ISO images.
 
 .Procedure
 

--- a/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
+++ b/guides/common/modules/proc_creating-a-remote-source-for-a-custom-file-type-repository.adoc
@@ -13,15 +13,15 @@ endif::[]
 
 .Prerequisites
 ifdef::katello,orcharhino[]
-* You have a server running {EL} 9 registered to your {Project}.
+* You have a server running {EL} 10 registered to your {Project}.
 endif::[]
 ifdef::satellite[]
-* You have a server running {EL} 9 registered to your {Project} or the Red{nbsp}Hat CDN.
+* You have a server running {EL} 10 registered to your {Project} or the Red{nbsp}Hat CDN.
 * Your server has an entitlement to the {RHELServer} and {ProjectName} repositories.
 endif::[]
 * You have installed an HTTP server.
 ifndef::orcharhino[]
-For more information about configuring a web server, see {RHELDocsBaseURL}9/html/deploying_web_servers_and_reverse_proxies/setting-apache-http-server_deploying-web-servers-and-reverse-proxies[Setting up the Apache HTTP web server] in {RHEL}{nbsp}9 _Deploying web servers and reverse proxies_.
+For more information about configuring a web server, see {RHELDocsBaseURL}10/html/deploying_web_servers_and_reverse_proxies/index[Setting up the Apache HTTP web server] in {RHEL}{nbsp}10 _Deploying web servers and reverse proxies_.
 endif::[]
 ifdef::orcharhino[]
 * Your HTTP server consumes the same content as {SmartProxies}.
@@ -33,9 +33,9 @@ ifdef::katello[]
 +
 [options="nowrap" subs="+quotes,attributes"]
 ----
-# dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el9/x86_64/
+# dnf config-manager --add-repo=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/el10/x86_64/
 # echo "gpgkey=https://yum.theforeman.org/pulpcore/{PulpcoreVersion}/GPG-RPM-KEY-pulpcore" \
->> /etc/yum.repos.d/yum.theforeman.org_pulpcore_{PulpcoreVersion}_el9_x86_64_.repo
+>> /etc/yum.repos.d/yum.theforeman.org_pulpcore_{PulpcoreVersion}_el10_x86_64_.repo
 ----
 endif::[]
 ifdef::satellite[]
@@ -44,9 +44,9 @@ ifdef::satellite[]
 [options="nowrap" subs="+quotes,attributes"]
 ----
 # subscription-manager repos \
---enable={RepoRHEL9AppStream} \
---enable={RepoRHEL9BaseOS} \
---enable={RepoRHEL9ServerSatelliteServerProjectVersion}
+--enable={RepoRHEL10AppStream} \
+--enable={RepoRHEL10BaseOS} \
+--enable={RepoRHEL10ServerSatelliteServerProjectVersion}
 ----
 endif::[]
 . Install the Pulp Manifest package:

--- a/guides/common/modules/proc_exporting-repositories-from-the-connected-project-server.adoc
+++ b/guides/common/modules/proc_exporting-repositories-from-the-connected-project-server.adoc
@@ -14,10 +14,9 @@ endif::[]
 .Procedure
 . Synchronize the following repositories on your connected {ProjectServer}:
 +
-* `{RepoRHEL9BaseOS}`
-* `{RepoRHEL9AppStream}`
-* `{RepoRHEL9ServerSatelliteServerProjectVersion}`
-* `{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}`
+* `{RepoRHEL10BaseOS}`
+* `{RepoRHEL10AppStream}`
+* `{RepoRHEL10ServerSatelliteServerProjectVersion}`
 
 +
 Ensure to set the download policy to *Immediate* for each repository.
@@ -34,6 +33,6 @@ $ hammer repository list \
 ----
 $ hammer content-export complete repository \
 --format syncable \
---id _My_Repository_ID_ 
+--id _My_Repository_ID_
 ----
 . Transfer the exported directories to your disconnected {ProjectServer}.

--- a/guides/common/modules/proc_installing-standalone-hammer.adoc
+++ b/guides/common/modules/proc_installing-standalone-hammer.adoc
@@ -13,23 +13,23 @@ endif::[]
 ifdef::katello[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
 * Ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {EL} 9 BaseOS
-** {EL} 9 AppStream
-** https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm[{Project} release RPM]
+** {EL} 10 BaseOS
+** {EL} 10 AppStream
+** https://yum.theforeman.org/releases/{ProjectVersion}/el10/x86_64/foreman-release.rpm[{Project} release RPM]
 endif::[]
 ifdef::orcharhino[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
-* If you are installing on {EL}{nbsp}9, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {EL} 9 BaseOS
-** {EL} 9 AppStream
+* If you are installing on {EL}{nbsp}10, ensure that the following repositories are enabled and synchronized on {ProjectServer}:
+** {EL} 10 BaseOS
+** {EL} 10 AppStream
 ** {SmartProxy} repository
 endif::[]
 ifdef::satellite[]
 * Ensure that you register the host to {ProjectServer} or {SmartProxyServer}.
 * Ensure that the following repositories are enabled and synchronized on {ProjectServer}:
-** {RepoRHEL9BaseOS}
-** {RepoRHEL9AppStream}
-** {RepoRHEL9ServerSatelliteUtils}
+** {RepoRHEL10BaseOS}
+** {RepoRHEL10AppStream}
+** {RepoRHEL10ServerSatelliteUtils}
 endif::[]
 
 .Procedure
@@ -60,14 +60,14 @@ ifdef::foreman-el[]
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
-# {client-package-install-el9} https://yum.theforeman.org/releases/{ProjectVersion}/el9/x86_64/foreman-release.rpm
+# {client-package-install-el10} https://yum.theforeman.org/releases/{ProjectVersion}/el10/x86_64/foreman-release.rpm
 ----
 +
 . Install Hammer CLI:
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
-# {client-package-install-el8} {project-context}-cli
+# {client-package-install-el10} {project-context}-cli
 ----
 . Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
 +
@@ -82,7 +82,7 @@ ifdef::katello,orcharhino,satellite[]
 +
 [options="nowrap" subs="verbatim,quotes,attributes"]
 ----
-# {client-package-install-el8} {project-context}-cli
+# {client-package-install-el10} {project-context}-cli
 ----
 . Set the `:host:` entry in the `/etc/hammer/cli.modules.d/foreman.yml` file to the {Project} URL:
 +

--- a/guides/common/modules/proc_installing-the-load-balancer.adoc
+++ b/guides/common/modules/proc_installing-the-load-balancer.adoc
@@ -4,7 +4,7 @@
 = Installing the load balancer
 
 [role="_abstract"]
-The following example provides general guidance for configuring an HAProxy load balancer using {EL} 9.
+The following example provides general guidance for configuring an HAProxy load balancer using {EL} 10.
 However, you can install any suitable load balancing software solution that supports TCP forwarding.
 
 .Procedure

--- a/guides/common/modules/proc_preparing-repositories-on-the-disconnected-project-server.adoc
+++ b/guides/common/modules/proc_preparing-repositories-on-the-disconnected-project-server.adoc
@@ -15,31 +15,24 @@ Create local repositories on your disconnected {ProjectServer}.
 +
 [source, ini, options="nowrap" subs="+quotes,verbatim,attributes"]
 ----
-[{RepoRHEL9BaseOS}]
-name=Red Hat Enterprise Linux 9 for x86_64 - BaseOS (RPMs)
+[{RepoRHEL10BaseOS}]
+name=Red Hat Enterprise Linux 10 for x86_64 - BaseOS (RPMs)
 enabled=1
 metadata_expire=-1
 gpgcheck=0
-baseurl=file:///_BaseOS_Export_Location_/content/dist/rhel9/9/x86_64/baseos/os
+baseurl=file:///_BaseOS_Export_Location_/content/dist/rhel10/10/x86_64/baseos/os
 
-[{RepoRHEL9AppStream}]
-name=Red Hat Enterprise Linux 9 for x86_64 - AppStream (RPMs)
+[{RepoRHEL10AppStream}]
+name=Red Hat Enterprise Linux 10 for x86_64 - AppStream (RPMs)
 enabled=1
 metadata_expire=-1
 gpgcheck=0
-baseurl=file:///_AppStream_Export_Location_/content/dist/rhel9/9/x86_64/appstream/os
+baseurl=file:///_AppStream_Export_Location_/content/dist/rhel10/10/x86_64/appstream/os
 
-[{RepoRHEL9ServerSatelliteServerProjectVersion}]
-name={ProjectName} {ProjectVersion} for RHEL 9 Server RPMs x86_64
+[{RepoRHEL10ServerSatelliteServerProjectVersion}]
+name={ProjectName} {ProjectVersion} for RHEL 10 Server RPMs x86_64
 enabled=1
 metadata_expire=-1
 gpgcheck=0
-baseurl=file:///_{Project}_Export_Location_/content/dist/layered/rhel9/x86_64/satellite/{ProjectVersion}/os/
-
-[{RepoRHEL9ServerSatelliteMaintenanceProjectVersion}]
-name={ProjectName} Maintenance {ProjectVersion} for RHEL 9 Server RPMs x86_64
-enabled=1
-metadata_expire=-1
-gpgcheck=0
-baseurl=file:///_{Project}_Maintenance_Export_Location_/content/dist/layered/rhel9/x86_64/sat-maintenance/{ProjectVersion}/os/
+baseurl=file:///_{Project}_Export_Location_/content/dist/layered/rhel10/x86_64/satellite/{ProjectVersion}/os/
 ----

--- a/guides/common/modules/ref_operating-system-requirements.adoc
+++ b/guides/common/modules/ref_operating-system-requirements.adoc
@@ -15,7 +15,7 @@ endif::[]
 ifndef::foreman-deb[]
 The following operating system is supported for deploying {Project}:
 
-* {EL} 9 (x86_64)
+* {EL} 10 (x86_64)
 endif::[]
 
 ifdef::foreman-el,katello,orcharhino[]
@@ -25,7 +25,7 @@ endif::[]
 ifdef::satellite[]
 You can install the operating system from a disc, local ISO image, Kickstart, or any other method that Red{nbsp}Hat supports.
 
-Red{nbsp}Hat {ProductName} is supported on the latest version of {RHEL} 9 available at the time of installation.
+Red{nbsp}Hat {ProductName} is supported on the latest version of {RHEL} 10 available at the time of installation.
 Previous versions of {RHEL} including EUS or z-stream are not supported.
 
 Red{nbsp}Hat {ProductName} requires a {RHEL} installation with the `@Base` package group with no other package-set modifications, and without third-party configurations or software not directly necessary for the direct operation of the server.

--- a/guides/common/modules/ref_system-requirements-quickstart.adoc
+++ b/guides/common/modules/ref_system-requirements-quickstart.adoc
@@ -16,7 +16,7 @@ ifndef::foreman-deb[]
 endif::[]
 +
 ifndef::foreman-deb[]
-** {EL} 9 (x86_64)
+** {EL} 10 (x86_64)
 endif::[]
 ifdef::foreman-deb[]
 ** Debian 12 (Bookworm) (amd64)
@@ -38,7 +38,7 @@ ifndef::foreman-deb[]
 endif::[]
 +
 ifndef::foreman-deb[]
-** {EL} 9 (x86_64)
+** {EL} 10 (x86_64)
 endif::[]
 ifdef::foreman-deb[]
 ** Debian 12 (Bookworm) (amd64)


### PR DESCRIPTION
#### What changes are you introducing?

* Remove `RepoRHEL9ServerSatelliteMaintenanceProjectVersion` from the codebase.
* Use EL10

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The maintenance repository will no longer exist.
In the upcoming downstream release, repositories will be merged into two:

* satellite-6.Y-for-rhel-10-x86_64-rpms
* satellite-utils-6.Y-for-rhel-10-x86_64-rpms

https://redhat.atlassian.net/browse/SAT-49920

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0

