### PR TITLE
Fix unescaped brace in client-os-context ID normalization

### DIFF
--- a/scripts/check-filename-id-heading-match.sh
+++ b/scripts/check-filename-id-heading-match.sh
@@ -78,7 +78,7 @@ check_file() {
     normalized_id="${normalized_id//\{OpenStack-id\}/openstack}"
     normalized_id="${normalized_id//\{KubeVirt-id\}/kubevirt}"
     normalized_id="${normalized_id//\{a-KubeVirt-id\}/a-kubevirt}"
-    normalized_id="${normalized_id//\{client-os-context}/client-os}"
+    normalized_id="${normalized_id//\{client-os-context\}/client-os}"
 
     # Normalize heading for comparison
     local normalized_heading=""


### PR DESCRIPTION
#### What changes are you introducing?
Fix unescaped brace in client-os-context ID normalization

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
The closing brace of {client-os-context} was not escaped, causing bash
to terminate the parameter expansion early and append a literal
"/client-os}" to every normalized ID. This made the filename-ID-heading
check fail for all modules. Escape the brace so the substitution works.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
Apparently introduced in https://github.com/theforeman/foreman-documentation/pull/5050

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
