### PR TITLE
Restructure content into JTBD-based navigation hierarchy

### DIFF
--- a/guides/doc-Configuring_User_Authentication/Makefile.preview
+++ b/guides/doc-Configuring_User_Authentication/Makefile.preview
@@ -1,0 +1,31 @@
+include ../common/Makefile
+
+# Preview build for JTBD navigation structure
+# Uses master-preview.adoc instead of master.adoc
+
+SOURCES_PREVIEW = master-preview.adoc $(shell find . -type f -name \*.adoc)
+DEST_HTML_PREVIEW = $(DEST_DIR)/index-preview-$(BUILD).html
+
+html-preview: prepare $(IMAGES_TS)
+	bundle exec asciidoctor -b html5 \
+		-a compat-mode \
+		-a experimental \
+		-a listing-caption! \
+		-a source-highlighter=highlightjs \
+		-a table-caption! \
+		-a toc=left \
+		-a build=$(BUILD) \
+		$(BASEURL_ATTR) \
+		-d book \
+		-o $(DEST_HTML_PREVIEW) \
+		master-preview.adoc
+	@echo "================================================"
+	@echo "JTBD Preview built: $(DEST_HTML_PREVIEW)"
+	@echo "================================================"
+	@echo "Compare with original: $(DEST_DIR)/index-$(BUILD).html"
+	@echo ""
+
+browser-preview: html-preview
+	${BROWSER_OPEN} "file://$(realpath $(ROOTDIR)/$(DEST_HTML_PREVIEW))"
+
+.PHONY: html-preview browser-preview

--- a/guides/doc-Configuring_User_Authentication/master-preview.adoc
+++ b/guides/doc-Configuring_User_Authentication/master-preview.adoc
@@ -1,0 +1,42 @@
+// PREVIEW BUILD: JTBD-Based Navigation Structure
+//
+// This file demonstrates the new Jobs-To-Be-Done (JTBD) navigation structure
+// for the Configuring User Authentication guide.
+//
+// To build this preview:
+//   make -f Makefile.preview html-preview
+//   make -f Makefile.preview browser-preview
+//
+// The new navigation is in: ../../maps/navigation.adoc
+// Original structure remains in: master.adoc (unchanged)
+//
+// This preview uses the official Satellite/Foreman JTBD taxonomy:
+//   - Job #11: Evaluate Satellite security capabilities (Discover)
+//   - Job #39: Get started with Satellite (Get started)
+//   - Job #7: Integrate identity management system (Integrate)
+//   - Job #38: Secure the Satellite environment (Secure)
+//   - Job #20: Control user access (Secure)
+//   - Troubleshoot authentication
+
+include::common/attributes.adoc[]
+include::common/header.adoc[]
+:context: authentication
+
+= {ConfiguringUserAuthenticationDocTitle} - JTBD Navigation Preview
+
+[NOTE]
+====
+This is a preview build demonstrating the new Jobs-To-Be-Done (JTBD) navigation structure.
+Content is organized by user goals aligned with the official Satellite/Foreman JTBD taxonomy.
+====
+
+ifdef::satellite[]
+include::common/modules/proc_providing-feedback-on-red-hat-documentation.adoc[leveloffset=+1]
+endif::[]
+
+// Include the new JTBD navigation map
+include::../../maps/navigation.adoc[leveloffset=+1]
+
+ifndef::orcharhino,satellite[]
+include::common/ribbons.adoc[]
+endif::[]

--- a/maps/discover/compare-authentication-methods.adoc
+++ b/maps/discover/compare-authentication-methods.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: MAP
+
+= Choose the right authentication method for your environment
+
+Understand which authentication method supports your requirements for single sign-on, two-factor authentication, and integration with existing infrastructure.
+
+include::../../guides/common/modules/ref_overview-of-authentication-methods-in-foreman.adoc[leveloffset=+1]

