### PR TITLE
Hide module for containerized-satellite builds

### DIFF
--- a/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
+++ b/guides/common/assembly_configuring-and-setting-up-remote-jobs.adoc
@@ -13,7 +13,9 @@ include::modules/con_getting-started-with-remote-execution.adoc[leveloffset=+1]
 include::modules/con_permissions-for-remote-execution.adoc[leveloffset=+2]
 
 ifdef::foreman-el,foreman-deb,containerized[]
+ifndef::satellite[]
 include::modules/proc_installing-the-remote-execution-plugin.adoc[leveloffset=+2]
+endif::[]
 endif::[]
 
 ifndef::containerized[]


### PR DESCRIPTION
As per the discussion in https://github.com/theforeman/foreman-documentation/pull/5093/changes#r3766831365, the `proc_installing-the-remote-execution-plugin.adoc` module should be hiddencfor Satellite builds after https://github.com/theforeman/foremanctl/pull/726/changes#diff-9a9cbfd956d49a7c9fb7a7eb2fcda57ff6f4e267a03e07b1934b45c682660d7aR13  is merged and made available for Capsules. It seems that this has been implemented for Capsules in https://github.com/theforeman/foremanctl/pull/735. Hiding the module for containerized Satellite.

JIRA: https://redhat.atlassian.net/browse/SAT-49059

#### What changes are you introducing?

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
