### PR TITLE
Customizing ansible configuration in containerized

### DIFF
--- a/guides/common/modules/proc_using-ansible-vault-with-project.adoc
+++ b/guides/common/modules/proc_using-ansible-vault-with-project.adoc
@@ -54,7 +54,7 @@ Secret=foreman-proxy-ansible-vault-password,type=mount,target=/etc/foreman-proxy
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-systemctl daemon-reload && systemctl restart foreman-proxy
+# systemctl daemon-reload && systemctl restart foreman-proxy
 ----
 endif::[]
 ifndef::containerized::[]

--- a/guides/common/modules/proc_using-ansible-vault-with-project.adoc
+++ b/guides/common/modules/proc_using-ansible-vault-with-project.adoc
@@ -50,12 +50,11 @@ ifdef::containerized[]
 [Container]
 Secret=foreman-proxy-ansible-vault-password,type=mount,target=/etc/foreman-proxy/.ansible_vault_password
 ----
-. Have systemd reload the container definitions and restart the service to recreate the container:
+. Restart the `foreman-proxy` container:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-systemctl daemon-reload
-systemctl restart foreman-proxy
+systemctl daemon-reload && systemctl restart foreman-proxy
 ----
 endif::[]
 ifndef::containerized::[]

--- a/guides/common/modules/proc_using-ansible-vault-with-project.adoc
+++ b/guides/common/modules/proc_using-ansible-vault-with-project.adoc
@@ -7,13 +7,17 @@
 You can encrypt sensitive Ansible data files using the Ansible Vault tool and configure Ansible to access the encrypted files using a password stored in a file.
 
 .Procedure
+ifndef::containerized[]
 . If you customized `/etc/ansible/ansible.cfg`, copy your configuration from `/etc/ansible/ansible.cfg` to `/usr/share/foreman-proxy/.ansible.cfg`.
+endif::[]
 . Encrypt the sensitive file using the `ansible-vault` command:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# ansible-vault encrypt /etc/ansible/roles/_Role_Name_/vars/main.yml
+ifndef::containerized[# ansible-vault encrypt /etc/ansible/roles/_Role_Name_/vars/main.yml]
+ifdef::containerized[# ansible-vault encrypt /var/lib/foreman-proxy/ansible/roles/_Role_Name_/vars/main.yml]
 ----
+ifndef::containerized[]
 +
 Note that `ansible-vault` changes the file permissions to `600`.
 . Change the group and permissions of the encrypted file to ensure that the `foreman-proxy` user can read it:
@@ -31,6 +35,30 @@ Note that `ansible-vault` changes the file permissions to `600`.
 # chown foreman-proxy:foreman-proxy /usr/share/foreman-proxy/.ansible_vault_password
 # chmod 0400 /usr/share/foreman-proxy/.ansible_vault_password
 ----
+endif::[]
+ifdef::containerized[]
+. Create a podman secret with the vault password:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+# printf '_My_Ansible_Vault_Password_' | podman secret create foreman-proxy-ansible-vault-password -
+----
+. Create a systemd drop-in at `/etc/containers/systemd/foreman-proxy.container.d/ansible-vault.conf` to propagate the secret into the container:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[Container]
+Secret=foreman-proxy-ansible-vault-password,type=mount,target=/etc/foreman-proxy/.ansible_vault_password
+----
+. Have systemd reload the container definitions and restart the service to recreate the container:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+systemctl daemon-reload
+systemctl restart foreman-proxy
+----
+endif::[]
+ifndef::containerized::[]
 . Add the path of the Vault password file to the `[defaults]` section in `/usr/share/foreman-proxy/.ansible.cfg`:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
@@ -38,5 +66,15 @@ Note that `ansible-vault` changes the file permissions to `600`.
 [defaults]
 vault_password_file = /usr/share/foreman-proxy/.ansible_vault_password
 ----
+endif::[]
+ifdef::containerized[]
+. Add the path of the Vault password file to the `[defaults]` section in `/var/lib/foreman-proxy/ansible/ansible.cfg`:
++
+[options="nowrap", subs="+quotes,verbatim,attributes"]
+----
+[defaults]
+vault_password_file = /etc/foreman-proxy/.ansible_vault_password
+----
+endif::[]
 +
 The path to the Vault password file must be absolute.

--- a/guides/common/modules/ref_customizing-ansible-configuration.adoc
+++ b/guides/common/modules/ref_customizing-ansible-configuration.adoc
@@ -7,20 +7,21 @@
 {Project} manages essential Ansible configuration that is required for Ansible integration with {Project}.
 However, you can customize other Ansible configuration options as usual.
 
-ifdef::containerized[]
-Ansible reads configuration provided by {SmartProxy}.
-endif::[]
-
 ifndef::containerized[]
 {Project} stores the essential Ansible configuration as environment variables in `/etc/foreman-proxy/ansible.env`.
 This file is managed by `{foreman-installer}`.
+endif::[]
 
 Ansible reads configuration from a configuration file and the environment provided by {SmartProxy}.
+ifndef::containerized[]
 If you need to customize Ansible configuration, you can do so in the system-wide `/etc/ansible/ansible.cfg` file or in the `/usr/share/foreman-proxy/.ansible.cfg` file in the home directory of the `foreman-proxy` user.
 Note that if you use `/usr/share/foreman-proxy/.ansible.cfg`, Ansible spawned by {Project} ignores configuration in `/etc/ansible/ansible.cfg`.
+endif::[]
+ifdef::containerized[]
+If you need to customize Ansible configuration, you can do so in the `/var/lib/foreman-proxy/ansible/ansible.cfg` file.
+endif::[]
 
 Note that environment variables take precedence over values in `ansible.cfg`, which ensures that the essential configuration required by {Project} is retained.
-endif::[]
 
 The following table lists the essential Ansible configuration options managed by {Project}.
 

--- a/guides/doc-Managing_Configurations_Ansible/master.adoc
+++ b/guides/doc-Managing_Configurations_Ansible/master.adoc
@@ -17,9 +17,7 @@ include::common/assembly_configuring-ansible-definitions-to-apply-to-hosts.adoc[
 
 include::common/assembly_applying-ansible-definitions-to-hosts.adoc[leveloffset=+1]
 
-ifndef::containerized[]
 include::common/modules/proc_using-ansible-vault-with-project.adoc[leveloffset=+1]
-endif::[]
 
 include::common/assembly_integrating-awx.adoc[leveloffset=+1]
 


### PR DESCRIPTION
#### What changes are you introducing?

Modify customizing ansible configuration modules to work in containerized deployments.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Tweaking ansible.cfg on the filesystem was possible in traditional deployments, but not in containers. This change closes that gap.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- Companion to https://github.com/theforeman/foremanctl/pull/822
- Closes this comment https://github.com/theforeman/foreman-documentation/pull/5118#discussion_r3675689329

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [ ] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
