### PR TITLE
Map Chapters 1-3 of Mng hosts

### DIFF
--- a/guides/common/modules/con_assign-hosts-to-logical-groups.adoc
+++ b/guides/common/modules/con_assign-hosts-to-logical-groups.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="assign-hosts-to-logical-groups"]
+= Assign hosts to logical groups
+
+[role="_abstract"]
+Assign hosts to logical groups to manage them under appropriate permissions, settings, and governance policies.
+
+{Project} uses organizations, locations, and content view environments to control how hosts are governed.
+Organizations determine content availability, permissions, and settings.
+Locations control subnets, domains, and location-specific configuration.
+Content view environments determine which repositories and package versions hosts can access.
+
+For virtualized infrastructure, you can also associate or disassociate virtual machines from {Project} management without affecting the running VMs on the hypervisor.
+
+Common host organization workflows include:
+
+Organizational governance:: Assign a host to an organization to control which content, permissions, and settings govern the host's behavior.
+Note that reassigning a registered host requires unregistering and re-registering the host.
+
+Geographic organization:: Assign a host to a location to control which subnets, domains, and location-specific settings apply.
+
+Content access control:: Change a host's content view environments to alter which repositories and package versions the host can consume, enabling staged promotion workflows from development through production.
+
+VM lifecycle management:: Associate existing virtual machines from a hypervisor to bring them under {Project} management, or disassociate VMs to remove them from management without deleting the running VM.
+
+Cross-organizational migration:: When moving a host between organizations, use the "Fix on mismatch" option to automatically add associated resources (subnets, domains, content sources) to the target organization.

--- a/guides/common/modules/con_configure-system-purpose-for-subscription-reporting.adoc
+++ b/guides/common/modules/con_configure-system-purpose-for-subscription-reporting.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="configure-system-purpose-for-subscription-reporting"]
+= Configure system purpose for subscription reporting
+
+[role="_abstract"]
+Configure system purpose attributes to improve subscription reporting accuracy in Red Hat Hybrid Cloud Console.
+
+System purpose defines the intended use of a host by specifying attributes such as role, usage type, and service level agreement.
+{Project} uses these attributes to improve subscription reporting in Red Hat Hybrid Cloud Console, helping you understand how your subscriptions are being used and optimize subscription allocation.
+
+You can configure system purpose through multiple methods depending on your workflow:
+
+* Web UI for interactive, single-host configuration
+* Hammer CLI for scriptable, automated configuration
+* Bulk editing for efficient multi-host configuration
+
+All system purpose changes require that hosts are registered with subscription-manager.
+
+Common system purpose configuration workflows include:
+
+Initial host setup:: Configure system purpose during or immediately after host registration using the web UI to set role (e.g., Red Hat Enterprise Linux Server, Red Hat Enterprise Linux Workstation) and usage type (e.g., Production, Development/Test).
+
+Bulk configuration:: Use bulk editing to configure system purpose for multiple hosts at once, maintaining existing values for some attributes with "No Change" or clearing attributes with "(unset)".
+
+Automated configuration:: Use Hammer CLI or subscription-manager commands in automation scripts to set system purpose as part of provisioning workflows.
+
+Subscription optimization:: Review system purpose attributes across your fleet to identify mismatches between intended use and actual usage, then adjust attributes to improve subscription reporting accuracy.
+
+Service level management:: Set service level attributes (e.g., Premium, Standard, Self-Support) to match your support subscription tier and ensure accurate support entitlement reporting.

--- a/guides/common/modules/con_configure-which-content-hosts-consume.adoc
+++ b/guides/common/modules/con_configure-which-content-hosts-consume.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="configure-which-content-hosts-consume"]
+= Configure which content hosts consume
+
+[role="_abstract"]
+Configure which repositories and content sources hosts use to control software availability, updates, and repository access.
+
+{Project} provides multiple mechanisms to control the content that hosts consume.
+You can manage module streams for {EL} 8 hosts to select specific software versions, enable custom repositories to make additional packages available, and change content sources to control which {SmartProxyServer} delivers content to hosts.
+
+These configuration options work together to give you fine-grained control over software availability and update management across your infrastructure.
+
+Common content configuration workflows include:
+
+Software version management:: For {EL} 8 hosts, change module streams to select the appropriate version of software packages such as different versions of Node.js, Ruby, or PostgreSQL.
+
+Custom package availability:: Enable custom repositories on hosts to make packages from your own custom repositories available for installation and updates.
+
+Content delivery optimization:: Change a host's content source to point to a different {SmartProxyServer}, either to balance load across multiple content sources or to direct hosts to a geographically closer or network-preferred content source.
+
+Content source migration:: When migrating hosts to a new {SmartProxyServer}, use the content source change workflow which provides both automated (remote execution job) and manual (generated commands) approaches.
+
+Repository lifecycle management:: Combine content view environment changes with custom repository enablement to control the lifecycle of packages from development through testing to production.

