### PR TITLE
Fix host email notification checkbox label in procedure

### DIFF
--- a/guides/common/modules/proc_changing-email-notification-settings-for-a-host.adoc
+++ b/guides/common/modules/proc_changing-email-notification-settings-for-a-host.adoc
@@ -15,7 +15,8 @@ Receiving email notifications for a host can be useful, but also overwhelming if
 .Procedure
 . In the {ProjectWebUI}, navigate to *Hosts* > *All Hosts*, locate the host that you want to view, and click *Edit* in the *Actions* column.
 . Go to the *Additional Information* tab.
-If the checkbox *Include this host within {Project} reporting* is checked, then the email notifications are enabled on that host.
+If the *Enabled* checkbox is checked, then email notifications are enabled on that host.
+The help text for this checkbox is *Include this host within {Project} reporting*.
 . Optional: Toggle the checkbox to enable or disable the email notifications.
 +
 [NOTE]


### PR DESCRIPTION
#### What changes are you introducing?

Update the procedure "Changing email notification settings for a host" to refer to the **Enabled** checkbox label shown in the Web UI, and mention the help text separately.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The documentation currently refers to "Include this host within Foreman reporting" as if it were the checkbox label. In the Web UI (Satellite 6.17–6.19), that text is help text; the checkbox label is **Enabled**.

- Red Hat JIRA: https://redhat.atlassian.net/browse/SAT-50175
- Upstream issue: Fixes #4886

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Verified against Satellite Web UI and published docs for Satellite 6.17, 6.18, and 6.19.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [x] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [x] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [x] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.