### PR TITLE
Turn off Vale's AsciiDocDITA.TaskInclude for upstream

### DIFF
--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -26,7 +26,9 @@ ifdef::satellite[]
 ----
 endif::[]
 ifdef::foreman-deb[]
+pass:[<!-- vale AsciiDocDITA.TaskInclude = NO -->]
 include::snip_configuring-repositories-foreman-deb.adoc[]
+pass:[<!-- vale AsciiDocDITA.TaskInclude = YES -->]
 endif::[]
 ifdef::foreman-el,katello[]
 . Clear any metadata:
@@ -37,9 +39,11 @@ ifdef::foreman-el,katello[]
 ----
 endif::[]
 ifndef::satellite[]
+pass:[<!-- vale AsciiDocDITA.TaskInclude = NO -->]
 ifdef::foreman-el,katello,containerized[]
 include::snip_configuring-repositories-foreman-rpm.adoc[]
 endif::[]
+pass:[<!-- vale AsciiDocDITA.TaskInclude = YES -->]
 endif::[]
 ifdef::orcharhino[]
 * Ensure the repositories required to install {ProductName} are enabled on your {EL} host.

--- a/guides/common/modules/proc_configuring-repositories.adoc
+++ b/guides/common/modules/proc_configuring-repositories.adoc
@@ -39,11 +39,11 @@ ifdef::foreman-el,katello[]
 ----
 endif::[]
 ifndef::satellite[]
-pass:[<!-- vale AsciiDocDITA.TaskInclude = NO -->]
 ifdef::foreman-el,katello,containerized[]
+pass:[<!-- vale AsciiDocDITA.TaskInclude = NO -->]
 include::snip_configuring-repositories-foreman-rpm.adoc[]
-endif::[]
 pass:[<!-- vale AsciiDocDITA.TaskInclude = YES -->]
+endif::[]
 endif::[]
 ifdef::orcharhino[]
 * Ensure the repositories required to install {ProductName} are enabled on your {EL} host.


### PR DESCRIPTION
#### What changes are you introducing?

Use Vale's [comments](https://docs.vale.sh/formats/asciidoc#comments) to disable a specific rule for upstream content: `AsciiDocDITA.TaskInclude`.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

In https://github.com/theforeman/foreman-documentation/pull/5261 I saw this warning and wonder if it's safe to disable the rule for upstream. This is a test to look at that.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

I have no idea if my assumption is valid so this is just a draft and I'm abusing CI to see if it even works.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.