### PR TITLE
SAT-50363: Adapt predefined tuning profile pages for containerized

### DIFF
--- a/guides/common/modules/con_how-predefined-tuning-profiles-apply.adoc
+++ b/guides/common/modules/con_how-predefined-tuning-profiles-apply.adoc
@@ -4,6 +4,9 @@
 = How predefined tuning profiles apply
 
 [role="_abstract"]
+When you apply a predefined tuning profile with the `--tuning` option, {Project} applies a set of deployment configuration settings that are sized for the number of hosts that you manage.
+
+ifndef::containerized[]
 When you run the `{foreman-installer}` command with the `--tuning` option, deployment configuration settings from multiple sources are applied to {Project} in a specific order.
 This order defines the priority of these settings.
 
@@ -23,3 +26,8 @@ When merging these settings, {Project} applies them in the following order:
 
 * Custom settings in the `/etc/foreman-installer/custom-hiera.yaml` file override the settings in any predefined profile and the base profile.
 * Predefined profile settings override the settings in the base profile.
+endif::[]
+ifdef::containerized[]
+You select the predefined tuning profile when you run the `{foremanctl} deploy` command with the `--tuning` option.
+The tuning profile is a persisted parameter, so it stays in effect for subsequent `{foremanctl} deploy` runs until you select a different profile.
+endif::[]

--- a/guides/common/modules/proc_applying-a-predefined-tuning-profile.adoc
+++ b/guides/common/modules/proc_applying-a-predefined-tuning-profile.adoc
@@ -4,7 +4,7 @@
 = Applying a predefined tuning profile
 
 [role="_abstract"]
-Run `{foreman-installer}` with the `--tuning` option to apply a profile.
+Apply a predefined tuning profile with the `--tuning` option.
 Choosing the right tuning profile helps your {ProjectServer} use its CPU cores and memory better.
 
 [NOTE]
@@ -13,6 +13,7 @@ You cannot use predefined tuning profiles on {SmartProxyServers}.
 ====
 
 .Procedure
+ifndef::containerized[]
 . If you use a `custom-hiera.yaml` file on your {ProjectServer}, perform the following steps:
 .. Optional: Back up your `custom-hiera.yaml` file:
 +
@@ -26,9 +27,11 @@ This ensures you can restore the `custom-hiera.yaml` file to its original state 
 .. Compare the configuration entries against the entries in your `/etc/foreman-installer/custom-hiera.yaml` file.
 .. Remove any duplicated configuration settings that you find in `custom-hiera.yaml`.
 This ensures the settings in `custom-hiera.yaml` do not override the settings in the base tuning profile and your chosen predefined tuning profile.
+endif::[]
 . Apply the tuning profile:
 +
 [options="nowrap", subs="+quotes,attributes"]
 ----
-# {foreman-installer} --tuning _medium_
+ifndef::containerized[# {foreman-installer} --tuning _medium_]
+ifdef::containerized[# {foremanctl} deploy --tuning _medium_]
 ----

--- a/guides/common/modules/proc_selecting-an-installation-size.adoc
+++ b/guides/common/modules/proc_selecting-an-installation-size.adoc
@@ -5,10 +5,13 @@
 
 [role="_abstract"]
 You can tune your {ProjectServer} based on expected host counts and hardware allocation by using built-in tuning profiles included in {Project} that are available by using the installation routine's tuning flag.
+
 For more information, see {InstallingServerDocURL}tuning-{project-context}-server-performance-with-predefined-profiles[Tuning {ProjectServer} performance with predefined profiles] in _{InstallingServerDocTitle}_.
 
-There are four sizes provided based on estimates of the number of hosts your {Project} manages.
+There are five sizes provided based on estimates of the number of hosts your {Project} manages.
+ifndef::containerized[]
 You can find the specific tuning settings for each profile in the configuration files contained in `/usr/share/foreman-installer/config/foreman.hiera/tuning/sizes`.
+endif::[]
 
 [width="100%",cols="25%,25%,25%,25%",options="header"]
 |===
@@ -23,11 +26,12 @@ You can find the specific tuning settings for each profile in the configuration 
 .Procedure
 . Select an installation size: `default`, `medium`, `large`, `extra-large`, or `extra-extra-large`.
 The default value is `default`.
-. Run `{foreman-installer}`:
+. Apply the installation size:
 +
 [options="nowrap", subs="+quotes,verbatim,attributes"]
 ----
-# {foreman-installer} --tuning "_My_Installation_Size_"
+ifndef::containerized[# {foreman-installer} --tuning "_My_Installation_Size_"]
+ifdef::containerized[# {foremanctl} deploy --tuning "_My_Installation_Size_"]
 ----
 . Optional: Run a health check.
 For more information, see xref:considerations-for-performance-tuning[].

--- a/guides/common/modules/ref_predefined-tuning-profiles.adoc
+++ b/guides/common/modules/ref_predefined-tuning-profiles.adoc
@@ -6,7 +6,9 @@
 [role="_abstract"]
 The following predefined tuning profiles are available in {Project} to right-size your {ProjectServer} based on the number of hosts your {Project} manages and available hardware resources.
 
+ifndef::containerized[]
 The predefined tuning profiles are available in the `/usr/share/foreman-installer/config/foreman.hiera/tuning/sizes` directory.
+endif::[]
 Each profile targets a managed-host range and minimum RAM and CPU cores.
 
 .Predefined tuning profiles


### PR DESCRIPTION
#### What changes are you introducing?

Adapt the predefined tuning profile modules so they render correctly in containerized builds:

  - Containerized builds now show foremanctl deploy --tuning <profile> instead of {foreman-installer} --tuning … (split via ifdef::containerized[] / ifndef::containerized[]).
  - Installer-only content is gated behind ifndef::containerized[]: the custom-hiera.yaml backup/compare steps, the Hiera merge-order explanation, and the /usr/share/foreman-installer/config/foreman.hiera/tuning/… and
    /etc/foreman-installer/custom-hiera.yaml paths (these do not exist in a containerized deployment).
  - Added a short containerized-only note describing that the profile is applied with foremanctl deploy --tuning and is a persisted parameter.
  - Removed {foreman-installer} from abstract prose where it would otherwise emit the containerized "do-not-use" poison string.
  - Drive-by fix: corrected "There are four sizes" → "five" in proc_selecting-an-installation-size.adoc (the table lists five profiles).

  Files: con_how-predefined-tuning-profiles-apply.adoc, proc_applying-a-predefined-tuning-profile.adoc, proc_selecting-an-installation-size.adoc, ref_predefined-tuning-profiles.adoc.

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

Containerized Foreman 5.0 / Katello 5.0 is deployed with foremanctl, not foreman-installer. In containerized builds {foreman-installer} is deliberately set to a DO_NOT_USE_… poison value, and the installer's
  Hiera/custom-hiera.yaml mechanism does not exist. As written, these tuning-profile modules emitted installer-only commands and filesystem paths that are wrong (and leak the poison string) in containerized output. This change
  makes the predefined-tuning-profile guidance correct for both package and containerized flavors from the shared modules.

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
(older branches — N/A; containerized deployment does not exist before 5.0)
