### PR TITLE
Release Foreman 5.0.0, deprecate 3.18

### DIFF
--- a/web/releases/3.18.json
+++ b/web/releases/3.18.json
@@ -1,6 +1,6 @@
 {
   "katello": "4.20",
-  "state": "supported",
+  "state": "unsupported",
   "builds": [
     {
       "title": "Katello on EL",

--- a/web/releases/5.0.json
+++ b/web/releases/5.0.json
@@ -1,6 +1,6 @@
 {
   "katello": "5.0",
-  "state": "RC",
+  "state": "supported",
   "builds": [
     {
       "title": "Katello on EL",


### PR DESCRIPTION
#### What changes are you introducing?
Config update for Foreman 5.0.0. Deprecation of Foreman 3.18 series.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)
release

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
