### PR TITLE
Enable BMC chapter for Smart Proxy (SAT-47359)

### DIFF
--- a/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
+++ b/guides/common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc
@@ -1,6 +1,8 @@
 include::modules/con_performing-additional-configuration-on-smart-proxy-server.adoc[]
 
+ifndef::containerized[]
 include::modules/proc_configuring-smart-proxy-server-for-host-registration-and-provisioning.adoc[leveloffset=+1]
+endif::containerized[]
 
 ifdef::foreman-el,foreman-deb,katello,orcharhino[]
 include::modules/proc_enabling-remote-execution.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
+++ b/guides/common/modules/proc_enabling-power-management-on-hosts.adoc
@@ -26,14 +26,20 @@ Enable the baseboard management controller (BMC) module on {ProductName} to perf
 [options="nowrap", subs="+quotes,attributes"]
 ----
 ifndef::containerized[# {foreman-installer} --foreman-proxy-bmc "true"]
-ifdef::containerized[# {foremanctl} deploy --add-feature bmc]
+ifdef::containerized[]
+ifdef::installing-capsule-server[# {foremanctl} deploy-proxy --add-feature bmc]
+ifndef::installing-capsule-server[# {foremanctl} deploy --add-feature bmc]
+endif::containerized[]
 ----
 . Optional: Select the IPMI implementation:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
 ifndef::containerized[# {foreman-installer} --foreman-proxy-bmc-default-provider "_freeipmi_"]
-ifdef::containerized[# {foremanctl} deploy --bmc-ipmi-implementation "_freeipmi_"]
+ifdef::containerized[]
+ifdef::installing-capsule-server[# {foremanctl} deploy-proxy --bmc-ipmi-implementation "_freeipmi_"]
+ifndef::installing-capsule-server[# {foremanctl} deploy --bmc-ipmi-implementation "_freeipmi_"]
+endif::containerized[]
 ----
 . In the {ProjectWebUI}, navigate to *Infrastructure* > *Subnets*.
 . Select the subnet of your host.

--- a/guides/doc-Installing_Proxy/master.adoc
+++ b/guides/doc-Installing_Proxy/master.adoc
@@ -23,9 +23,9 @@ include::common/assembly_preparing-your-environment-for-smart-proxy-installation
 // Installing {SmartProxyServer}
 include::common/assembly_installing-smart-proxy-server.adoc[leveloffset=+1]
 
-ifndef::containerized[]
 include::common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc[leveloffset=+1]
 
+ifndef::containerized[]
 :numbered!:
 
 // {SmartProxyServer} Scalability Considerations


### PR DESCRIPTION
I tested the command works as expected except it must be `deploy-proxy` and not `deploy`.

I have to hide all the other chapters from the section 3 because I do not know these are ready yet.

https://redhat.atlassian.net/browse/SAT-47359

Previous work: https://github.com/theforeman/foreman-documentation/pull/4860