### PR TITLE
Fixing http_proxy_except_list syntax for hammer

### DIFF
--- a/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests-by-using-cli.adoc
+++ b/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests-by-using-cli.adoc
@@ -11,5 +11,5 @@ If you use an HTTP proxy for all {Project} HTTP or HTTPS requests, you can preve
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ hammer settings set --name=http_proxy_except_list --value=[_hostname1.hostname2..._]
+$ hammer settings set --name=http_proxy_except_list --value='["_hostname1_","_hostname2_"]'
 ----

--- a/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests-by-using-cli.adoc
+++ b/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests-by-using-cli.adoc
@@ -11,5 +11,5 @@ If you use an HTTP proxy for all {Project} HTTP or HTTPS requests, you can preve
 +
 [options="nowrap" subs="+quotes"]
 ----
-$ hammer settings set --name=http_proxy_except_list --value='["_hostname1_","_hostname2_"]'
+$ hammer settings set --name=http_proxy_except_list --value=[_hostname1_,_hostname2_]
 ----


### PR DESCRIPTION
#### What changes are you introducing?

Correct the Hammer example for `http_proxy_except_list` so `--value` is a quoted JSON array of hostnames.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

`http_proxy_except_list` is an array setting. The current example uses `hostname1.hostname2...`, which is one dotted name, not a list.

https://redhat.atlassian.net/browse/SAT-49923

https://github.com/theforeman/foreman-documentation/blob/master/guides/common/modules/proc_excluding-hosts-from-receiving-proxied-requests-by-using-cli.adoc


#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [x] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [x] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [x] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.

Assisted-By: Cursor