### PR TITLE
Make -j default and serve without full rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+MAKEFLAGS += -j
 DEST := result
 PORT := 5000
 VERSION_LINKS := 5.0 3.19 3.18 3.17 3.16 3.15 3.14 3.13 3.12 3.11 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0 2.5 2.4
@@ -31,9 +32,9 @@ html: build-foreman-el build-foreman-deb build-containerized-katello build-conta
 # does not vary by BUILD, and compiling it redundantly from N parallel
 # build-% processes races on the same output file.
 css: prep
-	$(MAKE) -C guides/ css
+	$(MAKE) -j -C guides/ css
 
-build-%: FORCE prep css
+build-%: FORCE css
 	$(MAKE) -C guides/ html BUILD=$*
 
 web: prep
@@ -44,7 +45,7 @@ compile: web html
 	cp $(CP_ARGS) -nr guides/build/* $(DEST)/nightly/
 	for V in $(VERSION_LINKS); do ln -sf nightly $(DEST)/$$V; done
 
-serve: compile
+serve:
 	python3 -m http.server --directory ./$(DEST) $(PORT)
 
 toc: html

--- a/README.md
+++ b/README.md
@@ -40,10 +40,20 @@ To build both the static site and the guides for easy local testing, a global `M
 * `serve`: serves the result directory via a python web server (the default target)
 
 To use the `Makefile`, you must first install the `gcc`, `gcc-c++`, and `ruby-devel` packages.
-Then, to test the entire site locally, perform `make serve` command and open up `http://localhost:5000`.
-Use `PORT=5008` to change the web server port (5000 by default).
-This builds all contexts, so the initial build might be slow. 
-For faster builds on modern multi-core machines, use the `-j` option.
+To test the entire site locally, first build the guides and then serve them:
+
+```
+make html serve
+```
+
+Then open `http://localhost:5000`. Use `PORT=5008` to change the web server port (5000 by default).
+
+Building all contexts is slow. For faster development builds, build only one variant:
+
+```
+make build-foreman-el serve
+```
+
 Stable versions are symlinks to the nightly (current) version, which can cause issues for deleted (or renamed) guides.
 
 ### `.vale` subdirectory

--- a/guides/Makefile
+++ b/guides/Makefile
@@ -11,6 +11,7 @@ html: subdirs contributing
 
 css: subdirs contributing-css
 
+# Allow parallel jobs to flow through from parent make -j
 subdirs: $(SUBDIRS)
 
 contributing:

--- a/guides/common/linkchecker.ini
+++ b/guides/common/linkchecker.ini
@@ -16,6 +16,7 @@ ignore=example.com
   projects.theforeman.org
   access.redhat.com/solutions
   docs.tuxcare.com/live-patching-services
+  docs.tuxcare.com/eportal
   forge.puppetlabs.com
   sources/
   tuxcare.com/enterprise-live-patching-services


### PR DESCRIPTION
Building the whole site is extremely slow, `-j` should be the default. It is used already on CICD (`-j3`) and there is no reason not to use it. Passing it via `make -j` does not break your shell history it just works.

Also, pass the `-j` down the processes, specifically this helps a bit for CSS.

Finally, the `serve` target always rebuilds everything. This is a problem since I very often want to only build the upstream nightly guides which is much faster. The patch changes this behavior and updates the README with instructions how to now achieve the required behavior:

	make html serve

Or a tad faster:

	make build-foreman-el serve

Added one more commit - ignores `docs.tuxcare.com/eportal` link which always fails on CICD (probably the linter was blocked now).
