### PR TITLE
Use double colon for image macros

### DIFF
--- a/guides/common/modules/con_web-ui-overview.adoc
+++ b/guides/common/modules/con_web-ui-overview.adoc
@@ -14,4 +14,4 @@ ifndef::satellite[]
 The {ProjectWebUI} and command-line interface is translated into various languages.
 endif::[]
 
-image:web-ui-overview-{project-context}.png[title="{ProjectWebUI}", alt="Screenshot of dashboard in {ProjectWebUI}"]
+image::web-ui-overview-{project-context}.png[title="{ProjectWebUI}", alt="Screenshot of dashboard in {ProjectWebUI}"]


### PR DESCRIPTION
#### What changes are you introducing?

Align image macros: `rg "image:[a-z0-9]"`

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Follow-up to #5205

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
