### PR TITLE
Add Installing Proxy to Satellite Documentation Maps

### DIFF
--- a/guides/doc-Satellite_Documentation_Maps/maps/install-satellite-server.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/install-satellite-server.adoc
@@ -1,3 +1,9 @@
 :_mod-docs-content-type: MAP
 
 include::../../common/modules/con_install-project-server.adoc[]
+
+include::../../common/assembly_preparing-your-environment-for-smart-proxy-installation.adoc[leveloffset=+1]
+
+include::../../common/assembly_installing-smart-proxy-server.adoc[leveloffset=+1]
+
+include::../../common/assembly_performing-additional-configuration-on-smart-proxy-server.adoc[leveloffset=+1]

--- a/guides/doc-Satellite_Documentation_Maps/maps/optimize-performance-for-scale.adoc
+++ b/guides/doc-Satellite_Documentation_Maps/maps/optimize-performance-for-scale.adoc
@@ -1,3 +1,5 @@
 :_mod-docs-content-type: MAP
 
 include::../../common/modules/con_optimize-performance-for-scale.adoc[]
+
+include::../../common/modules/ref_smart-proxy-server-scalability-considerations-when-managing-puppet-clients.adoc[leveloffset=+1]


### PR DESCRIPTION
Added the contents of the Installation maps to the Installing Satellite map and the Optimize Performance map, as a part of the downstream JTBD effort.

JIRA: https://redhat.atlassian.net/browse/SAT-49522

#### Contributor checklists

* [x] I am okay with my commits getting squashed when you merge this PR.
* [x] I am familiar with the [contributing guidelines](https://docs.theforeman.org/nightly/Contributing/index-katello.html#_contributing_to_foreman_documentation).

Please cherry-pick my commits into:

* [x] Foreman 5.0/Katello 5.0
* [ ] Foreman 3.19/Katello 4.21
* [ ] Foreman 3.18/Katello 4.20 (Satellite 6.19; orcharhino 7.9 and 7.10)
* [ ] Foreman 3.17/Katello 4.19
* [ ] Foreman 3.16/Katello 4.18 (Satellite 6.18; orcharhino 7.6, 7.7, and 7.8)
* [ ] Foreman 3.15/Katello 4.17
* [ ] Foreman 3.14/Katello 4.16 (Satellite 6.17; orcharhino 7.4; orcharhino 7.5)
* We do not accept PRs for Foreman older than 3.14.