--- a/maps/discover/job-11-evaluate-satellite-security-capabilities.adoc
+++ b/maps/discover/job-11-evaluate-satellite-security-capabilities.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: MAP
+
+// Official Job #11: Evaluate Satellite security capabilities
+// Category: Discover
+// Priority: 3.83
+
+= Evaluate {Project} security capabilities
+
+When evaluating {Project} security, discover available authentication features and understand their purpose, so you can select appropriate protections for your environment.
+
+include::compare-authentication-methods.adoc[leveloffset=+1]

--- a/maps/get-started/job-39-get-started-with-satellite.adoc
+++ b/maps/get-started/job-39-get-started-with-satellite.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: MAP
+
+// Official Job #39: Get started with Satellite
+// Category: Get started
+// Priority: 5.00
+
+= Get started with {Project}
+
+When you're new to {Project} and about to configure authentication, complete these basic operations to access the system.
+
+include::log-in-to-satellite.adoc[leveloffset=+1]
+
+ifdef::katello,orcharhino,satellite[]
+include::trust-server-certificates.adoc[leveloffset=+1]
+endif::[]

--- a/maps/get-started/log-in-to-satellite.adoc
+++ b/maps/get-started/log-in-to-satellite.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: MAP
+
+= Access the {ProjectWebUI}
+
+Access the {ProjectWebUI} using username and password authentication.
+
+include::../../guides/common/modules/con_accessing-project-from-web-ui.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_logging-in-to-the-web-ui.adoc[leveloffset=+1]

--- a/maps/get-started/trust-server-certificates.adoc
+++ b/maps/get-started/trust-server-certificates.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: MAP
+
+= Establish secure browser connections
+
+Establish secure connections by importing the {Project} CA certificate to avoid browser certificate warnings.
+
+include::../../guides/common/modules/proc_importing-the-katello-root-ca-certificate-by-using-browser.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_importing-the-katello-root-ca-certificate-by-using-command-line.adoc[leveloffset=+1]

--- a/maps/integrate/integrate-active-directory.adoc
+++ b/maps/integrate/integrate-active-directory.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: MAP
+
+= Enable single sign-on with Active Directory
+
+Enable Active Directory domain users to authenticate with Kerberos SSO by joining {ProjectServer} to the AD domain.
+
+include::../../guides/common/modules/con_configuring-kerberos-sso-for-active-directory-users-in-project.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_joining-the-project-server-system-to-an-ad-domain.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-the-active-directory-authentication-source-on-project-server.adoc[leveloffset=+1]

--- a/maps/integrate/integrate-freeipa.adoc
+++ b/maps/integrate/integrate-freeipa.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: MAP
+
+= Enable single sign-on with {FreeIPA}
+
+Enable {FreeIPA} users to authenticate with Kerberos SSO and manage user access through host-based access control.
+
+include::../../guides/common/modules/con_configuring-kerberos-sso-with-freeipa-in-project.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_enrolling-project-server-in-your-freeipa-domain.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-the-freeipa-authentication-source-on-project-server.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-host-based-access-control-for-freeipa-users-logging-in-to-project.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-hammer-cli-to-accept-freeipa-credentials.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_logging-in-to-hammer-cli-with-freeipa-credentials.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-mozilla-firefox.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_logging-in-to-the-web-ui-with-freeipa-credentials-in-chrome.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-a-cross-forest-trust-between-freeipa-and-active-directory-for-project.adoc[leveloffset=+1]

--- a/maps/integrate/integrate-keycloak-quarkus.adoc
+++ b/maps/integrate/integrate-keycloak-quarkus.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: MAP
+
+= Enable single sign-on and two-factor authentication with {keycloak-quarkus}
+
+Enable {keycloak-quarkus} authentication with support for single sign-on, two-factor authentication (TOTP), and smart card (PIV) authentication.
+
+include::../../guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-quarkus-in-project.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/ref_prerequisites-for-configuring-project-with-keycloak-quarkus-authentication.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-the-project-client-in-keycloak-quarkus.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-a-project-client-to-provide-web-ui-authentication-with-keycloak.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-project-with-keycloak-for-totp-authentication.adoc[leveloffset=+1]
+
+ifndef::satellite,orcharhino[]
+include::../../guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc[leveloffset=+1]
+endif::[]
+
+include::../../guides/common/modules/proc_configuring-group-mapping-for-keycloak-authentication.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc[leveloffset=+1]