--- a/guides/common/modules/con_monitor-host-health.adoc
+++ b/guides/common/modules/con_monitor-host-health.adoc
@@ -3,6 +3,25 @@
 [id="monitor-host-health"]
 = Monitor host health
 
-// The wording in this introduction is temporary; make sure to review it before publishing based on what exacty content the top-level job ends up including.
 [role="_abstract"]
 Monitor host status to quickly identify systems that need attention and prioritize remediation efforts across your fleet.
+
+{Project} provides two levels of status monitoring:
+
+* *Global status* provides an at-a-glance view using OK, Warning, or Error indicators
+* *Sub-status* shows detailed information for specific areas like configuration, compliance, errata, and lifecycle
+
+Use global status for quick triage across your host inventory, then drill into sub-status details when investigating issues.
+This workflow helps you prioritize which hosts need immediate attention and understand exactly what requires remediation.
+
+Common monitoring workflows include:
+
+Daily operations:: Review the Hosts Overview page to identify hosts with Warning or Error global status, then investigate sub-status details to determine the specific issue.
+
+Compliance monitoring:: Track which hosts are non-compliant with OpenSCAP policies using the Compliance sub-status.
+
+Patch management:: Identify hosts requiring security updates using the Errata sub-status, prioritizing those with needed security errata.
+
+Post-update verification:: After applying system updates, check the Traces sub-status to identify hosts requiring process restarts or reboots.
+
+Lifecycle planning:: Monitor RHEL lifecycle sub-status to identify hosts approaching end-of-support dates and plan upgrades accordingly.

--- a/guides/common/modules/con_track-rhel-lifecycle-status.adoc
+++ b/guides/common/modules/con_track-rhel-lifecycle-status.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="track-rhel-lifecycle-status"]
+= Track RHEL lifecycle status
+
+[role="_abstract"]
+Track RHEL lifecycle status to plan upgrades before support expires and avoid running unsupported OS versions.
+
+{Project} provides lifecycle status tracking to help you identify hosts approaching end-of-support dates.
+Use lifecycle status information to prioritize upgrade planning and ensure compliance with support policies.
+
+{Project} displays lifecycle status through multiple mechanisms:
+
+* Notification banner for upcoming end-of-support (EOS) events
+* Lifecycle status column on the Hosts index page
+* Alerts for hosts with upcoming EOS within a year
+* Search capability to filter hosts by lifecycle status
+
+Common lifecycle tracking workflows include:
+
+Proactive upgrade planning:: Enable the RHEL Lifecycle status column to identify hosts in `approaching_end_of_maintenance` or `approaching_end_of_support` status, then prioritize upgrade planning based on business criticality.
+
+Support compliance verification:: Search for hosts with `support_ended` status to identify systems running unsupported OS versions that may violate compliance requirements.
+
+Maintenance window planning:: Filter hosts by `full_support` versus `maintenance_support` status to understand which systems have access to new features versus security-only updates.
+
+Extended support tracking:: Identify hosts in `extended_support` status that require Extended Update Support (EUS) or Extended Life Cycle Support (ELS) subscriptions.

--- a/guides/common/modules/con_view-all-hosts-in-a-central-location.adoc
+++ b/guides/common/modules/con_view-all-hosts-in-a-central-location.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="view-all-hosts-in-a-central-location"]
+= View all hosts in a central location
+
+[role="_abstract"]
+View all hosts in a central location to see the overall state of your infrastructure at a glance.
+
+{Project} provides a centralized Hosts Overview page where you can view and manage all hosts across your infrastructure.
+Use search and filtering capabilities to quickly locate specific hosts, and customize the table display to focus on information relevant to your daily work.
+
+Common workflows for viewing hosts include:
+
+Quick host lookup:: Search for hosts by name or pattern using the search bar, with asterisk (*) wildcard support for partial string matching.
+
+Filter by host type:: Filter the host list by All Hosts, Discovered Hosts, or Host Collections to focus on specific subsets of your infrastructure.
+
+Customize display:: Select relevant columns for your daily work, choosing individual columns or entire categories to reduce clutter and highlight important information.
+
+Monitor at a glance:: Use the customized view to quickly scan your infrastructure for hosts requiring attention based on status indicators, lifecycle information, or other key attributes.

--- a/guides/doc-Satellite_Documentation_Maps/administer.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/administer.adoc
@@ -13,3 +13,5 @@ include::maps/perform-routine-maintenance.adoc[leveloffset=+1]
 include::maps/manage-logging-in-a-containerized-satellite.adoc[leveloffset=+1]
 
 include::maps/remove-satellite-server-from-your-environment.adoc[leveloffset=+1]
