### PR TITLE
Fix map alignment with downstream plan

### DIFF
--- a/guides/common/modules/con_manage-project-programmatically.adoc
+++ b/guides/common/modules/con_manage-project-programmatically.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-[id="manage-{project-context}-programmatically"]
-= Manage {Project} programmatically
-
-// The wording in this introduction is temporary; make sure to review it before publishing based on what exacty content the top-level job ends up including.
-[role="_abstract"]
-Manage {Project} resources programmatically in complex environments to reduce manual effort and enable system integration.

--- a/guides/common/modules/con_organize-resources-by-geography.adoc
+++ b/guides/common/modules/con_organize-resources-by-geography.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-[id="organize-resources-by-geography"]
-= Organize resources by geography
-
-// The wording in this introduction is temporary; make sure to review it before publishing based on what exacty content the top-level job ends up including.
-[role="_abstract"]
-Organize {Project} resources by geographic or physical location to group configurations and updates and delegate management tasks.

--- a/guides/common/modules/con_reset-admin-password.adoc
+++ b/guides/common/modules/con_reset-admin-password.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: CONCEPT
-
-[id="reset-admin-password"]
-= Reset admin password
-
-// The wording in this introduction is temporary; make sure to review it before publishing based on what exacty content the top-level job ends up including.
-[role="_abstract"]
-Reset the administrative password to regain access to {Project} when administrative credentials are lost.

--- a/guides/doc-Satellite_Documentation_Maps/administer.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/administer.adoc
@@ -10,6 +10,14 @@ include::maps/test-updates-before-production-deployment.adoc[leveloffset=+1]
 
 include::maps/perform-routine-maintenance.adoc[leveloffset=+1]
 
-include::maps/manage-logging-in-a-containerized-satellite.adoc[leveloffset=+1]
+include::maps/manage-hosts-with-pull-based-methods.adoc[leveloffset=+1]
 
-include::maps/remove-satellite-server-from-your-environment.adoc[leveloffset=+1]
+include::maps/provision-hosts-with-standardized-configurations.adoc[leveloffset=+1]
+
+include::maps/discover-new-hosts-for-provisioning.adoc[leveloffset=+1]
+
+include::maps/set-up-disaster-recovery.adoc[leveloffset=+1]
+
+include::maps/enforce-host-configuration.adoc[leveloffset=+1]
+
+include::maps/manage-satellite-with-cli.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/configure.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/configure.adoc
@@ -4,12 +4,4 @@
 
 include::maps/organize-satellite-resources-for-management.adoc[leveloffset=+1]
 
-include::maps/organize-resources-by-geography.adoc[leveloffset=+1]
-
-include::maps/manage-hosts-with-pull-based-methods.adoc[leveloffset=+1]
-
 include::maps/configure-alerts-for-critical-events.adoc[leveloffset=+1]
-
-include::maps/set-up-disaster-recovery.adoc[leveloffset=+1]
-
-include::maps/enforce-host-configuration.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/deploy.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/deploy.adoc
@@ -1,7 +1,3 @@
 :_mod-docs-content-type: MAP
 
 = Deploy
-
-include::maps/provision-hosts-with-standardized-configurations.adoc[leveloffset=+1]
-
-include::maps/discover-new-hosts-for-provisioning.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/develop.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/develop.adoc
@@ -3,5 +3,3 @@
 = Develop
 
 include::maps/automate-satellite-operations.adoc[leveloffset=+1]
-
-include::maps/manage-satellite-programmatically.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/disconnected-environments.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/disconnected-environments.adoc
@@ -5,3 +5,5 @@
 include::maps/get-started-with-satellite-in-a-disconnected-environment.adoc[leveloffset=+1]
 
 include::maps/insights-architecture-for-disconnected-environments.adoc[leveloffset=+1]
+
+include::maps/host-documentation-offline.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/install.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/install.adoc
@@ -5,3 +5,5 @@
 include::maps/install-satellite-server.adoc[leveloffset=+1]
 
 include::maps/install-smart-proxy-servers-for-load-balancing.adoc[leveloffset=+1]
+
+include::maps/remove-satellite-server-from-your-environment.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/manage-satellite-programmatically.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/manage-satellite-programmatically.adoc
@@ -1,3 +1,0 @@
-:_mod-docs-content-type: MAP
-
-include::../../common/modules/con_manage-project-programmatically.adoc[]

--- a/guides/doc-Satellite_Documentation_Maps/maps/organize-resources-by-geography.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/organize-resources-by-geography.adoc
@@ -1,3 +1,0 @@
-:_mod-docs-content-type: MAP
-
-include::../../common/modules/con_organize-resources-by-geography.adoc[]

--- a/guides/doc-Satellite_Documentation_Maps/maps/reset-admin-password.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/reset-admin-password.adoc
@@ -1,3 +1,0 @@
-:_mod-docs-content-type: MAP
-
-include::../../common/modules/con_reset-admin-password.adoc[]

--- a/guides/doc-Satellite_Documentation_Maps/observe.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/observe.adoc
@@ -9,3 +9,5 @@ include::maps/monitor-satellite-performance.adoc[leveloffset=+1]
 include::maps/use-intelligent-monitoring.adoc[leveloffset=+1]
 
 include::maps/monitor-host-health.adoc[leveloffset=+1]
+
+include::maps/manage-logging-in-a-containerized-satellite.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/reference.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/reference.adoc
@@ -2,8 +2,4 @@
 
 = Reference
 
-include::maps/manage-satellite-with-cli.adoc[leveloffset=+1]
-
 include::maps/use-built-in-api-documentation.adoc[leveloffset=+1]
-
-include::maps/host-documentation-offline.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/troubleshoot.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/troubleshoot.adoc
@@ -8,6 +8,4 @@ include::maps/troubleshoot-upgrade-issues.adoc[leveloffset=+1]
 
 include::maps/gather-diagnostic-information-for-support.adoc[leveloffset=+1]
 
-include::maps/reset-admin-password.adoc[leveloffset=+1]
-
 include::maps/diagnose-and-resolve-insights-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Moving some Satellite maps to different categories, removing a few other maps.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

This is a mistake I made in https://github.com/theforeman/foreman-documentation/pull/5248, see https://github.com/theforeman/foreman-documentation/pull/5297#issuecomment-5619721893 for details. This PR aligns the map list and category placement with our downstream list.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

N/A

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