--- a/maps/integrate/integrate-keycloak-wildfly.adoc
+++ b/maps/integrate/integrate-keycloak-wildfly.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: MAP
+
+= Enable single sign-on and two-factor authentication with {keycloak-wildfly}
+
+[IMPORTANT]
+====
+{keycloak-wildfly} is deprecated. For new deployments, use {keycloak-quarkus} instead.
+====
+
+Enable {keycloak-wildfly} authentication with support for single sign-on, two-factor authentication (TOTP), and smart card (PIV) authentication.
+
+include::../../guides/common/modules/con_configuring-sso-and-2fa-with-keycloak-wildfly-in-project.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/ref_prerequisites-for-configuring-project-with-keycloak-wildfly-authentication.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_registering-project-as-a-client-of-keycloak.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-the-project-client-in-keycloak-wildfly.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-a-project-client-to-provide-web-ui-authentication-with-keycloak.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-a-project-client-to-provide-hammer-cli-authentication-with-keycloak.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-project-with-keycloak-for-totp-authentication.adoc[leveloffset=+1]
+
+ifndef::satellite,orcharhino[]
+include::../../guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc[leveloffset=+1]
+endif::[]
+
+include::../../guides/common/modules/proc_configuring-group-mapping-for-keycloak-authentication.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_logging-in-to-project-configured-with-keycloak-as-an-authentication-source.adoc[leveloffset=+1]

--- a/maps/integrate/integrate-ldap.adoc
+++ b/maps/integrate/integrate-ldap.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: MAP
+
+= Enable LDAP authentication
+
+Enable LDAP users to authenticate with username and password. LDAP authentication does not support Kerberos single sign-on.
+
+include::../../guides/common/modules/con_configuring-an-ldap-server-as-an-external-identity-provider-for-project.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_obtaining-a-ca-certificate-for-ldaps.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_configuring-project-to-use-ldap.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/ref_example-settings-for-ldap-connections.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/ref_examples-ldap-filters.adoc[leveloffset=+1]

--- a/maps/integrate/job-7-integrate-identity-management-system.adoc
+++ b/maps/integrate/job-7-integrate-identity-management-system.adoc
@@ -1,0 +1,50 @@
+:_mod-docs-content-type: MAP
+
+// Official Job #7: Integrate identity management system
+// Category: Integrate
+// Priority: 3.50
+
+= Integrate identity management system
+
+When provisioning hosts, integrate with an identity management system to manage user authentication and host identity lifecycle.
+
+[NOTE]
+====
+Before integrating an identity management system, ensure you can log in to {Project} with administrative privileges. See <<job-39-get-started-with-satellite>>.
+====
+
+include::integrate-freeipa.adoc[leveloffset=+1]
+
+ifndef::containerized[]
+ifndef::foreman-deb[]
+// Keycloak Wildfly (deprecated)
+:parent-context: {context}
+:context: keycloak-wildfly
+ifdef::satellite[]
+:keycloak: {keycloak-wildfly}
+:keycloak-example-com: rhsso.example.com
+endif::[]
+include::integrate-keycloak-wildfly.adoc[leveloffset=+1]
+:context: {parent-context}
+ifdef::satellite[]
+:!keycloak:
+endif::[]
+
+// Keycloak Quarkus (current)
+:parent-context: {context}
+:context: keycloak-quarkus
+ifdef::satellite[]
+:keycloak: {keycloak-quarkus}
+:keycloak-example-com: rhbk.example.com
+endif::[]
+include::integrate-keycloak-quarkus.adoc[leveloffset=+1]
+:context: {parent-context}
+ifdef::satellite[]
+:!keycloak:
+endif::[]
+endif::[]
+endif::[]
+
+include::integrate-active-directory.adoc[leveloffset=+1]
+
+include::integrate-ldap.adoc[leveloffset=+1]

