### PR TITLE
move podman login registry.redhat.io to preparing system

### DIFF
--- a/guides/common/assembly_preparing-your-environment-for-project-server-installation.adoc
+++ b/guides/common/assembly_preparing-your-environment-for-project-server-installation.adoc
@@ -17,3 +17,7 @@ include::modules/proc_registering-to-red-hat-subscription-management.adoc[levelo
 endif::[]
 
 include::modules/proc_configuring-repositories.adoc[leveloffset=+1]
+
+ifdef::satellite[]
+include::modules/proc_logging-in-to-the-redhat-container-registry.adoc[leveloffset=+1]
+endif::[]

--- a/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
+++ b/guides/common/modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc
@@ -29,16 +29,6 @@ endif::[]
 For more information, see https://access.redhat.com/solutions/7055981[How to switch to netavark network backend in Podman in the Red{nbsp}Hat Knowledgebase].
 
 .Procedure
-ifdef::satellite[]
-. Log in to the Red{nbsp}Hat registry by using Podman:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# podman login --authfile /etc/foreman/registry-auth.json registry.redhat.io
-----
-+
-This command creates the `/etc/foreman/registry-auth.json` file.
-endif::[]
 . Enable the plugin:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]

--- a/guides/common/modules/proc_logging-in-to-the-redhat-container-registry.adoc
+++ b/guides/common/modules/proc_logging-in-to-the-redhat-container-registry.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: PROCEDURE
+
+[id="logging-in-to-the-redhat-container-registry"]
+= Logging in to the Red{nbsp}Hat container registry
+
+[role="_abstract"]
+You must log in to the Red{nbsp}Hat container registry so that the host can consume container images needed for the deployment of {Project}.
+
+.Procedure
+* Log in to the Red{nbsp}Hat container registry by using Podman:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# podman login --authfile /etc/foreman/registry-auth.json registry.redhat.io
+----
++
+This command creates the `/etc/foreman/registry-auth.json` file.
+
+.Additional resources
+* link:https://access.redhat.com/articles/RegistryAuthentication[Red Hat Container Registry Authentication]

--- a/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
+++ b/guides/common/modules/proc_migrating-from-hosted-to-in-project-insights.adoc
@@ -7,14 +7,6 @@
 Migrate from hosted {Insights} to {insights-iop} when you need local analysis on your {ProjectServer} without sending host data to the {RHCloud}.
 
 .Procedure
-. Log in to the Red{nbsp}Hat container registry:
-+
-[options="nowrap", subs="+quotes,verbatim,attributes"]
-----
-# podman login --authfile /etc/foreman/registry-auth.json registry.redhat.io
-----
-+
-This command creates the `/etc/foreman/registry-auth.json` file.
 . On {ProjectServer}, enable {insights-iop}:
 ** If {insights-iop} was previously enabled:
 +


### PR DESCRIPTION
#### What changes are you introducing?

move podman login registry.redhat.io to preparing system

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

this is now needed for everything, not only IoP

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
