### PR TITLE
Fix path for importing playbook by name

### DIFF
--- a/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
+++ b/guides/common/modules/proc_importing-an-ansible-playbook-by-name.adoc
@@ -8,7 +8,12 @@ You can import Ansible Playbooks by name to {Project} from collections installed
 {Project} creates a job template from each playbook so you can run it on hosts via remote execution without writing the template manually.
 
 When you import an Ansible Playbook, {Project} creates a job template from the imported playbook and places the template in the `Ansible Playbook - Imported` job category.
+ifndef::containerized[]
 If you have a custom collection, place it in `/etc/ansible/collections/ansible_collections/_My_Namespace_/_My_Collection_`.
+endif::[]
+ifdef::containerized[]
+If you have a custom collection, place it in `/var/lib/foreman-proxy/ansible/collections/ansible_collections/_My_Namespace_/_My_Collection_`.
+endif::[]
 
 .Prerequisites
 * Ansible plugin is enabled.


### PR DESCRIPTION
in containerized

#### What changes are you introducing?

Use different ansible collection path in proc_importing-an-ansible-playbook-by-name.adoc in containerized deployments.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

The path is different in containerized deployments.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Draft until I stand up an instance to test this.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.