--- a/maps/navigation.adoc
+++ b/maps/navigation.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: MAP
+
+// Top-level navigation map for Configuring User Authentication
+// Organized by official Satellite/Foreman JTBD taxonomy
+
+= Configuring User Authentication
+
+This guide helps you integrate external authentication sources and secure user access to {Project}.
+
+// Job #11: Evaluate Satellite security capabilities (Discover)
+include::discover/job-11-evaluate-satellite-security-capabilities.adoc[leveloffset=+1]
+
+// Job #39: Get started with Satellite (Get started)
+include::get-started/job-39-get-started-with-satellite.adoc[leveloffset=+1]
+
+// Job #7: Integrate identity management system (Integrate)
+include::integrate/job-7-integrate-identity-management-system.adoc[leveloffset=+1]
+
+// Job #38: Secure the Satellite environment (Secure)
+include::secure/job-38-secure-satellite-environment.adoc[leveloffset=+1]
+
+// Job #20: Control user access (Secure)
+include::secure/job-20-control-user-access.adoc[leveloffset=+1]
+
+// Troubleshoot category
+include::troubleshoot/troubleshoot-authentication.adoc[leveloffset=+1]

--- a/maps/secure/enable-smart-card-authentication.adoc
+++ b/maps/secure/enable-smart-card-authentication.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: MAP
+
+= Enable smart card authentication
+
+Allow users to authenticate with PIV cards (Common Access Cards) for enhanced security through {keycloak}.
+
+[NOTE]
+====
+This procedure requires {keycloak} integration to be configured. See Job #7: Integrate identity management system.
+====
+
+include::../../guides/common/modules/proc_configuring-keycloak-settings-for-authentication-with-cac-cards.adoc[leveloffset=+1]

--- a/maps/secure/enable-two-factor-authentication.adoc
+++ b/maps/secure/enable-two-factor-authentication.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: MAP
+
+= Enable two-factor authentication
+
+Enhance security by requiring time-based one-time passwords (TOTP) for {keycloak} users.
+
+[NOTE]
+====
+This procedure requires {keycloak} integration to be configured. See Job #7: Integrate identity management system.
+====
+
+include::../../guides/common/modules/proc_configuring-project-with-keycloak-for-totp-authentication.adoc[leveloffset=+1]

--- a/maps/secure/job-20-control-user-access.adoc
+++ b/maps/secure/job-20-control-user-access.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: MAP
+
+// Official Job #20: Control user access
+// Category: Secure
+// Priority: 3.67
+
+= Control user access
+
+When you need to control who can perform which operations in {Project}, create users and assign them appropriate roles to implement least-privilege access control.
+
+This section covers managing external user groups from {FreeIPA}, {keycloak}, Active Directory, or LDAP to automatically assign roles based on directory group membership.
+
+include::map-external-groups-to-roles.adoc[leveloffset=+1]
+
+include::sync-group-membership.adoc[leveloffset=+1]

--- a/maps/secure/job-38-secure-satellite-environment.adoc
+++ b/maps/secure/job-38-secure-satellite-environment.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: MAP
+
+// Official Job #38: Secure the Satellite environment
+// Category: Secure
+// Priority: 4.67
+
+= Secure the {Project} environment
+
+When managing {Project} deployment, secure the environment against unauthorized access and threats to ensure the infrastructure management platform remains protected, compliant, and available for critical operations.
+
+include::set-custom-login-message.adoc[leveloffset=+1]
+
+ifndef::containerized[]
+ifndef::foreman-deb[]
+include::enable-two-factor-authentication.adoc[leveloffset=+1]
+
+ifndef::satellite,orcharhino[]
+include::enable-smart-card-authentication.adoc[leveloffset=+1]
+endif::[]
+endif::[]
+endif::[]

