### PR TITLE
Containerized RHEL system roles

### DIFF
--- a/guides/common/assembly_configuring-ansible-definitions-to-apply-to-hosts.adoc
+++ b/guides/common/assembly_configuring-ansible-definitions-to-apply-to-hosts.adoc
@@ -1,9 +1,7 @@
 include::modules/con_configuring-ansible-definitions-to-apply-to-hosts.adoc[]
 
 ifndef::foreman-deb[]
-ifndef::containerized[]
 include::modules/proc_adding-rhel-system-roles.adoc[leveloffset=+1]
-endif::[]
 endif::[]
 
 include::modules/proc_importing-ansible-roles-and-variables.adoc[leveloffset=+1]

--- a/guides/common/modules/proc_adding-rhel-system-roles.adoc
+++ b/guides/common/modules/proc_adding-rhel-system-roles.adoc
@@ -16,8 +16,13 @@ Before subscribing to the Extras or AppStream channels, see https://access.redha
 endif::[]
 endif::[]
 
-ifndef::containerized[]
+ifdef::containerized[]
+{RHEL} System Roles are shipped in the `rhel-system-roles` package.
+This package comes preinstalled in {SmartProxyServer} container images.
+endif::[]
+
 .Procedure
+ifndef::containerized[]
 . Ensure that the following repository is enabled:
 * On {RHEL} 10, 9, or 8, ensure that the *AppStream* repository is enabled:
 +
@@ -49,12 +54,6 @@ endif::[]
 +
 The `rhel-system-roles` package downloads to `/usr/share/ansible/roles/`.
 You can view and make any modifications that you want to the files before you import.
-endif::[]
-ifdef::containerized[]
-{RHEL} System Roles are shipped in the `rhel-system-roles` package.
-This package comes preinstalled in {SmartProxyServer} container images.
-
-.Procedure
 endif::[]
 . In the {ProjectWebUI}, navigate to *Configure* > *Ansible* > *Roles*.
 . Click the {SmartProxy} that contains the roles that you want to import.

--- a/guides/common/modules/proc_adding-rhel-system-roles.adoc
+++ b/guides/common/modules/proc_adding-rhel-system-roles.adoc
@@ -11,9 +11,12 @@ ifdef::foreman-el,katello,satellite,red_hat_enterprise_linux[]
 Support levels for some of the {RHEL} System Roles might be in Technology Preview.
 For up-to-date information about support levels and general information about {RHEL} System Roles, see https://access.redhat.com/articles/3050101[{RHEL} System Roles].
 
+ifndef::containerized[]
 Before subscribing to the Extras or AppStream channels, see https://access.redhat.com/support/policy/updates/extras[{RHEL} Extras Product Lifecycle] or https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle[{RHEL} Application Streams Life Cycle].
 endif::[]
+endif::[]
 
+ifndef::containerized[]
 .Procedure
 . Ensure that the following repository is enabled:
 * On {RHEL} 10, 9, or 8, ensure that the *AppStream* repository is enabled:
@@ -46,6 +49,13 @@ endif::[]
 +
 The `rhel-system-roles` package downloads to `/usr/share/ansible/roles/`.
 You can view and make any modifications that you want to the files before you import.
+endif::[]
+ifdef::containerized[]
+{RHEL} System Roles are shipped in the `rhel-system-roles` package.
+This package comes preinstalled in {SmartProxyServer} container images.
+
+.Procedure
+endif::[]
 . In the {ProjectWebUI}, navigate to *Configure* > *Ansible* > *Roles*.
 . Click the {SmartProxy} that contains the roles that you want to import.
 . From the list of Ansible roles, select the checkbox of the roles you want to import, and then click *Update*.


### PR DESCRIPTION
#### What changes are you introducing?

RHEL system roles are baked into the smart proxy container images and don't need to be installed explicitly in containerized deployments.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

To address a leftover from https://github.com/theforeman/foreman-documentation/pull/5118#discussion_r3675682895

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

Companion to https://github.com/theforeman/foreman-oci-images/pull/94

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
