### PR TITLE
Add Noble and Trixie release notes

### DIFF
--- a/guides/doc-Release_Notes/topics/foreman-5.0.0.adoc
+++ b/guides/doc-Release_Notes/topics/foreman-5.0.0.adoc
@@ -66,6 +66,7 @@ You can find the complete list of changes on https://projects.theforeman.org/iss
 * pass:[container_certs_setup snippet missing cert directories for load balancer backend hostnames] - https://projects.theforeman.org/issues/39193[#39193]
 * pass:[Subnet UI allows CIDR in Network Address causing duplicated prefix (/24/24)] - https://projects.theforeman.org/issues/39159[#39159]
 * pass:[Update host vmware form to PF5] - https://projects.theforeman.org/issues/38992[#38992]
+* pass:[Support Foreman installation on Ubuntu 24.04 and Debian 13] - https://projects.theforeman.org/issues/37520[#37520]
 
 === Authentication
 

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -146,4 +146,14 @@ endif::[]
 == Deprecations
 
 //If there are deprecations, comment out the following line.
+ifndef::foreman-deb[]
 There are no deprecations with Foreman {ProjectVersion}.
+endif::[]
+ifdef::foreman-deb[]
+Running Foreman on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated::
+Foreman supports running on Ubuntu 24.04 (Noble) and Debian 13 (Trixie), therefore running on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated.
+Support for these platforms will be removed in a future release, so users are encouraged to plan their upgrade.
+
+Note this is for running Foreman itself.
+Clients will remain supported.
+endif::[]

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -46,6 +46,9 @@ endif::[]
 ifdef::foreman-deb[]
 Ubuntu 24.04 and Debian 13 support::
 {Project} can now be installed on Ubuntu 24.04 (Noble) and Debian 13 (Trixie).
+
+The `foreman_google` plugin is currently not supported on Debian 13 (Trixie) because its `grpc` gem dependency cannot be compiled.
+Upgrades with the plugin enabled and new installations with the plugin enabled will fail.
 endif::[]
 
 Ruby 3.3 support::
@@ -152,7 +155,7 @@ endif::[]
 ifdef::foreman-deb[]
 Running Foreman on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated::
 Foreman supports running on Ubuntu 24.04 (Noble) and Debian 13 (Trixie), therefore running on Ubuntu 22.04 (Jammy) and Debian 12 (Bookworm) is deprecated.
-Support for these platforms will be removed in a future release, so users are encouraged to plan their upgrade.
+Users are encouraged to plan their upgrade to a newer supported platform.
 
 Note this is for running Foreman itself.
 Clients will remain supported.

--- a/guides/doc-Release_Notes/topics/foreman.adoc
+++ b/guides/doc-Release_Notes/topics/foreman.adoc
@@ -43,6 +43,11 @@ See https://developers.redhat.com/articles/2024/01/02/exploring-x86-64-v3-red-ha
 --
 endif::[]
 
+ifdef::foreman-deb[]
+Ubuntu 24.04 and Debian 13 support::
+{Project} can now be installed on Ubuntu 24.04 (Noble) and Debian 13 (Trixie).
+endif::[]
+
 Ruby 3.3 support::
 {Project} can now run on Ruby 3.3.
 


### PR DESCRIPTION
#### What changes are you introducing?

Add Foreman 5.0 release-note and changelog entries for Ubuntu 24.04 (Noble) and Debian 13 (Trixie).

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

https://projects.theforeman.org/issues/37520

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

None.

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