--- a/maps/secure/map-external-groups-to-roles.adoc
+++ b/maps/secure/map-external-groups-to-roles.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: MAP
+
+= Assign roles automatically based on directory group membership
+
+Grant {Project} roles automatically based on external directory group membership from {FreeIPA}, {keycloak}, Active Directory, or LDAP.
+
+[NOTE]
+====
+This procedure requires an external authentication source to be configured. See Job #7: Integrate identity management system.
+====
+
+include::../../guides/common/modules/con_managing-external-user-groups.adoc[leveloffset=+1]
+
+include::../../guides/common/modules/proc_associating-external-users-with-user-groups.adoc[leveloffset=+1]

--- a/maps/secure/set-custom-login-message.adoc
+++ b/maps/secure/set-custom-login-message.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: MAP
+
+= Display compliance warnings on the login page
+
+Display compliance-required warnings or organizational messages on the {ProjectWebUI} login page.
+
+include::../../guides/common/modules/proc_setting-a-custom-message-on-the-web-ui-login-page.adoc[leveloffset=+1]

--- a/maps/secure/sync-group-membership.adoc
+++ b/maps/secure/sync-group-membership.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: MAP
+
+= Update group membership
+
+Refresh external group membership changes instead of waiting for the scheduled sync or next user login.
+
+ifndef::containerized[]
+include::../../guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-cli.adoc[leveloffset=+1]
+endif::[]
+
+include::../../guides/common/modules/proc_refreshing-external-user-groups-for-ldap-using-web-ui.adoc[leveloffset=+1]

--- a/maps/troubleshoot/job-34-reset-admin-password.adoc
+++ b/maps/troubleshoot/job-34-reset-admin-password.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: MAP
+
+// Official Job #34: Reset admin password
+// Category: Troubleshoot
+// Priority: 1.17
+
+= Regain administrative access
+
+When administrative access is lost, reset the administrative password to regain access to {Project}.
+
+include::../../guides/common/modules/proc_resetting-the-administrative-user-password.adoc[leveloffset=+1]

--- a/maps/troubleshoot/reset-external-authentication.adoc
+++ b/maps/troubleshoot/reset-external-authentication.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: MAP
+
+= Disable external authentication to restore local login
+
+Disable {FreeIPA} or Active Directory authentication to prevent external users from accessing {Project} or to troubleshoot authentication issues.
+
+[NOTE]
+====
+This procedure resets Kerberos SSO configuration for {FreeIPA} and Active Directory. For {keycloak} or LDAP authentication, remove the authentication source through the {ProjectWebUI}.
+====
+
+include::../../guides/common/modules/proc_resetting-external-authentication-configuration-for-kerberos-sso.adoc[leveloffset=+1]

--- a/maps/troubleshoot/troubleshoot-authentication.adoc
+++ b/maps/troubleshoot/troubleshoot-authentication.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: MAP
+
+= Troubleshoot authentication
+
+When authentication issues occur, diagnose and resolve problems to restore user access.
+
+include::job-34-reset-admin-password.adoc[leveloffset=+1]
+
+include::reset-external-authentication.adoc[leveloffset=+1]


### PR DESCRIPTION
####  What changes are you introducing?
This PR:
* Restructures content into JTBD-based navigation hierarchy
* Rewrites titles to be user-goal oriented
* Creates a navigation layer without modifying source files: master.adoc (untouched), guides/common/modules/*.adoc (untouched), guides/common/assembly_*.adoc (untouched)
* Creates 2 files to enable reviewers a quick review 
** guides/doc-Configuring_User_Authentication/Makefile.preview
** guides/doc-Configuring_User_Authentication/master-preview.adoc

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
To  map the content to the new JTBD structure and implement JTBD changes 

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