+
+include::maps/assign-hosts-to-logical-groups.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/configure.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/configure.adoc
@@ -13,3 +13,7 @@ include::maps/configure-alerts-for-critical-events.adoc[leveloffset=+1]
 include::maps/set-up-disaster-recovery.adoc[leveloffset=+1]
 
 include::maps/enforce-host-configuration.adoc[leveloffset=+1]
+
+include::maps/configure-which-content-hosts-consume.adoc[leveloffset=+1]
+
+include::maps/configure-system-purpose-for-subscription-reporting.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/discover.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/discover.adoc
@@ -5,3 +5,5 @@
 include::maps/determine-if-project-meets-your-management-needs.adoc[leveloffset=+1]
 
 include::maps/evaluate-satellite-security-capabilities.adoc[leveloffset=+1]
+
+include::maps/view-all-hosts-in-a-central-location.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/assign-hosts-to-logical-groups.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/assign-hosts-to-logical-groups.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: MAP
+:context: assign-hosts-to-logical-groups
+
+include::../../common/modules/con_assign-hosts-to-logical-groups.adoc[]
+
+include::../../common/modules/proc_assigning-a-host-to-a-specific-organization.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_assigning-a-host-to-a-specific-location.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_changing-the-content-view-environments-of-a-host.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_associating-a-virtual-machine-from-a-hypervisor.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_disassociating-a-vm-from-project-without-removing-it-from-a-hypervisor.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/configure-system-purpose-for-subscription-reporting.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/configure-system-purpose-for-subscription-reporting.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: MAP
+:context: configure-system-purpose-for-subscription-reporting
+
+include::../../common/modules/con_configure-system-purpose-for-subscription-reporting.adoc[]
+
+include::../../common/modules/proc_editing-the-system-purpose-of-a-host-by-using-web-ui.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_editing-the-system-purpose-of-a-host-by-using-cli.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_editing-the-system-purpose-of-multiple-hosts.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/configure-which-content-hosts-consume.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/configure-which-content-hosts-consume.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: MAP
+:context: configure-which-content-hosts-consume
+
+include::../../common/modules/con_configure-which-content-hosts-consume.adoc[]
+
+include::../../common/modules/proc_changing-the-module-stream-for-a-host.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_enabling-custom-repositories-on-hosts.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_changing-the-content-source-of-a-host.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/monitor-host-health.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/monitor-host-health.adoc
@@ -1,3 +1,7 @@
 :_mod-docs-content-type: MAP
 
 include::../../common/modules/con_monitor-host-health.adoc[]
+
+include::../../common/modules/con_host-global-status-overview.adoc[leveloffset=+1]
+
+include::../../common/modules/con_host-substatus-overview.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/track-rhel-lifecycle-status.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/track-rhel-lifecycle-status.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: track-rhel-lifecycle-status
+
+include::../../common/modules/con_track-rhel-lifecycle-status.adoc[]
+
+include::../../common/modules/con_lifecycle-status-of-rhel-hosts.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_displaying-rhel-lifecycle-status.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/view-all-hosts-in-a-central-location.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/view-all-hosts-in-a-central-location.adoc
@@ -1,0 +1,8 @@
+:_mod-docs-content-type: MAP
+:context: view-all-hosts-in-a-central-location
+
+include::../../common/modules/con_view-all-hosts-in-a-central-location.adoc[]
+
+include::../../common/modules/proc_browsing-hosts-in-web-ui.adoc[leveloffset=+1]
+
+include::../../common/modules/proc_selecting-host-columns.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/observe.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/observe.adoc
@@ -9,3 +9,5 @@ include::maps/monitor-satellite-performance.adoc[leveloffset=+1]
 include::maps/use-intelligent-monitoring.adoc[leveloffset=+1]
 
 include::maps/monitor-host-health.adoc[leveloffset=+1]
+
+include::maps/track-rhel-lifecycle-status.adoc[leveloffset=+1]


### PR DESCRIPTION
#### What changes are you introducing?

Adding the following chapters of [the _Managing hosts_ guide](https://docs.theforeman.org/nightly/Managing_Hosts/index-satellite.html):

- Reviewing hosts in Satellite web UI
- Managing host placement and associations
- Managing host content settings and system purpose

...to the doc-Satellite_Documentation_Maps

#### Why are you introducing these changes? (Explanation, links to references, issues, etc.)

JTBD restructuralization of Satellite docs from guides into a single TOC

#### Anything else to add? (Considerations, potential downsides, alternative solutions you have explored, etc.)

- The `:context:` definitions are necessary for now, otherwise the build fails
- Relevant to the Satellite build only

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
