### PR TITLE
Hide Section 5.2.2, "Installing Red Hat Lightspeed in Satellite on a connected Satellite Server" of Installing Satellite guide

### DIFF
--- a/guides/common/assembly_installing-and-configuring-insights-iop.adoc
+++ b/guides/common/assembly_installing-and-configuring-insights-iop.adoc
@@ -2,8 +2,9 @@ include::modules/con_installing-and-configuring-insights-iop.adoc[]
 
 ifdef::installing-satellite-server-connected[]
 include::modules/proc_configuring-podman-to-use-an-http-proxy.adoc[leveloffset=+1]
-
+ifndef::containerized[]
 include::modules/proc_installing-insights-iop-on-a-connected-project-context-server.adoc[leveloffset=+1]
+endif::[]
 endif::[]
 
 ifdef::installing-satellite-server-disconnected[]

--- a/guides/doc-Installing_Server/master.adoc
+++ b/guides/doc-Installing_Server/master.adoc
@@ -42,8 +42,12 @@ endif::[]
 include::common/modules/con_performing-additional-configuration.adoc[leveloffset=+1]
 
 
+ifdef::satellite[]
+include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffset=+2]
+endif::[]
+
 ifndef::containerized[]
-ifdef::orcharhino,satellite[]
+ifdef::orcharhino[]
 include::common/assembly_installing-and-configuring-insights-iop.adoc[leveloffset=+2]
 endif::[]
 endif::[]


### PR DESCRIPTION


#### What changes are you introducing?
Hide Section 5.2.2, "Installing Red Hat Lightspeed in Satellite on a connected Satellite Server" of the Installing Satellite guide.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
Installing and configuring Red Hat Lightspeed in Satellite is no longer relevant to connected Satellite. Quote: 
> We need to take out the entire 5.2.2. Installing Red Hat Lightspeed in Satellite on a connected Satellite Server section. It's all for old rpm installs.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)
This ticket relates to SAT-48575

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
